### PR TITLE
Add a task which triggers tabulation of broadband luminosity tables

### DIFF
--- a/source/tasks.build_broadband_luminosity_tabulations.F90
+++ b/source/tasks.build_broadband_luminosity_tabulations.F90
@@ -1,0 +1,161 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Contains a class which implements a task to pre-build tabulations needed for broadband luminosity calculations.
+  !!}
+
+  use :: Stellar_Population_Broad_Band_Luminosities, only : stellarPopulationBroadBandLuminositiesClass
+  use :: Stellar_Populations                       , only : stellarPopulationClass
+
+  !![
+  <task name="taskBuildBroadbandLuminosityTabulations">
+   <description>A task which pre-builds tabulations needed for broadband luminosity calculations.</description>
+  </task>
+  !!]
+  type, extends(taskClass) :: taskBuildBroadbandLuminosityTabulations
+     !!{
+     Implementation of a task which pre-builds tabulations needed for broadband luminosity calculations.
+     !!}
+     private
+     class(stellarPopulationBroadBandLuminositiesClass), pointer :: stellarPopulationBroadBandLuminosities_ => null()
+     class(stellarPopulationClass                     ), pointer :: stellarPopulation_                      => null()
+   contains
+     final     ::                       buildBroadbandLuminosityTabulationsDestructor
+     procedure :: perform            => buildBroadbandLuminosityTabulationsPerform
+     procedure :: requiresOutputFile => buildBroadbandLuminosityTabulationsRequiresOutputFile
+  end type taskBuildBroadbandLuminosityTabulations
+
+  interface taskBuildBroadbandLuminosityTabulations
+     !!{
+     Constructors for the {\normalfont \ttfamily buildBroadbandLuminosityTabulations} task.
+     !!}
+     module procedure buildBroadbandLuminosityTabulationsParameters
+     module procedure buildBroadbandLuminosityTabulationsInternal
+  end interface taskBuildBroadbandLuminosityTabulations
+
+contains
+
+  function buildBroadbandLuminosityTabulationsParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily buildBroadbandLuminosityTabulations} task class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    use :: Node_Components , only : Node_Components_Initialize
+    implicit none
+    type (taskBuildBroadbandLuminosityTabulations    )                         :: self
+    type (inputParameters                            ), intent(inout), target  :: parameters
+    class(stellarPopulationBroadBandLuminositiesClass)               , pointer :: stellarPopulationBroadBandLuminosities_
+    class(stellarPopulationClass                     )               , pointer :: stellarPopulation_
+    type (inputParameters                            )               , pointer :: parametersRoot
+
+    ! Ensure the nodes objects are initialized.
+    parametersRoot => parameters
+    do while (associated(parametersRoot%parent))
+       parametersRoot => parametersRoot%parent
+    end do
+    call Node_Components_Initialize(parametersRoot)
+    !![
+    <objectBuilder class="stellarPopulationBroadBandLuminosities" name="stellarPopulationBroadBandLuminosities_" source="parameters"/>
+    <objectBuilder class="stellarPopulation"                      name="stellarPopulation_"                      source="parameters"/>
+    !!]
+    self=taskBuildBroadbandLuminosityTabulations(stellarPopulationBroadBandLuminosities_,stellarPopulation_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="stellarPopulationBroadBandLuminosities_"/>
+    <objectDestructor name="stellarPopulation_"                     />
+    !!]
+    return
+  end function buildBroadbandLuminosityTabulationsParameters
+
+  function buildBroadbandLuminosityTabulationsInternal(stellarPopulationBroadBandLuminosities_,stellarPopulation_) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily buildBroadbandLuminosityTabulations} task class which takes a parameter set as input.
+    !!}
+    implicit none
+    type (taskBuildBroadbandLuminosityTabulations    )                        :: self
+    class(stellarPopulationBroadBandLuminositiesClass), intent(in   ), target :: stellarPopulationBroadBandLuminosities_
+    class(stellarPopulationClass                     ), intent(in   ), target :: stellarPopulation_
+    !![
+    <constructorAssign variables="*stellarPopulationBroadBandLuminosities_, *stellarPopulation_"/>
+    !!]
+
+    return
+  end function buildBroadbandLuminosityTabulationsInternal
+
+  subroutine buildBroadbandLuminosityTabulationsDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily buildBroadbandLuminosityTabulations} task class.
+    !!}
+    use :: Node_Components, only : Node_Components_Uninitialize
+    implicit none
+    type(taskBuildBroadbandLuminosityTabulations), intent(inout) :: self
+    
+    !![
+    <objectDestructor name="self%stellarPopulationBroadBandLuminosities_"/>
+    <objectDestructor name="self%stellarPopulation_"                     />
+    !!]
+    call Node_Components_Uninitialize()
+    return
+  end subroutine buildBroadbandLuminosityTabulationsDestructor
+
+  subroutine buildBroadbandLuminosityTabulationsPerform(self,status)
+    !!{
+    Builds the tabulation.
+    !!}
+    use :: Display                       , only : displayIndent      , displayUnindent
+    use :: Galacticus_Error              , only : errorStatusSuccess
+    use :: Abundances_Structure          , only : abundances         , metallicityTypeLinearByMassSolar
+    use :: Stellar_Luminosities_Structure, only : stellarLuminosities
+    implicit none
+    class  (taskBuildBroadbandLuminosityTabulations), intent(inout), target   :: self
+    integer                                         , intent(  out), optional :: status
+    type   (abundances                             )                          :: abundancesStellar
+    type   (stellarLuminosities                    )                          :: luminosities
+    
+    call displayIndent ('Begin task: build broadband luminosity tabulations')
+    ! Set luminosities, which will trigger tabulation if necessary.
+    call abundancesStellar%metallicitySet (                                                                                      &
+         &                                 metallicity                            =1.0d0                                       , &
+         &                                 metallicityType                        =metallicityTypeLinearByMassSolar              &
+         &                                )
+    call luminosities     %setLuminosities(                                                                                      &
+         &                                 mass                                   =1.0d0                                       , &
+         &                                 time                                   =0.0d0                                       , &
+         &                                 abundancesStellar                      =abundancesStellar                           , &
+         &                                 stellarPopulation_                     =self%stellarPopulation_                     , &
+         &                                 stellarPopulationBroadBandLuminosities_=self%stellarPopulationBroadBandLuminosities_  &
+         &                                )
+    ! Finish up.
+    if (present(status)) status=errorStatusSuccess
+    call displayUnindent('Done task: build broadband luminosity tabulations')
+    return
+  end subroutine buildBroadbandLuminosityTabulationsPerform
+  
+  logical function buildBroadbandLuminosityTabulationsRequiresOutputFile(self)
+    !!{
+    Specifies that this task does not requires the main output file.
+    !!}
+    implicit none
+    class(taskBuildBroadbandLuminosityTabulations ), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    buildBroadbandLuminosityTabulationsRequiresOutputFile=.false.
+    return
+  end function buildBroadbandLuminosityTabulationsRequiresOutputFile

