### PR TITLE
Remove the molecular fraction floor from the krumholz2009 star formation rate surface density class

### DIFF
--- a/source/star_formation.rate_surface_density.disks.Krumholz2009.F90
+++ b/source/star_formation.rate_surface_density.disks.Krumholz2009.F90
@@ -115,12 +115,8 @@
   type            (treeNode                                        ), pointer   :: krumholz2009Node
   !$omp threadprivate(krumholz2009Self,krumholz2009Node)
 
-  ! Minimum fraction of molecular hydrogen allowed.
-  double precision                                                  , parameter :: krumholz2009MolecularFractionMinimum=1.0d-4
-
   ! Range of s-parameter to tabulate.
-  double precision                                                  , parameter :: sMinimum                            =0.0d+0, sMaximum=8.0d0
-
+  double precision                                                  , parameter :: sMinimum                            =0.0d+0, sMaximum=10.0d0
 
 contains
 
@@ -317,11 +313,19 @@ contains
     double precision                                                                  :: surfaceDensityFactor, molecularFraction             , &
          &                                                                               s                   , sigmaMolecularComplex         , &
          &                                                                               surfaceDensityGas   , surfaceDensityGasDimensionless
-
+    
     ! Compute factors.
     call self%computeFactors(node)
     ! Check if the disk is physical.
-    if (self%massGas <= 0.0d0 .or. self%radiusDisk <= 0.0d0) then
+    if     (                                                  &
+         &   self%massGas                            <= 0.0d0 &
+         &  .or.                                              &
+         &   self%radiusDisk                         <= 0.0d0 &
+         &  .or.                                              &
+         &   self%metallicityRelativeToSolar         <= 0.0d0 &
+         &  .or.                                              &
+         &   self%sigmaMolecularComplexNormalization <= 0.0d0 &
+         & ) then
        ! It is not, so return zero rate.
        krumholz2009Rate=0.0d0
     else
@@ -332,20 +336,12 @@ contains
           krumholz2009Rate=0.0d0
        else
           ! Compute the molecular fraction.
-          if (self%metallicityRelativeToSolar > 0.0d0) then
-             sigmaMolecularComplex=self%sigmaMolecularComplexNormalization*surfaceDensityGas
-             if (sigmaMolecularComplex > 0.0d0) then
-                if (sigmaMolecularComplex < self%sNormalization/sMaximum) then
-                   s=sMaximum
-                else
-                   s=self%sNormalization/sigmaMolecularComplex
-                end if
-                molecularFraction=self%molecularFraction%interpolate(s)
-             else
-                molecularFraction=krumholz2009MolecularFractionMinimum
-             end if
+          sigmaMolecularComplex=self%sigmaMolecularComplexNormalization*surfaceDensityGas
+          s                    =self%sNormalization/sigmaMolecularComplex
+          if (s > sMaximum) then
+             molecularFraction=self%molecularFraction_           (s)
           else
-             molecularFraction   =krumholz2009MolecularFractionMinimum
+             molecularFraction=self%molecularFraction%interpolate(s)
           end if
           ! Compute the cloud density factor.
           if      (surfaceDensityGasDimensionless <= 0.0d0) then
@@ -399,19 +395,24 @@ contains
     !!}
     implicit none
     double precision, intent(in   ) :: s
-    double precision, parameter     :: sMinimum=1.0d-6
-    double precision, parameter     :: sMaximum=8.0d0
+    double precision, parameter     :: sTiny        =1.000000d-06
+    double precision, parameter     :: sHuge        =1.000000d+10
+    double precision, parameter     :: deltaInfinity=0.214008d+00 ! The value of δ for s → ∞.
     double precision                :: delta
 
-    ! Check if s is below maximum. If not, simply truncate to the minimum fraction that we allow. Also use a simple series
-    ! expansion for cases of very small s.
-    if      (s <  sMinimum) then
+    if      (s <  sTiny   ) then
+       ! Series expansion for very small s.
        krumholz2009MolecularFractionSlow=1.0d0-0.75d0*s
+    else if (s >= sHuge   ) then
+       ! Truncate to zero for extremely large s.
+       krumholz2009MolecularFractionSlow=0.0d0
     else if (s >= sMaximum) then
-       krumholz2009MolecularFractionSlow=                                                               krumholz2009MolecularFractionMinimum
+       ! Simplified form for very large s.
+       krumholz2009MolecularFractionSlow=1.0d0/(0.75d0/(1.0d0+deltaInfinity))**5/5.0d0/s**5
     else
+       ! Full expression.
        delta                            =0.0712d0/((0.1d0/s+0.675d0)**2.8d0)
-       krumholz2009MolecularFractionSlow=max(1.0d0-1.0d0/((1.0d0+(((1.0d0+delta)/0.75d0/s)**5))**0.2d0),krumholz2009MolecularFractionMinimum)
+       krumholz2009MolecularFractionSlow=1.0d0-1.0d0/((1.0d0+(((1.0d0+delta)/0.75d0/s)**5))**0.2d0)
     end if
     return
   end function krumholz2009MolecularFractionSlow
@@ -424,11 +425,11 @@ contains
     implicit none
     double precision, intent(in   ) :: s
 
-    ! Check that s is below 2 - if it is, compute the molecular fraction, otherwise truncate to the minimum.
+    ! Check that s is below 2 - if it is, compute the molecular fraction, otherwise truncate to zero.
     if (s < 2.0d0) then
-       krumholz2009MolecularFractionFast=max(1.0d0-0.75d0*s/(1.0d0+0.25d0*s),krumholz2009MolecularFractionMinimum)
+       krumholz2009MolecularFractionFast=1.0d0-0.75d0*s/(1.0d0+0.25d0*s)
     else
-       krumholz2009MolecularFractionFast=                                    krumholz2009MolecularFractionMinimum
+       krumholz2009MolecularFractionFast=0.0d0
     end if
     return
   end function krumholz2009MolecularFractionFast

--- a/testSuite/test-methods.xml
+++ b/testSuite/test-methods.xml
@@ -104,7 +104,7 @@
       </nodeOperator>
     </darkMatterProfileDMO>
     <darkMatterProfileDMO value="accretionFlow">
-      <toleranceRelativePotential value="1.0e-5"/>
+      <toleranceRelativePotential value="1.0e-4"/>
       <darkMatterProfileDMO value="NFW"/>
       <accretionFlows value="diemerKravtsov2014" parameterLevel="top">
 	<darkMatterProfileDMO value="NFW"/>


### PR DESCRIPTION
This floor lead to discontinuities in the gradient of the star formation rate surface density which can be challenging for numerical integration. Since we now use a tabulation for the molecular fraction there's no real speed advantage to introducing this floor, so it has been removed.
