### PR TITLE
Use threadprivate interpolators for molecular hydrogen cross-sections

### DIFF
--- a/source/chemical.reaction_rates.hydrogen.F90
+++ b/source/chemical.reaction_rates.hydrogen.F90
@@ -1368,26 +1368,23 @@ contains
     integer                                   , parameter     :: energyCount    =100
     type            (table1DLogarithmicLinear), save          :: interpolator_
     logical                                   , save          :: initialized    =.false.
+    !$omp threadprivate(interpolator_,initialized)
     double precision                                          :: energy                         , crossSection
     integer                                                   :: i
 
     if (.not.initialized) then
-       !$omp critical (hydrogenNetworkCrossSection_Hminus_Gamma_to_H_ElectronInit)
-       if (.not.initialized) then
-          call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
-          do i=1,energyCount
-             energy=interpolator_%x(i)
-             ! Evaluate the fitting function for the cross-section.
-             if (energy >=  energyThreshold) then
-                crossSection=2.085d-16*(energy-energyThreshold)**1.5d0/energy**3
-             else
-                crossSection=0.000d+00
-             end if
-             call interpolator_%populate(crossSection,i)
-          end do
-          initialized=.true.
-       end if
-       !$omp end critical (hydrogenNetworkCrossSection_Hminus_Gamma_to_H_ElectronInit)
+       call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
+       do i=1,energyCount
+          energy=interpolator_%x(i)
+          ! Evaluate the fitting function for the cross-section.
+          if (energy >=  energyThreshold) then
+             crossSection=2.085d-16*(energy-energyThreshold)**1.5d0/energy**3
+          else
+             crossSection=0.000d+00
+          end if
+          call interpolator_%populate(crossSection,i)
+       end do
+       initialized=.true.
     end if
     ! Convert from wavelength (in Angstroms) to energy (in eV).
     energy=plancksConstant*speedLight*angstromsPerMeter/electronVolt/wavelength
@@ -1480,36 +1477,33 @@ contains
     integer                              , parameter     :: energyCount    =100
     type            (table1DLinearLinear), save          :: interpolator_
     logical                              , save          :: initialized    =.false.
+    !$omp threadprivate(interpolator_,initialized)
     double precision                                     :: energy                  , crossSection
     integer                                              :: i
 
     if (.not.initialized) then
-       !$omp critical (hydrogenNetworkCrossSection_H2plus_Gamma_to_H_HplusInit)
-       if (.not.initialized) then
-          call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
-          do i=1,energyCount
-             energy=interpolator_%x(i)
-             ! Evaluate the fitting function for the cross-section.
-             if      (energy >=  2.65d0 .and. energy < 11.27d0) then
-                crossSection=10.0d0**(-40.97d0+energy*(+6.030d+0 &
-                     &                        +energy*(-0.504d+0 &
-                     &                        +energy*(+1.387d-2 &
-                     &                                )))        &
-                     &               )
-             else if (energy >= 11.27d0 .and. energy < 21.00d0) then
-                crossSection=10.0d0**(-30.26d0+energy*(+2.790d+0 &
-                     &                        +energy*(-0.184d+0 &
-                     &                        +energy*(+3.535d-3 &
-                     &                                )))        &
-                     &               )
-             else
-                crossSection=0.0d0
-             end if
-             call interpolator_%populate(crossSection,i)
-          end do
-          initialized=.true.
-       end if
-       !$omp end critical (hydrogenNetworkCrossSection_H2plus_Gamma_to_H_HplusInit)
+       call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
+       do i=1,energyCount
+          energy=interpolator_%x(i)
+          ! Evaluate the fitting function for the cross-section.
+          if      (energy >=  2.65d0 .and. energy < 11.27d0) then
+             crossSection=10.0d0**(-40.97d0+energy*(+6.030d+0 &
+                  &                        +energy*(-0.504d+0 &
+                  &                        +energy*(+1.387d-2 &
+                  &                                )))        &
+                  &               )
+          else if (energy >= 11.27d0 .and. energy < 21.00d0) then
+             crossSection=10.0d0**(-30.26d0+energy*(+2.790d+0 &
+                  &                        +energy*(-0.184d+0 &
+                  &                        +energy*(+3.535d-3 &
+                  &                                )))        &
+                  &               )
+          else
+             crossSection=0.0d0
+          end if
+          call interpolator_%populate(crossSection,i)
+       end do
+       initialized=.true.
     end if
     ! Convert from wavelength (in Angstroms) to energy (in eV).
     energy=plancksConstant*speedLight*angstromsPerMeter/electronVolt/wavelength
