### PR TITLE
Fix issues with the fuzzy dark matter transfer function

### DIFF
--- a/doc/Definitions.tex
+++ b/doc/Definitions.tex
@@ -75,3 +75,6 @@ The elements of this colon-separated specifier determine the radius at which a p
  \item [{\normalfont \ttfamily massType}] specifies which types of mass should be counted---allowed values are {\normalfont \ttfamily all}, {\normalfont \ttfamily dark}, {\normalfont \ttfamily baryonic}, {\normalfont \ttfamily galactic}, {\normalfont \ttfamily gaseous}, {\normalfont \ttfamily stellar}, and {\normalfont \ttfamily blackHole}.
 \end{description}
 
+\section{Half-mode and quarter-mode masses}
+For non-cold dark matter models with a matter power spectrum suppressed on small scales, a characteristic suppression scale can be defined by comparing the linear transfer function with that in the\gls{cdm} model. A popular definition is the half-mode (quarter-mode) mass, which corresponds to the wavenumber at which the transfer function is suppressed by a factor of two (four) relative to a \gls{cdm} transfer function.
+

--- a/source/structure_formation.transfer_function.Hu2000.FDM.F90
+++ b/source/structure_formation.transfer_function.Hu2000.FDM.F90
@@ -47,6 +47,7 @@
      procedure :: value                 => hu2000FDMValue
      procedure :: logarithmicDerivative => hu2000FDMLogarithmicDerivative
      procedure :: halfModeMass          => hu2000FDMHalfModeMass
+     procedure :: quarterModeMass       => hu2000FDMQuarterModeMass
      procedure :: epochTime             => hu2000FDMEpochTime
   end type transferFunctionHu2000FDM
 
@@ -238,6 +239,35 @@ contains
     if (present(status)) status=errorStatusSuccess
     return
   end function hu2000FDMHalfModeMass
+
+  double precision function hu2000FDMQuarterModeMass(self,status)
+    !!{
+    Compute the mass corresponding to the wavenumber at which the transfer function is suppressed by a factor of four relative
+    to a \gls{cdm} transfer function.
+    !!}
+    use :: Error                   , only : errorStatusSuccess
+    use :: Numerical_Constants_Math, only : Pi
+    implicit none
+    class           (transferFunctionHu2000FDM), intent(inout), target   :: self
+    integer                                    , intent(  out), optional :: status
+    double precision                                                     :: matterDensity, wavenumberQuarterMode
+
+    matterDensity           =+self%cosmologyParameters_%OmegaMatter    () &
+         &                   *self%cosmologyParameters_%densityCritical()
+    wavenumberQuarterMode   =+1.230d0                 &
+         &                   *4.5d0                   &
+         &                   *self%m22**(4.0d0/9.0d0)
+    hu2000FDMQuarterModeMass=+4.0d0                   &
+         &                   *Pi                      &
+         &                   /3.0d0                   &
+         &                   *matterDensity           &
+         &                   *(                       &
+         &                     +Pi                    &
+         &                     /wavenumberQuarterMode &
+         &                    )**3
+    if (present(status)) status=errorStatusSuccess
+    return
+  end function hu2000FDMQuarterModeMass
 
   double precision function hu2000FDMEpochTime(self)
     !!{

--- a/source/structure_formation.transfer_function.Hu2000.FDM.F90
+++ b/source/structure_formation.transfer_function.Hu2000.FDM.F90
@@ -78,7 +78,7 @@ contains
     double precision                                           :: redshift
 
     ! Validate parameters.
-    if (.not.parameters%isPresent('transferFunctionMethod')) call Error_Report("an explicit 'transferFunctionMethod' must be given"//{introspection:location})
+    if (.not.parameters%isPresent('transferFunction')) call Error_Report("an explicit 'transferFunction' must be given"//{introspection:location})
     ! Read parameters.
     !![
     <objectBuilder class="cosmologyParameters" name="cosmologyParameters_" source="parameters"/>

--- a/source/structure_formation.transfer_function.Murgia2017.F90
+++ b/source/structure_formation.transfer_function.Murgia2017.F90
@@ -221,8 +221,8 @@ function murgia2017ConstructorParameters(parameters) result(self)
          &                    )                       &
          &                   *(                       &
          &                     +(                     &
-         &                       +     1.0d0          &
-         &                       /sqrt(2.0d0)         &
+         &                       +1.0d0               &
+         &                       /2.0d0               &
          &                      )**(1.0d0/self%gamma) &
          &                     -1.0d0                 &
          &                    )**(1.0d0/self%beta)    &

--- a/source/structure_formation.transfer_function.Murgia2017.F90
+++ b/source/structure_formation.transfer_function.Murgia2017.F90
@@ -46,6 +46,7 @@
      procedure :: value                 => murgia2017Value
      procedure :: logarithmicDerivative => murgia2017LogarithmicDerivative
      procedure :: halfModeMass          => murgia2017HalfModeMass
+     procedure :: quarterModeMass       => murgia2017QuarterModeMass
      procedure :: epochTime             => murgia2017EpochTime
   end type transferFunctionMurgia2017
 
@@ -187,16 +188,18 @@ function murgia2017ConstructorParameters(parameters) result(self)
          &                                 *self%gamma                      &
          &                                 *(                               &
          &                                   +self%alpha                    &
-         &                                   *wavenumber)**self%beta        &
+         &                                   *wavenumber                    &
+         &                                  )**self%beta                    &
          &                                 /(                               &
          &                                   +(                             &
          &                                     +1.0d0                       &
          &                                     +(                           &
          &                                       +self%alpha                &
-         &                                       *wavenumber)**self%beta    &
-         &                                      )                           &
-         &                                     *wavenumber                  &
-         &                                )                             
+         &                                       *wavenumber                &
+         &                                      )**self%beta                &
+         &                                    )                             &
+         &                                   *wavenumber                    &
+         &                                  )
     return
   end function murgia2017LogarithmicDerivative
 
