### PR TITLE
Get the state store/restore infrastructure working again

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -975,11 +975,11 @@ CODE
 						$assignments          .= "else\n";
 						$assignments          .= " allocate(destination%".$name.",mold=self%".$name.")\n";
 					    }
-					    $deepCopyResetCode .= "call self%".$name."%deepCopyReset   ()\n";
-					    $deepCopyResetCode .= "call self%".$name."%deepCopyFinalize()\n";
-					    $assignments       .= "call self%".$name."%deepCopy(destination%".$name.")\n";
-					    $assignments       .= "self%".$name."%copiedSelf => destination%".$name."\n";
-					    $assignments       .= "call destination%".$name."%autoHook()\n";
+					    $deepCopyResetCode    .= "call self%".$name."%deepCopyReset   ()\n";
+					    $deepCopyFinalizeCode .= "call self%".$name."%deepCopyFinalize()\n";
+					    $assignments          .= "call self%".$name."%deepCopy(destination%".$name.")\n";
+					    $assignments          .= "self%".$name."%copiedSelf => destination%".$name."\n";
+					    $assignments          .= "call destination%".$name."%autoHook()\n";
 					    if ( grep {$_ eq "pointer"}  @{$declaration->{'attributes'}} ) {
 						$assignments       .= "end if\n";
 					    }

--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -1459,6 +1459,8 @@ CODE
 	    # Add "stateStore" and "stateRestore" method.
 	    my $stateStoreCode;
 	    my $stateRestoreCode;
+	    my $stateLinkedListVariables;
+            @{$stateLinkedListVariables} = ();
 	    my %stateStoreModules   = ( "Display" => 1, "ISO_Varying_String" => 1, "String_Handling" => 1, "ISO_C_Binding" => 1 );
 	    my %stateRestoreModules = ( "Display" => 1, "ISO_Varying_String" => 1, "String_Handling" => 1, "ISO_C_Binding" => 1 );
 	    my @outputUnusedVariables;
@@ -1722,6 +1724,7 @@ CODE
 					}
 				    }
 				}
+				# Check for a custom state store/restore.
 				$hasCustomStateStore   = 1
 				    if
 				    (
@@ -1740,6 +1743,10 @@ CODE
 			}
 			$node = $node->{'type'} eq "contains" ? $node->{'firstChild'} : $node->{'sibling'};
 		    }
+		    # Handle linked lists.
+		    (my $linkedListInputCode, my $linkedListOutputCode) = &stateStoreLinkedList($nonAbstractClass,$stateLinkedListVariables);
+		    $inputCode  .= $linkedListInputCode;
+		    $outputCode .= $linkedListOutputCode;
 		    # Move to the parent class.
 		    $class = ($class->{'extends'} eq $directive->{'name'}) ? undef() : $classes{$class->{'extends'}};
 		}
@@ -2252,6 +2259,8 @@ CODE
                  if ( $labelUsed );
             $stateStoreCode   = " integer(c_size_t) :: position\n".$stateStoreCode;
             $stateRestoreCode = " integer(c_size_t) :: position\n".$stateRestoreCode;
