### PR TITLE
Optimize the blitz0026 star formation rate surface density class

### DIFF
--- a/source/star_formation.rate_surface_density.disks.Blitz2006.F90
+++ b/source/star_formation.rate_surface_density.disks.Blitz2006.F90
@@ -21,8 +21,10 @@
   Implementation of the \cite{blitz_role_2006} star formation rate surface density law for galactic disks.
   !!}
 
-  use :: Kind_Numbers      , only : kind_int8
-  use :: Galactic_Structure, only : galacticStructureClass
+  use :: Kind_Numbers       , only : kind_int8
+  use :: Galactic_Structure , only : galacticStructureClass
+  use :: Root_Finder        , only : rootFinder
+  use :: Math_Exponentiation, only : fastExponentiator
 
   !![
   <starFormationRateSurfaceDensityDisks name="starFormationRateSurfaceDensityDisksBlitz2006">
@@ -59,25 +61,35 @@
      Implementation of the \cite{blitz_role_2006} star formation rate surface density law for galactic disks.
      !!}
      private
-     class           (galacticStructureClass), pointer :: galacticStructure_        => null()
+     class           (galacticStructureClass), pointer :: galacticStructure_         => null()
      integer         (kind_int8             )          :: lastUniqueID
-     logical                                           :: factorsComputed
-     double precision                                  :: heightToRadialScaleDisk            , pressureCharacteristic             , &
-          &                                               pressureExponent                   , starFormationFrequencyNormalization, &
-          &                                               surfaceDensityCritical             , surfaceDensityExponent             , &
-          &                                               velocityDispersionDiskGas          , radiusDisk                         , &
-          &                                               massGas                            , hydrogenMassFraction               , &
-          &                                               massStellar
+     logical                                           :: factorsComputed                     , assumeMonotonicSurfaceDensity
+     double precision                                  :: heightToRadialScaleDisk             , pressureCharacteristic             , &
+          &                                               pressureExponent                    , starFormationFrequencyNormalization, &
+          &                                               surfaceDensityCritical              , surfaceDensityExponent             , &
+          &                                               velocityDispersionDiskGas           , radiusDisk                         , &
+          &                                               massGas                             , hydrogenMassFraction               , &
+          &                                               massStellar                         , massGasPrevious                    , &
+          &                                               massStellarPrevious                 , hydrogenMassFractionPrevious       , &
+          &                                               radiusDiskPrevious                  , radiusCritical
+     type            (rootFinder            )          :: finder
+     type            (fastExponentiator     )          :: pressureRatioExponentiator
    contains
      !![
      <methods>
-       <method description="Reset memoized calculations." method="calculationReset" />
+       <method description="Reset memoized calculations." method="calculationReset"/>
+       <method description="Compute various factors."     method="computeFactors"  />
+       <method description="Compute the pressure ratio."  method="pressureRatio"   />
      </methods>
      !!]
      final     ::                     blitz2006Destructor
      procedure :: autoHook         => blitz2006AutoHook
      procedure :: calculationReset => blitz2006CalculationReset
      procedure :: rate             => blitz2006Rate
+     procedure :: computeFactors   => blitz2006ComputeFactors
+     procedure :: unchanged        => blitz2006Unchanged
+     procedure :: intervals        => blitz2006Intervals
+     procedure :: pressureRatio    => blitz2006PressureRatio
   end type starFormationRateSurfaceDensityDisksBlitz2006
 
   interface starFormationRateSurfaceDensityDisksBlitz2006
@@ -87,6 +99,11 @@
      module procedure blitz2006ConstructorParameters
      module procedure blitz2006ConstructorInternal
   end interface starFormationRateSurfaceDensityDisksBlitz2006
+
+  ! Submodule-scope pointer to the active node.
+  class           (starFormationRateSurfaceDensityDisksBlitz2006), pointer   :: self_
+  type            (treeNode                                     ), pointer   :: node_
+  !$omp threadprivate(self_,node_)
 
 contains
 