--- a/testSuite/test-methods.xml
+++ b/testSuite/test-methods.xml
@@ -1763,8 +1763,8 @@
   
   <!-- WDM model -->
   <parameters>
-  <formatVersion>2</formatVersion>
-  <version>0.9.4</version>
+    <formatVersion>2</formatVersion>
+    <version>0.9.4</version>
     <nodeOperator value="darkMatterProfileScaleInterpolate"/>
     <componentBasic value="standard"/>
     <componentHotHalo value="null"/>
@@ -1879,9 +1879,9 @@
       <gamma2 value="-0.01"/>
     </mergerTreeBranchingProbabilityModifier>
     <mergerTreeBuildMasses value="sampledDistributionUniform">
-    <massTreeMinimum value="1.0e12"/>
-    <massTreeMaximum value="2.0e12"/>
-    <treesPerDecade value="20"/>
+      <massTreeMinimum value="1.0e12"/>
+      <massTreeMaximum value="2.0e12"/>
+      <treesPerDecade value="20"/>
     </mergerTreeBuildMasses>
     <mergerTreeMassResolution value="fixed">
       <massResolution value="1.0e9"/>
@@ -1892,28 +1892,27 @@
     <hotHaloMassDistribution value="null"/>
     <mergerRemnantSize value="null"/>
     <mergerTreeNodeEvolver value="standard">
