### PR TITLE
Test using the `workflow_run` dispatch for GitHub Actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -150,7 +150,7 @@ jobs:
           repository: galacticusorg/datasets
           path: datasets
       - run: echo "The $githubrepository repository has been cloned to the runner."
-      - name: update cache on every commit
+      - name: Cache dynamically-generated datasets
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/datasets/dynamic

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -150,6 +150,13 @@ jobs:
           repository: galacticusorg/datasets
           path: datasets
       - run: echo "The $githubrepository repository has been cloned to the runner."
+      - name: update cache on every commit
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/datasets/dynamic
+          key: benchmarks-milkyWay-${{ github.run_id }}
+          restore-keys: |
+            benchmarks-milkyWay
       - name: "Set environmental variables"
         run: |
           echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV

--- a/.github/workflows/buildCode.yml
+++ b/.github/workflows/buildCode.yml
@@ -74,6 +74,11 @@ jobs:
           grep -v -q Warning: build.log
           grep -v 'is up to date' build.log | grep -v -q make: 
           md5sum Galacticus.exe
+      - name: Upload executables
+        uses: actions/upload-artifact@v2
+        with:
+          name: galacticus-exec
+          path: '**.exe'
       - name: Update release
         if: ${{ steps.extract_branch.outputs.branch == 'master' }}
         uses: johnwbyrd/update-release@v1.0.0

--- a/.github/workflows/testCosmology.yml
+++ b/.github/workflows/testCosmology.yml
@@ -1,9 +1,8 @@
 name: Test-Cosmology
 on:
   workflow_run:
-    workflows: Builder
-    types:
-      - completed
+    workflows: [Builder]
+    types: [completed]
 defaults:
   run:
     shell: bash

--- a/.github/workflows/testCosmology.yml
+++ b/.github/workflows/testCosmology.yml
@@ -1,46 +1,9 @@
 name: Test-Cosmology
 on:
-  workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - master
-    paths:
-      - 'Makefile'
-      - 'source/**'
-      - 'source/Bivar/**'
-      - 'source/ISO_Varying_String/**'
-      - 'source/gslODEInitVal2/**'
-      - 'source/NSWC/**'
-      - 'source/pFq/**'
-      - 'source/gslSpecFuncApprox/**'
-      - 'source/FFTlog/**'
-      - 'perl/**'
-      - 'perl/File/**'
-      - 'perl/Galacticus/**'
-      - 'perl/Galacticus/Launch/**'
-      - 'perl/Galacticus/Constraints/**'
-      - 'perl/Galacticus/Build/**'
-      - 'perl/Galacticus/Build/Components/**'
-      - 'perl/Galacticus/Build/Components/Classes/**'
-      - 'perl/Galacticus/Build/Components/Implementations/**'
-      - 'perl/Galacticus/Build/Components/Properties/**'
-      - 'perl/Galacticus/Build/Components/TreeNodes/**'
-      - 'perl/Galacticus/Build/Components/Hierarchy/**'
-      - 'perl/Galacticus/Build/SourceTree/**'
-      - 'perl/Galacticus/Build/SourceTree/Parse/**'
-      - 'perl/Galacticus/Build/SourceTree/Analyze/**'
-      - 'perl/Galacticus/Build/SourceTree/Process/**'
-      - 'perl/Galacticus/Build/SourceTree/Process/FunctionClass/**'
-      - 'perl/List/**'
-      - 'perl/Sort/**'
-      - 'perl/LaTeX/**'
-      - 'perl/IO/**'
-      - 'perl/IO/Compress/**'
-      - 'perl/System/**'
-      - 'perl/Fortran/**'
-      - 'scripts/build/**'
-      - 'schema/**'
+  workflow_run:
+    workflows: Builder
+    types:
+      - completed
 defaults:
   run:
     shell: bash
@@ -48,35 +11,10 @@ concurrency:
   group: test-cosmology-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  Build-Executables:
-    runs-on: ubuntu-latest
-    container: docker://galacticusorg/buildenv:latest
-    steps:
-      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "This job is now running on a ${{ runner.os }} server."
-      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
-      - name: "Set environmental variables"
-        run: |
-          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
-      - name: Build the code
-        run: |
-          cd $GALACTICUS_EXEC_PATH
-          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
-          make -j2 Galacticus.exe
-      - name: Upload executables
-        uses: actions/upload-artifact@v2
-        with:
-          name: galacticus-exec
-          path: '**.exe'
-      - run: echo "This job's status is ${{ job.status }}."
   Runner-1:
     runs-on: ubuntu-latest
     container: docker://galacticusorg/buildenv:latest
-    needs: Build-Executables
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "This job is now running on a ${{ runner.os }} server."
@@ -94,9 +32,27 @@ jobs:
           echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
       - name: Download executables
-        uses: actions/download-artifact@v2
+        uses: actions/github-script@v6
         with:
-          name: galacticus-exec
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "galacticus-exec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/galacticus-exec.zip`, Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip galacticus-exec.zip
       - name: Create test suite output directory
         run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
       - name: Run test
@@ -113,7 +69,7 @@ jobs:
   Runner-2:
     runs-on: ubuntu-latest
     container: docker://galacticusorg/buildenv:latest
-    needs: Build-Executables
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "This job is now running on a ${{ runner.os }} server."
@@ -131,9 +87,27 @@ jobs:
           echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
       - name: Download executables
-        uses: actions/download-artifact@v2
+        uses: actions/github-script@v6
         with:
-          name: galacticus-exec
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "galacticus-exec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/galacticus-exec.zip`, Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip galacticus-exec.zip
       - name: Create test suite output directory
         run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
       - name: Run test

--- a/.github/workflows/testRegressions.yml
+++ b/.github/workflows/testRegressions.yml
@@ -265,6 +265,13 @@ jobs:
           repository: galacticusorg/datasets
           path: datasets
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: Cache dynamically-generated datasets
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/datasets/dynamic
+          key: benchmarks-milkyWay-${{ github.run_id }}
+          restore-keys: |
+            regressions-Cole2000
       - name: "Set environmental variables"
         run: |
           echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
@@ -475,6 +482,13 @@ jobs:
           repository: galacticusorg/datasets
           path: datasets
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: Cache dynamically-generated datasets
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/datasets/dynamic
+          key: benchmarks-milkyWay-${{ github.run_id }}
+          restore-keys: |
+            regressions-issue142
       - name: "Set environmental variables"
         run: |
           echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -151,6 +151,13 @@ jobs:
           repository: galacticusorg/datasets
           path: datasets
       - run: echo "The $githubrepository repository has been cloned to the runner."
+      - name: Cache dynamically-generated datasets
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/datasets/dynamic
+          key: benchmarks-milkyWay-${{ github.run_id }}
+          restore-keys: |
+            benchmarks-milkyWay
       - name: "Set environmental variables"
         run: |
           echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV


### PR DESCRIPTION
In this test `Galacticus.exe` is built by one workflow, another workflow is triggered by the completion of this and just uses the `Galacticus.exe` artifact from the first workflow, without needing to rebuild it itself.