@@ -102,6 +119,7 @@ contains
          &                                                                            surfaceDensityCritical             , surfaceDensityExponent , &
          &                                                                            starFormationFrequencyNormalization, pressureCharacteristic , &
          &                                                                            pressureExponent
+    logical                                                                        :: assumeMonotonicSurfaceDensity
 
     !![
     <inputParameter>
@@ -153,9 +171,15 @@ contains
       <description>The exponent in the scaling relation of molecular hydrogen fraction with disk pressure in the ``Blitz-Rosolowsky2006'' star formation timescale calculation.</description>
       <source>parameters</source>
     </inputParameter>
+    <inputParameter>
+      <name>assumeMonotonicSurfaceDensity</name>
+      <defaultValue>.false.</defaultValue>
+      <description>If true, assume that the surface density in disks is always monotonically decreasing.</description>
+      <source>parameters</source>
+    </inputParameter>
     <objectBuilder class="galacticStructure" name="galacticStructure_" source="parameters"/>
     !!]
-    self=starFormationRateSurfaceDensityDisksBlitz2006(velocityDispersionDiskGas,heightToRadialScaleDisk,surfaceDensityCritical,surfaceDensityExponent,starFormationFrequencyNormalization,pressureCharacteristic,pressureExponent,galacticStructure_)
+    self=starFormationRateSurfaceDensityDisksBlitz2006(velocityDispersionDiskGas,heightToRadialScaleDisk,surfaceDensityCritical,surfaceDensityExponent,starFormationFrequencyNormalization,pressureCharacteristic,pressureExponent,assumeMonotonicSurfaceDensity,galacticStructure_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="galacticStructure_"/>
@@ -163,14 +187,15 @@ contains
     return
   end function blitz2006ConstructorParameters
 
-  function blitz2006ConstructorInternal(velocityDispersionDiskGas,heightToRadialScaleDisk,surfaceDensityCritical,surfaceDensityExponent,starFormationFrequencyNormalization,pressureCharacteristic,pressureExponent,galacticStructure_) result(self)
+  function blitz2006ConstructorInternal(velocityDispersionDiskGas,heightToRadialScaleDisk,surfaceDensityCritical,surfaceDensityExponent,starFormationFrequencyNormalization,pressureCharacteristic,pressureExponent,assumeMonotonicSurfaceDensity,galacticStructure_) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily blitz2006} star formation surface density rate from disks class.
     !!}
     use :: Error                           , only : Error_Report
-    use :: Numerical_Constants_Astronomical, only : massSolar         , megaParsec
+    use :: Numerical_Constants_Astronomical, only : massSolar                , megaParsec
     use :: Numerical_Constants_Physical    , only : boltzmannsConstant
-    use :: Numerical_Constants_Prefixes    , only : giga              , hecto     , kilo, mega
+    use :: Numerical_Constants_Prefixes    , only : giga                     , hecto                        , kilo                         , mega
+    use :: Root_Finder                     , only : rangeExpandMultiplicative, rangeExpandSignExpectNegative, rangeExpandSignExpectPositive
     implicit none
     type            (starFormationRateSurfaceDensityDisksBlitz2006)                        :: self
     class           (galacticStructureClass                       ), intent(in   ), target :: galacticStructure_
@@ -178,8 +203,9 @@ contains
          &                                                                                    surfaceDensityCritical             , surfaceDensityExponent , &
          &                                                                                    starFormationFrequencyNormalization, pressureCharacteristic , &
          &                                                                                    pressureExponent
+    logical                                                        , intent(in   )         :: assumeMonotonicSurfaceDensity
      !![
-     <constructorAssign variables="velocityDispersionDiskGas, heightToRadialScaleDisk, surfaceDensityCritical, surfaceDensityExponent, starFormationFrequencyNormalization, pressureCharacteristic, pressureExponent, *galacticStructure_"/>
+     <constructorAssign variables="velocityDispersionDiskGas, heightToRadialScaleDisk, surfaceDensityCritical, surfaceDensityExponent, starFormationFrequencyNormalization, pressureCharacteristic, pressureExponent, assumeMonotonicSurfaceDensity, *galacticStructure_"/>
      !!]
 
     self%lastUniqueID   =-1_kind_int8
