### PR TITLE
Support meta-data for output properties

### DIFF
--- a/source/interface.FSPS.F90
+++ b/source/interface.FSPS.F90
@@ -27,7 +27,7 @@ module Interfaces_FSPS
   !!}
   use :: File_Utilities, only : lockDescriptor
   private
-  public :: Interface_FSPS_Initialize, Interface_FSPS_SSPs_Tabulate
+  public :: Interface_FSPS_Initialize, Interface_FSPS_SSPs_Tabulate, Interface_FSPS_Version
 
   ! Lock object to prevent multiple threads/processes attempting to build the code simultaneously.
   type(lockDescriptor) :: fspsLock
@@ -37,6 +37,18 @@ module Interfaces_FSPS
 
 contains
 
+  subroutine Interface_FSPS_Version(fspsVersion)
+    !!{
+    Set the version of FSPS being used.
+    !!}
+    use :: ISO_Varying_String, only : varying_string, assignment(=)
+    implicit none
+    type(varying_string), intent(  out) :: fspsVersion
+    
+    fspsVersion="3.2"
+    return
+  end subroutine Interface_FSPS_Version
+  
   subroutine Interface_FSPS_Initialize(fspsPath,fspsVersion,static)
     !!{
     Initialize the interface with FSPS, including downloading and compiling FSPS if necessary.
@@ -60,7 +72,7 @@ contains
     !!]
 
     ! Specify source code path.
-    fspsVersion="3.2"
+    call Interface_FSPS_Version(fspsVersion)
     fspsPath=galacticusPath(pathTypeDataDynamic)//"fsps-"//fspsVersion
     lockPath=galacticusPath(pathTypeDataDynamic)//"fsps" //fspsVersion
     call File_Lock(char(lockPath),fspsLock)

--- a/source/merger_trees.outputter.buffer_types.F90
+++ b/source/merger_trees.outputter.buffer_types.F90
@@ -26,6 +26,7 @@ module Merger_Tree_Outputter_Buffer_Types
   Provides buffer types for merger tree outputters.
   !!}
   use :: Kind_Numbers      , only : kind_int8
+  use :: Hashes            , only : doubleHash
   use :: IO_HDF5           , only : hdf5VarDouble
   use :: ISO_Varying_String, only : varying_string
   public
@@ -39,6 +40,7 @@ module Merger_Tree_Outputter_Buffer_Types
      !!}
      character       (len=propertyNameLengthMax   )                              :: name
      character       (len=propertyCommentLengthMax)                              :: comment
+     type            (doubleHash                  ), allocatable                 :: metaData
      double precision                                                            :: unitsInSI
      integer         (kind_int8                   ), allocatable, dimension(:  ) :: scalar
      integer         (kind_int8                   ), allocatable, dimension(:,:) :: rank1
@@ -51,6 +53,7 @@ module Merger_Tree_Outputter_Buffer_Types
      !!}
      character       (len=propertyNameLengthMax   )                              :: name
      character       (len=propertyCommentLengthMax)                              :: comment
+     type            (doubleHash                  ), allocatable                 :: metaData
      double precision                                                            :: unitsInSI
      double precision                              , allocatable, dimension(:  ) :: scalar
      double precision                              , allocatable, dimension(:,:) :: rank1

--- a/source/merger_trees.outputter.standard.F90
+++ b/source/merger_trees.outputter.standard.F90
@@ -192,6 +192,8 @@ contains
     self%integerBufferCount      = 0
     self%integerBufferSize       =standardBufferSizeIncrement
     self%doubleBufferSize        =standardBufferSizeIncrement
+    allocate(self%integerProperty(0))
+    allocate(self% doubleProperty(0))
     !$omp critical(mergerTreeOutputterStandardInitialize)
     if (.not.treeLockInitialized) then
        treeLock           =ompLock()
