### PR TITLE
Removes obsolete <calculationReset> elements

### DIFF
--- a/scripts/build/codeDirectivesParse.pl
+++ b/scripts/build/codeDirectivesParse.pl
@@ -204,11 +204,6 @@ sub addImplicitDirectives {
 	     always => $directive->{'rootElementType'} eq "functionClass"           ,
 	     tasks  => [ "galacticusStateRetrieveTask", "galacticusStateStoreTask" ]
 	 },
-	 calculationReset => 
-	 {
-	     always => 0                                                            ,
-	     tasks  => [ "calculationResetTask"                                    ]
-	 },
 	 functionClassDestroy => 
 	 {
 	     always => $directive->{'rootElementType'} eq "functionClass" && ! exists($directive->{'functionClassDestroy'}),

--- a/source/accretion.halo.F90
+++ b/source/accretion.halo.F90
@@ -35,7 +35,6 @@ module Accretion_Halos
   !#   gas.
   !#  </description>
   !#  <default>simple</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="branchHasBaryons" >
   !#   <description>Returns {\normalfont \ttfamily true} if this tree branch may accrete baryons, and {\normalfont \ttfamily false} otherwise.</description>
   !#   <type>logical</type>

--- a/source/cooling.cooling_radius.F90
+++ b/source/cooling.cooling_radius.F90
@@ -32,7 +32,6 @@ module Cooling_Radii
   !#   Class providing models of the cooling radius for gas in the hot atmosphere surrounding a galaxy.
   !#  </description>
   !#  <default>simple</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="radius" >
   !#   <description>Returns the cooling radius for gas in the hot atmosphere surrounding the galaxy in {\normalfont \ttfamily node} in units of Mpc.</description>
   !#   <type>double precision</type>

--- a/source/cooling.freefall_radii.F90
+++ b/source/cooling.freefall_radii.F90
@@ -30,7 +30,6 @@ module Freefall_Radii
   !#  <descriptiveName>Freefall radii.</descriptiveName>
   !#  <description>Class providing models of the freefall radius for gas in the hot atmosphere surrounding a galaxy.</description>
   !#  <default>darkMatterHalo</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="radius" >
   !#   <description>Returns the freefall radius for gas in the hot atmosphere surrounding the galaxy in {\normalfont \ttfamily node} in units of Mpc.</description>
   !#   <type>double precision</type>

--- a/source/cooling.freefall_time_available.F90
+++ b/source/cooling.freefall_time_available.F90
@@ -32,7 +32,6 @@ module Cooling_Freefall_Times_Available
   !#   Class providing models of the time available for freefall in cooling calculations.
   !#  </description>
   !#  <default>haloFormation</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="timeAvailable" >
   !#   <description>Returns the time available for freefall in cooling calculations in {\normalfont \ttfamily node}.</description>
   !#   <type>double precision</type>

--- a/source/cooling.specific_angular_momentum.F90
+++ b/source/cooling.specific_angular_momentum.F90
@@ -32,7 +32,6 @@ module Cooling_Specific_Angular_Momenta
   !#   Class providing models of the specific angular momentum of gas in the hot atmosphere surrounding a galaxy.
   !#  </description>
   !#  <default>constantRotation</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="angularMomentumSpecific" >
   !#   <description>Return the specific angular momentum (in units of km/s Mpc) of cooling gas in {\normalfont \ttfamily node}.</description>
   !#   <type>double precision</type>

--- a/source/dark_matter_halos.scales.F90
+++ b/source/dark_matter_halos.scales.F90
@@ -29,7 +29,6 @@ module Dark_Matter_Halo_Scales
   !#  <descriptiveName>Dark Matter Halo Scales</descriptiveName>
   !#  <description>Class providing dark matter halo scales.</description>
   !#  <default>virialDensityContrastDefinition</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="dynamicalTimescale" >
   !#   <description>The characteristic dynamical timescale of a dark matter halo.</description>
   !#   <type>double precision</type>

--- a/source/dark_matter_profiles.F90
+++ b/source/dark_matter_profiles.F90
@@ -32,7 +32,6 @@ module Dark_Matter_Profiles
   !#  <descriptiveName>Dark Matter Halo Profiles</descriptiveName>
   !#  <description>Object providing dark matter halo profiles.</description>
   !#  <default>adiabaticGnedin2004</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="density" >
   !#   <description>Returns the density (in $M_\odot$ Mpc$^{-3}$) in the dark matter profile of {\normalfont \ttfamily node} at the given {\normalfont \ttfamily radius} (given in units of Mpc).</description>
   !#   <type>double precision</type>

--- a/source/dark_matter_profiles_DMO.F90
+++ b/source/dark_matter_profiles_DMO.F90
@@ -34,7 +34,6 @@ module Dark_Matter_Profiles_DMO
   !#   Class providing dark matter-only halo profiles.
   !#  </description>
   !#  <default>NFW</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="density" >
   !#   <description>Returns the density (in $M_\odot$ Mpc$^{-3}$) in the dark matter profile of {\normalfont \ttfamily node} at the given {\normalfont \ttfamily radius} (given in units of Mpc).</description>
   !#   <type>double precision</type>
@@ -210,7 +209,6 @@ module Dark_Matter_Profiles_DMO
   !#   Class providing models of heating of dark matter profiles.
   !#  </description>
   !#  <default>null</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="specificEnergy" >
   !#   <description>The specific energy of heating at the given {\normalfont \ttfamily radius} in the given {\normalfont \ttfamily node}.</description>
   !#   <type>double precision</type>

--- a/source/geometry.lightcones.F90
+++ b/source/geometry.lightcones.F90
@@ -30,7 +30,6 @@ module Geometry_Lightcones
   !#  <descriptiveName>Lightcone Geometries</descriptiveName>
   !#  <description>Class providing geometries of lightcones.</description>
   !#  <default>square</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="isInLightcone" >
   !#   <description>Returns true if the provided node lies within the lightcone.</description>
   !#   <type>logical</type>

--- a/source/hot_halo.outflow_reincorporation.F90
+++ b/source/hot_halo.outflow_reincorporation.F90
@@ -31,7 +31,6 @@ module Hot_Halo_Outflows_Reincorporations
   !#   Class providing models of reincorportation of outflowed mass into the hot halo.
   !#  </description>
   !#  <default>haloDynamicalTime</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="rate" >
   !#   <description>Return the rate at which outflowed mass is being reincorporated into the hot halo.</description>
   !#   <type>double precision</type>

--- a/source/satellites.tidal_stripping.radius.F90
+++ b/source/satellites.tidal_stripping.radius.F90
@@ -33,7 +33,6 @@ module Satellite_Tidal_Stripping_Radii
   !#   Class providing models of tidal stripping radii for satellites.
   !#  </description>
   !#  <default>king1962</default>
-  !#  <calculationReset>yes</calculationReset>
   !#  <method name="radius" >
   !#   <description>Returns the tidal radius for {\normalfont \ttfamily node} (in units of Mpc).</description>
   !#   <type>double precision</type>

--- a/source/star_formation.rate_surface_density.disks.F90
+++ b/source/star_formation.rate_surface_density.disks.F90
@@ -30,7 +30,6 @@ module Star_Formation_Rate_Surface_Density_Disks
   !#  <description>
   !#   Class providing models of the surface density rate of star formation in disks.
   !#  </description>
-  !#  <calculationReset>yes</calculationReset>
   !#  <default>krumholz2009</default>
   !#  <method name="intervals" >
   !#   <description>Return a set of integration intervals to use when integrating over the surface density of star formation rate.</description>


### PR DESCRIPTION
The <calculationReset> element is obsolete in functionClass descriptors, but a few instances of it remained. This patch removes all such instances. It also removes the auto-dependency for calculationReset behavior from the codeDirectivesParse.pl script.

Fixes #148.