### PR TITLE
Optimize event hook code

### DIFF
--- a/.github/workflows/testMiscMPI.yml
+++ b/.github/workflows/testMiscMPI.yml
@@ -67,7 +67,6 @@ jobs:
         run: |
           cd $GALACTICUS_EXEC_PATH
           git config --global --add safe.directory $GALACTICUS_EXEC_PATH
-          sed -r -i~ s/"\-O3"/"\-O0"/  Makefile
           make -j2 GALACTICUS_BUILD_OPTION=MPI Galacticus.exe
       - name: Upload executables
         uses: actions/upload-artifact@v2
@@ -180,41 +179,5 @@ jobs:
           chmod u=wrx ./Galacticus.exe_MPI
           export OMP_NUM_THREADS=1
           mpirun --allow-run-as-root -np 4 ./Galacticus.exe_MPI parameters/tutorials/mcmcConfig.xml 2>&1 | tee test.log
-          ! grep -q FAIL test.log
-      - run: echo "This job's status is ${{ job.status }}."
-  Test-MCMC-v:
-    runs-on: ubuntu-latest
-    container: docker://galacticusorg/buildenv:latest
-    needs: Build-Executables
-    steps:
-      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "This job is now running on a ${{ runner.os }} server."
-      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Check out repository datasets
-        uses: actions/checkout@v2      
-        with:
-          repository: galacticusorg/datasets
-          path: datasets
-      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
-      - name: "Set environmental variables"
-        run: |
-          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
-      - name: Download executables
-        uses: actions/download-artifact@v2
-        with:
-          name: galacticus-exec-MPI
-      - name: Create test suite output directory
-        run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
-      - name: Run test
-        run: |
-          cd $GALACTICUS_EXEC_PATH
-          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
-          apt install -y valgrind
-          chmod u=wrx ./Galacticus.exe_MPI
-          export OMP_NUM_THREADS=1
-          mpirun --allow-run-as-root -np 4 valgrind --track-origins=yes ./Galacticus.exe_MPI parameters/tutorials/mcmcConfig.xml 2>&1 | tee test.log
           ! grep -q FAIL test.log
       - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/testMiscMPI.yml
+++ b/.github/workflows/testMiscMPI.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           cd $GALACTICUS_EXEC_PATH
           git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+          sed -r -i~ s/"\-O3"/"\-O0"/  Makefile
           make -j2 GALACTICUS_BUILD_OPTION=MPI Galacticus.exe
       - name: Upload executables
         uses: actions/upload-artifact@v2
@@ -179,5 +180,41 @@ jobs:
           chmod u=wrx ./Galacticus.exe_MPI
           export OMP_NUM_THREADS=1
           mpirun --allow-run-as-root -np 4 ./Galacticus.exe_MPI parameters/tutorials/mcmcConfig.xml 2>&1 | tee test.log
+          ! grep -q FAIL test.log
+      - run: echo "This job's status is ${{ job.status }}."
+  Test-MCMC-v:
+    runs-on: ubuntu-latest
+    container: docker://galacticusorg/buildenv:latest
+    needs: Build-Executables
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server."
+      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Check out repository datasets
+        uses: actions/checkout@v2      
+        with:
+          repository: galacticusorg/datasets
+          path: datasets
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
+      - name: Download executables
+        uses: actions/download-artifact@v2
+        with:
+          name: galacticus-exec-MPI
+      - name: Create test suite output directory
+        run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
+      - name: Run test
+        run: |
+          cd $GALACTICUS_EXEC_PATH
+          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+          apt install -y valgrind
+          chmod u=wrx ./Galacticus.exe_MPI
+          export OMP_NUM_THREADS=1
+          mpirun --allow-run-as-root -np 4 valgrind --track-origins=yes ./Galacticus.exe_MPI parameters/tutorials/mcmcConfig.xml 2>&1 | tee test.log
           ! grep -q FAIL test.log
       - run: echo "This job's status is ${{ job.status }}."

--- a/perl/Galacticus/Build/SourceTree.pm
+++ b/perl/Galacticus/Build/SourceTree.pm
@@ -17,6 +17,7 @@ use Galacticus::Build::SourceTree::Parse::Visibilities;
 use Galacticus::Build::SourceTree::Parse::ModuleUses;
 use Galacticus::Build::SourceTree::Parse::Declarations;
 use Galacticus::Build::SourceTree::Parse::ModuleProcedures;
+use Galacticus::Build::SourceTree::Parse::OpenMP;
 use Galacticus::Build::SourceTree::Process::AddMetaProperty;
 use Galacticus::Build::SourceTree::Process::MetaPropertyDatabase;
 use Galacticus::Build::SourceTree::Process::Enumeration;

--- a/perl/Galacticus/Build/SourceTree/Parse/OpenMP.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/OpenMP.pm
@@ -1,0 +1,204 @@
+# Contains a Perl module which implements parsing of OpenMP directives.
+
+package Galacticus::Build::SourceTree::Parse::OpenMP;
+use strict;
+use warnings;
+use utf8;
+use Cwd;
+use lib $ENV{'GALACTICUS_EXEC_PATH'}."/perl";
+use Data::Dumper;
+use Fortran::Utils;
+use Clone 'clone';
+use Regexp::Common;
+
+# Insert hooks for our functions.
+$Galacticus::Build::SourceTree::Hooks::parseHooks{'OpenMP'} = \&Parse_OpenMP;
+
+sub Parse_OpenMP {
+    # Get the tree.
+    my $tree = shift();
+    # Build a balanced parenthesis matcher.
+    my $balanced = $RE{balanced}{-parens=>'()'};
+    # List of options which attach to iterators.
+    my @iteratorOptions = ( "schedule" );
+    # Walk the tree, looking for code blocks.
+    my $node  = $tree;
+    my $depth = 0;
+    while ( $node ) {
+	# Find code blocks.
+	if ( $node->{'type'} eq "code" ) {
+	    # Read the code block.
+	    my $rawCode;
+	    my $moduleUses;
+	    my $lineNumber       = exists($node->{'line'  }) ? $node->{'line'  } : 0        ;
+	    my $source           = exists($node->{'source'}) ? $node->{'source'} : "unknown";
+	    my @newNodesCombined;
+	    open(my $code,"<",\$node->{'content'});
+	    do {
+		# Get a line.
+		&Fortran::Utils::Get_Fortran_Line($code,my $rawLine, my $processedLine, my $bufferedComments);
+		# Determine if line is an OpenMP parallel directive.
+		if ( $processedLine =~ m/^\s*!\$omp\s+(end\s+)?parallel\s+(do|workshare)?\s?(.*)/ ) {
+		    my $isCloser    = defined($1);
+		    my $composite   =         $2 ;
+		    my $options     =         $3 ;
+		    $options        =~ s/^\s*//;
+		    my @ompOptions;
+		    while ( $options ne "" ) {
+			if ( $options =~ m/^([a-z]+)(.*)/ ) {
+			    my $name      = $1;
+			    my $remainder = $2;
+			    my @contents  = $remainder =~ /$balanced/;
+			    my $content   = scalar(@contents) > 0 ? $contents[0] : "";
+			    $options =~ s/^$name\s*//;
+			    $options =~ s/^\Q$content//;
+			    $options =~ s/^\s*//;
+			    push(
+				@ompOptions,
+				{
+				    name    => $name   ,
+				    content => $content
+				}
+				);
+			}
+		    }
+		    # Generate new code.
+		    my $codeParallel;
+		    my $codeComposite;
+		    if ( defined($composite) ) {
+			$codeParallel  = "!\$omp ".($isCloser ? "end " : "")."parallel";
+			$codeComposite = "!\$omp ".($isCloser ? "end " : "").$composite;
+			foreach my $ompOption ( @ompOptions ) {
+			    my $codeOption = " ".$ompOption->{'name'}.$ompOption->{'content'};
+			    if ( grep {$_ eq $ompOption->{'name'}} @iteratorOptions ) {
+				$codeComposite .= $codeOption;
+			    } else {
+				$codeParallel  .= $codeOption;
+			    }
+			}
+			$codeParallel  .= "\n";
+			$codeComposite .= "\n";
+		    } else {
+			$codeParallel = $rawLine;
+		    }
+		    my @newNodes;
+		    my @ompOptionsParallel;
+		    foreach my $ompOption ( @ompOptions ) {
+			push(@ompOptionsParallel,$ompOption)
+			    unless ( grep {$_ eq $ompOption->{'name'}} @iteratorOptions );
+		    }
+		    my $nodeParallel =
+		    {
+			type     => "openMP"            ,
+			name     => "parallel"          ,
+			isCloser => $isCloser           ,
+			options  => \@ompOptionsParallel
+		    };	
+		    $nodeParallel->{'firstChild'} =
+		    {
+		    	type       => "code"       ,
+		    	content    => $codeParallel,
+		    	parent     => $nodeParallel,
+		    	sibling    => undef()      ,
+		    	firstChild => undef()      ,
+		    	source     => $source      ,
+		    	line       => $lineNumber
+		    };
+		    push(@newNodes,$nodeParallel);
+		    if ( defined($composite) ) {
+			my @ompOptionsComposite;
+			foreach my $ompOption ( @ompOptions ) {
+			    push(@ompOptionsComposite,$ompOption)
+				if ( grep {$_ eq $ompOption->{'name'}} @iteratorOptions );
+			}
+			my $nodeComposite =
+			{
+			    type     => "openMP"             ,
+			    name     => $composite           ,
+			    isCloser => $isCloser            ,
+			    options  => \@ompOptionsComposite
+			};	
+			$nodeComposite->{'firstChild'} =
+			{
+			    type       => "code"         ,
+			    content    => $codeComposite ,
+			    parent     => $nodeComposite ,
+			    sibling    => undef()        ,
+			    firstChild => undef()        ,
+			    source     => $source        ,
+			    line       => $lineNumber
+			};
+			if ( $isCloser ) {
+			    unshift(@newNodes,$nodeComposite);
+			} else {
+			    push   (@newNodes,$nodeComposite);
+			}
+		    }
+		    if ( defined($rawCode) ) {
+			my $rawNode =
+			{
+			    type    => "code",
+			    content => $rawCode
+			};
+			undef($rawCode);
+			unshift(@newNodes,$rawNode);
+		    }
+		    push(@newNodesCombined,@newNodes);
+		} else {
+		    $rawCode .= $rawLine;
+		}
+		$lineNumber += $rawLine =~ tr/\n//;
+	    } until ( eof($code) );
+	    close($code);
+	    if ( defined($rawCode) ) {
+		my $rawNode =
+		{
+		    type    => "code",
+		    content => $rawCode
+		};
+		undef($rawCode);
+		push(@newNodesCombined,$rawNode);
+	    }
+	    &Galacticus::Build::SourceTree::ReplaceNode($node,\@newNodesCombined); 
+	}
+	$node = &Galacticus::Build::SourceTree::Walk_Tree($node,\$depth);
+    }    
+}
+
+sub update {    
+    # Update the contained code.
+    my $node = shift();
+    # Create the new content.
+    $node->{'firstChild'}->{'content'} = "!\$omp ".($node->{'isCloser'} ? "end " : "").$node->{'name'}.join("",map {" ".$_->{'name'}.$_->{'content'}} @{$node->{'options'}})."\n";
+}
+
+sub copyin {
+    # Add copyin directives for named variables.
+    my $node          =   shift() ;
+    my @variableNames = @{shift()};
+    # If no copyin option exists, add one.
+    push(
+	@{$node->{'options'}},
+	{
+	    name    => "copyin",
+	    content => "()"
+	}
+	)
+	unless ( grep {$_->{'name'} eq "copyin"} @{$node->{'options'}} );
+    # Extract a list of current names.
+    my @option = grep {$_->{'name'} eq "copyin"} @{$node->{'options'}};
+    my $content = $option[0]->{'content'};
+    $content =~ s/^\((.*)\)$/$1/;
+    my @names = split(/\s*,\s*/,$content);
+    # Insert new names.
+    foreach my $name ( @variableNames ) {
+	push(@names,$name)
+	    unless ( grep {$_ eq $name} @names );
+    }
+    # Update the option.
+    $option[0]->{'content'} = "(".join(",",@names).")";
+    # Update the code content.
+    &update($node);
+}
+
+1;