@@ -318,11 +320,11 @@ contains
           if (.not.treeLock%ownedByThread()) call treeLock%set()
           !$ call hdf5Access%set()
           referenceLength(1)=max(self%integerPropertiesWritten,self%doublePropertiesWritten)
-          if      (allocated(self%integerProperty).and.self%outputGroups(indexOutput)%nodeDataGroup%hasDataset(self%integerProperty(1)%name)) then
+          if      (allocated(self%integerProperty).and.size(self%integerProperty) > 0.and.self%outputGroups(indexOutput)%nodeDataGroup%hasDataset(self%integerProperty(1)%name)) then
              toDataset=self%outputGroups(indexOutput)%nodeDataGroup%openDataset(self%integerProperty(1)%name)
              referenceStart(1)=toDataset%size(1)-referenceLength(1)
              call toDataset%close()
-          else if (allocated(self% doubleProperty).and.self%outputGroups(indexOutput)%nodeDataGroup%hasDataset(self% doubleProperty(1)%name)) then
+          else if (allocated(self% doubleProperty).and.size(self% doubleProperty) > 0.and.self%outputGroups(indexOutput)%nodeDataGroup%hasDataset(self% doubleProperty(1)%name)) then
              toDataset=self%outputGroups(indexOutput)%nodeDataGroup%openDataset(self% doubleProperty(1)%name)
              referenceStart(1)=toDataset%size(1)-referenceLength(1)
              call toDataset%close()
@@ -946,16 +948,20 @@ contains
          &                                                                        i
     type            (varying_string             ), allocatable  , dimension(:) :: namesTmp      , descriptionsTmp
 