+	    $stateStoreCode   = &Fortran::Utils::Format_Variable_Definitions($stateLinkedListVariables).$stateStoreCode;
+	    $stateRestoreCode = &Fortran::Utils::Format_Variable_Definitions($stateLinkedListVariables).$stateRestoreCode;
 	    $methods{'stateStore'} =
 	    {
 		description => "Store the state of this object to file.",
@@ -3717,6 +3726,45 @@ do while (associated(item_))
 end do
 CODE
     return ($deepCopyCode,$deepCopyResetCode,$deepCopyFinalizeCode);
+}
+
+sub stateStoreLinkedList {
+    # Create state store/restore instructions for linked list objects.
+    my $nonAbstractClass    = shift();
+    my $linkedListVariables = shift();
+    return ("","","")
+	unless ( exists($nonAbstractClass->{'stateStore'}->{'linkedList'}) );
+    my $linkedList = $nonAbstractClass->{'stateStore'}->{'linkedList'};
+    # Add variables needed for linked list processing.
+    push(
+	@{$linkedListVariables},
+	{
+	    intrinsic  => 'type',
+	    type       => $linkedList->{'type'},
+	    attributes => [ 'pointer' ],
+	    variables  => [ 'item_' ]
+	}
+	)
+	unless ( grep {$_->{'type'} eq $linkedList->{'type'}} @{$linkedListVariables} );
+    # Generate code for the walk through the linked list.
+    $code::variable = $linkedList->{'variable'};
+    $code::object   = $linkedList->{'object'  };
+    $code::next     = $linkedList->{'next'    };
+    my $inputCode   = fill_in_string(<<'CODE', PACKAGE => 'code');
+item_ => self%{$variable}
+do while (associated(item_))
+   call item_%{$object}%stateRestore(stateFile,gslStateFile,stateOperationID)
+   item_ => item_%{$next}
+end do
+CODE
+    my $outputCode = fill_in_string(<<'CODE', PACKAGE => 'code');
+item_ => self%{$variable}
+do while (associated(item_))
+   call item_%{$object}%stateStore(stateFile,gslStateFile,stateOperationID)
+   item_ => item_%{$next}
+end do
+CODE
+    return ($inputCode,$outputCode);
 }
 
 1;

--- a/source/cooling.cooling_function.summation.F90
+++ b/source/cooling.cooling_function.summation.F90
@@ -27,6 +27,9 @@
    <deepCopy>
     <linkedList type="coolantList" variable="coolants" next="next" object="coolingFunction" objectType="coolingFunctionClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="coolantList" variable="coolants" next="next" object="coolingFunction"/>
+   </stateStore>
   </coolingFunction>
   !!]
 

--- a/source/dark_matter_profiles.heating.summation.F90
+++ b/source/dark_matter_profiles.heating.summation.F90
@@ -27,6 +27,9 @@
    <deepCopy>
     <linkedList type="heatSourceList" variable="heatSources" next="next" object="heatSource" objectType="darkMatterProfileHeatingClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="heatSourceList" variable="heatSources" next="next" object="heatSource"/>
+   </stateStore>
   </darkMatterProfileHeating>
   !!]
 

--- a/source/dark_matter_profiles.structure.scale.concentration.F90
+++ b/source/dark_matter_profiles.structure.scale.concentration.F90
@@ -31,10 +31,13 @@
 
   !![
   <darkMatterProfileScaleRadius name="darkMatterProfileScaleRadiusConcentration">
-   <description>Dark matter halo scale radii are computed from the concentration.</description>
-   <deepCopy>
-    <functionClass variables="darkMatterHaloScaleDefinition"/>
-   </deepCopy>
+    <description>Dark matter halo scale radii are computed from the concentration.</description>
+    <deepCopy>
+      <functionClass variables="darkMatterHaloScaleDefinition"/>
+    </deepCopy>
+    <stateStorable>
+      <functionClass variables="darkMatterHaloScaleDefinition"/>
+    </stateStorable>
   </darkMatterProfileScaleRadius>
   !!]
   type, extends(darkMatterProfileScaleRadiusClass) :: darkMatterProfileScaleRadiusConcentration

--- a/source/galactic.filters.all.F90
+++ b/source/galactic.filters.all.F90
@@ -27,6 +27,9 @@ Contains a module which implements a galactic filter class which is the ``all'' 
    <deepCopy>
     <linkedList type="filterList" variable="filters" next="next" object="filter_" objectType="galacticFilterClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
+   </stateStore>
   </galacticFilter>
   !!]
   type, extends(galacticFilterClass) :: galacticFilterAll

--- a/source/galactic.filters.any.F90
+++ b/source/galactic.filters.any.F90
@@ -27,6 +27,9 @@ Contains a module which implements a galactic filter class which is the ``any'' 
    <deepCopy>
     <linkedList type="filterList" variable="filters" next="next" object="filter_" objectType="galacticFilterClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
