### PR TITLE
fix: Support allowed parameter names for linked-list functionClass objects

### DIFF
--- a/source/cooling.cooling_function.summation.F90
+++ b/source/cooling.cooling_function.summation.F90
@@ -30,6 +30,9 @@
    <stateStore>
     <linkedList type="coolantList" variable="coolants" next="next" object="coolingFunction"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="coolantList" variable="coolants" next="next" object="coolingFunction"/>
+   </allowedParameters>
   </coolingFunction>
   !!]
 

--- a/source/dark_matter_profiles.heating.summation.F90
+++ b/source/dark_matter_profiles.heating.summation.F90
@@ -30,6 +30,9 @@
    <stateStore>
     <linkedList type="heatSourceList" variable="heatSources" next="next" object="heatSource"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="heatSourceList" variable="heatSources" next="next" object="heatSource"/>
+   </allowedParameters>
   </darkMatterProfileHeating>
   !!]
 

--- a/source/galactic.filters.all.F90
+++ b/source/galactic.filters.all.F90
@@ -30,6 +30,9 @@ Contains a module which implements a galactic filter class which is the ``all'' 
    <stateStore>
     <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
+   </allowedParameters>
   </galacticFilter>
   !!]
   type, extends(galacticFilterClass) :: galacticFilterAll

--- a/source/galactic.filters.any.F90
+++ b/source/galactic.filters.any.F90
@@ -30,6 +30,9 @@ Contains a module which implements a galactic filter class which is the ``any'' 
    <stateStore>
     <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
+   </allowedParameters>
   </galacticFilter>
   !!]
 

--- a/source/galacticus.output.analyses.distribution_normalizer.sequence.F90
+++ b/source/galacticus.output.analyses.distribution_normalizer.sequence.F90
@@ -30,6 +30,9 @@
    <stateStore>
     <linkedList type="normalizerList" variable="normalizers" next="next" object="normalizer_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="normalizerList" variable="normalizers" next="next" object="normalizer_"/>
+   </allowedParameters>
   </outputAnalysisDistributionNormalizer>
   !!]
 

--- a/source/galacticus.output.analyses.distribution_operator.sequence.F90
+++ b/source/galacticus.output.analyses.distribution_operator.sequence.F90
@@ -35,6 +35,9 @@ Contains a module which implements a sequence output analysis distribution opera
    <stateStore>
     <linkedList type="distributionOperatorList" variable="operators" next="next" object="operator_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="distributionOperatorList" variable="operators" next="next" object="operator_"/>
+   </allowedParameters>
   </outputAnalysisDistributionOperator>
   !!]
   type, extends(outputAnalysisDistributionOperatorClass) :: outputAnalysisDistributionOperatorSequence

--- a/source/galacticus.output.analyses.multi.F90
+++ b/source/galacticus.output.analyses.multi.F90
@@ -33,8 +33,11 @@
     <linkedList type="multiAnalysisList" variable="analyses" next="next" object="analysis_" objectType="outputAnalysisClass"/>
    </deepCopy>
    <stateStore>
-    <linkedList type="multiAnalysisList" variable="analyses" next="next" object="analysis_"/>
+    <linkedList type="multiAnalysisList" variable="analyses" next="next" object="analysis_"                                 />
    </stateStore>
+   <allowedParameters>
+    <linkedList type="multiAnalysisList" variable="analyses" next="next" object="analysis_"                                 />
+   </allowedParameters>
   </outputAnalysis>
   !!]
   type, extends(outputAnalysisClass) :: outputAnalysisMulti

--- a/source/galacticus.output.analyses.property_operator.sequence.F90
+++ b/source/galacticus.output.analyses.property_operator.sequence.F90
@@ -35,6 +35,9 @@ Contains a module which implements a sequence output analysis property operator 
    <stateStore>
     <linkedList type="propertyOperatorList" variable="operators" next="next" object="operator_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="propertyOperatorList" variable="operators" next="next" object="operator_"/>
+   </allowedParameters>
   </outputAnalysisPropertyOperator>
   !!]
   type, extends(outputAnalysisPropertyOperatorClass) :: outputAnalysisPropertyOperatorSequence

--- a/source/galacticus.output.analyses.weight_operator.sequence.F90
+++ b/source/galacticus.output.analyses.weight_operator.sequence.F90
@@ -35,6 +35,9 @@ Contains a module which implements a sequence output analysis weight operator cl
    <stateStore>
     <linkedList type="weightOperatorList" variable="operators" next="next" object="operator_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="weightOperatorList" variable="operators" next="next" object="operator_"/>
+   </allowedParameters>
   </outputAnalysisWeightOperator>
   !!]
   type, extends(outputAnalysisWeightOperatorClass) :: outputAnalysisWeightOperatorSequence

