### PR TITLE
Add citation to Hearin et al. (2021).

### DIFF
--- a/doc/Galacticus.bib
+++ b/doc/Galacticus.bib
@@ -3067,6 +3067,44 @@ galaxy-halo connection.},
 	pages = {6747}
 }
 
+@article{hearin_differentiable_2021,
+	title = {A {Differentiable} {Model} of the {Assembly} of {Individual} and {Populations} of {Dark} {Matter} {Halos}},
+	volume = {2105},
+	url = {http://adsabs.harvard.edu/abs/2021arXiv210505859H},
+	abstract = {We present a new empirical model for the mass assembly of dark matter 
+halos. We approximate the growth of individual halos as a simple
+power-law function of time, where the power-law index smoothly decreases
+as the halo transitions from the fast-accretion regime at early times,
+to the slow-accretion regime at late times. Using large samples of halo
+merger trees taken from high-resolution cosmological simulations, we
+demonstrate that our 3-parameter model can approximate halo growth with
+a typical accuracy of 0.1 dex for t {\textgreater} 1 Gyr for all halos of
+present-day mass greater than 10{\textasciicircum}11Msun, including subhalos and host
+halos in gravity-only simulations, as well as in the TNG hydrodynamical
+simulation. We additionally present a new model for the assembly of halo
+populations, which not only reproduces average mass growth across time,
+but also faithfully captures the diversity with which halos assemble
+their mass. Our python implementation is based on the autodiff library
+JAX, and so our model self-consistently captures the mean and variance
+of halo mass accretion rate across cosmic time. We show that the
+connection between halo assembly and the large-scale density field,
+known as halo assembly bias, is accurately captured by our model, and
+that residual errors in our approximations to halo assembly history
+exhibit a negligible residual correlation with the density field. Our
+publicly available source code can be used to generate Monte Carlo
+realizations of cosmologically representative halo histories; our
+differentiable implementation facilitates the incorporation of our model
+into existing analytical halo model frameworks.},
+	urldate = {2021-05-14},
+	journal = {arXiv e-prints},
+	author = {Hearin, Andrew P. and Chaves-Montero, Jonás and Becker, Matthew R. and Alarcon, Alex},
+	month = may,
+	year = {2021},
+	keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics},
+	pages = {arXiv:2105.05859},
+	file = {Full Text PDF:/home/abensonca/.mozilla/firefox/f54gqgdx.default/zotero/storage/QNP5SKWU/Hearin et al. - 2021 - A Differentiable Model of the Assembly of Individu.pdf:application/pdf}
+}
+
 @article{heger_nucleosynthetic_2002,
 	title = {The Nucleosynthetic Signature of Population {III}},
 	volume = {567},

--- a/source/dark_matter_halos.mass_accretion_history.Hearin2021.F90
+++ b/source/dark_matter_halos.mass_accretion_history.Hearin2021.F90
@@ -17,13 +17,13 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !% An implementation of dark matter halo mass accretion histories using Andrew Hearin's rolling power-law model.
+  !% An implementation of dark matter halo mass accretion histories using the rolling power-law model of \cite{hearin_differentiable_2021}.
 
   !# <darkMatterHaloMassAccretionHistory name="darkMatterHaloMassAccretionHistoryHearin2021">
-  !#  <description>Dark matter halo mass accretion histories using Andrew Hearin's rolling power-law model.</description>
+  !#  <description>Dark matter halo mass accretion histories using the rolling power-law model of \cite{hearin_differentiable_2021}.</description>
   !# </darkMatterHaloMassAccretionHistory>
   type, extends(darkMatterHaloMassAccretionHistoryClass) :: darkMatterHaloMassAccretionHistoryHearin2021
-     !% A dark matter halo mass accretion history class using Andrew Hearin's rolling power-law model.
+     !% A dark matter halo mass accretion history class using the rolling power-law model of \cite{hearin_differentiable_2021}.
      private
      double precision :: powerLawIndexEarly, powerLawIndexLate, &
           &              rateRollOver      , timeMaximum

--- a/source/dark_matter_halos.mass_accretion_history.Hearin2021_stochastic.F90
+++ b/source/dark_matter_halos.mass_accretion_history.Hearin2021_stochastic.F90
@@ -17,7 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !% An implementation of dark matter halo mass accretion histories using Andrew Hearin's rolling power-law model with stochastic sampling of parameters.
+  !% An implementation of dark matter halo mass accretion histories using the rolling power-law model of \cite{hearin_differentiable_2021} with stochastic sampling of parameters.
 
   !# <enumeration>
   !#  <name>mass</name>
@@ -48,10 +48,10 @@
   !# </enumeration>
 
   !# <darkMatterHaloMassAccretionHistory name="darkMatterHaloMassAccretionHistoryHearin2021Stochastic">
-  !#  <description>Dark matter halo mass accretion histories using Andrew Hearin's rolling power-law model.</description>
+  !#  <description>Dark matter halo mass accretion histories using the rolling power-law model of \cite{hearin_differentiable_2021} with stochastic sampling of parameters.
   !# </darkMatterHaloMassAccretionHistory>
   type, extends(darkMatterHaloMassAccretionHistoryHearin2021) :: darkMatterHaloMassAccretionHistoryHearin2021Stochastic
-     !% A dark matter halo mass accretion history class using Andrew Hearin's rolling power-law model with stochastic sampling of parameters.
+     !% A dark matter halo mass accretion history class using the rolling power-law model of \cite{hearin_differentiable_2021} with stochastic sampling of parameters.
      private
      double precision                     :: fractionLateLow     , fractionLateHigh, &
           &                                  timeZeroLogarithmic_


### PR DESCRIPTION
Adds citations to the Andrew Hearin's 2021 paper on halo mass accretion histories now that the paper is submitted.