### PR TITLE
Fix issues related to molecular hydrogen calculations

### DIFF
--- a/source/accretion.halo.simple.F90
+++ b/source/accretion.halo.simple.F90
@@ -92,7 +92,7 @@
      <methods>
        <method description="Returns the fraction of potential accretion onto a halo from the \gls{igm} which fails." method="failedFraction"/>
        <method description="Returns the velocity scale to use for {\normalfont \ttfamily node}."                     method="velocityScale" />
-       <method description="Compute masses of chemical species given a total mass."                                  method="chemicalMassed"/>
+       <method description="Compute masses of chemical species given a total mass."                                  method="chemicalMasses"/>
      </methods>
      !!]
      final     ::                           simpleDestructor

--- a/source/chemical.reaction_rates.hydrogen.F90
+++ b/source/chemical.reaction_rates.hydrogen.F90
@@ -217,7 +217,7 @@ contains
     if (self%fast) then
        ! For the fast network, assume the hydrogen anion is always at equilibrium density. (Following eqn. 24 of Abel et al. 1997.)
        creationTerm   =+hydrogenNetworkH_Electron_to_Hminus_Photon_RateCoefficient   (temperature)*chemicalDensity%abundance(self%atomicHydrogenIndex      ) &
-            &                                                                                      *chemicalDensity%abundance(self%electronIndex            )
+            &                                                                                     *chemicalDensity%abundance(self%electronIndex            )
        destructionTerm=+hydrogenNetworkH_Hminus_to_H2_Electron_RateCoefficient       (temperature)*chemicalDensity%abundance(self%atomicHydrogenIndex      ) &
             &          +hydrogenNetworkHminus_Hplus_to_2H_RateCoefficient            (temperature)*chemicalDensity%abundance(self%atomicHydrogenCationIndex) &
             &          +hydrogenNetworkHminus_Electron_to_H_2Electron_RateCoefficient(temperature)*chemicalDensity%abundance(self%electronIndex            )
@@ -467,6 +467,7 @@ contains
     logical                                              , save          :: reactionActive                  =.false., reactionInitialized        =.false.
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex        , atomicHydrogenChemicalIndex        , &
          &                                                                  chemicalHydrogenChemicalIndex           , electronChemicalIndex
+    integer                                                              :: status
     double precision                                                     :: rate                                    , rateCoefficient
     !$GLC attributes unused :: radiation
 
