### PR TITLE
fix: Use consistent `darkMatterProfileClass` object for galactic structure calculations

### DIFF
--- a/source/dark_matter_profiles.structure_tasks.F90
+++ b/source/dark_matter_profiles.structure_tasks.F90
@@ -30,7 +30,7 @@ module Dark_Matter_Profile_Structure_Tasks
   public :: Dark_Matter_Profile_Enclosed_Mass_Task               , Dark_Matter_Profile_Density_Task                       , Dark_Matter_Profile_Rotation_Curve_Task        , Dark_Matter_Profile_Potential_Task               , &
        &    Dark_Matter_Profile_Rotation_Curve_Gradient_Task     , Dark_Matter_Profile_Acceleration_Task                  , Dark_Matter_Profile_Tidal_Tensor_Task          , Dark_Matter_Profile_Chandrasekhar_Integral_Task  , &
        &    Dark_Matter_Profile_Structure_Tasks_Thread_Initialize, Dark_Matter_Profile_Structure_Tasks_Thread_Uninitialize, Dark_Matter_Profile_Structure_Tasks_State_Store, Dark_Matter_Profile_Structure_Tasks_State_Restore, &
-       &    Dark_Matter_Profile_Density_Spherical_Average_Task
+       &    Dark_Matter_Profile_Density_Spherical_Average_Task   , Dark_Matter_Profile_Radius_Enclosing_Mass
 
   class(darkMatterProfileClass), pointer  :: darkMatterProfile_
   !$omp threadprivate(darkMatterProfile_)
@@ -393,6 +393,19 @@ contains
     if (present(status).and.statusLocal /= structureErrorCodeSuccess) status=structureErrorCodeSuccess
     return
   end function Dark_Matter_Profile_Potential_Task
+
+  double precision function Dark_Matter_Profile_Radius_Enclosing_Mass(node,mass)
+    !!{
+    Return the radius enclosing the given mass of dark matter.
+    !!}
+    use :: Galacticus_Nodes, only : treeNode
+    implicit none
+    type            (treeNode), intent(inout) :: node
+    double precision          , intent(in   ) :: mass
+
+    Dark_Matter_Profile_Radius_Enclosing_Mass=darkMatterProfile_%radiusEnclosingMass(node,mass)
+    return
+  end function Dark_Matter_Profile_Radius_Enclosing_Mass
 
   !![
   <stateStoreTask>

--- a/source/galactic.structure.standard.F90
+++ b/source/galactic.structure.standard.F90
@@ -411,11 +411,12 @@ contains
     !!{
     Return the radius enclosing a given mass (or fractional mass) in {\normalfont \ttfamily node}.
     !!}
-    use :: Display                   , only : displayMessage       , verbosityLevelWarn
-    use :: Galactic_Structure_Options, only : componentTypeDarkHalo, massTypeDark
-    use :: Error                     , only : Error_Report
-    use :: ISO_Varying_String        , only : assignment(=)        , operator(//)      , varying_string
-    use :: String_Handling           , only : operator(//)
+    use :: Dark_Matter_Profile_Structure_Tasks, only : Dark_Matter_Profile_Radius_Enclosing_Mass
+    use :: Display                            , only : displayMessage                           , verbosityLevelWarn
+    use :: Galactic_Structure_Options         , only : componentTypeDarkHalo                    , massTypeDark
+    use :: Error                              , only : Error_Report
+    use :: ISO_Varying_String                 , only : assignment(=)                            , operator(//)      , varying_string
+    use :: String_Handling                    , only : operator(//)
     implicit none
     class           (galacticStructureStandard   ), intent(inout), target   :: self
     type            (treeNode                    ), intent(inout), target   :: node
@@ -453,7 +454,9 @@ contains
          &   galacticStructureState_(galacticStructureStateCount)%massType_      == massTypeDark          &
          & ) then
        if (.not.associated(self%darkMatterProfile_)) call Error_Report('object is not expecting dark matter requests'//{introspection:location})       
-       standardRadiusEnclosingMass=self%darkMatterProfile_%radiusEnclosingMass(node_,massTarget)
+       ! Use the function provided by the dark matter profile structure tasks module here. This ensures precise consistency
+       ! between calculations here and in the enclosed mass function.
+       standardRadiusEnclosingMass=Dark_Matter_Profile_Radius_Enclosing_Mass(node_,massTarget)
     else
        ! Solve for the radius.
        if (massEnclosedRoot(0.0d0) >= 0.0d0) then


### PR DESCRIPTION
The `galacticStructureStandard` class uses a shortcut when computing the radius enclosing a given mass if the mass requested is dark matter only. Previously this used a different `darkMatterProfileClass` object for this calculation then for corresponding calculations of the mass within a given radius. In some instances this could lead to inconsistent results.

This patch avoids this by using the same `darkMatterProfileClass` object for both calculations.