### PR TITLE
Optimization of the `starFormationRateSurfaceDensityDisksBlitz2006` and `starFormationRateSurfaceDensityDisksKrumholz2009` classes

### DIFF
--- a/source/numerical.root_finder.F90
+++ b/source/numerical.root_finder.F90
@@ -378,6 +378,8 @@ contains
     else if (present(rootFunctionDerivative).or.present(rootFunctionBoth)) then
        call Error_Report('missing "rootFunction"'//{introspection:location})
     end if
+    ! If a stopping criterion is provided, set it.
+    if (present(stoppingCriterion)) self%stoppingCriterion=stoppingCriterion
     ! Validate stopping criterion.
     if (self%useDerivative .and. self%stoppingCriterion == stoppingCriterionInterval) &
          & call Error_Report('"interval" stopping criteria is not valid when using a derivative-based method'//{introspection:location})
@@ -387,8 +389,6 @@ contains
     call self%tolerance(toleranceAbsolute,toleranceRelative)
     ! If range expansion is defined, set it.
     call self%rangeExpand(rangeExpandUpward,rangeExpandDownward,rangeExpandType,rangeUpwardLimit,rangeDownwardLimit,rangeExpandDownwardSignExpect,rangeExpandUpwardSignExpect)
-    ! If a stopping criterion is provided, set it.
-    if (present(stoppingCriterion)) self%stoppingCriterion=stoppingCriterion
     return
   end function rootFinderConstructorInternal
   
@@ -480,7 +480,7 @@ contains
           if (.not.self%solverTypeIsValid()) then
              self%solverTypeID    =gsl_root_fdfsolver_steffenson
              self%solverType      =gsl_fdfsolver_type_get  (self%solverTypeID)
-            end if
+          end if
           self%gslFunction        =gslFunctionFdF          (                               &
                &                                            rootFunctionWrapper          , &
                &                                            rootFunctionDerivativeWrapper, &

--- a/source/objects.tables.F90
+++ b/source/objects.tables.F90
@@ -1787,22 +1787,22 @@ contains
     class           (table1D), intent(inout) :: self
     double precision         , intent(in   ) :: x
 
-    if      (x < self%x(+1)) then
+    if      (x < self%xv(1         )) then
        select case (self%extrapolationType(1)%ID)
        case (extrapolationTypeExtrapolate%ID,extrapolationTypeZero%ID)
-          Table1D_Find_Effective_X=x
+          Table1D_Find_Effective_X=     x
        case (extrapolationTypeFix        %ID)
-          Table1D_Find_Effective_X=self%x(+1)
+          Table1D_Find_Effective_X=self%xv(1          )
        case default
           Table1D_Find_Effective_X=0.0d0
           call Error_Report('x is below range'//{introspection:location})
        end select
-    else if (x > self%x(-1)) then
+    else if (x > self%x(self%xCount)) then
        select case (self%extrapolationType(2)%ID)
        case (extrapolationTypeExtrapolate%ID,extrapolationTypeZero%ID)
-          Table1D_Find_Effective_X=x
+          Table1D_Find_Effective_X=     x
        case (extrapolationTypeFix        %ID)
-          Table1D_Find_Effective_X=self%x(-1)
+          Table1D_Find_Effective_X=self%xv(self%xCount)
        case default
           Table1D_Find_Effective_X=0.0d0
           call Error_Report('x is above range'//{introspection:location})
@@ -1820,7 +1820,7 @@ contains
     implicit none
     class           (table1DNonUniformLinearLogarithmic)              , intent(inout)           :: self
     double precision                                    , dimension(:), intent(in   )           :: y
-    integer                                                          , intent(in   ), optional :: table
+    integer                                                           , intent(in   ), optional :: table
 
     call self%table1DGeneric%populate(log(y),table)
     return

--- a/source/star_formation.rate_surface_density.disks.F90
+++ b/source/star_formation.rate_surface_density.disks.F90
@@ -41,11 +41,15 @@ module Star_Formation_Rate_Surface_Density_Disks
     <type>double precision, allocatable, dimension(:,:)</type>
     <pass>yes</pass>
     <selfTarget>yes</selfTarget>
-    <argument>type            (treeNode), intent(inout), target :: node</argument>
-    <argument>double precision          , intent(in   )         :: radiusInner, radiusOuter</argument>
+    <argument>type            (treeNode), intent(inout), target                    :: node                           </argument>
+    <argument>double precision          , intent(in   )                            :: radiusInner       , radiusOuter</argument>
+    <argument>logical                   , intent(inout), allocatable, dimension(:) :: intervalIsAnalytic             </argument>
+    <argument>double precision          , intent(inout), allocatable, dimension(:) :: integralsAnalytic              </argument>
     <code>
      !$GLC attributes unused :: self, node
      allocate(starFormationRateSurfaceDensityDisksIntervals(2,1))
+     allocate(intervalIsAnalytic                           (  1))
+     intervalIsAnalytic                           =.false.
      starFormationRateSurfaceDensityDisksIntervals=reshape([radiusInner,radiusOuter],[2,1])
     </code>
    </method>

--- a/source/tests.root_finding.F90
+++ b/source/tests.root_finding.F90
@@ -26,7 +26,7 @@ program Test_Root_Finding
   Tests that routine finding routines work.
   !!}
   use :: Display                    , only : displayVerbositySet    , verbosityLevelStandard
-  use :: Error           , only : errorStatusDivideByZero
+  use :: Error                      , only : errorStatusDivideByZero
   use :: Root_Finder                , only : rangeExpandAdditive    , rangeExpandMultiplicative, rangeExpandSignExpectPositive, rootFinder                , &
        &                                     stoppingCriterionDelta
   use :: Test_Root_Finding_Functions, only : Root_Function_1        , Root_Function_2          , Root_Function_2_Both         , Root_Function_2_Derivative, &


### PR DESCRIPTION
In the `starFormationRateSurfaceDensityDisksKrumholz2009` the outer radius is limited to where the molecular fraction drops to zero (when using the "fast" molecular fraction calculation).

In the `starFormationRateSurfaceDensityDisksBlitz2006` class provide an analytic integral in fully molecular regions.