### PR TITLE
Use spherically-averaged densities when computing velocity dispersions

### DIFF
--- a/perl/Galacticus/Build/Components/Components.pm
+++ b/perl/Galacticus/Build/Components/Components.pm
@@ -203,6 +203,15 @@ sub Build_Node_Component_Class {
 	 },
 	 {
 	     type        => "procedure"                                                                                            ,
+	     name        => "densitySphericalAverage"                                                                              ,
+	     function    => "Node_Component_Density_Spherical_Average_Null"                                                        ,
+	     description => "Compute the spherically-averaged density."                                                            ,
+	     mappable    => "summation"                                                                                            ,
+	     returnType  => "\\doublezero"                                                                                         ,
+	     arguments   => "\\doublezero\\ radius\\argin, \\enumComponentType\\ [componentType]\\argin, \\enumMassType\\ [massType]\\argin, \\enumWeightBy\\ [weightBy]\\argin, \\intzero\\ [weightIndex]\\argin"
+	 },
+	 {
+	     type        => "procedure"                                                                                            ,
 	     name        => "surfaceDensity"                                                                                       ,
 	     function    => "Node_Component_Surface_Density_Null"                                                                  ,
 	     description => "Compute the surface density."                                                                         ,

--- a/source/dark_matter_profiles.structure_tasks.F90
+++ b/source/dark_matter_profiles.structure_tasks.F90
@@ -29,7 +29,8 @@ module Dark_Matter_Profile_Structure_Tasks
   private
   public :: Dark_Matter_Profile_Enclosed_Mass_Task               , Dark_Matter_Profile_Density_Task                       , Dark_Matter_Profile_Rotation_Curve_Task        , Dark_Matter_Profile_Potential_Task               , &
        &    Dark_Matter_Profile_Rotation_Curve_Gradient_Task     , Dark_Matter_Profile_Acceleration_Task                  , Dark_Matter_Profile_Tidal_Tensor_Task          , Dark_Matter_Profile_Chandrasekhar_Integral_Task  , &
-       &    Dark_Matter_Profile_Structure_Tasks_Thread_Initialize, Dark_Matter_Profile_Structure_Tasks_Thread_Uninitialize, Dark_Matter_Profile_Structure_Tasks_State_Store, Dark_Matter_Profile_Structure_Tasks_State_Restore
+       &    Dark_Matter_Profile_Structure_Tasks_Thread_Initialize, Dark_Matter_Profile_Structure_Tasks_Thread_Uninitialize, Dark_Matter_Profile_Structure_Tasks_State_Store, Dark_Matter_Profile_Structure_Tasks_State_Restore, &
+       &    Dark_Matter_Profile_Density_Spherical_Average_Task
 
   class(darkMatterProfileClass), pointer  :: darkMatterProfile_
   !$omp threadprivate(darkMatterProfile_)
@@ -285,6 +286,35 @@ contains
     Dark_Matter_Profile_Density_Task=darkMatterProfile_%density(node,positionSpherical(1))
     return
   end function Dark_Matter_Profile_Density_Task
+
+  !![
+  <densitySphericalAverageTask>
+   <unitName>Dark_Matter_Profile_Density_Spherical_Average_Task</unitName>
+  </densitySphericalAverageTask>
+  !!]
+  double precision function Dark_Matter_Profile_Density_Spherical_Average_Task(node,radius,componentType,massType,weightBy,weightIndex)
+    !!{
+    Computes the density at a given position for a dark matter profile.
+    !!}
+    use :: Galactic_Structure_Options, only : componentTypeAll, componentTypeDarkHalo , massTypeAll, massTypeDark, &
+          &                                   weightByMass
+    use :: Galacticus_Nodes          , only : treeNode
+    implicit none
+    type            (treeNode), intent(inout) :: node
+    integer                   , intent(in   ) :: componentType, massType   , &
+         &                                       weightBy     , weightIndex
+    double precision          , intent(in   ) :: radius
+    !$GLC attributes unused :: weightIndex
+
+    ! Return zero if the component and mass type is not matched.
+    Dark_Matter_Profile_Density_Spherical_Average_Task=0.0d0
+    if (.not.(componentType == componentTypeAll .or. componentType == componentTypeDarkHalo)) return
+    if (.not.(massType      == massTypeAll      .or. massType      == massTypeDark         )) return
+    if (.not.(weightBy      == weightByMass                                                )) return
+    ! Compute the density
+    Dark_Matter_Profile_Density_Spherical_Average_Task=darkMatterProfile_%density(node,radius)
+    return
+  end function Dark_Matter_Profile_Density_Spherical_Average_Task
 
   !![
   <rotationCurveGradientTask>

--- a/source/galactic.structure.F90
+++ b/source/galactic.structure.F90
@@ -35,12 +35,20 @@ module Galactic_Structure
    <description>Object providing galactic structure functions.</description>
    <default>standard</default>
    <method name="density">
-    <description>Return the mass enclosed at the given {\normalfont \ttfamily position} in {\normalfont \ttfamily node}.</description>
+    <description>Return the density at the given {\normalfont \ttfamily position} in {\normalfont \ttfamily node}.</description>
     <type>double precision</type>
     <pass>yes</pass>
     <argument>type            (treeNode), intent(inout)               :: node</argument>
     <argument>double precision          , intent(in   ), dimension(3) :: position</argument>
     <argument>integer                   , intent(in   ), optional     :: coordinateSystem, componentType, massType, weightBy, weightIndex</argument>
+   </method>
+   <method name="densitySphericalAverage">
+    <description>Return the spherically-averaged density at the given {\normalfont \ttfamily radius} in {\normalfont \ttfamily node}.</description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>type            (treeNode), intent(inout)           :: node</argument>
+    <argument>double precision          , intent(in   )           :: radius</argument>
+    <argument>integer                   , intent(in   ), optional :: componentType, massType, weightBy, weightIndex</argument>
    </method>
    <method name="massEnclosed">
     <description>Return the mass enclosed within the given {\normalfont \ttfamily radius} in {\normalfont \ttfamily node}.</description>

--- a/source/galactic.structure.standard.F90
+++ b/source/galactic.structure.standard.F90
@@ -58,6 +58,7 @@ Contains a module which implements the standard galactic structure functions.
      final     ::                                  standardDestructor
      procedure :: autoHook                      => standardAutoHook
      procedure :: density                       => standardDensity
+     procedure :: densitySphericalAverage       => standardDensitySphericalAverage
      procedure :: massEnclosed                  => standardMassEnclosed
      procedure :: radiusEnclosingMass           => standardRadiusEnclosingMass
      procedure :: velocityRotation              => standardVelocityRotation
@@ -293,6 +294,59 @@ contains
     densityComponent=component%density(positionSpherical_,galacticStructureState_(galacticStructureStateCount)%componentType_,galacticStructureState_(galacticStructureStateCount)%massType_,galacticStructureState_(galacticStructureStateCount)%weightBy_,galacticStructureState_(galacticStructureStateCount)%weightIndex_)
     return
   end function densityComponent
+
+  double precision function standardDensitySphericalAverage(self,node,radius,componentType,massType,weightBy,weightIndex) result(density)
+    !!{
+    Compute the density (of given {\normalfont \ttfamily massType}) at the specified {\normalfont \ttfamily position}. Assumes that galactic structure has already
+    been computed.
+    !!}
+    use :: Galactic_Structure_Options, only : componentTypeAll                           , massTypeAll       , weightByLuminosity, weightByMass
+    use :: Error                     , only : Error_Report
+    use :: Galacticus_Nodes          , only : optimizeForDensitySphericalAverageSummation, reductionSummation, treeNode
+    !![
+    <include directive="densitySphericalAverageTask" type="moduleUse">
+    !!]
+    include 'galactic_structure.density_spherical_average.tasks.modules.inc'
+    !![
+    </include>
+    !!]
+    implicit none
+    class           (galacticStructureStandard       ), intent(inout)           :: self
+    type            (treeNode                        ), intent(inout)           :: node
+    integer                                           , intent(in   ), optional :: componentType                     , massType   , &
+         &                                                                         weightBy                          , weightIndex
+    double precision                                  , intent(in   )           :: radius
+    procedure       (densitySphericalAverageComponent), pointer                 :: densitySphericalAverageComponent_
+    double precision                                                            :: densitySphericalAverageComponent__
+
+    call self%defaults(radius=radius,componentType=componentType,massType=massType,weightBy=weightBy,weightIndex=weightIndex)
+    ! Call routines to supply the densities for all components.
+    densitySphericalAverageComponent_ => densitySphericalAverageComponent
+    density                           =  node%mapDouble0(densitySphericalAverageComponent_,reductionSummation,optimizeFor=optimizeForDensitySphericalAverageSummation)
+    !![
+    <include directive="densitySphericalAverageTask" type="functionCall" functionType="function" returnParameter="densitySphericalAverageComponent__">
+     <functionArgs>node,radius,galacticStructureState_(galacticStructureStateCount)%componentType_,galacticStructureState_(galacticStructureStateCount)%massType_,galacticStructureState_(galacticStructureStateCount)%weightBy_,galacticStructureState_(galacticStructureStateCount)%weightIndex_</functionArgs>
+     <onReturn>density=density+densitySphericalAverageComponent__</onReturn>
+    !!]
+    include 'galactic_structure.density_spherical_average.tasks.inc'
+    !![
+    </include>
+    !!]
+    call self%restore()
+    return
+  end function standardDensitySphericalAverage
+  
+  double precision function densitySphericalAverageComponent(component)
+    !!{
+    Unary function returning the spherically-averaged density in a component. Suitable for mapping over components.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponent
+    implicit none
+    class(nodeComponent), intent(inout) :: component
+
+    densitySphericalAverageComponent=component%densitySphericalAverage(galacticStructureState_(galacticStructureStateCount)%radius_,galacticStructureState_(galacticStructureStateCount)%componentType_,galacticStructureState_(galacticStructureStateCount)%massType_,galacticStructureState_(galacticStructureStateCount)%weightBy_,galacticStructureState_(galacticStructureStateCount)%weightIndex_)
+    return
+  end function densitySphericalAverageComponent
 
   double precision function standardMassEnclosed(self,node,radius,componentType,massType,weightBy,weightIndex) result(massEnclosed)
     !!{
@@ -910,16 +964,12 @@ contains
     integrator_            =integrator           (integrandVelocityDispersion,toleranceRelative=1.0d-3)
     densityVelocityVariance=integrator_%integrate(radius                     ,radiusOuter             )
     ! Get the density at this radius.
-    densitySphericalAverage=+3.0d0                                                                                                 &
-         &                  /4.0d0                                                                                                 &
-         &                  /Pi                                                                                                    &
-         &                  *self_%massEnclosed(                                                                                   &
-         &                                                    node_                                                              , &
-         &                                                    radius                                                             , & 
-         &                                      componentType=galacticStructureState_(galacticStructureStateCount)%componentType_, &
-         &                                      massType     =galacticStructureState_(galacticStructureStateCount)%massType_       &
-         &                                     )                                                                                   &
-         &                  /radius**3
+    densitySphericalAverage=self_%densitySphericalAverage(                                                                                   &
+         &                                                              node_                                                              , &
+         &                                                              radius                                                             , & 
+         &                                                componentType=galacticStructureState_(galacticStructureStateCount)%componentType_, &
+         &                                                massType     =galacticStructureState_(galacticStructureStateCount)%massType_       &
+         &                                               )
     ! Check for zero density.
     if (densitySphericalAverage <= 0.0d0) then
        velocityDispersion=0.0d0
@@ -935,31 +985,24 @@ contains
     Integrand function used for finding velocity dispersions using Jeans equation.
     !!}
     use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
-    use :: Numerical_Constants_Math        , only : Pi
     implicit none
     double precision, intent(in   ) :: radius
-    double precision                :: densitySphericalAverage
 
     if (radius == 0.0d0) then
        integrandVelocityDispersion=0.0d0
     else
-       densitySphericalAverage    =+3.0d0                                                                                                 &
-            &                      /4.0d0                                                                                                 &
-            &                      /Pi                                                                                                    &
-            &                      *self_%massEnclosed(                                                                                   &
-            &                                                        node_                                                              , &
-            &                                                        radius                                                             , & 
-            &                                          componentType=galacticStructureState_(galacticStructureStateCount)%componentType_, &
-            &                                          massType     =galacticStructureState_(galacticStructureStateCount)%massType_       &
-            &                                         )                                                                                   &
-            &                      /radius**3
-       integrandVelocityDispersion=+gravitationalConstantGalacticus                                                                       &
-            &                      *self_%massEnclosed(                                                                                   &
-            &                                                         node_                                                             , &
-            &                                                         radius                                                              &
-            &                                         )                                                                                   &
-            &                      /radius**2                                                                                             &
-            &                      *densitySphericalAverage
+       integrandVelocityDispersion=+gravitationalConstantGalacticus                                                                                  &
+            &                      *self_%massEnclosed           (                                                                                   &
+            &                                                                    node_                                                             , &
+            &                                                                    radius                                                              &
+            &                                                    )                                                                                   &
+            &                      /radius**2                                                                                                        &
+            &                      *self_%densitySphericalAverage(                                                                                   &
+            &                                                                   node_                                                              , &
+            &                                                                   radius                                                             , & 
+            &                                                     componentType=galacticStructureState_(galacticStructureStateCount)%componentType_, &
+            &                                                     massType     =galacticStructureState_(galacticStructureStateCount)%massType_       &
+            &                                                    )
     end if
     return
   end function integrandVelocityDispersion

--- a/source/hot_halo.mass_distribution.F90
+++ b/source/hot_halo.mass_distribution.F90
@@ -33,7 +33,7 @@ module Hot_Halo_Mass_Distributions
        &    hotHaloMassDistributionAcceleration         , hotHaloMassDistributionAccelerationTidalTensor, &
        &    hotHaloMassDistributionChandrasekharIntegral, hotHaloMassDistributionThreadInitialize       , &
        &    hotHaloMassDistributionThreadUninitialize   , hotHaloMassDistributionDefaultStateStore      , &
-       &    hotHaloMassDistributionDefaultStateRestore
+       &    hotHaloMassDistributionDefaultStateRestore  , hotHaloMassDistributionDensitySphericalAverage
 
   !![
   <functionClass>
@@ -93,7 +93,7 @@ module Hot_Halo_Mass_Distributions
   !!]
   subroutine hotHaloMassDistributionThreadInitialize(parameters_)
     !!{
-    Initializes the dark matter profile structure tasks module.
+    Initializes the hot halo profile structure tasks module.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
@@ -113,7 +113,7 @@ module Hot_Halo_Mass_Distributions
   !!]
   subroutine hotHaloMassDistributionThreadUninitialize()
     !!{
-    Uninitializes the dark matter profile structure tasks module.
+    Uninitializes the hot halo profile structure tasks module.
     !!}
     implicit none
 
@@ -131,7 +131,7 @@ module Hot_Halo_Mass_Distributions
   !!]
   double precision function hotHaloMassDistributionEnclosedMass(node,radius,componentType,massType,weightBy,weightIndex)
     !!{
-    Computes the mass within a given radius for a dark matter profile.
+    Computes the mass within a given radius for a hot halo profile.
     !!}
     use :: Galactic_Structure_Options, only : componentTypeAll    , componentTypeHotHalo, massTypeAll , massTypeBaryonic, &
           &                                   massTypeGaseous     , radiusLarge         , weightByMass
@@ -166,7 +166,7 @@ module Hot_Halo_Mass_Distributions
   !!]
   function hotHaloMassDistributionAcceleration(node,positionCartesian,componentType,massType)
     !!{
-    Computes the acceleration due to a dark matter profile.
+    Computes the acceleration due to a hot halo profile.
     !!}
     use :: Galactic_Structure_Options      , only : weightByMass                   , weightIndexNull
     use :: Galacticus_Nodes                , only : treeNode
@@ -352,7 +352,7 @@ module Hot_Halo_Mass_Distributions
   !!]
   double precision function hotHaloMassDistributionDensity(node,positionSpherical,componentType,massType,weightBy,weightIndex)
     !!{
-    Computes the density at a given position for a dark matter profile.
+    Computes the density at a given position for a hot halo profile.
     !!}
     use :: Galactic_Structure_Options, only : componentTypeAll, componentTypeHotHalo, massTypeAll, massTypeBaryonic, &
           &                                   massTypeGaseous , weightByMass
