### PR TITLE
Correct file locking logic

### DIFF
--- a/source/access.c
+++ b/source/access.c
@@ -20,8 +20,18 @@
 //% Implements Fortran-callable wrappers around the POSIX access() function.
 
 #include <unistd.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <stdio.h>
 
 int access_C(const char *name) {
   //% Fortran-callable wrapper around the POSIX access() function to check file existance.
   return access(name,F_OK);
+}
+
+void syncdir_C(const char *name) {
+  //% Fortran-callable function to sync a directory. This is done by opening and closing the directory. According to the this
+  //% \href{https://stackoverflow.com/a/30630912}{answer} on Stackoverflow this will invalidate the NFS cache for this directory.
+  DIR *fd = opendir (name);
+  int i   = closedir(  fd);
 }

--- a/source/access.c
+++ b/source/access.c
@@ -35,7 +35,7 @@ void syncdir_C(const char *name) {
   //% Fortran-callable function to sync a directory. This is done by opening and closing the directory. According to the this
   //% \href{https://stackoverflow.com/a/30630912}{answer} on Stackoverflow this will invalidate the NFS cache for this directory.
 
-  DIR *fd = opendir (name);
+  DIR *fd = opendir(name);
   if (fd == NULL) {
     // Directory was not opened.
     if (errno != ENOENT) {
@@ -45,6 +45,6 @@ void syncdir_C(const char *name) {
     }
   } else {
     // Directory was opened - now close it.
-    int i   = closedir(  fd);
+    int i   = closedir(fd);
   }
 }

--- a/source/access.c
+++ b/source/access.c
@@ -23,6 +23,8 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
 
 int access_C(const char *name) {
   //% Fortran-callable wrapper around the POSIX access() function to check file existance.
@@ -33,12 +35,16 @@ void syncdir_C(const char *name) {
   //% Fortran-callable function to sync a directory. This is done by opening and closing the directory. According to the this
   //% \href{https://stackoverflow.com/a/30630912}{answer} on Stackoverflow this will invalidate the NFS cache for this directory.
 
-  printf("symcdir_C() #1 '%s'\n",name);
-
   DIR *fd = opendir (name);
-
-  printf("symcdir_C() #2 '%s'\n",name);
-
-  int i   = closedir(  fd);
-  printf("symcdir_C() #3 '%s'\n",name);
+  if (fd == NULL) {
+    // Directory was not opened.
+    if (errno != ENOENT) {
+      // Open failure for some reason other than the directory not existing. In this case report the error.
+      printf("Opening directory '%s' failed\n",name);
+      abort();
+    }
+  } else {
+    // Directory was opened - now close it.
+    int i   = closedir(  fd);
+  }
 }

--- a/source/access.c
+++ b/source/access.c
@@ -32,6 +32,13 @@ int access_C(const char *name) {
 void syncdir_C(const char *name) {
   //% Fortran-callable function to sync a directory. This is done by opening and closing the directory. According to the this
   //% \href{https://stackoverflow.com/a/30630912}{answer} on Stackoverflow this will invalidate the NFS cache for this directory.
+
+  printf("symcdir_C() #1 '%s'\n",name);
+
   DIR *fd = opendir (name);
+
+  printf("symcdir_C() #2 '%s'\n",name);
+
   int i   = closedir(  fd);
+  printf("symcdir_C() #3 '%s'\n",name);
 }

--- a/source/intergalactic_medium.filtering_mass.Gnedin2000.F90
+++ b/source/intergalactic_medium.filtering_mass.Gnedin2000.F90
@@ -269,7 +269,7 @@ contains
        ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
        call File_Lock(char(self%fileName),gnedin2000FileLock,lockIsShared=.true.)
        call self%fileRead()
-       call File_Unlock(gnedin2000FileLock)
+       call File_Unlock(gnedin2000FileLock,sync=.false.)
     end if
     if (self%remakeTable(time)) then
        ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.

--- a/source/star_formation.rate_surface_density.disks.Blitz2006.F90
+++ b/source/star_formation.rate_surface_density.disks.Blitz2006.F90
@@ -820,6 +820,7 @@ contains
       ! Read table if we do not have it.
       haveLock=.false.
       if (.not.self%tableInitialized) then
+         call Directory_Make(char(File_Path(char(self%filenameTable))))
          call File_Lock(char(self%filenameTable),fileLock,lockIsShared=.false.)
          haveLock=.true.
          if (File_Exists(self%filenameTable)) then

--- a/source/star_formation.rate_surface_density.disks.Blitz2006.F90
+++ b/source/star_formation.rate_surface_density.disks.Blitz2006.F90
@@ -814,15 +814,18 @@ contains
       type            (varying_string), save          :: message
       type            (hdf5Object    ), save          :: file
       type            (lockDescriptor), save          :: fileLock
+      logical                                         :: haveLock
       !$omp threadprivate(message,file,fileLock)
       
       ! Read table if we do not have it.
+      haveLock=.false.
       if (.not.self%tableInitialized) then
+         call File_Lock(char(self%filenameTable),fileLock,lockIsShared=.false.)
+         haveLock=.true.
          if (File_Exists(self%filenameTable)) then
             message='Reading Blitz2006 star formation rate tabulation from file: '//self%filenameTable
             call displayMessage(message,verbosityLevelWorking)
             ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
-            call File_Lock(char(self%filenameTable),fileLock,lockIsShared=.false.)
             !$ call hdf5Access%set()
             call file%openFile     (                                                      char(self%filenameTable                                      ),readOnly=.true.)
             call file%readAttribute('coefficientFactorBoostMinimum'                      ,     self%coefficientFactorBoostMinimum                                       )
@@ -840,7 +843,6 @@ contains
             call file%readDataset  ('integral'                                           ,     self%integralPartiallyMolecularTable                                     )
             call file%close        (                                                                                                                                    )
             !$ call hdf5Access%unset()
-            call File_Unlock(fileLock)
             self%tableInitialized=.true.
          end if
       end if
@@ -866,6 +868,11 @@ contains
            &  .or.                                                                             &
            &     radiusScaleFree                   > self%radiusScaleFreeMaximum               &
            & ) then
+         ! Obtain a file lock if we don't already have one.
+         if (.not.haveLock) then
+            call File_Lock(char(self%filenameTable),fileLock,lockIsShared=.false.)
+            haveLock=.true.
+         end if
          ! Find range encompassing the existing table and the new point (with some buffer).
          self%coefficientFactorBoostMinimum       =max(min(self%coefficientFactorBoostMinimum       ,coefficientFactorBoost       /2.0d0),coefficientFactorBoostTiny             )
          self%coefficientFactorBoostMaximum       =    max(self%coefficientFactorBoostMaximum       ,coefficientFactorBoost       *2.0d0 ,coefficientFactorBoostTiny       *2.0d0)
@@ -949,8 +956,6 @@ contains
          message='Writing Blitz2006 star formation rate tabulation to file: '//self%filenameTable
          call displayMessage(message,verbosityLevelWorking)
          call Directory_Make(char(File_Path(char(self%filenameTable))))
-         ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
-         call File_Lock     (char(self%filenameTable),fileLock,lockIsShared=.false.)
          !$ call hdf5Access%set()
          call file%openFile      (char(self%filenameTable                                      )                                                     ,overWrite=.true.,readOnly=.false.)
          call file%writeAttribute(     self%coefficientFactorBoostMinimum                       ,'coefficientFactorBoostMinimum'                                                       )
@@ -968,7 +973,10 @@ contains
          call file%writeDataset  (     self%integralPartiallyMolecularTable                     ,'integral'                                                                            )
          call file%close         (                                                                                                                                                     )
          !$ call hdf5Access%unset()
+      end if
+      if (haveLock) then
          call File_Unlock(fileLock)            
+         haveLock=.false.
       end if
       ! Interpolate in table.
       integralAnalyticPartiallyMolecularGeneric=0.0d0

--- a/source/utility.files.F90
+++ b/source/utility.files.F90
@@ -229,7 +229,7 @@ contains
          & parentName=parentName(1:lengthParent-1)
     parentName       =char(File_Path(parentName))
     ! Sync the parent directory to ensure that any file system caching is updated.
-    call syncdir_C(trim(parentName)//char(0))
+    !  TEMPORARILY REMOVED call syncdir_C(trim(parentName)//char(0))
     ! Test for file existance.
     !![
     <workaround type="gfortran" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;ml&#x2F;fortran&#x2F;2019-12&#x2F;msg00012.html">

--- a/source/utility.files.F90
+++ b/source/utility.files.F90
@@ -229,11 +229,7 @@ contains
          & parentName=parentName(1:lengthParent-1)
     parentName       =char(File_Path(parentName))
     ! Sync the parent directory to ensure that any file system caching is updated.
-    
-
-write (0,'(a,a,a)') "call symcdir_C '",trim(parentName),"'"
-
-call syncdir_C(trim(parentName)//char(0))
+    call syncdir_C(trim(parentName)//char(0))
     ! Test for file existance.
     !![
     <workaround type="gfortran" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;ml&#x2F;fortran&#x2F;2019-12&#x2F;msg00012.html">

--- a/source/utility.files.F90
+++ b/source/utility.files.F90
@@ -229,7 +229,11 @@ contains
          & parentName=parentName(1:lengthParent-1)
     parentName       =char(File_Path(parentName))
     ! Sync the parent directory to ensure that any file system caching is updated.
-    !  TEMPORARILY REMOVED call syncdir_C(trim(parentName)//char(0))
+    
+
+write (0,'(a,a,a)') "call symcdir_C '",trim(parentName),"'"
+
+call syncdir_C(trim(parentName)//char(0))
     ! Test for file existance.
     !![
     <workaround type="gfortran" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;ml&#x2F;fortran&#x2F;2019-12&#x2F;msg00012.html">


### PR DESCRIPTION
When building the Blitz2006 star formation rate integrals table, we now have the correct sequence of file locking to avoid multiple threads attempting to create the table simultaneously.