### PR TITLE
Add a merger tree build controller which allows for the construction of "branchless" merger trees

### DIFF
--- a/source/merger_trees.build.controller.branchless.F90
+++ b/source/merger_trees.build.controller.branchless.F90
@@ -1,0 +1,81 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which implements a merger tree build controller class which builds branchless trees.
+!!}
+
+  !![
+  <mergerTreeBuildController name="mergerTreeBuildControllerBranchless">
+   <description>A merger tree build controller class which builds branchless trees.</description>
+  </mergerTreeBuildController>
+  !!]
+  type, extends(mergerTreeBuildControllerClass) :: mergerTreeBuildControllerBranchless
+     !!{     
+     A merger tree build controller class which builds branchless trees. Specifically, whenever a branching occurs, only the
+     primary progenitor is followed. This results in a tree which consists of the main branch, along with stubs of any branches
+     off of the main branch, but those stubs do not grow full branches of their own.
+     !!}
+     private
+  contains
+     procedure :: control => controlBranchless
+  end type mergerTreeBuildControllerBranchless
+
+  interface mergerTreeBuildControllerBranchless
+     !!{
+     Constructors for the ``branchless'' merger tree build controller class.
+     !!}
+     module procedure branchlessConstructorParameters
+  end interface mergerTreeBuildControllerBranchless
+
+contains
+
+  function branchlessConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the ``branchless'' merger tree build controller class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type(mergerTreeBuildControllerBranchless)                :: self
+    type(inputParameters                    ), intent(inout) :: parameters
+  
+    self=mergerTreeBuildControllerBranchless()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function branchlessConstructorParameters
+
+  logical function controlBranchless(self,node,treeWalker_)
+    !!{
+    Skip side branches of a tree under construction.
+    !!}
+    implicit none
+    class(mergerTreeBuildControllerBranchless), intent(inout)          :: self    
+    type (treeNode                           ), intent(inout), pointer :: node
+    class(mergerTreeWalkerClass              ), intent(inout)          :: treeWalker_
+    !$GLC attributes unused :: self
+
+    controlBranchless=.true.
+    ! Move to the next node in the tree while such exists, and the current node is on a side branch.
+    do while (controlBranchless.and.associated(node%parent).and..not.node%isPrimaryProgenitor())
+       controlBranchless=treeWalker_%next(node)
+    end do
+    return
+  end function controlBranchless

--- a/source/merger_trees.build.controller.subsample.F90
+++ b/source/merger_trees.build.controller.subsample.F90
@@ -115,7 +115,6 @@ contains
     type            (treeNode                          )               , pointer :: nodeNext       , nodeChild
     class           (nodeComponentBasic                )               , pointer :: basic
     double precision                                                             :: rateSubsampling
-    !$GLC attributes unused :: self
 
     controlSubsample=.true.
     ! Root node is not eligible for pruning.

--- a/testSuite/parameters/mergerTreeBranchless.xml
+++ b/testSuite/parameters/mergerTreeBranchless.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+<!-- 30-October-2011                          -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <version>0.9.4</version>
+
+  <!-- Random number generator -->
+  <randomNumberGenerator value="GSL">
+    <seed value="882" />
+  </randomNumberGenerator>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="null"/>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="null"/>
+  <componentSpin value="null"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="fixedMass">
+    <massTree value="1.0e12"/>
+    <treeCount value="16"/>
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e8"/>
+  </mergerTreeMassResolution>
+  <mergerTreeBuildController value="branchless"/>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="gao2008"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Satellite orbit options -->
+  <satelliteOrbitStoreOrbitalParameters value="true"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="benson2005"/>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+ 
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <galacticusOutputFileName value="testSuite/outputs/mergerTreeBranchless.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <mergerTreeOperator value="sequence">
+    <mergerTreeOperator value="outputStructure">
+      <nodePropertyExtractor value="multi">
+	<nodePropertyExtractor value="nodeIndices"/>
+	<nodePropertyExtractor value="mainBranchStatus"/>
+      </nodePropertyExtractor>
+    </mergerTreeOperator>
+    <mergerTreeOperator value="dumpToGraphViz">
+      <path value="testSuite/outputs"/>
+    </mergerTreeOperator>
+  </mergerTreeOperator>
+
+</parameters>

--- a/testSuite/test-branchlessTrees.pl
+++ b/testSuite/test-branchlessTrees.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use PDL;
+use PDL::NiceSlice;
+use PDL::IO::HDF5;
+
+# Run models that test that the branchless merger tree algorithm.
+# Andrew Benson (15-July-2021)
+
+# Make output directory.
+system("mkdir -p outputs/");
+
+# Run the branchless model.
+system("cd ..; Galacticus.exe testSuite/parameters/mergerTreeBranchless.xml");
+unless ( $? == 0 ) {
+    print "FAIL: merger tree branchless model failed to run\n";
+    exit;
+}
+
+my $success   = 1;
+my $model     = new PDL::IO::HDF5("outputs/mergerTreeBranchless.hdf5");
+my $structure = $model->group('mergerTreeStructures');
+foreach my $treeName ( $structure->groups() ) {
+    my $tree = $structure->group($treeName);
+    my $properties;
+    $properties->{$_} = $tree->dataset($_)->get()
+	foreach ( 'nodeIndex', 'parentIndex', 'nodeIsOnMainBranch' );
+    # If this tree is truly branchless then any node which is not on the main branch should have its parent in the subsequent
+    # entry in the arrays, and that parent should be on the main branch.
+    my $sideBranch = which($properties->{'nodeIsOnMainBranch'} == 0);
+    my $mainBranch = $sideBranch+1;
+    $success = 0
+	unless ( all($properties->{'parentIndex'}->($sideBranch) == $properties->{'nodeIndex'}->($mainBranch)) && all($properties->{'nodeIsOnMainBranch'}->($mainBranch) == 1) );
+}
+
+my $status = $success ? "SUCCESS" : "FAILED";
+print $status.": branchless merger tree construction\n";
+
+exit;


### PR DESCRIPTION
This adds a `mergerTreeBuildController` which enforces construction of the main branch of the tree only - any side branches are left as stubs. This results in a tree such as the one on the left becoming the one of the right:

![tree](https://user-images.githubusercontent.com/7468651/125829383-b3c7cf6e-b2a3-465a-8f52-a44acd6d3fbb.png)
