### PR TITLE
fix: Improve parameter name validation

### DIFF
--- a/source/accretion.halo.total.Bertschinger.F90
+++ b/source/accretion.halo.total.Bertschinger.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(accretionHaloTotalBertschinger)                :: self
     type(inputParameters               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=accretionHaloTotalBertschinger()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function bertschingerConstructorParameters
 

--- a/source/accretion.halo.total.simple.F90
+++ b/source/accretion.halo.total.simple.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(accretionHaloTotalSimple)                :: self
     type(inputParameters         ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=accretionHaloTotalSimple()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function simpleConstructorParameters
 

--- a/source/accretion.halo.zero.F90
+++ b/source/accretion.halo.zero.F90
@@ -60,9 +60,11 @@ contains
     implicit none
     type(accretionHaloZero)                :: self
     type(inputParameters  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=accretionHaloZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/accretion_disks.Shakura_Sunyaev.F90
+++ b/source/accretion_disks.Shakura_Sunyaev.F90
@@ -65,6 +65,9 @@ contains
     !$GLC attributes unused :: parameters
 
     self=accretionDisksShakuraSunyaev()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function shakuraSunyaevConstructorParameters
 

--- a/source/accretion_disks.spectra.Hopkins2007.F90
+++ b/source/accretion_disks.spectra.Hopkins2007.F90
@@ -64,6 +64,9 @@ contains
     !$GLC attributes unused :: parameters
 
     self=accretionDiskSpectraHopkins2007()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function hopkins2007ConstructorParameters
 

--- a/source/atomic.cross_sections.ionization.photo.Verner.F90
+++ b/source/atomic.cross_sections.ionization.photo.Verner.F90
@@ -1953,9 +1953,11 @@ contains
     implicit none
     type(atomicCrossSectionIonizationPhotoVerner)                :: self
     type(inputParameters                        ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=atomicCrossSectionIonizationPhotoVerner()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function vernerConstructorParameters
 

--- a/source/atomic.ionization_potentials.Verner.F90
+++ b/source/atomic.ionization_potentials.Verner.F90
@@ -532,9 +532,11 @@ contains
     implicit none
     type(atomicIonizationPotentialVerner)                :: self
     type(inputParameters                ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=atomicIonizationPotentialVerner()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function vernerConstructorParameters
 

--- a/source/atomic.rates.excitation.collisional.ScholzWalters91.F90
+++ b/source/atomic.rates.excitation.collisional.ScholzWalters91.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(atomicExcitationRateCollisionalScholzWalters1991)                :: self
     type(inputParameters                                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=atomicExcitationRateCollisionalScholzWalters1991()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function scholzWalters1991ConstructorParameters
 

--- a/source/atomic.rates.ionization.collisional.Verner.F90
+++ b/source/atomic.rates.ionization.collisional.Verner.F90
@@ -466,9 +466,11 @@ contains
     implicit none
     type(atomicIonizationRateCollisionalVerner1996)                :: self
     type(inputParameters                          ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=atomicIonizationRateCollisionalVerner1996()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function verner1996ConstructorParameters
 

--- a/source/atomic.rates.ionization.collisional.zero.F90
+++ b/source/atomic.rates.ionization.collisional.zero.F90
@@ -53,9 +53,11 @@ contains
     implicit none
     type(atomicIonizationRateCollisionalZero)                :: self
     type(inputParameters                    ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=atomicIonizationRateCollisionalZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/atomic.rates.recombination.dielectronic.Arnaud85.F90
+++ b/source/atomic.rates.recombination.dielectronic.Arnaud85.F90
@@ -230,9 +230,11 @@ contains
     implicit none
     type(atomicRecombinationRateDielectronicArnaud1985)                :: self
     type(inputParameters                              ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=atomicRecombinationRateDielectronicArnaud1985()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function arnaud1985ConstructorParameters
 

--- a/source/atomic.rates.recombination.dielectronic.zero.F90
+++ b/source/atomic.rates.recombination.dielectronic.zero.F90
@@ -53,9 +53,11 @@ contains
     implicit none
     type(atomicRecombinationRateDielectronicZero)                :: self
     type(inputParameters                        ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=atomicRecombinationRateDielectronicZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/atomic.rates.recombination.radiative.Verner.F90
+++ b/source/atomic.rates.recombination.radiative.Verner.F90
@@ -553,9 +553,11 @@ contains
     implicit none
     type(atomicRecombinationRateRadiativeVerner1996)                :: self
     type(inputParameters                           ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=atomicRecombinationRateRadiativeVerner1996()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function verner1996ConstructorParameters
 

--- a/source/black_holes.binaries.recoil_velocity.Campanelli2007.F90
+++ b/source/black_holes.binaries.recoil_velocity.Campanelli2007.F90
@@ -82,9 +82,11 @@ contains
     implicit none
     type(blackHoleBinaryRecoilCampanelli2007)                :: self
     type(inputParameters                    ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=blackHoleBinaryRecoilCampanelli2007()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function campanelli2007ConstructorParameters
 

--- a/source/black_holes.binaries.recoil_velocity.zero.F90
+++ b/source/black_holes.binaries.recoil_velocity.zero.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(blackHoleBinaryRecoilZero)                :: self
     type(inputParameters          ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=blackHoleBinaryRecoilZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/black_holes.binaries.separation_growth_rate.zero.F90
+++ b/source/black_holes.binaries.separation_growth_rate.zero.F90
@@ -57,9 +57,11 @@ contains
     implicit none
     type(blackHoleBinarySeparationGrowthRateZero)                :: self
     type(inputParameters                        ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=blackHoleBinarySeparationGrowthRateZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/black_holes.binary_mergers.Rezzolla2008.F90
+++ b/source/black_holes.binary_mergers.Rezzolla2008.F90
@@ -58,9 +58,11 @@ contains
     implicit none
     type(blackHoleBinaryMergerRezzolla2008)                :: self
     type(inputParameters                  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=blackHoleBinaryMergerRezzolla2008()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function rezzolla2008ConstructorParameters
 

--- a/source/chemical.reaction_rates.zero.F90
+++ b/source/chemical.reaction_rates.zero.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(chemicalReactionRateZero)                :: self
     type(inputParameters         ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=chemicalReactionRateZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/chemical.state.atomic_CIE_cloudy.F90
+++ b/source/chemical.state.atomic_CIE_cloudy.F90
@@ -86,9 +86,11 @@ contains
     implicit none
     type(chemicalStateAtomicCIECloudy)                :: self
     type(inputParameters             ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=chemicalStateAtomicCIECloudy()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function atomicCIECloudyConstructorParameters
 

--- a/source/cooling.cooling_function.atomic_CIE_Cloudy.F90
+++ b/source/cooling.cooling_function.atomic_CIE_Cloudy.F90
@@ -86,9 +86,11 @@ contains
     implicit none
     type(coolingFunctionAtomicCIECloudy)                :: self
     type(inputParameters               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=coolingFunctionAtomicCIECloudy()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function atomicCIECloudyConstructorParameters
 

--- a/source/cooling.cooling_function.molecular_hydrogen_Galli_Palla.F90
+++ b/source/cooling.cooling_function.molecular_hydrogen_Galli_Palla.F90
@@ -131,9 +131,11 @@ contains
     implicit none
     type(coolingFunctionMolecularHydrogenGalliPalla)                :: self
     type(inputParameters                           ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=coolingFunctionMolecularHydrogenGalliPalla()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function molecularHydrogenGalliPallaConstructorParameters
 

--- a/source/cooling.cooling_rate.zero.F90
+++ b/source/cooling.cooling_rate.zero.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(coolingRateZero)                :: self
     type(inputParameters), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=coolingRateZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/cooling.freefall_time_available.halo_formation.F90
+++ b/source/cooling.freefall_time_available.halo_formation.F90
@@ -62,9 +62,11 @@ contains
     implicit none
     type(freefallTimeAvailableHaloFormation)                :: self
     type(inputParameters                   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=freefallTimeAvailableHaloFormation()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function haloFormationConstructorParameters
 

--- a/source/cooling.specific_angular_momentum.mean.F90
+++ b/source/cooling.specific_angular_momentum.mean.F90
@@ -59,9 +59,11 @@ contains
     implicit none
     type(coolingSpecificAngularMomentumMean)                :: self
     type(inputParameters                   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=coolingSpecificAngularMomentumMean()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function meanConstructorParameters
 

--- a/source/cooling.time_available.halo_formation.F90
+++ b/source/cooling.time_available.halo_formation.F90
@@ -62,9 +62,11 @@ contains
     implicit none
     type(coolingTimeAvailableFormationTime)                :: self
     type(inputParameters                  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=coolingTimeAvailableFormationTime()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function formationTimeConstructorParameters
 

--- a/source/dark_matter.particle.cold_dark_matter.F90
+++ b/source/dark_matter.particle.cold_dark_matter.F90
@@ -53,9 +53,11 @@ contains
     implicit none
     type(darkMatterParticleCDM)                :: CDMConstructorParameters
     type(inputParameters      ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     CDMConstructorParameters=darkMatterParticleCDM()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function CDMConstructorParameters
 

--- a/source/dark_matter_halos.mass_loss_rates.zero.F90
+++ b/source/dark_matter_halos.mass_loss_rates.zero.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(darkMatterHaloMassLossRateZero)                :: self
     type(inputParameters               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=darkMatterHaloMassLossRateZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/dark_matter_profiles.heating.null.F90
+++ b/source/dark_matter_profiles.heating.null.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(darkMatterProfileHeatingNull), target        :: self
     type(inputParameters             ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=darkMatterProfileHeatingNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/dark_matter_profiles.structure.scale.Ludlow2014.F90
+++ b/source/dark_matter_profiles.structure.scale.Ludlow2014.F90
@@ -63,6 +63,9 @@ contains
     type(inputParameters                       ), intent(inout) :: parameters
 
     self%darkMatterProfileScaleRadiusLudlow2016=darkMatterProfileScaleRadiusLudlow2016(parameters)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function ludlow2014ConstructorParameters
 

--- a/source/dark_matter_profiles.structure.scale.zero.F90
+++ b/source/dark_matter_profiles.structure.scale.zero.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(darkMatterProfileScaleRadiusZero)                :: self
     type(inputParameters                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=darkMatterProfileScaleRadiusZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/dark_matter_profiles_DMO.multiple.F90
+++ b/source/dark_matter_profiles_DMO.multiple.F90
@@ -83,6 +83,7 @@ contains
     !!]
     self=darkMatterProfileDMOMultiple(darkMatterProfileDMOHost_,darkMatterProfileDMOSatellite_)
     !![
+    <inputParametersValidate source="parameters"/>
     <objectDestructor name="darkMatterProfileDMOHost_"     />
     <objectDestructor name="darkMatterProfileDMOSatellite_"/>
     !!]

--- a/source/galactic.filters.always.F90
+++ b/source/galactic.filters.always.F90
@@ -51,10 +51,12 @@ contains
     use :: Input_Parameters, only : inputParameters
     implicit none
     type(galacticFilterAlways)                :: alwaysConstructorParameters
-    type(inputParameters     ), intent(in   ) :: parameters
-    !$GLC attributes unused :: parameters
+    type(inputParameters     ), intent(inout) :: parameters
 
     alwaysConstructorParameters=galacticFilterAlways()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function alwaysConstructorParameters
 

--- a/source/galactic.filters.halo_always_isolated.F90
+++ b/source/galactic.filters.halo_always_isolated.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(galacticFilterHaloAlwaysIsolated)                :: self
     type(inputParameters                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=galacticFilterHaloAlwaysIsolated()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function haloAlwaysIsolatedConstructorParameters
 

--- a/source/galactic.filters.halo_isolated.F90
+++ b/source/galactic.filters.halo_isolated.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(galacticFilterHaloIsolated)                :: self
     type(inputParameters           ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=galacticFilterHaloIsolated()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function haloIsolatedConstructorParameters
 

--- a/source/galactic.filters.halo_not_isolated.F90
+++ b/source/galactic.filters.halo_not_isolated.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(galacticFilterHaloNotIsolated)                :: self
     type(inputParameters              ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=galacticFilterHaloNotIsolated()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function haloNotIsolatedConstructorParameters
 

--- a/source/galactic.filters.main_branch.F90
+++ b/source/galactic.filters.main_branch.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(galacticFilterMainBranch)                :: self
     type(inputParameters         ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=galacticFilterMainBranch()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function mainBranchConstructorParameters
 

--- a/source/galactic.filters.root_node.F90
+++ b/source/galactic.filters.root_node.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(galacticFilterRootNode)                :: self
     type(inputParameters       ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=galacticFilterRootNode()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function rootNodeConstructorParameters
 

--- a/source/galactic.filters.tree_hosted.F90
+++ b/source/galactic.filters.tree_hosted.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(galacticFilterTreeHosted)                :: self
     type(inputParameters         ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=galacticFilterTreeHosted()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function treeHostedConstructorParameters
 

--- a/source/galactic_dynamics.bar_instability.stable.F90
+++ b/source/galactic_dynamics.bar_instability.stable.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(galacticDynamicsBarInstabilityStable)                :: self
     type(inputParameters                     ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=galacticDynamicsBarInstabilityStable()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function stableConstructorParameters
 

--- a/source/galactic_structure.radius_solver.null.F90
+++ b/source/galactic_structure.radius_solver.null.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(galacticStructureSolverNull)                :: self
     type(inputParameters            ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=galacticStructureSolverNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/galacticus.output.analyses.distribution_normalizer.bin_width.F90
+++ b/source/galacticus.output.analyses.distribution_normalizer.bin_width.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisDistributionNormalizerBinWidth)                :: self
     type(inputParameters                             ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=outputAnalysisDistributionNormalizerBinWidth()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function binWidthConstructorParameters
 

--- a/source/galacticus.output.analyses.distribution_normalizer.identity.F90
+++ b/source/galacticus.output.analyses.distribution_normalizer.identity.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisDistributionNormalizerIdentity)                :: self
     type(inputParameters                             ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=outputAnalysisDistributionNormalizerIdentity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function identityConstructorParameters
 

--- a/source/galacticus.output.analyses.distribution_normalizer.log10_to_log.F90
+++ b/source/galacticus.output.analyses.distribution_normalizer.log10_to_log.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisDistributionNormalizerLog10ToLog)                :: self
     type(inputParameters                               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=outputAnalysisDistributionNormalizerLog10ToLog()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function log10ToLogConstructorParameters
 

--- a/source/galacticus.output.analyses.distribution_normalizer.unitarity.F90
+++ b/source/galacticus.output.analyses.distribution_normalizer.unitarity.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisDistributionNormalizerUnitarity)                :: self
     type(inputParameters                              ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=outputAnalysisDistributionNormalizerUnitarity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function unitarityConstructorParameters
 

--- a/source/galacticus.output.analyses.distribution_operator.disk_size_inclination.F90
+++ b/source/galacticus.output.analyses.distribution_operator.disk_size_inclination.F90
@@ -63,9 +63,11 @@ contains
     implicit none
     type(outputAnalysisDistributionOperatorDiskSizeInclntn)                :: self
     type(inputParameters                                  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=outputAnalysisDistributionOperatorDiskSizeInclntn()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function diskSizeInclinationConstructorParameters
 

--- a/source/galacticus.output.analyses.distribution_operator.identity.F90
+++ b/source/galacticus.output.analyses.distribution_operator.identity.F90
@@ -53,9 +53,11 @@ contains
     implicit none
     type(outputAnalysisDistributionOperatorIdentity)                :: self
     type(inputParameters                           ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=outputAnalysisDistributionOperatorIdentity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function identityConstructorParameters
 

--- a/source/galacticus.output.analyses.null.F90
+++ b/source/galacticus.output.analyses.null.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(outputAnalysisNull)                :: nullConstructorParameters
     type(inputParameters   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     nullConstructorParameters=outputAnalysisNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/galacticus.output.analyses.property_operator.antiLog10.F90
+++ b/source/galacticus.output.analyses.property_operator.antiLog10.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisPropertyOperatorAntiLog10)                :: antiLog10ConstructorParameters
     type(inputParameters                        ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     antiLog10ConstructorParameters=outputAnalysisPropertyOperatorAntiLog10()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function antiLog10ConstructorParameters
 

--- a/source/galacticus.output.analyses.property_operator.boolean.F90
+++ b/source/galacticus.output.analyses.property_operator.boolean.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisPropertyOperatorBoolean)                :: self
     type(inputParameters                      ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=outputAnalysisPropertyOperatorBoolean()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function booleanConstructorParameters
 

--- a/source/galacticus.output.analyses.property_operator.identity.F90
+++ b/source/galacticus.output.analyses.property_operator.identity.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisPropertyOperatorIdentity)                :: identityConstructorParameters
     type(inputParameters                       ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     identityConstructorParameters=outputAnalysisPropertyOperatorIdentity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function identityConstructorParameters
 

--- a/source/galacticus.output.analyses.property_operator.log10.F90
+++ b/source/galacticus.output.analyses.property_operator.log10.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisPropertyOperatorLog10)                :: log10ConstructorParameters
     type(inputParameters                    ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     log10ConstructorParameters=outputAnalysisPropertyOperatorLog10()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function log10ConstructorParameters
 

--- a/source/galacticus.output.analyses.property_operator.magnitude.F90
+++ b/source/galacticus.output.analyses.property_operator.magnitude.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisPropertyOperatorMagnitude)                :: magnitudeConstructorParameters
     type(inputParameters                        ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     magnitudeConstructorParameters=outputAnalysisPropertyOperatorMagnitude()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function magnitudeConstructorParameters
 

--- a/source/galacticus.output.analyses.property_operator.square.F90
+++ b/source/galacticus.output.analyses.property_operator.square.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(outputAnalysisPropertyOperatorSquare)                :: squareConstructorParameters
     type(inputParameters                     ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     squareConstructorParameters=outputAnalysisPropertyOperatorSquare()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function squareConstructorParameters
 

--- a/source/galacticus.output.analyses.weight_operator.identity.F90
+++ b/source/galacticus.output.analyses.weight_operator.identity.F90
@@ -52,10 +52,12 @@ contains
     implicit none
     type(outputAnalysisWeightOperatorIdentity)                :: self
     type(inputParameters                     ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     ! Construct the object.
     self=outputAnalysisWeightOperatorIdentity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function identityConstructorParameters
 

--- a/source/galacticus.output.analyses.weight_operator.subsampling.F90
+++ b/source/galacticus.output.analyses.weight_operator.subsampling.F90
@@ -52,10 +52,11 @@ contains
     implicit none
     type(outputAnalysisWeightOperatorSubsampling)                :: self
     type(inputParameters                        ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
-    ! Construct the object.
     self=outputAnalysisWeightOperatorSubsampling()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function subsamplingConstructorParameters
 

--- a/source/geometry.surveys.Bernardi-2013-SDSS.F90
+++ b/source/geometry.surveys.Bernardi-2013-SDSS.F90
@@ -91,10 +91,11 @@ contains
     implicit none
     type(surveyGeometryBernardi2013SDSS)                :: self
     type(inputParameters               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
-    ! Build the object.
     self=surveyGeometryBernardi2013SDSS()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function bernardi2013SDSSConstructorParameters
 

--- a/source/halo_model.power_spectrum_modifier.identity.F90
+++ b/source/halo_model.power_spectrum_modifier.identity.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(haloModelPowerSpectrumModifierIdentity)                :: self
     type(inputParameters                       ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=haloModelPowerSpectrumModifierIdentity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function identityConstructorParameters
 

--- a/source/hot_halo.mass_distribution.null.F90
+++ b/source/hot_halo.mass_distribution.null.F90
@@ -59,9 +59,11 @@ contains
     implicit none
     type(hotHaloMassDistributionNull)                :: self
     type(inputParameters            ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=hotHaloMassDistributionNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/hot_halo.outflow_reincorporation.zero.F90
+++ b/source/hot_halo.outflow_reincorporation.zero.F90
@@ -53,9 +53,11 @@ contains
     implicit none
     type(hotHaloOutflowReincorporationZero)                :: self
     type(inputParameters                  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=hotHaloOutflowReincorporationZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/hot_halo.ram_pressure_force.zero.F90
+++ b/source/hot_halo.ram_pressure_force.zero.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(hotHaloRamPressureForceZero)                :: self
     type(inputParameters            ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=hotHaloRamPressureForceZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/math.operators.unary.identity.F90
+++ b/source/math.operators.unary.identity.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(operatorUnaryIdentity)                :: self
     type(inputParameters      ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=operatorUnaryIdentity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function identityConstructorParameters
 

--- a/source/math.operators.unary.inverse.F90
+++ b/source/math.operators.unary.inverse.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(operatorUnaryInverse)                :: self
     type(inputParameters     ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=operatorUnaryInverse()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function inverseConstructorParameters
 

--- a/source/math.operators.unary.logarithm.F90
+++ b/source/math.operators.unary.logarithm.F90
@@ -57,9 +57,11 @@ contains
     implicit none
     type(operatorUnaryLogarithm)                :: self
     type(inputParameters       ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=operatorUnaryLogarithm()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function logarithmConstructorParameters
 

--- a/source/merger_trees.branching_probability.modifier.identity.F90
+++ b/source/merger_trees.branching_probability.modifier.identity.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(mergerTreeBranchingProbabilityModifierIdentity)                :: self
     type(inputParameters                               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=mergerTreeBranchingProbabilityModifierIdentity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function identityConstructorParameters
 

--- a/source/merger_trees.build.controller.uncontrolled.F90
+++ b/source/merger_trees.build.controller.uncontrolled.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(mergerTreeBuildControllerUncontrolled)                :: self
     type(inputParameters                      ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=mergerTreeBuildControllerUncontrolled()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function uncontrolledConstructorParameters
 

--- a/source/merger_trees.construct.build.masses.sampled_distribution.pseudo_random.F90
+++ b/source/merger_trees.construct.build.masses.sampled_distribution.pseudo_random.F90
@@ -59,6 +59,7 @@ contains
     self%mergerTreeBuildMassesSampledDistribution=mergerTreeBuildMassesSampledDistribution(parameters)
     !![
     <objectBuilder class="randomNumberGenerator" name="self%randomNumberGenerator_" source="parameters"/>
+    <inputParametersValidate source="parameters"/>
     !!]
     return
   end function sampledDistributionPseudoRandomConstructorParameters

--- a/source/merger_trees.construct.build.masses.sampled_distribution.quasi_random.F90
+++ b/source/merger_trees.construct.build.masses.sampled_distribution.quasi_random.F90
@@ -54,6 +54,9 @@ contains
     type(inputParameters                                    ), intent(inout) :: parameters
 
     self%mergerTreeBuildMassesSampledDistribution=mergerTreeBuildMassesSampledDistribution(parameters)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function sampledDistributionQuasiRandomConstructorParameters
 

--- a/source/merger_trees.construct.build.masses.sampled_distribution.uniform.F90
+++ b/source/merger_trees.construct.build.masses.sampled_distribution.uniform.F90
@@ -54,6 +54,9 @@ contains
     type(inputParameters                                ), intent(inout) :: parameters
 
     self%mergerTreeBuildMassesSampledDistribution=mergerTreeBuildMassesSampledDistribution(parameters)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function sampledDistributionUniformConstructorParameters
 

--- a/source/merger_trees.construct.build.masses.union.F90
+++ b/source/merger_trees.construct.build.masses.union.F90
@@ -73,6 +73,9 @@ contains
        end if
        mergerTreeBuildMasses_%mergerTreeBuildMasses_ => mergerTreeBuildMasses(parameters,i)
     end do
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function unionConstructorParameters
 

--- a/source/merger_trees.evolve.profiler.null.F90
+++ b/source/merger_trees.evolve.profiler.null.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(mergerTreeEvolveProfilerNull)                :: self
     type(inputParameters           ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=mergerTreeEvolveProfilerNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/merger_trees.evolve.timesteps.satellite_destruction.F90
+++ b/source/merger_trees.evolve.timesteps.satellite_destruction.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(mergerTreeEvolveTimestepSatelliteDestruction)                :: self
     type(inputParameters                             ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=mergerTreeEvolveTimestepSatelliteDestruction()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function satelliteDestructionConstructorParameters
 

--- a/source/merger_trees.filter.always.F90
+++ b/source/merger_trees.filter.always.F90
@@ -51,10 +51,12 @@ contains
     use :: Input_Parameters, only : inputParameters
     implicit none
     type(mergerTreeFilterAlways)                :: alwaysConstructorParameters
-    type(inputParameters       ), intent(in   ) :: parameters
-    !$GLC attributes unused :: parameters
+    type(inputParameters       ), intent(inout) :: parameters
 
     alwaysConstructorParameters=mergerTreeFilterAlways()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function alwaysConstructorParameters
 

--- a/source/merger_trees.node_merger.multi_level_hierarchy.F90
+++ b/source/merger_trees.node_merger.multi_level_hierarchy.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(mergerTreeNodeMergerMultiLevelHierarchy)                :: self
     type(inputParameters                        ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=mergerTreeNodeMergerMultiLevelHierarchy()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function multiLevelHierarchyConstructorParameters
 

--- a/source/merger_trees.node_merger.single_level_hierarchy.F90
+++ b/source/merger_trees.node_merger.single_level_hierarchy.F90
@@ -57,9 +57,11 @@ contains
     implicit none
     type(mergerTreeNodeMergerSingleLevelHierarchy)                :: self
     type(inputParameters                         ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=mergerTreeNodeMergerSingleLevelHierarchy()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function singleLevelHierarchyConstructorParameters
 

--- a/source/merger_trees.operators.deforest.F90
+++ b/source/merger_trees.operators.deforest.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(mergerTreeOperatorDeforest)                :: deforestConstructorParameters
     type(inputParameters           ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     deforestConstructorParameters=mergerTreeOperatorDeforest()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function deforestConstructorParameters
 

--- a/source/merger_trees.operators.monotonize_mass_growth.F90
+++ b/source/merger_trees.operators.monotonize_mass_growth.F90
@@ -58,9 +58,11 @@ contains
     implicit none
     type(mergerTreeOperatorMonotonizeMassGrowth)                :: monotonizeMassGrowthConstructorParameters
     type(inputParameters                       ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     monotonizeMassGrowthConstructorParameters=mergerTreeOperatorMonotonizeMassGrowth()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function monotonizeMassGrowthConstructorParameters
 

--- a/source/merger_trees.operators.null.F90
+++ b/source/merger_trees.operators.null.F90
@@ -51,8 +51,10 @@ contains
     implicit none
     type(mergerTreeOperatorNull)                :: nullConstructorParameters
     type(inputParameters       ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     nullConstructorParameters=mergerTreeOperatorNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters

--- a/source/merger_trees.operators.prune_branch_tips.F90
+++ b/source/merger_trees.operators.prune_branch_tips.F90
@@ -53,9 +53,11 @@ contains
     implicit none
     type   (mergerTreeOperatorPruneBranchTips)                :: self
     type   (inputParameters                  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=mergerTreeOperatorPruneBranchTips()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function pruneBranchTipsConstructorParameters
 

--- a/source/merger_trees.operators.prune_clones.F90
+++ b/source/merger_trees.operators.prune_clones.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(mergerTreeOperatorPruneClones)                :: pruneClonesConstructorParameters
     type(inputParameters              ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     pruneClonesConstructorParameters=mergerTreeOperatorPruneClones()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function pruneClonesConstructorParameters
 

--- a/source/merger_trees.outputter.null.F90
+++ b/source/merger_trees.outputter.null.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(mergerTreeOutputterNull)                :: self
     type(inputParameters        ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=mergerTreeOutputterNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/meta.tree_processing_times.file.F90
+++ b/source/meta.tree_processing_times.file.F90
@@ -82,6 +82,9 @@ contains
     </inputParameter>
     !!]
     self=metaTreeProcessingTimeFile(fileName)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function fileConstructorParameters
 

--- a/source/models.likelihoods.independent_likelihoods.F90
+++ b/source/models.likelihoods.independent_likelihoods.F90
@@ -127,6 +127,9 @@ contains
           call Galacticus_Error_Report('invalid parameter'//{introspection:location})
        end if
     end do
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function independentLikelihoodsConstructorParameters
 

--- a/source/models.likelihoods.independent_likelihoods.sequential.F90
+++ b/source/models.likelihoods.independent_likelihoods.sequential.F90
@@ -114,6 +114,9 @@ contains
     self%evaluateCount                                  =0
     self%evaluateCountGlobal                            =0
     self%forceCount                                     =0
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function independentLikelihoodsSequentialConstructorParameters
 

--- a/source/nBody.operator.null.F90
+++ b/source/nBody.operator.null.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type   (nbodyOperatorNull)                :: self
     type   (inputParameters  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nbodyOperatorNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/nodes.operators.metadata.index_branch_tip.F90
+++ b/source/nodes.operators.metadata.index_branch_tip.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(nodeOperatorIndexBranchTip)                :: self
     type(inputParameters           ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=nodeOperatorIndexBranchTip()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function indexBranchTipConstructorParameters
 

--- a/source/nodes.operators.metadata.index_shift.F90
+++ b/source/nodes.operators.metadata.index_shift.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(nodeOperatorIndexShift)                :: self
     type(inputParameters       ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=nodeOperatorIndexShift()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function indexShiftConstructorParameters
 

--- a/source/nodes.operators.metadata.preset_named_shift.F90
+++ b/source/nodes.operators.metadata.preset_named_shift.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(nodeOperatorPresetNamedShift)                :: self
     type(inputParameters             ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=nodeOperatorPresetNamedShift()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function presetNamedShiftConstructorParameters
 

--- a/source/nodes.operators.null.F90
+++ b/source/nodes.operators.null.F90
@@ -51,8 +51,10 @@ contains
     implicit none
     type(nodeOperatorNull)                :: self
     type(inputParameters ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodeOperatorNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters

--- a/source/nodes.property_extractor.dark_matter_profile.scale_radius.F90
+++ b/source/nodes.property_extractor.dark_matter_profile.scale_radius.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type (nodePropertyExtractorDarkMatterProfileScaleRadius)                :: self
     type (inputParameters                                  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=nodePropertyExtractorDarkMatterProfileScaleRadius()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function darkMatterProfileScaleRadiusConstructorParameters
 

--- a/source/nodes.property_extractor.dark_matter_profile.shape_parameter.F90
+++ b/source/nodes.property_extractor.dark_matter_profile.shape_parameter.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type (nodePropertyExtractorDarkMatterProfileShapeParameter)                :: self
     type (inputParameters                                  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=nodePropertyExtractorDarkMatterProfileShapeParameter()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function darkMatterProfileShapeParameterConstructorParameters
 

--- a/source/nodes.property_extractor.final_descendent.F90
+++ b/source/nodes.property_extractor.final_descendent.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(nodePropertyExtractorFinalDescendent)                :: finalDescendentConstructorParameters
     type(inputParameters                     ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     finalDescendentConstructorParameters=nodePropertyExtractorFinalDescendent()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function finalDescendentConstructorParameters
 

--- a/source/nodes.property_extractor.host_mass.F90
+++ b/source/nodes.property_extractor.host_mass.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(nodePropertyExtractorMassHost)                :: self
     type(inputParameters              ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodePropertyExtractorMassHost()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function massHostConstructorParameters
 

--- a/source/nodes.property_extractor.index_branch_tip.F90
+++ b/source/nodes.property_extractor.index_branch_tip.F90
@@ -57,9 +57,11 @@ contains
     implicit none
     type(nodePropertyExtractorIndexBranchTip)                :: self
     type(inputParameters                    ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodePropertyExtractorIndexBranchTip()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function indexBranchTipConstructorParameters
 

--- a/source/nodes.property_extractor.main_branch.F90
+++ b/source/nodes.property_extractor.main_branch.F90
@@ -61,9 +61,11 @@ contains
     implicit none
     type(nodePropertyExtractorMainBranchStatus)                :: mainBranchStatusConstructorParameters
     type(inputParameters                      ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     mainBranchStatusConstructorParameters=nodePropertyExtractorMainBranchStatus()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function mainBranchStatusConstructorParameters
 

--- a/source/nodes.property_extractor.mass_basic.F90
+++ b/source/nodes.property_extractor.mass_basic.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type (nodePropertyExtractorMassBasic)                :: self
     type (inputParameters               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=nodePropertyExtractorMassBasic()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function massBasicConstructorParameters
 

--- a/source/nodes.property_extractor.mass_black_hole.F90
+++ b/source/nodes.property_extractor.mass_black_hole.F90
@@ -57,9 +57,11 @@ contains
     implicit none
     type(nodePropertyExtractorMassBlackHole)                :: massBlackHoleConstructorParameters
     type(inputParameters                   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     massBlackHoleConstructorParameters=nodePropertyExtractorMassBlackHole()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function massBlackHoleConstructorParameters
 

--- a/source/nodes.property_extractor.mass_bound.F90
+++ b/source/nodes.property_extractor.mass_bound.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type (nodePropertyExtractorMassBound)                :: self
     type (inputParameters               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=nodePropertyExtractorMassBound()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function massBoundConstructorParameters
 

--- a/source/nodes.property_extractor.most_massive_progenitor.F90
+++ b/source/nodes.property_extractor.most_massive_progenitor.F90
@@ -61,9 +61,11 @@ contains
     implicit none
     type(nodePropertyExtractorMostMassiveProgenitor)                :: self
     type(inputParameters                           ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodePropertyExtractorMostMassiveProgenitor()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function mostMassiveProgenitorConstructorParameters
 

--- a/source/nodes.property_extractor.node_indices.F90
+++ b/source/nodes.property_extractor.node_indices.F90
@@ -90,9 +90,11 @@ contains
     implicit none
     type(nodePropertyExtractorNodeIndices)                :: self
     type(inputParameters                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodePropertyExtractorNodeIndices()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nodeIndicesConstructorParameters
 

--- a/source/nodes.property_extractor.null.F90
+++ b/source/nodes.property_extractor.null.F90
@@ -51,10 +51,12 @@ contains
     use :: Input_Parameters, only : inputParameters
     implicit none
     type(nodePropertyExtractorNull)                :: nullConstructorParameters
-    type(inputParameters                    ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
+    type(inputParameters          ), intent(inout) :: parameters
 
     nullConstructorParameters=nodePropertyExtractorNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/nodes.property_extractor.position_orbital.F90
+++ b/source/nodes.property_extractor.position_orbital.F90
@@ -66,9 +66,11 @@ contains
     implicit none
     type(nodePropertyExtractorPositionOrbital)                :: self
     type(inputParameters                     ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodePropertyExtractorPositionOrbital()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function positionOrbitalConstructorParameters
 

--- a/source/nodes.property_extractor.radius_orbital.F90
+++ b/source/nodes.property_extractor.radius_orbital.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(nodePropertyExtractorRadiusOrbital)                :: self
     type(inputParameters                   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodePropertyExtractorRadiusOrbital()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function radiusOrbitalConstructorParameters
 

--- a/source/nodes.property_extractor.speed_orbital.F90
+++ b/source/nodes.property_extractor.speed_orbital.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(nodePropertyExtractorSpeedOrbital)                :: self
     type(inputParameters                  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodePropertyExtractorSpeedOrbital()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function speedOrbitalConstructorParameters
 

--- a/source/nodes.property_extractor.time.F90
+++ b/source/nodes.property_extractor.time.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type (nodePropertyExtractorTime)                :: self
     type (inputParameters          ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=nodePropertyExtractorTime()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function timeConstructorParameters
 

--- a/source/nodes.property_extractor.tree_indices.F90
+++ b/source/nodes.property_extractor.tree_indices.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(nodePropertyExtractorIndicesTree)                :: indicesTreeConstructorParameters
     type(inputParameters                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     indicesTreeConstructorParameters=nodePropertyExtractorIndicesTree()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function indicesTreeConstructorParameters
 

--- a/source/nodes.property_extractor.tree_weight.F90
+++ b/source/nodes.property_extractor.tree_weight.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(nodePropertyExtractorTreeWeight)                :: self
     type(inputParameters                ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodePropertyExtractorTreeWeight()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function treeWeightConstructorParameters
 

--- a/source/nodes.property_extractor.velocity_orbital.F90
+++ b/source/nodes.property_extractor.velocity_orbital.F90
@@ -66,9 +66,11 @@ contains
     implicit none
     type(nodePropertyExtractorVelocityOrbital)                :: self
     type(inputParameters                     ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=nodePropertyExtractorVelocityOrbital()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function velocityOrbitalConstructorParameters
 

--- a/source/posterior_sampling.convergence.always.F90
+++ b/source/posterior_sampling.convergence.always.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(posteriorSampleConvergenceAlways)                :: self
     type(inputParameters                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=posteriorSampleConvergenceAlways()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function alwaysConstructorParameters
 

--- a/source/posterior_sampling.convergence.never.F90
+++ b/source/posterior_sampling.convergence.never.F90
@@ -59,9 +59,11 @@ contains
     implicit none
     type(posteriorSampleConvergenceNever)                :: self
     type(inputParameters                ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=posteriorSampleConvergenceNever()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function neverConstructorParameters
 

--- a/source/posterior_sampling.differential_random_jump.adaptive.F90
+++ b/source/posterior_sampling.differential_random_jump.adaptive.F90
@@ -60,9 +60,11 @@ contains
     implicit none
     type(posteriorSampleDffrntlEvltnRandomJumpAdaptive)                 :: self
     type(inputParameters                              ), intent(inout)  :: parameters
-    !$GLC attributes unused :: parameters
 
     self=posteriorSampleDffrntlEvltnRandomJumpAdaptive()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function adaptiveConstructorParameters
 

--- a/source/posterior_sampling.differential_random_jump.simple.F90
+++ b/source/posterior_sampling.differential_random_jump.simple.F90
@@ -58,9 +58,11 @@ contains
     implicit none
     type(posteriorSampleDffrntlEvltnRandomJumpSimple)                 :: self
     type(inputParameters                            ), intent(inout)  :: parameters
-    !$GLC attributes unused :: parameters
 
     self=posteriorSampleDffrntlEvltnRandomJumpSimple()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function simpleConstructorParameters
 

--- a/source/posterior_sampling.state.initialize.prior_random.F90
+++ b/source/posterior_sampling.state.initialize.prior_random.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(posteriorSampleStateInitializePriorRandom)                :: self
     type(inputParameters                          ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=posteriorSampleStateInitializePriorRandom()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function priorRandomConstructorParameters
 

--- a/source/posterior_sampling.stopping_criteria.never.F90
+++ b/source/posterior_sampling.stopping_criteria.never.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(posteriorSampleStoppingCriterionNever)                :: self
     type(inputParameters                      ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=posteriorSampleStoppingCriterionNever()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function neverConstructorParameters
 

--- a/source/radiation.null.F90
+++ b/source/radiation.null.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(radiationFieldNull)                :: self
     type(inputParameters   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=radiationFieldNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/radiative_transfer.convergence.Lyc_escape.F90
+++ b/source/radiative_transfer.convergence.Lyc_escape.F90
@@ -63,6 +63,9 @@ contains
     </inputParameter>
     !!]
     self=radiativeTransferConvergenceLycEscape(toleranceRelative)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function lycEscapeConstructorParameters
 

--- a/source/radiative_transfer.convergence.always.F90
+++ b/source/radiative_transfer.convergence.always.F90
@@ -49,9 +49,11 @@ contains
     implicit none
     type(radiativeTransferConvergenceAlways)                :: self
     type(inputParameters                   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=radiativeTransferConvergenceAlways()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function alwaysConstructorParameters
 

--- a/source/radiative_transfer.convergence.atomic_recombination_rate.F90
+++ b/source/radiative_transfer.convergence.atomic_recombination_rate.F90
@@ -63,6 +63,9 @@ contains
     </inputParameter>
     !!]
     self=radiativeTransferConvergenceHydrogenRecombinationRate(toleranceRelative)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function hydrogenRecombinationRateConstructorParameters
 

--- a/source/radiative_transfer.matter.atomic.F90
+++ b/source/radiative_transfer.matter.atomic.F90
@@ -229,6 +229,7 @@ contains
     !!]
     self=radiativeTransferMatterAtomic(abundancePattern,metallicity,elements,iterationAverageCount,temperatureMinimum,outputRates,outputAbsorptionCoefficients,convergencePercentile,massDistribution_,atomicCrossSectionIonizationPhoto_,atomicRecombinationRateRadiative_,atomicRecombinationRateRadiativeCooling_,atomicIonizationRateCollisional_,atomicRecombinationRateDielectronic_,atomicIonizationPotential_,atomicExcitationRateCollisional_,gauntFactor_)
     !![
+    <inputParametersValidate source="parameters"/>
     <objectDestructor name="massDistribution_"                       />
     <objectDestructor name="atomicCrossSectionIonizationPhoto_"      />
     <objectDestructor name="atomicRecombinationRateRadiative_"       />

--- a/source/radiative_transfer.outputter.Lyman_Continuum_rate.F90
+++ b/source/radiative_transfer.outputter.Lyman_Continuum_rate.F90
@@ -57,9 +57,11 @@ contains
     implicit none
     type(radiativeTransferOutputterLymanContinuumRate)                :: self
     type(inputParameters                             ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=radiativeTransferOutputterLymanContinuumRate()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function lymanContinuumRateConstructorParameters
   

--- a/source/radiative_transfer.outputter.null.F90
+++ b/source/radiative_transfer.outputter.null.F90
@@ -48,8 +48,10 @@ contains
     implicit none
     type(radiativeTransferOutputterNull)                :: self
     type(inputParameters               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=radiativeTransferOutputterNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters

--- a/source/satellites.dynamical_friction.acceleration.zero.F90
+++ b/source/satellites.dynamical_friction.acceleration.zero.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(satelliteDynamicalFrictionZero)                :: self
     type(inputParameters               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=satelliteDynamicalFrictionZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/satellites.merging.remnant_sizes.null.F90
+++ b/source/satellites.merging.remnant_sizes.null.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(mergerRemnantSizeNull)                :: self
     type(inputParameters      ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=mergerRemnantSizeNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/satellites.merging.timescale.Lacey-Cole_Tormen.F90
+++ b/source/satellites.merging.timescale.Lacey-Cole_Tormen.F90
@@ -69,6 +69,9 @@ contains
     type (inputParameters                              ), intent(inout) :: parameters
 
     self%satelliteMergingTimescalesLaceyCole1993=satelliteMergingTimescalesLaceyCole1993(parameters)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function laceyCole1993TormenConstructorParameters
 

--- a/source/satellites.merging.timescale.infinite.F90
+++ b/source/satellites.merging.timescale.infinite.F90
@@ -59,9 +59,11 @@ contains
     implicit none
     type(satelliteMergingTimescalesInfinite)                :: self
     type(inputParameters                   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=satelliteMergingTimescalesInfinite()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function infiniteConstructorParameters
 

--- a/source/satellites.merging.timescale.preset.F90
+++ b/source/satellites.merging.timescale.preset.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(satelliteMergingTimescalesPreset)                :: self
     type(inputParameters                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=satelliteMergingTimescalesPreset()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function presetConstructorParameters
 

--- a/source/satellites.merging.timescale.random.F90
+++ b/source/satellites.merging.timescale.random.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(satelliteMergingTimescalesRandom)                  :: self
     type(inputParameters                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=satelliteMergingTimescalesRandom()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function randomConstructorParameters
 

--- a/source/satellites.merging.timescale.zero.F90
+++ b/source/satellites.merging.timescale.zero.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(satelliteMergingTimescalesZero)                :: self
     type(inputParameters               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=satelliteMergingTimescalesZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/satellites.tidal_fields.null.F90
+++ b/source/satellites.tidal_fields.null.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(satelliteTidalFieldNull)                :: self
     type(inputParameters        ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=satelliteTidalFieldNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/satellites.tidal_heating.rate.zero.F90
+++ b/source/satellites.tidal_heating.rate.zero.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(satelliteTidalHeatingRateZero)                :: self
     type(inputParameters              ), intent(inout) :: parameters
-    !$GLC attributes unused :: self, parameters
 
     self=satelliteTidalHeatingRateZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/satellites.tidal_stripping.rate.zero.F90
+++ b/source/satellites.tidal_stripping.rate.zero.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(satelliteTidalStrippingZero)                :: self
     type(inputParameters            ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=satelliteTidalStrippingZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/star_formation.active_masses.total_ISM.F90
+++ b/source/star_formation.active_masses.total_ISM.F90
@@ -53,9 +53,11 @@ contains
     implicit none
     type(starFormationActiveMassTotalISM)                :: self
     type(inputParameters                ), intent(inout) :: parameters
-    !$GLC attributes unused : parameters
     
     self=starFormationActiveMassTotalISM()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function totalISMConstructorParameters
 

--- a/source/star_formation.histories.null.F90
+++ b/source/star_formation.histories.null.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(starFormationHistoryNull)                :: self
     type(inputParameters         ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=starFormationHistoryNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/statistics.mass_function.incompleteness.complete.F90
+++ b/source/statistics.mass_function.incompleteness.complete.F90
@@ -54,9 +54,11 @@ contains
     implicit none
     type(massFunctionIncompletenessComplete)                :: self
     type(inputParameters                   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=massFunctionIncompletenessComplete()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function completeConstructorParameters
 

--- a/source/stellar_feedback.outflows.zero.F90
+++ b/source/stellar_feedback.outflows.zero.F90
@@ -52,9 +52,11 @@ contains
     implicit none
     type(stellarFeedbackOutflowsZero)                :: self
     type(inputParameters            ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=stellarFeedbackOutflowsZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zeroConstructorParameters
 

--- a/source/stellar_populations.initial_mass_functions.BPASS.F90
+++ b/source/stellar_populations.initial_mass_functions.BPASS.F90
@@ -61,9 +61,11 @@ contains
     implicit none
     type(initialMassFunctionBPASS)                :: self
     type(inputParameters         ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=initialMassFunctionBPASS()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function bpassConstructorParameters
 

--- a/source/stellar_populations.initial_mass_functions.Baugh2005TopHeavy.F90
+++ b/source/stellar_populations.initial_mass_functions.Baugh2005TopHeavy.F90
@@ -60,9 +60,11 @@ contains
     implicit none
     type(initialMassFunctionBaugh2005TopHeavy)                :: self
     type(inputParameters                     ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=initialMassFunctionBaugh2005TopHeavy()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function baugh2005TopHeavyConstructorParameters
 

--- a/source/stellar_populations.initial_mass_functions.Kennicutt1983.F90
+++ b/source/stellar_populations.initial_mass_functions.Kennicutt1983.F90
@@ -62,9 +62,11 @@ contains
     implicit none
     type(initialMassFunctionKennicutt1983)                :: self
     type(inputParameters                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=initialMassFunctionKennicutt1983()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function kennicutt1983ConstructorParameters
 

--- a/source/stellar_populations.initial_mass_functions.Kroupa2001.F90
+++ b/source/stellar_populations.initial_mass_functions.Kroupa2001.F90
@@ -63,9 +63,11 @@ contains
     implicit none
     type(initialMassFunctionKroupa2001)                :: self
     type(inputParameters              ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=initialMassFunctionKroupa2001()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function kroupa2001ConstructorParameters
 

--- a/source/stellar_populations.initial_mass_functions.MillerScalo1979.F90
+++ b/source/stellar_populations.initial_mass_functions.MillerScalo1979.F90
@@ -63,9 +63,11 @@ contains
     implicit none
     type(initialMassFunctionMillerScalo1979)                :: self
     type(inputParameters                   ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=initialMassFunctionMillerScalo1979()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function millerScalo1979ConstructorParameters
 

--- a/source/stellar_populations.initial_mass_functions.Salpeter1955.F90
+++ b/source/stellar_populations.initial_mass_functions.Salpeter1955.F90
@@ -62,9 +62,11 @@ contains
     implicit none
     type(initialMassFunctionSalpeter1955)                :: self
     type(inputParameters                ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=initialMassFunctionSalpeter1955()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function salpeter1955ConstructorParameters
 

--- a/source/stellar_populations.initial_mass_functions.Scalo1986.F90
+++ b/source/stellar_populations.initial_mass_functions.Scalo1986.F90
@@ -65,9 +65,11 @@ contains
     implicit none
     type(initialMassFunctionScalo1986)                :: self
     type(inputParameters             ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=initialMassFunctionScalo1986()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function scalo1986ConstructorParameters
 

--- a/source/stellar_populations.spectra.dust_attenuation.Calzetti2000.F90
+++ b/source/stellar_populations.spectra.dust_attenuation.Calzetti2000.F90
@@ -53,9 +53,11 @@ contains
     implicit none
     type(stellarSpectraDustAttenuationCalzetti2000)                :: self
     type(inputParameters                          ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=stellarSpectraDustAttenuationCalzetti2000()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function calzetti2000ConstructorParameters
 

--- a/source/stellar_populations.spectra.dust_attenuation.null.F90
+++ b/source/stellar_populations.spectra.dust_attenuation.null.F90
@@ -52,10 +52,12 @@ contains
     implicit none
     type(stellarSpectraDustAttenuationZero)                :: self
     type(inputParameters                  ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=stellarSpectraDustAttenuationZero()
-   return
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
   end function zeroConstructorParameters
 
   double precision function zeroAttenuation(self,wavelength,age,vBandAttenuation)

--- a/source/stellar_populations.spectra.postprocess.Inoue2014.F90
+++ b/source/stellar_populations.spectra.postprocess.Inoue2014.F90
@@ -147,9 +147,11 @@ contains
     implicit none
     type(stellarPopulationSpectraPostprocessorInoue2014)                :: self
     type(inputParameters                               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=stellarPopulationSpectraPostprocessorInoue2014()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function inoue2014ConstructorParameters
 

--- a/source/stellar_populations.spectra.postprocess.Lyman_continuum_suppress.F90
+++ b/source/stellar_populations.spectra.postprocess.Lyman_continuum_suppress.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(stellarPopulationSpectraPostprocessorLycSuppress)                :: self
     type(inputParameters                                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=stellarPopulationSpectraPostprocessorLycSuppress()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function lycSuppressConstructorParameters
 

--- a/source/stellar_populations.spectra.postprocess.Madau1995.F90
+++ b/source/stellar_populations.spectra.postprocess.Madau1995.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(stellarPopulationSpectraPostprocessorMadau1995)                :: self
     type(inputParameters                               ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=stellarPopulationSpectraPostprocessorMadau1995()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function madau1995ConstructorParameters
 

--- a/source/stellar_populations.spectra.postprocess.Meiksin2006.F90
+++ b/source/stellar_populations.spectra.postprocess.Meiksin2006.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(stellarPopulationSpectraPostprocessorMeiksin2006)                :: self
     type(inputParameters                                 ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=stellarPopulationSpectraPostprocessorMeiksin2006()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function meiksin2006ConstructorParameters
 

--- a/source/stellar_populations.spectra.postprocess.identity.F90
+++ b/source/stellar_populations.spectra.postprocess.identity.F90
@@ -55,9 +55,11 @@ contains
     implicit none
     type(stellarPopulationSpectraPostprocessorIdentity)                :: self
     type(inputParameters                              ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=stellarPopulationSpectraPostprocessorIdentity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function identityConstructorParameters
 

--- a/source/stellar_populations.spectra.postprocess.recent.F90
+++ b/source/stellar_populations.spectra.postprocess.recent.F90
@@ -68,6 +68,9 @@ contains
     </inputParameter>
     !!]
     self=stellarPopulationSpectraPostprocessorRecent(timeLimit)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function recentConstructorParameters
 

--- a/source/stellar_populations.spectra.postprocess.unescaped.F90
+++ b/source/stellar_populations.spectra.postprocess.unescaped.F90
@@ -65,6 +65,9 @@ contains
     </inputParameter>
     !!]
     self=stellarPopulationSpectraPostprocessorUnescaped(timescale)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function unescapedConstructorParameters
 

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.midpoint.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.midpoint.F90
@@ -58,6 +58,9 @@ contains
     type(inputParameters                        ), intent(inout) :: parameters
 
     self%excursionSetFirstCrossingFarahi=excursionSetFirstCrossingFarahi(parameters)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function farahiMidpointConstructorParameters
 

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Zhang_Hui_high_order.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Zhang_Hui_high_order.F90
@@ -147,6 +147,9 @@ contains
 
     self%excursionSetFirstCrossingZhangHui=excursionSetFirstCrossingZhangHui(parameters)
     call self%initialize()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function zhangHuiHighOrderConstructorParameters
 

--- a/source/structure_formation.gravitational_lensing.null.F90
+++ b/source/structure_formation.gravitational_lensing.null.F90
@@ -50,9 +50,11 @@ contains
     implicit none
     type(gravitationalLensingNull)                :: self
     type(inputParameters         ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
     
     self=gravitationalLensingNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function nullConstructorParameters
 

--- a/source/structure_formation.halo_environment.uniform.F90
+++ b/source/structure_formation.halo_environment.uniform.F90
@@ -60,9 +60,11 @@ contains
     implicit none
     type(haloEnvironmentUniform)                :: self
     type(inputParameters       ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=haloEnvironmentUniform()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function uniformConstructorParameters
 

--- a/source/structure_formation.virial_density_contrast.friends-of-friends.F90
+++ b/source/structure_formation.virial_density_contrast.friends-of-friends.F90
@@ -92,6 +92,9 @@ contains
     </inputParameter>
     !!]
     self=virialDensityContrastFriendsOfFriends(linkingLength,densityRatio)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function friendsOfFriendsConstructorParameters
 

--- a/source/tasks.evolve_forests.work_share.cyclic.F90
+++ b/source/tasks.evolve_forests.work_share.cyclic.F90
@@ -56,9 +56,11 @@ contains
     implicit none
     type(evolveForestsWorkShareCyclic)                :: self
     type(inputParameters             ), intent(inout) :: parameters
-    !$GLC attributes unused :: parameters
 
     self=evolveForestsWorkShareCyclic()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function cyclicConstructorParameters
 

--- a/source/tasks.evolve_forests.work_share.first_come_first_served.F90
+++ b/source/tasks.evolve_forests.work_share.first_come_first_served.F90
@@ -72,6 +72,9 @@ contains
     else
        self=evolveForestsWorkShareFCFS(                  )
     end if
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function fcfsConstructorParameters
 

--- a/source/universe.operators.identity.F90
+++ b/source/universe.operators.identity.F90
@@ -51,6 +51,9 @@ contains
     !$GLC attributes unused :: parameters
 
     self=universeOperatorIdentity()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
     return
   end function identityConstructorParameters
 

--- a/testSuite/parameters/test-allowed-parameters.xml
+++ b/testSuite/parameters/test-allowed-parameters.xml
@@ -134,7 +134,11 @@
   <darkMatterProfileDMO value="NFW"/>
 
   <!-- Halo accretion options -->
-  <accretionHalo value="zero"/>
+  <accretionHalo value="coldMode">
+    <widthTransitionStabilityShock value="0.01"/>
+    <redshiftReionization value="10.5"/>
+    <velocitySuppressionReionization value="35.0"/>
+  </accretionHalo>
 
   <!-- Hot halo gas model options -->
   <hotHaloMassDistribution value="null"/>


### PR DESCRIPTION
Correctly handle parameter names allowed in parent/child classes

Do not include parameters from included objects - only the names of those objects