--- a/source/geometry.surveys.combined.F90
+++ b/source/geometry.surveys.combined.F90
@@ -35,6 +35,9 @@ Implements a survey geometry which combines multiple other surveys.
    <stateStore>
     <linkedList type="surveyGeometryList" variable="surveyGeometries" next="next" object="surveyGeometry_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="surveyGeometryList" variable="surveyGeometries" next="next" object="surveyGeometry_"/>
+   </allowedParameters>
   </surveyGeometry>
   !!]
   type, extends(surveyGeometryClass) :: surveyGeometryCombined

--- a/source/interface.FSPS.F90
+++ b/source/interface.FSPS.F90
@@ -27,7 +27,7 @@ module Interfaces_FSPS
   !!}
   use :: File_Utilities, only : lockDescriptor
   private
-  public :: Interface_FSPS_Initialize, Interface_FSPS_SSPs_Tabulate
+  public :: Interface_FSPS_Initialize, Interface_FSPS_SSPs_Tabulate, Interface_FSPS_Version
 
   ! Lock object to prevent multiple threads/processes attempting to build the code simultaneously.
   type(lockDescriptor) :: fspsLock
@@ -37,6 +37,18 @@ module Interfaces_FSPS
 
 contains
 
+  subroutine Interface_FSPS_Version(fspsVersion)
+    !!{
+    Set the version of FSPS being used.
+    !!}
+    use :: ISO_Varying_String, only : varying_string, assignment(=)
+    implicit none
+    type(varying_string), intent(  out) :: fspsVersion
+    
+    fspsVersion="3.2"
+    return
+  end subroutine Interface_FSPS_Version
+  
   subroutine Interface_FSPS_Initialize(fspsPath,fspsVersion,static)
     !!{
     Initialize the interface with FSPS, including downloading and compiling FSPS if necessary.
@@ -60,7 +72,7 @@ contains
     !!]
 
     ! Specify source code path.
-    fspsVersion="3.2"
+    call Interface_FSPS_Version(fspsVersion)
     fspsPath=galacticusPath(pathTypeDataDynamic)//"fsps-"//fspsVersion
     lockPath=galacticusPath(pathTypeDataDynamic)//"fsps" //fspsVersion
     call File_Lock(char(lockPath),fspsLock)

--- a/source/merger_trees.evolve.timesteps.multi.F90
+++ b/source/merger_trees.evolve.timesteps.multi.F90
@@ -35,6 +35,9 @@
    <stateStore>
     <linkedList type="multiMergerTreeEvolveTimestepList" variable="mergerTreeEvolveTimesteps" next="next" object="mergerTreeEvolveTimestep_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="multiMergerTreeEvolveTimestepList" variable="mergerTreeEvolveTimesteps" next="next" object="mergerTreeEvolveTimestep_"/>
+   </allowedParameters>
   </mergerTreeEvolveTimestep>
   !!]
   type, extends(mergerTreeEvolveTimestepClass) :: mergerTreeEvolveTimestepMulti

--- a/source/merger_trees.filter.all.F90
+++ b/source/merger_trees.filter.all.F90
@@ -30,6 +30,9 @@ Contains a module which implements a merger tree filter class which is the ``all
    <stateStore>
     <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
+   </allowedParameters>
   </mergerTreeFilter>
   !!]
   type, extends(mergerTreeFilterClass) :: mergerTreeFilterAll

--- a/source/merger_trees.filter.any.F90
+++ b/source/merger_trees.filter.any.F90
@@ -30,6 +30,9 @@ Contains a module which implements a merger tree filter class which is the ``any
    <stateStore>
     <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="filterList" variable="filters" next="next" object="filter_"/>
+   </allowedParameters>
   </mergerTreeFilter>
   !!]
   type, extends(mergerTreeFilterClass) :: mergerTreeFilterAny

--- a/source/merger_trees.operators.sequence.F90
+++ b/source/merger_trees.operators.sequence.F90
@@ -30,6 +30,9 @@ Contains a module which implements a sequence of operators on merger trees.
    <stateStore>
     <linkedList type="operatorList" variable="operators" next="next" object="operator_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="operatorList" variable="operators" next="next" object="operator_"/>
+   </allowedParameters>
   </mergerTreeOperator>
   !!]
 

--- a/source/merger_trees.outputter.buffer_types.F90
+++ b/source/merger_trees.outputter.buffer_types.F90
@@ -26,6 +26,7 @@ module Merger_Tree_Outputter_Buffer_Types
   Provides buffer types for merger tree outputters.
   !!}
   use :: Kind_Numbers      , only : kind_int8