-    do i=1,size(self%integerProperty)
-       if (allocated(self%integerProperty(i)%metaData)) deallocate(self%integerProperty(i)%metaData)
-       allocate(self%integerProperty(i)%metaData)
-       self%integerProperty(i)%metaData=doubleHash()
-    end do
-    do i=1,size(self%doubleProperty )
-       if (allocated(self%doubleProperty (i)%metaData)) deallocate(self%doubleProperty (i)%metaData)
-       allocate(self%doubleProperty (i)%metaData)
-       self%doubleProperty (i)%metaData=doubleHash()
-    end do
+    if (allocated(self%integerProperty)) then
+       do i=1,size(self%integerProperty)
+          if (allocated(self%integerProperty(i)%metaData)) deallocate(self%integerProperty(i)%metaData)
+          allocate(self%integerProperty(i)%metaData)
+          self%integerProperty(i)%metaData=doubleHash()
+       end do
+    end if
+    if (allocated(self%doubleProperty )) then
+       do i=1,size(self%doubleProperty )
+          if (allocated(self%doubleProperty (i)%metaData)) deallocate(self%doubleProperty (i)%metaData)
+          allocate(self%doubleProperty (i)%metaData)
+          self%doubleProperty (i)%metaData=doubleHash()
+       end do
+    end if
     integerProperty=0
     doubleProperty =0
     !![

--- a/source/nodes.property_extractor.array.F90
+++ b/source/nodes.property_extractor.array.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  use :: Hashes, only : doubleHash
+
   !![
   <nodePropertyExtractor name="nodePropertyExtractorArray" abstract="yes">
    <description>An abstract output analysis property extractor class which provieds a array of floating point properties.</description>
@@ -37,6 +39,7 @@
        <method method="names"              description="Return the name of the properties extracted."                       />
        <method method="descriptions"       description="Return a description of the properties extracted."                  />
        <method method="unitsInSI"          description="Return the units of the properties extracted in the SI system."     />
+       <method method="metaData"           description="Populate a hash with meta-data for the property."                   />
      </methods>
      !!]
      procedure(arrayDescriptions), deferred :: columnDescriptions
@@ -46,6 +49,7 @@
      procedure(arrayNames       ), deferred :: names
      procedure(arrayDescriptions), deferred :: descriptions
      procedure(arrayUnitsInSI   ), deferred :: unitsInSI
+     procedure                              :: metaData           => arrayMetaData
   end type nodePropertyExtractorArray
 
   abstract interface
@@ -120,3 +124,18 @@
        double precision                            , intent(in   ) :: time
      end function arraySize
   end interface
+
+contains
+  
+  subroutine arrayMetaData(self,indexProperty,metaData)
+    !!{
+    Interface for array property meta-data.
+    !!}
+    implicit none
+    class(  nodePropertyExtractorArray), intent(inout) :: self
+    integer                            , intent(in   ) :: indexProperty
+    type   (doubleHash                ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, indexProperty, metaData
+    
+    return
+  end subroutine arrayMetaData

--- a/source/nodes.property_extractor.integer_scalar.F90
+++ b/source/nodes.property_extractor.integer_scalar.F90
@@ -18,6 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   use :: Kind_Numbers, only : kind_int8
+  use :: Hashes      , only : doubleHash
 
   !![
   <nodePropertyExtractor name="nodePropertyExtractorIntegerScalar" abstract="yes">
@@ -36,12 +37,14 @@
        <method method="name"        description="Return the name of the property extracted."                       />
        <method method="description" description="Return a description of the property extracted."                  />
        <method method="unitsInSI"   description="Return the units of the property extracted in the SI system."     />
+       <method method="metaData"    description="Populate a hash with meta-data for the property."                 />
      </methods>
      !!]
      procedure(integerScalarExtract), deferred :: extract
      procedure(integerScalarName   ), deferred :: name
      procedure(integerScalarName   ), deferred :: description
      procedure                                 :: unitsInSI   => integerScalarUnitsInSI
+     procedure                                 :: metaData    => integerScalarMetaData
   end type nodePropertyExtractorIntegerScalar
 
   abstract interface
@@ -82,3 +85,15 @@ contains
     integerScalarUnitsInSI=0.0d0
     return
   end function integerScalarUnitsInSI
+
+  subroutine integerScalarMetaData(self,metaData)
+    !!{
+    Interface for integerScalar property meta-data.
+    !!}
+    implicit none
+    class(nodePropertyExtractorIntegerScalar), intent(inout) :: self
+    type (doubleHash                        ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, metaData
+    
+    return
+  end subroutine integerScalarMetaData

--- a/source/nodes.property_extractor.integer_tuple.F90
+++ b/source/nodes.property_extractor.integer_tuple.F90
@@ -18,6 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   use :: Kind_Numbers, only : kind_int8
+  use :: Hashes      , only : doubleHash
 
   !![
   <nodePropertyExtractor name="nodePropertyExtractorIntegerTuple" abstract="yes">
@@ -37,6 +38,7 @@
        <method method="names"        description="Return the names of the properties extracted."                      />
        <method method="descriptions" description="Return descriptions of the properties extracted."                   />
        <method method="unitsInSI"    description="Return the units of the properties extracted in the SI system."     />
+       <method method="metaData"     description="Populate a hash with meta-data for the property."                   />
      </methods>
      !!]
      procedure(integerTupleElementCount), deferred :: elementCount
@@ -44,6 +46,7 @@
      procedure(integerTupleNames       ), deferred :: names
      procedure(integerTupleDescriptions), deferred :: descriptions
      procedure(integerTupleUnitsInSI   ), deferred :: unitsInSI
+     procedure                                     :: metaData    => integerTupleMetaData
   end type nodePropertyExtractorIntegerTuple
 
   abstract interface
@@ -106,3 +109,18 @@
        double precision                                   , intent(in   ) :: time
      end function integerTupleElementCount
   end interface
+
+contains
+
+  subroutine integerTupleMetaData(self,indexProperty,metaData)
+    !!{
+    Interface for integerTuple property meta-data.
+    !!}
+    implicit none
+    class  (nodePropertyExtractorIntegerTuple), intent(inout) :: self
+    integer                                   , intent(in   ) :: indexProperty
+    type   (doubleHash                       ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, indexProperty, metaData
+    
+    return
+  end subroutine integerTupleMetaData

--- a/source/nodes.property_extractor.list.F90
+++ b/source/nodes.property_extractor.list.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  use :: Hashes, only : doubleHash
+
   !![
   <nodePropertyExtractor name="nodePropertyExtractorList" abstract="yes">
    <description>An abstract output analysis property extractor class which provieds a list of floating point properties.</description>
@@ -34,12 +36,14 @@
        <method method="name"        description="Return the name of the properties extracted."                       />
        <method method="description" description="Return a description of the properties extracted."                  />
        <method method="unitsInSI"   description="Return the units of the properties extracted in the SI system."     />
+       <method method="metaData"    description="Populate a hash with meta-data for the property."                   />
      </methods>
      !!]
      procedure(listExtract    ), deferred :: extract
      procedure(listName       ), deferred :: name
      procedure(listDescription), deferred :: description
      procedure(listUnitsInSI  ), deferred :: unitsInSI
+     procedure                            :: metaData    => listMetaData
   end type nodePropertyExtractorList
 
   abstract interface
@@ -86,3 +90,17 @@
        class (nodePropertyExtractorList), intent(inout) :: self
      end function listUnitsInSI
   end interface
+
+contains
+  
+  subroutine listMetaData(self,metaData)
+    !!{
+    Interface for list property meta-data.
+    !!}
+    implicit none
+    class(nodePropertyExtractorList), intent(inout) :: self
+    type (doubleHash               ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, metaData
+    
+    return
+  end subroutine listMetaData

--- a/source/nodes.property_extractor.scalar.F90
+++ b/source/nodes.property_extractor.scalar.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  use :: Hashes, only : doubleHash
+
   !![
   <nodePropertyExtractor name="nodePropertyExtractorScalar" abstract="yes">
    <description>An abstract output analysis property extractor class which provieds a scalar floating point property.</description>
@@ -34,12 +36,14 @@
        <method method="name"        description="Return the name of the property extracted."                       />
        <method method="description" description="Return a description of the property extracted."                  />
        <method method="unitsInSI"   description="Return the units of the property extracted in the SI system."     />
+       <method method="metaData"    description="Populate a hash with meta-data for the property."                 />
      </methods>
      !!]
      procedure(scalarExtract  ), deferred :: extract
      procedure(scalarName     ), deferred :: name
      procedure(scalarName     ), deferred :: description
      procedure(scalarUnitsInSI), deferred :: unitsInSI
+     procedure                            :: metaData    => scalarMetaData
   end type nodePropertyExtractorScalar
 
   abstract interface
@@ -74,3 +78,17 @@
        class(nodePropertyExtractorScalar), intent(inout) :: self
      end function scalarUnitsInSI
   end interface
+
+contains
+  
+  subroutine scalarMetaData(self,metaData)
+    !!{
+    Interface for scalar property meta-data.
+    !!}
+    implicit none
+    class(nodePropertyExtractorScalar), intent(inout) :: self
+    type (doubleHash                 ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, metaData
+    
+    return
+  end subroutine scalarMetaData

--- a/source/nodes.property_extractor.tuple.F90
+++ b/source/nodes.property_extractor.tuple.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  use :: Hashes, only : doubleHash
+
   !![
   <nodePropertyExtractor name="nodePropertyExtractorTuple" abstract="yes">
    <description>An abstract output analysis property extractor class which provieds a tuple of floating point properties.</description>
@@ -35,6 +37,7 @@
        <method method="names"        description="Return the names of the properties extracted."                      />
        <method method="descriptions" description="Return descriptions of the properties extracted."                   />
        <method method="unitsInSI"    description="Return the units of the properties extracted in the SI system."     />
+       <method method="metaData"    description="Populate a hash with meta-data for the property."                    />
      </methods>
      !!]
      procedure(tupleElementCount), deferred :: elementCount
@@ -42,6 +45,7 @@
      procedure(tupleNames       ), deferred :: names
      procedure(tupleDescriptions), deferred :: descriptions
      procedure(tupleUnitsInSI   ), deferred :: unitsInSI
+     procedure                              :: metaData     => tupleMetaData
   end type nodePropertyExtractorTuple
 
   abstract interface
@@ -104,3 +108,18 @@
        double precision                            , intent(in   ) :: time
      end function tupleElementCount
   end interface
+
+contains
+  
+  subroutine tupleMetaData(self,indexProperty,metaData)
+    !!{
+    Interface for scalar property meta-data.
+    !!}
+    implicit none
+    class  (nodePropertyExtractorTuple), intent(inout) :: self
+    integer                            , intent(in   ) :: indexProperty
+    type   (doubleHash                ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, indexProperty, metaData
+    
+    return
+  end subroutine tupleMetaData

--- a/source/objects.nodes.components.position.preset.interpolated.F90
+++ b/source/objects.nodes.components.position.preset.interpolated.F90
@@ -603,13 +603,19 @@ contains
                   &   Dot_Product(positionRelative(2,:),+vectorInPlaneNormal(k,2,:)) &
                   & ) vectorInPlaneNormal(k,2,:)=-vectorInPlaneNormal(k,2,:)
              !! Find the linear fit coefficients to angle.
-             coefficientsAngle    (k,2)=+acos(                                                                    &
-                  &                           +Dot_Product     (positionRelative(2,:),vectorInPlaneNormal(k,1,:)) &
-                  &                           /Vector_Magnitude(positionRelative(2,:)                           ) &
-                  &                          )                                                                    &
-                  &                     /    (                                                                    &
-                  &                           +time(2) &
-                  &                           -time(1) &
+             coefficientsAngle    (k,2)=+acos(                                                                              &
+                  &                           min(                                                                          &
+                  &                               +1.0d0                                                                  , &
+                  &                               max(                                                                      &
+                  &                                   -1.0d0                                                              , &
+                  &                                   +Dot_Product     (positionRelative(2,:),vectorInPlaneNormal(k,1,:))   &
+                  &                                   /Vector_Magnitude(positionRelative(2,:)                           )   &
+                  &                                  )                                                                      &
+                  &                               )                                                                         &
+                  &                          )                                                                              &
+                  &                     /    (                                                                              &
+                  &                           +time(2)                                                                      &
+                  &                           -time(1)                                                                      &
                   &                          )
              coefficientsAngle    (k,1)=-time(1) &
                   &                     *coefficientsAngle(k,2)

--- a/source/stellar_populations.spectra.FSPS.F90
+++ b/source/stellar_populations.spectra.FSPS.F90
@@ -29,8 +29,9 @@ Implements a stellar population spectra class which utilizes the FSPS package \c
     A stellar population spectra class utilizing the FSPS package \citep{conroy_propagation_2009}. If necessary, the
     \href{https://github.com/cconroy20/fsps}{\normalfont \ttfamily FSPS} code will be downloaded, patched and compiled and run
     to generate spectra. These tabulations are then stored to file for later re-use. The file name used is {\normalfont
-    \ttfamily datasets/dynamic/stellarPopulations/simpleStellarPopulationsFSPS:v2.5\_$&lt;$descriptor$&gt;$.hdf5} where
-    $&lt;${\normalfont \ttfamily descriptor}$&gt;$ is an MD5 hash descriptor of the selected stellar population.
+    \ttfamily datasets/dynamic/stellarPopulations/simpleStellarPopulationsFSPS:v$&lt;$version$&gt;$\_$&lt;$descriptor$&gt;$.hdf5} where
+    $&lt;{\normalfont \ttfamily version}$&gt;$ is the FSPS version used, and $&lt;${\normalfont \ttfamily descriptor}$&gt;$ is
+    an MD5 hash descriptor of the selected stellar population.
    </description>
   </stellarPopulationSpectra>
   !!]
@@ -86,16 +87,20 @@ contains
     !!{
     Internal constructor for the FSPS stellar spectra class.
     !!}
-    use :: Galacticus_Paths, only : galacticusPath, pathTypeDataDynamic
+    use :: Galacticus_Paths  , only : galacticusPath        , pathTypeDataDynamic
+    use :: ISO_Varying_String, only : varying_string        , operator(//)
+    use :: Interfaces_FSPS   , only : Interface_FSPS_Version
     implicit none
     type   (stellarPopulationSpectraFSPS)                        :: self
     logical                              , intent(in   )         :: forceZeroMetallicity
     class  (initialMassFunctionClass    ), intent(in   ), target :: initialMassFunction_
+    type   (varying_string              )                        :: fspsVersion
     !![
     <constructorAssign variables="forceZeroMetallicity, *initialMassFunction_"/>
     !!]
 
-    self%stellarPopulationSpectraFile=stellarPopulationSpectraFile(forceZeroMetallicity,char(galacticusPath(pathTypeDataDynamic)//'stellarPopulations/simpleStellarPopulationsFSPS:v2.5_'//self%hashedDescriptor(includeSourceDigest=.true.)//'.hdf5'))
+    call Interface_FSPS_Version(fspsVersion)
+    self%stellarPopulationSpectraFile=stellarPopulationSpectraFile(forceZeroMetallicity,char(galacticusPath(pathTypeDataDynamic)//'stellarPopulations/simpleStellarPopulationsFSPS:v'//fspsVersion//'_'//self%hashedDescriptor(includeSourceDigest=.true.)//'.hdf5'))
     return
   end function fspsConstructorInternal
 

--- a/source/stellar_populations.spectra.FSPS.F90
+++ b/source/stellar_populations.spectra.FSPS.F90
@@ -30,7 +30,7 @@ Implements a stellar population spectra class which utilizes the FSPS package \c
     \href{https://github.com/cconroy20/fsps}{\normalfont \ttfamily FSPS} code will be downloaded, patched and compiled and run
     to generate spectra. These tabulations are then stored to file for later re-use. The file name used is {\normalfont
     \ttfamily datasets/dynamic/stellarPopulations/simpleStellarPopulationsFSPS:v$&lt;$version$&gt;$\_$&lt;$descriptor$&gt;$.hdf5} where
-    $&lt;{\normalfont \ttfamily version}$&gt;$ is the FSPS version used, and $&lt;${\normalfont \ttfamily descriptor}$&gt;$ is
+    $&lt;${\normalfont \ttfamily version}$&gt;$ is the FSPS version used, and $&lt;${\normalfont \ttfamily descriptor}$&gt;$ is
     an MD5 hash descriptor of the selected stellar population.
    </description>
   </stellarPopulationSpectra>

--- a/source/system.downloader.F90
+++ b/source/system.downloader.F90
@@ -83,7 +83,7 @@ contains
     use :: Galacticus_Error, only : Galacticus_Error_Report, errorStatusSuccess, errorStatusFail
     use :: System_Command  , only : System_Command_Do
     implicit none
-    character(len=*), intent(in   )           :: url, outputFileName
+    character(len=*), intent(in   )           :: url    , outputFileName
     integer         , intent(  out), optional :: status
     integer                                   :: status_
     
@@ -96,7 +96,11 @@ contains
     else if (.not.present(status)) then
        call Galacticus_Error_Report('no downloader available'//{introspection:location})
     end if
-    if (present(status)) status=status_
+    if (present(status)) then
+       status=status_
+    else if (status_ /= 0) then
+       call Galacticus_Error_Report('failed to download "'//trim(url)//'"'//{introspection:location})
+    end if
     return
   end subroutine downloadChar
 


### PR DESCRIPTION
Supports adding meta-data to any output property. Uses this new functionality to add effective wavelength and Vega-AB offset meta-data for all output broadband luminosity properties. Vega-AB offsets are now computed internally for all filters.

Closes #46 