### PR TITLE
Fix issues in SIDM models

### DIFF
--- a/source/galactic_structure.radius_solver.equilibrium.F90
+++ b/source/galactic_structure.radius_solver.equilibrium.F90
@@ -23,6 +23,7 @@
 
   use :: Dark_Matter_Profiles    , only : darkMatterProfileClass
   use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMOClass
+  use :: Dark_Matter_Halo_Scales , only : darkMatterHaloScaleClass
   use :: Galactic_Structure      , only : galacticStructureClass
 
   !![
@@ -38,6 +39,7 @@
      logical                                              :: includeBaryonGravity                , useFormationHalo         , &
           &                                                  solveForInactiveProperties          , convergenceFailureIsFatal
      double precision                                     :: solutionTolerance
+     class           (darkMatterHaloScaleClass ), pointer :: darkMatterHaloScale_       => null()
      class           (darkMatterProfileClass   ), pointer :: darkMatterProfile_         => null()
      class           (darkMatterProfileDMOClass), pointer :: darkMatterProfileDMO_      => null()
      class           (galacticStructureClass   ), pointer :: galacticStructure_         => null()
@@ -75,6 +77,7 @@ contains
     implicit none
     type            (galacticStructureSolverEquilibrium)                :: self
     type            (inputParameters                   ), intent(inout) :: parameters
+    class           (darkMatterHaloScaleClass          ), pointer       :: darkMatterHaloScale_
     class           (darkMatterProfileClass            ), pointer       :: darkMatterProfile_
     class           (darkMatterProfileDMOClass         ), pointer       :: darkMatterProfileDMO_
     class           (galacticStructureClass            ), pointer       :: galacticStructure_
@@ -113,13 +116,15 @@ contains
       <description>Maximum allowed mean fractional error in the radii of all components when seeking equilibrium solutions for galactic structure.</description>
       <source>parameters</source>
     </inputParameter>
+    <objectBuilder class="darkMatterHaloScale"  name="darkMatterHaloScale_"  source="parameters"/>
     <objectBuilder class="darkMatterProfile"    name="darkMatterProfile_"    source="parameters"/>
     <objectBuilder class="darkMatterProfileDMO" name="darkMatterProfileDMO_" source="parameters"/>
     <objectBuilder class="galacticStructure"    name="galacticStructure_"    source="parameters"/>
     !!]
-    self=galacticStructureSolverEquilibrium(convergenceFailureIsFatal,useFormationHalo,includeBaryonGravity,solutionTolerance,solveForInactiveProperties,darkMatterProfile_,darkMatterProfileDMO_,galacticStructure_)
+    self=galacticStructureSolverEquilibrium(convergenceFailureIsFatal,useFormationHalo,includeBaryonGravity,solutionTolerance,solveForInactiveProperties,darkMatterHaloScale_,darkMatterProfile_,darkMatterProfileDMO_,galacticStructure_)
     !![
     <inputParametersValidate source="parameters"/>
+    <objectDestructor name="darkMatterHaloScale_" />
     <objectDestructor name="darkMatterProfile_"   />
     <objectDestructor name="darkMatterProfileDMO_"/>
     <objectDestructor name="galacticStructure_"   />
@@ -127,7 +132,7 @@ contains
     return
   end function equilibriumConstructorParameters
 
-  function equilibriumConstructorInternal(convergenceFailureIsFatal,useFormationHalo,includeBaryonGravity,solutionTolerance,solveForInactiveProperties,darkMatterProfile_,darkMatterProfileDMO_,galacticStructure_) result(self)
+  function equilibriumConstructorInternal(convergenceFailureIsFatal,useFormationHalo,includeBaryonGravity,solutionTolerance,solveForInactiveProperties,darkMatterHaloScale_,darkMatterProfile_,darkMatterProfileDMO_,galacticStructure_) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily equilibrium} galactic structure solver class.
     !!}
@@ -136,11 +141,12 @@ contains
     logical                                             , intent(in   )         :: useFormationHalo          , includeBaryonGravity     , &
          &                                                                         solveForInactiveProperties, convergenceFailureIsFatal
     double precision                                    , intent(in   )         :: solutionTolerance
