### PR TITLE
Add functionality for controlling tree building

### DIFF
--- a/source/merger_trees.build.controller.F90
+++ b/source/merger_trees.build.controller.F90
@@ -1,0 +1,48 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which provides controller objects for building merger trees.
+!!}
+
+module Merger_Tree_Build_Controllers
+  !!{
+  Provides controller objects for building merger trees.
+  !!}
+  use :: Galacticus_Nodes   , only : treeNode
+  use :: Merger_Tree_Walkers, only : mergerTreeWalkerClass
+  private
+
+  !![
+  <functionClass>
+   <name>mergerTreeBuildController</name>
+   <descriptiveName>Merger Tree Build Controllers</descriptiveName>
+   <description>Class providing merger tree build controllers.</description>
+   <default>uncontrolled</default>
+   <method name="control" >
+    <description>Control the behavior of a tree build.</description>
+    <type>logical</type>
+    <pass>yes</pass>
+    <argument>type (treeNode             ), intent(inout), pointer :: node       </argument>
+    <argument>class(mergerTreeWalkerClass), intent(inout)          :: treeWalker_</argument>
+   </method>
+  </functionClass>
+  !!]
+
+end module Merger_Tree_Build_Controllers

--- a/source/merger_trees.build.controller.subsample.F90
+++ b/source/merger_trees.build.controller.subsample.F90
@@ -1,0 +1,156 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which implements a merger tree build controller class which performs subsampling of branches.
+!!}
+
+  !![
+  <mergerTreeBuildController name="mergerTreeBuildControllerSubsample">
+   <description>A merger tree build controller class which performs subsampling of branches.</description>
+  </mergerTreeBuildController>
+  !!]
+  type, extends(mergerTreeBuildControllerClass) :: mergerTreeBuildControllerSubsample
+     !!{     
+     A merger tree build controller class which performs subsampling of branches. A branch of mass $M$ will be retained with
+     probability
+     \begin{equation}
+       P(M) = \left\{ \begin{array}{ll} 1 & \hbox{if } M \ge M_0 \\ P_0 (M/M_0)^\alpha & \hbox{if } M &lt; M_0, \end{array} \right.
+     \end{equation}
+     where $M_0=${\normalfont \ttfamily [massThreshold]}, $P_0=${\normalfont \ttfamily [subsamplingRateAtThreshold]} and
+     $\alpha=${\normalfont \ttfamily [exponent]}, otherwise being pruned. Node weights are adjusted to account for this pruning.     
+     !!}
+     private
+     double precision :: massThreshold, subsamplingRateAtThreshold, &
+          &              exponent
+  contains
+     procedure :: control => controlSubsample
+  end type mergerTreeBuildControllerSubsample
+
+  interface mergerTreeBuildControllerSubsample
+     !!{
+     Constructors for the ``subsample'' merger tree build controller class.
+     !!}
+     module procedure subsampleConstructorParameters
+     module procedure subsampleConstructorInternal
+  end interface mergerTreeBuildControllerSubsample
+
+contains
+
+  function subsampleConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the ``subsample'' merger tree build controller class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (mergerTreeBuildControllerSubsample)                :: self
+    type            (inputParameters                   ), intent(inout) :: parameters
+    double precision                                                    :: massThreshold, subsamplingRateAtThreshold, &
+         &                                                                 exponent
+    
+    !![
+    <inputParameter>
+      <name>massThreshold</name>
+      <source>parameters</source>
+      <description>The mass threshold, $M_0$, below which subsampling is applied.</description>
+    </inputParameter>
+    <inputParameter>
+      <name>subsamplingRateAtThreshold</name>
+      <source>parameters</source>
+      <description>The subsampling rate at the mass treshold, $P_0$.</description>
+    </inputParameter>
+    <inputParameter>
+      <name>exponent</name>
+      <source>parameters</source>
+      <description>The exponent, $\alpha$, of mass in the subsampling probability, i.e. $P(M) = (M/M_0)^\alpha$ for $M &lt; M_0$.</description>
+    </inputParameter>
+    !!]
+    self=mergerTreeBuildControllerSubsample(massThreshold,subsamplingRateAtThreshold,exponent)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function subsampleConstructorParameters
+
+  function subsampleConstructorInternal(massThreshold,subsamplingRateAtThreshold,exponent) result(self)
+    !!{
+    Internal constructor for the ``subsample'' merger tree build controller class.
+    !!}
+    implicit none
+    type            (mergerTreeBuildControllerSubsample)                :: self
+    double precision                                    , intent(in   ) :: massThreshold, subsamplingRateAtThreshold, &
+         &                                                                 exponent
+    !![
+    <constructorAssign variables="massThreshold, subsamplingRateAtThreshold, exponent"/>
+    !!]
+    
+    return
+  end function subsampleConstructorInternal
+
+  logical function controlSubsample(self,node,treeWalker_)
+    !!{
+    Subsample branches of a tree under construction.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentBasic
+    implicit none
+    class           (mergerTreeBuildControllerSubsample), intent(inout)          :: self    
+    type            (treeNode                          ), intent(inout), pointer :: node
+    class           (mergerTreeWalkerClass             ), intent(inout)          :: treeWalker_
+    type            (treeNode                          )               , pointer :: nodeNext       , nodeChild
+    class           (nodeComponentBasic                )               , pointer :: basic
+    double precision                                                             :: rateSubsampling
+    !$GLC attributes unused :: self
+
+    controlSubsample=.true.
+    ! Root node is not eligible for pruning.
+    if (.not.associated(node%parent)) return
+    ! Set the subsampling weight for this node to equal that of its parent.
+    call node%subsamplingWeightSet(node%parent%subsamplingWeight())
+    ! Primary progenitors are not eligible for pruning.
+    if (node%isPrimaryProgenitor()) return
+    ! Nodes above the mass threshold are not eligible for pruning.
+    basic => node%basic()
+    if (basic%mass() >= self%massThreshold) return
+    ! Compute subsampling rate, perform sampling.
+    rateSubsampling=+self%subsamplingRateAtThreshold &
+         &          *(                               &
+         &            +basic%mass         ()         &
+         &            /self %massThreshold           &
+         &           )**self%exponent
+    if (node%hostTree%randomNumberGenerator_%uniformSample() < rateSubsampling) then
+       ! Node is to be kept - increase its weight to account for corresponding branches which will have been lost.
+       call node%subsamplingWeightSet(node%subsamplingWeight()/rateSubsampling)
+    else
+       ! Prune the node.
+       !! Get the next node to walk to in the tree.
+       controlSubsample=treeWalker_%next(nodeNext)
+       !! Decouple the node from the tree.
+       nodeChild => node%parent%firstChild
+       do while (.not.associated(nodeChild%sibling,node))
+          nodeChild => nodeChild%sibling
+       end do
+       nodeChild%sibling => node%sibling
+       ! Destroy and deallocate the node.
+       call node%destroy()
+       deallocate(node)
+       ! Set the current node to the next node in the tree walk.
+       node => nodeNext
+    end if
+    return
+  end function controlSubsample

--- a/source/merger_trees.build.controller.uncontrolled.F90
+++ b/source/merger_trees.build.controller.uncontrolled.F90
@@ -1,0 +1,74 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which implements a merger tree build controller class which provides no control.
+!!}
+
+  !![
+  <mergerTreeBuildController name="mergerTreeBuildControllerUncontrolled">
+   <description>A merger tree build controller class which provides no control.</description>
+  </mergerTreeBuildController>
+  !!]
+  type, extends(mergerTreeBuildControllerClass) :: mergerTreeBuildControllerUncontrolled
+     !!{
+     A merger tree build controller class which provides no control.
+     !!}
+     private
+  contains
+     procedure :: control => controlUncontrolled
+  end type mergerTreeBuildControllerUncontrolled
+
+  interface mergerTreeBuildControllerUncontrolled
+     !!{
+     Constructors for the ``uncontrolled'' merger tree build controller class.
+     !!}
+     module procedure uncontrolledConstructorParameters
+  end interface mergerTreeBuildControllerUncontrolled
+
+contains
+
+  function uncontrolledConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the ``uncontrolled'' merger tree build controller class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type(mergerTreeBuildControllerUncontrolled)                :: self
+    type(inputParameters                      ), intent(inout) :: parameters
+    !$GLC attributes unused :: parameters
+    
+    self=mergerTreeBuildControllerUncontrolled()
+    return
+  end function uncontrolledConstructorParameters
+
+  logical function controlUncontrolled(self,node,treeWalker_)
+    !!{
+    Apply a set of filters to a {\normalfont \ttfamily tree} combined with ``all'' operations.
+    !!}
+    implicit none
+    class(mergerTreeBuildControllerUncontrolled), intent(inout)          :: self
+    type (treeNode                             ), intent(inout), pointer :: node
+    class(mergerTreeWalkerClass                ), intent(inout)          :: treeWalker_
+    !$GLC attributes unused :: self, node, treeWalker_
+
+    ! Always return true as we never want to halt tree building.
+    controlUncontrolled=.true.
+    return
+  end function controlUncontrolled

--- a/source/merger_trees.construct.builder.Cole2000.F90
+++ b/source/merger_trees.construct.builder.Cole2000.F90
@@ -26,7 +26,8 @@
   use :: Merger_Tree_Branching             , only : mergerTreeBranchingProbabilityClass
   use :: Merger_Trees_Build_Mass_Resolution, only : mergerTreeMassResolutionClass
   use :: Statistics_Distributions          , only : distributionFunction1DNegativeExponential
-
+  use :: Merger_Tree_Build_Controllers     , only : mergerTreeBuildControllerClass
+  
   !![
   <mergerTreeBuilder name="mergerTreeBuilderCole2000">
    <description>
@@ -87,6 +88,7 @@
      class           (criticalOverdensityClass                 ), pointer :: criticalOverdensity_                     => null()
      class           (mergerTreeBranchingProbabilityClass      ), pointer :: mergerTreeBranchingProbability_          => null()
      class           (cosmologicalMassVarianceClass            ), pointer :: cosmologicalMassVariance_                => null()
+     class           (mergerTreeBuildControllerClass           ), pointer :: mergerTreeBuildController_               => null()
      logical                                                              :: timeParameterIsMassDependent
      ! Variables controlling merger tree accuracy.
      double precision                                                     :: accretionLimit                                    , timeEarliest             , &
@@ -101,16 +103,12 @@
    contains
      !![
      <methods>
-       <method description="Return true if construction of the merger tree should be aborted." method="shouldAbort"              />
-       <method description="Return true if the branch should be followed."                     method="shouldFollowBranch"       />
-       <method description="Set the critical overdensity object."                              method="criticalOverdensitySet"   />
-       <method description="Set the critical overdensity object."                              method="criticalOverdensityUpdate"/>
+       <method description="Set the critical overdensity object." method="criticalOverdensitySet"   />
+       <method description="Set the critical overdensity object." method="criticalOverdensityUpdate"/>
      </methods>
      !!]
      final     ::                              cole2000Destructor
      procedure :: build                     => cole2000Build
-     procedure :: shouldAbort               => cole2000ShouldAbort
-     procedure :: shouldFollowBranch        => cole2000ShouldFollowBranch
      procedure :: timeEarliestSet           => cole2000TimeEarliestSet
      procedure :: criticalOverdensitySet    => cole2000CriticalOverdensitySet
      procedure :: criticalOverdensityUpdate => cole2000CriticalOverdensityUpdate
@@ -138,6 +136,7 @@ contains
     class           (criticalOverdensityClass           ), pointer       :: criticalOverdensity_
     class           (mergerTreeBranchingProbabilityClass), pointer       :: mergerTreeBranchingProbability_
     class           (cosmologicalMassVarianceClass      ), pointer       :: cosmologicalMassVariance_
+    class           (mergerTreeBuildControllerClass     ), pointer       :: mergerTreeBuildController_
     double precision                                                     :: mergeProbability               , accretionLimit         , &
          &                                                                  redshiftMaximum                , toleranceResolutionSelf, &
          &                                                                  toleranceResolutionParent
@@ -186,6 +185,7 @@ contains
     <objectBuilder class="cosmologyFunctions"             name="cosmologyFunctions_"             source="parameters"/>
     <objectBuilder class="criticalOverdensity"            name="criticalOverdensity_"            source="parameters"/>
     <objectBuilder class="cosmologicalMassVariance"       name="cosmologicalMassVariance_"       source="parameters"/>
+    <objectBuilder class="mergerTreeBuildController"      name="mergerTreeBuildController_"      source="parameters"/>
     !!]
     self   =mergerTreeBuilderCole2000(                                                                                                                  &
          &                                                                                                           mergeProbability                 , &
@@ -198,7 +198,8 @@ contains
          &                                                                                                           mergerTreeMassResolution_        , &
          &                                                                                                           cosmologyFunctions_              , &
          &                                                                                                           criticalOverdensity_             , &
-         &                                                                                                           cosmologicalMassVariance_          &
+         &                                                                                                           cosmologicalMassVariance_        , &
+         &                                                                                                           mergerTreeBuildController_         &
          &                           )
     !![
     <inputParametersValidate source="parameters"/>
@@ -207,11 +208,12 @@ contains
     <objectDestructor name="cosmologyFunctions_"            />
     <objectDestructor name="criticalOverdensity_"           />
     <objectDestructor name="cosmologicalMassVariance_"      />
+    <objectDestructor name="mergerTreeBuildController_"     />
     !!]
     return
   end function cole2000ConstructorParameters
 
-  function cole2000ConstructorInternal(mergeProbability,accretionLimit,timeEarliest,branchIntervalStep,toleranceResolutionSelf,toleranceResolutionParent,mergerTreeBranchingProbability_,mergerTreeMassResolution_,cosmologyFunctions_,criticalOverdensity_,cosmologicalMassVariance_) result(self)
+  function cole2000ConstructorInternal(mergeProbability,accretionLimit,timeEarliest,branchIntervalStep,toleranceResolutionSelf,toleranceResolutionParent,mergerTreeBranchingProbability_,mergerTreeMassResolution_,cosmologyFunctions_,criticalOverdensity_,cosmologicalMassVariance_,mergerTreeBuildController_) result(self)
     !!{
     Internal constructor for the \cite{cole_hierarchical_2000} merger tree building class.
     !!}
@@ -227,8 +229,9 @@ contains
     class           (cosmologyFunctionsClass            ), intent(in   ), target :: cosmologyFunctions_
     class           (criticalOverdensityClass           ), intent(in   ), target :: criticalOverdensity_
     class           (cosmologicalMassVarianceClass      ), intent(in   ), target :: cosmologicalMassVariance_
+    class           (mergerTreeBuildControllerClass     ), intent(in   ), target :: mergerTreeBuildController_
     !![
-    <constructorAssign variables="mergeProbability, accretionLimit, timeEarliest, branchIntervalStep, toleranceResolutionSelf, toleranceResolutionParent, *mergerTreeBranchingProbability_, *mergerTreeMassResolution_, *cosmologyFunctions_, *criticalOverdensity_, *cosmologicalMassVariance_"/>
+    <constructorAssign variables="mergeProbability, accretionLimit, timeEarliest, branchIntervalStep, toleranceResolutionSelf, toleranceResolutionParent, *mergerTreeBranchingProbability_, *mergerTreeMassResolution_, *cosmologyFunctions_, *criticalOverdensity_, *cosmologicalMassVariance_, *mergerTreeBuildController_"/>
     !!]
 
     ! Initialize state.
@@ -255,6 +258,7 @@ contains
     <objectDestructor name="self%cosmologyFunctions_"            />
     <objectDestructor name="self%criticalOverdensity_"           />
     <objectDestructor name="self%cosmologicalMassVariance_"      />
+    <objectDestructor name="self%mergerTreeBuildController_"     />
     !!]
     return
   end subroutine cole2000Destructor