@@ -190,6 +216,19 @@ contains
     self%surfaceDensityCritical             =self%surfaceDensityCritical*(mega**2)                                                    ! Convert to M☉/Mpc².
     self%starFormationFrequencyNormalization=self%starFormationFrequencyNormalization*giga                                            ! Convert to Gyr⁻¹.
     self%pressureCharacteristic             =self%pressureCharacteristic*boltzmannsConstant*((hecto*megaParsec)**3)/massSolar/kilo**2 ! Convert to M☉(km/s)²/Mpc.
+    ! Build fast exponentiator.
+    self%pressureRatioExponentiator         =fastExponentiator(0.0d0,1.0d0,pressureExponent,1000.0d0,.false.)
+    ! Build root finder.
+    self%finder=rootFinder(                                                             &
+         &                 rootFunction                 =blitz2006CriticalDensityRoot , &
+         &                 toleranceAbsolute            =0.0d+0                       , &
+         &                 toleranceRelative            =1.0d-4                       , &
+         &                 rangeExpandUpward            =2.0d0                        , &
+         &                 rangeExpandDownward          =0.5d0                        , &
+         &                 rangeExpandUpwardSignExpect  =rangeExpandSignExpectNegative, &
+         &                 rangeExpandDownwardSignExpect=rangeExpandSignExpectPositive, &
+         &                 rangeExpandType              =rangeExpandMultiplicative      &
+         &                )
     return
   end function blitz2006ConstructorInternal
 
@@ -239,69 +278,36 @@ contains
     in the galactic disk of {\normalfont \ttfamily node}. The disk is assumed to obey the
     \cite{blitz_role_2006} star formation rule.
     !!}
-    use :: Abundances_Structure            , only : abundances
-    use :: Galactic_Structure_Options      , only : componentTypeDisk              , coordinateSystemCylindrical, massTypeGaseous, massTypeStellar
-    use :: Galacticus_Nodes                , only : nodeComponentDisk              , treeNode
-    use :: Numerical_Constants_Math        , only : Pi
-    use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
     implicit none
     class           (starFormationRateSurfaceDensityDisksBlitz2006), intent(inout) :: self
     type            (treeNode                                     ), intent(inout) :: node
     double precision                                               , intent(in   ) :: radius
-    class           (nodeComponentDisk                            ), pointer       :: disk
-    type            (abundances                                   ), save          :: abundancesFuel
-    !$omp threadprivate(abundancesFuel)
-    double precision                                                               :: molecularFraction, pressureRatio        , &
-         &                                                                            surfaceDensityGas, surfaceDensityStellar
+    double precision                                                               :: molecularFraction, pressureRatio, &
+         &                                                                            surfaceDensityGas, factorBoost
 
     ! Check if node differs from previous one for which we performed calculations.
     if (node%uniqueID() /= self%lastUniqueID) call self%calculationReset(node)
-    ! Check if factors have been precomputed.
-    if (.not.self%factorsComputed) then
-       ! Get the disk properties.
-       disk             => node%disk       ()
-       self%massGas     =  disk%massGas    ()
-       self%massStellar =  disk%massStellar()
-       self%radiusDisk  =  disk%radius     ()
-       ! Find the hydrogen fraction in the disk gas of the fuel supply.
-       abundancesFuel=disk%abundancesGas()
-       call abundancesFuel%massToMassFraction(self%massGas)
-       self%hydrogenMassFraction=abundancesFuel%hydrogenMassFraction()
-       ! Record that factors have now been computed.
-       self%factorsComputed=.true.
-    end if
+    ! Compute factors.
+    call self%computeFactors(node)
     ! Return zero rate for non-positive radius or mass.
     if (self%massGas <= 0.0d0 .or. self%massStellar < 0.0d0 .or. self%radiusDisk <= 0.0d0) then
        blitz2006Rate=0.0d0
        return
     end if
