### PR TITLE
Fix a bug in parameter tree traversal

### DIFF
--- a/.github/workflows/testMiscMPI.yml
+++ b/.github/workflows/testMiscMPI.yml
@@ -146,3 +146,38 @@ jobs:
           ./test-radiativeTransfer-StromgrenSphere_MPI.pl --processesPerNode 2 --allow-run-as-root yes 2>&1 | tee test.log
           ! grep -q FAIL test.log
       - run: echo "This job's status is ${{ job.status }}."
+  Test-MCMC:
+    runs-on: ubuntu-latest
+    container: docker://galacticusorg/buildenv:latest
+    needs: Build-Executables
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server."
+      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Check out repository datasets
+        uses: actions/checkout@v2      
+        with:
+          repository: galacticusorg/datasets
+          path: datasets
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
+      - name: Download executables
+        uses: actions/download-artifact@v2
+        with:
+          name: galacticus-exec-MPI
+      - name: Create test suite output directory
+        run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
+      - name: Run test
+        run: |
+          cd $GALACTICUS_EXEC_PATH
+          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+          chmod u=wrx ./Galacticus.exe_MPI
+          export OMP_NUM_THREADS=1
+          mpirun -np 4 ./Galacticus.exe_MPI parameters/tutorials/mcmcConfig.xml 2>&1 | tee test.log
+          ! grep -q FAIL test.log
+      - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/testMiscMPI.yml
+++ b/.github/workflows/testMiscMPI.yml
@@ -178,6 +178,6 @@ jobs:
           git config --global --add safe.directory $GALACTICUS_EXEC_PATH
           chmod u=wrx ./Galacticus.exe_MPI
           export OMP_NUM_THREADS=1
-          mpirun -np 4 ./Galacticus.exe_MPI parameters/tutorials/mcmcConfig.xml 2>&1 | tee test.log
+          mpirun --allow-run-as-root -np 4 ./Galacticus.exe_MPI parameters/tutorials/mcmcConfig.xml 2>&1 | tee test.log
           ! grep -q FAIL test.log
       - run: echo "This job's status is ${{ job.status }}."

--- a/parameters/tutorials/mcmcConfig.xml
+++ b/parameters/tutorials/mcmcConfig.xml
@@ -13,19 +13,19 @@
   <outputFileName value="galacticus.hdf5"/>
 
   <posteriorSampleLikelihood value="galaxyPopulation">
-    <baseParametersFileName   value="parameters/tutorials/mcmcBase.xml"      />
-    <failedParametersFileName value="./failedParameters.xml"/>
-    <randomize                value="false"                                    />
-    <evolveForestsVerbosity   value="0"                                        />
+    <baseParametersFileName   value="parameters/tutorials/mcmcBase.xml"/>
+    <failedParametersFileName value="./failedParameters.xml"           />
+    <randomize                value="false"                            />
+    <evolveForestsVerbosity   value="silent"                           />
   </posteriorSampleLikelihood>
 
   <!-- MCMC -->
   <posteriorSampleSimulation value="differentialEvolution">
     <stepsMaximum           value="1000"/>
-    <acceptanceAverageCount value="    10"/>
-    <stateSwapCount         value="     100"/>
+    <acceptanceAverageCount value="  10"/>
+    <stateSwapCount         value=" 100"/>
     <logFileRoot            value="mcmcChains"/>
-    <reportCount            value="10"/>
+    <reportCount            value="  10"/>
     <sampleOutliers         value="false"/>
     <logFlushCount          value="      1"/>
 

--- a/source/models.likelihoods.base_parameters.F90
+++ b/source/models.likelihoods.base_parameters.F90
@@ -84,7 +84,7 @@ contains
           parameterCount=String_Count_Words(char(modelParametersActive_(i)%modelParameter_%name()),"::")
           allocate(parameterNames(parameterCount))
           call String_Split_Words(parameterNames,char(modelParametersActive_(i)%modelParameter_%name()),"::")
-          parameters_=self%parametersModel
+          parameters_=inputParameters(self%parametersModel)
           do j=1,parameterCount
              instance    =1
              indexElement=0

--- a/source/output.analyses.HI_vs_halo_mass_relation.ALFALFA_Padmanabhan_2017.F90
+++ b/source/output.analyses.HI_vs_halo_mass_relation.ALFALFA_Padmanabhan_2017.F90
@@ -52,6 +52,7 @@ contains
     !!}
     use :: Cosmology_Functions             , only : cosmologyFunctions                                      , cosmologyFunctionsClass
     use :: Cosmology_Parameters            , only : cosmologyParameters                                     , cosmologyParametersClass
+    use :: Galactic_Structure              , only : galacticStructureClass
     use :: Functions_Global                , only : Virial_Density_Contrast_Percolation_Objects_Constructor_
     use :: Input_Parameters                , only : inputParameter                                          , inputParameters
     use :: Output_Analysis_Molecular_Ratios, only : outputAnalysisMolecularRatio                            , outputAnalysisMolecularRatioClass
@@ -64,6 +65,7 @@ contains
     class           (cosmologyParametersClass                         ), pointer                     :: cosmologyParameters_
     class           (virialDensityContrastClass                       ), pointer                     :: virialDensityContrast_
     class           (darkMatterProfileDMOClass                        ), pointer                     :: darkMatterProfileDMO_
+    class           (galacticStructureClass                           ), pointer                     :: galacticStructure_
     class           (outputAnalysisMolecularRatioClass                ), pointer                     :: outputAnalysisMolecularRatio_
     class           (*                                                ), pointer                     :: percolationObjects_
     integer         (c_size_t                                         )                              :: likelihoodBin
@@ -94,9 +96,10 @@ contains
     <objectBuilder class="outputAnalysisMolecularRatio" name="outputAnalysisMolecularRatio_" source="parameters"/>
     <objectBuilder class="virialDensityContrast"        name="virialDensityContrast_"        source="parameters"/>
     <objectBuilder class="darkMatterProfileDMO"         name="darkMatterProfileDMO_"         source="parameters"/>
+    <objectBuilder class="galacticStructure"            name="galacticStructure_"            source="parameters"/>
     !!]
     percolationObjects_ => Virial_Density_Contrast_Percolation_Objects_Constructor_(parameters)
-    self                =  outputAnalysisHIVsHaloMassRelationPadmanabhan2017(likelihoodBin,systematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,virialDensityContrast_,darkMatterProfileDMO_,outputAnalysisMolecularRatio_,outputTimes_,percolationObjects_)
+    self                =  outputAnalysisHIVsHaloMassRelationPadmanabhan2017(likelihoodBin,systematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,virialDensityContrast_,darkMatterProfileDMO_,outputAnalysisMolecularRatio_,outputTimes_,galacticStructure_,percolationObjects_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyParameters_"         />
@@ -105,11 +108,12 @@ contains
     <objectDestructor name="outputAnalysisMolecularRatio_"/>
     <objectDestructor name="darkMatterProfileDMO_"        />
     <objectDestructor name="virialDensityContrast_"       />
+    <objectDestructor name="galacticStructure_"           />
     !!]
     return
   end function hiVsHaloMassRelationPadmanabhan2017ConstructorParameters
 
-  function hiVsHaloMassRelationPadmanabhan2017ConstructorInternal(likelihoodBin,systematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,virialDensityContrast_,darkMatterProfileDMO_,outputAnalysisMolecularRatio_,outputTimes_,percolationObjects_) result (self)
+  function hiVsHaloMassRelationPadmanabhan2017ConstructorInternal(likelihoodBin,systematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,virialDensityContrast_,darkMatterProfileDMO_,outputAnalysisMolecularRatio_,outputTimes_,galacticStructure_,percolationObjects_) result (self)
     !!{
     Constructor for the ``hiVsHaloMassRelationPadmanabhan2017'' output analysis class for internal use.
     !!}
@@ -142,6 +146,7 @@ contains
     class           (cosmologyFunctionsClass                           ), intent(inout), target         :: cosmologyFunctions_
     class           (virialDensityContrastClass                        ), intent(in   )                 :: virialDensityContrast_
     class           (darkMatterProfileDMOClass                         ), intent(in   )                 :: darkMatterProfileDMO_
+    class           (galacticStructureClass                            ), intent(in   ), target         :: galacticStructure_
     class           (outputTimesClass                                  ), intent(inout), target         :: outputTimes_
     class           (outputAnalysisMolecularRatioClass                 ), intent(in   ), target         :: outputAnalysisMolecularRatio_
     class           (*                                                 ), intent(in   ), target         :: percolationObjects_
@@ -311,7 +316,7 @@ contains
     ! Create an HI mass weight property extractor.
     allocate(outputAnalysisWeightPropertyExtractor_                )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"                 constructor="nodePropertyExtractorMassISM                          (                                                                                  )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"                 constructor="nodePropertyExtractorMassISM                          (galacticStructure_                                                                )"/>
     !!]
     ! Create a halo mass weight property extractor. The virial density contrast is chosen to equal that expected for a
     ! friends-of-friends algorithm with linking length parameter b=0.2 since that is what was used by Sheth, Mo & Tormen (2001) in

--- a/source/output.analyses.Local_Group_mass_functions.F90
+++ b/source/output.analyses.Local_Group_mass_functions.F90
@@ -71,12 +71,14 @@ contains
     !!{
     Constructor for the ``localGroupMassFunction'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
-    use :: Output_Times    , only : outputTimes   , outputTimesClass
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
+    use :: Output_Times      , only : outputTimes           , outputTimesClass
     implicit none
     type            (outputAnalysisLocalGroupMassFunction)                              :: self
     type            (inputParameters                     ), intent(inout)               :: parameters
     class           (outputTimesClass                    ), pointer                     :: outputTimes_
+    class           (galacticStructureClass              ), pointer                     :: galacticStructure_
     double precision                                      , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                             :: covarianceBinomialBinsPerDecade
     double precision                                                                    :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
@@ -151,9 +153,10 @@ contains
       <defaultValue>1.0d16</defaultValue>
       <description>The maximum halo mass to consider when constructing Local Group stellar mass function covariance matrices for main branch galaxies.</description>
     </inputParameter>
-    <objectBuilder class="outputTimes" name="outputTimes_" source="parameters"/>
+    <objectBuilder class="outputTimes"       name="outputTimes_"       source="parameters"/>
+    <objectBuilder class="galacticStructure" name="galacticStructure_" source="parameters"/>
     !!]