@@ -238,6 +241,45 @@ function murgia2017ConstructorParameters(parameters) result(self)
     if (present(status)) status=errorStatusSuccess
     return
   end function murgia2017HalfModeMass
+
+  double precision function murgia2017QuarterModeMass(self,status)
+    !!{
+    Compute the mass corresponding to the wavenumber at which the transfer function is suppressed by a factor of four relative
+    to a \gls{cdm} transfer function.
+    !!}
+    use :: Error                   , only : errorStatusSuccess
+    use :: Numerical_Constants_Math, only : Pi
+    implicit none
+    class           (transferFunctionMurgia2017), intent(inout), target   :: self
+    integer                                     , intent(  out), optional :: status
+    double precision                                                      :: matterDensity, wavenumberQuarterMode
+
+    matterDensity            =+self%cosmologyParameters_%OmegaMatter    () &
+         &                    *self%cosmologyParameters_%densityCritical()
+    wavenumberQuarterMode    =+(                         &
+         &                      +(                       &
+         &                        +1.0d0                 &
+         &                        /self%alpha            &
+         &                       )                       &
+         &                      *(                       &
+         &                        +(                     &
+         &                          +1.0d0               &
+         &                          /4.0d0               &
+         &                         )**(1.0d0/self%gamma) &
+         &                        -1.0d0                 &
+         &                       )**(1.0d0/self%beta)    &
+         &                     )
+    murgia2017QuarterModeMass=+4.0d0                   &
+         &                    *Pi                      &
+         &                    /3.0d0                   &
+         &                    *matterDensity           &
+         &                    *(                       &
+         &                      +Pi                    &
+         &                      /wavenumberQuarterMode &
+         &                    )**3
+    if (present(status)) status=errorStatusSuccess
+    return
+  end function murgia2017QuarterModeMass
 
   double precision function murgia2017EpochTime(self)
     !!{

--- a/source/structure_formation.transfer_function.file.fuzzy_dark_matter.F90
+++ b/source/structure_formation.transfer_function.file.fuzzy_dark_matter.F90
@@ -316,7 +316,7 @@ contains
     return
   end function fileFuzzyDarkMatterHalfModeMass
 
-  double precision function fileFuzzyDarkMatterQuarterModeMass
+  double precision function fileFuzzyDarkMatterQuarterModeMass(self,status)
     !!{
     Compute the mass corresponding to the wavenumber at which the transfer function is
     suppressed by a factor of four relative to a \gls{cdm} transfer function.

--- a/source/structure_formation.transfer_function.file.fuzzy_dark_matter.F90
+++ b/source/structure_formation.transfer_function.file.fuzzy_dark_matter.F90
@@ -150,6 +150,7 @@
    contains
      procedure :: readFile        => fileFuzzyDarkMatterReadFile
      procedure :: halfModeMass    => fileFuzzyDarkMatterHalfModeMass
+     procedure :: quarterModeMass => fileFuzzyDarkMatterQuarterModeMass
   end type transferFunctionFileFuzzyDarkMatter
 
   interface transferFunctionFileFuzzyDarkMatter
@@ -314,3 +315,48 @@ contains
     if (present(status)) status=errorStatusSuccess
     return
   end function fileFuzzyDarkMatterHalfModeMass
+
+  double precision function fileFuzzyDarkMatterQuarterModeMass
+    !!{
+    Compute the mass corresponding to the wavenumber at which the transfer function is
+    suppressed by a factor of four relative to a \gls{cdm} transfer function.
+    !!}
+    use :: Error                       , only : errorStatusSuccess
+    use :: Numerical_Constants_Math    , only : Pi
+    use :: Numerical_Constants_Prefixes, only : kilo
+    implicit none
+    class           (transferFunctionFileFuzzyDarkMatter), intent(inout), target   :: self
+    integer                                              , intent(  out), optional :: status
+    double precision                                                               :: matterDensity, wavenumberQuarterMode
+    double precision                                                               :: m22
+
+    fileFuzzyDarkMatterQuarterModeMass=0.0d0
+    select type (darkMatterParticle_ => self%darkMatterParticle_)
+    class is (darkMatterParticleFuzzyDarkMatter)
+       if (darkMatterParticle_%densityFraction() == 1.0d0) then
+          matterDensity=+self%cosmologyParameters_%OmegaMatter    () &
+               &        *self%cosmologyParameters_%densityCritical()
+          ! Particle mass in units of $10^{-22}$~eV.
+          m22                               =+darkMatterParticle_%mass() &
+               &                             *kilo                       &
+               &                             /1.0d-22
+          wavenumberQuarterMode             =+1.230d0                 &
+               &                             *4.5d0                   &
+               &                             *m22**(4.0d0/9.0d0)
+          fileFuzzyDarkMatterQuarterModeMass=+4.0d0                   &
+               &                             *Pi                      &
+               &                             /3.0d0                   &
+               &                             *matterDensity           &
+               &                             *(                       &
+               &                               +Pi                    &
+               &                               /wavenumberQuarterMode &
+               &                              )**3
+       else
+          call Error_Report('quarter-mode mass is not well defined for a mixed CDM and fuzzy dark matter model'//{introspection:location})
+       end if
+    class default
+       call Error_Report('transfer function expects a fuzzy dark matter particle'//{introspection:location})
+    end select
+    if (present(status)) status=errorStatusSuccess
+    return
+  end function fileFuzzyDarkMatterQuarterModeMass


### PR DESCRIPTION
1. In some of the fuzzy dark matter transfer function classes, the quarter-mode mass is not defined;
2. In "Murgia2017"  transfer function class, the definition of half-mode mass is different from the one used at other places. There are two definitions used in literature:
    a) T^2(k_half) = 1/2;
    b) T(k_half) = 1/2.
In Galacticus, we use the latter.