+   </stateStore>
   </galacticFilter>
   !!]
 

--- a/source/galacticus.output.analyses.distribution_normalizer.sequence.F90
+++ b/source/galacticus.output.analyses.distribution_normalizer.sequence.F90
@@ -27,6 +27,9 @@
    <deepCopy>
     <linkedList type="normalizerList" variable="normalizers" next="next" object="normalizer_" objectType="outputAnalysisDistributionNormalizerClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="normalizerList" variable="normalizers" next="next" object="normalizer_"/>
+   </stateStore>
   </outputAnalysisDistributionNormalizer>
   !!]
 

--- a/source/galacticus.output.analyses.distribution_operator.sequence.F90
+++ b/source/galacticus.output.analyses.distribution_operator.sequence.F90
@@ -32,6 +32,9 @@ Contains a module which implements a sequence output analysis distribution opera
    <deepCopy>
     <linkedList type="distributionOperatorList" variable="operators" next="next" object="operator_" objectType="outputAnalysisDistributionOperatorClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="distributionOperatorList" variable="operators" next="next" object="operator_"/>
+   </stateStore>
   </outputAnalysisDistributionOperator>
   !!]
   type, extends(outputAnalysisDistributionOperatorClass) :: outputAnalysisDistributionOperatorSequence

--- a/source/galacticus.output.analyses.multi.F90
+++ b/source/galacticus.output.analyses.multi.F90
@@ -32,6 +32,9 @@
    <deepCopy>
     <linkedList type="multiAnalysisList" variable="analyses" next="next" object="analysis_" objectType="outputAnalysisClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="multiAnalysisList" variable="analyses" next="next" object="analysis_"/>
+   </stateStore>
   </outputAnalysis>
   !!]
   type, extends(outputAnalysisClass) :: outputAnalysisMulti

--- a/source/galacticus.output.analyses.property_operator.sequence.F90
+++ b/source/galacticus.output.analyses.property_operator.sequence.F90
@@ -32,6 +32,9 @@ Contains a module which implements a sequence output analysis property operator 
    <deepCopy>
     <linkedList type="propertyOperatorList" variable="operators" next="next" object="operator_" objectType="outputAnalysisPropertyOperatorClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="propertyOperatorList" variable="operators" next="next" object="operator_"/>
+   </stateStore>
   </outputAnalysisPropertyOperator>
   !!]
   type, extends(outputAnalysisPropertyOperatorClass) :: outputAnalysisPropertyOperatorSequence

--- a/source/galacticus.output.analyses.weight_operator.sequence.F90
+++ b/source/galacticus.output.analyses.weight_operator.sequence.F90
@@ -32,6 +32,9 @@ Contains a module which implements a sequence output analysis weight operator cl
    <deepCopy>
     <linkedList type="weightOperatorList" variable="operators" next="next" object="operator_" objectType="outputAnalysisWeightOperatorClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="weightOperatorList" variable="operators" next="next" object="operator_"/>
+   </stateStore>
   </outputAnalysisWeightOperator>
   !!]
   type, extends(outputAnalysisWeightOperatorClass) :: outputAnalysisWeightOperatorSequence

--- a/source/geometry.surveys.combined.F90
+++ b/source/geometry.surveys.combined.F90
@@ -32,6 +32,9 @@ Implements a survey geometry which combines multiple other surveys.
    <deepCopy>
     <linkedList type="surveyGeometryList" variable="surveyGeometries" next="next" object="surveyGeometry_" objectType="surveyGeometryClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="surveyGeometryList" variable="surveyGeometries" next="next" object="surveyGeometry_"/>
+   </stateStore>
   </surveyGeometry>
   !!]
   type, extends(surveyGeometryClass) :: surveyGeometryCombined

