### PR TITLE
Correct chemical densities in cooling calculations

### DIFF
--- a/source/chemical.reaction_rates.utilities.F90
+++ b/source/chemical.reaction_rates.utilities.F90
@@ -27,13 +27,13 @@ module Chemical_Reaction_Rates_Utilities
   !!}
   implicit none
   private
-  public :: Chemicals_Mass_To_Density_Conversion
+  public :: Chemicals_Mass_To_Density_Conversion, Chemicals_Mass_To_Fraction_Conversion
 
 contains
 
   double precision function Chemicals_Mass_To_Density_Conversion(radius)
     !!{
-    Returns the conversion factor from mass of chemicals in ($M_\odot/M_\mathrm{atomic}$) to number density in cm$^{-3}$ assuming
+    Returns the conversion factor from mass of chemicals in ($M_\odot$) to number density in cm$^{-3}$ assuming
     that the mass is distributed uniformly in a sphere of the given {\normalfont \ttfamily radius} (in Mpc).
     !!}
     use :: Numerical_Constants_Astronomical, only : massSolar     , megaParsec
@@ -46,5 +46,20 @@ contains
     Chemicals_Mass_To_Density_Conversion=3.0d0*massSolar/atomicMassUnit/4.0d0/Pi/(hecto*megaParsec*radius)**3
     return
   end function Chemicals_Mass_To_Density_Conversion
+
+  double precision function Chemicals_Mass_To_Fraction_Conversion(massTotal)
+    !!{
+    Returns the conversion factor from mass of chemicals in ($M_\odot$) to a number density (in cm$^{-3}$) per unit total mass
+    density given a total {\normalfont \ttfamily mass} (in $\mathrm{M}_\odot$).
+    !!}
+    use :: Numerical_Constants_Astronomical, only : massSolar     , megaParsec
+    use :: Numerical_Constants_Atomic      , only : atomicMassUnit
+    use :: Numerical_Constants_Prefixes    , only : hecto
+    implicit none
+    double precision, intent(in   ) :: massTotal
+
+    Chemicals_Mass_To_Fraction_Conversion=massSolar/atomicMassUnit/(hecto*megaParsec)**3/massTotal
+    return
+  end function Chemicals_Mass_To_Fraction_Conversion
 
 end module Chemical_Reaction_Rates_Utilities

--- a/source/cooling.cooling_radius.beta_profile.F90
+++ b/source/cooling.cooling_radius.beta_profile.F90
@@ -259,8 +259,8 @@ contains
     !!}
     use :: Abundances_Structure             , only : abundances
     use :: Chemical_Abundances_Structure    , only : chemicalAbundances
-    use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Density_Conversion
-    use :: Galacticus_Nodes                 , only : nodeComponentBasic                  , nodeComponentHotHalo, treeNode
+    use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Fraction_Conversion
+    use :: Galacticus_Nodes                 , only : nodeComponentBasic                   , nodeComponentHotHalo, treeNode
     implicit none
     class           (coolingRadiusBetaProfile), intent(inout) :: self
     type            (treeNode                ), intent(inout) :: node
@@ -271,7 +271,7 @@ contains
          &                                                       temperature      , outerRadius            , &
          &                                                       densityOuter     , coolingTimeOuter
     type            (abundances              )                :: hotAbundances
-    type            (chemicalAbundances      )                :: chemicalDensities, chemicalMasses
+    type            (chemicalAbundances      )                :: chemicalFractions, chemicalMasses
 
     ! Check if node differs from previous one for which we performed calculations.
     if (node%uniqueID() /= self%lastUniqueID) call self%calculationReset(node)
@@ -288,14 +288,14 @@ contains
        if (self%chemicalsCount > 0) then
           chemicalMasses=hotHalo%chemicals()
           ! Scale all chemical masses by their mass in atomic mass units to get a number density.
-          call chemicalMasses%massToNumber(chemicalDensities)
-          if (hotHalo%outerRadius() > 0.0d0) then
-             massToDensityConversion=Chemicals_Mass_To_Density_Conversion(hotHalo%outerRadius())
+          call chemicalMasses%massToNumber(chemicalFractions)
+          if (hotHalo%mass() > 0.0d0) then
+             massToDensityConversion=Chemicals_Mass_To_Fraction_Conversion(hotHalo%mass())
           else
              massToDensityConversion=0.0d0
-          end if
-          ! Convert to number density.
-          chemicalDensities=chemicalDensities*massToDensityConversion
+          end if          
+          ! Convert to number density per unit total mass density.
+          chemicalFractions=chemicalFractions*massToDensityConversion
        end if
        ! Set epoch for radiation field.
        basic => node%basic()