+  use :: Hashes            , only : doubleHash
   use :: IO_HDF5           , only : hdf5VarDouble
   use :: ISO_Varying_String, only : varying_string
   public
@@ -39,6 +40,7 @@ module Merger_Tree_Outputter_Buffer_Types
      !!}
      character       (len=propertyNameLengthMax   )                              :: name
      character       (len=propertyCommentLengthMax)                              :: comment
+     type            (doubleHash                  ), allocatable                 :: metaData
      double precision                                                            :: unitsInSI
      integer         (kind_int8                   ), allocatable, dimension(:  ) :: scalar
      integer         (kind_int8                   ), allocatable, dimension(:,:) :: rank1
@@ -51,6 +53,7 @@ module Merger_Tree_Outputter_Buffer_Types
      !!}
      character       (len=propertyNameLengthMax   )                              :: name
      character       (len=propertyCommentLengthMax)                              :: comment
+     type            (doubleHash                  ), allocatable                 :: metaData
      double precision                                                            :: unitsInSI
      double precision                              , allocatable, dimension(:  ) :: scalar
      double precision                              , allocatable, dimension(:,:) :: rank1

--- a/source/merger_trees.outputter.multi.F90
+++ b/source/merger_trees.outputter.multi.F90
@@ -35,6 +35,9 @@
    <stateStore>
     <linkedList type="multiOutputterList" variable="outputters" next="next" object="outputter_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="multiOutputterList" variable="outputters" next="next" object="outputter_"/>
+   </allowedParameters>
   </mergerTreeOutputter>
   !!]
   type, extends(mergerTreeOutputterClass) :: mergerTreeOutputterMulti

--- a/source/merger_trees.outputter.standard.F90
+++ b/source/merger_trees.outputter.standard.F90
@@ -192,6 +192,8 @@ contains
     self%integerBufferCount      = 0
     self%integerBufferSize       =standardBufferSizeIncrement
     self%doubleBufferSize        =standardBufferSizeIncrement
+    allocate(self%integerProperty(0))
+    allocate(self% doubleProperty(0))
     !$omp critical(mergerTreeOutputterStandardInitialize)
     if (.not.treeLockInitialized) then
        treeLock           =ompLock()
@@ -318,11 +320,11 @@ contains
           if (.not.treeLock%ownedByThread()) call treeLock%set()
           !$ call hdf5Access%set()
           referenceLength(1)=max(self%integerPropertiesWritten,self%doublePropertiesWritten)
-          if      (allocated(self%integerProperty).and.self%outputGroups(indexOutput)%nodeDataGroup%hasDataset(self%integerProperty(1)%name)) then
+          if      (allocated(self%integerProperty).and.size(self%integerProperty) > 0.and.self%outputGroups(indexOutput)%nodeDataGroup%hasDataset(self%integerProperty(1)%name)) then
              toDataset=self%outputGroups(indexOutput)%nodeDataGroup%openDataset(self%integerProperty(1)%name)
              referenceStart(1)=toDataset%size(1)-referenceLength(1)
              call toDataset%close()
-          else if (allocated(self% doubleProperty).and.self%outputGroups(indexOutput)%nodeDataGroup%hasDataset(self% doubleProperty(1)%name)) then
+          else if (allocated(self% doubleProperty).and.size(self% doubleProperty) > 0.and.self%outputGroups(indexOutput)%nodeDataGroup%hasDataset(self% doubleProperty(1)%name)) then
              toDataset=self%outputGroups(indexOutput)%nodeDataGroup%openDataset(self% doubleProperty(1)%name)
              referenceStart(1)=toDataset%size(1)-referenceLength(1)
              call toDataset%close()
@@ -946,16 +948,20 @@ contains
          &                                                                        i
     type            (varying_string             ), allocatable  , dimension(:) :: namesTmp      , descriptionsTmp
 