@@ -475,10 +476,10 @@ contains
        !$omp critical(hydrogenNetworkRateH_Hminus_to_H2_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
-          atomicHydrogenChemicalIndex     =Chemicals_Index("AtomicHydrogen"     )
-          atomicHydrogenAnionChemicalIndex=Chemicals_Index("AtomicHydrogenAnion")
-          chemicalHydrogenChemicalIndex   =Chemicals_Index("MolecularHydrogen"  )
-          electronChemicalIndex           =Chemicals_Index("Electron"           )
+          atomicHydrogenChemicalIndex     =Chemicals_Index("AtomicHydrogen"     ,status)
+          atomicHydrogenAnionChemicalIndex=Chemicals_Index("AtomicHydrogenAnion",status)
+          chemicalHydrogenChemicalIndex   =Chemicals_Index("MolecularHydrogen"  ,status)
+          electronChemicalIndex           =Chemicals_Index("Electron"           ,status)
           ! This reaction is active if all species were found.
           reactionActive=       atomicHydrogenChemicalIndex      > 0                 &
                &         .and.  chemicalHydrogenChemicalIndex    > 0                 &
@@ -548,7 +549,7 @@ contains
 
   subroutine hydrogenNetworkRateH_Hplus_to_H2plus_Photon(self,temperature,radiation,chemicalDensity,chemicalRates)
     !!{
-    Computes the rate (in units of c$^{-3}$ s$^{-1}$) for the reaction $\hbox{H} + \hbox{H}^+ \rightarrow \hbox{H}_2^+ + \gamma$.
+    Computes the rate (in units of cm$^{-3}$ s$^{-1}$) for the reaction $\hbox{H} + \hbox{H}^+ \rightarrow \hbox{H}_2^+ + \gamma$.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Numerical_Constants_Physical , only : boltzmannsConstant
@@ -571,7 +572,7 @@ contains
     if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitialized) then
-       !$omp critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp critical(hydrogenNetworkRateH_Hplus_to_H2plus_Photon_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenChemicalIndex        =Chemicals_Index("AtomicHydrogen"         )
@@ -582,7 +583,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp end critical(hydrogenNetworkRateH_Hplus_to_H2plus_Photon_Init)
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -690,9 +691,11 @@ contains
          &                                                                  rateCoefficient                            , temperatureElectronVolts
     !$GLC attributes unused :: self, radiation
 
+    ! If using the fast network, this reaction is ignored so simply return in such cases.
+    if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitialized) then
-       !$omp critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp critical(hydrogenNetworkRateH2_Hplus_to_H2plus_H_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenChemicalIndex        =Chemicals_Index("AtomicHydrogen"         )
@@ -705,7 +708,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp end critical(hydrogenNetworkRateH2_Hplus_to_H2plus_H_Init)
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -767,7 +770,7 @@ contains
 
     ! Check if this reaction needs initializing.
     if (.not.reactionInitialized) then
-       !$omp critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp critical(hydrogenNetworkRateH2_Electron_to_2H_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenChemicalIndex  =Chemicals_Index("AtomicHydrogen"   )
@@ -778,7 +781,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp end critical(hydrogenNetworkRateH2_Electron_to_2H_Electron_Init)
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -825,7 +828,7 @@ contains
     if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitialized) then
-       !$omp critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp critical(hydrogenNetworkRateH2_H_to_3H_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenChemicalIndex  =Chemicals_Index("AtomicHydrogen"   )
@@ -835,7 +838,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp end critical(hydrogenNetworkRateH2_H_to_3H_Init)
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -864,7 +867,7 @@ contains
 
   subroutine hydrogenNetworkRateHminus_Electron_to_H_2Electron(self,temperature,radiation,chemicalDensity,chemicalRates)
     !!{
-    Computes the rate (in units of cm$^{-3}$ s$^{-1}$) for the reaction $\hbox{H}_2^+ + \hbox{H} \rightarrow \hbox{H}_2 + \hbox{H}^+$.
+    Computes the rate (in units of cm$^{-3}$ s$^{-1}$) for the reaction $\hbox{H}_2^- + \hbox{e}^- \rightarrow \hbox{H} + 2 \hbox{e}^-$.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -1304,6 +1307,7 @@ contains
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex                                                                                , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
     double precision                                                     :: rate                                                                                                            , rateCoefficient
+    integer                                                              :: status
     !$GLC attributes unused :: self, temperature
 
     ! Check if this reaction needs initializing.
@@ -1311,11 +1315,11 @@ contains
        !$omp critical(hydrogenNetworkRateHminus_Gamma_to_H_Electron)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
-          atomicHydrogenAnionChemicalIndex=Chemicals_Index("AtomicHydrogenAnion")
-          atomicHydrogenChemicalIndex     =Chemicals_Index("AtomicHydrogen"     )
-          electronChemicalIndex           =Chemicals_Index("Electron"           )
+          atomicHydrogenAnionChemicalIndex=Chemicals_Index("AtomicHydrogenAnion",status)
+          atomicHydrogenChemicalIndex     =Chemicals_Index("AtomicHydrogen"            )
+          electronChemicalIndex           =Chemicals_Index("Electron"                  )
           ! This reaction is active if all species were found.
-          reactionActive=atomicHydrogenAnionChemicalIndex > 0 .and. atomicHydrogenChemicalIndex > 0 .and. electronChemicalIndex > 0
+          reactionActive=(atomicHydrogenAnionChemicalIndex > 0 .or. self%fast) .and. atomicHydrogenChemicalIndex > 0 .and. electronChemicalIndex > 0
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
@@ -1331,18 +1335,17 @@ contains
           rateCoefficient=radiation%integrateOverCrossSection([0.0d0,crossSectionWavelengthHigh],hydrogenNetworkCrossSection_Hminus_Gamma_to_H_Electron,node)
        end select
        ! Compute rate.
-       rate=rateCoefficient*chemicalDensity%abundance(atomicHydrogenAnionChemicalIndex)
+       rate=rateCoefficient*self%densityAtomicHydrogenAnion
        ! Record rate.
-       call   chemicalRates%abundanceSet(atomicHydrogenAnionChemicalIndex, &
-            & chemicalRates%abundance   (atomicHydrogenAnionChemicalIndex) &
-            & -rate                     )
-       call   chemicalRates%abundanceSet(atomicHydrogenChemicalIndex     , &
-            & chemicalRates%abundance   (atomicHydrogenChemicalIndex     ) &
-            & +rate                     )
-       call   chemicalRates%abundanceSet(electronChemicalIndex           , &
-            & chemicalRates%abundance   (electronChemicalIndex           ) &
-            & +rate                     )
-
+       if (.not.self%fast) call   chemicalRates%abundanceSet(atomicHydrogenAnionChemicalIndex, &
+            &                     chemicalRates%abundance   (atomicHydrogenAnionChemicalIndex) &
+            &                     -rate                     )
+       call                       chemicalRates%abundanceSet(atomicHydrogenChemicalIndex     , &
+            &                     chemicalRates%abundance   (atomicHydrogenChemicalIndex     ) &
+            &                     +rate                     )
+       call                       chemicalRates%abundanceSet(electronChemicalIndex           , &
+            &                     chemicalRates%abundance   (electronChemicalIndex           ) &
+            &                     +rate                     )
     end if
     return
   end subroutine hydrogenNetworkRateHminus_Gamma_to_H_Electron
@@ -1420,6 +1423,8 @@ contains
     double precision                                                     :: rate                                                                                                                , rateCoefficient
     !$GLC attributes unused :: self, temperature
 
+    ! If using the fast network, this reaction is ignored so simply return in such cases.
+    if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitialized) then
        !$omp critical(hydrogenNetworkRateH2plus_Gamma_to_H_Hplus)
@@ -1595,6 +1600,8 @@ contains
     double precision                                                     :: rate                                                                                                                , rateCoefficient
     !$GLC attributes unused :: self, temperature
 
+    ! If using the fast network, this reaction is ignored so simply return in such cases.
+    if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitialized) then
        !$omp critical(hydrogenNetworkRateH2_Gamma_to_H2plus_Electron)
@@ -1710,6 +1717,8 @@ contains
     double precision                                                     :: rate                                                                                                              , rateCoefficient
     !$GLC attributes unused :: self, temperature
 
+    ! If using the fast network, this reaction is ignored so simply return in such cases.
+    if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitialized) then
        !$omp critical(hydrogenNetworkRateH2plus_Gamma_to_2Hplus_Electron)
@@ -1797,7 +1806,7 @@ contains
 
   subroutine hydrogenNetworkRateH2_Gamma_to_2H(self,temperature,radiation,chemicalDensity,chemicalRates,node)
     !!{
-    Computes the rate (in units of cm$^{-3}$ s$^{-1}$) for the reaction $\hbox{H}_2^+ + \gamma \rightarrow 2\hbox{H}^+ +
+    Computes the rate (in units of cm$^{-3}$ s$^{-1}$) for the reaction $\hbox{H}_2 + \gamma \rightarrow 2\hbox{H} +
     \hbox{e}^-$.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index

--- a/source/cooling.cooling_function.molecular_hydrogen_Galli_Palla.F90
+++ b/source/cooling.cooling_function.molecular_hydrogen_Galli_Palla.F90
@@ -145,13 +145,14 @@ contains
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     implicit none
-    type(coolingFunctionMolecularHydrogenGalliPalla) :: self
-
+    type   (coolingFunctionMolecularHydrogenGalliPalla) :: self
+    integer                                             :: status
+    
     ! Get the indices of chemicals that will be used.
-    self%electronIndex               =Chemicals_Index("Electron"               )
-    self%atomicHydrogenIndex         =Chemicals_Index("AtomicHydrogen"         )
-    self%molecularHydrogenCationIndex=Chemicals_Index("MolecularHydrogenCation")
-    self%molecularHydrogenIndex      =Chemicals_Index("MolecularHydrogen"      )
+    self%electronIndex               =Chemicals_Index("Electron"               ,status)
+    self%atomicHydrogenIndex         =Chemicals_Index("AtomicHydrogen"         ,status)
+    self%molecularHydrogenCationIndex=Chemicals_Index("MolecularHydrogenCation",status)
+    self%molecularHydrogenIndex      =Chemicals_Index("MolecularHydrogen"      ,status)
     ! Initialized stored calculations to unphysical values.
     self%temperaturePrevious1             =-1.0d0
     self%temperaturePrevious2             =-1.0d0
@@ -585,6 +586,15 @@ contains
     double precision                                                            :: electronDensity               , logarithmic10Temperature, &
          &                                                                         molecularHydrogenCationDensity
 
+    ! Set to zero if species are not present.
+    if     (                                       &
+         &   self%molecularHydrogenCationIndex < 0 &
+         &  .or.                                   &
+         &   self%electronIndex                < 0 &
+         & ) then
+       molecularHydrogenGalliPallaCoolingFunctionH2Plus_Electron=0.0d0
+       return
+    end if
     ! Get the relevant densities.
     electronDensity               =chemicalDensities%abundance(self%electronIndex               )
     molecularHydrogenCationDensity=chemicalDensities%abundance(self%molecularHydrogenCationIndex)
@@ -624,6 +634,15 @@ contains
     double precision                                                            :: atomicHydrogenDensity         , logarithmic10Temperature, &
          &                                                                         molecularHydrogenCationDensity
 
+    ! Set to zero if species are not present.
+    if     (                                       &
+         &   self%molecularHydrogenCationIndex < 0 &
+         &  .or.                                   &
+         &   self%atomicHydrogenIndex          < 0 &
+         & ) then
+       molecularHydrogenGalliPallaCoolingFunctionH_H2Plus=0.0d0
+       return
+    end if
     ! Get the relevant densities.
     atomicHydrogenDensity         =chemicalDensities%abundance(self%atomicHydrogenIndex         )
     molecularHydrogenCationDensity=chemicalDensities%abundance(self%molecularHydrogenCationIndex)
@@ -663,6 +682,15 @@ contains
          &                                                                         coolingFunctionLowDensityLimit                , molecularHydrogenDensity                    , &
          &                                                                         numberDensityCriticalOverNumberDensityHydrogen
 
+    ! Set to zero if species are not present.
+    if     (                                 &
+         &   self%molecularHydrogenIndex < 0 &
+         &  .or.                             &
+         &   self%atomicHydrogenIndex    < 0 &
+         & ) then
+       molecularHydrogenGalliPallaCoolingFunctionH_H2=0.0d0
+       return
+    end if
     ! Get the relevant densities.
     atomicHydrogenDensity   =chemicalDensities%abundance(self%atomicHydrogenIndex   )
     molecularHydrogenDensity=chemicalDensities%abundance(self%molecularHydrogenIndex)

--- a/source/galactic_structure.radius_solver.equilibrium.F90
+++ b/source/galactic_structure.radius_solver.equilibrium.F90
@@ -258,7 +258,6 @@ contains
        end if
        ! Begin iteration to find a converged solution.
        do while (equilibriumIterationCount <= 2 .or. ( equilibriumFitMeasure > self%solutionTolerance .and. equilibriumIterationCount < iterationMaximum ) )
-          call Calculations_Reset(node)
           equilibriumIterationCount      =equilibriumIterationCount+1
           equilibriumActiveComponentCount=0
           if (equilibriumIterationCount > 1) equilibriumFitMeasure=0.0d0
@@ -324,8 +323,9 @@ contains
       if (equilibriumIterationCount == 1) then
          ! If structure is to be reverted, do so now.
          if (equilibriumRevertStructure.and.allocated(equilibriumRadiusStored)) then
-            call   radiusSet(node,  equilibriumRadiusStored(equilibriumActiveComponentCount))
-            call velocitySet(node,equilibriumVelocityStored(equilibriumActiveComponentCount))
+            call          radiusSet(node,  equilibriumRadiusStored(equilibriumActiveComponentCount))
+            call        velocitySet(node,equilibriumVelocityStored(equilibriumActiveComponentCount))
+            call Calculations_Reset(node                                                           )
          end if
          ! On first iteration, see if we have a previous radius set for this component.
          radius=radiusGet(node)
@@ -445,8 +445,9 @@ contains
          end if
       end if
       ! Set the component size to new radius and velocity.
-      call   radiusSet(node,radius  )
-      call velocitySet(node,velocity)
+      call          radiusSet(node,radius  )
+      call        velocitySet(node,velocity)
+      call Calculations_Reset(node         )
       return
     end subroutine radiusSolve
 

--- a/source/mass_distributions.cylindrical.F90
+++ b/source/mass_distributions.cylindrical.F90
@@ -38,7 +38,8 @@
        <method description="Returns the $n^\mathrm{th}$ moment of the integral of the surface density over radius, $\int_0^\infty \Sigma(\mathbf{x}) |x|^n \mathrm{d} \mathbf{x}$." method="surfaceDensityRadialMoment" />
        <method description="Returns the circular velocity at the given {\normalfont \ttfamily radius}." method="rotationCurve" />
        <method description="Returns the gradient of the circular velocity at the given {\normalfont \ttfamily radius}." method="rotationCurveGradient" />
-       <method description="Returns the surface density at the given {\normalfont \ttfamily coordinates}." method="surfaceDensity" />
+       <method description="Returns the surface density at the given {\normalfont \ttfamily coordinates}." method="surfaceDensity"          />
+       <method description="Returns the spherically-averagef density at the given {\normalfont \ttfamily radius}." method="densitySphericalAverage" />
      </methods>
      !!]
      procedure                                                  :: symmetry                   => cylindricalSymmetry

--- a/source/objects.chemical_abundances.F90
+++ b/source/objects.chemical_abundances.F90
@@ -100,6 +100,10 @@ module Chemical_Abundances_Structure
      procedure         :: dump            => Chemicals_Dump
      procedure         :: dumpRaw         => Chemicals_Dump_Raw
      procedure         :: readRaw         => Chemicals_Read_Raw
+     procedure         :: output          => Chemicals_Output
+     procedure         :: postOutput      => Chemicals_Post_Output
+     procedure         :: outputCount     => Chemicals_Output_Count
+     procedure         :: outputNames     => Chemicals_Output_Names
   end type chemicalAbundances
 
   ! Count of the number of elements being tracked.
@@ -641,5 +645,86 @@ contains
     end if
     return
   end function Chemicals_Non_Static_Size_Of
+
+  subroutine Chemicals_Output(self,integerProperty,integerBufferCount,integerProperties,doubleProperty,doubleBufferCount,doubleProperties,time,outputInstance)
+    !!{
+    Store an abundances object in the output buffers.
+    !!}
+    use :: Kind_Numbers                      , only : kind_int8
+    use :: Multi_Counters                    , only : multiCounter
+    use :: Merger_Tree_Outputter_Buffer_Types, only : outputPropertyInteger , outputPropertyDouble
+    implicit none
+    class           (chemicalAbundances   ), intent(in   )               :: self
+    double precision                       , intent(in   )               :: time
+    integer                                , intent(inout)               :: doubleBufferCount , doubleProperty , &
+         &                                                                  integerBufferCount, integerProperty
+    type            (outputPropertyInteger), intent(inout), dimension(:) :: integerProperties
+    type            (outputPropertyDouble ), intent(inout), dimension(:) :: doubleProperties
+    type            (multiCounter         ), intent(in   )               :: outputInstance
+    integer                                                              :: i
+    !$GLC attributes unused :: time, integerBufferCount, integerProperty, integerProperties, outputInstance
+
+    if (chemicalsCount > 0) then
+       do i=1,chemicalsCount
+          doubleProperties(doubleProperty+i)%scalar(doubleBufferCount)=self%chemicalValue(i)
+       end do
+       doubleProperty=doubleProperty+chemicalsCount
+    end if
+    return
+  end subroutine Chemicals_Output
+
+  subroutine Chemicals_Post_Output(self,time)
+    !!{
+    Perform post-output processing of abundances objects.
+    !!}
+    implicit none
+    class           (chemicalAbundances), intent(in   ) :: self
+    double precision                    , intent(in   ) :: time
+    !$GLC attributes unused :: self, time
+
+    return
+  end subroutine Chemicals_Post_Output
+
+  subroutine Chemicals_Output_Count(self,integerPropertyCount,doublePropertyCount,time)
+    !!{
+    Increment the output count to account for an abundances object.
+    !!}
+    implicit none
+    class           (chemicalAbundances), intent(in   ) :: self
+    integer                             , intent(inout) :: doublePropertyCount, integerPropertyCount
+    double precision                    , intent(in   ) :: time
+    !$GLC attributes unused :: self, integerPropertyCount, time
+
+    doublePropertyCount=doublePropertyCount+chemicalsCount
+    return
+  end subroutine Chemicals_Output_Count
+
+  subroutine Chemicals_Output_Names(self,integerProperty,integerProperties,doubleProperty,doubleProperties,time,prefix,comment,unitsInSI)
+    !!{
+    Assign names to output buffers for an abundances object.
+    !!}
+    use :: ISO_Varying_String                , only : char
+    use :: Merger_Tree_Outputter_Buffer_Types, only : outputPropertyInteger, outputPropertyDouble
+    implicit none
+    class           (chemicalAbundances   )              , intent(in   ) :: self
+    double precision                                     , intent(in   ) :: time
+    integer                                              , intent(inout) :: doubleProperty    , integerProperty
+    type            (outputPropertyInteger), dimension(:), intent(inout) :: integerProperties
+    type            (outputPropertyDouble ), dimension(:), intent(inout) :: doubleProperties
+    character       (len=*                )              , intent(in   ) :: comment           , prefix
+    double precision                                     , intent(in   ) :: unitsInSI
+    integer                                                              :: i
+    !$GLC attributes unused :: self, time, integerProperty, integerProperties
+
+    if (chemicalsCount > 0) then
+       do i=1,chemicalsCount
+          doubleProperty=doubleProperty+1
+          doubleProperties(doubleProperty)%name     =trim(prefix )//      char(chemicalsToTrack(i))
+          doubleProperties(doubleProperty)%comment  =trim(comment)//' ['//char(chemicalsToTrack(i))//']'
+          doubleProperties(doubleProperty)%unitsInSI=unitsInSI
+       end do
+    end if
+    return
+  end subroutine Chemicals_Output_Names
 
 end module Chemical_Abundances_Structure

--- a/source/objects.chemical_abundances.F90
+++ b/source/objects.chemical_abundances.F90
@@ -1,3 +1,4 @@
+
 !! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
 !!           2019, 2020, 2021, 2022
 !!    Andrew Benson <abenson@carnegiescience.edu>
@@ -72,6 +73,10 @@ module Chemical_Abundances_Structure
        <method description="Dump a chemical abundances object in binary." method="dumpRaw" />
        <method description="Read a chemical abundances object in binary." method="readRaw" />
        <method description="Returns the size of any non-static components of the type." method="nonStaticSizeOf" />
+       <method description="Store a chemical abundances object in the output buffers." method="output" />
+       <method description="Store a chemical abundances object in the output buffers." method="postOutput" />
+       <method description="Specify the count of a chemical abundances object for output." method="outputCount" />
+       <method description="Specify the names of chemical abundance object properties for output." method="outputNames" />
      </methods>
      !!]
      procedure         ::                    Chemical_Abundances_Add