@@ -1657,30 +1651,27 @@ contains
     integer                                   , parameter     :: energyCount    =100
     type            (table1DLogarithmicLinear), save          :: interpolator_
     logical                                   , save          :: initialized    =.false.
+    !$omp threadprivate(interpolator_,initialized)
     double precision                                          :: energy                 , crossSection
     integer                                                   :: i
 
     if (.not.initialized) then
-       !$omp critical (hydrogenNetworkCrossSection_H2_Gamma_to_H2plus_ElectronInit)
-       if (.not.initialized) then
-          call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
-          do i=1,energyCount
-             energy=interpolator_%x(i)
-             ! Evaluate the fitting function for the cross-section.
-             if      (energy < 15.42d0) then
-                crossSection=0.0d0
-             else if (energy < 16.50d0) then
-                crossSection=6.2d-18*energy-9.40d-17
-             else if (energy < 17.70d0) then
-                crossSection=1.4d-18*energy-1.48d-17
-             else
-                crossSection=2.5d-14/energy**2.71d0
-             end if
-             call interpolator_%populate(crossSection,i)
-          end do
-          initialized=.true.
-       end if
-       !$omp end critical (hydrogenNetworkCrossSection_H2_Gamma_to_H2plus_ElectronInit)
+       call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
+       do i=1,energyCount
+          energy=interpolator_%x(i)
+          ! Evaluate the fitting function for the cross-section.
+          if      (energy < 15.42d0) then
+             crossSection=0.0d0
+          else if (energy < 16.50d0) then
+             crossSection=6.2d-18*energy-9.40d-17
+          else if (energy < 17.70d0) then
+             crossSection=1.4d-18*energy-1.48d-17
+          else
+             crossSection=2.5d-14/energy**2.71d0
+          end if
+          call interpolator_%populate(crossSection,i)
+       end do
+       initialized=.true.
     end if
     ! Convert from wavelength (in Angstroms) to energy (in eV).
     energy=plancksConstant*speedLight*angstromsPerMeter/electronVolt/wavelength
@@ -1771,31 +1762,28 @@ contains
     integer                              , parameter     :: energyCount    =100
     type            (table1DLinearLinear), save          :: interpolator_
     logical                              , save          :: initialized    =.false.
+    !$omp threadprivate(interpolator_,initialized)
     double precision                                     :: energy                 , crossSection
     integer                                              :: i
 
     if (.not.initialized) then
-       !$omp critical (hydrogenNetworkCrossSection_H2plus_Gamma_to_2Hplus_ElectronInit)
-       if (.not.initialized) then
-          call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
-          do i=1,energyCount
-             energy=interpolator_%x(i)
-             ! Evaluate the fitting function for the cross-section.
-             if (energy >= 30.0d0 .and. energy <= 90.0d0) then
-                crossSection=10.0d0**(         -16.926d+0 &
-                     &                +energy*(- 4.528d-2 &
-                     &                +energy*(  2.238d-4 &
-                     &                +energy*(  4.245d-7 &
-                     &                        )))         &
-                     &               )
-             else
-                crossSection=0.0d0
-             end if
-             call interpolator_%populate(crossSection,i)
-          end do
-          initialized=.true.
-       end if
-       !$omp end critical (hydrogenNetworkCrossSection_H2plus_Gamma_to_2Hplus_ElectronInit)
+       call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
+       do i=1,energyCount
+          energy=interpolator_%x(i)
+          ! Evaluate the fitting function for the cross-section.
+          if (energy >= 30.0d0 .and. energy <= 90.0d0) then
+             crossSection=10.0d0**(         -16.926d+0 &
+                  &                +energy*(- 4.528d-2 &
+                  &                +energy*(  2.238d-4 &
+                  &                +energy*(  4.245d-7 &
+                  &                        )))         &
+                  &               )
+          else
+             crossSection=0.0d0
+          end if
+          call interpolator_%populate(crossSection,i)
+       end do
+       initialized=.true.
     end if
     ! Convert from wavelength (in Angstroms) to energy (in eV).
     energy=plancksConstant*speedLight*angstromsPerMeter/electronVolt/wavelength