--- a/source/merger_trees.evolve.timesteps.multi.F90
+++ b/source/merger_trees.evolve.timesteps.multi.F90
@@ -32,6 +32,9 @@
    <deepCopy>
     <linkedList type="multiMergerTreeEvolveTimestepList" variable="mergerTreeEvolveTimesteps" next="next" object="mergerTreeEvolveTimestep_" objectType="mergerTreeEvolveTimestepClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="multiMergerTreeEvolveTimestepList" variable="mergerTreeEvolveTimesteps" next="next" object="mergerTreeEvolveTimestep_"/>
+   </stateStore>
   </mergerTreeEvolveTimestep>
   !!]
   type, extends(mergerTreeEvolveTimestepClass) :: mergerTreeEvolveTimestepMulti

--- a/source/merger_trees.filter.all.F90
+++ b/source/merger_trees.filter.all.F90
@@ -27,6 +27,9 @@ Contains a module which implements a merger tree filter class which is the ``all
    <deepCopy>
     <linkedList type="filterList" variable="filters" next="next" object="filter_" objectType="mergerTreeFilterClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
+   </stateStore>
   </mergerTreeFilter>
   !!]
   type, extends(mergerTreeFilterClass) :: mergerTreeFilterAll

--- a/source/merger_trees.filter.any.F90
+++ b/source/merger_trees.filter.any.F90
@@ -27,6 +27,9 @@ Contains a module which implements a merger tree filter class which is the ``any
    <deepCopy>
     <linkedList type="filterList" variable="filters" next="next" object="filter_" objectType="mergerTreeFilterClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
+   </stateStore>
   </mergerTreeFilter>
   !!]
   type, extends(mergerTreeFilterClass) :: mergerTreeFilterAny

--- a/source/merger_trees.operators.sequence.F90
+++ b/source/merger_trees.operators.sequence.F90
@@ -27,6 +27,9 @@ Contains a module which implements a sequence of operators on merger trees.
    <deepCopy>
     <linkedList type="operatorList" variable="operators" next="next" object="operator_" objectType="mergerTreeOperatorClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="operatorList" variable="operators" next="next" object="operator_"/>
+   </stateStore>
   </mergerTreeOperator>
   !!]
 

--- a/source/merger_trees.outputter.multi.F90
+++ b/source/merger_trees.outputter.multi.F90
@@ -32,6 +32,9 @@
    <deepCopy>
     <linkedList type="multiOutputterList" variable="outputters" next="next" object="outputter_" objectType="mergerTreeOutputterClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="multiOutputterList" variable="outputters" next="next" object="outputter_"/>
+   </stateStore>
   </mergerTreeOutputter>
   !!]
   type, extends(mergerTreeOutputterClass) :: mergerTreeOutputterMulti

--- a/source/nBody.import.merge.F90
+++ b/source/nBody.import.merge.F90
@@ -27,6 +27,9 @@ Contains a module which implements an N-body data importer which merges data fro
    <deepCopy>
     <linkedList type="nbodyImporterList" variable="importers" next="next" object="importer_" objectType="nbodyImporterClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="nbodyImporterList" variable="importers" next="next" object="importer_"/>
+   </stateStore>
   </nbodyImporter>
   !!]
   type, extends(nbodyImporterClass) :: nbodyImporterMerge

--- a/source/nBody.import.multiple.F90
+++ b/source/nBody.import.multiple.F90
@@ -27,7 +27,10 @@ Contains a module which implements an N-body data importer which imports using m
    <deepCopy>
     <linkedList type="nbodyImporterList" variable="importers" next="next" object="importer_" objectType="nbodyImporterClass"/>
    </deepCopy>
-  </nbodyImporter>
+   <stateStore>
+    <linkedList type="nbodyImporterList" variable="importers" next="next" object="importer_"/>
+   </stateStore> 
+ </nbodyImporter>
   !!]
   type, extends(nbodyImporterClass) :: nbodyImporterMultiple
      !!{

--- a/source/nBody.operator.sequence.F90
+++ b/source/nBody.operator.sequence.F90
@@ -32,6 +32,9 @@ Contains a module which implements an N-body data operator which applies a seque
    <deepCopy>
     <linkedList type="nbodyOperatorList" variable="operators" next="next" object="operator_" objectType="nbodyOperatorClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="nbodyOperatorList" variable="operators" next="next" object="operator_"/>
+   </stateStore>
   </nbodyOperator>
   !!]
   type, extends(nbodyOperatorClass) :: nbodyOperatorSequence

