### PR TITLE
Escape XML in LaTeX sections so that it is not parsed as XML

### DIFF
--- a/source/merger_trees.construct.build.masses.read.XML.F90
+++ b/source/merger_trees.construct.build.masses.read.XML.F90
@@ -25,21 +25,21 @@
   <mergerTreeBuildMasses name="mergerTreeBuildMassesReadXML">
    <description>
     A merger tree build masses class which reads masses from an XML file. The XML file should have the following form:
-  \begin{verbatim}
-     <mergerTrees>
-      <treeRootMass>13522377303.5998</treeRootMass>
-      <treeRootMass>19579530191.8709</treeRootMass>
-      <treeRootMass>21061025282.9613</treeRootMass>
+    \begin{verbatim}
+     &lt;mergerTrees>
+      &lt;treeRootMass>13522377303.5998&lt;/treeRootMass>
+      &lt;treeRootMass>19579530191.8709&lt;/treeRootMass>
+      &lt;treeRootMass>21061025282.9613&lt;/treeRootMass>
       .
       .
       .
-      <treeWeight>13522377303.5998</treeWeight>
-      <treeWeight>19579530191.8709</treeWeight>
-      <treeWeight>21061025282.9613</treeWeight>
+      &lt;treeWeight>13522377303.5998&lt;/treeWeight>
+      &lt;treeWeight>19579530191.8709&lt;/treeWeight>
+      &lt;treeWeight>21061025282.9613&lt;/treeWeight>
       .
       .
       .
