### PR TITLE
Add tolerances for minimum metallicity in disk and spheroid components

### DIFF
--- a/testSuite/test-inactive_luminosities.pl
+++ b/testSuite/test-inactive_luminosities.pl
@@ -48,7 +48,7 @@ for(my $i=1;$i<=4;++$i) {
 	}
 	my $errorFractional = abs($property->{'inactive'}-$property->{'active'})/$property->{'active'};
 	my $status = "SUCCESS";
-	if ( $errorFractional->((0)) > 1.0e-3 ) {
+	if ( $errorFractional->((0)) > 1.5e-3 ) {
 	    $status  = "FAILED";
 	    $success = 0;
 	}


### PR DESCRIPTION
Adds parameters which control the minimum metallicity (for gas and stars) in the standard disk and spheroid components. Prior to this, galaxies with very low metallicity could be rate-limited by that metallicity in ODE solver steps. Since we likely do not care about such tiny metallicities it makes sense to introduce some tolerance.

Also removes the factor 0.1 introduced into the absolute tolerance scale for gas mass in the standard spheroid component - this was introduced long ago and seems to be no longer needed, so it makes sense to restore parity with the treatment in the standard disk component.