--- a/perl/Galacticus/Build/SourceTree/Process/EventHooks.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/EventHooks.pm
@@ -189,6 +189,7 @@ CODE
           select type (hook_ => self%hooks_(i)%hook_)
           type is (hook{$interfaceType})
              if (associated(hook_%object_,object_).and.associated(hook_%function_,function_)) then
+                deallocate(self%hooks_(i)%hook_)
                 if (self%count_ > 1) then
                    call move_alloc(self%hooks_,hooksTmp)
                    allocate(self%hooks_(self%count_-1))
@@ -199,7 +200,6 @@ CODE
                    deallocate(self%hooks_)
                 end if
                 self%count_=self%count_-1
-                deallocate(hook_)
                 return
              end if
           end select

--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -1678,6 +1678,20 @@ CODE
 		# Build the code.
 		$stateStoreCode   .= "type is (".$nonAbstractClass->{'name'}.")\n";
 		$stateRestoreCode .= "type is (".$nonAbstractClass->{'name'}.")\n";
+		if ( exists($nonAbstractClass->{'recursive'}) && $nonAbstractClass->{'recursive'} eq "yes" ) {
+		    # Object allows recursion. If this object is a recursive copy, call the state store/restore functions on the actual copy.
+		    $stateStoreCode   .= "if (self%isRecursive) then\n";
+		    $stateStoreCode   .= " call displayUnindent('recursive copy - moving to actual',verbosity=verbosityLevelWorking)\n";
+		    $stateStoreCode   .= " call self%recursiveSelf%stateStore  (stateFile,gslStateFile,stateOperationID)\n";
+		    $stateStoreCode   .= " return\n";
+		    $stateStoreCode   .= "end if\n";
+		    $stateRestoreCode .= "if (self%isRecursive) then\n";
+		    $stateRestoreCode .= " call displayUnindent('recursive copy - moving to actual',verbosity=verbosityLevelWorking)\n";
+		    $stateRestoreCode .= " call self%recursiveSelf%stateRestore(stateFile,gslStateFile,stateOperationID)\n";
+		    $stateRestoreCode .= " return\n";
+		    $stateRestoreCode .= "end if\n";
+		    print "WTF ".$nonAbstractClass->{'name'}."\n";
+		}
 		$stateStoreCode   .= "if (self%stateOperationID == stateOperationID) then\n"; # If this object was already stored, don't do it again.
 		$stateStoreCode   .= " call displayUnindent('skipping - already stored',verbosity=verbosityLevelWorking)\n";
 		$stateStoreCode   .= " return\n";

--- a/perl/Galacticus/Build/SourceTree/Process/ObjectBuilder.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/ObjectBuilder.pm
@@ -376,7 +376,7 @@ sub Process_ObjectBuilder {
 			$nodeParent = $nodeParent->{'parent'};
 		    }
 		}
-		$debugMessage = "if (debugReporting.and.mpiSelf\%isMaster()) call displayMessage(var_str('functionClass[disown] (class : ownerName : ownerLoc : objectLoc : sourceLoc): [".($node->{'directive'}->{'name'} =~ m/([a-zA-Z0-9]+)_$/ ? $1 : "unknown")."] : ".$ownerName." : ')//".$ownerLoc."//' : '//loc(".$node->{'directive'}->{'name'}.")//' : '//".&Galacticus::Build::SourceTree::Process::SourceIntrospection::Location($node,$node->{'line'},compact => 1).",verbosityLevelSilent)\n";
+		$debugMessage = "if (debugReporting.and.mpiSelf\%isMaster()) call displayMessage(var_str('functionClass[disown] (class : ownerName : ownerLoc : objectLoc : sourceLoc): [".($node->{'directive'}->{'name'} =~ m/([a-zA-Z0-9]+)_+$/ ? $1 : "unknown")."] : ".$ownerName." : ')//".$ownerLoc."//' : '//loc(".$node->{'directive'}->{'name'}.")//' : '//".&Galacticus::Build::SourceTree::Process::SourceIntrospection::Location($node,$node->{'line'},compact => 1).",verbosityLevelSilent)\n";
 	    } else {
 		$debugMessage = "";
 	    }

--- a/scripts/build/useDependencies.pl
+++ b/scripts/build/useDependencies.pl
@@ -275,6 +275,9 @@ foreach my $sourceFile ( @sourceFilesToProcess ) {
 		    push(@{$usesPerFile->{$fileIdentifier}->{'modulesUsed'}},$workDirectoryName.lc($usedModule).".mod")
 			unless ( grep {$_ eq lc($usedModule)} @externalModules );
 		}
+		# Find any OpenMP parallel directives - these require a dependence on the event hooks module.
+		push(@{$usesPerFile->{$fileIdentifier}->{'modulesUsed'}},$workDirectoryName."events_filters.mod")
+		    if ( $line =~ m/^\s*\!\$omp\s+parallel/i );
 		# Find any OpenMP critical directives - these require a dependence on the OpenMP utilities data module.
 		push(@{$usesPerFile->{$fileIdentifier}->{'modulesUsed'}},$workDirectoryName."openmp_utilities_data.mod")
 		    if ( $line =~ m/^\s*\!\$omp\s+critical\s*\([a-z0-9_]+\)/i );

--- a/source/Galacticus.F90
+++ b/source/Galacticus.F90
@@ -92,6 +92,7 @@ program Galacticus
   !!]
   if (task_%requiresOutputFile()) call Output_HDF5_Open_File (parameters)
   call task_     %perform()
+  call parameters%reset  ()
   call parameters%destroy()
   if (task_%requiresOutputFile()) call Output_HDF5_Close_File(          )
   !![

--- a/source/accretion.halo.Naoz_Barkana_2007.F90
+++ b/source/accretion.halo.Naoz_Barkana_2007.F90
@@ -186,7 +186,7 @@ contains
     implicit none
     class(accretionHaloNaozBarkana2007), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,naozBarkana2007CalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,naozBarkana2007CalculationReset,openMPThreadBindingAllLevels,label='accretionHaloNaozBarkana2007')
     return
   end subroutine naozBarkana2007AutoHook
 

--- a/source/accretion.halo.cold_mode.F90
+++ b/source/accretion.halo.cold_mode.F90
@@ -167,7 +167,7 @@ contains
     implicit none
     class(accretionHaloColdMode), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,coldModeCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,coldModeCalculationReset,openMPThreadBindingAllLevels,label='accretionHaloColdMode')
     return
   end subroutine coldModeAutoHook
 

--- a/source/cooling.cooling_radius.beta_profile.F90
+++ b/source/cooling.cooling_radius.beta_profile.F90
@@ -214,7 +214,7 @@ contains
     implicit none
     class(coolingRadiusBetaProfile), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,betaProfileCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,betaProfileCalculationReset,openMPThreadBindingAllLevels,label='coolingRadiusBetaProfile')
     return
   end subroutine betaProfileAutoHook
 

--- a/source/cooling.cooling_radius.isothermal_profile.F90
+++ b/source/cooling.cooling_radius.isothermal_profile.F90
@@ -203,7 +203,7 @@ contains
     implicit none
     class(coolingRadiusIsothermal), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,isothermalCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,isothermalCalculationReset,openMPThreadBindingAllLevels,label='coolingRadiusIsothermal')
     return
   end subroutine isothermalAutoHook
 

--- a/source/cooling.cooling_radius.simple.F90
+++ b/source/cooling.cooling_radius.simple.F90
@@ -204,7 +204,7 @@ contains
     implicit none
     class(coolingRadiusSimple), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,simpleCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,simpleCalculationReset,openMPThreadBindingAllLevels,label='coolingRadiusSimple')
     return
   end subroutine simpleAutoHook
 

--- a/source/cooling.specific_angular_momentum.constant_rotation.F90
+++ b/source/cooling.specific_angular_momentum.constant_rotation.F90
@@ -181,8 +181,7 @@ contains
     use :: Events_Hooks, only : calculationResetEvent, openMPThreadBindingAllLevels
     implicit none
     class(coolingSpecificAngularMomentumConstantRotation), intent(inout) :: self
-
-    call calculationResetEvent%attach(self,constantRotationCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,constantRotationCalculationReset,openMPThreadBindingAllLevels,label='coolingSpecificAngularMomentumConstantRotation')
     return
   end subroutine constantRotationAutoHook
 

--- a/source/dark_matter_halos.mass_accretion_history.Wechsler2002.F90
+++ b/source/dark_matter_halos.mass_accretion_history.Wechsler2002.F90
@@ -152,7 +152,7 @@ contains
     implicit none
     class(darkMatterHaloMassAccretionHistoryWechsler2002), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,wechsler2002CalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,wechsler2002CalculationReset,openMPThreadBindingAllLevels,label='darkMatterHaloMassAccretionHistoryWechsler2002')
     return
   end subroutine wechsler2002AutoHook
   

--- a/source/dark_matter_halos.scales.virial_density_contrast.F90
+++ b/source/dark_matter_halos.scales.virial_density_contrast.F90
@@ -170,13 +170,13 @@ contains
     implicit none
     class(darkMatterHaloScaleVirialDensityContrastDefinition), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,virialDensityContrastDefinitionCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,virialDensityContrastDefinitionCalculationReset,openMPThreadBindingAllLevels,label='darkMatterHaloScaleVirialDensityContrastDefinition')
     return
   end subroutine virialDensityContrastDefinitionAutoHook
 
   subroutine virialDensityContrastDefinitionDestructor(self)
     !!{
-    Destructir for the {\normalfont \ttfamily virialDensityContrastDefinition} dark matter halo scales class.
+    Destructor for the {\normalfont \ttfamily virialDensityContrastDefinition} dark matter halo scales class.
     !!}
     use :: Events_Hooks, only : calculationResetEvent
     implicit none
