### PR TITLE
Optimize code parsing

### DIFF
--- a/perl/Fortran/Utils.pm
+++ b/perl/Fortran/Utils.pm
@@ -336,36 +336,57 @@ sub Get_Fortran_Line {
 	my $inDoubleQuotes  =  0;
 	my $inSingleQuotes  =  0;
 	my $inBraces        =  0;
-	my $commentPosition = -1;
-	for(my $iChar=0;$iChar<length($tmpLine);++$iChar) {
-	    my $char = substr($tmpLine,$iChar,1);
-	    if ( $char eq "'" ) {
-		if ( $inDoubleQuotes == 0 ) {
-		    $inDoubleQuotes = 1;
-		} else {
-		    $inDoubleQuotes = 0;
-		}
+	my $commentPosition;
+	# Search for start of comment in the line, if any. Regex is fast here.
+	if ( $tmpLine !~ m/!/ ) {
+	    ## This regex tests for the possible existance of any comment. If no "!" is present there can be no comment, and most lines don't contain comments, so we can quickly ignored them.
+	    $commentPosition = -1;
+	} elsif ( $tmpLine =~ m/^([^'"\{]+)![^\$]/ ) {
+	    ## This regex checks for a "!" prior to any of "'{, and not followed by a "$" (which indicates an OpenMP directive). If found, this must be the start of a comment.
+	    $commentPosition = length($1)+1;
+	} else {
+	    # General case. Comments begin with a "!" symbol, but not if it is found inside a string literal, or inside braces, "{}".
+	    my $removedCount = 0;
+	    while ( $tmpLine =~ m/([!'"\{])/ ) {
+	    	if ( $1 eq "!" ) {
+	    	    # Comment character is prior to any other, so we're done.
+		    if ( $tmpLine =~ s/^([^!]*!\$)// ) {
+			$removedCount += length($1);
+		    } else {
+			last;
+		    }
+	    	} elsif ( $1 eq "{" ) {
+	    	    # Braces can be nested so must be counted.
+	    	    my $iChar = index($tmpLine,"{");
+	    	    my $depth = 0;
+	    	    while ( $iChar < length($tmpLine) ) {
+	    		++$depth
+	    		    if ( substr($tmpLine,$iChar+1,1) eq "{" );
+	    		--$depth
+	    		    if ( substr($tmpLine,$iChar+1,1) eq "}" );
+	    		last
+	    		    if ( $depth == 0 );
+	    		++$iChar;
+	    	    }
+	    	    $removedCount += $iChar+1;
+	    	    $tmpLine = substr($tmpLine,$iChar+1);
+	    	} else {
+	    	    # Quotes are not nested, so can be removed by regex.
+	    	    my $quote = $1;
+	    	    $tmpLine =~ s/^(.*?$quote[^$quote]*$quote)//;
+	    	    $removedCount += length($1);
+	    	}
 	    }
-	    if ( $char eq '"' ) {
-		if ( $inSingleQuotes == 0 ) {
-		    $inSingleQuotes = 1;
-		} else {
-		    $inSingleQuotes = 0;
-		}
-	    }
-	    ++$inBraces
-		if ( $char eq "{" );
-	    --$inBraces
-		if ( $char eq "}" );
-	    # Detect comments. Exclude comment characters within quotes, or which begin an OpenMP directive.
-	    if ( $commentPosition == -1 && $char eq "!" && ($iChar == length($tmpLine)-1 || substr($tmpLine,$iChar+1,1) ne "\$") && $inDoubleQuotes == 0 && $inSingleQuotes == 0 && $inBraces == 0 ) {$commentPosition = $iChar};
+	    $commentPosition = index($tmpLine,"!");
+	    $commentPosition += $removedCount
+	    	unless ( $commentPosition == -1 );
 	}
 	$rawLine .= $line;
 	chomp($processedLine);
 	if ( $commentPosition == -1 ) {
 	    $tmpLine = $line;
 	} else {
-	    $tmpLine = substr($line,0,$commentPosition)."\n";	       
+	    $tmpLine = substr($line,0,$commentPosition)."\n";
 	    $bufferedComments .= substr($line,$commentPosition+1,length($line)-$commentPosition)."\n";
 	    chomp($bufferedComments);
 	}

--- a/scripts/build/buildProfiler.pl
+++ b/scripts/build/buildProfiler.pl
@@ -113,6 +113,7 @@ for(my $i=0;$i<=$timeMaximum;++$i) {
 
 # Compute a cost for each task. This is the sum of the inverse of the number of threads running each second.
 my $costMaximum = 0.0;
+my $costTotal   = 0.0;
 my $taskMaximum;
 foreach my $task ( @tasks ) {
     $task->{'cost'} = 0.0;
@@ -120,6 +121,7 @@ foreach my $task ( @tasks ) {
     for(my $i=$task->{'start'};$i<=$task->{'end'};++$i) {
 	$task->{'cost'} += 1.0/$threadCount[$i];
     }
+    $costTotal += $task->{'cost'};
     if ( $task->{'cost'} > $costMaximum ) {
 	$costMaximum = $task->{'cost'};
 	$taskMaximum = $task;
@@ -169,6 +171,8 @@ print $profileFile "  </style>\n";
 print $profileFile " </head>\n";
 print $profileFile "<body>\n";
 print $profileFile "Total compile time = ".$timeMaximum." seconds<p>\n";
+# Table of build profile.
+print $profileFile "Build profile (all tasks which ran for ".$options{'durationMinimum'}." seconds or longer: ".sprintf("%5.2f",100.0*$costTotal/$timeMaximum)."% of total time)<br>\n";
 print $profileFile "<div>\n";
 print $profileFile "<table style=\"border-spacing: 0; border-collapse: separate; border-top: 1px\">\n";
 foreach my $task ( @tasks ) {
@@ -188,7 +192,17 @@ foreach my $task ( @tasks ) {
     print $profileFile "</tr>\n";
 }
 print $profileFile "</table>\n";
-print $profileFile "</div>\n";
+print $profileFile "</div><p>\n";
+
+
+# Table of task costs.
+my @tasksOrdered = sort {$b->{'cost'} <=> $a->{'cost'}} @tasks;
+print $profileFile "Task costs (ordered)<br>\n";
+print $profileFile "<table>\n";
+foreach my $task ( @tasksOrdered ) {
+    print $profileFile "<tr><td>".$task->{'description'}."</td><td>".sprintf("%7.2f",$task->{'cost'})."</td><td>(".sprintf("%5.2f",100.0*$task->{'cost'}/$timeMaximum)."%)</td></tr>\n";
+}
+print $profileFile "</table>\n";
 print $profileFile "</body>\n";
 print $profileFile "</html>\n";
 close($profileFile);

--- a/scripts/build/sourceDigests.pl
+++ b/scripts/build/sourceDigests.pl
@@ -28,9 +28,16 @@ my $workDirectoryName = $ENV{'BUILDPATH'}."/";
 # Get an XML parser.
 my $xml                     = new XML::Simple();
 # Load the state storables file which lists all known functionClasses.
-my $stateStorables = -e $workDirectoryName."stateStorables.xml" ? $xml->XMLin($workDirectoryName."stateStorables.xml") : undef();
+my $stateStorables          = -e $workDirectoryName."stateStorables.xml" ? $xml->XMLin($workDirectoryName."stateStorables.xml") : undef();
+# Load the file of directive locations.
+die("Error: directiveLocations.xml not found")
+    unless ( -e $workDirectoryName."directiveLocations.xml" );
+my $locations               = $xml->XMLin($workDirectoryName."directiveLocations.xml");
 # Extract names of functionClasses.
 my @functionClasses = map {$_ =~ s/Class$//; $_} sort(keys(%{$stateStorables->{'functionClasses'}}));
+# Build a list of files containing functionClass implementations.
+my @functionClassFileList = map {&List::ExtraUtils::as_array($locations->{$_}->{'file'})} @functionClasses;
+my %functionClassFiles = map { $_ => 1 } @functionClassFileList;
 # Build list of allowed names.
 my @allowedNames = ( "functionClass", @functionClasses, @{$stateStorables->{'functionClassInstances'}} );
 if ( exists($stateStorables->{'functionClassTypes'}->{'name'}) ) {
@@ -94,40 +101,62 @@ while ( my $fileName = readdir($sourceDirectory) ) {
 	    }
 	}
 	close($dependencyFile);
-	# Walk the source code tree.
-	my $tree  = &Galacticus::Build::SourceTree::ParseFile($fileToProcess);
-	my $depth = 0;
-	my $node  = $tree;
-	while ( $node ) {
-	    my $isImplementation = grep {$node->{'type'} eq $_} @functionClasses;
-	    if ( $node->{'type'} eq "functionClass" || $node->{'type'} eq "functionClassType" || $node->{'type'} eq "sourceDigest" || $isImplementation ) {
-		my $hashName = $node->{'directive'}->{'name'}.($node->{'type'} eq "functionClass" ? "Class" : "");
-		# Find which class it extends.
-		my @classDependencies;
-		if ( $isImplementation ) {
-		    my $classNode = $node;
-		    (my $class, @classDependencies) = &Galacticus::Build::SourceTree::Process::FunctionClass::Utils::Class_Dependencies($classNode,$node->{'type'});
-		    # For self-referencing types, remove the self-reference here.
-		    @classDependencies = map {$_ eq $class->{'type'} ? () : $_} @classDependencies;
-		} elsif ( $node->{'type'} eq "functionClassType" ) {
-		    push(@classDependencies,"functionClass");
-		} elsif ( $node->{'type'} eq "sourceDigest" ) {
-		    # No dependency here.
-		} else {
-		    # functionClass directive.
-		    if ( exists($node->{'directive'}->{'extends'}) ) {
-			push(@classDependencies,$node->{'directive'}->{'extends'});
-		    } else {
-			push(@classDependencies,"functionClass");
-		    }
-		}
-		# Store hash and dependencies.
+	# Handle any directives in this file.
+	## sourceDigest directive.
+	if ( grep {$_ eq $fileToProcess} &List::ExtraUtils::as_array($locations->{'sourceDigest'}->{'file'}) ) {
+	    my @sourceDigests = &Galacticus::Build::Directives::Extract_Directives($fileToProcess,'sourceDigest');
+	    foreach my $sourceDigest ( @sourceDigests ) {
+		my $hashName = $sourceDigest->{'name'};
 		$digestsPerFile->{'types'}->{$hashName}->{'sourceMD5'} = &Galacticus::Build::SourceTree::Process::SourceDigest::Find_Hash([$fileName]);
-		@{$digestsPerFile->{'types'}->{$hashName}->{'dependencies'}} = @classDependencies;
+		@{$digestsPerFile->{'types'}->{$hashName}->{'dependencies'}} = ();
 		push(@updatedTypes,$hashName);		
 	    }
-	    $node = &Galacticus::Build::SourceTree::Walk_Tree($node,\$depth);
-	}		
+	}
+	## functionClassType directive.
+	if ( grep {$_ eq $fileToProcess} &List::ExtraUtils::as_array($locations->{'functionClassType'}->{'file'}) ) {
+	    my @functionClassTypes = &Galacticus::Build::Directives::Extract_Directives($fileToProcess,'functionClassType');
+	    foreach my $functionClassType ( @functionClassTypes ) {
+		my $hashName = $functionClassType->{'name'};
+		$digestsPerFile->{'types'}->{$hashName}->{'sourceMD5'} = &Galacticus::Build::SourceTree::Process::SourceDigest::Find_Hash([$fileName]);
+		@{$digestsPerFile->{'types'}->{$hashName}->{'dependencies'}} = ( "functionClass" );
+		push(@updatedTypes,$hashName);
+	    }
+	}
+	## functionClass directive.
+	if ( grep {$_ eq $fileToProcess} &List::ExtraUtils::as_array($locations->{'functionClass'}->{'file'}) ) {
+	    my @functionClasses = &Galacticus::Build::Directives::Extract_Directives($fileToProcess,'functionClass');
+	    foreach my $functionClass ( @functionClasses ) {
+		my $hashName = $functionClass->{'name'}."Class";
+		$digestsPerFile->{'types'}->{$hashName}->{'sourceMD5'} = &Galacticus::Build::SourceTree::Process::SourceDigest::Find_Hash([$fileName]);
+		if ( exists($functionClass->{'extends'}) ) {
+		    @{$digestsPerFile->{'types'}->{$hashName}->{'dependencies'}} = ( $functionClass->{'extends'} );
+		} else {
+		    @{$digestsPerFile->{'types'}->{$hashName}->{'dependencies'}} = ( "functionClass"             );
+		}
+		push(@updatedTypes,$hashName);
+	    }
+	}
+	# Walk the source code tree.
+	if ( exists($functionClassFiles{$fileToProcess}) ) {
+	    my $tree  = &Galacticus::Build::SourceTree::ParseFile($fileToProcess);
+	    my $depth = 0;
+	    my $node  = $tree;
+	    while ( $node ) {
+		if ( grep {$node->{'type'} eq $_} @functionClasses ) {
+		    my $hashName = $node->{'directive'}->{'name'};
+		    # Find which class it extends.
+		    my $classNode = $node;
+		    (my $class, my @classDependencies) = &Galacticus::Build::SourceTree::Process::FunctionClass::Utils::Class_Dependencies($classNode,$node->{'type'});
+		    # For self-referencing types, remove the self-reference here.
+		    @classDependencies = map {$_ eq $class->{'type'} ? () : $_} @classDependencies;
+		    # Store hash and dependencies.
+		    $digestsPerFile->{'types'}->{$hashName}->{'sourceMD5'} = &Galacticus::Build::SourceTree::Process::SourceDigest::Find_Hash([$fileName]);
+		    @{$digestsPerFile->{'types'}->{$hashName}->{'dependencies'}} = @classDependencies;
+		    push(@updatedTypes,$hashName);
+		}
+		$node = &Galacticus::Build::SourceTree::Walk_Tree($node,\$depth);
+	    }
+	}
     }
 }
 close($sourceDirectory);


### PR DESCRIPTION
Use regexes to speed up locating comments in source code lines. These are much faster than stepping through each character of the line one at a time.

Also optimize source digest calculation by only parsing source files when necessary.