@@ -307,8 +307,8 @@ contains
        ! Compute density and cooling time at outer radius and zero radius.
        densityZero     =self%hotHaloMassDistribution_  %density(node,0.0d0      )
        densityOuter    =self%hotHaloMassDistribution_  %density(node,outerRadius)
-       coolingTimeZero =self%coolingTime_              %time   (node,temperature,densityZero ,hotAbundances,chemicalDensities,self%radiation)
-       coolingTimeOuter=self%coolingTime_              %time   (node,temperature,densityOuter,hotAbundances,chemicalDensities,self%radiation)
+       coolingTimeZero =self%coolingTime_              %time   (node,temperature,densityZero ,hotAbundances,chemicalFractions*densityZero,self%radiation)
+       coolingTimeOuter=self%coolingTime_              %time   (node,temperature,densityOuter,hotAbundances,chemicalFractions*densityOuter,self%radiation)
        if (coolingTimeOuter < timeAvailable .or. coolingTimeZero > timeAvailable) then
           ! Cooling radius is static.
           self%radiusGrowthRateStored=0.0d0
@@ -337,8 +337,8 @@ contains
     !!}
     use :: Abundances_Structure             , only : abundances
     use :: Chemical_Abundances_Structure    , only : chemicalAbundances
-    use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Density_Conversion
-    use :: Galacticus_Nodes                 , only : nodeComponentBasic                  , nodeComponentHotHalo, treeNode
+    use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Fraction_Conversion
+    use :: Galacticus_Nodes                 , only : nodeComponentBasic                   , nodeComponentHotHalo, treeNode
     implicit none
     class           (coolingRadiusBetaProfile), intent(inout), target  :: self
     type            (treeNode                ), intent(inout), target  :: node
@@ -349,7 +349,7 @@ contains
          &                                                                temperature      , outerRadius            , &
          &                                                                densityOuter     , coolingTimeOuter
     type            (abundances              )                         :: hotAbundances
-    type            (chemicalAbundances      )                         :: chemicalDensities, chemicalMasses
+    type            (chemicalAbundances      )                         :: chemicalFractions, chemicalMasses
 
     ! Check if node differs from previous one for which we performed calculations.
     if (node%uniqueID() /= self%lastUniqueID) call self%calculationReset(node)
@@ -365,14 +365,14 @@ contains
        if (self%chemicalsCount > 0) then
           chemicalMasses=hotHalo%chemicals()
           ! Scale all chemical masses by their mass in atomic mass units to get a number density.
-          call chemicalMasses%massToNumber(chemicalDensities)
-          if (hotHalo%outerRadius() > 0.0d0) then
-             massToDensityConversion=Chemicals_Mass_To_Density_Conversion(hotHalo%outerRadius())
+          call chemicalMasses%massToNumber(chemicalFractions)
+          if (hotHalo%mass() > 0.0d0) then
+             massToDensityConversion=Chemicals_Mass_To_Fraction_Conversion(hotHalo%mass())
           else
              massToDensityConversion=0.0d0
-          end if
-          ! Convert to number density.
-          chemicalDensities=chemicalDensities*massToDensityConversion
+          end if          
+          ! Convert to number density per unit total mass density.
+          chemicalFractions=chemicalFractions*massToDensityConversion
        end if
        ! Set epoch for radiation field.
        basic => node%basic()
@@ -384,8 +384,8 @@ contains
        ! Compute density and cooling time at outer radius and zero radius.
        densityZero     =self%hotHaloMassDistribution_  %density(node,0.0d0                                                                  )
        densityOuter    =self%hotHaloMassDistribution_  %density(node,outerRadius                                                            )
-       coolingTimeZero =self%coolingTime_              %time   (node,temperature,densityZero ,hotAbundances,chemicalDensities,self%radiation)
-       coolingTimeOuter=self%coolingTime_              %time   (node,temperature,densityOuter,hotAbundances,chemicalDensities,self%radiation)
+       coolingTimeZero =self%coolingTime_              %time   (node,temperature,densityZero ,hotAbundances,chemicalFractions*densityZero,self%radiation)
+       coolingTimeOuter=self%coolingTime_              %time   (node,temperature,densityOuter,hotAbundances,chemicalFractions*densityOuter,self%radiation)
        if (coolingTimeOuter < timeAvailable) then
           ! Cooling time available exceeds cooling time at virial radius, return virial radius.
           self%radiusStored=outerRadius

