### PR TITLE
Correct calculation of Local Group occupation fraction

### DIFF
--- a/source/output.analyses.Local_Group.occupation_fraction.F90
+++ b/source/output.analyses.Local_Group.occupation_fraction.F90
@@ -232,7 +232,7 @@ contains
     ! Create a stellar mass weight property extractor.
     allocate(outputAnalysisWeightPropertyExtractor_                )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"                 constructor="nodePropertyExtractorMassStellar               (galacticStructure_                                                                  )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyExtractor_"                 constructor="nodePropertyExtractorMassStellar               (galacticStructure_                                                                 )"/>
     !!]
     ! Build a size weight property operator.
     allocate(outputAnalysisWeightPropertyOperatorSystmtcPolynomial_)
@@ -241,15 +241,15 @@ contains
     !!]
     allocate(outputAnalysisWeightPropertyOperatorLog10_            )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyOperatorLog10_"             constructor="outputAnalysisPropertyOperatorLog10              (                                                                                   )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyOperatorLog10_"             constructor="outputAnalysisPropertyOperatorLog10              (                                                                                 )"/>
     !!]
     allocate(outputAnalysisWeightPropertyOperatorFilterHighPass_            )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyOperatorFilterHighPass_"    constructor="outputAnalysisPropertyOperatorFilterHighPass    (log10(massStellarThreshold)                                                      )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyOperatorFilterHighPass_"    constructor="outputAnalysisPropertyOperatorFilterHighPass    (log10(massStellarThreshold)                                                       )"/>
     !!]
     allocate(outputAnalysisWeightPropertyOperatorBoolean_            )
     !![
-    <referenceConstruct object="outputAnalysisWeightPropertyOperatorBoolean_"           constructor="outputAnalysisPropertyOperatorBoolean           (                                                                                  )"/>
+    <referenceConstruct object="outputAnalysisWeightPropertyOperatorBoolean_"           constructor="outputAnalysisPropertyOperatorBoolean           (.false.                                                                           )"/>
     !!]
     allocate(weightPropertyOperators_                              )
     allocate(weightPropertyOperators_%next                         )

--- a/source/output.analyses.mean_function_1d.F90
+++ b/source/output.analyses.mean_function_1d.F90
@@ -457,7 +457,7 @@ contains
     ! Build a sequence property operator for the unweight property. This includes any property operator passed to this
     ! constructor, plus the boolean operator.
     !![
-    <referenceConstruct object="propertyOperatorUnweightedBoolean_" constructor="outputAnalysisPropertyOperatorBoolean()"/>
+    <referenceConstruct object="propertyOperatorUnweightedBoolean_" constructor="outputAnalysisPropertyOperatorBoolean(preciseZero=.true.)"/>
     !!]
     propertyOperatorUnweighted_     %operator_ => outputAnalysisWeightPropertyOperator_ ! First operator in the sequence is whatever operator was passed to this constructor.
     propertyOperatorUnweighted_%next%operator_ => propertyOperatorUnweightedBoolean_

--- a/source/radiation.intergalactic_background.file.F90
+++ b/source/radiation.intergalactic_background.file.F90
@@ -111,6 +111,7 @@ contains
     !!{
     Constructor for the {\normalfont \ttfamily intergalacticBackgroundFile} radiation field class which takes a parameter list as input.
     !!}
+    use :: File_Utilities  , only : File_Name_Expand
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
     type (radiationFieldIntergalacticBackgroundFile)                :: self
@@ -126,7 +127,7 @@ contains
     </inputParameter>
     <objectBuilder class="cosmologyFunctions" name="cosmologyFunctions_" source="parameters"/>
     !!]
-    self=radiationFieldIntergalacticBackgroundFile(fileName,cosmologyFunctions_)
+    self=radiationFieldIntergalacticBackgroundFile(File_Name_Expand(char(fileName)),cosmologyFunctions_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"/>


### PR DESCRIPTION
This requires having the `outputAnalysisPropertyOperatorBoolean` class optionally return a small non-zero value instead of precisely zero (for unoccupied subhalos in this case). A precise value causes the result to be ignored by the `outputAnalysisMeanFunction1D` class, which is not what we want.