-    self=outputAnalysisLocalGroupMassFunction(outputTimes_,negativeBinomialScatterFractional,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum)
+    self=outputAnalysisLocalGroupMassFunction(outputTimes_,galacticStructure_,negativeBinomialScatterFractional,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="outputTimes_"/>
@@ -161,7 +164,7 @@ contains
     return
   end function localGroupMassFunctionConstructorParameters
 
-  function localGroupMassFunctionConstructorInternal(outputTimes_,negativeBinomialScatterFractional,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum) result (self)
+  function localGroupMassFunctionConstructorInternal(outputTimes_,galacticStructure_,negativeBinomialScatterFractional,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum) result (self)
     !!{
     Constructor for the ``localGroupMassFunction'' output analysis class for internal use.
     !!}
@@ -190,6 +193,7 @@ contains
     double precision                                                     , intent(in   )                 :: randomErrorMinimum                                         , randomErrorMaximum
     double precision                                                     , intent(in   ), dimension(:  ) :: randomErrorPolynomialCoefficient                           , systematicErrorPolynomialCoefficient
     class           (outputTimesClass                                   ), intent(inout)                 :: outputTimes_
+    class           (galacticStructureClass                             ), intent(in   ), target         :: galacticStructure_
     type            (nodePropertyExtractorMassStellar                   )               , pointer        :: nodePropertyExtractor_
     type            (outputAnalysisPropertyOperatorSystmtcPolynomial    )               , pointer        :: outputAnalysisPropertyOperatorSystmtcPolynomial_
     type            (outputAnalysisPropertyOperatorLog10                )               , pointer        :: outputAnalysisPropertyOperatorLog10_
@@ -256,7 +260,7 @@ contains
     ! Create a stellar mass property extractor.
     allocate(nodePropertyExtractor_                )
     !![
-    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorMassStellar               (                                                   )"/>
+    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorMassStellar               (galacticStructure_                                 )"/>
     !!]
     ! Create property operators and unoperators to perform conversion to/from logarithmic mass.
     allocate(outputAnalysisPropertyOperatorLog10_            )

--- a/source/output.analyses.Sunyaev-Zeldovich_Planck2013.F90
+++ b/source/output.analyses.Sunyaev-Zeldovich_Planck2013.F90
@@ -49,7 +49,8 @@ contains
     !!{
     Constructor for the ``sunyaevZeldovichPlanck2013'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisSunyaevZeldovichPlanck2013)                              :: self
     type            (inputParameters                         ), intent(inout)               :: parameters
@@ -295,12 +296,12 @@ contains
     ! Build anti-log10() property operator.
     allocate(outputAnalysisPropertyUnoperator_     )
     !![
-    <referenceConstruct object="outputAnalysisPropertyUnoperator_" constructor="outputAnalysisPropertyOperatorAntiLog10()"/>
+    <referenceConstruct object="outputAnalysisPropertyUnoperator_" constructor="outputAnalysisPropertyOperatorAntiLog10(                  )"/>
     !!]
     ! Create a stellar mass property extractor.
     allocate(nodePropertyExtractor_                )
     !![
-    <referenceConstruct object="nodePropertyExtractor_"            constructor="nodePropertyExtractorMassStellar       ()"/>
+    <referenceConstruct object="nodePropertyExtractor_"            constructor="nodePropertyExtractorMassStellar       (galacticStructure_)"/>
     !!]
     ! Create a thermal Sunyaev-Zelodvich property extractor.
     allocate(outputAnalysisWeightPropertyExtractor_)

--- a/source/output.analyses.correlation_function.Hearin2014_SDSS.F90
+++ b/source/output.analyses.correlation_function.Hearin2014_SDSS.F90
@@ -47,8 +47,9 @@ contains
     !!{
     Constructor for the ``correlationFunctionHearin2013SDSS'' output analysis class which takes a parameter set as input.
     !!}
-    use, intrinsic :: ISO_C_Binding   , only : c_size_t
-    use            :: Input_Parameters, only : inputParameter, inputParameters
+    use, intrinsic :: ISO_C_Binding     , only : c_size_t
+    use            :: Input_Parameters  , only : inputParameter        , inputParameters
+    use            :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisCorrelationFunctionHearin2013SDSS)                              :: self
     type            (inputParameters                                ), intent(inout)               :: parameters
@@ -58,6 +59,7 @@ contains
     class           (darkMatterHaloBiasClass                        ), pointer                     :: darkMatterHaloBias_
     class           (haloModelPowerSpectrumModifierClass            ), pointer                     :: haloModelPowerSpectrumModifier_
     class           (powerSpectrumClass                             ), pointer                     :: powerSpectrum_
+    class           (galacticStructureClass                         ), pointer                     :: galacticStructure_
     double precision                                                 , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient, systematicErrorPolynomialCoefficient
     double precision                                                                               :: massHaloMinimum                 , massHaloMaximum                     , &
          &                                                                                            randomErrorMinimum              , randomErrorMaximum
@@ -127,8 +129,9 @@ contains
     <objectBuilder class="darkMatterHaloBias"             name="darkMatterHaloBias_"             source="parameters"/>
     <objectBuilder class="powerSpectrum"                  name="powerSpectrum_"                  source="parameters"/>
     <objectBuilder class="haloModelPowerSpectrumModifier" name="haloModelPowerSpectrumModifier_" source="parameters"/>
+    <objectBuilder class="galacticStructure"              name="galacticStructure_"              source="parameters"/>
     !!]
-    self=outputAnalysisCorrelationFunctionHearin2013SDSS(massHaloBinsPerDecade,massHaloMinimum, massHaloMaximum,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,cosmologyFunctions_,outputTimes_,darkMatterProfileDMO_,darkMatterHaloBias_,haloModelPowerSpectrumModifier_,powerSpectrum_)
+    self=outputAnalysisCorrelationFunctionHearin2013SDSS(massHaloBinsPerDecade,massHaloMinimum, massHaloMaximum,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,cosmologyFunctions_,outputTimes_,darkMatterProfileDMO_,darkMatterHaloBias_,haloModelPowerSpectrumModifier_,powerSpectrum_,galacticStructure_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"            />
@@ -137,11 +140,12 @@ contains
     <objectDestructor name="darkMatterHaloBias_"            />
     <objectDestructor name="haloModelPowerSpectrumModifier_"/>
     <objectDestructor name="powerSpectrum_"                 />
+    <objectDestructor name="galacticStructure_"             />
     !!]
     return
   end function correlationFunctionHearin2013SDSSConstructorParameters
 
-  function correlationFunctionHearin2013SDSSConstructorInternal(massHaloBinsPerDecade,massHaloMinimum,massHaloMaximum,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,cosmologyFunctions_,outputTimes_,darkMatterProfileDMO_,darkMatterHaloBias_,haloModelPowerSpectrumModifier_,powerSpectrum_) result (self)
+  function correlationFunctionHearin2013SDSSConstructorInternal(massHaloBinsPerDecade,massHaloMinimum,massHaloMaximum,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,cosmologyFunctions_,outputTimes_,darkMatterProfileDMO_,darkMatterHaloBias_,haloModelPowerSpectrumModifier_,powerSpectrum_,galacticStructure_) result (self)
     !!{
     Constructor for the ``correlationFunctionHearin2013SDSS'' output analysis class for internal use.
     !!}
@@ -167,6 +171,7 @@ contains
     class           (darkMatterHaloBiasClass                            ), intent(in   ), target         :: darkMatterHaloBias_
     class           (haloModelPowerSpectrumModifierClass                ), intent(in   ), target         :: haloModelPowerSpectrumModifier_
     class           (powerSpectrumClass                                 ), intent(in   ), target         :: powerSpectrum_
+    class           (galacticStructureClass                             ), intent(in   ), target         :: galacticStructure_
     type            (cosmologyParametersSimple                          ), pointer                       :: cosmologyParametersData_
     type            (cosmologyFunctionsMatterLambda                     ), pointer                       :: cosmologyFunctionsData_
     type            (galacticFilterStellarMass                          ), pointer                       :: galacticFilter_
@@ -220,7 +225,7 @@ contains
     ! Stellar mass property extractor.
     allocate(massPropertyExtractor_                )
     !![
-    <referenceConstruct object="massPropertyExtractor_" constructor="nodePropertyExtractorMassStellar                               (                                                                           )"/>
+    <referenceConstruct object="massPropertyExtractor_" constructor="nodePropertyExtractorMassStellar                               (galacticStructure_                                                         )"/>
     !!]
     ! Sequence of property operators to correct for cosmological model, convert to logarithm, and apply systematic errors.
     allocate(massPropertyOperatorCsmlgyLmnstyDstnc_)

--- a/source/output.analyses.galaxy_sizes_SDSS.F90
+++ b/source/output.analyses.galaxy_sizes_SDSS.F90
@@ -63,13 +63,15 @@ contains
     !!{
     Constructor for the ``galaxySizesSDSS'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisGalaxySizesSDSS)                :: self
     type            (inputParameters              ), intent(inout) :: parameters
     class           (cosmologyFunctionsClass      ), pointer       :: cosmologyFunctions_
     class           (outputTimesClass             ), pointer       :: outputTimes_
     class           (gravitationalLensingClass    ), pointer       :: gravitationalLensing_
+    class           (galacticStructureClass       ), pointer       :: galacticStructure_
     double precision                                               :: massStellarRatio     , sizeSourceLensing
     integer                                                        :: distributionNumber
 
@@ -95,18 +97,20 @@ contains
     <objectBuilder class="cosmologyFunctions"   name="cosmologyFunctions_"   source="parameters"/>
     <objectBuilder class="outputTimes"          name="outputTimes_"          source="parameters"/>
     <objectBuilder class="gravitationalLensing" name="gravitationalLensing_" source="parameters"/>
+    <objectBuilder class="galacticStructure"    name="galacticStructure_"    source="parameters"/>
     !!]
-    self=outputAnalysisGalaxySizesSDSS(distributionNumber,massStellarRatio,sizeSourceLensing,cosmologyFunctions_,outputTimes_,gravitationalLensing_)
+    self=outputAnalysisGalaxySizesSDSS(distributionNumber,massStellarRatio,sizeSourceLensing,cosmologyFunctions_,outputTimes_,gravitationalLensing_,galacticStructure_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"  />
     <objectDestructor name="outputTimes_"         />
     <objectDestructor name="gravitationalLensing_"/>
+    <objectDestructor name="galacticStructure_"   />
     !!]
     return
   end function galaxySizesSDSSConstructorParameters
 
-  function galaxySizesSDSSConstructorInternal(distributionNumber,massStellarRatio,sizeSourceLensing,cosmologyFunctions_,outputTimes_,gravitationalLensing_) result(self)
+  function galaxySizesSDSSConstructorInternal(distributionNumber,massStellarRatio,sizeSourceLensing,cosmologyFunctions_,outputTimes_,gravitationalLensing_,galacticStructure_) result(self)
     !!{
     Internal constructor for the ``galaxySizesSDSS'' output analysis class.
     !!}
@@ -141,6 +145,7 @@ contains
     class           (cosmologyFunctionsClass                        ), target     , intent(in   )  :: cosmologyFunctions_
     class           (outputTimesClass                               ), target     , intent(inout)  :: outputTimes_
     class           (gravitationalLensingClass                      ), target     , intent(in   )  :: gravitationalLensing_
+    class           (galacticStructureClass                         ), target     , intent(in   )  :: galacticStructure_
     type            (cosmologyParametersSimple                      ), pointer                     :: cosmologyParametersData
     type            (cosmologyFunctionsMatterLambda                 ), pointer                     :: cosmologyFunctionsData
     type            (nodePropertyExtractorRadiusHalfMassStellar     ), pointer                     :: nodePropertyExtractor_
@@ -251,12 +256,12 @@ contains
     ! Create a half-mass radius property extractor.
     allocate(nodePropertyExtractor_        )
     !![
-    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorRadiusHalfMassStellar       (                                                                                                                                                             )"/>
+    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorRadiusHalfMassStellar       (galacticStructure_                                                                                                                                           )"/>
     !!]
     ! Create a stellar mass property extractor.
     allocate(outputAnalysisWeightPropertyExtractor_        )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"           constructor="nodePropertyExtractorMassStellar                 (                                                                                                                                                             )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"           constructor="nodePropertyExtractorMassStellar                 (galacticStructure_                                                                                                                                           )"/>
     !!]
     ! Create multiply, log10, cosmological angular distance, and cosmological luminosity distance property operators.
     allocate(outputAnalysisPropertyOperatorMultiply_         )

--- a/source/output.analyses.mass_function_HI.ALFALFA_Martin2010.F90
+++ b/source/output.analyses.mass_function_HI.ALFALFA_Martin2010.F90
@@ -55,6 +55,7 @@ contains
     Constructor for the ``massFunctionHIALFALFAMartin2010'' output analysis class which takes a parameter set as input.
     !!}
     use :: Cosmology_Parameters            , only : cosmologyParameters         , cosmologyParametersClass
+    use :: Galactic_Structure              , only : galacticStructureClass
     use :: Input_Parameters                , only : inputParameter              , inputParameters
     use :: Output_Analysis_Molecular_Ratios, only : outputAnalysisMolecularRatio, outputAnalysisMolecularRatioClass
     implicit none
@@ -66,6 +67,7 @@ contains
     class           (gravitationalLensingClass                    ), pointer                     :: gravitationalLensing_
     class           (outputAnalysisMolecularRatioClass            ), pointer                     :: outputAnalysisMolecularRatio_
     class           (outputAnalysisDistributionOperatorClass      ), pointer                     :: outputAnalysisDistributionOperatorRandomError_
+    class           (galacticStructureClass                       ), pointer                     :: galacticStructure_
     double precision                                               , allocatable  , dimension(:) :: systematicErrorPolynomialCoefficient
     integer                                                                                      :: covarianceBinomialBinsPerDecade
     double precision                                                                             :: covarianceBinomialMassHaloMinimum             , covarianceBinomialMassHaloMaximum, &
@@ -119,9 +121,10 @@ contains
     <objectBuilder class="gravitationalLensing"               name="gravitationalLensing_"                          source="parameters"/>
     <objectBuilder class="outputAnalysisDistributionOperator" name="outputAnalysisDistributionOperatorRandomError_" source="parameters"/>
     <objectBuilder class="outputAnalysisMolecularRatio"       name="outputAnalysisMolecularRatio_"                  source="parameters"/>