-    ! Get gas and stellar surface densities.
-    surfaceDensityGas    =self%galacticStructure_%surfaceDensity(node,[radius,0.0d0,0.0d0],coordinateSystem=coordinateSystemCylindrical,componentType=componentTypeDisk,massType=massTypeGaseous)
-    surfaceDensityStellar=self%galacticStructure_%surfaceDensity(node,[radius,0.0d0,0.0d0],coordinateSystem=coordinateSystemCylindrical,componentType=componentTypeDisk,massType=massTypeStellar)
-    ! Compute the pressure ratio that Blitz & Rosolowsky (2006) use to compute the molecular fraction.
-    pressureRatio=+0.5d0                                   &
-         &        *Pi                                      &
-         &        *gravitationalConstantGalacticus         &
-         &        *surfaceDensityGas                       &
-         &        *(                                       &
-         &          +surfaceDensityGas                     &
-         &          +self%velocityDispersionDiskGas        &
-         &          *sqrt(                                 &
-         &                +surfaceDensityStellar           &
-         &                /Pi                              &
-         &                /gravitationalConstantGalacticus &
-         &                /self%heightToRadialScaleDisk    &
-         &                /self%radiusDisk                 &
-         &               )                                 &
-         &         )                                       &
-         &        /self%pressureCharacteristic
+    ! Compute the pressure ratio that Blitz & Rosolowsky (2006) use to compute the molecular fraction.    
+    !! We first compute the pressure ratio ignoring the boost from the stellar mass. If this already exceeds the characteristic
+    !! limit then we will not need to compute the stellar contribution.
+    pressureRatio=self%pressureRatio(node,radius,surfaceDensityGas)
     ! Compute the molecular fraction, limited to 100% molecular.
     if (pressureRatio >= 1.0d0) then
        molecularFraction=                                         1.0d0
     else
-       molecularFraction=min(pressureRatio**self%pressureExponent,1.0d0)
+       molecularFraction=min(self%pressureRatioExponentiator%exponentiate(pressureRatio),1.0d0)
     end if
     ! Compute the star formation rate surface density.
+    factorBoost  =+self%hydrogenMassFraction                &
+         &        *surfaceDensityGas                        &
+         &        /self%surfaceDensityCritical
     blitz2006Rate=+surfaceDensityGas                        &
          &        *self%hydrogenMassFraction                &
          &        *molecularFraction                        &
@@ -316,3 +322,182 @@ contains
          &         )
     return
   end function blitz2006Rate