--- a/source/nodes.operators.multi.F90
+++ b/source/nodes.operators.multi.F90
@@ -32,6 +32,9 @@
    <deepCopy>
     <linkedList type="multiProcessList" variable="processes" next="next" object="process_" objectType="nodeOperatorClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="multiProcessList" variable="processes" next="next" object="process_"/>
+   </stateStore>
   </nodeOperator>
   !!]
   type, extends(nodeOperatorClass) :: nodeOperatorMulti

--- a/source/nodes.property_extractor.multi.F90
+++ b/source/nodes.property_extractor.multi.F90
@@ -32,6 +32,9 @@
    <deepCopy>
     <linkedList type="multiExtractorList" variable="extractors" next="next" object="extractor_" objectType="nodePropertyExtractorClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="multiExtractorList" variable="extractors" next="next" object="extractor_"/>
+   </stateStore>
   </nodePropertyExtractor>
   !!]
   type, extends(nodePropertyExtractorClass) :: nodePropertyExtractorMulti

--- a/source/radiation.summation.F90
+++ b/source/radiation.summation.F90
@@ -32,6 +32,9 @@ Implements a radiation field class which sums over other radiation fields.
    <deepCopy>
     <linkedList type="radiationFieldList" variable="radiationFields" next="next" object="radiationField_" objectType="radiationFieldClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="radiationFieldList" variable="radiationFields" next="next" object="radiationField_"/>
+   </stateStore>
   </radiationField>
   !!]
   type, extends(radiationFieldClass) :: radiationFieldSummation

--- a/source/radiative_transfer.outputter.multi.F90
+++ b/source/radiative_transfer.outputter.multi.F90
@@ -32,6 +32,9 @@
    <deepCopy>
     <linkedList type="multiOutputterList" variable="outputters" next="next" object="outputter_" objectType="radiativeTransferOutputterClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="multiOutputterList" variable="outputters" next="next" object="outputter_"/>
+   </stateStore>
   </radiativeTransferOutputter>
   !!]
   type, extends(radiativeTransferOutputterClass) :: radiativeTransferOutputterMulti

--- a/source/radiative_transfer.source.summation.F90
+++ b/source/radiative_transfer.source.summation.F90
@@ -30,6 +30,9 @@
    <deepCopy>
     <linkedList type="radiativeTransferSourceList" variable="radiativeTransferSources" next="next" object="radiativeTransferSource" objectType="radiativeTransferSourceClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="radiativeTransferSourceList" variable="radiativeTransferSources" next="next" object="radiativeTransferSource"/>
+   </stateStore>
   </radiativeTransferSource>
   !!]
   type, extends(radiativeTransferSourceClass) :: radiativeTransferSourceSummation

--- a/source/stellar_feedback.outflows.summation.F90
+++ b/source/stellar_feedback.outflows.summation.F90
@@ -28,6 +28,9 @@
    <deepCopy>
     <linkedList type="stellarFeedbackOutflowsList" variable="stellarFeedbackOutflowss" next="next" object="stellarFeedbackOutflows" objectType="stellarFeedbackOutflowsClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="stellarFeedbackOutflowsList" variable="stellarFeedbackOutflowss" next="next" object="stellarFeedbackOutflows"/>
+   </stateStore>
   </stellarFeedbackOutflows>
   !!]
   type, extends(stellarFeedbackOutflowsClass) :: stellarFeedbackOutflowsSummation

--- a/source/stellar_populations.spectra.postprocess.sequence.F90
+++ b/source/stellar_populations.spectra.postprocess.sequence.F90
@@ -32,6 +32,9 @@ Implements a stellar population spectra postprocessor class which applies a sequ
    <deepCopy>
     <linkedList type="postprocessorList" variable="postprocessors" next="next" object="postprocessor_" objectType="stellarPopulationSpectraPostprocessorClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="postprocessorList" variable="postprocessors" next="next" object="postprocessor_"/>