@@ -1879,55 +1867,52 @@ contains
     integer                              , parameter     :: energyCount           =100
     type            (table1DLinearLinear), save          :: interpolator_
     logical                              , save          :: initialized           =.false.
+    !$omp threadprivate(interpolator_,initialized)
     double precision                                     :: energy                         , crossSection                    , &
          &                                                  crossSectionLymanPara          , crossSectionWernerPara          , &
          &                                                  crossSectionLymanOrtho         , crossSectionWernerOrtho
     integer                                              :: i
 
     if (.not.initialized) then
-       !$omp critical (hydrogenNetworkCrossSection_H2_Gamma_to_2HInit)
-       if (.not.initialized) then
-          call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
-          do i=1,energyCount
-             energy=interpolator_%x(i)
-             ! Evaluate the Lyman and Werner band cross sections for para- and ortho- configurations.
-             if         (energy > 14.675d0 .and. energy <= 16.820d0) then
-                crossSectionLymanPara     =10.0d0**(-18.0d0+15.1289d0-1.0513900000d+0*energy                       )
-             else if    (energy > 16.820d0 .and. energy <= 17.600d0) then
-                crossSectionLymanPara     =10.0d0**(-18.0d0-31.4100d0+1.8042000000d-2*energy**3-4.2339d-5*energy**5)
+       call interpolator_%create(energyMinimum,energyMaximum,energyCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
+       do i=1,energyCount
+          energy=interpolator_%x(i)
+          ! Evaluate the Lyman and Werner band cross sections for para- and ortho- configurations.
+          if         (energy > 14.675d0 .and. energy <= 16.820d0) then
+             crossSectionLymanPara     =10.0d0**(-18.0d0+15.1289d0-1.0513900000d+0*energy                       )
+          else if    (energy > 16.820d0 .and. energy <= 17.600d0) then
+             crossSectionLymanPara     =10.0d0**(-18.0d0-31.4100d0+1.8042000000d-2*energy**3-4.2339d-5*energy**5)
+          else
+             crossSectionLymanPara     = 0.0d0
+          end if
+          if         (energy > 14.675d0 .and. energy <= 17.700d0) then
+             crossSectionWernerPara    =10.0d0**(-18.0d0+13.5311d0-0.9182618000d0*energy                        )
+          else
+             crossSectionWernerPara    = 0.0d0
+          end if
+          if (ratioOrthoToPara > 0.0d0) then
+             if      (energy > 14.159d0 .and. energy <= 15.302d0) then
+                crossSectionLymanOrtho =10.0d0**(-18.0d0+12.0218406d0-0.8194290d0*energy                        )
+             else if (energy > 15.302d0 .and. energy <= 17.200d0) then
+                crossSectionLymanOrtho =10.0d0**(-18.0d0+16.0464400d0-1.0824380d0*energy                        )
              else
-                crossSectionLymanPara     = 0.0d0
+                crossSectionLymanOrtho = 0.0d0
              end if
-             if         (energy > 14.675d0 .and. energy <= 17.700d0) then
-                crossSectionWernerPara    =10.0d0**(-18.0d0+13.5311d0-0.9182618000d0*energy                        )
+             if      (energy > 14.159d0 .and. energy <= 17.200d0) then
+                crossSectionWernerOrtho=10.0d0**(-18.0d0+12.8736700d0-0.85088597d0*energy                       )
              else
-                crossSectionWernerPara    = 0.0d0
+                crossSectionWernerOrtho= 0.0d0
              end if
-             if (ratioOrthoToPara > 0.0d0) then
-                if      (energy > 14.159d0 .and. energy <= 15.302d0) then
-                   crossSectionLymanOrtho =10.0d0**(-18.0d0+12.0218406d0-0.8194290d0*energy                        )
-                else if (energy > 15.302d0 .and. energy <= 17.200d0) then
-                   crossSectionLymanOrtho =10.0d0**(-18.0d0+16.0464400d0-1.0824380d0*energy                        )
-                else
-                   crossSectionLymanOrtho = 0.0d0
-                end if
-                if      (energy > 14.159d0 .and. energy <= 17.200d0) then
-                   crossSectionWernerOrtho=10.0d0**(-18.0d0+12.8736700d0-0.85088597d0*energy                       )
-                else
-                   crossSectionWernerOrtho= 0.0d0
-                end if
-             else
-                crossSectionLymanOrtho =0.0d0
-                crossSectionWernerOrtho=0.0d0
-             end if
-             ! Construct the combined cross-section weighted by the appropriate ortho- to para- ratio.
-             crossSection=+(      1.0d0/(ratioOrthoToPara+1.0d0))*(crossSectionLymanPara +crossSectionWernerPara ) &
-                  &       +(1.0d0-1.0d0/(ratioOrthoToPara+1.0d0))*(crossSectionLymanOrtho+crossSectionWernerOrtho)
-             call interpolator_%populate(crossSection,i)
-          end do
-          initialized=.true.
-       end if
-       !$omp end critical(hydrogenNetworkCrossSection_H2_Gamma_to_2HInit)
+          else
+             crossSectionLymanOrtho =0.0d0
+             crossSectionWernerOrtho=0.0d0
+          end if
+          ! Construct the combined cross-section weighted by the appropriate ortho- to para- ratio.
+          crossSection=+(      1.0d0/(ratioOrthoToPara+1.0d0))*(crossSectionLymanPara +crossSectionWernerPara ) &
+               &       +(1.0d0-1.0d0/(ratioOrthoToPara+1.0d0))*(crossSectionLymanOrtho+crossSectionWernerOrtho)
+          call interpolator_%populate(crossSection,i)
+       end do
+       initialized=.true.
     end if
     ! Convert from wavelength (in Angstroms) to energy (in eV).
     energy=plancksConstant*speedLight*angstromsPerMeter/electronVolt/wavelength
@@ -2014,21 +1999,18 @@ contains
     integer                                   , parameter     :: wavelengthCount =100
     type            (table1DLogarithmicLinear), save          :: interpolator_
     logical                                   , save          :: initialized     =.false.
+    !$omp threadprivate(interpolator_,initialized)
     double precision                                          :: crossSection
     integer                                                   :: i
 
     if (.not.initialized) then
-       !$omp critical (hydrogenNetworkCrossSection_H_Gamma_to_Hplus_ElectronInit)
-       if (.not.initialized) then
-          call interpolator_%create(wavelengthFactor*lymanSeriesLimitWavelengthHydrogen,lymanSeriesLimitWavelengthHydrogen,wavelengthCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
-          do i=1,wavelengthCount
-             ! Use the hydrogen photoionization cross section method.
-             crossSection=hydrogenNetworkSelf%atomicCrossSectionIonizationPhoto_%crossSection(1,1,1,interpolator_%x(i))
-             call interpolator_%populate(crossSection,i)
-          end do
-          initialized=.true.
-       end if
-       !$omp end critical (hydrogenNetworkCrossSection_H_Gamma_to_Hplus_ElectronInit)
+       call interpolator_%create(wavelengthFactor*lymanSeriesLimitWavelengthHydrogen,lymanSeriesLimitWavelengthHydrogen,wavelengthCount,extrapolationType=[extrapolationTypeZero,extrapolationTypeZero])
+       do i=1,wavelengthCount
+          ! Use the hydrogen photoionization cross section method.
+          crossSection=hydrogenNetworkSelf%atomicCrossSectionIonizationPhoto_%crossSection(1,1,1,interpolator_%x(i))
+          call interpolator_%populate(crossSection,i)
+       end do
+       initialized=.true.
     end if
     ! Evaluate the cross-section.
     hydrogenNetworkCrossSection_H_Gamma_to_Hplus_Electron=interpolator_%interpolate(wavelength)


### PR DESCRIPTION
This is necessary as GSL functions are not thread safe.