### PR TITLE
fix: Use the thread-safe GSL error handler throughout

### DIFF
--- a/source/error.F90
+++ b/source/error.F90
@@ -618,11 +618,11 @@ contains
        !$    write (0,*) " => Error occurred in master thread"
        !$ end if
 #ifndef UNCLEANEXIT
-    !$ if (.not.hdf5Access%ownedByThread()) &
-    !$      & call hdf5Access%set  (     )
-    call           H5Close_F       (error)
-    call           H5Close_C       (     )
-    !$ call        hdf5Access%unset(     )
+       !$ if (.not.hdf5Access%ownedByThread()) &
+       !$      & call hdf5Access%set  (     )
+       call           H5Close_F       (error)
+       call           H5Close_C       (     )
+       !$ call        hdf5Access%unset(     )
 #endif
        call Warn_Review( )
        call BackTrace  ( )

--- a/source/tests.root_finding.F90
+++ b/source/tests.root_finding.F90
@@ -26,7 +26,7 @@ program Test_Root_Finding
   Tests that routine finding routines work.
   !!}
   use :: Display                    , only : displayVerbositySet    , verbosityLevelStandard
-  use :: Error                      , only : errorStatusDivideByZero
+  use :: Error                      , only : errorStatusDivideByZero, Error_Handler_Register
   use :: Root_Finder                , only : rangeExpandAdditive    , rangeExpandMultiplicative, rangeExpandSignExpectPositive, rootFinder                , &
        &                                     stoppingCriterionDelta
   use :: Test_Root_Finding_Functions, only : Root_Function_1        , Root_Function_2          , Root_Function_2_Both         , Root_Function_2_Derivative, &
@@ -38,6 +38,9 @@ program Test_Root_Finding
   double precision                           :: xGuess , xRoot
   double precision            , dimension(2) :: xRange
   integer                                    :: status
+
+  ! Register error handlers.
+  call Error_Handler_Register()
 
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)


### PR DESCRIPTION
A thread-safe wrapper around the GSL library error handler exists in Galacticus. This patch causes it to be used throughout.

Resolves #194