### PR TITLE
Add a workaround for missing `pthread_mutex_destroy()` function in `GLIBC >= 2.34`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,14 +71,23 @@ FCFLAGS_NOOPT := $(FCFLAGS)
 # Optimization flags.
 FCFLAGS += -O3 -ffinite-math-only -fno-math-errno
 # For OpenMP compilation.
-FCFLAGS += -fopenmp
+FCFLAGS  += -fopenmp
+CFLAGS   += -fopenmp
+CPPFLAGS += -fopenmp
+# Detect static compilation
+STATIC=$(findstring -static,${FCFLAGS})
+ifeq '${STATIC}' '-static'
+FCFLAGS  += -DSTATIC
+CFLAGS   += -DSTATIC
+CPPFLAGS += -DSTATIC
+endif
 
 # C compiler flags:
-CFLAGS += -DBUILDPATH=\'$(BUILDPATH)\' -I./source/ -I$(BUILDPATH)/ -fopenmp ${GALACTICUS_CFLAGS}
+CFLAGS += -DBUILDPATH=\'$(BUILDPATH)\' -I./source/ -I$(BUILDPATH)/ ${GALACTICUS_CFLAGS}
 export CFLAGS
 
 # C++ compiler flags:
-CPPFLAGS += -DBUILDPATH=\'$(BUILDPATH)\' -I./source/ -I$(BUILDPATH)/ -fopenmp ${GALACTICUS_CPPFLAGS}
+CPPFLAGS += -DBUILDPATH=\'$(BUILDPATH)\' -I./source/ -I$(BUILDPATH)/ ${GALACTICUS_CPPFLAGS}
 
 # Detect library compile.
 ifeq '$(GALACTICUS_BUILD_OPTION)' 'lib'

--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -3319,7 +3319,8 @@ CODE
                 my @unusedVariables = ( "self" );
 		foreach my $argument ( @arguments ) {
 		    (my $variables = $argument) =~ s/^.*::\s*(.*?)\s*$/$1/;
-		    $argumentList .= $separator.$variables;
+		    my $isOpenMP = $argument =~ m/^\s*!\$/;
+		    $argumentList .= ($isOpenMP ? " &\n!\$ & " : "").$separator.$variables.($isOpenMP ? " &\n& " : "");
 		    $argumentCode .= "      ".$argument."\n";
 		    $separator     = ",";
 		    my $declaration = &Fortran::Utils::Unformat_Variables($argument);

--- a/source/utility.OpenMP.F90
+++ b/source/utility.OpenMP.F90
@@ -28,6 +28,9 @@ module OpenMP_Utilities
   private
   public :: OpenMP_Critical_Wait_Times
 
+  ! Add a dependency on the OpenMP workarounds code.
+  !: $(BUILDPATH)/utility.OpenMP.workaround.o
+  
 contains
 
   !![

--- a/source/utility.OpenMP.workaround.c
+++ b/source/utility.OpenMP.workaround.c
@@ -1,0 +1,21 @@
+/* From glibc version 2.34 onward libpthread.so no longer exists and is part of the main libc.so.       */
+/* This causes problems for statitically-linked OpenMP codes because (for some reason) the function     */
+/* pthread_mutex_destroy() is not linked so results in a segfault when called. The following workaround */
+/* adds a call to pthread_mutex_destroy() so that is is included in the static executable.              */
+
+#ifdef STATIC
+#ifdef __GNUC__
+#include <gnu/libc-version.h>
+#ifdef __GLIBC__
+#if ( __GLIBC__ == 2 && __GLIBC_MINOR__ >= 34 ) || __GLIBC__ > 2
+#include "pthread.h"
+#define nullptr ((void*)0)
+
+void pthread_workaround() {
+  pthread_mutex_destroy((pthread_mutex_t *) nullptr);
+}
+
+#endif
+#endif
+#endif
+#endif


### PR DESCRIPTION
In `GLIBC >= 2.34` the functionality `libpthread` is absorbed into `libc`. This results in statically-linked Fortran codes not having `pthread_mutex_destroy()` linked into them. This adds a workaround by including a dummy C function that calls `pthread_mutex_destroy()` (but which itself is never called) for force `pthread_mutex_destroy()` to be linked.