-    do i=1,size(self%integerProperty)
-       if (allocated(self%integerProperty(i)%metaData)) deallocate(self%integerProperty(i)%metaData)
-       allocate(self%integerProperty(i)%metaData)
-       self%integerProperty(i)%metaData=doubleHash()
-    end do
-    do i=1,size(self%doubleProperty )
-       if (allocated(self%doubleProperty (i)%metaData)) deallocate(self%doubleProperty (i)%metaData)
-       allocate(self%doubleProperty (i)%metaData)
-       self%doubleProperty (i)%metaData=doubleHash()
-    end do
+    if (allocated(self%integerProperty)) then
+       do i=1,size(self%integerProperty)
+          if (allocated(self%integerProperty(i)%metaData)) deallocate(self%integerProperty(i)%metaData)
+          allocate(self%integerProperty(i)%metaData)
+          self%integerProperty(i)%metaData=doubleHash()
+       end do
+    end if
+    if (allocated(self%doubleProperty )) then
+       do i=1,size(self%doubleProperty )
+          if (allocated(self%doubleProperty (i)%metaData)) deallocate(self%doubleProperty (i)%metaData)
+          allocate(self%doubleProperty (i)%metaData)
+          self%doubleProperty (i)%metaData=doubleHash()
+       end do
+    end if
     integerProperty=0
     doubleProperty =0
     !![

--- a/source/nBody.import.merge.F90
+++ b/source/nBody.import.merge.F90
@@ -30,7 +30,10 @@ Contains a module which implements an N-body data importer which merges data fro
    <stateStore>
     <linkedList type="nbodyImporterList" variable="importers" next="next" object="importer_"/>
    </stateStore>
-  </nbodyImporter>
+   <allowedParameters>
+    <linkedList type="nbodyImporterList" variable="importers" next="next" object="importer_"/>
+   </allowedParameters>
+ </nbodyImporter>
   !!]
   type, extends(nbodyImporterClass) :: nbodyImporterMerge
      !!{

--- a/source/nBody.import.multiple.F90
+++ b/source/nBody.import.multiple.F90
@@ -30,6 +30,9 @@ Contains a module which implements an N-body data importer which imports using m
    <stateStore>
     <linkedList type="nbodyImporterList" variable="importers" next="next" object="importer_"/>
    </stateStore> 
+   <allowedParameters>
+    <linkedList type="nbodyImporterList" variable="importers" next="next" object="importer_"/>
+   </allowedParameters> 
  </nbodyImporter>
   !!]
   type, extends(nbodyImporterClass) :: nbodyImporterMultiple

--- a/source/nBody.operator.sequence.F90
+++ b/source/nBody.operator.sequence.F90
@@ -35,6 +35,9 @@ Contains a module which implements an N-body data operator which applies a seque
    <stateStore>
     <linkedList type="nbodyOperatorList" variable="operators" next="next" object="operator_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="nbodyOperatorList" variable="operators" next="next" object="operator_"/>
+   </allowedParameters>
   </nbodyOperator>
   !!]
   type, extends(nbodyOperatorClass) :: nbodyOperatorSequence

--- a/source/nodes.operators.multi.F90
+++ b/source/nodes.operators.multi.F90
@@ -35,6 +35,9 @@
    <stateStore>
     <linkedList type="multiProcessList" variable="processes" next="next" object="process_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="multiProcessList" variable="processes" next="next" object="process_"/>
+   </allowedParameters>
   </nodeOperator>
   !!]
   type, extends(nodeOperatorClass) :: nodeOperatorMulti

--- a/source/nodes.property_extractor.array.F90
+++ b/source/nodes.property_extractor.array.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  use :: Hashes, only : doubleHash
+
   !![
   <nodePropertyExtractor name="nodePropertyExtractorArray" abstract="yes">
    <description>An abstract output analysis property extractor class which provieds a array of floating point properties.</description>
@@ -37,6 +39,7 @@
        <method method="names"              description="Return the name of the properties extracted."                       />
        <method method="descriptions"       description="Return a description of the properties extracted."                  />
        <method method="unitsInSI"          description="Return the units of the properties extracted in the SI system."     />
+       <method method="metaData"           description="Populate a hash with meta-data for the property."                   />
      </methods>
      !!]
      procedure(arrayDescriptions), deferred :: columnDescriptions
@@ -46,6 +49,7 @@
      procedure(arrayNames       ), deferred :: names
      procedure(arrayDescriptions), deferred :: descriptions
      procedure(arrayUnitsInSI   ), deferred :: unitsInSI
+     procedure                              :: metaData           => arrayMetaData
   end type nodePropertyExtractorArray
 
   abstract interface
@@ -120,3 +124,18 @@
        double precision                            , intent(in   ) :: time
      end function arraySize
   end interface