--- a/source/nodes.property_extractor.ICM_Xray_luminosity.F90
+++ b/source/nodes.property_extractor.ICM_Xray_luminosity.F90
@@ -167,19 +167,19 @@ contains
       !!}
       use :: Abundances_Structure             , only : abundances
       use :: Chemical_Abundances_Structure    , only : chemicalAbundances
-      use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Density_Conversion
-      use :: Numerical_Constants_Astronomical , only : massSolar                           , megaParsec
+      use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Fraction_Conversion
+      use :: Numerical_Constants_Astronomical , only : massSolar                            , megaParsec
       use :: Numerical_Constants_Atomic       , only : massHydrogenAtom
       use :: Numerical_Constants_Math         , only : Pi
-      use :: Numerical_Constants_Prefixes     , only : centi                               , hecto
+      use :: Numerical_Constants_Prefixes     , only : centi                                , hecto
       implicit none
       double precision                      , intent(in   ) :: radius
       class           (nodeComponentHotHalo), pointer       :: hotHalo
-      double precision                                      :: density                , temperature       , &
-           &                                                   numberDensityHydrogen  , massICM           , &
+      double precision                                      :: density                , temperature        , &
+           &                                                   numberDensityHydrogen  , massICM            , &
            &                                                   massToDensityConversion
       type            (abundances          )                :: abundancesICM
-      type            (chemicalAbundances  )                :: massChemicalICM        , densityChemicalICM
+      type            (chemicalAbundances  )                :: massChemicalICM        , fractionChemicalICM
 
       ! Get the density of the ICM.
       density    =self%hotHaloMassDistribution_  %density    (node,radius)
@@ -190,16 +190,16 @@ contains
       massICM         =  hotHalo%mass      ()
       abundancesICM   =  hotHalo%abundances()
       massChemicalICM =  hotHalo%chemicals ()
-      call abundancesICM  %massToMassFraction(           massICM)
-      call massChemicalICM%massToNumber      (densityChemicalICM)
+      call abundancesICM  %massToMassFraction(            massICM)
+      call massChemicalICM%massToNumber      (fractionChemicalICM)
       ! Compute factor converting mass of chemicals in (M☉/Mₐₘᵤ) to number density in cm⁻³.
-      if (hotHalo%outerRadius() > 0.0d0) then
-         massToDensityConversion=Chemicals_Mass_To_Density_Conversion(hotHalo%outerRadius())
+      if (hotHalo%mass() > 0.0d0) then
+         massToDensityConversion=Chemicals_Mass_To_Fraction_Conversion(hotHalo%mass())
       else
          massToDensityConversion=0.0d0
       end if
-      ! Convert to number density.
-      densityChemicalICM=densityChemicalICM*massToDensityConversion
+      ! Convert to number density per unit total mass density.
+      fractionChemicalICM=fractionChemicalICM*massToDensityConversion
       ! Compute number density of hydrogen (in cm⁻³).
       numberDensityHydrogen  =+density                                    &
            &                  *abundancesICM   %hydrogenMassFraction()    &
@@ -208,13 +208,13 @@ contains
            &                  /hecto                                  **3 &
            &                  /megaParsec                             **3
       ! Evaluate the integrand.