+   </stateStore>
   </stellarPopulationSpectraPostprocessor>
   !!]
   type, extends(stellarPopulationSpectraPostprocessorClass) :: stellarPopulationSpectraPostprocessorSequence

--- a/source/tasks.evolve_forests.F90
+++ b/source/tasks.evolve_forests.F90
@@ -269,12 +269,12 @@ contains
     integer(c_size_t         ), intent(in   ) :: stateOperationID
     !$GLC attributes unused :: self
 
-    call evolveForestsMergerTreeConstructor_%stateStore(stateFile,gslStateFile,stateOperationID)
-    call evolveForestsMergerTreeOperator_   %stateStore(stateFile,gslStateFile,stateOperationID)
-    call evolveForestsNodeOperator_         %stateStore(stateFile,gslStateFile,stateOperationID)
     call evolveForestsMergerTreeEvolver_    %stateStore(stateFile,gslStateFile,stateOperationID)
     call evolveForestsMergerTreeOutputter_  %stateStore(stateFile,gslStateFile,stateOperationID)
     call evolveForestsMergerTreeInitializor_%stateStore(stateFile,gslStateFile,stateOperationID)
+    call evolveForestsMergerTreeConstructor_%stateStore(stateFile,gslStateFile,stateOperationID)
+    call evolveForestsMergerTreeOperator_   %stateStore(stateFile,gslStateFile,stateOperationID)
+    call evolveForestsNodeOperator_         %stateStore(stateFile,gslStateFile,stateOperationID)
     return
   end subroutine evolveForestsStateStore
 
@@ -290,12 +290,12 @@ contains
     integer(c_size_t         ), intent(in   ) :: stateOperationID
     !$GLC attributes unused :: self
 
-    call evolveForestsMergerTreeConstructor_%stateRestore(stateFile,gslStateFile,stateOperationID)
-    call evolveForestsMergerTreeOperator_   %stateRestore(stateFile,gslStateFile,stateOperationID)
-    call evolveForestsNodeOperator_         %stateRestore(stateFile,gslStateFile,stateOperationID)
     call evolveForestsMergerTreeEvolver_    %stateRestore(stateFile,gslStateFile,stateOperationID)
     call evolveForestsMergerTreeOutputter_  %stateRestore(stateFile,gslStateFile,stateOperationID)
     call evolveForestsMergerTreeInitializor_%stateRestore(stateFile,gslStateFile,stateOperationID)
+    call evolveForestsMergerTreeConstructor_%stateRestore(stateFile,gslStateFile,stateOperationID)
+    call evolveForestsMergerTreeOperator_   %stateRestore(stateFile,gslStateFile,stateOperationID)
+    call evolveForestsNodeOperator_         %stateRestore(stateFile,gslStateFile,stateOperationID)
     return
   end subroutine evolveForestsStateRestore
 

--- a/source/tasks.multi.F90
+++ b/source/tasks.multi.F90
@@ -28,6 +28,9 @@
    <deepCopy>
     <linkedList type="multiTaskList" variable="tasks" next="next" object="task_" objectType="taskClass"/>
    </deepCopy>
+   <stateStore>
+    <linkedList type="multiTaskList" variable="tasks" next="next" object="task_"/>
+   </stateStore>
   </task>
   !!]
   type, extends(taskClass) :: taskMulti


### PR DESCRIPTION
State store/restore was broken for a number of reasons:

1. Recent changes in the syntax of embedded XML blocks resulted in missing of directives in preprocessed source which resulted in all default objects being missed in state store/restore.
2. The `darkMatterProfileScaleRadiusConcentration` failed to tag its `darkMatterHaloScaleDefinition` object as `stateStorable`.
3. Code generation for `deepCopyFinalization` had a bug such that some of its code was inserted into the corresponding `deepCopyReset` code instead.