-    <odeToleranceAbsolute value="0.01"/>
-    <odeToleranceRelative value="0.01"/>
-  </mergerTreeNodeEvolver>
+      <odeToleranceAbsolute value="0.01"/>
+      <odeToleranceRelative value="0.01"/>
+    </mergerTreeNodeEvolver>
 
-  <mergerTreeEvolver value="standard">
-    <timestepHostAbsolute value="1.00"/>
-    <timestepHostRelative value="0.10"/>
-  </mergerTreeEvolver>
+    <mergerTreeEvolver value="standard">
+      <timestepHostAbsolute value="1.00"/>
+      <timestepHostRelative value="0.10"/>
+    </mergerTreeEvolver>
 
-  <mergerTreeEvolveTimestep value="multi">
-    <mergerTreeEvolveTimestep value="simple"    iterable="no" >
-      <timeStepAbsolute value="10.00"/>
-      <timeStepRelative value="10.00"/>
+    <mergerTreeEvolveTimestep value="multi">
+      <mergerTreeEvolveTimestep value="simple"    iterable="no" >
+	<timeStepAbsolute value="10.00"/>
+	<timeStepRelative value="10.00"/>
+      </mergerTreeEvolveTimestep>
+      <mergerTreeEvolveTimestep value="satellite" iterable="no"/>
     </mergerTreeEvolveTimestep>
-    <mergerTreeEvolveTimestep value="satellite" iterable="no"/>
-  </mergerTreeEvolveTimestep>
-  <outputTimestepHistory value="false"/>
-  <outputTimes value="list">
-    <redshifts value="0.0"/>
-  </outputTimes>
-  
-  <verbosityLevel value="standard"/>
+    <outputTimestepHistory value="false"/>
+    <outputTimes value="list">
+      <redshifts value="0.0"/>
+    </outputTimes>  
+    <verbosityLevel value="standard"/>
   </parameters>
 
   <!-- Power spectrum calculation -->
@@ -1934,9 +1933,21 @@
       <temperatureCMB value="2.72548"/>
     </cosmologyParameters>
     <outputTimes value="list">
-    <redshifts value="0.0 1.0"/>
-  </outputTimes>
-
+      <redshifts value="0.0 1.0"/>
+    </outputTimes>
   </parameters>
 
+  <!-- Broadband luminosity tabulation -->
+  <parameters>
+    <formatVersion>2</formatVersion>
+    <version>0.9.4</version>
+    <task value="buildBroadbandLuminosityTabulations"/>
+    <outputTimes value="list">
+      <redshifts value="0.0 1.0"/>
+    </outputTimes>
+    <luminosityFilter   value="LSST_g   LSST_i   LSST_r   LSST_u   LSST_y   LSST_z   LSST_g   LSST_i   LSST_r   LSST_u   LSST_y   LSST_z"/>
+    <luminosityType     value="observed observed observed observed observed observed rest     rest     rest     rest     rest     rest  "/>
+    <luminosityRedshift value="all      all      all      all      all      all      all      all      all      all      all      all   "/>
+  </parameters>
+  
 </parameterGrid>


### PR DESCRIPTION
Using a task:
```
<task value="buildBroadbandLuminosityTabulations"/>
```
will trigger tabulation of all broadband luminosity datasets required for the model. This can be used to efficiently tabulate all required broadband luminosities prior to commencing a production run.