+    class           (darkMatterHaloScaleClass          ), intent(in   ), target :: darkMatterHaloScale_
     class           (darkMatterProfileClass            ), intent(in   ), target :: darkMatterProfile_
     class           (darkMatterProfileDMOClass         ), intent(in   ), target :: darkMatterProfileDMO_
     class           (galacticStructureClass            ), intent(in   ), target :: galacticStructure_
     !![
-    <constructorAssign variables="convergenceFailureIsFatal, useFormationHalo, includeBaryonGravity, solutionTolerance, solveForInactiveProperties, *darkMatterProfile_, *darkMatterProfileDMO_, *galacticStructure_"/>
+    <constructorAssign variables="convergenceFailureIsFatal, useFormationHalo, includeBaryonGravity, solutionTolerance, solveForInactiveProperties, *darkMatterHaloScale_, *darkMatterProfile_, *darkMatterProfileDMO_, *galacticStructure_"/>
     !!]
 
     return
@@ -173,6 +179,7 @@ contains
     type(galacticStructureSolverEquilibrium), intent(inout) :: self
 
     !![
+    <objectDestructor name="self%darkMatterHaloScale_" />
     <objectDestructor name="self%darkMatterProfile_"   />
     <objectDestructor name="self%darkMatterProfileDMO_"/>
     <objectDestructor name="self%galacticStructure_"   />
@@ -293,7 +300,7 @@ contains
       Solve for the equilibrium radius of the given component.
       !!}
       use :: Display                         , only : displayVerbosity               , displayVerbositySet, verbosityLevelStandard
-      use :: Galactic_Structure_Options      , only : massTypeBaryonic
+      use :: Galactic_Structure_Options      , only : massTypeBaryonic               , radiusLarge
       use :: Error                           , only : Error_Report
       use :: ISO_Varying_String              , only : varying_string
       use :: Memory_Management               , only : allocateArray                  , deallocateArray
@@ -317,7 +324,8 @@ contains
       !$omp threadprivate(message)
       double precision                                                        :: baryonicVelocitySquared             , darkMatterMassFinal         , &
            &                                                                     darkMatterVelocitySquared           , velocity                    , &
-           &                                                                     radius                              , radiusNew
+           &                                                                     radius                              , radiusNew                   , &
+           &                                                                     specificAngularMomentumMaximum
 
       ! Count the number of active comonents.
       equilibriumActiveComponentCount=equilibriumActiveComponentCount+1
@@ -332,10 +340,18 @@ contains
          radius=radiusGet(node)
          if (radius <= 0.0d0) then
             ! No previous radius was set, so make a simple estimate of sizes of all components ignoring equilibrium contraction and self-gravity.
-            ! Find the radius in the dark matter profile with the required specific angular momentum
-            radius  =self%darkMatterProfileDMO_%radiusFromSpecificAngularMomentum(equilibriumHaloNode,specificAngularMomentum)
+            ! First check that there is a solution within a reasonable radius.
+            specificAngularMomentumMaximum=+self%darkMatterProfileDMO_%circularVelocity(equilibriumHaloNode,radiusLarge) & 
+                 &                         *                                                                radiusLarge
+            if (specificAngularMomentumMaximum < specificAngularMomentum) then
+               ! No solution exists even within a very large radius. Use a simple estimate of the virial radius.
+               radius=self%darkMatterHaloScale_%radiusVirial                      (equilibriumHaloNode                        )
+            else
+               ! Find the radius in the dark matter profile with the required specific angular momentum
+               radius=self%darkMatterProfileDMO_%radiusFromSpecificAngularMomentum(equilibriumHaloNode,specificAngularMomentum)
+            end if
             ! Find the velocity at this radius.
-            velocity=self%darkMatterProfileDMO_%circularVelocity                 (equilibriumHaloNode,radius                 )
+            velocity=self%darkMatterProfileDMO_%circularVelocity                  (equilibriumHaloNode,radius                 )
          else
             ! A previous radius was set, so use it, and the previous circular velocity, as the initial guess.
             velocity=velocityGet(node)