+
+  logical function blitz2006Unchanged(self,node)
+    !!{
+    Determine if the surface rate density of star formation is unchanged.
+    !!}
+    implicit none
+    class(starFormationRateSurfaceDensityDisksBlitz2006), intent(inout) :: self
+    type (treeNode                                     ), intent(inout) :: node
+
+    call self%computeFactors(node)
+    blitz2006Unchanged= self%massGas              == self%massGasPrevious              &
+         &             .and.                                                           &
+         &              self%massStellar          == self%massStellarPrevious          &
+         &             .and.                                                           &
+         &              self%radiusDisk           == self%radiusDiskPrevious           &
+         &             .and.                                                           &
+         &              self%hydrogenMassFraction == self%hydrogenMassFractionPrevious
+    if (.not.blitz2006Unchanged) then
+       self%massGasPrevious             =self%massGas
+       self%massStellarPrevious         =self%massStellar
+       self%radiusDiskPrevious          =self%radiusDisk
+       self%hydrogenMassFractionPrevious=self%hydrogenMassFraction
+    end if
+    return
+  end function blitz2006Unchanged
+  
+  subroutine blitz2006ComputeFactors(self,node)
+    !!{
+    Compute various factors for the {\normalfont \ttfamily blitz2006} star formation rate surface density calculation.
+    !!}
+    use :: Abundances_Structure, only : abundances
+    use :: Galacticus_Nodes    , only : nodeComponentDisk
+    implicit none
+    class(starFormationRateSurfaceDensityDisksBlitz2006), intent(inout) :: self
+    type (treeNode                                     ), intent(inout) :: node
+    class(nodeComponentDisk                            ), pointer       :: disk
+    type (abundances                                   ), save          :: abundancesFuel
+    !$omp threadprivate(abundancesFuel)
+
+    ! Check if factors have been precomputed.
+    if (.not.self%factorsComputed) then
+       ! Get the disk properties.
+       disk         => node%disk   ()
+       self%massGas =  disk%massGas()
+       if (self%massGas > 0.0d0) then
+          self%massStellar=disk%massStellar()
+          self%radiusDisk =disk%radius     ()
+          ! Find the hydrogen fraction in the disk gas of the fuel supply.
+          abundancesFuel=disk%abundancesGas()
+          call abundancesFuel%massToMassFraction(self%massGas)
+          self%hydrogenMassFraction=abundancesFuel%hydrogenMassFraction()
+       else
+          ! No gas mass, so other factors are irrelevant.
+          self%massStellar         =0.0d0
+          self%radiusDisk          =0.0d0
+          self%hydrogenMassFraction=0.0d0
+       end if
+       ! Record that factors have now been computed.
+       self%factorsComputed=.true.
+    end if
+    return
+  end subroutine blitz2006ComputeFactors
+
+  function blitz2006Intervals(self,node,radiusInner,radiusOuter)
+    !!{
+    Returns intervals to use for integrating the \cite{krumholz_star_2009} star formation rate over a galactic disk.
+    !!}
+    implicit none
+    class           (starFormationRateSurfaceDensityDisksBlitz2006), intent(inout), target         :: self
+    double precision                                               , allocatable  , dimension(:,:) :: blitz2006Intervals
+    type            (treeNode                                     ), intent(inout), target         :: node
+    double precision                                               , intent(in   )                 :: radiusInner       , radiusOuter
+
+    ! Check if we can assume a monotonic surface density.
+    if (self%assumeMonotonicSurfaceDensity) then
+       ! Set the critical radius to a very negative value so that pressure ratio is always computed.
+       self%radiusCritical=-huge(0.0d0)
+       ! Compute factors.
+       call self%computeFactors(node)
+       ! Set single interval for non-positive radius or mass.
+       if (self%massGas <= 0.0d0 .or. self%massStellar < 0.0d0 .or. self%radiusDisk <= 0.0d0) then
+          allocate(blitz2006Intervals(2,1))
+          blitz2006Intervals=reshape([radiusInner,radiusOuter],[2,1])
+          self%radiusCritical=-huge(0.0d0)
+       else
+          ! Test if the inner radius is below the pressure threshold.
+          if (self%pressureRatio(node,radiusInner) <= 1.0d0) then
+             ! The entire disk is below the pressure threshold so use a single interval.
+             allocate(blitz2006Intervals(2,1))
+             blitz2006Intervals=reshape([radiusInner,radiusOuter],[2,1])
+             self%radiusCritical=-huge(0.0d0)
+          else
+             ! Test the surface density at the outer radius.
+             if (self%pressureRatio(node,radiusOuter) >= 1.0d0) then
+                ! Entire disk is above the pressure threshold so use a single interval.
+                allocate(blitz2006Intervals(2,1))
+                blitz2006Intervals=reshape([radiusInner,radiusOuter],[2,1])
+                self%radiusCritical=radiusOuter
+             else
+                ! The disk transitions the pressure ratio - attempt to locate the radius at which this happens and use two
+                ! intervals split at this point.
+                self_                => self
+                node_                => node
+                self %radiusCritical =  self%finder%find(rootRange=[radiusInner,radiusOuter])
+                allocate(blitz2006Intervals(2,2))
+                blitz2006Intervals=reshape([radiusInner,self%radiusCritical,self%radiusCritical,radiusOuter],[2,2])
+             end if
+          end if
+       end if
+    else
+       ! Disk pressure can not be assumed to be monotonic - use a single interval.
+       allocate(blitz2006Intervals(2,1))
+       blitz2006Intervals=reshape([radiusInner,radiusOuter],[2,1])
+       self%radiusCritical=radiusInner
+    end if
+    return
+  end function blitz2006Intervals
+
+  double precision function blitz2006CriticalDensityRoot(radius)
+    !!{
+    Root function used in finding the radius in a disk where the pressure ratio exceeds the critical ratio.
+    !!}
+    implicit none
+    double precision, intent(in   ) :: radius
+
+    blitz2006CriticalDensityRoot=self_%pressureRatio(node_,radius)-1.0d0
+    return
+  end function blitz2006CriticalDensityRoot
+
+  double precision function blitz2006PressureRatio(self,node,radius,surfaceDensityGas) result(pressureRatio)
+    !!{
+    Root function used in finding the radius in a disk where the pressure ratio exceeds the critical ratio.
+    !!}
+    use :: Numerical_Constants_Math        , only : Pi
+    use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
+    use :: Galactic_Structure_Options      , only : componentTypeDisk              , coordinateSystemCylindrical, massTypeGaseous, massTypeStellar
+    implicit none
+    class           (starFormationRateSurfaceDensityDisksBlitz2006), intent(inout)           :: self
+    type            (treeNode                                     ), intent(inout)           :: node
+    double precision                                               , intent(in   )           :: radius
+    double precision                                               , intent(  out), optional :: surfaceDensityGas
+    double precision                                                                         :: surfaceDensityGas_, surfaceDensityStellar, &
+         &                                                                                      factorBoostStellar
+
+    ! Get gas surface density.
+    surfaceDensityGas_=self%galacticStructure_%surfaceDensity(node,[radius,0.0d0,0.0d0],coordinateSystem=coordinateSystemCylindrical,componentType=componentTypeDisk,massType=massTypeGaseous)
+    if (present(surfaceDensityGas)) surfaceDensityGas=surfaceDensityGas_
+    ! If the radius is less than the critical radius the pressure radius is above 1 by definition, so simply pin it to that value.
+    if (radius <= self%radiusCritical) then
+       pressureRatio=1.0d0
+    else
+       ! Compute the pressure ratio that Blitz & Rosolowsky (2006) use to compute the molecular fraction.    
+       !! We first compute the pressure ratio ignoring the boost from the stellar mass. If this already exceeds the characteristic
+       !! limit then we will not need to compute the stellar contribution.
+       pressureRatio=+0.5d0                              &
+            &        *Pi                                 &
+            &        *gravitationalConstantGalacticus    &
+            &        *surfaceDensityGas_             **2 &
+            &        /self%pressureCharacteristic
+       if (pressureRatio > 0.0d0 .and. pressureRatio < 1.0d0) then
+          ! Compute the stellar boost factor.
+          surfaceDensityStellar=+self%galacticStructure_%surfaceDensity(node,[radius,0.0d0,0.0d0],coordinateSystem=coordinateSystemCylindrical,componentType=componentTypeDisk,massType=massTypeStellar) 
+          factorBoostStellar   =+1.0d0                                 &
+               &                +self%velocityDispersionDiskGas        &
+               &                /surfaceDensityGas_                    &
+               &                *sqrt(                                 &
+               &                      +surfaceDensityStellar           &
+               &                      /Pi                              &
+               &                      /gravitationalConstantGalacticus &
+               &                      /self%heightToRadialScaleDisk    &
+               &                      /self%radiusDisk                 &
+               &                     ) 
+          pressureRatio        =+pressureRatio                         &
+               &                *factorBoostStellar
+       end if
+    end if
+    return
+  end function blitz2006PressureRatio
+  


### PR DESCRIPTION
Optimizations are:

- Mark the function as unchanged when possible to avoid duplicated calculation;
- Compute the stellar surface density only if needed;
- Split the integration at the radius where the molecular fraction reaches 100% (to avoid the discontinuity in the integrand);
- Use a fast exponentiator for evaluating the pressure term.