+
+contains
+  
+  subroutine arrayMetaData(self,indexProperty,metaData)
+    !!{
+    Interface for array property meta-data.
+    !!}
+    implicit none
+    class(  nodePropertyExtractorArray), intent(inout) :: self
+    integer                            , intent(in   ) :: indexProperty
+    type   (doubleHash                ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, indexProperty, metaData
+    
+    return
+  end subroutine arrayMetaData

--- a/source/nodes.property_extractor.integer_scalar.F90
+++ b/source/nodes.property_extractor.integer_scalar.F90
@@ -18,6 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   use :: Kind_Numbers, only : kind_int8
+  use :: Hashes      , only : doubleHash
 
   !![
   <nodePropertyExtractor name="nodePropertyExtractorIntegerScalar" abstract="yes">
@@ -36,12 +37,14 @@
        <method method="name"        description="Return the name of the property extracted."                       />
        <method method="description" description="Return a description of the property extracted."                  />
        <method method="unitsInSI"   description="Return the units of the property extracted in the SI system."     />
+       <method method="metaData"    description="Populate a hash with meta-data for the property."                 />
      </methods>
      !!]
      procedure(integerScalarExtract), deferred :: extract
      procedure(integerScalarName   ), deferred :: name
      procedure(integerScalarName   ), deferred :: description
      procedure                                 :: unitsInSI   => integerScalarUnitsInSI
+     procedure                                 :: metaData    => integerScalarMetaData
   end type nodePropertyExtractorIntegerScalar
 
   abstract interface
@@ -82,3 +85,15 @@ contains
     integerScalarUnitsInSI=0.0d0
     return
   end function integerScalarUnitsInSI
+
+  subroutine integerScalarMetaData(self,metaData)
+    !!{
+    Interface for integerScalar property meta-data.
+    !!}
+    implicit none
+    class(nodePropertyExtractorIntegerScalar), intent(inout) :: self
+    type (doubleHash                        ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, metaData
+    
+    return
+  end subroutine integerScalarMetaData

--- a/source/nodes.property_extractor.integer_tuple.F90
+++ b/source/nodes.property_extractor.integer_tuple.F90
@@ -18,6 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   use :: Kind_Numbers, only : kind_int8
+  use :: Hashes      , only : doubleHash
 
   !![
   <nodePropertyExtractor name="nodePropertyExtractorIntegerTuple" abstract="yes">
@@ -37,6 +38,7 @@
        <method method="names"        description="Return the names of the properties extracted."                      />
        <method method="descriptions" description="Return descriptions of the properties extracted."                   />
        <method method="unitsInSI"    description="Return the units of the properties extracted in the SI system."     />
+       <method method="metaData"     description="Populate a hash with meta-data for the property."                   />
      </methods>
      !!]
      procedure(integerTupleElementCount), deferred :: elementCount
@@ -44,6 +46,7 @@
      procedure(integerTupleNames       ), deferred :: names
      procedure(integerTupleDescriptions), deferred :: descriptions
      procedure(integerTupleUnitsInSI   ), deferred :: unitsInSI
+     procedure                                     :: metaData    => integerTupleMetaData
   end type nodePropertyExtractorIntegerTuple
 
   abstract interface
@@ -106,3 +109,18 @@
        double precision                                   , intent(in   ) :: time
      end function integerTupleElementCount
   end interface
+
+contains
+
+  subroutine integerTupleMetaData(self,indexProperty,metaData)
+    !!{
+    Interface for integerTuple property meta-data.
+    !!}
+    implicit none
+    class  (nodePropertyExtractorIntegerTuple), intent(inout) :: self
+    integer                                   , intent(in   ) :: indexProperty
+    type   (doubleHash                       ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, indexProperty, metaData
+    
+    return
+  end subroutine integerTupleMetaData

--- a/source/nodes.property_extractor.list.F90
+++ b/source/nodes.property_extractor.list.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  use :: Hashes, only : doubleHash
+
   !![
   <nodePropertyExtractor name="nodePropertyExtractorList" abstract="yes">
    <description>An abstract output analysis property extractor class which provieds a list of floating point properties.</description>
@@ -34,12 +36,14 @@
        <method method="name"        description="Return the name of the properties extracted."                       />
        <method method="description" description="Return a description of the properties extracted."                  />
        <method method="unitsInSI"   description="Return the units of the properties extracted in the SI system."     />
+       <method method="metaData"    description="Populate a hash with meta-data for the property."                   />
      </methods>
      !!]
      procedure(listExtract    ), deferred :: extract
      procedure(listName       ), deferred :: name
      procedure(listDescription), deferred :: description
      procedure(listUnitsInSI  ), deferred :: unitsInSI
+     procedure                            :: metaData    => listMetaData
   end type nodePropertyExtractorList
 
   abstract interface
@@ -86,3 +90,17 @@
        class (nodePropertyExtractorList), intent(inout) :: self
      end function listUnitsInSI
   end interface
+
+contains
+  
+  subroutine listMetaData(self,metaData)
+    !!{
+    Interface for list property meta-data.
+    !!}
+    implicit none
+    class(nodePropertyExtractorList), intent(inout) :: self
+    type (doubleHash               ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, metaData
+    
+    return
+  end subroutine listMetaData

--- a/source/nodes.property_extractor.multi.F90
+++ b/source/nodes.property_extractor.multi.F90
@@ -37,6 +37,9 @@
    <stateStore>
     <linkedList type="multiExtractorList" variable="extractors" next="next" object="extractor_"/>
    </stateStore>
+   <allowedParameters>
+     <linkedList type="multiExtractorList" variable="extractors" next="next" object="extractor_"/>
+   </allowedParameters>
   </nodePropertyExtractor>
   !!]
   type, extends(nodePropertyExtractorClass) :: nodePropertyExtractorMulti

--- a/source/nodes.property_extractor.scalar.F90
+++ b/source/nodes.property_extractor.scalar.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  use :: Hashes, only : doubleHash
+
   !![
   <nodePropertyExtractor name="nodePropertyExtractorScalar" abstract="yes">
    <description>An abstract output analysis property extractor class which provieds a scalar floating point property.</description>
@@ -34,12 +36,14 @@
        <method method="name"        description="Return the name of the property extracted."                       />
        <method method="description" description="Return a description of the property extracted."                  />
        <method method="unitsInSI"   description="Return the units of the property extracted in the SI system."     />
+       <method method="metaData"    description="Populate a hash with meta-data for the property."                 />
      </methods>
      !!]
      procedure(scalarExtract  ), deferred :: extract
      procedure(scalarName     ), deferred :: name
      procedure(scalarName     ), deferred :: description
      procedure(scalarUnitsInSI), deferred :: unitsInSI
+     procedure                            :: metaData    => scalarMetaData
   end type nodePropertyExtractorScalar
 
   abstract interface
@@ -74,3 +78,17 @@
        class(nodePropertyExtractorScalar), intent(inout) :: self
      end function scalarUnitsInSI
   end interface
+
+contains
+  
+  subroutine scalarMetaData(self,metaData)
+    !!{
+    Interface for scalar property meta-data.
+    !!}
+    implicit none
+    class(nodePropertyExtractorScalar), intent(inout) :: self
+    type (doubleHash                 ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, metaData
+    
+    return
+  end subroutine scalarMetaData

--- a/source/nodes.property_extractor.tuple.F90
+++ b/source/nodes.property_extractor.tuple.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  use :: Hashes, only : doubleHash
+
   !![
   <nodePropertyExtractor name="nodePropertyExtractorTuple" abstract="yes">
    <description>An abstract output analysis property extractor class which provieds a tuple of floating point properties.</description>
@@ -35,6 +37,7 @@
        <method method="names"        description="Return the names of the properties extracted."                      />
        <method method="descriptions" description="Return descriptions of the properties extracted."                   />
        <method method="unitsInSI"    description="Return the units of the properties extracted in the SI system."     />
+       <method method="metaData"    description="Populate a hash with meta-data for the property."                    />
      </methods>
      !!]
      procedure(tupleElementCount), deferred :: elementCount
@@ -42,6 +45,7 @@
      procedure(tupleNames       ), deferred :: names
      procedure(tupleDescriptions), deferred :: descriptions
      procedure(tupleUnitsInSI   ), deferred :: unitsInSI
+     procedure                              :: metaData     => tupleMetaData
   end type nodePropertyExtractorTuple
 
   abstract interface
@@ -104,3 +108,18 @@
        double precision                            , intent(in   ) :: time
      end function tupleElementCount
   end interface
+
+contains
+  
+  subroutine tupleMetaData(self,indexProperty,metaData)
+    !!{
+    Interface for scalar property meta-data.
+    !!}
+    implicit none
+    class  (nodePropertyExtractorTuple), intent(inout) :: self
+    integer                            , intent(in   ) :: indexProperty
+    type   (doubleHash                ), intent(inout) :: metaData
+    !$GLC attributes unused :: self, indexProperty, metaData
+    
+    return
+  end subroutine tupleMetaData

--- a/source/objects.nodes.components.position.preset.interpolated.F90
+++ b/source/objects.nodes.components.position.preset.interpolated.F90
@@ -603,13 +603,19 @@ contains
                   &   Dot_Product(positionRelative(2,:),+vectorInPlaneNormal(k,2,:)) &
                   & ) vectorInPlaneNormal(k,2,:)=-vectorInPlaneNormal(k,2,:)
              !! Find the linear fit coefficients to angle.
-             coefficientsAngle    (k,2)=+acos(                                                                    &
-                  &                           +Dot_Product     (positionRelative(2,:),vectorInPlaneNormal(k,1,:)) &
-                  &                           /Vector_Magnitude(positionRelative(2,:)                           ) &
-                  &                          )                                                                    &
-                  &                     /    (                                                                    &
-                  &                           +time(2) &
-                  &                           -time(1) &
+             coefficientsAngle    (k,2)=+acos(                                                                              &
+                  &                           min(                                                                          &
+                  &                               +1.0d0                                                                  , &
+                  &                               max(                                                                      &
+                  &                                   -1.0d0                                                              , &
+                  &                                   +Dot_Product     (positionRelative(2,:),vectorInPlaneNormal(k,1,:))   &
+                  &                                   /Vector_Magnitude(positionRelative(2,:)                           )   &
+                  &                                  )                                                                      &
+                  &                               )                                                                         &
+                  &                          )                                                                              &
+                  &                     /    (                                                                              &
+                  &                           +time(2)                                                                      &
+                  &                           -time(1)                                                                      &
                   &                          )
              coefficientsAngle    (k,1)=-time(1) &
                   &                     *coefficientsAngle(k,2)

--- a/source/radiation.summation.F90
+++ b/source/radiation.summation.F90
@@ -35,6 +35,9 @@ Implements a radiation field class which sums over other radiation fields.
    <stateStore>
     <linkedList type="radiationFieldList" variable="radiationFields" next="next" object="radiationField_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="radiationFieldList" variable="radiationFields" next="next" object="radiationField_"/>
+   </allowedParameters>
   </radiationField>
   !!]
   type, extends(radiationFieldClass) :: radiationFieldSummation

--- a/source/radiative_transfer.outputter.multi.F90
+++ b/source/radiative_transfer.outputter.multi.F90
@@ -35,6 +35,9 @@
    <stateStore>
     <linkedList type="multiOutputterList" variable="outputters" next="next" object="outputter_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="multiOutputterList" variable="outputters" next="next" object="outputter_"/>
+   </allowedParameters>
   </radiativeTransferOutputter>
   !!]
   type, extends(radiativeTransferOutputterClass) :: radiativeTransferOutputterMulti

--- a/source/radiative_transfer.source.summation.F90
+++ b/source/radiative_transfer.source.summation.F90
@@ -33,6 +33,9 @@
    <stateStore>
     <linkedList type="radiativeTransferSourceList" variable="radiativeTransferSources" next="next" object="radiativeTransferSource"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="radiativeTransferSourceList" variable="radiativeTransferSources" next="next" object="radiativeTransferSource"/>
+   </allowedParameters>
   </radiativeTransferSource>
   !!]
   type, extends(radiativeTransferSourceClass) :: radiativeTransferSourceSummation

--- a/source/stellar_feedback.outflows.summation.F90
+++ b/source/stellar_feedback.outflows.summation.F90
@@ -31,6 +31,9 @@
    <stateStore>
     <linkedList type="stellarFeedbackOutflowsList" variable="stellarFeedbackOutflowss" next="next" object="stellarFeedbackOutflows"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="stellarFeedbackOutflowsList" variable="stellarFeedbackOutflowss" next="next" object="stellarFeedbackOutflows"/>
+   </allowedParameters>
   </stellarFeedbackOutflows>
   !!]
   type, extends(stellarFeedbackOutflowsClass) :: stellarFeedbackOutflowsSummation