--- a/source/output.analyses.Local_Group.mass_velocity_dispersion_relation.F90
+++ b/source/output.analyses.Local_Group.mass_velocity_dispersion_relation.F90
@@ -212,12 +212,12 @@ contains
          &                                                                                                     massesNonZero
     double precision                                                        , allocatable  , dimension(:,:) :: outputWeight                                                , functionCovarianceTarget                                         , &
          &                                                                                                     functionCovarianceTargetNonZero
-    double precision                                                        , parameter                     :: bufferWidthLogarithmic                          =+3.0d+0    , errorZeroPoint                                       =10.00d0    , &
-         &                                                                                                     velocityDispersionErrorPolynomialZeroPoint      =+1.0d+0    , covarianceLarge                                      = 1.00d0    , &
-         &                                                                                                     velocityDispersionUndefined                     =+1.3d+0
+    double precision                                                        , parameter                     :: bufferWidthLogarithmic                          =+3.0d+0    , errorZeroPoint                                       =10.00d+0   , &
+         &                                                                                                     velocityDispersionErrorPolynomialZeroPoint      =+1.0d+0    , covarianceLarge                                      = 1.00d+0   , &
+         &                                                                                                     velocityDispersionUndefined                     =+1.3d+0    , toleranceRelative                                    = 1.00d-2
     integer         (c_size_t                                              ), parameter                     :: binCount                                        = 7_c_size_t, bufferCountMinimum                                   = 5_c_size_t
-    double precision                                                        , parameter                     :: massMinimum                                     =+1.0d+3    , massMaximum                                          = 1.00d9    , &
-         &                                                                                                     radiusOuter                                     =+3.0d-1    , sizeUncertaintyDefault                               = 0.25d0
+    double precision                                                        , parameter                     :: massMinimum                                     =+1.0d+3    , massMaximum                                          = 1.00d+9   , &
+         &                                                                                                     radiusOuter                                     =+3.0d-1    , sizeUncertaintyDefault                               = 0.25d+0
     logical                                                                 , parameter                     :: likelihoodNormalize                             =.false.
     integer         (c_size_t                                              )                                :: i                                                           , j                                                                , &
          &                                                                                                     bufferCount                                                 , binCountNonZero
@@ -306,25 +306,25 @@ contains
     ! Create a stellar mass property extractor.
     allocate(nodePropertyExtractor_                                )
     !![
-    <referenceConstruct object="nodePropertyExtractor_"                                 constructor="nodePropertyExtractorMassStellar               (galacticStructure_                                                                                               )"/>
+    <referenceConstruct object="nodePropertyExtractor_"                                 constructor="nodePropertyExtractorMassStellar               (galacticStructure_                                                                                                                  )"/>
     !!]
     ! Create a velocity dispersion weight property extractor.
     allocate(outputAnalysisWeightPropertyExtractor_                )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"                 constructor="nodePropertyExtractorVelocityDispersion        ([var_str('stellarMassFraction{0.5}:all:galactic:lineOfSight:1.0')],.false.,darkMatterHaloScale_,galacticStructure_)"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"                 constructor="nodePropertyExtractorVelocityDispersion        ([var_str('stellarMassFraction{0.5}:all:galactic:lineOfSight:1.0')],.false.,toleranceRelative,darkMatterHaloScale_,galacticStructure_                   )"/>
     !!]
     allocate(outputAnalysisWeightPropertyScalarizer_               )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyScalarizer_"                 constructor="nodePropertyExtractorScalarizer               (1,1,outputAnalysisWeightPropertyExtractor_                                                                        )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyScalarizer_"                 constructor="nodePropertyExtractorScalarizer               (1,1,outputAnalysisWeightPropertyExtractor_                                                                                           )"/>
     !!]
     ! Build a size weight property operator.
     allocate(outputAnalysisWeightPropertyOperatorSystmtcPolynomial_)
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyOperatorSystmtcPolynomial_" constructor="outputAnalysisPropertyOperatorSystmtcPolynomial(velocityDispersionErrorPolynomialZeroPoint,velocityDispersionSystematicErrorPolynomialCoefficient                 )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyOperatorSystmtcPolynomial_" constructor="outputAnalysisPropertyOperatorSystmtcPolynomial(velocityDispersionErrorPolynomialZeroPoint,velocityDispersionSystematicErrorPolynomialCoefficient                                    )"/>
     !!]
     allocate(outputAnalysisWeightPropertyOperatorLog10_            )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyOperatorLog10_"             constructor="outputAnalysisPropertyOperatorLog10            (                                                                                                                  )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyOperatorLog10_"             constructor="outputAnalysisPropertyOperatorLog10            (                                                                                                                                     )"/>
     !!]
     allocate(weightPropertyOperators_                              )
     allocate(weightPropertyOperators_%next                         )