-     </mergerTrees>
+     &lt;/mergerTrees>
     \end{verbatim}
     where each {\normalfont \ttfamily treeRootMass} element gives the mass (in Solar masses) of the root halo of a tree to
     generate, and the (optional) {\normalfont \ttfamily treeWeight} elements give the corresponding weight (in units of

--- a/source/merger_trees.construct.read.importer.galacticus.F90
+++ b/source/merger_trees.construct.read.importer.galacticus.F90
@@ -37,42 +37,44 @@
 
   !![
   <mergerTreeImporter name="mergerTreeImporterGalacticus">
-   <description>
-   A merger tree importer class which imports trees from an HDF5 file. HDF5 file should follow the general purpose format described
-   \href{https://github.com/galacticusorg/galacticus/wiki/Merger-Tree-File-Format}{here}. An example of how to construct such a file
-   can be found in the {\normalfont \ttfamily tests/nBodyMergerTrees} folder. In that folder, the {\normalfont \ttfamily
-     getMillenniumTrees.pl} script will retrieve a sample of merger trees from the
-   \href{http://gavo.mpa-garching.mpg.de/Millennium/}{Millennium Simulation database} and use the {\normalfont \ttfamily
-     Merger\_Tree\_File\_Maker.exe} code supplied with \glc\ to convert these into an HDF5 file suitable for reading into \glc. The
-   {\normalfont \ttfamily getMillenniumTrees.pl} script requires you to have a username and password to access the Millennium
-   Simulation database\footnote{If you do not have a username and password for the Millennium Simulation database you can request one
-     from \href{mailto:contact@g-vo.org}{\normalfont \ttfamily contact@g-vo.org}.}. These can be entered manually or stored in a
-   section of the {\normalfont \ttfamily galacticusConfig.xml} file (see \S\ref{sec:ConfigFile}) as follows:
-   \begin{verbatim}
-     <millenniumDB>
-       <host>
-         <name>^myHost$</name>
-         <user>myUserName</user>
-         <passwordFrom>input</passwordFrom>
-         <treePath>/path/to/trees</treePath>
-       </host>
-       <host>
-         <name>default</name>
-         <user>myUserName</user>
-         <password>myPassword</password>
-       </host>
-     </millenniumDB>
-   \end{verbatim}
-   Here, each {\normalfont \ttfamily host} section describes rules for a given computer (with ``default'' being used if no specific
-   match to the regular expression give in {\normalfont \ttfamily name} is found). The {\normalfont \ttfamily user} element gives the
-   user name to use, while the {\normalfont \ttfamily passwordFrom} element specifies how the password should be obtained. Currently
-   the only allowed mechanism is ``input'', in which case the password is read from standard input. Alternatively, you can include a
-   {\normalfont \ttfamily password} element which contains the password itself. Of course, this is insecure\ldots
-   
-   The optional {\normalfont \ttfamily treePath} element gives the location where merger trees from the Millennium Simulation can be
-   stored. Some scripts will make use of this location so that Millennium Simulation merger trees can be shared between multiple
-   scripts.
-   </description>
+    <description>
+    A merger tree importer class which imports trees from an HDF5 file. HDF5 file should follow the general purpose format
+    described \href{https://github.com/galacticusorg/galacticus/wiki/Merger-Tree-File-Format}{here}. An example of how to
+    construct such a file can be found in the {\normalfont \ttfamily tests/nBodyMergerTrees} folder. In that folder, the
+    {\normalfont \ttfamily getMillenniumTrees.pl} script will retrieve a sample of merger trees from the
+    \href{http://gavo.mpa-garching.mpg.de/Millennium/}{Millennium Simulation database} and use the {\normalfont \ttfamily
+    Merger\_Tree\_File\_Maker.exe} code supplied with \glc\ to convert these into an HDF5 file suitable for reading into \glc. The
+    {\normalfont \ttfamily getMillenniumTrees.pl} script requires you to have a username and password to access the Millennium
+    Simulation database\footnote{If you do not have a username and password for the Millennium Simulation database you can request
+    one from \href{mailto:contact@g-vo.org}{\normalfont \ttfamily contact@g-vo.org}.}. These can be entered manually or stored in
+    a section of the
+    \href{https://github.com/galacticusorg/galacticus/releases/download/masterRelease/Galacticus_Usage.pdf\#sec.ConfigFile}{\normalfont
+    \ttfamily galacticusConfig.xml} file as follows:   
+    \begin{verbatim}
+      &lt;millenniumDB>
+        &lt;host>
+          &lt;name>^myHost$&lt;/name>
+          &lt;user>myUserName&lt;/user>
+          &lt;passwordFrom>input&lt;/passwordFrom>
+          &lt;treePath>/path/to/trees&lt;/treePath>
+        &lt;/host>
+        &lt;host>
+          &lt;name>default&lt;/name>
+          &lt;user>myUserName&lt;/user>
+          &lt;password>myPassword&lt;/password>
+        &lt;/host>
+      &lt;/millenniumDB>
+    \end{verbatim}
+    Here, each {\normalfont \ttfamily host} section describes rules for a given computer (with ``default'' being used if no specific
+    match to the regular expression give in {\normalfont \ttfamily name} is found). The {\normalfont \ttfamily user} element gives the
+    user name to use, while the {\normalfont \ttfamily passwordFrom} element specifies how the password should be obtained. Currently
+    the only allowed mechanism is ``input'', in which case the password is read from standard input. Alternatively, you can include a
+    {\normalfont \ttfamily password} element which contains the password itself. Of course, this is insecure\ldots
+    
+    The optional {\normalfont \ttfamily treePath} element gives the location where merger trees from the Millennium Simulation can be
+    stored. Some scripts will make use of this location so that Millennium Simulation merger trees can be shared between multiple
+    scripts.
+    </description>
   </mergerTreeImporter>
   !!]
   type, extends(mergerTreeImporterClass) :: mergerTreeImporterGalacticus

--- a/source/meta.tree_processing_times.file.F90
+++ b/source/meta.tree_processing_times.file.F90
@@ -32,13 +32,13 @@ Contains a module which implements a merger tree processing time estimator using
     where $M$ is the root mass of the tree and the coefficients $C_i$ are read from a file, the name of which is specified via
     the {\normalfont \ttfamily [fileName]} parameter. This file should be an XML document with the structure:
     \begin{verbatim}
-    <timing>
-     <fit>
-       <coefficient>-0.73</coefficient>
-       <coefficient>-0.20</coefficient>
-       <coefficient>0.03</coefficient>
-     </fit>
-    </timing>
+    &lt;timing>
+     &lt;fit>
+       &lt;coefficient>-0.73&lt;/coefficient>
+       &lt;coefficient>-0.20&lt;/coefficient>
+       &lt;coefficient>0.03&lt;/coefficient>
+     &lt;/fit>
+    &lt;/timing>
     \end{verbatim}
     where the array of coefficients give the values $C_0$, $C_1$ and $C_2$.
    </description>

--- a/source/models.likelihoods.multivariate_normal.F90
+++ b/source/models.likelihoods.multivariate_normal.F90
@@ -29,11 +29,11 @@
     The likelihood is a simple multivariate Gaussian, intended primarily for testing purposes. The distribution parameters are
     specified within the {\normalfont \ttfamily likelihood} element using:
     \begin{verbatim}
-      <mean>0.45 0.50</mean>
-      <covariance>
-        <row>1.0e-4 -0.9e-4</row>
-        <row>-0.9e-4 1.0e-4</row>
-      </covariance>
+      &lt;mean>0.45 0.50&lt;/mean>
+      &lt;covariance>
+        &lt;row>1.0e-4 -0.9e-4&lt;/row>
+        &lt;row>-0.9e-4 1.0e-4&lt;/row>
+      &lt;/covariance>
     \end{verbatim}
     where the {\normalfont \ttfamily mean} element gives the mean vector of $N$ elements, and the {\normalfont \ttfamily covariance}
     element contains $N$ {\normalfont \ttfamily row} elements each containing a vector of $N$ elements giving a single row of the

--- a/source/models.likelihoods.multivariate_normal.stochastic.F90
+++ b/source/models.likelihoods.multivariate_normal.stochastic.F90
@@ -30,8 +30,8 @@
     is evaluated stochastically. In addition to the parameter of the {\normalfont \ttfamily multivariateNormal} class, two additional
     parameters are required and are specified within the {\normalfont \ttfamily likelihood} element using:
     \begin{verbatim}
-      <realizationCount>4000</realizationCount>
-      <realizationCountMinimum>10</realizationCountMinimum>
+      &lt;realizationCount>4000&lt;/realizationCount>
+      &lt;realizationCountMinimum>10&lt;/realizationCountMinimum>
     \end{verbatim}
     When evaluating the likelihood, the state vector is set equal to 
     \begin{equation}

--- a/source/radiation.intergalactic_background.file.F90
+++ b/source/radiation.intergalactic_background.file.F90
@@ -31,34 +31,33 @@
     A radiation field class for intergalactic background light with properties read from file. The flux is determined by
     linearly interpolating to the required time and wavelength. The XML file to read is specified by {\normalfont \ttfamily
     [fileName]}. An example of the required file structure is:
-     \begin{verbatim}
-    <spectrum>
-      <URL>http://adsabs.harvard.edu/abs/1996ApJ...461...20H</URL>
-      <description>Cosmic background radiation spectrum from quasars alone.</description>
-      <reference>Haardt, F. &amp; Madau, P. 1996, ApJ, 461, 20</reference>
-      <source>Francesco Haardt on Aug 6 2005, via Cloudy 08.00</source>
-      <wavelengths>
-        <datum>0.0002481</datum>
-        <datum>0.001489</datum>
+    \begin{verbatim}
+    &lt;spectrum>
+      &lt;URL>http://adsabs.harvard.edu/abs/1996ApJ...461...20H&lt;/URL>
+      &lt;description>Cosmic background radiation spectrum from quasars alone.&lt;/description>
+      &lt;reference>Haardt, F. &amp; Madau, P. 1996, ApJ, 461, 20&lt;/reference>
+      &lt;source>Francesco Haardt on Aug 6 2005, via Cloudy 08.00&lt;/source>
+      &lt;wavelengths>
+        &lt;datum>0.0002481&lt;/datum>
+        &lt;datum>0.001489&lt;/datum>
         .
         .
         .
-        <units>Angstroms</units>
-      </wavelengths>
-      <spectra>
-        <datum>7.039E-49</datum>
-        <datum>8.379E-48</datum>
-        <datum>1.875E-39</datum>
-        <datum>7.583E-38</datum>
+        &lt;units>Angstroms&lt;/units>
+      &lt;/wavelengths>
+      &lt;spectra>
+        &lt;datum>7.039E-49&lt;/datum>
+        &lt;datum>8.379E-48&lt;/datum>
+        &lt;datum>1.875E-39&lt;/datum>
+        &lt;datum>7.583E-38&lt;/datum>
         .
         .
         .
-        <redshift>0</redshift>
-        <units>erg cm^-2 s^-1 Hz^-1 sr^-1</units>
-      </spectra>
-    </spectrum>
-     \end{verbatim}
-    \end{description}
+        &lt;redshift>0&lt;/redshift>
+        &lt;units>erg cm^-2 s^-1 Hz^-1 sr^-1&lt;/units>
+      &lt;/spectra>
+    &lt;/spectrum>
+    \end{verbatim}
     The optional {\normalfont \ttfamily URL}, {\normalfont \ttfamily description}, {\normalfont \ttfamily reference} and
     {\normalfont \ttfamily source} elements can be used to give the provenance of the data. The {\normalfont \ttfamily
     wavelengths} element should contain a set of {\normalfont \ttfamily datum} elements each containing a wavelength (in

--- a/source/tasks.merger_tree_file_builder.F90
+++ b/source/tasks.merger_tree_file_builder.F90
@@ -64,11 +64,11 @@
     
     Properties to read from the file are specified through multiple {\normalfont \ttfamily property} sub-parameter sections, which take the form:
     \begin{verbatim}
-     <property>
-      <name             value="propertyName"/>
-      <column           value="columnNumber"/>
-      <conversionFactor value="1.0e0"       />
-     </property>
+     &lt;property>
+      &lt;name             value="propertyName"/>
+      &lt;column           value="columnNumber"/>
+      &lt;conversionFactor value="1.0e0"       />
+     &lt;/property>
     \end{verbatim}
     where {\normalfont \ttfamily [name]} is the property name (see below), {\normalfont \ttfamily [column]} is the column number
     (starting from 1) from which to read the property, and the optional {\normalfont \ttfamily [conversionFactor]} specifies an
@@ -126,10 +126,10 @@
     Properties of particles to read from the (optional) particle data file are specified through multiple {\normalfont \ttfamily
       particleProperty} sub-parameter sections, which take the form:
     \begin{verbatim}
-     <particleProperty>
-      <name   value="propertyName"/>
-      <column value="columnNumber"/>
-     </particleProperty>
+     &lt;particleProperty>
+      &lt;name   value="propertyName"/>
+      &lt;column value="columnNumber"/>
+     &lt;/particleProperty>
     \end{verbatim}
     where {\normalfont \ttfamily [name]} is the particle property name (see below), {\normalfont \ttfamily [column]} is the column
     number (starting from 1) from which to read the particle property.
@@ -151,12 +151,12 @@
     The units used in the files are specified via the {\normalfont \ttfamily unitsMass}, {\normalfont \ttfamily unitsLength}, and
     {\normalfont \ttfamily unitsVelocity} sub-parameter sections. These have the following form:
     \begin{verbatim}
-     <unitsMass>
-      <name                value="Solar masses/h"/>
-      <unitsInSI           value="1.99e30"       />
-      <hubbleExponent      value="-1"            />
-      <scaleFactorExponent value=" 0"            />
-     </unitsMass>
+     &lt;unitsMass>
+      &lt;name                value="Solar masses/h"/>
+      &lt;unitsInSI           value="1.99e30"       />
+      &lt;hubbleExponent      value="-1"            />
+      &lt;scaleFactorExponent value=" 0"            />
+     &lt;/unitsMass>
     \end{verbatim}
     where {\normalfont \ttfamily [name]} is a human-readable name for the units, {\normalfont \ttfamily [unitsInSI]} gives the units
     in the SI system, {\normalfont \ttfamily [hubbleExponent]} specifies the power to which $h$ appears in the units and {\normalfont
@@ -167,11 +167,11 @@
     details of the simulation, or halo finder used). Metadata is specified via {\normalfont \ttfamily metaData} sub-parameter
     sections. These have the following form:
     \begin{verbatim}
-     <metaData>
-      <name    value="simulationCode"/>
-      <content value="Gadget2"       />
-      <type    value="simulation"    />
-     </metaData>
+     &lt;metaData>
+      &lt;name    value="simulationCode"/>
+      &lt;content value="Gadget2"       />
+      &lt;type    value="simulation"    />
+     &lt;/metaData>
     \end{verbatim}
     where {\normalfont \ttfamily [name]} is a name for this metadatum, {\normalfont \ttfamily [content]} is the value for the
     metadatum (integer, floating point, and text content is allowed), and {\normalfont \ttfamily [type]} specifies the type of


### PR DESCRIPTION
This fixes a problem in which the "description" section of some classes would be parsed into a Perl data structure (instead of plain text) because of the presence of XML in the description. This lead to the description not being entered into the documentation.