### PR TITLE
Prevent the `mergerTreeEvolveTimestepHostTidalMassLoss` from taking tiny timesteps

### DIFF
--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -254,7 +254,8 @@
       <!-- This timestep criterion makes sure that subsubahlos do not evolve too far ahead of their host subhalos when
            the host density and mass change rapidily due to tidal effects. It also limits the evolution time of subhalos
            to the time at which the hosts first becomes subhalos. -->
-      <timeStepRelative value="0.1"/>
+      <timeStepRelative        value="0.1"/>
+      <fractionTimestepMinimum value="0.1"/>
     </mergerTreeEvolveTimestep>
   </mergerTreeEvolveTimestep>
 

--- a/source/merger_trees.evolve.timesteps.F90
+++ b/source/merger_trees.evolve.timesteps.F90
@@ -89,6 +89,16 @@ module Merger_Tree_Timesteps
     <argument>type            (treeNode      ), intent(  out), optional, pointer :: lockNode</argument>
     <argument>type            (varying_string), intent(  out), optional          :: lockType</argument>
    </method>
+   <method name="refuseToEvolve">
+    <description>Return true if evolution should be refused.</description>
+    <type>logical</type>
+    <pass>yes</pass>
+    <argument>type(treeNode), intent(inout) :: node</argument>
+    <code>
+      !$GLC attributes unused :: self, node
+      mergerTreeEvolveTimestepRefuseToEvolve=.false.
+    </code>
+   </method>
   </functionClass>
   !!]
 

--- a/source/merger_trees.evolve.timesteps.multi.F90
+++ b/source/merger_trees.evolve.timesteps.multi.F90
@@ -30,6 +30,12 @@
   <mergerTreeEvolveTimestep name="mergerTreeEvolveTimestepMulti">
    <description>A merger tree evolution timestepping class which takes the minimum over multiple other timesteppers.</description>
    <linkedList type="multiMergerTreeEvolveTimestepList" variable="mergerTreeEvolveTimesteps" next="next" object="mergerTreeEvolveTimestep_" objectType="mergerTreeEvolveTimestepClass"/>
+   <deepCopy>
+     <ignore  variables="mergerTreeEvolveTimestep_"/>
+   </deepCopy>
+   <stateStorable>
+     <exclude variables="mergerTreeEvolveTimestep_"/>
+   </stateStorable> 
   </mergerTreeEvolveTimestep>
   !!]
   type, extends(mergerTreeEvolveTimestepClass) :: mergerTreeEvolveTimestepMulti
@@ -37,10 +43,12 @@
      Implementation of a merger tree evolution timestepping class which takes the minimum over multiple other timesteppers.
      !!}
      private
-     type(multiMergerTreeEvolveTimestepList), pointer :: mergerTreeEvolveTimesteps => null()
+     type (multiMergerTreeEvolveTimestepList), pointer :: mergerTreeEvolveTimesteps => null()
+     class(mergerTreeEvolveTimestepClass    ), pointer :: mergerTreeEvolveTimestep_ => null()
    contains
-     final     ::                       multiDestructor
-     procedure :: timeEvolveTo       => multiTimeEvolveTo
+     final     ::                   multiDestructor
+     procedure :: timeEvolveTo   => multiTimeEvolveTo
+     procedure :: refuseToEvolve => multiRefuseToEvolve
   end type mergerTreeEvolveTimestepMulti
 
   interface mergerTreeEvolveTimestepMulti
@@ -162,6 +170,7 @@ contains
        </conditionalCall>
        !!]
        if (timeEvolveTo < multiTimeEvolveTo) then
+          self%mergerTreeEvolveTimestep_  => mergerTreeEvolveTimestep_%mergerTreeEvolveTimestep_
           multiTimeEvolveTo               =  timeEvolveTo
           task                            => task_
           taskSelf                        => taskSelf_
@@ -172,3 +181,15 @@ contains
     end do
     return
   end function multiTimeEvolveTo
+
+  logical function multiRefuseToEvolve(self,node)
+    !!{
+    Refuse to evolve if the timestep is too small.
+    !!}
+    implicit none
+    class(mergerTreeEvolveTimestepMulti), intent(inout) :: self
+    type (treeNode                     ), intent(inout) :: node
+
+    multiRefuseToEvolve=self%mergerTreeEvolveTimestep_%refuseToEvolve(node)
+    return
+  end function multiRefuseToEvolve

--- a/testSuite/parameters/impulsiveHeating.xml
+++ b/testSuite/parameters/impulsiveHeating.xml
@@ -458,7 +458,8 @@
       <!-- This timestep criterion makes sure that subsubahlos do not evolve too far ahead of their host subhalos when
            the host density and mass change rapidily due to tidal effects. It also limits the evolution time of subhalos
            to the time at which the hosts first becomes subhalos. -->
-      <timeStepRelative value="0.1"/>
+      <timeStepRelative        value="0.1"/>
+      <fractionTimestepMinimum value="0.1"/>
     </mergerTreeEvolveTimestep>
   </mergerTreeEvolveTimestep>
 


### PR DESCRIPTION
If tree evolution is using the `backtrackToSatellites` option, this timestep limiter could lead to extremely tiny timesteps for a satellite as it is allowed to evolve only a slight amount beyond the time of its host. This fix prevents this by refusing the evolve the satellite (if this class is the limiting factor in evolution) unless the step that can be taken is a sufficiently large fraction of the mass loss timescale. If a step is refused, this will force the host halo to evolve instead. This evoids tiny timesteps.