--- a/source/stellar_populations.spectra.FSPS.F90
+++ b/source/stellar_populations.spectra.FSPS.F90
@@ -29,8 +29,9 @@ Implements a stellar population spectra class which utilizes the FSPS package \c
     A stellar population spectra class utilizing the FSPS package \citep{conroy_propagation_2009}. If necessary, the
     \href{https://github.com/cconroy20/fsps}{\normalfont \ttfamily FSPS} code will be downloaded, patched and compiled and run
     to generate spectra. These tabulations are then stored to file for later re-use. The file name used is {\normalfont
-    \ttfamily datasets/dynamic/stellarPopulations/simpleStellarPopulationsFSPS:v2.5\_$&lt;$descriptor$&gt;$.hdf5} where
-    $&lt;${\normalfont \ttfamily descriptor}$&gt;$ is an MD5 hash descriptor of the selected stellar population.
+    \ttfamily datasets/dynamic/stellarPopulations/simpleStellarPopulationsFSPS:v$&lt;$version$&gt;$\_$&lt;$descriptor$&gt;$.hdf5} where
+    $&lt;{\normalfont \ttfamily version}$&gt;$ is the FSPS version used, and $&lt;${\normalfont \ttfamily descriptor}$&gt;$ is
+    an MD5 hash descriptor of the selected stellar population.
    </description>
   </stellarPopulationSpectra>
   !!]