--- a/source/objects.nodes.components.hot_halo.standard.F90
+++ b/source/objects.nodes.components.hot_halo.standard.F90
@@ -83,6 +83,7 @@ module Node_Component_Hot_Halo_Standard
       <type>chemicalAbundances</type>
       <rank>0</rank>
       <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <output unitsInSI="massSolar" comment="Mass of chemicals in the hot phase of the hot halo."/>
     </property>
     <property>
       <name>angularMomentum</name>
@@ -1665,7 +1666,7 @@ contains
                &                  *fractionChemicalsAccreted         &
                &                  *basic           %          mass() &
                &                  /parentBasic     %          mass()
-          !! Reaccrete the metals.
+          !! Reaccrete the chemicals.
           call hotHaloParent%chemicalsSet(hotHaloParent%chemicals()+massChemicalsReaccreted)
        end if
        ! Determine if starvation is to be applied.
@@ -1853,8 +1854,8 @@ contains
     Ensure that {\normalfont \ttfamily node} is ready for promotion to its parent. In this case, we simply update the hot halo mass of {\normalfont \ttfamily
     node} to account for any hot halo already in the parent.
     !!}
-    use :: Abundances_Structure         , only : abundances            , zeroAbundances
-    use :: Chemical_Abundances_Structure, only : zeroChemicalAbundances
+    use :: Abundances_Structure         , only : zeroAbundances
+    use :: Chemical_Abundances_Structure, only : zeroChemicalAbundances, chemicalAbundances
     use :: Galacticus_Nodes             , only : nodeComponentHotHalo  , nodeComponentHotHaloStandard, treeNode
     implicit none
     class(*                   ), intent(inout) :: self
@@ -1876,8 +1877,8 @@ contains
        ! If the parent node has a hot halo component, then add it to that of this node, and perform other changes needed prior to
        ! promotion.
        select type (hotHaloParent)
-          class is (nodeComponentHotHaloStandard)
-             ! If (outflowed) mass is non-positive, set mass and all related quantities to zero.
+       class is (nodeComponentHotHaloStandard)
+          ! If (outflowed) mass is non-positive, set mass and all related quantities to zero.
           if (hotHalo%         mass() <= 0.0d0) then
              call hotHalo%massSet           (0.0d0                 )
              call hotHalo%angularMomentumSet(0.0d0                 )


### PR DESCRIPTION
Major change is to correctly account for exchange of metals and chemicals between the hot halo and unaccrated mass reservoirs. These must be accounted for explicitly as gas is moved between these reservoirs due to a time-varying filtering mass.

Various other minor fixes also.

Adds output of hot halo chemical masses.