### PR TITLE
fix: Correct logic for when to evaluate properties during differential evolution

### DIFF
--- a/source/objects.nodes.F90
+++ b/source/objects.nodes.F90
@@ -1914,7 +1914,7 @@ module Galacticus_Nodes
          &           .or.                                                                  &
          &            (propertyType == propertyTypeActive   .and. .not.propertyIsInactive) &
          &           .or.                                                                  &
-         &            (propertyType == propertyTypeNumerics .and. .not.propertyIsInactive) &
+         &             propertyType == propertyTypeNumerics                                &
          &           .or.                                                                  &
          &            (propertyType == propertyTypeInactive .and.      propertyIsInactive)
     return


### PR DESCRIPTION
For "numeric" properties they must be solved even if marked as inactive, since "numeric" indicates that we are using an ODE solver that does not support inactive property calculation.