@@ -544,7 +544,14 @@ contains
     !!{
     Perform a deep copy of the object.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
+#ifdef OBJECTDEBUG
+    use :: Display           , only : displayMessage            , verbosityLevelSilent
+    use :: MPI_Utilities     , only : mpiSelf
+    use :: Function_Classes  , only : debugReporting
+    use :: ISO_Varying_String, only : operator(//)              , var_str
+    use :: String_Handling   , only : operator(//)
+#endif
     implicit none
     class(darkMatterHaloScaleVirialDensityContrastDefinition), intent(inout) :: self
     class(darkMatterHaloScaleClass                          ), intent(inout) :: destination
@@ -601,6 +608,9 @@ contains
              self%cosmologyParameters_%copiedSelf => destination%cosmologyParameters_
              call destination%cosmologyParameters_%autoHook()
           end if
+#ifdef OBJECTDEBUG
+          if (debugReporting.and.mpiSelf%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): cosmologyparameters : [destination] : ')//loc(destination)//' : '//loc(destination%cosmologyParameters_)//' : '//{introspection:location:compact},verbosityLevelSilent)
+#endif
        end if
        if (associated(self%cosmologyFunctions_)) then
           if (associated(self%cosmologyFunctions_%copiedSelf)) then
@@ -617,6 +627,9 @@ contains
              self%cosmologyFunctions_%copiedSelf => destination%cosmologyFunctions_
              call destination%cosmologyFunctions_%autoHook()
           end if
+#ifdef OBJECTDEBUG
+          if (debugReporting.and.mpiSelf%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): cosmologyfunctions : [destination] : ')//loc(destination)//' : '//loc(destination%cosmologyFunctions_)//' : '//{introspection:location:compact},verbosityLevelSilent)
+#endif
        end if
        if (associated(self%virialDensityContrast_)) then
           if (associated(self%virialDensityContrast_%copiedSelf)) then
@@ -633,6 +646,9 @@ contains
              self%virialDensityContrast_%copiedSelf => destination%virialDensityContrast_
              call destination%virialDensityContrast_%autoHook()
           end if
+#ifdef OBJECTDEBUG
+          if (debugReporting.and.mpiSelf%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): virialdensitycontrast : [destination] : ')//loc(destination)//' : '//loc(destination%virialDensityContrast_)//' : '//{introspection:location:compact},verbosityLevelSilent)
+#endif
        end if
        call destination%densityMeanTable%deepCopyActions()
     class default

--- a/source/dark_matter_profiles.SIDM.isothermal.F90
+++ b/source/dark_matter_profiles.SIDM.isothermal.F90
@@ -164,7 +164,7 @@ contains
     implicit none
     class(darkMatterProfileSIDMIsothermal), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,sidmIsothermalCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,sidmIsothermalCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileSIDMIsothermal')
     return
   end subroutine sidmIsothermalAutoHook
 

--- a/source/dark_matter_profiles.accelerator.F90
+++ b/source/dark_matter_profiles.accelerator.F90
@@ -142,7 +142,7 @@ contains
     implicit none
     class(darkMatterProfileAccelerator), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,acceleratorCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,acceleratorCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileAccelerator')
     return
   end subroutine acceleratorAutoHook
 

--- a/source/dark_matter_profiles.adiabatic_Gnedin2004.F90
+++ b/source/dark_matter_profiles.adiabatic_Gnedin2004.F90
@@ -313,7 +313,7 @@ contains
     implicit none
     class(darkMatterProfileAdiabaticGnedin2004), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,adiabaticGnedin2004CalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,adiabaticGnedin2004CalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileAdiabaticGnedin2004')
     return
   end subroutine adiabaticGnedin2004AutoHook
 
@@ -1094,8 +1094,15 @@ contains
     !!{
     Perform a deep copy of the object.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Functions_Global, only : galacticStructureDeepCopy_
+    use :: Error             , only : Error_Report
+    use :: Functions_Global  , only : galacticStructureDeepCopy_
+#ifdef OBJECTDEBUG
+    use :: Display           , only : displayMessage            , verbosityLevelSilent
+    use :: MPI_Utilities     , only : mpiSelf
+    use :: Function_Classes  , only : debugReporting
+    use :: ISO_Varying_String, only : operator(//)              , var_str
+    use :: String_Handling   , only : operator(//)
+#endif
     implicit none
     class(darkMatterProfileAdiabaticGnedin2004), intent(inout) :: self
     class(darkMatterProfileClass              ), intent(inout) :: destination
@@ -1157,6 +1164,9 @@ contains
              self%cosmologyParameters_%copiedSelf => destination%cosmologyParameters_
              call destination%cosmologyParameters_%autoHook()
           end if
+#ifdef OBJECTDEBUG
+          if (debugReporting.and.mpiSelf%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): cosmologyparameters : [destination] : ')//loc(destination)//' : '//loc(destination%cosmologyParameters_)//' : '//{introspection:location:compact},verbosityLevelSilent)
+#endif
        end if
        nullify(destination%darkMatterProfileDMO_)
        if (associated(self%darkMatterProfileDMO_)) then
@@ -1174,11 +1184,17 @@ contains
              self%darkMatterProfileDMO_%copiedSelf => destination%darkMatterProfileDMO_
              call destination%darkMatterProfileDMO_%autoHook()
           end if
+#ifdef OBJECTDEBUG
+          if (debugReporting.and.mpiSelf%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): darkmatterprofiledmo_ : [destination] : ')//loc(destination)//' : '//loc(destination%darkMatterProfileDMO_)//' : '//{introspection:location:compact},verbosityLevelSilent)
+#endif
        end if
        nullify(destination%galacticStructure_)
        if (associated(self%galacticStructure_)) then
           allocate(destination%galacticStructure_,mold=self%galacticStructure_)
           call galacticStructureDeepCopy_(self%galacticStructure_,destination%galacticStructure_)
+#ifdef OBJECTDEBUG
+          if (debugReporting.and.mpiSelf%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): galacticstructure : [destination] : ')//loc(destination)//' : '//loc(destination%galacticStructure_)//' : '//{introspection:location:compact},verbosityLevelSilent)
+#endif
        end if
        nullify(destination%darkMatterHaloScale_)
        if (associated(self%darkMatterHaloScale_)) then
@@ -1196,6 +1212,9 @@ contains
              self%darkMatterHaloScale_%copiedSelf => destination%darkMatterHaloScale_
              call destination%darkMatterHaloScale_%autoHook()
           end if
+#ifdef OBJECTDEBUG
+          if (debugReporting.and.mpiSelf%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): darkmatterhaloscale : [destination] : ')//loc(destination)//' : '//loc(destination%darkMatterHaloScale_)//' : '//{introspection:location:compact},verbosityLevelSilent)
+#endif
        end if
        call destination%finder%deepCopyActions()
     class default

--- a/source/dark_matter_profiles.heating.impulsive_outflow.F90
+++ b/source/dark_matter_profiles.heating.impulsive_outflow.F90
@@ -283,8 +283,15 @@ contains
     !!{
     Perform a deep copy of the object.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Functions_Global, only : galacticStructureDeepCopy_
+    use :: Error             , only : Error_Report
+    use :: Functions_Global  , only : galacticStructureDeepCopy_
+#ifdef OBJECTDEBUG
+    use :: Display           , only : displayMessage            , verbosityLevelSilent
+    use :: MPI_Utilities     , only : mpiSelf
+    use :: Function_Classes  , only : debugReporting
+    use :: ISO_Varying_String, only : operator(//)              , var_str
+    use :: String_Handling   , only : operator(//)
+#endif
     implicit none
     class(darkMatterProfileHeatingImpulsiveOutflow), intent(inout) :: self
     class(darkMatterProfileHeatingClass           ), intent(inout) :: destination
@@ -299,6 +306,9 @@ contains
        if (associated(self%galacticStructure_)) then
           allocate(destination%galacticStructure_,mold=self%galacticStructure_)
           call galacticStructureDeepCopy_(self%galacticStructure_,destination%galacticStructure_)
+#ifdef OBJECTDEBUG
+          if (debugReporting.and.mpiSelf%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): galacticstructure : [destination] : ')//loc(destination)//' : '//loc(destination%galacticStructure_)//' : '//{introspection:location:compact},verbosityLevelSilent)
+#endif
           destination%referenceCount=1          
        end if
     class default

--- a/source/dark_matter_profiles.heating.tidal.F90
+++ b/source/dark_matter_profiles.heating.tidal.F90
@@ -151,7 +151,7 @@ contains
     implicit none
     class(darkMatterProfileHeatingTidal), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,tidalCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,tidalCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileHeatingTidal')
     return
   end subroutine tidalAutoHook
 

--- a/source/dark_matter_profiles_DMO.Burkert.F90
+++ b/source/dark_matter_profiles_DMO.Burkert.F90
@@ -248,7 +248,7 @@ contains
     implicit none
     class(darkMatterProfileDMOBurkert), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,burkertCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,burkertCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOBurkert')
     return
   end subroutine burkertAutoHook
 

--- a/source/dark_matter_profiles_DMO.NFW.F90
+++ b/source/dark_matter_profiles_DMO.NFW.F90
@@ -234,7 +234,7 @@ contains
     implicit none
     class(darkMatterProfileDMONFW), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,nfwCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,nfwCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMONFW')
     return
   end subroutine nfwAutoHook
 

--- a/source/dark_matter_profiles_DMO.Penarrubia2010.F90
+++ b/source/dark_matter_profiles_DMO.Penarrubia2010.F90
@@ -197,7 +197,7 @@ contains
     implicit none
     class(darkMatterProfileDMOPenarrubia2010), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,penarrubia2010CalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,penarrubia2010CalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOPenarrubia2010')
     return
   end subroutine penarrubia2010AutoHook
 

--- a/source/dark_matter_profiles_DMO.SIDM.coreNFW.F90
+++ b/source/dark_matter_profiles_DMO.SIDM.coreNFW.F90
@@ -161,7 +161,7 @@ contains
     implicit none
     class(darkMatterProfileDMOSIDMCoreNFW), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,sidmCoreNFWCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,sidmCoreNFWCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOSIDMCoreNFW')
     return
   end subroutine sidmCoreNFWAutoHook
 

--- a/source/dark_matter_profiles_DMO.SIDM.isothermal.F90
+++ b/source/dark_matter_profiles_DMO.SIDM.isothermal.F90
@@ -198,7 +198,7 @@ contains
     implicit none
     class(darkMatterProfileDMOSIDMIsothermal), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,sidmIsothermalCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,sidmIsothermalCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOSIDMIsothermal')
     return
   end subroutine sidmIsothermalAutoHook
 

--- a/source/dark_matter_profiles_DMO.Zhao1996.F90
+++ b/source/dark_matter_profiles_DMO.Zhao1996.F90
@@ -210,7 +210,7 @@ contains
     implicit none
     class(darkMatterProfileDMOZhao1996), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,zhao1996CalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,zhao1996CalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOZhao1996')
     return
   end subroutine zhao1996AutoHook
 

--- a/source/dark_matter_profiles_DMO.accelerator.F90
+++ b/source/dark_matter_profiles_DMO.accelerator.F90
@@ -139,7 +139,7 @@ contains
     implicit none
     class(darkMatterProfileDMOAccelerator), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,acceleratorCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,acceleratorCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOAccelerator')
     return
   end subroutine acceleratorAutoHook
 

--- a/source/dark_matter_profiles_DMO.finite_resolution.F90
+++ b/source/dark_matter_profiles_DMO.finite_resolution.F90
@@ -181,7 +181,7 @@ contains
     implicit none
     class(darkMatterProfileDMOFiniteResolution), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,finiteResolutionCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,finiteResolutionCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOFiniteResolution')
     return
   end subroutine finiteResolutionAutoHook
 

--- a/source/dark_matter_profiles_DMO.finite_resolution.NFW.F90
+++ b/source/dark_matter_profiles_DMO.finite_resolution.NFW.F90
@@ -298,7 +298,7 @@ contains
     implicit none
     class(darkMatterProfileDMOFiniteResolutionNFW), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,finiteResolutionNFWCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,finiteResolutionNFWCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOFiniteResolutionNFW')
     return
   end subroutine finiteResolutionNFWAutoHook
 

--- a/source/dark_matter_profiles_DMO.heated.F90
+++ b/source/dark_matter_profiles_DMO.heated.F90
@@ -201,7 +201,7 @@ contains
     implicit none
     class(darkMatterProfileDMOHeated), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,heatedCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,heatedCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOHeated')
     return
   end subroutine heatedAutoHook
 

--- a/source/dark_matter_profiles_DMO.heated.monotonic.F90
+++ b/source/dark_matter_profiles_DMO.heated.monotonic.F90
@@ -198,7 +198,7 @@ contains
     implicit none
     class(darkMatterProfileDMOHeatedMonotonic), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,heatedMonotonicCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,heatedMonotonicCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOHeatedMonotonic')
     return
   end subroutine heatedMonotonicAutoHook
 

--- a/source/dark_matter_profiles_DMO.truncated.F90
+++ b/source/dark_matter_profiles_DMO.truncated.F90
@@ -156,7 +156,7 @@ contains
     implicit none
     class(darkMatterProfileDMOTruncated), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,truncatedCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,truncatedCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOTruncated)')
     return
   end subroutine truncatedAutoHook
 

--- a/source/dark_matter_profiles_DMO.truncated.exponential.F90
+++ b/source/dark_matter_profiles_DMO.truncated.exponential.F90
@@ -178,7 +178,7 @@ contains
     implicit none
     class(darkMatterProfileDMOTruncatedExponential), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,truncatedExponentialCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,truncatedExponentialCalculationReset,openMPThreadBindingAllLevels,label='darkMatterProfileDMOTruncatedExponential')
     return
   end subroutine truncatedExponentialAutoHook
 

--- a/source/events.filter.F90
+++ b/source/events.filter.F90
@@ -1,0 +1,38 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains module which provides a globally-callable event filtering function.
+!!}
+
+module Events_Filters
+  !!{
+  Provides a globally-callable event filtering function.
+  !!}
+  private
+  public :: eventsHooksFilterFunction, eventsHooksFilterCopyOut, eventsHooksFilterCopyIn, eventsHooksFilterCopyDone, &
+       &    eventsHooksFilterRestore
+
+  procedure(), pointer :: eventsHooksFilterCopyOut
+  procedure(), pointer :: eventsHooksFilterFunction
+  procedure(), pointer :: eventsHooksFilterCopyIn
+  procedure(), pointer :: eventsHooksFilterCopyDone
+  procedure(), pointer :: eventsHooksFilterRestore
+  
+end module Events_Filters

--- a/source/events.hooks.F90
+++ b/source/events.hooks.F90
@@ -151,6 +151,14 @@ module Events_Hooks
      procedure :: filter              => eventHookFilter
   end type eventHook
 
+  type :: eventHookList
+     !!{
+     List of event hooks.
+     !!}
+     class(eventHook    ), allocatable :: eventHook_
+     class(eventHookList), pointer     :: next       => null()
+  end type eventHookList
+  
   type, extends(eventHook) :: eventHookUnspecified
      !!{
      Class used to define a set of hooked function calls for a given event.
@@ -185,9 +193,9 @@ contains
     !!{
     Attach an object to an event hook.
     !!}
-    use    :: Display           , only : displayMessage             , verbosityLevelStandard
+    use    :: Display           , only : displayMessage             , verbosityLevelInfo
     use    :: Error             , only : Error_Report
-    use    :: ISO_Varying_String, only : varying_string             , var_str               , assignment(=), operator(//)
+    use    :: ISO_Varying_String, only : varying_string             , var_str           , assignment(=), operator(//)
     use    :: String_Handling   , only : operator(//)
     !$ use :: OMP_Lib           , only : OMP_Get_Ancestor_Thread_Num, OMP_Get_Level
     implicit none
@@ -242,7 +250,7 @@ contains
     self%count_=self%count_+1
     call self%resolveDependencies(hook_,dependencies)
     ! Report
-    call displayMessage(var_str("attaching '")//trim(hook_%label)//"' ["//hook_%eventID//"] to event"//threadLabel//" [count="//self%count_//"]",verbosityLevelStandard)
+    call displayMessage(var_str("attaching '")//trim(hook_%label)//"' ["//hook_%eventID//"] to event"//threadLabel//" [count="//self%count_//"]",verbosityLevelInfo)
     return
   end subroutine eventHookUnspecifiedAttach
 
@@ -364,9 +372,9 @@ contains
     !!{
     Attach an object to an event hook.
     !!}
-    use    :: Display           , only : displayMessage             , verbosityLevelStandard
+    use    :: Display           , only : displayMessage             , verbosityLevelInfo
     use    :: Error             , only : Error_Report
-    use    :: ISO_Varying_String, only : varying_string             , var_str               , assignment(=), operator(//)
+    use    :: ISO_Varying_String, only : varying_string             , var_str           , assignment(=), operator(//)
     use    :: String_Handling   , only : operator(//)
     !$ use :: OMP_Lib           , only : OMP_Get_Ancestor_Thread_Num, OMP_Get_Level
     implicit none
@@ -389,7 +397,7 @@ contains
                 !$    if (j > 0) threadLabel=threadLabel//" -> "
                 !$    threadLabel=threadLabel//OMP_Get_Ancestor_Thread_Num(j)
                 !$ end do
-                call displayMessage(var_str("detaching '")//trim(self%hooks_(i)%hook_%label)//"' ["//self%hooks_(i)%hook_%eventID//"] from event"//threadLabel//" [count="//self%count_//"]",verbosityLevelStandard)
+                call displayMessage(var_str("detaching '")//trim(self%hooks_(i)%hook_%label)//"' ["//self%hooks_(i)%hook_%eventID//"] from event"//threadLabel//" [count="//self%count_//"]",verbosityLevelInfo)
                 deallocate(self%hooks_(i)%hook_)
                 if (self%count_ > 1) then
                    call move_alloc(self%hooks_,hooksTmp)

--- a/source/events.hooks.F90
+++ b/source/events.hooks.F90
@@ -184,6 +184,9 @@ contains
     !!}
     use    :: Error  , only : Error_Report
     !$ use :: OMP_Lib, only : OMP_Get_Ancestor_Thread_Num, OMP_Get_Level
+#ifdef USEMPI
+    use :: MPI_Utilities, only : mpiSelf
+#endif
     implicit none
     class     (eventHookUnspecified              ), intent(inout)                            :: self
     class     (*                                 ), intent(in   ), target                    :: object_
@@ -228,7 +231,13 @@ contains
     self%hooks_(self%count_+1)%hook_ => hook_
     ! Increment the count of hooks into this event and resolve dependencies.
     self%count_=self%count_+1
+#ifdef USEMPI
+    write (0,*) "GO RESDEP  ",mpiSelf%rank()
+#endif
     call self%resolveDependencies(hook_,dependencies)
+#ifdef USEMPI
+    write (0,*) "DONE RESDEP  ",mpiSelf%rank()
+#endif
     return
   end subroutine eventHookUnspecifiedAttach
 

--- a/source/events.hooks.F90
+++ b/source/events.hooks.F90
@@ -184,9 +184,6 @@ contains
     !!}
     use    :: Error  , only : Error_Report
     !$ use :: OMP_Lib, only : OMP_Get_Ancestor_Thread_Num, OMP_Get_Level
-#ifdef USEMPI
-    use :: MPI_Utilities, only : mpiSelf
-#endif
     implicit none
     class     (eventHookUnspecified              ), intent(inout)                            :: self
     class     (*                                 ), intent(in   ), target                    :: object_
@@ -231,13 +228,7 @@ contains
     self%hooks_(self%count_+1)%hook_ => hook_
     ! Increment the count of hooks into this event and resolve dependencies.
     self%count_=self%count_+1
-#ifdef USEMPI
-    write (0,*) "GO RESDEP  ",mpiSelf%rank()
-#endif
     call self%resolveDependencies(hook_,dependencies)
-#ifdef USEMPI
-    write (0,*) "DONE RESDEP  ",mpiSelf%rank()
-#endif
     return
   end subroutine eventHookUnspecifiedAttach
 
@@ -247,9 +238,6 @@ contains
     !!}
     use :: Error              , only : Error_Report    , errorStatusSuccess
     use :: Sorting_Topological, only : Sort_Topological
-#ifdef USEMPI
-    use :: MPI_Utilities, only : mpiSelf
-#endif
     implicit none
     class    (eventHook ), intent(inout)                           :: self
     class    (hook      ), intent(inout)                           :: hookNew
@@ -264,9 +252,6 @@ contains
     logical                                                        :: matches
     
     ! Add dependencies to the new hooked function.
-#ifdef USEMPI
-    write (0,*) "RESDEP #1 ",mpiSelf%rank(),present(dependencies)
-#endif
     if (present(dependencies)) then
        allocate(hookNew%dependencies(size(dependencies)),mold=dependencies)
        hookNew%dependencies=dependencies
@@ -277,26 +262,14 @@ contains
           end select
        end do
     end if
-#ifdef USEMPI
-    write (0,*) "RESDEP #2 ",mpiSelf%rank()
-#endif
     ! Build the dependency array.
     allocate(dependentIndices(1,2))
     dependencyCount =  0
     do i=1,self%count_
-#ifdef USEMPI
-    write (0,*) "RESDEP #2.i ",mpiSelf%rank(),i,self%count_
-#endif
        if (allocated(self%hooks_(i)%hook_%dependencies)) then
           do k=1,size(self%hooks_(i)%hook_%dependencies)
-#ifdef USEMPI
-    write (0,*) "RESDEP #2.k ",mpiSelf%rank(),k,size(self%hooks_(i)%hook_%dependencies)
-#endif
              j    = 0
              do j=1,self%count_
-#ifdef USEMPI
-    write (0,*) "RESDEP #2.j ",mpiSelf%rank(),j,self%count_
-#endif
                 matches=.false.
                 select type (dependency_ => self%hooks_(i)%hook_%dependencies(k))
                 type is (dependencyExact)
@@ -332,36 +305,18 @@ contains
        end if
     end do
     ! If there are dependencies present then generate an ordering which satisfies all dependencies.
-#ifdef USEMPI
-    write (0,*) "RESDEP #3 ",mpiSelf%rank(),dependencyCount
-#endif
     if (dependencyCount > 0) then
        allocate(order(self%count_))
-#ifdef USEMPI
-    write (0,*) "RESDEP #3.1 ",mpiSelf%rank()
-#endif
        call Sort_Topological(self%count_,dependencyCount,dependentIndices(1:dependencyCount,:),order,countOrdered,status)
        if (status /= errorStatusSuccess) call Error_Report('unable to resolve hooked function dependencies'//{introspection:location})
        ! Build an array of pointers to our hooks with this ordering.
        allocate(hooksOrdered(self%count_))
        do i=1,self%count_
-#ifdef USEMPI
-    write (0,*) "RESDEP #3.i ",mpiSelf%rank(),i,self%count_
-#endif
           hooksOrdered(i)%hook_ => self%hooks_(order(i))%hook_
        end do
-#ifdef USEMPI
-    write (0,*) "RESDEP #3.2 ",mpiSelf%rank(),i,self%count_
-#endif
        deallocate(self%hooks_)
        call move_alloc(hooksOrdered,self%hooks_)
-#ifdef USEMPI
-    write (0,*) "RESDEP #3.3 ",mpiSelf%rank(),i,self%count_
-#endif
     end if
-#ifdef USEMPI
-    write (0,*) "RESDEP #4 ",mpiSelf%rank()
-#endif
     return
   end subroutine eventHookResolveDependencies
   

--- a/source/galactic.structure.standard.F90
+++ b/source/galactic.structure.standard.F90
@@ -187,7 +187,7 @@ contains
     implicit none
     class(galacticStructureStandard), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,standardCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,standardCalculationReset,openMPThreadBindingAllLevels,label='galacticStructureStandard')
     return
   end subroutine standardAutoHook
 

--- a/source/galactic.structure.utilities.F90
+++ b/source/galactic.structure.utilities.F90
@@ -42,7 +42,7 @@ contains
    <unitName>galacticStructureConstruct</unitName>
    <type>void</type>
    <module>Input_Parameters, only : inputParameters</module>
-   <arguments>type (inputParameters), intent(inout)          :: parameters</arguments>
+   <arguments>type (inputParameters), intent(inout), target  :: parameters</arguments>
    <arguments>class(*              ), intent(  out), pointer :: galacticStructure_</arguments>
   </functionGlobal>
   !!]
@@ -55,12 +55,18 @@ contains
     use :: Input_Parameters  , only : inputParameter        , inputParameters
     use :: Galactic_Structure, only : galacticStructureClass, galacticStructure
     implicit none
-    type (inputParameters), intent(inout)          :: parameters
+    type (inputParameters), intent(inout), target  :: parameters
     class(*              ), intent(  out), pointer :: galacticStructure_
+    type (inputParameters)               , pointer :: parametersCurrent
 
+    parametersCurrent => parameters
+    do while (.not.parametersCurrent%isPresent('galacticStructurw').and.associated(parametersCurrent%parent))
+       parametersCurrent => parametersCurrent%parent
+    end do
+    if (.not.parametersCurrent%isPresent('galacticStructure')) parametersCurrent => parameters
     galacticStructure__ => galacticStructure(parameters)
     select type (galacticStructure__)
-    class is (galacticStructureClass)
+    class is (galacticStructureClass) 
        !![
        <referenceCountIncrement object="galacticStructure__"/>
        !!]

--- a/source/galactic_structure.radius_solver.equilibrium.F90
+++ b/source/galactic_structure.radius_solver.equilibrium.F90
@@ -163,7 +163,7 @@ contains
     type (dependencyRegEx                   ), dimension(1)  :: dependencies
 
     dependencies(1)=dependencyRegEx(dependencyDirectionAfter,'^nodeComponent')
-    call   preDerivativeEvent%attach(self,equilibriumSolvePreDeriativeHook,openMPThreadBindingAtLevel                                                             )
+    call   preDerivativeEvent%attach(self,equilibriumSolvePreDeriativeHook,openMPThreadBindingAtLevel,label='structureSolverEquilibrium'                          )
     call      postEvolveEvent%attach(self,equilibriumSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverEquilibrium',dependencies=dependencies)
     call satelliteMergerEvent%attach(self,equilibriumSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverEquilibrium',dependencies=dependencies)
     call   nodePromotionEvent%attach(self,equilibriumSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverEquilibrium',dependencies=dependencies)

--- a/source/galactic_structure.radius_solver.fixed.F90
+++ b/source/galactic_structure.radius_solver.fixed.F90
@@ -153,7 +153,7 @@ contains
     type (dependencyRegEx             ), dimension(1)  :: dependencies
 
     dependencies(1)=dependencyRegEx(dependencyDirectionAfter,'^nodeComponent')
-    call   preDerivativeEvent%attach(self,fixedSolvePreDeriativeHook,openMPThreadBindingAtLevel                                                       )
+    call   preDerivativeEvent%attach(self,fixedSolvePreDeriativeHook,openMPThreadBindingAtLevel,label='structureSolverFixed',dependencies=dependencies)
     call      postEvolveEvent%attach(self,fixedSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverFixed',dependencies=dependencies)
     call satelliteMergerEvent%attach(self,fixedSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverFixed',dependencies=dependencies)
     call   nodePromotionEvent%attach(self,fixedSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverFixed',dependencies=dependencies)

--- a/source/galactic_structure.radius_solver.linear.F90
+++ b/source/galactic_structure.radius_solver.linear.F90
@@ -109,7 +109,7 @@ contains
     type (dependencyRegEx              ), dimension(1)  :: dependencies
 
     dependencies(1)=dependencyRegEx(dependencyDirectionAfter,'^nodeComponent')
-    call   preDerivativeEvent%attach(self,linearSolvePreDeriativeHook,openMPThreadBindingAtLevel                                                        )
+    call   preDerivativeEvent%attach(self,linearSolvePreDeriativeHook,openMPThreadBindingAtLevel,label='structureSolverLinear',dependencies=dependencies)
     call      postEvolveEvent%attach(self,linearSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverLinear',dependencies=dependencies)
     call satelliteMergerEvent%attach(self,linearSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverLinear',dependencies=dependencies)
     call   nodePromotionEvent%attach(self,linearSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverLinear',dependencies=dependencies)

--- a/source/galactic_structure.radius_solver.null.F90
+++ b/source/galactic_structure.radius_solver.null.F90
@@ -72,10 +72,10 @@ contains
     implicit none
     class(galacticStructureSolverNull), intent(inout) :: self
 
-    call   preDerivativeEvent%attach(self,nullSolvePreDeriativeHook,openMPThreadBindingAtLevel)
-    call      postEvolveEvent%attach(self,nullSolveHook            ,openMPThreadBindingAtLevel)
-    call satelliteMergerEvent%attach(self,nullSolveHook            ,openMPThreadBindingAtLevel)
-    call   nodePromotionEvent%attach(self,nullSolveHook            ,openMPThreadBindingAtLevel)
+    call   preDerivativeEvent%attach(self,nullSolvePreDeriativeHook,openMPThreadBindingAtLevel,label='galacticStructureSolverNull')
+    call      postEvolveEvent%attach(self,nullSolveHook            ,openMPThreadBindingAtLevel,label='galacticStructureSolverNull')
+    call satelliteMergerEvent%attach(self,nullSolveHook            ,openMPThreadBindingAtLevel,label='galacticStructureSolverNull')
+    call   nodePromotionEvent%attach(self,nullSolveHook            ,openMPThreadBindingAtLevel,label='galacticStructureSolverNull')
     return
   end subroutine nullAutoHook
 

--- a/source/galactic_structure.radius_solver.simple.F90
+++ b/source/galactic_structure.radius_solver.simple.F90
@@ -125,7 +125,7 @@ contains
     type (dependencyRegEx              ), dimension(1)  :: dependencies
 
     dependencies(1)=dependencyRegEx(dependencyDirectionAfter,'^nodeComponent')
-    call   preDerivativeEvent%attach(self,simpleSolvePreDeriativeHook,openMPThreadBindingAtLevel                                                        )
+    call   preDerivativeEvent%attach(self,simpleSolvePreDeriativeHook,openMPThreadBindingAtLevel,label='structureSolverSimple',dependencies=dependencies)
     call      postEvolveEvent%attach(self,simpleSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverSimple',dependencies=dependencies)
     call satelliteMergerEvent%attach(self,simpleSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverSimple',dependencies=dependencies)
     call   nodePromotionEvent%attach(self,simpleSolveHook            ,openMPThreadBindingAtLevel,label='structureSolverSimple',dependencies=dependencies)

--- a/source/hot_halo.outflow_reincorporation.velocity_maximum_scaling.F90
+++ b/source/hot_halo.outflow_reincorporation.velocity_maximum_scaling.F90
@@ -187,7 +187,7 @@ contains
     implicit none
     class(hotHaloOutflowReincorporationVelocityMaximumScaling), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,velocityMaximumScalingCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,velocityMaximumScalingCalculationReset,openMPThreadBindingAllLevels,label='hotHaloOutflowReincorporationVelocityMaximumScaling')
     return
   end subroutine velocityMaximumScalingAutoHook
 

--- a/source/intergalactic_medium.state.internal.F90
+++ b/source/intergalactic_medium.state.internal.F90
@@ -118,11 +118,11 @@ contains
     !!{
     Hook into the internal intergalactic medium state evolver to receive updates.
     !!}
-    use :: Events_Hooks, only : intergalacticMediumStateEvolveUpdateEvent
+    use :: Events_Hooks, only : intergalacticMediumStateEvolveUpdateEventGlobal
     implicit none
     class(intergalacticMediumStateInternal), intent(inout) :: self
 
-    call intergalacticMediumStateEvolveUpdateEvent%attach(self,internalStateSet,label='intergalacticMediumStateInternal')
+    call intergalacticMediumStateEvolveUpdateEventGlobal%attach(self,internalStateSet,label='intergalacticMediumStateInternal')
     return
   end subroutine internalAutoHook
 
@@ -130,6 +130,7 @@ contains
     !!{
     Destructor for the internal \gls{igm} state class.
     !!}
+    use :: Events_Hooks, only : intergalacticMediumStateEvolveUpdateEventGlobal
     implicit none
     type(intergalacticMediumStateInternal), intent(inout) :: self
 
@@ -137,6 +138,7 @@ contains
     <objectDestructor name="self%cosmologyParameters_"/>
     <objectDestructor name="self%cosmologyFunctions_" />
     !!]
+    if (intergalacticMediumStateEvolveUpdateEventGlobal%isAttached(self,internalStateSet)) call intergalacticMediumStateEvolveUpdateEventGlobal%detach(self,internalStateSet)
     return
   end subroutine internalDestructor
 
@@ -337,7 +339,6 @@ contains
          &                                              densityHydrogen2, densityHelium1  , &
          &                                              densityHelium2  , densityHelium3  , &
          &                                              temperature     , massFiltering
-
     select type (self)
     class is (intergalacticMediumStateInternal)
        if (allocated(self%time            )) call deallocateArray(self%time            )

--- a/source/intergalactic_medium.state.internal.F90
+++ b/source/intergalactic_medium.state.internal.F90
@@ -122,7 +122,7 @@ contains
     implicit none
     class(intergalacticMediumStateInternal), intent(inout) :: self
 
-    call intergalacticMediumStateEvolveUpdateEvent%attach(self,internalStateSet)
+    call intergalacticMediumStateEvolveUpdateEvent%attach(self,internalStateSet,label='intergalacticMediumStateInternal')
     return
   end subroutine internalAutoHook
 

--- a/source/math.linear_algebra.F90
+++ b/source/math.linear_algebra.F90
@@ -1023,6 +1023,7 @@ contains
     class  (matrix  ), intent(inout)           :: self
     type   (vector  ), intent(in   )           :: y
     integer          , intent(  out), optional :: status
+    type   (vector  )                          :: CyT
     integer(c_size_t)                          :: i      , j
     logical                                    :: allZero
 
@@ -1058,7 +1059,8 @@ contains
           end if
        end do
     end if
-    matrixCovarianceProduct=y.dot.self%linearSystemSolve(y)
+    CyT=self%linearSystemSolve(y)
+    matrixCovarianceProduct=y.dot.CyT
     if (matrixCovarianceProduct < 0.0d0) then
        if (present(status)) then
           status=GSL_ESing

--- a/source/merger_trees.evolve.timesteps.history.F90
+++ b/source/merger_trees.evolve.timesteps.history.F90
@@ -205,7 +205,7 @@ contains
     implicit none
     class(mergerTreeEvolveTimestepHistory), intent(inout) :: self
 
-    call hdf5PreCloseEvent%attach(self,historyWrite)
+    call hdf5PreCloseEvent%attach(self,historyWrite,label='mergerTreeEvolveTimestepHistory')
     return
   end subroutine historyAutoHook
 

--- a/source/merger_trees.evolve.timesteps.history.F90
+++ b/source/merger_trees.evolve.timesteps.history.F90
@@ -201,11 +201,11 @@ contains
     !!{
     Create a hook to the HDF5 pre-close event to allow us to finalize and write out our data.
     !!}
-    use :: Events_Hooks, only : hdf5PreCloseEvent
+    use :: Events_Hooks, only : hdf5PreCloseEventGlobal
     implicit none
     class(mergerTreeEvolveTimestepHistory), intent(inout) :: self
 
-    call hdf5PreCloseEvent%attach(self,historyWrite,label='mergerTreeEvolveTimestepHistory')
+    call hdf5PreCloseEventGlobal%attach(self,historyWrite,label='mergerTreeEvolveTimestepHistory')
     return
   end subroutine historyAutoHook
 
@@ -213,11 +213,11 @@ contains
     !!{
     Destructor for the {\normalfont \ttfamily history} merger tree evolution timestep class.
     !!}
-    use :: Events_Hooks, only : hdf5PreCloseEvent
+    use :: Events_Hooks, only : hdf5PreCloseEventGlobal
     implicit none
     type(mergerTreeEvolveTimestepHistory), intent(inout) :: self
 
-    if (hdf5PreCloseEvent%isAttached(self,historyWrite)) call hdf5PreCloseEvent%detach(self,historyWrite)
+    if (hdf5PreCloseEventGlobal%isAttached(self,historyWrite)) call hdf5PreCloseEventGlobal%detach(self,historyWrite)
     !![
     <objectDestructor name="self%cosmologyFunctions_"        />
     <objectDestructor name="self%starFormationRateDisks_"    />

--- a/source/merger_trees.evolve.timesteps.record_evolution.F90
+++ b/source/merger_trees.evolve.timesteps.record_evolution.F90
@@ -179,7 +179,7 @@ contains
     implicit none
     class(mergerTreeEvolveTimestepRecordEvolution), intent(inout) :: self
 
-    call mergerTreeExtraOutputEvent%attach(self,recordEvolutionOutput)
+    call mergerTreeExtraOutputEvent%attach(self,recordEvolutionOutput,label='mergerTreeEvolveTimestepRecordEvolution')
    return
   end subroutine recordEvolutionAutoHook
 

--- a/source/merger_trees.evolve.timesteps.record_evolution.F90
+++ b/source/merger_trees.evolve.timesteps.record_evolution.F90
@@ -175,18 +175,19 @@ contains
     !!{
     Create a hook to the merger tree extra output event to allow us to write out our data.
     !!}
-    use :: Events_Hooks, only : mergerTreeExtraOutputEvent
+    use :: Events_Hooks, only : mergerTreeExtraOutputEvent, openMPThreadBindingAtLevel
     implicit none
     class(mergerTreeEvolveTimestepRecordEvolution), intent(inout) :: self
 
-    call mergerTreeExtraOutputEvent%attach(self,recordEvolutionOutput,label='mergerTreeEvolveTimestepRecordEvolution')
-   return
+    call mergerTreeExtraOutputEvent%attach(self,recordEvolutionOutput,label='mergerTreeEvolveTimestepRecordEvolution',openMPThreadBinding=openMPThreadBindingAtLevel)
+    return
   end subroutine recordEvolutionAutoHook
 
   subroutine recordEvolutionDestructor(self)
     !!{
     Destructor for the {\normalfont \ttfamily recordEvolution} merger tree evolution timestep class.
     !!}
+    use :: Events_Hooks, only : mergerTreeExtraOutputEvent
     implicit none
     type(mergerTreeEvolveTimestepRecordEvolution), intent(inout) :: self
 
@@ -195,6 +196,7 @@ contains
     <objectDestructor name="self%outputTimes_"       />
     <objectDestructor name="self%galacticStructure_" />
     !!]
+    if (mergerTreeExtraOutputEvent%isAttached(self,recordEvolutionOutput)) call mergerTreeExtraOutputEvent%detach(self,recordEvolutionOutput)
     return
   end subroutine recordEvolutionDestructor
 
@@ -314,14 +316,14 @@ contains
              self%oneTimeDatasetsWritten=.true.
           end if
           datasetName=var_str("stellarMass")//treeIndex
-          call outputGroup%writeDataset  (self%massStellar,char(datasetName),"The stellar mass of the main progenitor."       ,datasetReturned=dataset)
-          call dataset    %writeAttribute(massSolar       ,"unitsInSI"                                                                                )
-          call dataset    %close         (                                                                                                            )
+          call outputGroup%writeDataset  (self%massStellar,char(datasetName),"The stellar mass of the main progenitor."           ,datasetReturned=dataset)
+          call dataset    %writeAttribute(massSolar       ,"unitsInSI"                                                                                    )
+          call dataset    %close         (                                                                                                                )
           datasetName=var_str("totalMass"  )//treeIndex
-          call outputGroup%writeDataset  (self%massTotal  ,char(datasetName),"The total baryonic mass of the main progenitor.",datasetReturned=dataset)
-          call dataset    %writeAttribute(massSolar       ,"unitsInSI"                                                                                )
-          call dataset    %close         (                                                                                                            )
-          call outputGroup%close         (                                                                                                            )
+          call outputGroup%writeDataset  (self%massTotal  ,char(datasetName),"The total baryonic mass of the main progenitor."    ,datasetReturned=dataset)
+          call dataset    %writeAttribute(massSolar       ,"unitsInSI"                                                                                    )
+          call dataset    %close         (                                                                                                                )
+          call outputGroup%close         (                                                                                                                )
           !$ call hdf5Access%unset()
           call    self      %reset()
        end if

--- a/source/merger_trees.operators.tree_processing_timer.F90
+++ b/source/merger_trees.operators.tree_processing_timer.F90
@@ -124,7 +124,7 @@ contains
     implicit none
     class(mergerTreeOperatorTreeProcessingTimer), intent(inout) :: self
 
-    if (self%collectMemoryUsageData) call postEvolveEvent%attach(self,treeProcessingTimerPostEvolve,openMPThreadBindingAtLevel)
+    if (self%collectMemoryUsageData) call postEvolveEvent%attach(self,treeProcessingTimerPostEvolve,openMPThreadBindingAtLevel,label='mergerTreeOperatorTreeProcessingTimer')
     return
   end subroutine treeProcessingTimerAutoHook
 

--- a/source/nodes.operators.physics.satellite.mass_loss.F90
+++ b/source/nodes.operators.physics.satellite.mass_loss.F90
@@ -83,6 +83,7 @@ contains
     self=nodeOperatorSatelliteMassLoss(massBoundIsInactive,darkMatterHaloMassLossRate_)
     !![
     <inputParametersValidate source="parameters"/>
+    <objectDestructor name="darkMatterHaloMassLossRate_"/>
     !!]
     return
   end function satelliteMassLossConstructorParameters

--- a/source/nodes.operators.physics.satellite_merging.time.F90
+++ b/source/nodes.operators.physics.satellite_merging.time.F90
@@ -87,6 +87,8 @@ contains
     self=nodeOperatorSatelliteMergingTime(resetOnHaloFormation,virialOrbit_,satelliteMergingTimescales_)
     !![
     <inputParametersValidate source="parameters"/>
+    <objectDestructor name="virialOrbit_"               />
+    <objectDestructor name="satelliteMergingTimescales_"/>
     !!]
     return
   end function satelliteMergingTimeConstructorParameters

--- a/source/nodes.property_extractor.mass_stellar.F90
+++ b/source/nodes.property_extractor.mass_stellar.F90
@@ -35,6 +35,7 @@ Contains a module which implements a stellar mass property extractor class.
      private
      class(galacticStructureClass), pointer :: galacticStructure_ => null()
    contains
+     final     ::                massStellarDestructor
      procedure :: extract     => massStellarExtract
      procedure :: name        => massStellarName
      procedure :: description => massStellarDescription

--- a/source/objects.nodes.components.black_hole.non_central.F90
+++ b/source/objects.nodes.components.black_hole.non_central.F90
@@ -70,11 +70,11 @@ module Node_Component_Black_Hole_Noncentral
   logical :: tripleBlackHoleInteraction
 
   ! Index of black hole instance about to merge.
-  integer          :: mergingInstance
+  integer :: mergingInstance
   !$omp threadprivate(mergingInstance)
 
   ! Index of black hole involved in three-body interactions
-  integer          :: binaryInstance           , tripleInstance
+  integer :: binaryInstance           , tripleInstance
   !$omp threadprivate(binaryInstance,tripleInstance)
 
 contains

--- a/source/radiation.intergalactic_background.internal.F90
+++ b/source/radiation.intergalactic_background.internal.F90
@@ -289,13 +289,13 @@ contains
   end function intergalacticBackgroundInternalConstructorInternal
 
   subroutine intergalacticBackgroundInternalAutoHook(self)
-    use :: Events_Hooks, only : universePreEvolveEvent
+    use :: Events_Hooks, only : universePreEvolveEventGlobal
     implicit none
     class(radiationFieldIntergalacticBackgroundInternal), intent(inout) :: self
 
     ! Hook to universe pre-evolve events.
     !$omp master
-    call universePreEvolveEvent%attach(self,intergalacticBackgroundInternalUniversePreEvolve,label='radiationFieldIntergalacticBackgroundInternal')
+    call universePreEvolveEventGlobal%attach(self,intergalacticBackgroundInternalUniversePreEvolve,label='radiationFieldIntergalacticBackgroundInternal')
     !$omp end master
     return
   end subroutine intergalacticBackgroundInternalAutoHook
@@ -304,6 +304,7 @@ contains
     !!{
     Destructor for the {\normalfont \ttfamily intergalacticBackgroundInternal} radiation field class.
     !!}
+    use :: Events_Hooks, only : universePreEvolveEventGlobal
     implicit none
     type(radiationFieldIntergalacticBackgroundInternal), intent(inout) :: self
 
@@ -318,6 +319,9 @@ contains
     <objectDestructor name="self%stellarPopulationSelector_"        />
     <objectDestructor name="self%outputTimes_"                      />
     !!]
+    !$omp master
+    if (universePreEvolveEventGlobal%isAttached(self,intergalacticBackgroundInternalUniversePreEvolve)) call universePreEvolveEventGlobal%detach(self,intergalacticBackgroundInternalUniversePreEvolve)
+    !$omp end master
     return
   end subroutine intergalacticBackgroundInternalDestructor
 

--- a/source/radiation.intergalactic_background.internal.F90
+++ b/source/radiation.intergalactic_background.internal.F90
@@ -295,7 +295,7 @@ contains
 
     ! Hook to universe pre-evolve events.
     !$omp master
-    call universePreEvolveEvent%attach(self,intergalacticBackgroundInternalUniversePreEvolve)
+    call universePreEvolveEvent%attach(self,intergalacticBackgroundInternalUniversePreEvolve,label='radiationFieldIntergalacticBackgroundInternal')
     !$omp end master
     return
   end subroutine intergalacticBackgroundInternalAutoHook

--- a/source/satellites.dynamical_friction.acceleration.Petts2015.F90
+++ b/source/satellites.dynamical_friction.acceleration.Petts2015.F90
@@ -116,7 +116,10 @@ contains
     type(satelliteDynamicalFrictionPetts2015), intent(inout) :: self
 
     !![
-    <objectDestructor name="self%cosmologyParameters_"/>
+    <objectDestructor name="self%cosmologyParameters_" />
+    <objectDestructor name="self%darkMatterHaloScale_" />
+    <objectDestructor name="self%darkMatterProfileDMO_"/>
+    <objectDestructor name="self%galacticStructure_"   />
     !!]
     return
   end subroutine petts2015Destructor

--- a/source/satellites.merging.mass_movements.Baugh2005.F90
+++ b/source/satellites.merging.mass_movements.Baugh2005.F90
@@ -155,7 +155,7 @@ contains
     implicit none
     class(mergerMassMovementsBaugh2005), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,baugh2005CalculationReset,openMPThreadBindingAllLevels                                                )
+    call calculationResetEvent%attach(self,baugh2005CalculationReset,openMPThreadBindingAllLevels,label='remnantStructure:massMovementsBaugh2005')
     call satelliteMergerEvent %attach(self,baugh2005GetHook         ,openMPThreadBindingAllLevels,label='remnantStructure:massMovementsBaugh2005')
     return
   end subroutine baugh2005AutoHook

--- a/source/satellites.merging.mass_movements.simple.F90
+++ b/source/satellites.merging.mass_movements.simple.F90
@@ -140,7 +140,7 @@ contains
     implicit none
     class(mergerMassMovementsSimple), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,simpleCalculationReset,openMPThreadBindingAllLevels                                             )
+    call calculationResetEvent%attach(self,simpleCalculationReset,openMPThreadBindingAllLevels,label='remnantStructure:massMovementsSimple')
     call satelliteMergerEvent %attach(self,simpleGetHook         ,openMPThreadBindingAllLevels,label='remnantStructure:massMovementsSimple')
     return
   end subroutine simpleAutoHook

--- a/source/satellites.merging.mass_movements.very_simple.F90
+++ b/source/satellites.merging.mass_movements.very_simple.F90
@@ -111,7 +111,7 @@ contains
     implicit none
     class(mergerMassMovementsVerySimple), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,verySimpleCalculationReset,openMPThreadBindingAllLevels                                                 )
+    call calculationResetEvent%attach(self,verySimpleCalculationReset,openMPThreadBindingAllLevels,label='remnantStructure:massMovementsVerySimple')
     call satelliteMergerEvent %attach(self,verySimpleGetHook         ,openMPThreadBindingAllLevels,label='remnantStructure:massMovementsVerySimple')
     return
   end subroutine verySimpleAutoHook

--- a/source/satellites.merging.remnant_sizes.Cole2000.F90
+++ b/source/satellites.merging.remnant_sizes.Cole2000.F90
@@ -155,7 +155,7 @@ contains
     implicit none
     class(mergerRemnantSizeCole2000), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,cole2000CalculationReset,openMPThreadBindingAllLevels                                             )
+    call calculationResetEvent%attach(self,cole2000CalculationReset,openMPThreadBindingAllLevels,label='remnantStructure:remnantSizeCole2000')
     call satelliteMergerEvent %attach(self,cole2000GetHook         ,openMPThreadBindingAllLevels,label='remnantStructure:remnantSizeCole2000')
     return
   end subroutine cole2000AutoHook

--- a/source/satellites.merging.remnant_sizes.Covington2008.F90
+++ b/source/satellites.merging.remnant_sizes.Covington2008.F90
@@ -145,7 +145,7 @@ contains
     implicit none
     class(mergerRemnantSizeCovington2008), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,covington2008CalculationReset,openMPThreadBindingAllLevels                                                  )
+    call calculationResetEvent%attach(self,covington2008CalculationReset,openMPThreadBindingAllLevels,label='remnantStructure:remnantSizeCovington2008')
     call satelliteMergerEvent %attach(self,covington2008GetHook         ,openMPThreadBindingAllLevels,label='remnantStructure:remnantSizeCovington2008')
     return
   end subroutine covington2008AutoHook

--- a/source/satellites.tidal_stripping.radius.King1962.F90
+++ b/source/satellites.tidal_stripping.radius.King1962.F90
@@ -145,7 +145,7 @@ contains
     implicit none
     class(satelliteTidalStrippingRadiusKing1962), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,king1962CalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,king1962CalculationReset,openMPThreadBindingAllLevels,label='satelliteTidalStrippingRadiusKing1962')
     return
   end subroutine king1962AutoHook
 

--- a/source/star_formation.histories.in_situ.F90
+++ b/source/star_formation.histories.in_situ.F90
@@ -141,7 +141,7 @@ contains
     implicit none
     class(starFormationHistoryInSitu), intent(inout) :: self
 
-    call satelliteMergerEvent%attach(self,inSituSatelliteMerger,openMPThreadBindingAllLevels)
+    call satelliteMergerEvent%attach(self,inSituSatelliteMerger,openMPThreadBindingAllLevels,label='starFormationHistoryInSitu')
     return
   end subroutine inSituAutoHook
 

--- a/source/star_formation.rate_surface_density.disks.Blitz2006.F90
+++ b/source/star_formation.rate_surface_density.disks.Blitz2006.F90
@@ -306,7 +306,7 @@ contains
     implicit none
     class(starFormationRateSurfaceDensityDisksBlitz2006), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,blitz2006CalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,blitz2006CalculationReset,openMPThreadBindingAllLevels,label='starFormationRateSurfaceDensityDisksBlitz2006')
     return
   end subroutine blitz2006AutoHook
 

--- a/source/star_formation.rate_surface_density.disks.Kennicutt-Schmidt.F90
+++ b/source/star_formation.rate_surface_density.disks.Kennicutt-Schmidt.F90
@@ -184,7 +184,7 @@ contains
     implicit none
     class(starFormationRateSurfaceDensityDisksKennicuttSchmidt), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,kennicuttSchmidtCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,kennicuttSchmidtCalculationReset,openMPThreadBindingAllLevels,label='starFormationRateSurfaceDensityDisksKennicutt\Schmidt')
     return
   end subroutine kennicuttSchmidtAutoHook
 

--- a/source/star_formation.rate_surface_density.disks.Krumholz2009.F90
+++ b/source/star_formation.rate_surface_density.disks.Krumholz2009.F90
@@ -242,7 +242,7 @@ contains
     implicit none
     class(starFormationRateSurfaceDensityDisksKrumholz2009), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,krumholz2009CalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,krumholz2009CalculationReset,openMPThreadBindingAllLevels,label='starFormationRateSurfaceDensityDisksKrumholz2009')
     return
   end subroutine krumholz2009AutoHook
 

--- a/source/star_formation.rate_surface_density.disks.extended_Schmidt.F90
+++ b/source/star_formation.rate_surface_density.disks.extended_Schmidt.F90
@@ -146,7 +146,7 @@ contains
     implicit none
     class(starFormationRateSurfaceDensityDisksExtendedSchmidt), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,extendedSchmidtCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,extendedSchmidtCalculationReset,openMPThreadBindingAllLevels,label='starFormationRateSurfaceDensityDisksExtendedS\chmidt')
     return
   end subroutine extendedSchmidtAutoHook
 

--- a/source/star_formation.timescales.halo_scaling.F90
+++ b/source/star_formation.timescales.halo_scaling.F90
@@ -154,7 +154,7 @@ contains
     implicit none
     class(starFormationTimescaleHaloScaling), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,haloScalingCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,haloScalingCalculationReset,openMPThreadBindingAllLevels,label='starFormationTimescaleHaloScaling')
     return
   end subroutine haloScalingAutoHook
 

--- a/source/star_formation.timescales.velocity_maximum_scaling.F90
+++ b/source/star_formation.timescales.velocity_maximum_scaling.F90
@@ -154,7 +154,7 @@ contains
     implicit none
     class(starFormationTimescaleVelocityMaxScaling), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,velocityMaxScalingCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,velocityMaxScalingCalculationReset,openMPThreadBindingAllLevels,label='starFormationTimescaleVelocityMaxScaling')
     return
   end subroutine velocityMaxScalingAutoHook
 

--- a/source/stellar_feedback.outflows.Creasey2012.F90
+++ b/source/stellar_feedback.outflows.Creasey2012.F90
@@ -106,6 +106,7 @@ contains
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="starFormationRateSurfaceDensityDisks_"/>
+    <objectDestructor name="galacticStructure_"                   />
     !!]
     return
   end function creasey2012ConstructorParameters

--- a/source/structure_formation.cosmological_density_field.F90
+++ b/source/structure_formation.cosmological_density_field.F90
@@ -152,7 +152,7 @@ module Cosmological_Density_Field
      <only>calculationResetEvent, openMPThreadBindingAllLevels</only>
     </modules>
     <code>
-     call calculationResetEvent%attach(self,criticalOverdensityCalculationReset,openMPThreadBindingAllLevels)
+     call calculationResetEvent%attach(self,criticalOverdensityCalculationReset,openMPThreadBindingAllLevels,label='criticalOverdensity')
      return
     </code>
    </autoHook>

--- a/source/structure_formation.critical_overdensity.spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation.critical_overdensity.spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
@@ -76,13 +76,13 @@ contains
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
     type            (criticalOverdensitySphericalCollapseClsnlssMttrCsmlgclCnstnt)                :: self
-    type            (inputParameters                                              ), intent(inout) :: parameters
-    class           (cosmologyFunctionsClass                                      ), pointer       :: cosmologyFunctions_
-    class           (linearGrowthClass                                            ), pointer       :: linearGrowth_
-    class           (cosmologicalMassVarianceClass                                ), pointer       :: cosmologicalMassVariance_
-    class           (darkMatterParticleClass                                      ), pointer       :: darkMatterParticle_
-    double precision                                                                               :: normalization
-    logical                                                                                        :: tableStore
+    type            (inputParameters                                             ), intent(inout) :: parameters
+    class           (cosmologyFunctionsClass                                     ), pointer       :: cosmologyFunctions_
+    class           (linearGrowthClass                                           ), pointer       :: linearGrowth_
+    class           (cosmologicalMassVarianceClass                               ), pointer       :: cosmologicalMassVariance_
+    class           (darkMatterParticleClass                                     ), pointer       :: darkMatterParticle_
+    double precision                                                                              :: normalization
+    logical                                                                                       :: tableStore
 
     !![
     <inputParameter>

--- a/source/structure_formation.halo_environment.normal.F90
+++ b/source/structure_formation.halo_environment.normal.F90
@@ -243,7 +243,7 @@ contains
     implicit none
     class(haloEnvironmentNormal), intent(inout) :: self
 
-    call calculationResetEvent%attach(self,normalCalculationReset,openMPThreadBindingAllLevels)
+    call calculationResetEvent%attach(self,normalCalculationReset,openMPThreadBindingAllLevels,label='haloEnvironmentNormal')
     return
   end subroutine normalAutoHook
 

--- a/source/tasks.evolve_forests.F90
+++ b/source/tasks.evolve_forests.F90
@@ -249,12 +249,12 @@ contains
     !!{
     Attach to state store/restore event hooks.
     !!}
-    use :: Events_Hooks, only : openMPThreadBindingNone, stateRestoreEvent, stateStoreEvent
+    use :: Events_Hooks, only : openMPThreadBindingNone, stateRestoreEventGlobal, stateStoreEventGlobal
     implicit none
     class(taskEvolveForests), intent(inout) :: self
 
-    call stateStoreEvent  %attach(self,evolveForestsStateStore  ,openMPThreadBindingNone,label='evolveForests')
-    call stateRestoreEvent%attach(self,evolveForestsStateRestore,openMPThreadBindingNone,label='evolveForests')
+    call   stateStoreEventGlobal%attach(self,evolveForestsStateStore  ,openMPThreadBindingNone,label='evolveForests')
+    call stateRestoreEventGlobal%attach(self,evolveForestsStateRestore,openMPThreadBindingNone,label='evolveForests')
     return
   end subroutine evolveForestsAutoHook
 
@@ -304,7 +304,7 @@ contains
     !!{
     Destructor for the {\normalfont \ttfamily evolveForests} task class.
     !!}
-    use :: Events_Hooks   , only : stateRestoreEvent           , stateStoreEvent
+    use :: Events_Hooks   , only : stateRestoreEventGlobal     , stateStoreEventGlobal
     use :: Node_Components, only : Node_Components_Uninitialize
     implicit none
     type(taskEvolveForests), intent(inout) :: self
@@ -321,9 +321,9 @@ contains
     <objectDestructor name="self%mergerTreeOutputter_"   />
     <objectDestructor name="self%mergerTreeInitializor_" />
     !!]
-    if (stateStoreEvent  %isAttached(self,evolveForestsStateStore  )) call stateStoreEvent  %detach(self,evolveForestsStateStore  )
-    if (stateRestoreEvent%isAttached(self,evolveForestsStateRestore)) call stateRestoreEvent%detach(self,evolveForestsStateRestore)
-    if (self%nodeComponentsInitialized)                               call Node_Components_Uninitialize()
+    if (stateStoreEventGlobal  %isAttached(self,evolveForestsStateStore  )) call stateStoreEventGlobal  %detach(self,evolveForestsStateStore  )
+    if (stateRestoreEventGlobal%isAttached(self,evolveForestsStateRestore)) call stateRestoreEventGlobal%detach(self,evolveForestsStateRestore)
+    if (self%nodeComponentsInitialized                                    ) call Node_Components_Uninitialize()
     return
   end subroutine evolveForestsDestructor
 

--- a/source/tasks.evolve_forests.F90
+++ b/source/tasks.evolve_forests.F90
@@ -62,7 +62,7 @@
      class           (outputTimesClass           ), pointer :: outputTimes_                  => null()
      class           (universeOperatorClass      ), pointer :: universeOperator_             => null()
      ! Pointer to the parameters for this task.
-     type            (inputParameters            )          :: parameters
+     type            (inputParameters            ), pointer          :: parameters
      logical                                                :: initialized                   =.false., nodeComponentsInitialized=.false.
    contains
      !![
@@ -240,10 +240,9 @@ contains
     <constructorAssign variables="evolveSingleForest, evolveSingleForestSections, evolveSingleForestMassMinimum, walltimeMaximum, suspendToRAM, suspendPath, *mergerTreeConstructor_, *mergerTreeOperator_, *nodeOperator_, *evolveForestsWorkShare_, *outputTimes_, *universeOperator_, *mergerTreeEvolver_, *mergerTreeOutputter_, *mergerTreeInitializor_"/>
     !!]
 
-    self%parameters=inputParameters(parameters)
-    call self%parameters%parametersGroupCopy(parameters)
-    self%initialized=.true.
-    return
+    self%parameters  => parameters
+    self%initialized =  .true.
+    return 
   end function evolveForestsConstructorInternal
 
   subroutine evolveForestsAutoHook(self)
@@ -254,8 +253,8 @@ contains
     implicit none
     class(taskEvolveForests), intent(inout) :: self
 
-    call stateStoreEvent  %attach(self,evolveForestsStateStore  ,openMPThreadBindingNone)
-    call stateRestoreEvent%attach(self,evolveForestsStateRestore,openMPThreadBindingNone)
+    call stateStoreEvent  %attach(self,evolveForestsStateStore  ,openMPThreadBindingNone,label='evolveForests')
+    call stateRestoreEvent%attach(self,evolveForestsStateRestore,openMPThreadBindingNone,label='evolveForests')
     return
   end subroutine evolveForestsAutoHook
 
@@ -392,6 +391,7 @@ contains
     double precision                               , allocatable, dimension(:), save :: massBranch
     integer                                                                   , save :: forestSection
     double precision                                                          , save :: timeSectionForestBegin
+    type            (inputParameters              ) , allocatable             , save :: parameters
     logical                                                                          :: triggerExit                               , triggerFinishUniverse       , &
          &                                                                              disableSingleForestEvolution              , triggerFinishFinal          , &
          &                                                                              triggerFinish
@@ -399,7 +399,7 @@ contains
     integer         (omp_lock_kind                )                                  :: initializationLock
     integer         (kind_int8                    )                                  :: systemClockRate                           , systemClockMaximum
     double precision                                                                 :: evolveToTimeForest
-    !$omp threadprivate(node,basic,basicChild,timeBranchSplit,branchNew,branchNext,i,iBranch,branchAccept,massBranch,timeSectionForestBegin,forestSection,treeNumber,treesFinished)
+    !$omp threadprivate(node,basic,basicChild,timeBranchSplit,branchNew,branchNext,i,iBranch,branchAccept,massBranch,timeSectionForestBegin,forestSection,treeNumber,treesFinished,parameters)
 
     ! The following processes merger trees, one at a time, to each successive output time, then dumps their contents to file. It
     ! allows for the possibility of "universal events" - events which require all merger trees to reach the same cosmic time. If
@@ -425,6 +425,7 @@ contains
     ! Initialize universes which will act as tree stacks. We use two stacks: one for trees waiting to be processed, one for trees
     ! that have already been processed.
     self%universeWaiting  =universe()
+
     self%universeProcessed=universe()
 
     ! Set record of whether any trees were evolved to false initially.
@@ -460,7 +461,10 @@ contains
     !!]
     !$omp end critical(evolveForestsDeepCopy)
     ! Call routines to perform initializations which must occur for all threads if run in parallel.
-    call Node_Components_Thread_Initialize(self%parameters)
+    allocate(parameters)
+    parameters=inputParameters(self%parameters)
+    call parameters%parametersGroupCopy(self%parameters)
+    call Node_Components_Thread_Initialize(parameters)
     ! Allow events to be attached to the universe.
     !$omp master
     self%universeWaiting%event => null()
@@ -977,7 +981,6 @@ contains
     ! Reduce outputs back into the original outputter object.
     call evolveForestsMergerTreeOutputter_%reduce  (self%mergerTreeOutputter_)
     ! Explicitly deallocate objects.
-    call Node_Components_Thread_Uninitialize()
     !![
     <objectDestructor name="evolveForestsMergerTreeOutputter_"  />
     <objectDestructor name="evolveForestsMergerTreeInitializor_"/>
@@ -986,6 +989,13 @@ contains
     <objectDestructor name="evolveForestsMergerTreeOperator_"   />
     <objectDestructor name="evolveForestsNodeOperator_"         />
     !!]
+    call Node_Components_Thread_Uninitialize()
+    !$omp barrier
+    !$omp critical(evolveForestReset)
+    call parameters%reset()
+    !$omp end critical(evolveForestReset)
+    !$omp barrier
+    deallocate(parameters)
     !$omp end parallel
 
     ! Finalize outputs.

--- a/source/tasks.halo_mass_function.F90
+++ b/source/tasks.halo_mass_function.F90
@@ -514,6 +514,7 @@ contains
     class           (darkMatterProfileScaleRadiusClass      ), pointer                               :: darkMatterProfileScaleRadius_                 => null()
     class           (darkMatterHaloMassAccretionHistoryClass), pointer                               :: darkMatterHaloMassAccretionHistory_           => null()
     class           (virialDensityContrastClass             ), pointer                               :: virialDensityContrast_                        => null()
+    !$omp threadprivate(haloEnvironment_,cosmologyFunctions_,cosmologyParameters_,cosmologicalMassVariance_,haloMassFunction_,darkMatterHaloScale_,darkMatterProfileDMO_,unevolvedSubhaloMassFunction_,darkMatterHaloBias_,darkMatterProfileScaleRadius_,darkMatterHaloMassAccretionHistory_,virialDensityContrast_,criticalOverdensity_)
     type            (virialDensityContrastList              ), allocatable   , dimension(:   )       :: virialDensityContrasts
     type            (mergerTree                             ), allocatable   , target         , save :: tree
     !$omp threadprivate(tree)
@@ -646,7 +647,7 @@ contains
     end if
     massHalo                   =Make_Range(massHaloMinimum,massHaloMaximum,int(massCount),rangeTypeLogarithmic)
     massHaloLogarithmicInterval=log(massHaloMaximum/massHaloMinimum)/dble(massCount-1)
-    !$omp parallel private(iOutput,iMass,densityMean,densityCritical,basic,darkMatterProfileHalo,massHaloBinMinimum,massHaloBinMaximum,haloEnvironment_,cosmologyFunctions_,cosmologyParameters_,cosmologicalMassVariance_,criticalOverdensity_,haloMassFunction_,darkMatterHaloScale_,darkMatterProfileDMO_,unevolvedSubhaloMassFunction_,darkMatterHaloBias_,darkMatterProfileScaleRadius_,darkMatterHaloMassAccretionHistory_,virialDensityContrast_,virialDensityContrasts,integrator_)
+    !$omp parallel private(iOutput,iMass,densityMean,densityCritical,basic,darkMatterProfileHalo,massHaloBinMinimum,massHaloBinMaximum,virialDensityContrasts,integrator_)
     allocate(haloEnvironment_                   ,mold=self%haloEnvironment_                   )
     allocate(cosmologyFunctions_                ,mold=self%cosmologyFunctions_                )
     allocate(cosmologyParameters_               ,mold=self%cosmologyParameters_               )
@@ -783,7 +784,7 @@ contains
        massFunctionDifferentialLogarithmic(:,iOutput)=+massFunctionDifferential(:,iOutput) &
             &                                         *massHalo
        !$omp end single
-    end do
+    end do    
     call tree%destroy()
     nullify   (basic                )
     nullify   (darkMatterProfileHalo)
@@ -794,6 +795,7 @@ contains
     <objectDestructor name="virialDensityContrast_             "/>
     <objectDestructor name="cosmologyParameters_               "/>
     <objectDestructor name="cosmologyFunctions_                "/>
+    <objectDestructor name="criticalOverdensity_               "/>
     <objectDestructor name="cosmologicalMassVariance_          "/>
     <objectDestructor name="haloMassFunction_                  "/>
     <objectDestructor name="darkMatterHaloScale_               "/>

--- a/source/tests.MPI.F90
+++ b/source/tests.MPI.F90
@@ -30,17 +30,22 @@ program Test_MPI
   use               :: Display      , only : displayMessage     , displayVerbositySet   , verbosityLevelStandard
   !$ use            :: OMP_Lib      , only : OMP_Get_Max_Threads
 #ifdef USEMPI
+  use               :: Events_Hooks , only : eventsHooksInitialize
   use               :: MPI          , only : MPI_Thread_Multiple
   use               :: MPI_Utilities, only : mpiBarrier         , mpiCounter            , mpiFinalize           , mpiInitialize    , &
           &                                  mpiSelf
+#endif
   implicit none
+#ifdef USEMPI
   type   (mpiCounter) :: counter
   integer(c_size_t  ) :: i
-
+#endif
+  
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
-
-  call mpiInitialize(MPI_Thread_Multiple)
+#ifdef USEMPI
+  call mpiInitialize        (MPI_Thread_Multiple)
+  call eventsHooksInitialize(                   )
   if (mpiSelf%rank() == 0) call Unit_Tests_Begin_Group("MPI")
   ! Test MPI/OpenMP counters.
   counter=mpiCounter()

--- a/source/tests.linear_growth.baryons.EdS.F90
+++ b/source/tests.linear_growth.baryons.EdS.F90
@@ -24,6 +24,7 @@ program Tests_Linear_Growth_EdS_Baryons
   use :: Cosmology_Functions       , only : cosmologyFunctionsMatterLambda
   use :: Cosmology_Parameters      , only : cosmologyParametersSimple
   use :: Display                   , only : displayVerbositySet           , verbosityLevelStandard
+  use :: Events_Hooks              , only : eventsHooksInitialize
   use :: Intergalactic_Medium_State, only : intergalacticMediumStateSimple
   use :: Linear_Growth             , only : componentDarkMatter           , linearGrowthBaryonsDarkMatter
   use :: Unit_Tests                , only : Assert                        , Unit_Tests_Begin_Group       , Unit_Tests_End_Group, Unit_Tests_Finish
@@ -40,6 +41,8 @@ program Tests_Linear_Growth_EdS_Baryons
 
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
+  ! Initialize event hooks.
+  call eventsHooksInitialize()
   ! Construct model.
   cosmologyParameters_=cosmologyParametersSimple          (                                                      &
        &                                                   OmegaMatter               = 1.00d0                  , &

--- a/source/tests.locks.F90
+++ b/source/tests.locks.F90
@@ -25,13 +25,14 @@ program Test_Locks
   !!{
   Tests of OpenMP locking functions.
   !!}
-  use            :: Array_Utilities   , only : Array_Is_Monotonic, directionIncreasing
-  use            :: Display           , only : displayMessage    , displayVerbositySet   , verbosityLevelStandard
+  use            :: Array_Utilities   , only : Array_Is_Monotonic   , directionIncreasing
+  use            :: Display           , only : displayMessage       , displayVerbositySet   , verbosityLevelStandard
   use, intrinsic :: ISO_C_Binding     , only : c_size_t
-  use            :: ISO_Varying_String, only : operator(//)      , var_str               , varying_string
+  use            :: ISO_Varying_String, only : operator(//)         , var_str               , varying_string
   use            :: Locks             , only : ompIncrementalLock
   use            :: String_Handling   , only : operator(//)
-  use            :: Unit_Tests        , only : Assert            , Unit_Tests_Begin_Group, Unit_Tests_End_Group  , Unit_Tests_Finish
+  use            :: Unit_Tests        , only : Assert               , Unit_Tests_Begin_Group, Unit_Tests_End_Group  , Unit_Tests_Finish
+  use            :: Events_Hooks      , only : eventsHooksInitialize
   implicit none
   integer         (c_size_t          ), parameter               :: elementCount   =100_c_size_t
   integer         (c_size_t          ), dimension(elementCount) :: orderedCount
@@ -44,7 +45,8 @@ program Test_Locks
 
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
-
+  ! Initialize event hooks.
+  call eventsHooksInitialize()
   call Unit_Tests_Begin_Group("OpenMP")
   ! Test incremental locks. We generate a counter which is not guaranteed to be ordered in terms of OpenMP threads. Then we use an
   ! incremental lock to force the access back to being ordered by counter value and thereby construct and ordered array.

--- a/source/tests.mass_distributions.F90
+++ b/source/tests.mass_distributions.F90
@@ -29,6 +29,7 @@ program Test_Mass_Distributions
   use :: Display                 , only : displayVerbositySet        , verbosityLevelStandard
   use :: Error_Functions         , only : Error_Function
   use :: Error                   , only : Error_Report
+  use :: Events_Hooks            , only : eventsHooksInitialize
   use :: Linear_Algebra          , only : assignment(=)              , vector
   use :: Mass_Distributions      , only : massDistributionBetaProfile, massDistributionClass , massDistributionExponentialDisk, massDistributionGaussianEllipsoid, &
           &                               massDistributionHernquist  , massDistributionSersic, massDistributionSpherical
@@ -60,6 +61,8 @@ program Test_Mass_Distributions
   
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
+  ! Initialize event hooks.
+  call eventsHooksInitialize()
   ! Begin unit tests.
   call Unit_Tests_Begin_Group("Mass distributions")
 

--- a/source/tests.stellar_populations.F90
+++ b/source/tests.stellar_populations.F90
@@ -27,6 +27,7 @@ program Test_Stellar_Populations
   !!}
   use :: Abundances_Structure                      , only : abundances
   use :: Display                                   , only : displayVerbositySet                    , verbosityLevelWorking
+  use :: Events_Hooks                              , only : eventsHooksInitialize
   use :: Functions_Global_Utilities                , only : Functions_Global_Set
   use :: Input_Paths                               , only : inputPath                              , pathTypeDataStatic
   use :: ISO_Varying_String                        , only : char
@@ -61,6 +62,7 @@ program Test_Stellar_Populations
   call displayVerbositySet(verbosityLevelWorking)
   parameters=inputParameters()
   call Functions_Global_Set      (          )
+  call eventsHooksInitialize     (          )
   call Node_Components_Initialize(parameters)
   call abundances_%metallicitySet(metallicitySolar)
   initialMassFunction_     =initialMassFunctionChabrier2001        (                                                                                                                                   &

--- a/source/utility.regular_expressions.F90
+++ b/source/utility.regular_expressions.F90
@@ -21,7 +21,7 @@
 Contains a module which implements regular expressions by wrappring the GNU C Library implementations.
 !!}
 
-! Specify an explicit dependence on the semaphores.o object file.
+! Specify an explicit dependence on the regular_expressions.o object file.
 !: $(BUILDPATH)/regular_expressions.o
 
 module Regular_Expressions


### PR DESCRIPTION
Instead of checking each hooked event on each call to see if it matches the appropriate OpenMP thread(s), we now instead perform this check once, at the start of each new OpenMP parallel region, creating a custom array of functions which need to be called by that thread. Execution of the event then simply involves iterating through that array and calling each function, with no checking to be done. The parent thread's array is restored on exiting the OpenMP parallel region.

Fixes #130 