@@ -332,16 +332,16 @@ contains
     weightPropertyOperators_%next%operator_ => outputAnalysisWeightPropertyOperatorSystmtcPolynomial_
     allocate(outputAnalysisWeightPropertyOperator_                 )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyOperator_"                  constructor="outputAnalysisPropertyOperatorSequence         (weightPropertyOperators_                                                                                         )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyOperator_"                  constructor="outputAnalysisPropertyOperatorSequence         (weightPropertyOperators_                                                                                                            )"/>
     !!]
     ! Create property operators and unoperators to perform conversion to/from logarithmic mass.
     allocate(outputAnalysisPropertyOperatorLog10_            )
     !![
-    <referenceConstruct object="outputAnalysisPropertyOperatorLog10_"                   constructor="outputAnalysisPropertyOperatorLog10            (                                                                                                                 )"/>
+    <referenceConstruct object="outputAnalysisPropertyOperatorLog10_"                   constructor="outputAnalysisPropertyOperatorLog10            (                                                                                                                                    )"/>
     !!]
     allocate(outputAnalysisPropertyOperatorSystmtcPolynomial_)
     !![
-    <referenceConstruct object="outputAnalysisPropertyOperatorSystmtcPolynomial_"       constructor="outputAnalysisPropertyOperatorSystmtcPolynomial(errorZeroPoint              ,systematicErrorPolynomialCoefficient                                                )"/>
+    <referenceConstruct object="outputAnalysisPropertyOperatorSystmtcPolynomial_"       constructor="outputAnalysisPropertyOperatorSystmtcPolynomial(errorZeroPoint              ,systematicErrorPolynomialCoefficient                                                                   )"/>
     !!]
     allocate(operators_     )
     allocate(operators_%next)
@@ -349,16 +349,16 @@ contains
     operators_%next%operator_ => outputAnalysisPropertyOperatorSystmtcPolynomial_
     allocate(outputAnalysisPropertyOperator_                 )
     !![
-    <referenceConstruct object="outputAnalysisPropertyOperator_"                        constructor="outputAnalysisPropertyOperatorSequence         (operators_                                                                                                       )"/>
+    <referenceConstruct object="outputAnalysisPropertyOperator_"                        constructor="outputAnalysisPropertyOperatorSequence         (operators_                                                                                                                          )"/>
     !!]
     allocate(outputAnalysisPropertyUnoperator_               )
     !![
-    <referenceConstruct object="outputAnalysisPropertyUnoperator_"                      constructor="outputAnalysisPropertyOperatorAntiLog10        (                                                                                                                 )"/>
+    <referenceConstruct object="outputAnalysisPropertyUnoperator_"                      constructor="outputAnalysisPropertyOperatorAntiLog10        (                                                                                                                                    )"/>
     !!]
     ! Create a subsampling weight operator.
     allocate(outputAnalysisWeightOperator_                   )
     !![
-    <referenceConstruct object="outputAnalysisWeightOperator_"                          constructor="outputAnalysisWeightOperatorSubsampling        (                                                                                                                 )"/>
+    <referenceConstruct object="outputAnalysisWeightOperator_"                          constructor="outputAnalysisWeightOperatorSubsampling        (                                                                                                                                    )"/>
     !!]
     ! Build a random error distribution operator.
     allocate(outputAnalysisDistributionOperator_             )


### PR DESCRIPTION
Handle cases where strongly heated halos have no viable solution for the initial guess at galactic structure radii.

Allow control over the tolerance used in velocity dispersion calculations.