### PR TITLE
Reset memoized data in the `darkMatterProfileGeneric` class

### DIFF
--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -254,7 +254,8 @@
       <!-- This timestep criterion makes sure that subsubahlos do not evolve too far ahead of their host subhalos when
            the host density and mass change rapidily due to tidal effects. It also limits the evolution time of subhalos
            to the time at which the hosts first becomes subhalos. -->
-      <timeStepRelative value="0.1"/>
+      <timeStepRelative        value="0.1"/>
+      <fractionTimestepMinimum value="0.1"/>
     </mergerTreeEvolveTimestep>
   </mergerTreeEvolveTimestep>
 

--- a/source/dark_matter_profiles_DMO.heated.monotonic.F90
+++ b/source/dark_matter_profiles_DMO.heated.monotonic.F90
@@ -228,18 +228,24 @@ contains
     type (treeNode                           ), intent(inout) :: node
 
     ! Reset calculations for this profile.
-    self%lastUniqueID                    =node%uniqueID()
-    self%genericLastUniqueID             =node%uniqueID() 
-    self%isBound                         =.true.
-    self%radiusInitialMinimum            =+huge(0.0d0)
-    self%radiusInitialMaximum            =-huge(0.0d0)
-    self%radiusFinalMinimum              =+huge(0.0d0)
-    self%radiusFinalMaximum              =-huge(0.0d0)
-    self%genericEnclosedMassRadiusMinimum=+huge(0.0d0)
-    self%genericEnclosedMassRadiusMaximum=-huge(0.0d0)
-    if (allocated(self%massProfile              )) deallocate(self%massProfile              )
-    if (allocated(self%genericEnclosedMassMass  )) deallocate(self%genericEnclosedMassMass  )
-    if (allocated(self%genericEnclosedMassRadius)) deallocate(self%genericEnclosedMassRadius)
+    self%lastUniqueID                                =node%uniqueID()
+    self%genericLastUniqueID                         =node%uniqueID() 
+    self%isBound                                     =.true.
+    self%radiusInitialMinimum                        =+huge(0.0d0)
+    self%radiusInitialMaximum                        =-huge(0.0d0)
+    self%radiusFinalMinimum                          =+huge(0.0d0)
+    self%radiusFinalMaximum                          =-huge(0.0d0)
+    self%genericEnclosedMassRadiusMinimum            =+huge(0.0d0)
+    self%genericEnclosedMassRadiusMaximum            =-huge(0.0d0)
+    self%genericEnclosedMassRadiusMinimum            =+huge(0.0d0)
+    self%genericEnclosedMassRadiusMaximum            =-huge(0.0d0)
+    self%genericVelocityDispersionRadialRadiusMinimum=+huge(0.0d0)
+    self%genericVelocityDispersionRadialRadiusMaximum=-huge(0.0d0)
+    if (allocated(self%massProfile                            )) deallocate(self%massProfile                            )
+    if (allocated(self%genericVelocityDispersionRadialVelocity)) deallocate(self%genericVelocityDispersionRadialVelocity)
+    if (allocated(self%genericVelocityDispersionRadialRadius  )) deallocate(self%genericVelocityDispersionRadialRadius  )
+    if (allocated(self%genericEnclosedMassMass                )) deallocate(self%genericEnclosedMassMass                )
+    if (allocated(self%genericEnclosedMassRadius              )) deallocate(self%genericEnclosedMassRadius              )
     return
   end subroutine heatedMonotonicCalculationReset
 

--- a/source/merger_trees.evolve.timesteps.F90
+++ b/source/merger_trees.evolve.timesteps.F90
@@ -89,6 +89,16 @@ module Merger_Tree_Timesteps
     <argument>type            (treeNode      ), intent(  out), optional, pointer :: lockNode</argument>
     <argument>type            (varying_string), intent(  out), optional          :: lockType</argument>
    </method>
+   <method name="refuseToEvolve">
+    <description>Return true if evolution should be refused.</description>
+    <type>logical</type>
+    <pass>yes</pass>
+    <argument>type(treeNode), intent(inout) :: node</argument>
+    <code>
+      !$GLC attributes unused :: self, node
+      mergerTreeEvolveTimestepRefuseToEvolve=.false.
+    </code>
+   </method>
   </functionClass>
   !!]
 