+    <objectBuilder class="galacticStructure"                  name="galacticStructure_"                             source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassFunctionHIALFALFAMartin2010(cosmologyFunctions_,cosmologyParameters_,outputAnalysisDistributionOperatorRandomError_,outputAnalysisMolecularRatio_,gravitationalLensing_,outputTimes_,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisMassFunctionHIALFALFAMartin2010(cosmologyFunctions_,cosmologyParameters_,outputAnalysisDistributionOperatorRandomError_,outputAnalysisMolecularRatio_,gravitationalLensing_,outputTimes_,galacticStructure_,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"                           />
@@ -130,11 +133,12 @@ contains
     <objectDestructor name="gravitationalLensing_"                         />
     <objectDestructor name="outputAnalysisDistributionOperatorRandomError_"/>
     <objectDestructor name="outputAnalysisMolecularRatio_"                 />
+    <objectDestructor name="galacticStructure_"                            />
     !!]
     return
   end function massFunctionHIALFALFAMartin2010ConstructorParameters
 
-  function massFunctionHIALFALFAMartin2010ConstructorInternal(cosmologyFunctions_,cosmologyParameters_,outputAnalysisDistributionOperatorRandomError_,outputAnalysisMolecularRatio_,gravitationalLensing_,outputTimes_,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function massFunctionHIALFALFAMartin2010ConstructorInternal(cosmologyFunctions_,cosmologyParameters_,outputAnalysisDistributionOperatorRandomError_,outputAnalysisMolecularRatio_,gravitationalLensing_,outputTimes_,galacticStructure_,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{
     Constructor for the ``massFunctionHIALFALFAMartin2010'' output analysis class for internal use.
     !!}
@@ -155,6 +159,7 @@ contains
     class           (gravitationalLensingClass                      ), intent(in   ), target       :: gravitationalLensing_
     class           (outputAnalysisMolecularRatioClass              ), intent(in   ), target       :: outputAnalysisMolecularRatio_
     class           (outputAnalysisDistributionOperatorClass        ), intent(in   ), target       :: outputAnalysisDistributionOperatorRandomError_
+    class           (galacticStructureClass                         ), intent(in   ), target       :: galacticStructure_
     double precision                                                 , intent(in   )               :: sizeSourceLensing
     double precision                                                 , intent(in   ), dimension(:) :: systematicErrorPolynomialCoefficient
     integer                                                          , intent(in   )               :: covarianceBinomialBinsPerDecade
@@ -250,6 +255,7 @@ contains
          &                              outputAnalysisDistributionOperator_                                                                    , &
          &                              outputAnalysisMolecularRatio_                                                                          , &
          &                              outputTimes_                                                                                           , &
+         &                              galacticStructure_                                                                                     , &
          &                              covarianceBinomialBinsPerDecade                                                                        , &
          &                              covarianceBinomialMassHaloMinimum                                                                      , &
          &                              covarianceBinomialMassHaloMaximum                                                                        &

--- a/source/output.analyses.mass_function_HI.F90
+++ b/source/output.analyses.mass_function_HI.F90
@@ -57,6 +57,7 @@ contains
     !!}
     use :: Error                           , only : Error_Report
     use :: Input_Parameters                , only : inputParameter              , inputParameters
+    use :: Galactic_Structure              , only : galacticStructureClass
     use :: Output_Analysis_Molecular_Ratios, only : outputAnalysisMolecularRatio, outputAnalysisMolecularRatioClass
     implicit none
     type            (outputAnalysisMassFunctionHI           )                              :: self
@@ -65,6 +66,7 @@ contains
     class           (surveyGeometryClass                    ), pointer                     :: surveyGeometry_
     class           (cosmologyFunctionsClass                ), pointer                     :: cosmologyFunctions_                , cosmologyFunctionsData
     class           (outputTimesClass                       ), pointer                     :: outputTimes_
+    class           (galacticStructureClass                 ), pointer                     :: galacticStructure_
     class           (outputAnalysisDistributionOperatorClass), pointer                     :: outputAnalysisDistributionOperator_
     class           (outputAnalysisPropertyOperatorClass    ), pointer                     :: outputAnalysisPropertyOperator_
     class           (outputAnalysisMolecularRatioClass      ), pointer                     :: outputAnalysisMolecularRatio_
@@ -163,8 +165,9 @@ contains
     <objectBuilder class="outputAnalysisDistributionOperator" name="outputAnalysisDistributionOperator_" source="parameters"            />
     <objectBuilder class="outputAnalysisMolecularRatio"       name="outputAnalysisMolecularRatio_"       source="parameters"            />
     <objectBuilder class="surveyGeometry"                     name="surveyGeometry_"                     source="parameters"            />
+    <objectBuilder class="galacticStructure"                  name="galacticStructure_"                  source="parameters"            />
     <conditionalCall>
-     <call>self=outputAnalysisMassFunctionHI(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisMolecularRatio_,outputTimes_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
+     <call>self=outputAnalysisMassFunctionHI(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisMolecularRatio_,outputTimes_,galacticStructure_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
      <argument name="targetLabel"              value="targetLabel"              parameterPresent="parameters"/>
      <argument name="functionValueTarget"      value="functionValueTarget"      parameterPresent="parameters"/>
      <argument name="functionCovarianceTarget" value="functionCovarianceTarget" parameterPresent="parameters"/>
@@ -178,11 +181,12 @@ contains
     <objectDestructor name="outputAnalysisDistributionOperator_"/>
     <objectDestructor name="outputAnalysisMolecularRatio_"      />
     <objectDestructor name="surveyGeometry_"                    />
+    <objectDestructor name="galacticStructure_"                 />
     !!]
     return
   end function massFunctionHIConstructorParameters
 
-  function massFunctionHIConstructorFile(label,comment,fileName,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisMolecularRatio_,outputTimes_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum) result (self)
+  function massFunctionHIConstructorFile(label,comment,fileName,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisMolecularRatio_,outputTimes_,galacticStructure_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum) result (self)
     !!{
     Constructor for the ``massFunctionHI'' output analysis class which reads bin information from a standard format file.
     !!}
@@ -200,6 +204,7 @@ contains
     class           (outputAnalysisPropertyOperatorClass    ), intent(inout) , target      :: outputAnalysisPropertyOperator_
     class           (outputAnalysisDistributionOperatorClass), intent(in   ) , target      :: outputAnalysisDistributionOperator_
     class           (outputAnalysisMolecularRatioClass      ), intent(in   ) , target      :: outputAnalysisMolecularRatio_
+    class           (galacticStructureClass                 ), intent(in   ) , target       :: galacticStructure_
     double precision                                         , dimension(:  ), allocatable :: masses                             , functionValueTarget
     double precision                                         , dimension(:,:), allocatable :: functionCovarianceTarget
     integer                                                  , intent(in   )               :: covarianceBinomialBinsPerDecade
@@ -222,7 +227,7 @@ contains
     ! Construct the object.
     !![
     <conditionalCall>
-     <call>self=outputAnalysisMassFunctionHI(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisMolecularRatio_,outputTimes_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
+     <call>self=outputAnalysisMassFunctionHI(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisMolecularRatio_,outputTimes_,galacticStructure_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
      <argument name="targetLabel"              value="targetLabel"              condition="haveTarget"/>
      <argument name="functionValueTarget"      value="functionValueTarget"      condition="haveTarget"/>
      <argument name="functionCovarianceTarget" value="functionCovarianceTarget" condition="haveTarget"/>
@@ -231,7 +236,7 @@ contains
     return
   end function massFunctionHIConstructorFile
 
-  function massFunctionHIConstructorInternal(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisMolecularRatio_,outputTimes_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,targetLabel,functionValueTarget,functionCovarianceTarget) result(self)
+  function massFunctionHIConstructorInternal(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisMolecularRatio_,outputTimes_,galacticStructure_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,targetLabel,functionValueTarget,functionCovarianceTarget) result(self)
     !!{
     Constructor for the ``massFunctionHI'' output analysis class which takes a parameter set as input.
     !!}
@@ -263,6 +268,7 @@ contains
     class           (outputAnalysisPropertyOperatorClass            ), intent(inout), target                   :: outputAnalysisPropertyOperator_
     class           (outputAnalysisDistributionOperatorClass        ), intent(in   ), target                   :: outputAnalysisDistributionOperator_
     class           (outputAnalysisMolecularRatioClass              ), intent(in   ), target                   :: outputAnalysisMolecularRatio_
+    class           (galacticStructureClass                         ), intent(in   ), target                   :: galacticStructure_
     integer                                                          , intent(in   )                           :: covarianceBinomialBinsPerDecade
     double precision                                                 , intent(in   )                           :: covarianceBinomialMassHaloMinimum                     , covarianceBinomialMassHaloMaximum
     type            (varying_string                                 ), intent(in   ), optional                 :: targetLabel
@@ -297,7 +303,7 @@ contains
     ! Create a HI mass property extractor.
     allocate(nodePropertyExtractor_)
     !![
-    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorMassISM                   (                                                                 )"/>
+    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorMassISM                   (galacticStructure_                                               )"/>
     !!]
     ! Prepend log10, cosmological luminosity distance, and HI mass property operators.
     allocate(outputAnalysisPropertyOperatorHIMass_           )

--- a/source/output.analyses.mass_function_stellar.Bernardi_SDSS.F90
+++ b/source/output.analyses.mass_function_stellar.Bernardi_SDSS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an output analyis class for the \cite{bernardi_massive_2013} stellar mass function.
+Contains a module which implements an output analysis class for the \cite{bernardi_massive_2013} stellar mass function.
 !!}
 
 
@@ -48,12 +48,14 @@ contains
     !!{
     Constructor for the ``massFunctionStellarBernardi2013SDSS'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisMassFunctionStellarBernardi2013SDSS)                              :: self
     type            (inputParameters                                  ), intent(inout)               :: parameters
     class           (cosmologyFunctionsClass                          ), pointer                     :: cosmologyFunctions_
     class           (outputTimesClass                                 ), pointer                     :: outputTimes_
+    class           (galacticStructureClass                           ), pointer                     :: galacticStructure_
     class           (gravitationalLensingClass                        ), pointer                     :: gravitationalLensing_
     double precision                                                   , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                                          :: covarianceBinomialBinsPerDecade
@@ -132,19 +134,21 @@ contains
     <objectBuilder class="cosmologyFunctions"   name="cosmologyFunctions_"   source="parameters"/>
     <objectBuilder class="outputTimes"          name="outputTimes_"          source="parameters"/>
     <objectBuilder class="gravitationalLensing" name="gravitationalLensing_" source="parameters"/>
+    <objectBuilder class="galacticStructure"    name="galacticStructure_"    source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassFunctionStellarBernardi2013SDSS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisMassFunctionStellarBernardi2013SDSS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"  />
     <objectDestructor name="outputTimes_"         />
     <objectDestructor name="gravitationalLensing_"/>
+    <objectDestructor name="galacticStructure_"   />
     !!]
     return
   end function massFunctionStellarBernardi2013SDSSConstructorParameters
 
-  function massFunctionStellarBernardi2013SDSSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function massFunctionStellarBernardi2013SDSSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{
     Constructor for the ``massFunctionStellarBernardi2013SDSS'' output analysis class for internal use.
     !!}
@@ -161,6 +165,7 @@ contains
     class           (cosmologyFunctionsClass                            ), intent(in   ), target       :: cosmologyFunctions_
     class           (outputTimesClass                                   ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                          ), intent(in   ), target       :: gravitationalLensing_
+    class           (galacticStructureClass                             ), intent(in   ), target       :: galacticStructure_
     double precision                                                     , intent(in   )               :: randomErrorMinimum                                         , randomErrorMaximum                  , &
          &                                                                                                sizeSourceLensing
     double precision                                                     , intent(in   ), dimension(:) :: randomErrorPolynomialCoefficient                           , systematicErrorPolynomialCoefficient
@@ -271,6 +276,7 @@ contains
          &                                   outputAnalysisPropertyOperator_                                                                                   , &
          &                                   outputAnalysisDistributionOperator_                                                                               , &
          &                                   outputTimes_                                                                                                      , &
+         &                                   galacticStructure_                                                                                                , &
          &                                   covarianceBinomialBinsPerDecade                                                                                   , &
          &                                   covarianceBinomialMassHaloMinimum                                                                                 , &
          &                                   covarianceBinomialMassHaloMaximum                                                                                   &

--- a/source/output.analyses.mass_function_stellar.F90
+++ b/source/output.analyses.mass_function_stellar.F90
@@ -55,8 +55,9 @@ contains
     !!{
     Constructor for the ``massFunctionStellar'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Error             , only : Error_Report
+    use :: Galactic_Structure, only : galacticStructureClass
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
     implicit none
     type            (outputAnalysisMassFunctionStellar      )                              :: self
     type            (inputParameters                        ), intent(inout)               :: parameters
@@ -66,6 +67,7 @@ contains
     class           (outputAnalysisDistributionOperatorClass), pointer                     :: outputAnalysisDistributionOperator_
     class           (outputAnalysisPropertyOperatorClass    ), pointer                     :: outputAnalysisPropertyOperator_
     class           (outputTimesClass                       ), pointer                     :: outputTimes_
+    class           (galacticStructureClass                 ), pointer                     :: galacticStructure_
     double precision                                         , dimension(:  ), allocatable :: masses                             , functionValueTarget              , &
          &                                                                                    functionCovarianceTarget1D
     double precision                                         , dimension(:,:), allocatable :: functionCovarianceTarget
@@ -159,9 +161,10 @@ contains
     <objectBuilder class="outputAnalysisPropertyOperator"     name="outputAnalysisPropertyOperator_"     source="parameters"            />
     <objectBuilder class="outputAnalysisDistributionOperator" name="outputAnalysisDistributionOperator_" source="parameters"            />
     <objectBuilder class="surveyGeometry"                     name="surveyGeometry_"                     source="parameters"            />
-    <objectBuilder class="outputTimes"                        name="outputTimes_"                        source="parameters"          />
+    <objectBuilder class="outputTimes"                        name="outputTimes_"                        source="parameters"            />
+    <objectBuilder class="galacticStructure"                  name="galacticStructure_"                  source="parameters"            />
     <conditionalCall>
-     <call>self=outputAnalysisMassFunctionStellar(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
+     <call>self=outputAnalysisMassFunctionStellar(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,galacticStructure_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
      <argument name="targetLabel"              value="targetLabel"              parameterPresent="parameters"/>
      <argument name="functionValueTarget"      value="functionValueTarget"      parameterPresent="parameters"/>
      <argument name="functionCovarianceTarget" value="functionCovarianceTarget" parameterPresent="parameters"/>
@@ -173,12 +176,13 @@ contains
     <objectDestructor name="outputAnalysisPropertyOperator_"    />
     <objectDestructor name="outputAnalysisDistributionOperator_"/>
     <objectDestructor name="surveyGeometry_"                    />
+    <objectDestructor name="galacticStructure_"                 />
     <objectDestructor name="outputTimes_"                       />
     !!]
     return
   end function massFunctionStellarConstructorParameters
 
-  function massFunctionStellarConstructorFile(label,comment,fileName,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum) result (self)
+  function massFunctionStellarConstructorFile(label,comment,fileName,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,galacticStructure_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum) result (self)
     !!{
     Constructor for the ``massFunctionStellar'' output analysis class which reads bin information from a standard format file.
     !!}
@@ -194,6 +198,7 @@ contains
     class           (outputAnalysisPropertyOperatorClass    ), intent(inout) , target      :: outputAnalysisPropertyOperator_
     class           (outputAnalysisDistributionOperatorClass), intent(in   ) , target      :: outputAnalysisDistributionOperator_
     class           (outputTimesClass                       ), intent(inout) , target      :: outputTimes_
+    class           (galacticStructureClass                 ), intent(in   ) , target      :: galacticStructure_
     double precision                                         , dimension(:  ), allocatable :: masses                             , functionValueTarget
     double precision                                         , dimension(:,:), allocatable :: functionCovarianceTarget
     integer                                                  , intent(in   )               :: covarianceBinomialBinsPerDecade
@@ -216,7 +221,7 @@ contains
     ! Construct the object.
     !![
     <conditionalCall>
-     <call>self=outputAnalysisMassFunctionStellar(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
+     <call>self=outputAnalysisMassFunctionStellar(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,galacticStructure_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
      <argument name="targetLabel"              value="targetLabel"              condition="haveTarget"/>
      <argument name="functionValueTarget"      value="functionValueTarget"      condition="haveTarget"/>
      <argument name="functionCovarianceTarget" value="functionCovarianceTarget" condition="haveTarget"/>
@@ -225,7 +230,7 @@ contains
     return
   end function massFunctionStellarConstructorFile
 
-  function massFunctionStellarConstructorInternal(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,targetLabel,functionValueTarget,functionCovarianceTarget) result(self)
+  function massFunctionStellarConstructorInternal(label,comment,masses,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,galacticStructure_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,targetLabel,functionValueTarget,functionCovarianceTarget) result(self)
     !!{
     Constructor for the ``massFunctionStellar'' output analysis class which takes a parameter set as input.
     !!}
@@ -251,6 +256,7 @@ contains
     class           (outputAnalysisPropertyOperatorClass            ), intent(inout), target                   :: outputAnalysisPropertyOperator_
     class           (outputAnalysisDistributionOperatorClass        ), intent(in   ), target                   :: outputAnalysisDistributionOperator_
     class           (outputTimesClass                               ), intent(inout), target                   :: outputTimes_
+    class           (galacticStructureClass                         ), intent(in   ), target                   :: galacticStructure_
     integer                                                          , intent(in   )                           :: covarianceBinomialBinsPerDecade
     double precision                                                 , intent(in   )                           :: covarianceBinomialMassHaloMinimum                     , covarianceBinomialMassHaloMaximum
     type            (varying_string                                 ), intent(in   ), optional                 :: targetLabel
@@ -284,7 +290,7 @@ contains
     ! Create a stellar mass property extractor.
     allocate(nodePropertyExtractor_)
     !![
-    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorMassStellar               (                                                       )"/>
+    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorMassStellar               (galacticStructure_                                     )"/>
     !!]
     ! Prepend log10 and cosmological luminosity distance property operators.
     allocate(outputAnalysisPropertyOperatorLog10_            )

--- a/source/output.analyses.mass_function_stellar.GAMA.F90
+++ b/source/output.analyses.mass_function_stellar.GAMA.F90
@@ -69,7 +69,8 @@ contains
     !!{
     Constructor for the ``massFunctionStellarBaldry2012GAMA'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisMassFunctionStellarBaldry2012GAMA)                              :: self
     type            (inputParameters                                ), intent(inout)               :: parameters
@@ -77,6 +78,7 @@ contains
     class           (outputTimesClass                               ), pointer                     :: outputTimes_
     class           (gravitationalLensingClass                      ), pointer                     :: gravitationalLensing_
     class           (massFunctionIncompletenessClass                ), pointer                     :: massFunctionIncompleteness_
+    class           (galacticStructureClass                         ), pointer                     :: galacticStructure_
     double precision                                                 , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                                        :: covarianceBinomialBinsPerDecade
     double precision                                                                               :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
@@ -155,20 +157,22 @@ contains
     <objectBuilder class="outputTimes"                name="outputTimes_"                source="parameters"/>
     <objectBuilder class="gravitationalLensing"       name="gravitationalLensing_"       source="parameters"/>
     <objectBuilder class="massFunctionIncompleteness" name="massFunctionIncompleteness_" source="parameters"/>
+    <objectBuilder class="galacticStructure"          name="galacticStructure_"          source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassFunctionStellarBaldry2012GAMA(cosmologyFunctions_,gravitationalLensing_,massFunctionIncompleteness_,outputTimes_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisMassFunctionStellarBaldry2012GAMA(cosmologyFunctions_,gravitationalLensing_,massFunctionIncompleteness_,outputTimes_,galacticStructure_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"        />
     <objectDestructor name="outputTimes_"               />
     <objectDestructor name="gravitationalLensing_"      />
     <objectDestructor name="massFunctionIncompleteness_"/>
+    <objectDestructor name="galacticStructure_"         />
     !!]
     return
   end function massFunctionStellarBaldry2012GAMAConstructorParameters
 
-  function massFunctionStellarBaldry2012GAMAConstructorInternal(cosmologyFunctions_,gravitationalLensing_,massFunctionIncompleteness_,outputTimes_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function massFunctionStellarBaldry2012GAMAConstructorInternal(cosmologyFunctions_,gravitationalLensing_,massFunctionIncompleteness_,outputTimes_,galacticStructure_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{
     Constructor for the ``massFunctionStellarBaldry2012GAMA'' output analysis class for internal use.
     !!}
@@ -188,6 +192,7 @@ contains
     class           (outputTimesClass                                    ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                           ), intent(in   ), target       :: gravitationalLensing_
     class           (massFunctionIncompletenessClass                     ), intent(in   ), target       :: massFunctionIncompleteness_
+    class           (galacticStructureClass                              ), intent(in   ), target       :: galacticStructure_
     double precision                                                      , intent(in   )               :: randomErrorMinimum                                          , randomErrorMaximum                  , &
          &                                                                                                sizeSourceLensing
     double precision                                                      , intent(in   ), dimension(:) :: randomErrorPolynomialCoefficient                            , systematicErrorPolynomialCoefficient
@@ -312,6 +317,7 @@ contains
          &                                   outputAnalysisPropertyOperator_                                                                               , &
          &                                   outputAnalysisDistributionOperator_                                                                           , &
          &                                   outputTimes_                                                                                                  , &
+         &                                   galacticStructure_                                                                                            , &
          &                                   covarianceBinomialBinsPerDecade                                                                               , &
          &                                   covarianceBinomialMassHaloMinimum                                                                             , &
          &                                   covarianceBinomialMassHaloMaximum                                                                               &

--- a/source/output.analyses.mass_function_stellar.PRIMUS.F90
+++ b/source/output.analyses.mass_function_stellar.PRIMUS.F90
@@ -70,13 +70,15 @@ contains
     !!{
     Constructor for the ``massFunctionStellarPRIMUS'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisMassFunctionStellarPRIMUS)                              :: self
     type            (inputParameters                        ), intent(inout)               :: parameters
     class           (cosmologyFunctionsClass                ), pointer                     :: cosmologyFunctions_
     class           (outputTimesClass                       ), pointer                     :: outputTimes_
     class           (gravitationalLensingClass              ), pointer                     :: gravitationalLensing_
+    class           (galacticStructureClass                 ), pointer                     :: galacticStructure_
     double precision                                         , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                                :: covarianceBinomialBinsPerDecade  , redshiftInterval
     double precision                                                                       :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
@@ -160,19 +162,21 @@ contains
     <objectBuilder class="cosmologyFunctions"   name="cosmologyFunctions_"   source="parameters"/>
     <objectBuilder class="outputTimes"          name="outputTimes_"          source="parameters"/>
     <objectBuilder class="gravitationalLensing" name="gravitationalLensing_" source="parameters"/>
+    <objectBuilder class="galacticStructure"    name="galacticStructure_"    source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassFunctionStellarPRIMUS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisMassFunctionStellarPRIMUS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"  />
     <objectDestructor name="outputTimes_"         />
     <objectDestructor name="gravitationalLensing_"/>
+    <objectDestructor name="galacticStructure_"   />
     !!]
     return
   end function massFunctionStellarPRIMUSConstructorParameters
 
-  function massFunctionStellarPRIMUSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function massFunctionStellarPRIMUSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{
     Constructor for the ``massFunctionStellarPRIMUS'' output analysis class for internal use.
     !!}
@@ -192,6 +196,7 @@ contains
     class           (cosmologyFunctionsClass                            ), intent(in   ), target       :: cosmologyFunctions_
     class           (outputTimesClass                                   ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                          ), intent(in   ), target       :: gravitationalLensing_
+    class           (galacticStructureClass                             ), intent(in   ), target       :: galacticStructure_
     integer                                                              , intent(in   )               :: redshiftInterval
     double precision                                                     , intent(in   )               :: randomErrorMinimum                                         , randomErrorMaximum                  , &
          &                                                                                                sizeSourceLensing
@@ -328,6 +333,7 @@ contains
          &                                   outputAnalysisPropertyOperator_                                                     , &
          &                                   outputAnalysisDistributionOperator_                                                 , &
          &                                   outputTimes_                                                                        , &
+         &                                   galacticStructure_                                                                  , &
          &                                   covarianceBinomialBinsPerDecade                                                     , &
          &                                   covarianceBinomialMassHaloMinimum                                                   , &
          &                                   covarianceBinomialMassHaloMaximum                                                     &

--- a/source/output.analyses.mass_function_stellar.SDSS.F90
+++ b/source/output.analyses.mass_function_stellar.SDSS.F90
@@ -75,13 +75,15 @@ contains
     !!{
     Constructor for the ``massFunctionStellarSDSS'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisMassFunctionStellarSDSS)                              :: self
     type            (inputParameters                      ), intent(inout)               :: parameters
     class           (cosmologyFunctionsClass              ), pointer                     :: cosmologyFunctions_
     class           (outputTimesClass                     ), pointer                     :: outputTimes_
     class           (gravitationalLensingClass            ), pointer                     :: gravitationalLensing_
+    class           (galacticStructureClass               ), pointer                     :: galacticStructure_
     double precision                                       , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                              :: covarianceBinomialBinsPerDecade
     double precision                                                                     :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
@@ -159,19 +161,21 @@ contains
     <objectBuilder class="cosmologyFunctions"   name="cosmologyFunctions_"   source="parameters"/>
     <objectBuilder class="outputTimes"          name="outputTimes_"          source="parameters"/>
     <objectBuilder class="gravitationalLensing" name="gravitationalLensing_" source="parameters"/>
+    <objectBuilder class="galacticStructure"    name="galacticStructure_"    source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassFunctionStellarSDSS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisMassFunctionStellarSDSS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"  />
     <objectDestructor name="outputTimes_"         />
     <objectDestructor name="gravitationalLensing_"/>
+    <objectDestructor name="galacticStructure_"   />
     !!]
     return
   end function massFunctionStellarSDSSConstructorParameters
 
-  function massFunctionStellarSDSSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function massFunctionStellarSDSSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{
     Constructor for the ``massFunctionStellarSDSS'' output analysis class for internal use.
     !!}
@@ -188,6 +192,7 @@ contains
     class           (cosmologyFunctionsClass                            ), intent(in   ), target       :: cosmologyFunctions_
     class           (outputTimesClass                                   ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                          ), intent(in   ), target       :: gravitationalLensing_
+    class           (galacticStructureClass                             ), intent(in   ) , target      :: galacticStructure_
     double precision                                                     , intent(in   )               :: randomErrorMinimum                                         , randomErrorMaximum                  , &
          &                                                                                                sizeSourceLensing
     double precision                                                     , intent(in   ), dimension(:) :: randomErrorPolynomialCoefficient                           , systematicErrorPolynomialCoefficient
@@ -298,6 +303,7 @@ contains
          &                                   outputAnalysisPropertyOperator_                                                                                   , &
          &                                   outputAnalysisDistributionOperator_                                                                               , &
          &                                   outputTimes_                                                                                                      , &
+         &                                   galacticStructure_                                                                                                , &
          &                                   covarianceBinomialBinsPerDecade                                                                                   , &
          &                                   covarianceBinomialMassHaloMinimum                                                                                 , &
          &                                   covarianceBinomialMassHaloMaximum                                                                                   &

--- a/source/output.analyses.mass_function_stellar.UKIDSS_UDS.F90
+++ b/source/output.analyses.mass_function_stellar.UKIDSS_UDS.F90
@@ -70,13 +70,15 @@ contains
     !!{
     Constructor for the ``massFunctionStellarUKIDSSUDS'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisMassFunctionStellarUKIDSSUDS)                              :: self
     type            (inputParameters                           ), intent(inout)               :: parameters
     class           (cosmologyFunctionsClass                   ), pointer                     :: cosmologyFunctions_
     class           (outputTimesClass                          ), pointer                     :: outputTimes_
     class           (gravitationalLensingClass                 ), pointer                     :: gravitationalLensing_
+    class           (galacticStructureClass                    ), pointer                     :: galacticStructure_
     double precision                                            , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                                   :: covarianceBinomialBinsPerDecade  , redshiftInterval
     double precision                                                                          :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
@@ -160,19 +162,21 @@ contains
     <objectBuilder class="cosmologyFunctions"   name="cosmologyFunctions_"   source="parameters"/>
     <objectBuilder class="outputTimes"          name="outputTimes_"          source="parameters"/>
     <objectBuilder class="gravitationalLensing" name="gravitationalLensing_" source="parameters"/>
+    <objectBuilder class="galacticStructure"    name="galacticStructure_"    source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassFunctionStellarUKIDSSUDS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisMassFunctionStellarUKIDSSUDS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"  />
     <objectDestructor name="outputTimes_"         />
     <objectDestructor name="gravitationalLensing_"/>
+    <objectDestructor name="galacticStructure_"   />
     !!]
     return
   end function massFunctionStellarUKIDSSUDSConstructorParameters
 
-  function massFunctionStellarUKIDSSUDSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function massFunctionStellarUKIDSSUDSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{
     Constructor for the ``massFunctionStellarUKIDSSUDS'' output analysis class for internal use.
     !!}
@@ -192,6 +196,7 @@ contains
     class           (cosmologyFunctionsClass                            ), intent(in   ), target       :: cosmologyFunctions_
     class           (outputTimesClass                                   ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                          ), intent(in   ), target       :: gravitationalLensing_
+    class           (galacticStructureClass                             ), intent(in   ), target       :: galacticStructure_
     integer                                                              , intent(in   )               :: redshiftInterval
     double precision                                                     , intent(in   )               :: randomErrorMinimum                                         , randomErrorMaximum                  , &
          &                                                                                                sizeSourceLensing
@@ -319,6 +324,7 @@ contains
          &                                   outputAnalysisPropertyOperator_                                                     , &
          &                                   outputAnalysisDistributionOperator_                                                 , &
          &                                   outputTimes_                                                                        , &
+         &                                   galacticStructure_                                                                  , &
          &                                   covarianceBinomialBinsPerDecade                                                     , &
          &                                   covarianceBinomialMassHaloMinimum                                                   , &
          &                                   covarianceBinomialMassHaloMaximum                                                     &

--- a/source/output.analyses.mass_function_stellar.ULTRAVISTA.F90
+++ b/source/output.analyses.mass_function_stellar.ULTRAVISTA.F90
@@ -70,13 +70,15 @@ contains
     !!{
     Constructor for the ``massFunctionStellarULTRAVISTA'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisMassFunctionStellarULTRAVISTA)                              :: self
     type            (inputParameters                            ), intent(inout)               :: parameters
     class           (cosmologyFunctionsClass                    ), pointer                     :: cosmologyFunctions_
     class           (outputTimesClass                           ), pointer                     :: outputTimes_
     class           (gravitationalLensingClass                  ), pointer                     :: gravitationalLensing_
+    class           (galacticStructureClass                     ), pointer                     :: galacticStructure_
     double precision                                             , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                                    :: covarianceBinomialBinsPerDecade  , redshiftInterval
     double precision                                                                           :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
@@ -160,19 +162,21 @@ contains
     <objectBuilder class="cosmologyFunctions"   name="cosmologyFunctions_"   source="parameters"/>
     <objectBuilder class="outputTimes"          name="outputTimes_"          source="parameters"/>
     <objectBuilder class="gravitationalLensing" name="gravitationalLensing_" source="parameters"/>
+    <objectBuilder class="galacticStructure"    name="galacticStructure_"    source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassFunctionStellarULTRAVISTA(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisMassFunctionStellarULTRAVISTA(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"  />
     <objectDestructor name="outputTimes_"         />
     <objectDestructor name="gravitationalLensing_"/>
+    <objectDestructor name="galacticStructure_"   />
     !!]
     return
   end function massFunctionStellarULTRAVISTAConstructorParameters
 
-  function massFunctionStellarULTRAVISTAConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function massFunctionStellarULTRAVISTAConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{
     Constructor for the ``massFunctionStellarULTRAVISTA'' output analysis class for internal use.
     !!}
@@ -192,6 +196,7 @@ contains
     class           (cosmologyFunctionsClass                            ), intent(in   ), target       :: cosmologyFunctions_
     class           (outputTimesClass                                   ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                          ), intent(in   ), target       :: gravitationalLensing_
+    class           (galacticStructureClass                             ), intent(in   ) , target      :: galacticStructure_
     integer                                                              , intent(in   )               :: redshiftInterval
     double precision                                                     , intent(in   )               :: randomErrorMinimum                                         , randomErrorMaximum                  , &
          &                                                                                                sizeSourceLensing
@@ -339,6 +344,7 @@ contains
          &                                   outputAnalysisPropertyOperator_                                                     , &
          &                                   outputAnalysisDistributionOperator_                                                 , &
          &                                   outputTimes_                                                                        , &
+         &                                   galacticStructure_                                                                  , &
          &                                   covarianceBinomialBinsPerDecade                                                     , &
          &                                   covarianceBinomialMassHaloMinimum                                                   , &
          &                                   covarianceBinomialMassHaloMaximum                                                     &

--- a/source/output.analyses.mass_function_stellar.VIPERS.F90
+++ b/source/output.analyses.mass_function_stellar.VIPERS.F90
@@ -70,13 +70,15 @@ contains
     !!{
     Constructor for the ``massFunctionStellarVIPERS'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisMassFunctionStellarVIPERS)                              :: self
     type            (inputParameters                        ), intent(inout)               :: parameters
     class           (cosmologyFunctionsClass                ), pointer                     :: cosmologyFunctions_
     class           (outputTimesClass                       ), pointer                     :: outputTimes_
     class           (gravitationalLensingClass              ), pointer                     :: gravitationalLensing_
+    class           (galacticStructureClass                 ), pointer                     :: galacticStructure_
     double precision                                         , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                                :: covarianceBinomialBinsPerDecade  , redshiftInterval
     double precision                                                                       :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
@@ -160,19 +162,21 @@ contains
     <objectBuilder class="cosmologyFunctions"   name="cosmologyFunctions_"   source="parameters"/>
     <objectBuilder class="outputTimes"          name="outputTimes_"          source="parameters"/>
     <objectBuilder class="gravitationalLensing" name="gravitationalLensing_" source="parameters"/>
+    <objectBuilder class="galacticStructure"    name="galacticStructure_"    source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassFunctionStellarVIPERS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisMassFunctionStellarVIPERS(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"  />
     <objectDestructor name="outputTimes_"         />
     <objectDestructor name="gravitationalLensing_"/>
+    <objectDestructor name="galacticStructure_"   />
     !!]
     return
   end function massFunctionStellarVIPERSConstructorParameters
 
-  function massFunctionStellarVIPERSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function massFunctionStellarVIPERSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{
     Constructor for the ``massFunctionStellarVIPERS'' output analysis class for internal use.
     !!}
@@ -192,6 +196,7 @@ contains
     class           (cosmologyFunctionsClass                            ), intent(in   ), target       :: cosmologyFunctions_
     class           (outputTimesClass                                   ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                          ), intent(in   ), target       :: gravitationalLensing_
+    class           (galacticStructureClass                             ), intent(in   ), target       :: galacticStructure_
     integer                                                              , intent(in   )               :: redshiftInterval
     double precision                                                     , intent(in   )               :: randomErrorMinimum                                         , randomErrorMaximum                  , &
          &                                                                                                sizeSourceLensing
@@ -319,6 +324,7 @@ contains
          &                                   outputAnalysisPropertyOperator_                                                     , &
          &                                   outputAnalysisDistributionOperator_                                                 , &
          &                                   outputTimes_                                                                        , &
+         &                                   galacticStructure_                                                                  , &
          &                                   covarianceBinomialBinsPerDecade                                                     , &
          &                                   covarianceBinomialMassHaloMinimum                                                   , &
          &                                   covarianceBinomialMassHaloMaximum                                                     &

--- a/source/output.analyses.mass_function_stellar.ZFOURGE.F90
+++ b/source/output.analyses.mass_function_stellar.ZFOURGE.F90
@@ -71,6 +71,7 @@ contains
     Constructor for the ``massFunctionStellarZFOURGE'' output analysis class which takes a parameter set as input.
     !!}
     use :: Gravitational_Lensing, only : gravitationalLensingClass
+    use :: Galactic_Structure   , only : galacticStructureClass
     use :: Input_Parameters     , only : inputParameter           , inputParameters
     implicit none
     type            (outputAnalysisMassFunctionStellarZFOURGE)                              :: self
@@ -78,6 +79,7 @@ contains
     class           (cosmologyFunctionsClass                 ), pointer                     :: cosmologyFunctions_
     class           (outputTimesClass                        ), pointer                     :: outputTimes_
     class           (gravitationalLensingClass               ), pointer                     :: gravitationalLensing_
+    class           (galacticStructureClass                  ), pointer                     :: galacticStructure_
     double precision                                          , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                                 :: covarianceBinomialBinsPerDecade  , redshiftInterval
     double precision                                                                        :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
@@ -161,19 +163,21 @@ contains
     <objectBuilder class="cosmologyFunctions"   name="cosmologyFunctions_"   source="parameters"/>
     <objectBuilder class="outputTimes"          name="outputTimes_"          source="parameters"/>
     <objectBuilder class="gravitationalLensing" name="gravitationalLensing_" source="parameters"/>
+    <objectBuilder class="galacticStructure"    name="galacticStructure_"    source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassFunctionStellarZFOURGE(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisMassFunctionStellarZFOURGE(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"  />
     <objectDestructor name="outputTimes_"         />
     <objectDestructor name="gravitationalLensing_"/>
+    <objectDestructor name="galacticStructure_"   />
     !!]
     return
   end function massFunctionStellarZFOURGEConstructorParameters
 
-  function massFunctionStellarZFOURGEConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function massFunctionStellarZFOURGEConstructorInternal(cosmologyFunctions_,gravitationalLensing_,outputTimes_,galacticStructure_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{
     Constructor for the ``massFunctionStellarZFOURGE'' output analysis class for internal use.
     !!}
@@ -193,6 +197,7 @@ contains
     class           (cosmologyFunctionsClass                            ), intent(in   ), target       :: cosmologyFunctions_
     class           (outputTimesClass                                   ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                          ), intent(in   ), target       :: gravitationalLensing_
+    class           (galacticStructureClass                             ), intent(in   ), target       :: galacticStructure_
     integer                                                              , intent(in   )               :: redshiftInterval
     double precision                                                     , intent(in   )               :: randomErrorMinimum                                         , randomErrorMaximum                  , &
          &                                                                                                sizeSourceLensing
@@ -335,6 +340,7 @@ contains
          &                                   outputAnalysisPropertyOperator_                                                     , &
          &                                   outputAnalysisDistributionOperator_                                                 , &
          &                                   outputTimes_                                                                        , &
+         &                                   galacticStructure_                                                                  , &
          &                                   covarianceBinomialBinsPerDecade                                                     , &
          &                                   covarianceBinomialMassHaloMinimum                                                   , &
          &                                   covarianceBinomialMassHaloMaximum                                                     &

--- a/source/output.analyses.mass_metallicity_relation.Andrews2013.F90
+++ b/source/output.analyses.mass_metallicity_relation.Andrews2013.F90
@@ -51,6 +51,7 @@ contains
     use :: Input_Parameters              , only : inputParameter                 , inputParameters
     use :: Star_Formation_Rates_Disks    , only : starFormationRateDisksClass
     use :: Star_Formation_Rates_Spheroids, only : starFormationRateSpheroidsClass
+    use :: Galactic_Structure            , only : galacticStructureClass
     implicit none
     type            (outputAnalysisMassMetallicityAndrews2013)                              :: self
     type            (inputParameters                         ), intent(inout)               :: parameters
@@ -60,6 +61,7 @@ contains
     class           (outputTimesClass                        ), pointer                     :: outputTimes_
     class           (starFormationRateDisksClass             ), pointer                     :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass         ), pointer                     :: starFormationRateSpheroids_
+    class           (galacticStructureClass                  ), pointer                     :: galacticStructure_
     double precision                                                                        :: randomErrorMinimum                             , randomErrorMaximum              , &
          &                                                                                     fractionGasThreshold
 
@@ -113,20 +115,22 @@ contains
     <objectBuilder class="outputTimes"                name="outputTimes_"                source="parameters"/>
     <objectBuilder class="starFormationRateDisks"     name="starFormationRateDisks_"     source="parameters"/>
     <objectBuilder class="starFormationRateSpheroids" name="starFormationRateSpheroids_" source="parameters"/>
+    <objectBuilder class="galacticStructure"          name="galacticStructure_"          source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassMetallicityAndrews2013(metallicitySystematicErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,fractionGasThreshold,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_)
+    self=outputAnalysisMassMetallicityAndrews2013(metallicitySystematicErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,fractionGasThreshold,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"        />
     <objectDestructor name="outputTimes_"               />
     <objectDestructor name="starFormationRateDisks_"    />
     <objectDestructor name="starFormationRateSpheroids_"/>
+    <objectDestructor name="galacticStructure_"         />
     !!]
     return
   end function massMetallicityAndrews2013ConstructorParameters
 
-  function massMetallicityAndrews2013ConstructorInternal(metallicitySystematicErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,fractionGasThreshold,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_) result (self)
+  function massMetallicityAndrews2013ConstructorInternal(metallicitySystematicErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,fractionGasThreshold,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_) result (self)
     !!{
     Constructor for the ``massMetallicityAndrews2013'' output analysis class for internal use.
     !!}
@@ -164,6 +168,7 @@ contains
     class           (outputTimesClass                                   ), intent(inout), target         :: outputTimes_
     class           (starFormationRateDisksClass                        ), intent(in   ), target         :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass                    ), intent(in   ), target         :: starFormationRateSpheroids_
+    class           (galacticStructureClass                             ), intent(in   ), target         :: galacticStructure_
     integer                                                              , parameter                     :: covarianceBinomialBinsPerDecade                 =10
     double precision                                                     , parameter                     :: covarianceBinomialMassHaloMinimum               = 1.0d08, covarianceBinomialMassHaloMaximum                      =1.0d16
     double precision                                                     , allocatable  , dimension(:  ) :: masses                                                  , functionValueTarget
@@ -358,7 +363,7 @@ contains
     ! Create a stellar mass property extractor.
     allocate(nodePropertyExtractor_                      )
     !![
-    <referenceConstruct object="nodePropertyExtractor_"                                 constructor="nodePropertyExtractorMassStellar                (                                                             )"/>
+    <referenceConstruct object="nodePropertyExtractor_"                                 constructor="nodePropertyExtractorMassStellar                (galacticStructure_                                           )"/>
     !!]
     ! Find the index for the oxygen abundance.
     indexOxygen=Abundances_Index_From_Name("O")

--- a/source/output.analyses.mass_metallicity_relation.Blanc2019.F90
+++ b/source/output.analyses.mass_metallicity_relation.Blanc2019.F90
@@ -51,6 +51,7 @@ contains
     use :: Input_Parameters              , only : inputParameter                 , inputParameters
     use :: Star_Formation_Rates_Disks    , only : starFormationRateDisksClass
     use :: Star_Formation_Rates_Spheroids, only : starFormationRateSpheroidsClass
+    use :: Galactic_Structure            , only : galacticStructureClass
     implicit none
     type            (outputAnalysisMassMetallicityBlanc2019)                              :: self
     type            (inputParameters                       ), intent(inout)               :: parameters
@@ -60,6 +61,7 @@ contains
     class           (outputTimesClass                      ), pointer                     :: outputTimes_
     class           (starFormationRateDisksClass           ), pointer                     :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass       ), pointer                     :: starFormationRateSpheroids_
+    class           (galacticStructureClass                ), pointer                     :: galacticStructure_
     double precision                                                                      :: randomErrorMinimum                             , randomErrorMaximum              , &
          &                                                                                   fractionGasThreshold
 
@@ -113,20 +115,22 @@ contains
     <objectBuilder class="outputTimes"                name="outputTimes_"                source="parameters"/>
     <objectBuilder class="starFormationRateDisks"     name="starFormationRateDisks_"     source="parameters"/>
     <objectBuilder class="starFormationRateSpheroids" name="starFormationRateSpheroids_" source="parameters"/>
+    <objectBuilder class="galacticStructure"          name="galacticStructure_"          source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMassMetallicityBlanc2019(metallicitySystematicErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,fractionGasThreshold,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_)
+    self=outputAnalysisMassMetallicityBlanc2019(metallicitySystematicErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,fractionGasThreshold,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"        />
     <objectDestructor name="outputTimes_"               />
     <objectDestructor name="starFormationRateDisks_"    />
     <objectDestructor name="starFormationRateSpheroids_"/>
+    <objectDestructor name="galacticStructure_"         />
     !!]
     return
   end function massMetallicityBlanc2019ConstructorParameters
 
-  function massMetallicityBlanc2019ConstructorInternal(metallicitySystematicErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,fractionGasThreshold,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_) result (self)
+  function massMetallicityBlanc2019ConstructorInternal(metallicitySystematicErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,fractionGasThreshold,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_) result (self)
     !!{
     Constructor for the ``massMetallicityBlanc2019'' output analysis class for internal use.
     !!}
@@ -164,6 +168,7 @@ contains
     class           (outputTimesClass                                   ), intent(inout), target         :: outputTimes_
     class           (starFormationRateDisksClass                        ), intent(in   ), target         :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass                    ), intent(in   ), target         :: starFormationRateSpheroids_
+    class           (galacticStructureClass                             ), intent(in   ), target         :: galacticStructure_
     integer                                                              , parameter                     :: covarianceBinomialBinsPerDecade                 =10
     double precision                                                     , parameter                     :: covarianceBinomialMassHaloMinimum               = 1.0d08, covarianceBinomialMassHaloMaximum                      =1.0d16
     double precision                                                     , allocatable  , dimension(:  ) :: masses                                                  , functionValueTarget                                           , &
@@ -363,7 +368,7 @@ contains
     ! Create a stellar mass property extractor.
     allocate(nodePropertyExtractor_                      )
     !![
-    <referenceConstruct object="nodePropertyExtractor_"                                 constructor="nodePropertyExtractorMassStellar                (                                                             )"/>
+    <referenceConstruct object="nodePropertyExtractor_"                                 constructor="nodePropertyExtractorMassStellar                (galacticStructure_                                           )"/>
     !!]
     ! Find the index for the oxygen abundance.
     indexOxygen=Abundances_Index_From_Name("O")

--- a/source/output.analyses.morphological_fraction.GAMA_Moffett2016.F90
+++ b/source/output.analyses.morphological_fraction.GAMA_Moffett2016.F90
@@ -52,13 +52,15 @@ contains
     !!{
     Constructor for the ``morphologicalFractionGAMAMoffett2016'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Cosmology_Functions, only : cosmologyFunctions, cosmologyFunctionsClass
-    use :: Input_Parameters   , only : inputParameter    , inputParameters
+    use :: Cosmology_Functions, only : cosmologyFunctions    , cosmologyFunctionsClass
+    use :: Galactic_Structure , only : galacticStructureClass
+    use :: Input_Parameters   , only : inputParameter        , inputParameters
     implicit none
     type            (outputAnalysisMorphologicalFractionGAMAMoffett2016)                              :: self
     type            (inputParameters                                   ), intent(inout)               :: parameters
     double precision                                                    , allocatable  , dimension(:) :: systematicErrorPolynomialCoefficient, randomErrorPolynomialCoefficient
     class           (cosmologyFunctionsClass                           ), pointer                     :: cosmologyFunctions_
+    class           (galacticStructureClass                            ), pointer                     :: galacticStructure_
     class           (outputTimesClass                                  ), pointer                     :: outputTimes_
     double precision                                                                                  :: ratioEarlyType                      , ratioEarlyTypeError             , &
          &                                                                                               randomErrorMinimum                  , randomErrorMaximum
@@ -110,18 +112,20 @@ contains
     </inputParameter>
     <objectBuilder class="cosmologyFunctions" name="cosmologyFunctions_" source="parameters"/>
     <objectBuilder class="outputTimes"        name="outputTimes_"        source="parameters"/>
+    <objectBuilder class="galacticStructure"  name="galacticStructure_"  source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisMorphologicalFractionGAMAMoffett2016(ratioEarlyType,ratioEarlyTypeError,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,cosmologyFunctions_,outputTimes_)
+    self=outputAnalysisMorphologicalFractionGAMAMoffett2016(ratioEarlyType,ratioEarlyTypeError,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,cosmologyFunctions_,outputTimes_,galacticStructure_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"/>
     <objectDestructor name="outputTimes_"       />
+    <objectDestructor name="galacticStructure_" />
     !!]
     return
   end function morphologicalFractionGAMAMoffett2016ConstructorParameters
 
-  function morphologicalFractionGAMAMoffett2016ConstructorInternal(ratioEarlyType,ratioEarlyTypeError,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,cosmologyFunctions_,outputTimes_) result (self)
+  function morphologicalFractionGAMAMoffett2016ConstructorInternal(ratioEarlyType,ratioEarlyTypeError,systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,cosmologyFunctions_,outputTimes_,galacticStructure_) result (self)
     !!{
     Constructor for the ``morphologicalFractionGAMAMoffett2016'' output analysis class for internal use.
     !!}
@@ -150,6 +154,7 @@ contains
     double precision                                                       , intent(in   ), dimension(:  ) :: systematicErrorPolynomialCoefficient                                   , randomErrorPolynomialCoefficient
     class           (cosmologyFunctionsClass                              ), intent(inout), target         :: cosmologyFunctions_
     class           (outputTimesClass                                     ), intent(inout), target         :: outputTimes_
+    class           (galacticStructureClass                               ), intent(in   ), target         :: galacticStructure_
     integer                                                                , parameter                     :: covarianceBinomialBinsPerDecade                 =10
     double precision                                                       , parameter                     :: covarianceBinomialMassHaloMinimum               = 1.000d08             , covarianceBinomialMassHaloMaximum=1.0d16
     double precision                                                       , allocatable  , dimension(:  ) :: masses                                                                 , functionValueTarget
@@ -343,12 +348,12 @@ contains
     ! Create a stellar mass property extractor.
     allocate(nodePropertyExtractor_                      )
     !![
-    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorMassStellar          (                                                                          )"/>
+    <referenceConstruct object="nodePropertyExtractor_"                           constructor="nodePropertyExtractorMassStellar          (galacticStructure_                                                        )"/>
     !!]
     ! Create a morpology weight property extractor.
     allocate(outputAnalysisWeightPropertyExtractor_                )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"           constructor="nodePropertyExtractorMassStellarMorphology(                                                                          )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"           constructor="nodePropertyExtractorMassStellarMorphology(galacticStructure_                                                        )"/>
     !!]
     ! Build the object.
     self%outputAnalysisMeanFunction1D=outputAnalysisMeanFunction1D(                                                 &

--- a/source/output.analyses.quiescent_fraction.Wagner2016.F90
+++ b/source/output.analyses.quiescent_fraction.Wagner2016.F90
@@ -66,6 +66,7 @@ contains
     use :: Cosmology_Functions     , only : cosmologyFunctions        , cosmologyFunctionsClass
     use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMOClass
     use :: Virial_Density_Contrast , only : virialDensityContrastClass
+    use :: Galactic_Structure      , only : galacticStructureClass
     use :: Input_Parameters        , only : inputParameter            , inputParameters
     implicit none
     type            (outputAnalysisQuiescentFractionWagner2016)                              :: self
@@ -77,6 +78,7 @@ contains
     class           (starFormationRateSpheroidsClass          ), pointer                     :: starFormationRateSpheroids_
     class           (darkMatterProfileDMOClass                ), pointer                     :: darkMatterProfileDMO_
     class           (virialDensityContrastClass               ), pointer                     :: virialDensityContrast_
+    class           (galacticStructureClass                   ), pointer                     :: galacticStructure_
     double precision                                           , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient          , systematicErrorPolynomialCoefficient, &
          &                                                                                      weightSystematicErrorPolynomialCoefficient
     double precision                                                                         :: randomErrorMinimum                        , randomErrorMaximum
@@ -138,8 +140,9 @@ contains
     <objectBuilder class="outputTimes"                name="outputTimes_"                source="parameters"/>
     <objectBuilder class="starFormationRateDisks"     name="starFormationRateDisks_"     source="parameters"/>
     <objectBuilder class="starFormationRateSpheroids" name="starFormationRateSpheroids_" source="parameters"/>
+    <objectBuilder class="galacticStructure"          name="galacticStructure_"          source="parameters"/>
     !!]
-    self=outputAnalysisQuiescentFractionWagner2016(enumerationWagner2016QuiescentRedshiftRangeEncode(char(redshiftRange),includesPrefix=.false.),randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_)
+    self=outputAnalysisQuiescentFractionWagner2016(enumerationWagner2016QuiescentRedshiftRangeEncode(char(redshiftRange),includesPrefix=.false.),randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_)
     !![
     <inputParametersValidate source="parameters" />
     <objectDestructor name="cosmologyParameters_"       />
@@ -149,11 +152,12 @@ contains
     <objectDestructor name="outputTimes_"               />
     <objectDestructor name="starFormationRateDisks_"    />
     <objectDestructor name="starFormationRateSpheroids_"/>
+    <objectDestructor name="galacticStructure_"         />
     !!]
     return
   end function quiescentFractionWagner2016ConstructorParameters
 
-  function quiescentFractionWagner2016ConstructorInternal(redshiftRange,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_) result(self)
+  function quiescentFractionWagner2016ConstructorInternal(redshiftRange,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_) result(self)
     !!{
     Internal constructor for the ``quiescentFractionWagner2016'' output analysis class.
     !!}
@@ -185,6 +189,7 @@ contains
     class           (starFormationRateSpheroidsClass                    ), intent(in   ), target       :: starFormationRateSpheroids_
     class           (virialDensityContrastClass                         ), intent(in   ), target       :: virialDensityContrast_
     class           (darkMatterProfileDMOClass                          ), intent(in   ), target       :: darkMatterProfileDMO_
+    class           (galacticStructureClass                             ), intent(in   ), target       :: galacticStructure_
     type            (galacticFilterHaloNotIsolated                      )               , pointer      :: galacticFilterIsSubhalo_
     type            (galacticFilterHighPass                             )               , pointer      :: galacticFilterHostHaloMass_
     type            (galacticFilterStellarMass                          )               , pointer      :: galacticFilterStellarMass_
@@ -348,7 +353,8 @@ contains
          &                                 outputAnalysisDistributionOperator_          , &
          &                                 outputAnalysisWeightPropertyOperator_        , &
          &                                 starFormationRateDisks_                      , &
-         &                                 starFormationRateSpheroids_                    &
+         &                                 starFormationRateSpheroids_                  , &
+         &                                 galacticStructure_                             &
          &                                )
     !![
     <objectDestructor name="galacticFilterIsSubhalo_"             />

--- a/source/output.analyses.star_forming_main_sequence.F90
+++ b/source/output.analyses.star_forming_main_sequence.F90
@@ -55,9 +55,10 @@ contains
     !!{
     Constructor for the ``starFormingMainSequence'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Input_Parameters, only : inputParameter, inputParameters
-    use :: Numerical_Ranges, only : Make_Range    , rangeTypeLogarithmic
+    use :: Error             , only : Error_Report
+    use :: Input_Parameters  , only : inputParameter        , inputParameters
+    use :: Numerical_Ranges  , only : Make_Range            , rangeTypeLogarithmic
+    use :: Galactic_Structure, only : galacticStructureClass
     implicit none
     type            (outputAnalysisStarFormingMainSequence  )                              :: self
     type            (inputParameters                        ), intent(inout)               :: parameters
@@ -69,6 +70,7 @@ contains
     class           (starFormationRateSpheroidsClass        ), pointer                     :: starFormationRateSpheroids_
     class           (outputAnalysisPropertyOperatorClass    ), pointer                     :: outputAnalysisPropertyOperator_    , outputAnalysisWeightPropertyOperator_
     class           (outputAnalysisDistributionOperatorClass), pointer                     :: outputAnalysisDistributionOperator_
+    class           (galacticStructureClass                 ), pointer                     :: galacticStructure_
     double precision                                         , dimension(:  ), allocatable :: functionValueTarget                , functionCovarianceTarget1D           , &
          &                                                                                    massesStellar
     double precision                                         , dimension(:,:), allocatable :: functionCovarianceTarget
@@ -91,6 +93,7 @@ contains
     <objectBuilder class="outputAnalysisPropertyOperator"     name="outputAnalysisPropertyOperator_"       source="parameters"                                                                 />
     <objectBuilder class="outputAnalysisDistributionOperator" name="outputAnalysisDistributionOperator_"   source="parameters"                                                                 />
     <objectBuilder class="outputAnalysisPropertyOperator"     name="outputAnalysisWeightPropertyOperator_" source="parameters"             parameterName="outputAnalysisWeightPropertyOperator"/>
+    <objectBuilder class="galacticStructure"                  name="galacticStructure_"                    source="parameters"                                                                 />
     !!]
     if (parameters%isPresent('fileName')) then
        !![
@@ -110,7 +113,7 @@ contains
          <description>A label for this analysis.</description>
        </inputParameter>
        !!]
-       self=outputAnalysisStarFormingMainSequence(char(fileName),label,comment,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputTimes_,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisWeightPropertyOperator_,starFormationRateDisks_,starFormationRateSpheroids_)
+       self=outputAnalysisStarFormingMainSequence(char(fileName),label,comment,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputTimes_,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisWeightPropertyOperator_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_)
     else
        !![
        <inputParameter>
@@ -198,7 +201,8 @@ contains
 	  &amp;                                     outputAnalysisDistributionOperator_  , &amp;
 	  &amp;                                     outputAnalysisWeightPropertyOperator_, &amp;
 	  &amp;                                     starFormationRateDisks_              , &amp;
-	  &amp;                                     starFormationRateSpheroids_            &amp;
+	  &amp;                                     starFormationRateSpheroids_          , &amp;
+	  &amp;                                     galacticStructure_                     &amp;
           &amp;                                     {conditions}                           &amp;
           &amp;                                    )
         </call>
@@ -220,11 +224,12 @@ contains
     <objectDestructor name="outputAnalysisPropertyOperator_"      />
     <objectDestructor name="outputAnalysisDistributionOperator_"  />
     <objectDestructor name="outputAnalysisWeightPropertyOperator_"/>
+    <objectDestructor name="galacticStructure_"                   />
     !!]
     return
   end function starFormingMainSequenceConstructorParameters
 
-  function starFormingMainSequenceConstructorFile(fileName,label,comment,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputTimes_,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisWeightPropertyOperator_,starFormationRateDisks_,starFormationRateSpheroids_) result(self)
+  function starFormingMainSequenceConstructorFile(fileName,label,comment,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputTimes_,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisWeightPropertyOperator_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_) result(self)
     !!{
     Constructor for the ``starFormingMainSequence'' output analysis class which reads all required properties from file.
     !!}
@@ -244,6 +249,7 @@ contains
     class           (outputAnalysisPropertyOperatorClass    ), intent(inout), target         :: outputAnalysisPropertyOperator_
     class           (outputAnalysisPropertyOperatorClass    ), intent(inout), target         :: outputAnalysisWeightPropertyOperator_
     class           (outputAnalysisDistributionOperatorClass), intent(inout), target         :: outputAnalysisDistributionOperator_
+    class           (galacticStructureClass                 ), intent(in   ), target         :: galacticStructure_
     double precision                                         , allocatable  , dimension(:  ) :: functionValueTarget                  , massesStellar
     double precision                                         , allocatable  , dimension(:,:) :: functionCovarianceTarget
     double precision                                                                         :: massesStellarBinWidthLogarithmic
@@ -274,14 +280,14 @@ contains
     ! Build the object.
     !![
     <conditionalCall>
-      <call>self=starFormingMainSequenceConstructorInternal(label,comment,massesStellar,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputTimes_,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisWeightPropertyOperator_,starFormationRateDisks_,starFormationRateSpheroids_,targetLabel,functionValueTarget,functionCovarianceTarget{conditions})</call>
+      <call>self=starFormingMainSequenceConstructorInternal(label,comment,massesStellar,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputTimes_,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisWeightPropertyOperator_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_,targetLabel,functionValueTarget,functionCovarianceTarget{conditions})</call>
       <argument name="massesStellarBinWidthLogarithmic" value="massesStellarBinWidthLogarithmic" condition="size(massesStellar) == 1"/>
     </conditionalCall>
     !!]
     return
   end function starFormingMainSequenceConstructorFile
 
-  function starFormingMainSequenceConstructorInternal(label,comment,massesStellar,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputTimes_,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisWeightPropertyOperator_,starFormationRateDisks_,starFormationRateSpheroids_,targetLabel,functionValueTarget,functionCovarianceTarget,massesStellarBinWidthLogarithmic) result(self)
+  function starFormingMainSequenceConstructorInternal(label,comment,massesStellar,galacticFilter_,surveyGeometry_,cosmologyFunctions_,cosmologyFunctionsData,outputTimes_,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputAnalysisWeightPropertyOperator_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_,targetLabel,functionValueTarget,functionCovarianceTarget,massesStellarBinWidthLogarithmic) result(self)
     !!{
     Internal constructor for the ``starFormingMainSequence'' output analysis class.
     !!}
@@ -309,6 +315,7 @@ contains
     class           (outputAnalysisDistributionOperatorClass        ), intent(inout), target                        :: outputAnalysisDistributionOperator_
     class           (starFormationRateDisksClass                    ), intent(in   ), target                        :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass                ), intent(in   ), target                        :: starFormationRateSpheroids_
+    class           (galacticStructureClass                         ), intent(in   ), target                        :: galacticStructure_
     type            (varying_string                                 ), optional                     , intent(in   ) :: targetLabel
     double precision                                                 , optional     , dimension(:  ), intent(in   ) :: functionValueTarget                                         , massesStellar
     double precision                                                 , optional     , dimension(:,:), intent(in   ) :: functionCovarianceTarget
@@ -396,7 +403,7 @@ contains
     !![
     <referenceConstruct object="nodePropertyExtractor_">
       <constructor>
-	nodePropertyExtractorMassStellar()
+	nodePropertyExtractorMassStellar(galacticStructure_)
       </constructor>
     </referenceConstruct>
     !!]

--- a/source/output.analyses.star_forming_main_sequence.Schreiber2015.F90
+++ b/source/output.analyses.star_forming_main_sequence.Schreiber2015.F90
@@ -48,9 +48,10 @@ contains
     !!{
     Constructor for the ``starFormingMainSequenceSchreiber2015'' output analysis class which takes a parameter set as input.
     !!}
-    use :: Cosmology_Parameters, only : cosmologyParameters, cosmologyParametersClass
-    use :: Cosmology_Functions , only : cosmologyFunctions , cosmologyFunctionsClass
-    use :: Input_Parameters    , only : inputParameter     , inputParameters
+    use :: Cosmology_Parameters, only : cosmologyParameters   , cosmologyParametersClass
+    use :: Cosmology_Functions , only : cosmologyFunctions    , cosmologyFunctionsClass
+    use :: Galactic_Structure  , only : galacticStructureClass
+    use :: Input_Parameters    , only : inputParameter        , inputParameters
     implicit none
     type            (outputAnalysisStarFormingMainSequenceSchreiber2015)                              :: self
     type            (inputParameters                                   ), intent(inout)               :: parameters
@@ -59,6 +60,7 @@ contains
     class           (outputTimesClass                                  ), pointer                     :: outputTimes_
     class           (starFormationRateDisksClass                       ), pointer                     :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass                   ), pointer                     :: starFormationRateSpheroids_
+    class           (galacticStructureClass                            ), pointer                     :: galacticStructure_
     double precision                                                    , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient          , systematicErrorPolynomialCoefficient, &
          &                                                                                               weightSystematicErrorPolynomialCoefficient
     double precision                                                                                  :: randomErrorMinimum                        , randomErrorMaximum
@@ -118,8 +120,9 @@ contains
     <objectBuilder class="outputTimes"                name="outputTimes_"                source="parameters"/>
     <objectBuilder class="starFormationRateDisks"     name="starFormationRateDisks_"     source="parameters"/>
     <objectBuilder class="starFormationRateSpheroids" name="starFormationRateSpheroids_" source="parameters"/>
+    <objectBuilder class="galacticStructure"          name="galacticStructure_"          source="parameters"/>
     !!]
-    self=outputAnalysisStarFormingMainSequenceSchreiber2015(redshiftIndex,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_)
+    self=outputAnalysisStarFormingMainSequenceSchreiber2015(redshiftIndex,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_)
     !![
     <inputParametersValidate source="parameters" />
     <objectDestructor name="cosmologyParameters_"       />
@@ -127,11 +130,12 @@ contains
     <objectDestructor name="outputTimes_"               />
     <objectDestructor name="starFormationRateDisks_"    />
     <objectDestructor name="starFormationRateSpheroids_"/>
+    <objectDestructor name="galacticStructure_"         />
     !!]
     return
   end function starFormingMainSequenceSchreiber2015ConstructorParameters
 
-  function starFormingMainSequenceSchreiber2015ConstructorInternal(redshiftIndex,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_) result(self)
+  function starFormingMainSequenceSchreiber2015ConstructorInternal(redshiftIndex,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_) result(self)
     !!{
     Internal constructor for the ``starFormingMainSequenceSchreiber2015'' output analysis class.
     !!}
@@ -157,6 +161,7 @@ contains
     class           (outputTimesClass                                   ), intent(inout), target       :: outputTimes_
     class           (starFormationRateDisksClass                        ), intent(in   ), target       :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass                    ), intent(in   ), target       :: starFormationRateSpheroids_
+    class           (galacticStructureClass                             ), intent(in   ), target       :: galacticStructure_
     type            (galacticFilterStellarMass                          )               , pointer      :: galacticFilterStellarMass_
     type            (galacticFilterStarFormationRate                    )               , pointer      :: galacticFilterStarFormationRate_
     type            (galacticFilterAll                                  )               , pointer      :: galacticFilter_
@@ -311,7 +316,8 @@ contains
          &                                       outputAnalysisDistributionOperator_  , &
          &                                       outputAnalysisWeightPropertyOperator_, &
          &                                       starFormationRateDisks_              , &
-         &                                       starFormationRateSpheroids_            &
+         &                                       starFormationRateSpheroids_          , &
+         &                                       galacticStructure_                     &
          &                                      )
     !![
     <objectDestructor name="galacticFilterStellarMass_"           />

--- a/source/output.analyses.star_forming_main_sequence.Wagner2016.F90
+++ b/source/output.analyses.star_forming_main_sequence.Wagner2016.F90
@@ -74,6 +74,7 @@ contains
     use :: Cosmology_Functions     , only : cosmologyFunctions        , cosmologyFunctionsClass
     use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMOClass
     use :: Virial_Density_Contrast , only : virialDensityContrastClass
+    use :: Galactic_Structure      , only : galacticStructureClass
     use :: Input_Parameters        , only : inputParameter            , inputParameters
     implicit none
     type            (outputAnalysisStarFormingMainSequenceWagner2016)                              :: self
@@ -85,6 +86,7 @@ contains
     class           (outputTimesClass                               ), pointer                     :: outputTimes_
     class           (starFormationRateDisksClass                    ), pointer                     :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass                ), pointer                     :: starFormationRateSpheroids_
+    class           (galacticStructureClass                         ), pointer                     :: galacticStructure_
     double precision                                                 , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient          , systematicErrorPolynomialCoefficient, &
          &                                                                                            weightSystematicErrorPolynomialCoefficient
     double precision                                                                               :: randomErrorMinimum                        , randomErrorMaximum
@@ -151,8 +153,9 @@ contains
     <objectBuilder class="outputTimes"                name="outputTimes_"                source="parameters"/>
     <objectBuilder class="starFormationRateDisks"     name="starFormationRateDisks_"     source="parameters"/>
     <objectBuilder class="starFormationRateSpheroids" name="starFormationRateSpheroids_" source="parameters"/>
+    <objectBuilder class="galacticStructure"          name="galacticStructure_"          source="parameters"/>
     !!]
-    self=outputAnalysisStarFormingMainSequenceWagner2016(enumerationWagner2016SSFRRedshiftRangeEncode(char(redshiftRange),includesPrefix=.false.),enumerationWagner2016SSFRGalaxyTypeEncode(char(galaxyType),includesPrefix=.false.),randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_)
+    self=outputAnalysisStarFormingMainSequenceWagner2016(enumerationWagner2016SSFRRedshiftRangeEncode(char(redshiftRange),includesPrefix=.false.),enumerationWagner2016SSFRGalaxyTypeEncode(char(galaxyType),includesPrefix=.false.),randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_)
     !![
     <inputParametersValidate source="parameters" />
     <objectDestructor name="cosmologyParameters_"       />
@@ -162,11 +165,12 @@ contains
     <objectDestructor name="outputTimes_"               />
     <objectDestructor name="starFormationRateDisks_"    />
     <objectDestructor name="starFormationRateSpheroids_"/>
+    <objectDestructor name="galacticStructure_"         />
     !!]
     return
   end function starFormingMainSequenceWagner2016ConstructorParameters
 
-  function starFormingMainSequenceWagner2016ConstructorInternal(redshiftRange,galaxyType,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_) result(self)
+  function starFormingMainSequenceWagner2016ConstructorInternal(redshiftRange,galaxyType,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,weightSystematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,galacticStructure_) result(self)
     !!{
     Internal constructor for the ``starFormingMainSequenceWagner2016'' output analysis class.
     !!}
@@ -200,6 +204,7 @@ contains
     class           (starFormationRateSpheroidsClass                    ), intent(in   ), target       :: starFormationRateSpheroids_
     class           (virialDensityContrastClass                         ), intent(in   ), target       :: virialDensityContrast_
     class           (darkMatterProfileDMOClass                          ), intent(in   ), target       :: darkMatterProfileDMO_
+    class           (galacticStructureClass                             ), intent(in   ), target       :: galacticStructure_
     type            (galacticFilterHaloNotIsolated                      )               , pointer      :: galacticFilterIsSubhalo_
     type            (galacticFilterHighPass                             )               , pointer      :: galacticFilterHostHaloMass_
     type            (galacticFilterStellarMass                          )               , pointer      :: galacticFilterStellarMass_
@@ -397,7 +402,8 @@ contains
          &                                       outputAnalysisDistributionOperator_  , &
          &                                       outputAnalysisWeightPropertyOperator_, &
          &                                       starFormationRateDisks_              , &
-         &                                       starFormationRateSpheroids_            &
+         &                                       starFormationRateSpheroids_          , &
+         &                                       galacticStructure_                     &
          &                                      )
     !![
     <objectDestructor name="galacticFilterIsSubhalo_"               />

--- a/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
+++ b/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
@@ -61,6 +61,7 @@ contains
     use :: Cosmology_Functions     , only : cosmologyFunctionsClass
     use :: Cosmology_Parameters    , only : cosmologyParametersClass
     use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMOClass
+    use :: Galactic_Structure      , only : galacticStructureClass
     use :: Virial_Density_Contrast , only : virialDensityContrastClass
     use :: Input_Parameters        , only : inputParameters
     implicit none
@@ -70,6 +71,7 @@ contains
     class           (cosmologyParametersClass                            ), pointer                     :: cosmologyParameters_
     class           (cosmologyFunctionsClass                             ), pointer                     :: cosmologyFunctions_
     class           (darkMatterProfileDMOClass                           ), pointer                     :: darkMatterProfileDMO_
+    class           (galacticStructureClass                              ), pointer                     :: galacticStructure_
     class           (virialDensityContrastClass                          ), pointer                     :: virialDensityContrast_
     class           (outputTimesClass                                    ), pointer                     :: outputTimes_
     integer                                                                                             :: redshiftInterval
@@ -113,22 +115,24 @@ contains
     <objectBuilder class="cosmologyFunctions"    name="cosmologyFunctions_"    source="parameters"/>
     <objectBuilder class="darkMatterProfileDMO"  name="darkMatterProfileDMO_"  source="parameters"/>
     <objectBuilder class="virialDensityContrast" name="virialDensityContrast_" source="parameters"/>
+    <objectBuilder class="galacticStructure"     name="galacticStructure_"     source="parameters"/>
     <objectBuilder class="outputTimes"           name="outputTimes_"           source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisStellarVsHaloMassRelationLeauthaud2012(redshiftInterval,likelihoodBin,computeScatter,systematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_)
+    self=outputAnalysisStellarVsHaloMassRelationLeauthaud2012(redshiftInterval,likelihoodBin,computeScatter,systematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,galacticStructure_,outputTimes_)
     !![
     <inputParametersValidate source="parameters" />
     <objectDestructor name="cosmologyParameters_"  />
     <objectDestructor name="cosmologyFunctions_"   />
     <objectDestructor name="darkMatterProfileDMO_" />
     <objectDestructor name="virialDensityContrast_"/>
+    <objectDestructor name="galacticStructure_"    />
     <objectDestructor name="outputTimes_"          />
     !!]
     return
   end function stellarVsHaloMassRelationLeauthaud2012ConstructorParameters
 
-  function stellarVsHaloMassRelationLeauthaud2012ConstructorInternal(redshiftInterval,likelihoodBin,computeScatter,systematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,outputTimes_) result (self)
+  function stellarVsHaloMassRelationLeauthaud2012ConstructorInternal(redshiftInterval,likelihoodBin,computeScatter,systematicErrorPolynomialCoefficient,cosmologyParameters_,cosmologyFunctions_,darkMatterProfileDMO_,virialDensityContrast_,galacticStructure_,outputTimes_) result (self)
     !!{
     Constructor for the ``stellarVsHaloMassRelationLeauthaud2012'' output analysis class for internal use.
     !!}
@@ -165,6 +169,7 @@ contains
     class           (cosmologyFunctionsClass                             ), intent(inout), target         :: cosmologyFunctions_
     class           (virialDensityContrastClass                          ), intent(in   ), target         :: virialDensityContrast_
     class           (darkMatterProfileDMOClass                           ), intent(in   ), target         :: darkMatterProfileDMO_
+    class           (galacticStructureClass                              ), intent(in   ), target         :: galacticStructure_
     class           (outputTimesClass                                    ), intent(inout), target         :: outputTimes_
     integer         (c_size_t                                            ), parameter                     :: massHaloCount                                         =26
     integer                                                               , parameter                     :: covarianceBinomialBinsPerDecade                       =10
@@ -386,7 +391,7 @@ contains
     ! Create a stellar mass weight property extractor.
     allocate(outputAnalysisWeightPropertyExtractor_                )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_" constructor="nodePropertyExtractorMassStellar                      (                                                                                                                      )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_" constructor="nodePropertyExtractorMassStellar                      (                                   galacticStructure_                                                                 )"/>
     !!]
     ! Create a halo mass weight property extractor.
     allocate(virialDensityContrastDefinition_                                )


### PR DESCRIPTION
It's necessary to use a copy constructor when walking the parameter tree so that OpenMP locks associated with parameter objects are correctly handled.