@@ -324,7 +328,9 @@ contains
     call basic%timeSet(deltaCritical)
     ! Begin tree build loop.
     treeWalkerConstruction=mergerTreeWalkerTreeConstruction(tree)
-    do while (treeWalkerConstruction%next(node).and..not.self%shouldAbort(tree))
+    do while (treeWalkerConstruction%next(node))
+       ! Apply control.
+       if (.not.self%mergerTreeBuildController_%control(node,treeWalkerConstruction)) exit
        ! Get the basic component of the node.
        basic                       => node %basic()
        ! Initialize the state for this branch.
@@ -342,8 +348,6 @@ contains
                &   branchMassCurrent <= massResolution                                  &
                &  .or.                                                                  &
                &   time              <  self%timeEarliest*(1.0d0+toleranceTimeEarliest) &
-               &  .or.                                                                  &
-               &   .not.self%shouldFollowBranch(tree,node)                              &
                & ) then
              ! Branch should be terminated. If we have any accumulated accretion, terminate the branch with a final node.
              if (accretionFractionCumulative > 0.0d0) then
@@ -662,36 +666,6 @@ contains
     end do
     return
   end subroutine cole2000Build
-
-  logical function cole2000ShouldAbort(self,tree)
-    !!{
-    Return {\normalfont \ttfamily true} if tree construction should be aborted. In the {\normalfont \ttfamily cole2000} tree
-    builder we never abort.
-    !!}
-    implicit none
-    class(mergerTreeBuilderCole2000), intent(inout) :: self
-    type (mergerTree               ), intent(in   ) :: tree
-    !$GLC attributes unused :: self, tree
-
-    cole2000ShouldAbort=.false.
-    return
-  end function cole2000ShouldAbort
-
-  logical function cole2000ShouldFollowBranch(self,tree,node)
-    !!{
-    Return {\normalfont \ttfamily true} if tree construction should continue to follow the current branch. In the {\normalfont
-    \ttfamily cole2000} tree builder we always continue.
-    !!}
-    use :: Galacticus_Nodes, only : mergerTree, treeNode
-    implicit none
-    class(mergerTreeBuilderCole2000), intent(inout) :: self
-    type (mergerTree               ), intent(in   ) :: tree
-    type (treeNode                 ), intent(inout) :: node
-    !$GLC attributes unused :: self, tree, node
-
-    cole2000ShouldFollowBranch=.true.
-    return
-  end function cole2000ShouldFollowBranch
 
   subroutine cole2000TimeEarliestSet(self,timeEarliest)
     !!{

--- a/source/merger_trees.walkers.tree_construction.F90
+++ b/source/merger_trees.walkers.tree_construction.F90
@@ -58,7 +58,7 @@ contains
     use :: Input_Parameters, only : inputParameters
     implicit none
     type(mergerTreeWalkerTreeConstruction)                :: self
-    type(inputParameters         ), intent(inout) :: parameters
+    type(inputParameters                 ), intent(inout) :: parameters
     !$GLC attributes unused :: self, parameters
 
     call Galacticus_Error_Report('this class can not be built from parameters'//{introspection:location})

--- a/testSuite/parameters/mergerTreeBranchNotSubsampled.xml
+++ b/testSuite/parameters/mergerTreeBranchNotSubsampled.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+<!-- 30-October-2011                          -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <version>0.9.4</version>
+
+  <!-- Random number generator -->
+  <randomNumberGenerator value="GSL">
+    <seed value="219" />
+  </randomNumberGenerator>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="null"/>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="null"/>
+  <componentSpin value="null"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="fixedMass">
+    <massTree  value="1.0e12"/>
+    <treeCount value="128"/>
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e8"/>
+  </mergerTreeMassResolution>
+  <mergerTreeBuildController value="uncontrolled"/>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="gao2008"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Satellite orbit options -->
+  <satelliteOrbitStoreOrbitalParameters value="true"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="benson2005"/>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+ 
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <galacticusOutputFileName value="testSuite/outputs/mergerTreeBranchNotSubsampled.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+
+</parameters>

--- a/testSuite/parameters/mergerTreeBranchSubsampled.xml
+++ b/testSuite/parameters/mergerTreeBranchSubsampled.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+<!-- 30-October-2011                          -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <version>0.9.4</version>
+
+  <!-- Random number generator -->
+  <randomNumberGenerator value="GSL">
+    <seed value="882" />
+  </randomNumberGenerator>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="null"/>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="null"/>
+  <componentSpin value="null"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="fixedMass">
+    <massTree value="1.0e12"/>
+    <treeCount value="128"/>
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e8"/>
+  </mergerTreeMassResolution>
+  <mergerTreeBuildController value="subsample">
+    <massThreshold value="1.0e10"/>
+    <subsamplingRateAtThreshold value="1.0"/>
+    <exponent value="1.0"/>
+  </mergerTreeBuildController>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="gao2008"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Satellite orbit options -->
+  <satelliteOrbitStoreOrbitalParameters value="true"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="benson2005"/>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+ 
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <galacticusOutputFileName value="testSuite/outputs/mergerTreeBranchSubsampled.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+
+</parameters>

--- a/testSuite/test-branchSubsampling.pl
+++ b/testSuite/test-branchSubsampling.pl
@@ -1,0 +1,66 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use PDL;
+use PDL::NiceSlice;
+use PDL::IO::HDF5;
+
+# Run models that test that the merger tree branch subsampling algorithm.
+# Andrew Benson (14-July-2021)
+
+# Make output directory.
+system("mkdir -p outputs/");
+
+# Run the subsampled model.
+system("cd ..; Galacticus.exe testSuite/parameters/mergerTreeBranchSubsampled.xml");
+unless ( $? == 0 ) {
+    print "FAIL: merger tree branch subsampling model failed to run\n";
+    exit;
+}
+
+# Run the not subsampled model.
+system("cd ..; Galacticus.exe testSuite/parameters/mergerTreeBranchNotSubsampled.xml");
+unless ( $? == 0 ) {
+    print "FAIL: merger tree branch no subsampling model failed to run\n";
+    exit;
+}
+
+# Read data and construct counts of subhalos.
+my @models =
+    (
+     {
+	 label    => "subsampled",
+	 fileName => "outputs/mergerTreeBranchSubsampled.hdf5"
+     },
+     {
+	 label    => "notSubsampled",
+	 fileName => "outputs/mergerTreeBranchNotSubsampled.hdf5"
+     }
+    );
+foreach my $model ( @models ) {
+    my $modelFile = new PDL::IO::HDF5($model->{'fileName'});
+    my $outputs   = $modelFile->group('Outputs' );
+    my $output    = $outputs  ->group('Output1' );
+    my $nodeData  = $output   ->group('nodeData');
+    $model->{$_} = $nodeData->dataset($_)->get()
+	foreach ( "basicMass", "nodeIsIsolated", "nodeSubsamplingWeight" );
+}
+my @massesLogarithmic = ( 11, 10, 9, 8 );
+foreach my $model ( @models ) {
+    $model->{'countSubhalos'     } = pdl zeros(scalar(@massesLogarithmic));
+    $model->{'countSubhalosError'} = pdl zeros(scalar(@massesLogarithmic));
+    for(my $i=0;$i<scalar(@massesLogarithmic);++$i) {
+	my $selectionSubhalos                   = which(($model->{'nodeIsIsolated'} == 0) & ($model->{'basicMass'}->log10() >= $massesLogarithmic[$i]));
+	my $selectionHalos                      = which(($model->{'nodeIsIsolated'} == 1)                                                       );
+	$model->{'countSubhalos'     }->(($i)) .= $model->{'nodeSubsamplingWeight'}->($selectionSubhalos)        ->sumover()        /$model->{'nodeSubsamplingWeight'}->($selectionHalos)->sumover();
+	$model->{'countSubhalosError'}->(($i)) .= $model->{'nodeSubsamplingWeight'}->($selectionSubhalos)->pow(2)->sumover()->sqrt()/$model->{'nodeSubsamplingWeight'}->($selectionHalos)->sumover();
+    }
+}
+# Compare counts.
+my $offsetScaled = abs(+$models[0]->{'countSubhalos'}-$models[1]->{'countSubhalos'})/sqrt(+$models[0]->{'countSubhalosError'}**2+$models[1]->{'countSubhalosError'}**2);
+if ( any($offsetScaled > 3.0) ) {
+    print "FAIL: merger tree branch subsampling changes subhalo mass function at > 3σ\n";
+} else {
+    print "SUCCESS: merger tree branch subsampling does not change subhalo mass function at > 3σ\n";
+}
+exit;


### PR DESCRIPTION
Add a `mergerTreeBuildController` class which can provide arbitrary control over how merger trees are built. This is now called by the Cole2000 merger tree builder class.
    
Adds a `mergerTreeBuildController` which performs subsampling of branches based on their mass.