--- a/source/merger_trees.evolve.timesteps.multi.F90
+++ b/source/merger_trees.evolve.timesteps.multi.F90
@@ -30,6 +30,12 @@
   <mergerTreeEvolveTimestep name="mergerTreeEvolveTimestepMulti">
    <description>A merger tree evolution timestepping class which takes the minimum over multiple other timesteppers.</description>
    <linkedList type="multiMergerTreeEvolveTimestepList" variable="mergerTreeEvolveTimesteps" next="next" object="mergerTreeEvolveTimestep_" objectType="mergerTreeEvolveTimestepClass"/>
+   <deepCopy>
+     <ignore  variables="mergerTreeEvolveTimestep_"/>
+   </deepCopy>
+   <stateStorable>
+     <exclude variables="mergerTreeEvolveTimestep_"/>
+   </stateStorable> 
   </mergerTreeEvolveTimestep>
   !!]
   type, extends(mergerTreeEvolveTimestepClass) :: mergerTreeEvolveTimestepMulti
@@ -37,10 +43,12 @@
      Implementation of a merger tree evolution timestepping class which takes the minimum over multiple other timesteppers.
      !!}
      private
-     type(multiMergerTreeEvolveTimestepList), pointer :: mergerTreeEvolveTimesteps => null()
+     type (multiMergerTreeEvolveTimestepList), pointer :: mergerTreeEvolveTimesteps => null()
+     class(mergerTreeEvolveTimestepClass    ), pointer :: mergerTreeEvolveTimestep_ => null()
    contains
-     final     ::                       multiDestructor
-     procedure :: timeEvolveTo       => multiTimeEvolveTo
+     final     ::                   multiDestructor
+     procedure :: timeEvolveTo   => multiTimeEvolveTo
+     procedure :: refuseToEvolve => multiRefuseToEvolve
   end type mergerTreeEvolveTimestepMulti
 
   interface mergerTreeEvolveTimestepMulti
@@ -162,6 +170,7 @@ contains
        </conditionalCall>
        !!]
        if (timeEvolveTo < multiTimeEvolveTo) then
+          self%mergerTreeEvolveTimestep_  => mergerTreeEvolveTimestep_%mergerTreeEvolveTimestep_
           multiTimeEvolveTo               =  timeEvolveTo
           task                            => task_
           taskSelf                        => taskSelf_
@@ -172,3 +181,15 @@ contains
     end do
     return
   end function multiTimeEvolveTo
+
+  logical function multiRefuseToEvolve(self,node)
+    !!{
+    Refuse to evolve if the timestep is too small.
+    !!}
+    implicit none
+    class(mergerTreeEvolveTimestepMulti), intent(inout) :: self
+    type (treeNode                     ), intent(inout) :: node
+
+    multiRefuseToEvolve=self%mergerTreeEvolveTimestep_%refuseToEvolve(node)
+    return
+  end function multiRefuseToEvolve

--- a/testSuite/parameters/impulsiveHeating.xml
+++ b/testSuite/parameters/impulsiveHeating.xml
@@ -458,7 +458,8 @@
       <!-- This timestep criterion makes sure that subsubahlos do not evolve too far ahead of their host subhalos when
            the host density and mass change rapidily due to tidal effects. It also limits the evolution time of subhalos
            to the time at which the hosts first becomes subhalos. -->
-      <timeStepRelative value="0.1"/>
+      <timeStepRelative        value="0.1"/>
+      <fractionTimestepMinimum value="0.1"/>
     </mergerTreeEvolveTimestep>
   </mergerTreeEvolveTimestep>
 


### PR DESCRIPTION
Two classes, `darkMatterProfileDMOHeatedMonotonic` and `darkMatterProfileDMOAccretionFlow`, were failing to reset some of the memoized data structures inherited from the `darkMatterProfileGeneric` class, which caused incorrect results to be returned in some cases (e.g. for velocity dispersions).