@@ -86,16 +87,20 @@ contains
     !!{
     Internal constructor for the FSPS stellar spectra class.
     !!}
-    use :: Galacticus_Paths, only : galacticusPath, pathTypeDataDynamic
+    use :: Galacticus_Paths  , only : galacticusPath        , pathTypeDataDynamic
+    use :: ISO_Varying_String, only : varying_string        , operator(//)
+    use :: Interfaces_FSPS   , only : Interface_FSPS_Version
     implicit none
     type   (stellarPopulationSpectraFSPS)                        :: self
     logical                              , intent(in   )         :: forceZeroMetallicity
     class  (initialMassFunctionClass    ), intent(in   ), target :: initialMassFunction_
+    type   (varying_string              )                        :: fspsVersion
     !![
     <constructorAssign variables="forceZeroMetallicity, *initialMassFunction_"/>
     !!]
 
-    self%stellarPopulationSpectraFile=stellarPopulationSpectraFile(forceZeroMetallicity,char(galacticusPath(pathTypeDataDynamic)//'stellarPopulations/simpleStellarPopulationsFSPS:v2.5_'//self%hashedDescriptor(includeSourceDigest=.true.)//'.hdf5'))
+    call Interface_FSPS_Version(fspsVersion)
+    self%stellarPopulationSpectraFile=stellarPopulationSpectraFile(forceZeroMetallicity,char(galacticusPath(pathTypeDataDynamic)//'stellarPopulations/simpleStellarPopulationsFSPS:v'//fspsVersion//'_'//self%hashedDescriptor(includeSourceDigest=.true.)//'.hdf5'))
     return
   end function fspsConstructorInternal
 

--- a/source/stellar_populations.spectra.FSPS.F90
+++ b/source/stellar_populations.spectra.FSPS.F90
@@ -30,7 +30,7 @@ Implements a stellar population spectra class which utilizes the FSPS package \c
     \href{https://github.com/cconroy20/fsps}{\normalfont \ttfamily FSPS} code will be downloaded, patched and compiled and run
     to generate spectra. These tabulations are then stored to file for later re-use. The file name used is {\normalfont
     \ttfamily datasets/dynamic/stellarPopulations/simpleStellarPopulationsFSPS:v$&lt;$version$&gt;$\_$&lt;$descriptor$&gt;$.hdf5} where
-    $&lt;{\normalfont \ttfamily version}$&gt;$ is the FSPS version used, and $&lt;${\normalfont \ttfamily descriptor}$&gt;$ is
+    $&lt;${\normalfont \ttfamily version}$&gt;$ is the FSPS version used, and $&lt;${\normalfont \ttfamily descriptor}$&gt;$ is
     an MD5 hash descriptor of the selected stellar population.
    </description>
   </stellarPopulationSpectra>

--- a/source/stellar_populations.spectra.postprocess.sequence.F90
+++ b/source/stellar_populations.spectra.postprocess.sequence.F90
@@ -35,6 +35,9 @@ Implements a stellar population spectra postprocessor class which applies a sequ
    <stateStore>
     <linkedList type="postprocessorList" variable="postprocessors" next="next" object="postprocessor_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="postprocessorList" variable="postprocessors" next="next" object="postprocessor_"/>
+   </allowedParameters>
   </stellarPopulationSpectraPostprocessor>
   !!]
   type, extends(stellarPopulationSpectraPostprocessorClass) :: stellarPopulationSpectraPostprocessorSequence

--- a/source/system.downloader.F90
+++ b/source/system.downloader.F90
@@ -83,7 +83,7 @@ contains
     use :: Galacticus_Error, only : Galacticus_Error_Report, errorStatusSuccess, errorStatusFail
     use :: System_Command  , only : System_Command_Do
     implicit none
-    character(len=*), intent(in   )           :: url, outputFileName
+    character(len=*), intent(in   )           :: url    , outputFileName
     integer         , intent(  out), optional :: status
     integer                                   :: status_
     
@@ -96,7 +96,11 @@ contains
     else if (.not.present(status)) then
        call Galacticus_Error_Report('no downloader available'//{introspection:location})
     end if
-    if (present(status)) status=status_
+    if (present(status)) then
+       status=status_
+    else if (status_ /= 0) then
+       call Galacticus_Error_Report('failed to download "'//trim(url)//'"'//{introspection:location})
+    end if
     return
   end subroutine downloadChar
 

--- a/source/tasks.multi.F90
+++ b/source/tasks.multi.F90
@@ -31,6 +31,9 @@
    <stateStore>
     <linkedList type="multiTaskList" variable="tasks" next="next" object="task_"/>
    </stateStore>
+   <allowedParameters>
+    <linkedList type="multiTaskList" variable="tasks" next="next" object="task_"/>
+   </allowedParameters>
   </task>
   !!]
   type, extends(taskClass) :: taskMulti


### PR DESCRIPTION
Supports a `allowedParameters` element in `functionClass` instances which identifies linked lists of `functionClass` objects to be called when establishing lists of allowed parameter names.

Closes #220 