@@ -371,6 +371,33 @@ module Hot_Halo_Mass_Distributions
     hotHaloMassDistributionDensity=max(hotHaloMassDistribution_%density(node,positionSpherical(1)),0.0d0)
     return
   end function hotHaloMassDistributionDensity
+
+  !![
+  <densitySphericalAverageTask>
+   <unitName>hotHaloMassDistributionDensitySphericalAverage</unitName>
+  </densitySphericalAverageTask>
+  !!]
+  double precision function hotHaloMassDistributionDensitySphericalAverage(node,radius,componentType,massType,weightBy,weightIndex)
+    !!{
+    Computes the sphreically-averaged density at a given radius for a hot halo profile.
+    !!}
+    use :: Galactic_Structure_Options, only : componentTypeAll, componentTypeHotHalo, massTypeAll, massTypeBaryonic, &
+          &                                   massTypeGaseous , weightByMass
+    implicit none
+    type            (treeNode), intent(inout) :: node
+    integer                   , intent(in   ) :: componentType, massType, weightBy, &
+         &                                       weightIndex
+    double precision          , intent(in   ) :: radius
+    !$GLC attributes unused :: weightIndex
+
+    hotHaloMassDistributionDensitySphericalAverage=0.0d0
+    if (.not.(componentType == componentTypeAll .or. componentType == componentTypeHotHalo                                 )) return
+    if (.not.(massType      == massTypeAll      .or. massType      == massTypeBaryonic     .or. massType == massTypeGaseous)) return
+    if (.not.(weightBy      == weightByMass                                                                                )) return
+
+    hotHaloMassDistributionDensitySphericalAverage=max(hotHaloMassDistribution_%density(node,radius),0.0d0)
+    return
+  end function hotHaloMassDistributionDensitySphericalAverage
 
   !![
   <stateStoreTask>

--- a/source/mass_distributions.cylindrical.F90
+++ b/source/mass_distributions.cylindrical.F90
@@ -47,6 +47,7 @@
      procedure(cylindricalRotationCurve             ), deferred :: rotationCurve
      procedure(cylindricalRotationCurveGradient     ), deferred :: rotationCurveGradient
      procedure(cylindricalSurfaceDensityRadialMoment), deferred :: surfaceDensityRadialMoment
+     procedure(cylindricalDensitySphericalAverage   ), deferred :: densitySphericalAverage
   end type massDistributionCylindrical
 
   abstract interface
@@ -96,6 +97,15 @@
        double precision                             , intent(in   ), optional :: radiusMinimum, radiusMaximum
        logical                                      , intent(  out), optional :: isInfinite
      end function cylindricalSurfaceDensityRadialMoment
+
+     double precision function cylindricalDensitySphericalAverage(self,radius)
+       !!{
+       Interface for cylindrically symmetric mass distribution spherically-averaged density functions.
+       !!}
+       import massDistributionCylindrical
+       class           (massDistributionCylindrical), intent(inout)           :: self
+       double precision                             , intent(in   )           :: radius
+     end function cylindricalDensitySphericalAverage
 
   end interface
 

--- a/source/mass_distributions.cylindrical.Gaussian_slab.F90
+++ b/source/mass_distributions.cylindrical.Gaussian_slab.F90
@@ -34,6 +34,7 @@
      double precision :: scaleHeight, densityCentral
    contains
      procedure :: density                    => gaussianSlabDensity
+     procedure :: densitySphericalAverage    => gaussianSlabDensitySphericalAverage
      procedure :: rotationCurve              => gaussianSlabRotationCurve
      procedure :: rotationCurveGradient      => gaussianSlabRotationCurveGradient
      procedure :: surfaceDensity             => gaussianSlabSurfaceDensity
@@ -150,6 +151,19 @@ contains
     gaussianSlabDensity=self%densityCentral*exp(-0.5d0*z**2)
     return
   end function gaussianSlabDensity
+
+  double precision function gaussianSlabDensitySphericalAverage(self,radius)
+    !!{
+    Return the spherically-averaged density at the specified {\normalfont \ttfamily radius} in a Gaussian slab mass distribution.
+    !!}
+    implicit none
+    class           (massDistributionGaussianSlab), intent(inout) :: self
+    double precision                              , intent(in   ) :: radius
+
+    gaussianSlabDensitySphericalAverage=0.0d0
+    call Error_Report('spherically-averaged density profile is not implemented'//{introspection:location})
+    return
+  end function gaussianSlabDensitySphericalAverage
 
   double precision function gaussianSlabRotationCurve(self,radius)
     !!{

--- a/source/mass_distributions.cylindrical.Miyamoto_Nagai.F90
+++ b/source/mass_distributions.cylindrical.Miyamoto_Nagai.F90
@@ -41,11 +41,12 @@
    contains
      !![
      <methods>
-       <method description="Initialize the surface density tabulation." method="surfaceDensityTabulate" />
-       <method description="Initialize the enclosed mass tabulation." method="massEnclosedTabulate" />
+       <method description="Initialize the surface density tabulation." method="surfaceDensityTabulate"/>
+       <method description="Initialize the enclosed mass tabulation."    method="massEnclosedTabulate" />
      </methods>
      !!]
      procedure :: density                    => miyamotoNagaiDensity
+     procedure :: densitySphericalAverage    => miyamotoNagaiDensitySphericalAverage
      procedure :: surfaceDensity             => miyamotoNagaiSurfaceDensity
      procedure :: surfaceDensityTabulate     => miyamotoNagaiSurfaceDensityTabulate
      procedure :: surfaceDensityRadialMoment => miyamotoNagaiSurfaceDensityRadialMoment
@@ -173,7 +174,7 @@ contains
 
   double precision function miyamotoNagaiDensity(self,coordinates)
     !!{
-    Return the density at the specified {\normalfont \ttfamily coordinates} in an exponential disk mass distribution.
+    Return the density at the specified {\normalfont \ttfamily coordinates} in an \citep{miyamoto_three-dimensional_1975} disk mass distribution.
     !!}
     use :: Coordinates, only : assignment(=), coordinateCylindrical
     implicit none
@@ -227,9 +228,22 @@ contains
     return
   end function miyamotoNagaiDensity
 
+  double precision function miyamotoNagaiDensitySphericalAverage(self,radius)
+    !!{
+    Return the spherically-averaged density at the specified {\normalfont \ttfamily radius} in an \citep{miyamoto_three-dimensional_1975} disk mass distribution.
+    !!}
+    implicit none
+    class           (massDistributionMiyamotoNagai), intent(inout) :: self
+    double precision                               , intent(in   ) :: radius
+
+    miyamotoNagaiDensitySphericalAverage=0.0d0
+    call Error_Report('spherically-averaged density profile is not implemented'//{introspection:location})
+    return
+  end function miyamotoNagaiDensitySphericalAverage
+
   double precision function miyamotoNagaiMassEnclosedBySphere(self,radius)
     !!{
-    Computes the mass enclosed within a sphere of given {\normalfont \ttfamily radius} for exponential disk mass distributions.
+    Computes the mass enclosed within a sphere of given {\normalfont \ttfamily radius} for \citep{miyamoto_three-dimensional_1975} disk mass distributions.
     !!}
     implicit none
     class           (massDistributionMiyamotoNagai), intent(inout), target :: self
@@ -541,7 +555,7 @@ contains
 
   double precision function miyamotoNagaiRotationCurveGradient(self,radius)
     !!{
-    Return the mid-plane rotation curve gradient for an exponential disk.
+    Return the mid-plane rotation curve gradient for an \citep{miyamoto_three-dimensional_1975} disk.
     !!}
     use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
     implicit none
@@ -583,7 +597,7 @@ contains
 
   double precision function miyamotoNagaiPotential(self,coordinates)
     !!{
-    Return the gravitational potential for an exponential disk.
+    Return the gravitational potential for an \citep{miyamoto_three-dimensional_1975} disk.
     !!}
     use :: Coordinates                 , only : assignment(=)                  , coordinateCylindrical
     use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus

--- a/source/mass_distributions.cylindrical.exponential_disk.F90
+++ b/source/mass_distributions.cylindrical.exponential_disk.F90
@@ -73,6 +73,7 @@ contains
      procedure :: besselFactorRotationCurveGradient => exponentialDiskBesselFactorRotationCurveGradient
      procedure :: besselFactorPotential             => exponentialDiskBesselFactorPotential
      procedure :: density                           => exponentialDiskDensity
+     procedure :: densitySphericalAverage           => exponentialDiskDensitySphericalAverage
      procedure :: surfaceDensity                    => exponentialDiskSurfaceDensity
      procedure :: massEnclosedBySphere              => exponentialDiskMassEnclosedBySphere
      procedure :: potential                         => exponentialDiskPotential
@@ -321,9 +322,29 @@ contains
     return
   end function exponentialDiskDensity
 
+  double precision function exponentialDiskDensitySphericalAverage(self,radius)
+    !!{
+    Return the spherically-averaged density at the specified {\normalfont \ttfamily coordinates} in an exponential disk mass
+    distribution. Note that this assumes the thin-disk approximation.
+    !!}
+    implicit none
+    class           (massDistributionExponentialDisk), intent(inout) :: self
+    double precision                                 , intent(in   ) :: radius
+
+    exponentialDiskDensitySphericalAverage=+0.5d0                              &
+         &                              *     self%surfaceDensityNormalization &
+         &                              /                               radius &
+         &                              *exp(                                  &
+         &                                   -                          radius &
+         &                                   /self                %scaleRadius &
+         &                                  )
+    return
+  end function exponentialDiskDensitySphericalAverage
+
   double precision function exponentialDiskMassEnclosedBySphere(self,radius)
     !!{
-    Computes the mass enclosed within a sphere of given {\normalfont \ttfamily radius} for exponential disk mass distributions.
+    Computes the mass enclosed within a sphere of given {\normalfont \ttfamily radius} for exponential disk mass
+    distributions. Note that this assumes the thin-disk approximation.
     !!}
     use :: Numerical_Constants_Math, only : Pi
     implicit none

--- a/source/nodes.property_extractor.density.F90
+++ b/source/nodes.property_extractor.density.F90
@@ -184,6 +184,7 @@ contains
           &                                             radiusTypeGalacticMassFraction , radiusTypeRadius            , radiusTypeSpheroidHalfMassRadius, radiusTypeSpheroidRadius       , &
           &                                             radiusTypeStellarMassFraction  , radiusTypeVirialRadius
     use :: Galacticus_Nodes                    , only : nodeComponentDarkMatterProfile , nodeComponentDisk           , nodeComponentSpheroid           , treeNode
+    use :: Numerical_Constants_Math            , only : Pi
     implicit none
     double precision                                     , dimension(:,:), allocatable :: densityProfileExtract
     class           (nodePropertyExtractorDensityProfile), intent(inout) , target      :: self
@@ -248,7 +249,7 @@ contains
             &                                                            node                                 , &
             &                                                            [                                      &
             &                                                             radius                              , &
-            &                                                             0.0d0                               , &
+            &                                                             Pi/2.0d0                            , &
             &                                                             0.0d0                                 &
             &                                                            ]                                    , &
             &                                                            componentType=self%radii(i)%component, &

--- a/source/nodes.property_extractor.velocity_dispersion.F90
+++ b/source/nodes.property_extractor.velocity_dispersion.F90
@@ -705,21 +705,28 @@ contains
     !!{
     Integrand function used for computing line-of-sight velocity dispersions.
     !!}
+    use :: Numerical_Constants_Math, only : Pi
     implicit none
     double precision, intent(in   ) :: radius
+    double precision                :: densitySphericalAverage
 
     if (radius <= velocityDispersionRadiusImpact) then
        velocityDispersionDensityIntegrand=+0.0d0
     else
-       velocityDispersionDensityIntegrand=+velocityDispersionSelf%galacticStructure_%density(                                               &
-            &                                                                                              velocityDispersionNode         , &
-            &                                                                                              [radius,0.0d0,0.0d0]           , &
-            &                                                                                massType     =velocityDispersionMassType     , &
-            &                                                                                componentType=velocityDispersionComponentType, &
-            &                                                                                weightBy     =velocityDispersionWeightBy     , &
-            &                                                                                weightIndex  =velocityDispersionWeightIndex    &
-            &                                                                               )                                               &
-            &                             *     radius                                                                                      &
+       densitySphericalAverage           =+3.0d0                                                                                                 &
+            &                             /4.0d0                                                                                                 &
+            &                             /Pi                                                                                                    &
+            &                             *velocityDispersionSelf%galacticStructure_%massEnclosed(                                               &
+            &                                                                                     velocityDispersionNode                       , &
+            &                                                                                                   radius                         , &
+            &                                                                                     massType     =velocityDispersionMassType     , &
+            &                                                                                     componentType=velocityDispersionComponentType, &
+            &                                                                                     weightBy     =velocityDispersionWeightBy     , &
+            &                                                                                     weightIndex  =velocityDispersionWeightIndex    &
+            &                                                                                    )                                               &
+            &                             /radius**3
+       velocityDispersionDensityIntegrand=+densitySphericalAverage                                                                               &
+            &                             *     radius                                                                                           &
             &                             /sqrt(radius**2-velocityDispersionRadiusImpact**2)
     end if
     return
@@ -746,7 +753,7 @@ contains
     \left[ \sigma^2(r)\rho(r)\sqrt{r^2-r_\mathrm{i}^2}\right]_{r_\mathrm{i}}^{r_\mathrm{o}} + \int_{r_\mathrm{i}}^{r_\mathrm{o}} {\mathrm{d}\over \mathrm{d}r} \left[ \sigma^2(r) \rho(r) \right] \sqrt{r^2-r_\mathrm{i}^2} \mathrm{d}r.
     \end{equation}
     The first term is zero at both limits (due to the constraint $\rho(r_\mathrm{o})\sigma^2(r_\mathrm{o}) = 0$ at $r_\mathrm{o}$ and
-    due to $sqrt{r^2-r_\mathrm{i}^2}=0$ at $r_\mathrm{i}$), and the second term can be simplified using
+    due to $\sqrt{r^2-r_\mathrm{i}^2}=0$ at $r_\mathrm{i}$), and the second term can be simplified using
     eqn.~(\ref{eq:sphericalIsotropicJeans}) to give
     \begin{equation}
     \int_{r_\mathrm{i}}^{r_\mathrm{o}} {\mathrm{G} M(<r) \over r^2} \rho(r) \sqrt{r^2-r_\mathrm{i}^2} \mathrm{d}r.
@@ -754,21 +761,28 @@ contains
     !!}
     use :: Galactic_Structure_Options      , only : componentTypeAll               , massTypeAll
     use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
+    use :: Numerical_Constants_Math        , only : Pi
     implicit none
     double precision, intent(in   ) :: radius
+    double precision                :: densitySphericalAverage
 
     if (radius <= velocityDispersionRadiusImpact) then
        velocityDispersionVelocityDensityIntegrand=+0.0d0
     else
-       velocityDispersionVelocityDensityIntegrand=+gravitationalConstantGalacticus                                                                       &
-            &                                     *velocityDispersionSelf%galacticStructure_%density    (                                                &
+       densitySphericalAverage                   =+3.0d0                                                                                                 &
+            &                                     /4.0d0                                                                                                 &
+            &                                     /Pi                                                                                                    &
+            &                                     *velocityDispersionSelf%galacticStructure_%massEnclosed(                                               &
             &                                                                                                           velocityDispersionNode         , &
-            &                                                                                                           [radius,0.0d0,0.0d0]           , &
+            &                                                                                                           radius                         , &
             &                                                                                             massType     =velocityDispersionMassType     , &
             &                                                                                             componentType=velocityDispersionComponentType, &
             &                                                                                             weightBy     =velocityDispersionWeightBy     , &
             &                                                                                             weightIndex  =velocityDispersionWeightIndex    &
             &                                                                                            )                                               &
+            &                                     /radius**3
+       velocityDispersionVelocityDensityIntegrand=+gravitationalConstantGalacticus                                                                       &
+            &                                     *densitySphericalAverage                                                                               &
             &                                     *velocityDispersionSelf%galacticStructure_%massEnclosed(                                               &
             &                                                                                                           velocityDispersionNode         , &
             &                                                                                                           radius                         , &

--- a/source/nodes.property_extractor.velocity_dispersion.F90
+++ b/source/nodes.property_extractor.velocity_dispersion.F90
@@ -705,28 +705,21 @@ contains
     !!{
     Integrand function used for computing line-of-sight velocity dispersions.
     !!}
-    use :: Numerical_Constants_Math, only : Pi
     implicit none
     double precision, intent(in   ) :: radius
-    double precision                :: densitySphericalAverage
 
     if (radius <= velocityDispersionRadiusImpact) then
        velocityDispersionDensityIntegrand=+0.0d0
     else
-       densitySphericalAverage           =+3.0d0                                                                                                 &
-            &                             /4.0d0                                                                                                 &
-            &                             /Pi                                                                                                    &
-            &                             *velocityDispersionSelf%galacticStructure_%massEnclosed(                                               &
-            &                                                                                     velocityDispersionNode                       , &
-            &                                                                                                   radius                         , &
-            &                                                                                     massType     =velocityDispersionMassType     , &
-            &                                                                                     componentType=velocityDispersionComponentType, &
-            &                                                                                     weightBy     =velocityDispersionWeightBy     , &
-            &                                                                                     weightIndex  =velocityDispersionWeightIndex    &
-            &                                                                                    )                                               &
-            &                             /radius**3
-       velocityDispersionDensityIntegrand=+densitySphericalAverage                                                                               &
-            &                             *     radius                                                                                           &
+        velocityDispersionDensityIntegrand=+velocityDispersionSelf%galacticStructure_%densitySphericalAverage(                                               &
+            &                                                                                                 velocityDispersionNode                       , &
+            &                                                                                                               radius                         , &
+            &                                                                                                 massType     =velocityDispersionMassType     , &
+            &                                                                                                 componentType=velocityDispersionComponentType, &
+            &                                                                                                 weightBy     =velocityDispersionWeightBy     , &
+            &                                                                                                 weightIndex  =velocityDispersionWeightIndex    &
+            &                                                                                                )                                               &
+            &                             *     radius                                                                                                       &
             &                             /sqrt(radius**2-velocityDispersionRadiusImpact**2)
     end if
     return
@@ -761,35 +754,28 @@ contains
     !!}
     use :: Galactic_Structure_Options      , only : componentTypeAll               , massTypeAll
     use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
-    use :: Numerical_Constants_Math        , only : Pi
     implicit none
     double precision, intent(in   ) :: radius
-    double precision                :: densitySphericalAverage
 
     if (radius <= velocityDispersionRadiusImpact) then
        velocityDispersionVelocityDensityIntegrand=+0.0d0
     else
-       densitySphericalAverage                   =+3.0d0                                                                                                 &
-            &                                     /4.0d0                                                                                                 &
-            &                                     /Pi                                                                                                    &
-            &                                     *velocityDispersionSelf%galacticStructure_%massEnclosed(                                               &
-            &                                                                                                           velocityDispersionNode         , &
-            &                                                                                                           radius                         , &
-            &                                                                                             massType     =velocityDispersionMassType     , &
-            &                                                                                             componentType=velocityDispersionComponentType, &
-            &                                                                                             weightBy     =velocityDispersionWeightBy     , &
-            &                                                                                             weightIndex  =velocityDispersionWeightIndex    &
-            &                                                                                            )                                               &
-            &                                     /radius**3
-       velocityDispersionVelocityDensityIntegrand=+gravitationalConstantGalacticus                                                                       &
-            &                                     *densitySphericalAverage                                                                               &
-            &                                     *velocityDispersionSelf%galacticStructure_%massEnclosed(                                               &
-            &                                                                                                           velocityDispersionNode         , &
-            &                                                                                                           radius                         , &
-            &                                                                                             massType     =massTypeAll                    , &
-            &                                                                                             componentType=componentTypeAll                 &
-            &                                                                                            )                                               &
-            &                                     /     radius**2                                                                                        &
+       velocityDispersionVelocityDensityIntegrand=+gravitationalConstantGalacticus                                                                                  &
+            &                                     *velocityDispersionSelf%galacticStructure_%densitySphericalAverage(                                               &
+            &                                                                                                                      velocityDispersionNode         , &
+            &                                                                                                                      radius                         , &
+            &                                                                                                        massType     =velocityDispersionMassType     , &
+            &                                                                                                        componentType=velocityDispersionComponentType, &
+            &                                                                                                        weightBy     =velocityDispersionWeightBy     , &
+            &                                                                                                        weightIndex  =velocityDispersionWeightIndex    &
+            &                                                                                                       )                                               &
+            &                                     *velocityDispersionSelf%galacticStructure_%massEnclosed           (                                               &
+            &                                                                                                                      velocityDispersionNode         , &
+            &                                                                                                                      radius                         , &
+            &                                                                                                        massType     =massTypeAll                    , &
+            &                                                                                                        componentType=componentTypeAll                 &
+            &                                                                                                       )                                               &
+            &                                     /     radius**2                                                                                                   &
             &                                     *sqrt(radius**2-velocityDispersionRadiusImpact**2)
     end if
     return

--- a/source/objects.nodes.F90
+++ b/source/objects.nodes.F90
@@ -1423,6 +1423,21 @@ module Galacticus_Nodes
     return
   end function Node_Component_Density_Null
 
+  double precision function Node_Component_Density_Spherical_Average_Null(self,radius,componentType,massType,weightBy,weightIndex)
+    !!{
+    A null implementation of the spherically-averaged density in a component. Always returns zero.
+    !!}
+    implicit none
+    class           (nodeComponent), intent(inout) :: self
+    integer                        , intent(in   ) :: componentType, massType, weightBy, &
+         &                                            weightIndex
+    double precision               , intent(in   ) :: radius
+    !$GLC attributes unused :: self, radius, componentType, massType, weightBy, weightIndex
+
+    Node_Component_Density_Spherical_Average_Null=0.0d0
+    return
+  end function Node_Component_Density_Spherical_Average_Null
+
   double precision function Node_Component_Surface_Density_Null(self,positionCylindrical,componentType,massType,weightBy,weightIndex)
     !!{
     A null implementation of the surface density in a component. Always returns zero.

--- a/source/objects.nodes.components.disk.standard.F90
+++ b/source/objects.nodes.components.disk.standard.F90
@@ -140,16 +140,17 @@ module Node_Component_Disk_Standard
     </property>
    </properties>
    <bindings>
-    <binding method="attachPipes" function="Node_Component_Disk_Standard_Attach_Pipes" description="Attach pipes to the standard disk component." returnType="\void" arguments="" bindsTo="component" />
-    <binding method="enclosedMass"          function="Node_Component_Disk_Standard_Enclosed_Mass"           bindsTo="component" />
-    <binding method="acceleration"          function="Node_Component_Disk_Standard_Acceleration"            bindsTo="component" />
-    <binding method="tidalTensor"           function="Node_Component_Disk_Standard_Tidal_Tensor"            bindsTo="component" />
-    <binding method="chandrasekharIntegral" function="Node_Component_Disk_Standard_Chandrasekhar_Integral"  bindsTo="component" />
-    <binding method="density"               function="Node_Component_Disk_Standard_Density"                 bindsTo="component" />
-    <binding method="potential"             function="Node_Component_Disk_Standard_Potential"               bindsTo="component" />
-    <binding method="rotationCurve"         function="Node_Component_Disk_Standard_Rotation_Curve"          bindsTo="component" />
-    <binding method="rotationCurveGradient" function="Node_Component_Disk_Standard_Rotation_Curve_Gradient" bindsTo="component" />
-    <binding method="surfaceDensity"        function="Node_Component_Disk_Standard_Surface_Density"         bindsTo="component" />
+    <binding method="attachPipes"             function="Node_Component_Disk_Standard_Attach_Pipes"              bindsTo="component" description="Attach pipes to the standard disk component." returnType="\void" arguments=""/>
+    <binding method="enclosedMass"            function="Node_Component_Disk_Standard_Enclosed_Mass"             bindsTo="component"                                                                                           />
+    <binding method="acceleration"            function="Node_Component_Disk_Standard_Acceleration"              bindsTo="component"                                                                                           />
+    <binding method="tidalTensor"             function="Node_Component_Disk_Standard_Tidal_Tensor"              bindsTo="component"                                                                                           />
+    <binding method="chandrasekharIntegral"   function="Node_Component_Disk_Standard_Chandrasekhar_Integral"    bindsTo="component"                                                                                           />
+    <binding method="density"                 function="Node_Component_Disk_Standard_Density"                   bindsTo="component"                                                                                           />
+    <binding method="densitySphericalAverage" function="Node_Component_Disk_Standard_Density_Spherical_Average" bindsTo="component"                                                                                           />
+    <binding method="potential"               function="Node_Component_Disk_Standard_Potential"                 bindsTo="component"                                                                                           />
+    <binding method="rotationCurve"           function="Node_Component_Disk_Standard_Rotation_Curve"            bindsTo="component"                                                                                           />
+    <binding method="rotationCurveGradient"   function="Node_Component_Disk_Standard_Rotation_Curve_Gradient"   bindsTo="component"                                                                                           />
+    <binding method="surfaceDensity"          function="Node_Component_Disk_Standard_Surface_Density"           bindsTo="component"                                                                                           />
    </bindings>
    <functions>objects.nodes.components.disk.standard.bound_functions.inc</functions>
   </component>

--- a/source/objects.nodes.components.disk.standard.bound_functions.Inc
+++ b/source/objects.nodes.components.disk.standard.bound_functions.Inc
@@ -368,6 +368,53 @@ double precision function Node_Component_Disk_Standard_Density(self,positionSphe
    return
 end function Node_Component_Disk_Standard_Density
 
+double precision function Node_Component_Disk_Standard_Density_Spherical_Average(self,radius,componentType,massType,weightBy,weightIndex)
+  !!{
+  Computes the density at a given position for an standard disk.
+  !!}
+  use :: Galactic_Structure_Options       , only : componentTypeAll    , componentTypeDisk  , massTypeAll    , massTypeBaryonic  , &
+          &                                        massTypeGalactic    , massTypeGaseous    , massTypeStellar, weightByLuminosity, &
+          &                                        weightByMass
+  use :: Node_Component_Disk_Standard_Data, only : diskMassDistribution
+  implicit none
+  class           (nodeComponentDiskStandard), intent(inout) :: self
+  integer                                    , intent(in   ) :: componentType       , massType   , &
+       &                                                        weightBy            , weightIndex
+  double precision                           , intent(in   ) :: radius
+  type            (stellarLuminosities      ), save          :: luminositiesDisk
+  !$omp threadprivate(luminositiesDisk)
+
+  ! Return immediately if disk component is not requested.
+  Node_Component_Disk_Standard_Density_Spherical_Average=0.0d0
+  if (.not.(componentType == componentTypeAll .or. componentType == componentTypeDisk)) return
+  ! Determine mass/luminosity type.
+  select case (weightBy)
+  case (weightByMass      )
+     select case (massType)
+     case (massTypeAll,massTypeBaryonic,massTypeGalactic)
+        Node_Component_Disk_Standard_Density_Spherical_Average=self%massGas()+self%massStellar()
+     case (massTypeGaseous)
+        Node_Component_Disk_Standard_Density_Spherical_Average=self%massGas()
+     case (massTypeStellar)
+        Node_Component_Disk_Standard_Density_Spherical_Average=               self%massStellar()
+     end select
+  case (weightByLuminosity)
+     select case (massType)
+     case (massTypeAll,massTypeBaryonic,massTypeGalactic,massTypeStellar)
+        luminositiesDisk=self%luminositiesStellar()
+        Node_Component_Disk_Standard_Density_Spherical_Average=luminositiesDisk%luminosity(weightIndex)
+     end select
+  end select
+  ! Skip further calculation if mass or radius is zero.
+  if (Node_Component_Disk_Standard_Density_Spherical_Average > 0.0d0 .and. self%radius() > 0.0d0) then
+     ! Compute the actual density.
+      Node_Component_Disk_Standard_Density_Spherical_Average=+Node_Component_Disk_Standard_Density_Spherical_Average                &
+           &                                                 /self                %radius                 (                    )**3 &
+           &                                                 *diskMassDistribution%densitySphericalAverage(radius/self%radius())
+   end if
+   return
+ end function Node_Component_Disk_Standard_Density_Spherical_Average
+
 double precision function Node_Component_Disk_Standard_Potential(self,radius,componentType,massType,status)
   !!{
   Compute the gravitational potential due to an standard disk.

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -508,7 +508,7 @@ contains
           call spheroid%angularMomentumSet(specificAngularMomentum*spheroid%massStellar())
           ! Indicate that ODE evolution should continue after this state change.
           if (status == GSL_Success) status=GSL_Continue
-      end if
+       end if
        ! Trap negative stellar masses.
        if (spheroid%massStellar() < 0.0d0) then
           ! Check if this exceeds the maximum previously recorded error.
@@ -554,6 +554,18 @@ contains
           call spheroid%        massStellarSet(                                 0.0d0)
           call spheroid%  abundancesStellarSet(                        zeroAbundances)
           call spheroid%angularMomentumSet(specificAngularMomentum*spheroid%massGas())
+          ! Indicate that ODE evolution should continue after this state change.
+          if (status == GSL_Success) status=GSL_Continue
+       end if
+       ! Trap negative angular momentum.
+       if (spheroid%angularMomentum() < 0.0d0) then
+          ! Estimate a reasonable specific angular momentum.
+          specificAngularMomentum=spheroid%radius()*spheroid%velocity()
+          ! Get the mass of the spheroid.
+          massSpheroid= spheroid%massGas    () &
+               &       +spheroid%massStellar()
+          ! Reset the angular momentum of the spheroid.
+          call spheroid%angularMomentumSet(specificAngularMomentum*massSpheroid)
           ! Indicate that ODE evolution should continue after this state change.
           if (status == GSL_Success) status=GSL_Continue
        end if

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -149,14 +149,15 @@ module Node_Component_Spheroid_Standard
     </property>
    </properties>
    <bindings>
-    <binding method="enclosedMass"          function="Node_Component_Spheroid_Standard_Enclosed_Mass"           bindsTo="component" />
-    <binding method="acceleration"          function="Node_Component_Spheroid_Standard_Acceleration"            bindsTo="component" />
-    <binding method="tidalTensor"           function="Node_Component_Spheroid_Standard_Tidal_Tensor"            bindsTo="component" />
-    <binding method="chandrasekharIntegral" function="Node_Component_Spheroid_Standard_Chandrasekhar_Integral"  bindsTo="component" />
-    <binding method="density"               function="Node_Component_Spheroid_Standard_Density"                 bindsTo="component" />
-    <binding method="rotationCurve"         function="Node_Component_Spheroid_Standard_Rotation_Curve"          bindsTo="component" />
-    <binding method="rotationCurveGradient" function="Node_Component_Spheroid_Standard_Rotation_Curve_Gradient" bindsTo="component" />
-    <binding method="potential"             function="Node_Component_Spheroid_Standard_Potential"               bindsTo="component" />
+    <binding method="enclosedMass"            function="Node_Component_Spheroid_Standard_Enclosed_Mass"             bindsTo="component" />
+    <binding method="acceleration"            function="Node_Component_Spheroid_Standard_Acceleration"              bindsTo="component" />
+    <binding method="tidalTensor"             function="Node_Component_Spheroid_Standard_Tidal_Tensor"              bindsTo="component" />
+    <binding method="chandrasekharIntegral"   function="Node_Component_Spheroid_Standard_Chandrasekhar_Integral"    bindsTo="component" />
+    <binding method="density"                 function="Node_Component_Spheroid_Standard_Density"                   bindsTo="component" />
+    <binding method="densitySphericalAverage" function="Node_Component_Spheroid_Standard_Density_Spherical_Average" bindsTo="component" />
+    <binding method="rotationCurve"           function="Node_Component_Spheroid_Standard_Rotation_Curve"            bindsTo="component" />
+    <binding method="rotationCurveGradient"   function="Node_Component_Spheroid_Standard_Rotation_Curve_Gradient"   bindsTo="component" />
+    <binding method="potential"               function="Node_Component_Spheroid_Standard_Potential"                 bindsTo="component" />
    </bindings>
    <functions>objects.nodes.components.spheroid.standard.bound_functions.inc</functions>
   </component>

--- a/source/objects.nodes.components.spheroid.standard.bound_functions.Inc
+++ b/source/objects.nodes.components.spheroid.standard.bound_functions.Inc
@@ -320,6 +320,66 @@ double precision function Node_Component_Spheroid_Standard_Density(self,position
   return
 end function Node_Component_Spheroid_Standard_Density
 
+double precision function Node_Component_Spheroid_Standard_Density_Spherical_Average(self,radius,componentType,massType,weightBy,weightIndex)
+  !!{
+  Computes the spherically-averaged density at a given radius for an standard spheroid.
+  !!}
+  use :: Coordinates                          , only : assignment(=)           , coordinateSpherical
+  use :: Galactic_Structure_Options           , only : componentTypeAll        , componentTypeSpheroid, massTypeAll    , massTypeBaryonic  , &
+          &                                            massTypeGalactic        , massTypeGaseous      , massTypeStellar, weightByLuminosity, &
+          &                                            weightByMass
+  use :: Node_Component_Spheroid_Standard_Data, only : spheroidMassDistribution
+  implicit none
+  class           (nodeComponentSpheroidStandard), intent(inout) :: self
+  integer                                        , intent(in   ) :: componentType                , massType   , &
+       &                                                            weightBy                     , weightIndex
+  double precision                               , intent(in   ) :: radius
+  double precision                               , parameter     :: radiusHuge          =1.0d+100
+  type            (coordinateSpherical          )                :: position
+  type            (stellarLuminosities          ), save          :: luminositiesSpheroid
+  !$omp threadprivate(luminositiesSpheroid)
+
+  Node_Component_Spheroid_Standard_Density_Spherical_Average=0.0d0
+  if (.not.(componentType == componentTypeAll .or. componentType == componentTypeSpheroid)) return
+
+  ! Get the spheroid component and check that it is of the standard class.
+  select type (self)
+     class is (nodeComponentSpheroidStandard)
+
+     if (self%radius() <= 0.0d0 .or. self%radius() > radiusHuge) return
+     select case (weightBy)
+     case (weightByMass      )
+        select case (massType)
+        case (massTypeAll,massTypeBaryonic,massTypeGalactic)
+           Node_Component_Spheroid_Standard_Density_Spherical_Average=self%massGas()+self%massStellar()
+        case (massTypeGaseous)
+           Node_Component_Spheroid_Standard_Density_Spherical_Average=self%massGas()
+        case (massTypeStellar)
+           Node_Component_Spheroid_Standard_Density_Spherical_Average=               self%massStellar()
+        end select
+     case (weightByLuminosity)
+        select case (massType)
+        case (massTypeAll,massTypeBaryonic,massTypeGalactic,massTypeStellar)
+           luminositiesSpheroid=self%luminositiesStellar()
+           Node_Component_Spheroid_Standard_Density_Spherical_Average=luminositiesSpheroid%luminosity(weightIndex)
+        end select
+     end select
+     ! Return if density is zero.
+     if (Node_Component_Spheroid_Standard_Density_Spherical_Average <= 0.0d0) then
+        Node_Component_Spheroid_Standard_Density_Spherical_Average=0.0d0
+        return
+     end if
+     ! Compute actual density.
+     position=[radius/self%radius(),0.0d0,0.0d0]
+     Node_Component_Spheroid_Standard_Density_Spherical_Average       =+Node_Component_Spheroid_Standard_Density_Spherical_Average     &
+          &                                                            *spheroidMassDistribution                %density(position)
+     if (Node_Component_Spheroid_Standard_Density_Spherical_Average > 0.0d0)                                                           &
+          & Node_Component_Spheroid_Standard_Density_Spherical_Average=+Node_Component_Spheroid_Standard_Density_Spherical_Average     &
+          &                                                             /self                                    %radius (        )**3
+  end select
+  return
+end function Node_Component_Spheroid_Standard_Density_Spherical_Average
+
 double precision function Node_Component_Spheroid_Standard_Potential(self,radius,componentType,massType,status)
   use :: Coordinates                          , only : assignment(=)                  , coordinateSpherical
   use :: Galactic_Structure_Options           , only : radiusLarge                    , weightByMass       , weightIndexNull


### PR DESCRIPTION
This avoids problems with deciding where (in 3D) to evaluate density in non-spherical systems (e.g. disks). It is also consistent with the assumptions of the spherical Jeans equation that we're solving.