### PR TITLE
Add missing "radiusCircularVelocityMaximum" methods to darkMatterProfileDMO classes

### DIFF
--- a/source/dark_matter_profiles_DMO.Burkert.F90
+++ b/source/dark_matter_profiles_DMO.Burkert.F90
@@ -126,6 +126,7 @@
      procedure :: potential                         => burkertPotential
      procedure :: circularVelocity                  => burkertCircularVelocity
      procedure :: circularVelocityMaximum           => burkertCircularVelocityMaximum
+     procedure :: radiusCircularVelocityMaximum     => burkertRadiusCircularVelocityMaximum
      procedure :: radialVelocityDispersion          => burkertRadialVelocityDispersion
      procedure :: radiusFromSpecificAngularMomentum => burkertRadiusFromSpecificAngularMomentum
      procedure :: rotationNormalization             => burkertRotationNormalization
@@ -563,6 +564,24 @@ contains
     burkertCircularVelocityMaximum=self%maximumVelocityPrevious
     return
   end function burkertCircularVelocityMaximum
+
+  double precision function burkertRadiusCircularVelocityMaximum(self,node)
+    !!{
+    Returns the radius (in Mpc) at which the maximum circular velocity is acheived in the dark matter profile of {\normalfont \ttfamily node}.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentDarkMatterProfile, treeNode
+    implicit none
+    class           (darkMatterProfileDMOBurkert   ), intent(inout) :: self
+    type            (treeNode                      ), intent(inout) :: node
+    ! The radius (in units of the scale radius) at which the rotation speed peaks in a Burkert halo.
+    double precision                                , parameter     :: radiusMaximum    =3.2446257246042642d0
+    class           (nodeComponentDarkMatterProfile), pointer       :: darkMatterProfile
+    
+    darkMatterProfile                    =>  node             %darkMatterProfile(autoCreate=.true.)
+    burkertRadiusCircularVelocityMaximum =  +                  radiusMaximum                        &
+         &                                  *darkMatterProfile%scale            (                 )
+    return
+  end function burkertRadiusCircularVelocityMaximum
 
   double precision function burkertRadialVelocityDispersion(self,node,radius)
     !!{

--- a/source/dark_matter_profiles_DMO.Einasto.F90
+++ b/source/dark_matter_profiles_DMO.Einasto.F90
@@ -129,6 +129,7 @@
      procedure :: potential                                  => einastoPotential
      procedure :: circularVelocity                           => einastoCircularVelocity
      procedure :: circularVelocityMaximum                    => einastoCircularVelocityMaximum
+     procedure :: radiusCircularVelocityMaximum              => einastoRadiusCircularVelocityMaximum
      procedure :: radialVelocityDispersion                   => einastoRadialVelocityDispersion
      procedure :: radiusFromSpecificAngularMomentum          => einastoRadiusFromSpecificAngularMomentum
      procedure :: rotationNormalization                      => einastoRotationNormalization
@@ -469,6 +470,19 @@ contains
     !!{
     Returns the maximum circular velocity (in km/s) in the dark matter profile of {\normalfont \ttfamily node}.
     !!}
+    implicit none
+    class(darkMatterProfileDMOEinasto), intent(inout) :: self
+    type (treeNode                   ), intent(inout) :: node
+
+    ! Find the peak velocity.
+    einastoCircularVelocityMaximum=self%circularVelocity(node,self%radiusCircularVelocityMaximum(node))
+    return
+  end function einastoCircularVelocityMaximum
+  
+  double precision function einastoRadiusCircularVelocityMaximum(self,node)
+    !!{
+    Returns the radius (in Mpc) at which the maximum circular velocity is acheived in the dark matter profile of {\normalfont \ttfamily node}.
+    !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic, nodeComponentDarkMatterProfile, treeNode
     implicit none
     class           (darkMatterProfileDMOEinasto   ), intent(inout) :: self
@@ -484,10 +498,10 @@ contains
     ! Solve for the radius (in units of the scale radius) at which the rotation curve peaks.
     einastoAlpha=alpha
     radiusPeak  =self%finderVelocityPeak%find(rootGuess=radiusScale)
-    ! Find the peak velocity.
-    einastoCircularVelocityMaximum=self%circularVelocity(node,radiusPeak*radiusScale)
+    ! Convert to a physical radius.
+    einastoRadiusCircularVelocityMaximum=radiusPeak*radiusScale
     return
-  end function einastoCircularVelocityMaximum
+  end function einastoRadiusCircularVelocityMaximum
   
   double precision function einastoCircularVelocityPeakRadius(radius)
     !!{

--- a/source/dark_matter_profiles_DMO.SIDM.coreNFW.F90
+++ b/source/dark_matter_profiles_DMO.SIDM.coreNFW.F90
@@ -60,6 +60,7 @@
      procedure :: potential                         => sidmCoreNFWPotential
      procedure :: circularVelocity                  => sidmCoreNFWCircularVelocity
      procedure :: circularVelocityMaximum           => sidmCoreNFWCircularVelocityMaximum
+     procedure :: radiusCircularVelocityMaximum     => sidmCoreNFWRadiusCircularVelocityMaximum
      procedure :: radialVelocityDispersion          => sidmCoreNFWRadialVelocityDispersion
      procedure :: radiusFromSpecificAngularMomentum => sidmCoreNFWRadiusFromSpecificAngularMomentum
      procedure :: rotationNormalization             => sidmCoreNFWRotationNormalization
@@ -438,6 +439,18 @@ contains
     sidmCoreNFWCircularVelocityMaximum=self%circularVelocityMaximumNumerical(node)
     return
   end function sidmCoreNFWCircularVelocityMaximum
+
+  double precision function sidmCoreNFWRadiusCircularVelocityMaximum(self,node)
+    !!{
+    Returns the radius (in Mpc) at which the maximum circular velocity is acheived in the dark matter profile of {\normalfont \ttfamily node}.
+    !!}
+    implicit none
+    class(darkMatterProfileDMOSIDMCoreNFW), intent(inout) :: self
+    type (treeNode                       ), intent(inout) :: node
+
+    sidmCoreNFWRadiusCircularVelocityMaximum=self%radiusCircularVelocityMaximumNumerical(node)
+    return
+  end function sidmCoreNFWRadiusCircularVelocityMaximum
 
   double precision function sidmCoreNFWRadialVelocityDispersion(self,node,radius)
     !!{

--- a/source/dark_matter_profiles_DMO.SIDM.isothermal.F90
+++ b/source/dark_matter_profiles_DMO.SIDM.isothermal.F90
@@ -104,6 +104,7 @@
      procedure :: potential                         => sidmIsothermalPotential
      procedure :: circularVelocity                  => sidmIsothermalCircularVelocity
      procedure :: circularVelocityMaximum           => sidmIsothermalCircularVelocityMaximum
+     procedure :: radiusCircularVelocityMaximum     => sidmIsothermalRadiusCircularVelocityMaximum
      procedure :: radialVelocityDispersion          => sidmIsothermalRadialVelocityDispersion
      procedure :: radiusFromSpecificAngularMomentum => sidmIsothermalRadiusFromSpecificAngularMomentum
      procedure :: rotationNormalization             => sidmIsothermalRotationNormalization
@@ -681,6 +682,18 @@ contains
     sidmIsothermalCircularVelocityMaximum=self%circularVelocityMaximumNumerical(node)
     return
   end function sidmIsothermalCircularVelocityMaximum
+
+  double precision function sidmIsothermalRadiusCircularVelocityMaximum(self,node)
+    !!{
+    Returns the radius (in Mpc) at which the maximum circular velocity is acheived in the dark matter profile of {\normalfont \ttfamily node}.
+    !!}
+    implicit none
+    class(darkMatterProfileDMOSIDMIsothermal), intent(inout) :: self
+    type (treeNode                          ), intent(inout) :: node
+
+    sidmIsothermalRadiusCircularVelocityMaximum=self%radiusCircularVelocityMaximumNumerical(node)
+    return
+  end function sidmIsothermalRadiusCircularVelocityMaximum
 
   double precision function sidmIsothermalRadialVelocityDispersion(self,node,radius)
     !!{

--- a/source/dark_matter_profiles_DMO.truncated.F90
+++ b/source/dark_matter_profiles_DMO.truncated.F90
@@ -61,6 +61,7 @@
      procedure :: potential                         => truncatedPotential
      procedure :: circularVelocity                  => truncatedCircularVelocity
      procedure :: circularVelocityMaximum           => truncatedCircularVelocityMaximum
+     procedure :: radiusCircularVelocityMaximum     => truncatedRadiusCircularVelocityMaximum
      procedure :: radialVelocityDispersion          => truncatedRadialVelocityDispersion
      procedure :: radiusFromSpecificAngularMomentum => truncatedRadiusFromSpecificAngularMomentum
      procedure :: rotationNormalization             => truncatedRotationNormalization
@@ -417,6 +418,22 @@ contains
     end if
     return
   end function truncatedCircularVelocityMaximum
+
+  double precision function truncatedRadiusCircularVelocityMaximum(self,node)
+    !!{
+    Returns the radius (in Mpc) at which the maximum circular velocity is acheived in the dark matter profile of {\normalfont \ttfamily node}.
+    !!}
+    implicit none
+    class(darkMatterProfileDMOTruncated), intent(inout) :: self
+    type (treeNode                     ), intent(inout) :: node
+
+    if (self%nonAnalyticSolver == nonAnalyticSolversFallThrough) then
+       truncatedRadiusCircularVelocityMaximum=self%darkMatterProfileDMO_%radiusCircularVelocityMaximum         (node)
+    else
+       truncatedRadiusCircularVelocityMaximum=self                      %radiusCircularVelocityMaximumNumerical(node)
+    end if
+    return
+  end function truncatedRadiusCircularVelocityMaximum
 
   double precision function truncatedRadialVelocityDispersion(self,node,radius)
     !!{


### PR DESCRIPTION
Several of the `darkMatterProfileDMO` classes were missing implementations of the `radiusCircularVelocityMaximum` method. This patch fixes those omissions.