-      integrandLuminosityXray=+4.0d0                                                                                                                     &
-           &                  *Pi                                                                                                                        &
-           &                  *radius**2                                                                                                                 &
-           &                  *self%coolingFunction_%coolingFunction(node,numberDensityHydrogen,temperature,abundancesICM,densityChemicalICM,radiation_) &
-           &                  *(                                                                                                                         &
-           &                    +megaParsec                                                                                                              &
-           &                    /centi                                                                                                                   &
+      integrandLuminosityXray=+4.0d0                                                                                                                              &
+           &                  *Pi                                                                                                                                 &
+           &                  *radius**2                                                                                                                          &
+           &                  *self%coolingFunction_%coolingFunction(node,numberDensityHydrogen,temperature,abundancesICM,fractionChemicalICM*density,radiation_) &
+           &                  *(                                                                                                                                  &
+           &                    +megaParsec                                                                                                                       &
+           &                    /centi                                                                                                                            &
            &                   )**3
       return
     end function integrandLuminosityXray

--- a/source/nodes.property_extractor.ICM_cooling_power_in_band.F90
+++ b/source/nodes.property_extractor.ICM_cooling_power_in_band.F90
@@ -233,11 +233,11 @@ contains
     subroutine icmProperties(radius,numberDensityHydrogen,temperature,abundancesICM,densityChemicalICM)
       use :: Abundances_Structure             , only : abundances
       use :: Chemical_Abundances_Structure    , only : chemicalAbundances
-      use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Density_Conversion
+      use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Fraction_Conversion
       use :: Galacticus_Nodes                 , only : nodeComponentHotHalo
       use :: Numerical_Constants_Atomic       , only : massHydrogenAtom
       use :: Numerical_Constants_Prefixes     , only : hecto
-      use :: Numerical_Constants_Astronomical , only : massSolar                           , megaParsec
+      use :: Numerical_Constants_Astronomical , only : massSolar                            , megaParsec
       implicit none
       double precision                      , intent(in   ) :: radius
       double precision                      , intent(  out) :: numberDensityHydrogen  , temperature
@@ -259,14 +259,16 @@ contains
       massChemicalICM =  hotHalo%chemicals ()
       call abundancesICM  %massToMassFraction(           massICM)
       call massChemicalICM%massToNumber      (densityChemicalICM)
-      ! Compute factor converting mass of chemicals in (M☉/Mₐₘᵤ) to number density in cm⁻³.
-      if (hotHalo%outerRadius() > 0.0d0) then
-         massToDensityConversion=Chemicals_Mass_To_Density_Conversion(hotHalo%outerRadius())
+      ! Compute factor converting mass of chemicals in (M☉) to number density in cm⁻³ per total mass density.
+      if (hotHalo%mass() > 0.0d0) then
+         massToDensityConversion=Chemicals_Mass_To_Fraction_Conversion(hotHalo%mass())
       else
          massToDensityConversion=0.0d0
       end if
       ! Convert to number density.
-      densityChemicalICM=densityChemicalICM*massToDensityConversion
+      densityChemicalICM= densityChemicalICM      &
+           &             *massToDensityConversion &
+           &             *density
       ! Compute number density of hydrogen (in cm⁻³).
       numberDensityHydrogen=+density                                    &
            &                *abundancesICM   %hydrogenMassFraction()    &

--- a/source/nodes.property_extractor.ICM_optical_depth_LymanAlpha.F90
+++ b/source/nodes.property_extractor.ICM_optical_depth_LymanAlpha.F90
@@ -177,19 +177,17 @@ contains
     subroutine icmProperties(radius,numberDensityHydrogen,temperature,abundancesICM,densityChemicalICM)
       use :: Abundances_Structure             , only : abundances
       use :: Chemical_Abundances_Structure    , only : chemicalAbundances
-      use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Density_Conversion
+      use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Fraction_Conversion
       use :: Galacticus_Nodes                 , only : nodeComponentHotHalo
       use :: Numerical_Constants_Atomic       , only : massHydrogenAtom
       use :: Numerical_Constants_Prefixes     , only : hecto
-      use :: Numerical_Constants_Astronomical , only : massSolar                           , megaParsec
+      use :: Numerical_Constants_Astronomical , only : massSolar                            , megaParsec
       implicit none
       double precision                      , intent(in   ) :: radius
       double precision                      , intent(  out) :: numberDensityHydrogen  , temperature
       type            (abundances          ), intent(  out) :: abundancesICM
       type            (chemicalAbundances  ), intent(  out) :: densityChemicalICM
       class           (nodeComponentHotHalo), pointer       :: hotHalo
-
-      
       type            (chemicalAbundances  )                :: massChemicalICM
       double precision                                      :: density                , massICM     , &
            &                                                   massToDensityConversion
@@ -205,14 +203,16 @@ contains
       massChemicalICM =  hotHalo%chemicals ()
       call abundancesICM  %massToMassFraction(           massICM)
       call massChemicalICM%massToNumber      (densityChemicalICM)
-      ! Compute factor converting mass of chemicals in (M☉/Mₐₘᵤ) to number density in cm⁻³.
-      if (hotHalo%outerRadius() > 0.0d0) then
-         massToDensityConversion=Chemicals_Mass_To_Density_Conversion(hotHalo%outerRadius())
+      ! Compute factor converting mass of chemicals in (M☉) to number density in cm⁻³ per total mass density.
+      if (hotHalo%mass() > 0.0d0) then
+         massToDensityConversion=Chemicals_Mass_To_Fraction_Conversion(hotHalo%mass())
       else
          massToDensityConversion=0.0d0
       end if
       ! Convert to number density.
-      densityChemicalICM=densityChemicalICM*massToDensityConversion
+      densityChemicalICM= densityChemicalICM      &
+           &             *massToDensityConversion &
+           &             *density
       ! Compute number density of hydrogen (in cm⁻³).
       numberDensityHydrogen=+density                                    &
            &                *abundancesICM   %hydrogenMassFraction()    &


### PR DESCRIPTION
Previously the mean chemical density was erroneously used instead of the radius-dependent density.