### PR TITLE
Fix off-by-one bug when populating output buffers with rank-1 properties

### DIFF
--- a/perl/Galacticus/Build/Components/Classes/Output.pm
+++ b/perl/Galacticus/Build/Components/Classes/Output.pm
@@ -426,7 +426,7 @@ CODE
 		    $function->{'content'} .= fill_in_string(<<'CODE', PACKAGE => 'code');
 {$bufferType}OutputTmp=reshape(self%{$property->{'name'}}(),[{$count}])
 do i=1,{$count}
-  {$bufferType}Properties({$bufferType}Property+i-1)%scalar({$bufferType}BufferCount)={$bufferType}OutputTmp(i)
+  {$bufferType}Properties({$bufferType}Property+i)%scalar({$bufferType}BufferCount)={$bufferType}OutputTmp(i)
 end do
 deallocate({$bufferType}OutputTmp)
 {$bufferType}Property={$bufferType}Property+{$count}


### PR DESCRIPTION
The refactor of output buffer structure in f0f31a1e8cba348f2004d1b4f30d11c39221cb63 lead to the introduction of an off-by-one error when populating those buffers with values from rank-1 properties. This patch fixes that error.