### PR TITLE
Expand timestep profiler functionality

### DIFF
--- a/source/gslODEInitVal2/driver2.c
+++ b/source/gslODEInitVal2/driver2.c
@@ -150,7 +150,7 @@ gsl_odeiv2_driver2_apply (gsl_odeiv2_driver * d, double *t,
 			  const double t1, double y[],
 			  void(*postStep)(double t, double y[], int *s),
 			  void(*latentIntegrator)(double *t),
-			  void(*stepAnalyzer)(double y[], double yerr[], double h, int s)
+			  void(*stepAnalyzer)(double t, double t1, double y[], double yerr[], double h, int s)
 			  )
 {
   /* Main driver function that evolves the system from t to t1. In
@@ -194,7 +194,7 @@ gsl_odeiv2_driver2_apply (gsl_odeiv2_driver * d, double *t,
 
       if (stepAnalyzer != NULL ) 
 	{
-	  stepAnalyzer(y,d->e->yerr,d->e->last_step,s);
+	  stepAnalyzer(*t,t1,y,d->e->yerr,d->e->last_step,s);
 	}
 
       if (s != GSL_SUCCESS)

--- a/source/gslODEInitVal2/gsl_odeiv2.h
+++ b/source/gslODEInitVal2/gsl_odeiv2.h
@@ -51,5 +51,5 @@ int gsl_odeiv2_driver2_apply (gsl_odeiv2_driver * d, double *t,
 			      const double t1, double y[],
 			      void(*postStep)(double t, double y[], int *s),
 			      void(*latentIntegrator)(double *t),
-			      void(*stepAnalyzer)(double y[], double yerr[], double h, int s)
+			      void(*stepAnalyzer)(double t, double t1, double y[], double yerr[], double h, int s)
 			      );

--- a/source/merger_trees.evolve.profiler.F90
+++ b/source/merger_trees.evolve.profiler.F90
@@ -35,16 +35,24 @@ module Merger_Tree_Evolve_Profilers
    <descriptiveName>Merger Tree Evolver Profiler</descriptiveName>
    <description>Class providing profilers for merger tree evolution.</description>
    <default>null</default>
+   <method name="stepDescriptor" >
+    <description>Provide a descriptor of the current step.</description>
+    <type>void</type>
+    <pass>yes</pass>
+    <argument>type            (varying_string), intent(in   )               :: descriptor                                                  </argument>
+   </method>
    <method name="profile" >
     <description>Profile a differential evolution step.</description>
     <type>void</type>
     <pass>yes</pass>
-    <argument>type            (treeNode      ), intent(in   ) :: node</argument>
-    <argument>double precision                , intent(in   ) :: timeStep</argument>
-    <argument>integer         (c_size_t      ), intent(in   ) :: countEvaluations</argument>
-    <argument>logical                         , intent(in   ) :: interrupted</argument>
-    <argument>type            (varying_string), intent(in   ) :: propertyName</argument>
-    <argument>double precision                , intent(in   ) :: timeCPU</argument>
+    <argument>type            (treeNode      ), intent(in   )               :: node                                                        </argument>
+    <argument>double precision                , intent(in   )               :: time            , timeStart   , timeEnd      , timeStep     </argument>
+    <argument>integer         (c_size_t      ), intent(in   )               :: countEvaluations                                            </argument>
+    <argument>logical                         , intent(in   )               :: interrupted                                                 </argument>
+    <argument>integer         (c_size_t      ), intent(in   )               :: propertyIndex                                               </argument>
+    <argument>type            (varying_string), intent(in   )               :: propertyName                                                </argument>
+    <argument>double precision                , intent(in   ), dimension(:) :: propertyValue   , propertyRate, propertyScale, propertyError</argument>
+    <argument>double precision                , intent(in   )               :: timeCPU                                                     </argument>
    </method>
   </functionClass>
   !!]

--- a/source/merger_trees.evolve.profiler.null.F90
+++ b/source/merger_trees.evolve.profiler.null.F90
@@ -32,7 +32,8 @@ Implements a merger tree evolve profiler that does nothing.
      !!}
      private
    contains
-     procedure :: profile => nullProfile
+     procedure :: stepDescriptor => nullStepDescriptor
+     procedure :: profile        => nullProfile
   end type mergerTreeEvolveProfilerNull
 
   interface mergerTreeEvolveProfilerNull
@@ -60,18 +61,35 @@ contains
     return
   end function nullConstructorParameters
 
-  subroutine nullProfile(self,node,timestep,countEvaluations,interrupted,propertyName,timeCPU)
+  subroutine nullStepDescriptor(self,descriptor)
+    !!{
+    Set the descriptor for the current step.
+    !!}
+    implicit none
+    class(mergerTreeEvolveProfilerNull), intent(inout) :: self
+    type (varying_string              ), intent(in   ) :: descriptor
+    !$GLC attributes unused :: self, descriptor
+    
+    return
+  end subroutine nullStepDescriptor
+  
+  subroutine nullProfile(self,node,time,timeStart,timeEnd,timestep,countEvaluations,interrupted,propertyIndex,propertyName,propertyValue,propertyRate,propertyScale,propertyError,timeCPU)
     !!{
     Profile the differential evolution step.
     !!}
     implicit none
-    class           (mergerTreeEvolveProfilerNull), intent(inout) :: self
-    type            (treeNode                    ), intent(in   ) :: node
-    double precision                              , intent(in   ) :: timeStep        , timeCPU
-    integer         (c_size_t                    ), intent(in   ) :: countEvaluations
-    logical                                       , intent(in   ) :: interrupted
-    type            (varying_string              ), intent(in   ) :: propertyName
-    !$GLC attributes unused :: self, node, timeStep, countEvaluations, interrupted, propertyName, timeCPU
+    class           (mergerTreeEvolveProfilerNull), intent(inout)               :: self
+    type            (treeNode                    ), intent(in   )               :: node
+    double precision                              , intent(in   )               :: time            , timeStep     , &
+         &                                                                         timeStart       , timeEnd      , &
+         &                                                                         timeCPU
+    integer         (c_size_t                    ), intent(in   )               :: countEvaluations
+    logical                                       , intent(in   )               :: interrupted
+    integer         (c_size_t                    ), intent(in   )               :: propertyIndex
+    type            (varying_string              ), intent(in   )               :: propertyName
+    double precision                              , intent(in   ), dimension(:) :: propertyValue   , propertyScale, &
+         &                                                                         propertyError   , propertyRate
+    !$GLC attributes unused :: self, node, time, timeStart, timeEnd, timeStep, countEvaluations, interrupted, propertyIndex, propertyName, propertyValue, propertyRate, propertyScale, propertyError, timeCPU
 
     return
   end subroutine nullProfile

--- a/source/merger_trees.evolve.profiler.simple.F90
+++ b/source/merger_trees.evolve.profiler.simple.F90
@@ -55,8 +55,9 @@
      type            (integerHash)                            :: propertyHits
      type            (treeNode   ), pointer                   :: node                     => null()
    contains
-     final     ::            simpleDestructor
-     procedure :: profile => simpleProfile
+     final     ::                   simpleDestructor
+     procedure :: stepDescriptor => simpleStepDescriptor
+     procedure :: profile        => simpleProfile
   end type mergerTreeEvolveProfilerSimple
 
   interface mergerTreeEvolveProfilerSimple
@@ -107,6 +108,18 @@ contains
     return
   end function simpleConstructorParameters
 
+  subroutine simpleStepDescriptor(self,descriptor)
+    !!{
+    Set the descriptor for the current step.
+    !!}
+    implicit none
+    class(mergerTreeEvolveProfilerSimple), intent(inout) :: self
+    type (varying_string                ), intent(in   ) :: descriptor
+    !$GLC attributes unused :: self, descriptor
+    
+    return
+  end subroutine simpleStepDescriptor
+  
   function simpleConstructorInternal(timeStepMinimum,timeStepMaximum,timeStepPointsPerDecade) result(self)
     use :: Numerical_Ranges, only : Make_Range, rangeTypeLogarithmic
     implicit none
@@ -241,21 +254,27 @@ contains
     return
   end subroutine simpleDestructor
 
-  subroutine simpleProfile(self,node,timestep,countEvaluations,interrupted,propertyName,timeCPU)
+  subroutine simpleProfile(self,node,time,timeStart,timeEnd,timestep,countEvaluations,interrupted,propertyIndex,propertyName,propertyValue,propertyRate,propertyScale,propertyError,timeCPU)
     !!{
     Profile the differential evolution step.
     !!}
     use, intrinsic :: ISO_C_Binding, only : c_size_t
     use            :: Arrays_Search, only : searchArray
     implicit none
-    class           (mergerTreeEvolveProfilerSimple), intent(inout) :: self
-    type            (treeNode                      ), intent(in   ) :: node
-    double precision                                , intent(in   ) :: timeStep        , timeCPU
-    integer         (c_size_t                      ), intent(in   ) :: countEvaluations
-    logical                                         , intent(in   ) :: interrupted
-    type            (varying_string                ), intent(in   ) :: propertyName
-    integer                                                         :: hitCount
-    integer         (c_size_t                      )                :: i
+    class           (mergerTreeEvolveProfilerSimple), intent(inout)               :: self
+    type            (treeNode                      ), intent(in   )               :: node
+    double precision                                , intent(in   )               :: time            , timeStep     , &
+         &                                                                           timeStart       , timeEnd      , &
+         &                                                                           timeCPU
+    integer         (c_size_t                      ), intent(in   )               :: countEvaluations
+    logical                                         , intent(in   )               :: interrupted
+    integer         (c_size_t                      ), intent(in   )               :: propertyIndex
+    type            (varying_string                ), intent(in   )               :: propertyName
+    double precision                                , intent(in   ), dimension(:) :: propertyValue   , propertyScale, &
+         &                                                                           propertyError   , propertyRate
+    integer                                                                       :: hitCount
+    integer         (c_size_t                      )                              :: i
+    !$GLC attributes unused :: time, timeStart, timeEnd, propertyIndex, propertyValue, propertyScale, propertyError, propertyRate
 
     ! Accumulate timestep.
     i                                    =searchArray(self%timeStep,timeStep)

--- a/source/merger_trees.evolve.profiler.tiny_steps.F90
+++ b/source/merger_trees.evolve.profiler.tiny_steps.F90
@@ -1,0 +1,195 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a merger tree evolve profiler that warns about tiny steps.
+  !!}
+  
+  !![
+  <mergerTreeEvolveProfiler name="mergerTreeEvolveProfilerTinySteps">
+   <description>
+    A merger tree evolve profiler that warns about tiny steps.
+   </description>
+  </mergerTreeEvolveProfiler>
+  !!]
+  type, extends(mergerTreeEvolveProfilerClass) :: mergerTreeEvolveProfilerTinySteps
+     !!{
+     A merger tree evolve profiler that warns about tiny steps.
+     !!}
+     private
+     double precision                 :: timeStepTiny   , timeStepMinimum
+     type            (varying_string) :: stepDescriptor_
+   contains
+     procedure :: stepDescriptor => tinyStepsStepDescriptor
+     procedure :: profile        => tinyStepsProfile
+  end type mergerTreeEvolveProfilerTinySteps
+
+  interface mergerTreeEvolveProfilerTinySteps
+     !!{
+     Constructors for the {\normalfont \ttfamily tinySteps} merger tree evolve profiler class.
+     !!}
+     module procedure tinyStepsConstructorParameters
+     module procedure tinyStepsConstructorInternal
+  end interface mergerTreeEvolveProfilerTinySteps
+
+contains
+  
+  function tinyStepsConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily tinySteps} merger tree evolve profiler class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (mergerTreeEvolveProfilerTinySteps)                :: self
+    type            (inputParameters                  ), intent(inout) :: parameters
+    double precision                                                   :: timeStepTiny
+
+    !![
+    <inputParameter>
+      <name>timeStepTiny</name>
+      <defaultValue>1.0d-9</defaultValue>
+      <description>The time step below which warnings will be issued.</description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=mergerTreeEvolveProfilerTinySteps(timeStepTiny)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function tinyStepsConstructorParameters
+
+  function tinyStepsConstructorInternal(timeStepTiny) result(self)
+    implicit none
+    type            (mergerTreeEvolveProfilerTinySteps)                :: self
+    double precision                                   , intent(in   ) :: timeStepTiny
+    !![
+    <constructorAssign variables="timeStepTiny"/>
+    !!]
+
+    self%timeStepMinimum=huge(0.0d0)
+    return
+  end function tinyStepsConstructorInternal
+
+  subroutine tinyStepsStepDescriptor(self,descriptor)
+    !!{
+    Set the descriptor for the current step.
+    !!}
+    implicit none
+    class(mergerTreeEvolveProfilerTinySteps), intent(inout) :: self
+    type (varying_string                   ), intent(in   ) :: descriptor
+
+    self%stepDescriptor_=descriptor
+    return
+  end subroutine tinyStepsStepDescriptor
+  
+  subroutine tinyStepsProfile(self,node,time,timeStart,timeEnd,timestep,countEvaluations,interrupted,propertyIndex,propertyName,propertyValue,propertyRate,propertyScale,propertyError,timeCPU)
+    !!{
+    Profile the differential evolution step.
+    !!}
+    use :: Display           , only : displayIndent, displayUnindent, displayMessage, displayMagenta, &
+         &                            displayReset , displayRed
+    use :: ISO_Varying_String, only : var_str      , assignment(=)  , operator(//)
+    use :: String_Handling   , only : operator(//)
+    implicit none
+    class           (mergerTreeEvolveProfilerTinySteps), intent(inout)               :: self
+    type            (treeNode                         ), intent(in   )               :: node
+    double precision                                   , intent(in   )               :: time                   , timeStep     , &
+         &                                                                              timeStart              , timeEnd      , &
+         &                                                                              timeCPU
+    integer         (c_size_t                         ), intent(in   )               :: countEvaluations
+    logical                                            , intent(in   )               :: interrupted
+    integer         (c_size_t                         ), intent(in   )               :: propertyIndex
+    type            (varying_string                   ), intent(in   )               :: propertyName
+    double precision                                   , intent(in   ), dimension(:) :: propertyValue          , propertyScale, &
+         &                                                                              propertyError          , propertyRate
+    double precision                                   , parameter                   :: tolerance       =1.0d-2
+    character       (len=24                           )                              :: label
+    type            (varying_string                   )                              :: report
+
+    ! Return immediately if the timestep is not tiny.
+    if     (                                             &
+         &   timeStep               >= self%timeStepTiny &
+         & ) return
+    ! Check for cases where the timestep is small, but was likely set to hit the end time precisely.
+    if     (                                              &
+         &   timeEnd     -timeStart >= self%timeStepTiny  &
+         &  .and.                                         &
+         &   timeEnd-time-timeStep  <  tolerance*timeStep &
+         & ) return
+    ! Timestep is tiny - issue a report.
+    write (label,'(e12.6)') timeStep
+    report=displayMagenta()//'Warning:'//displayReset()//' tiny timestep of '//trim(adjustl(label))//' Gyr taken'
+    call displayIndent(report)
+    report=var_str('     tree index = ')//node%hostTree%index
+    call displayMessage(report)
+    report=var_str('     node index = ')//node         %index()
+    call displayMessage(report)
+    write (label,'(e12.6)') time
+    report=        '           time = '//trim(adjustl(label))//' Gyr'
+    call displayMessage(report)
+    call displayMessage('step descriptor = "'//self%stepDescriptor_//'"')
+    if (timeStep < self%timeStepMinimum) then
+       call displayMessage(displayRed()//'this is the smallest timestep seen so far'//displayReset())
+       self%timeStepMinimum=timeStep
+    end if
+    ! Determine cause of the tiny timestep.
+    if (timeEnd-timeStart < self%timeStepTiny) then
+       ! Timestep was limited by the end time.
+       report='Cause: imposed evolution interval'
+       call displayIndent(report)
+       write (label,'(e24.16)')         timeStart
+       report='t₀ = '//label//' Gyr'
+       call displayMessage(report)
+       write (label,'(e24.16)') timeEnd
+       report='t₁ = '//label//' Gyr'
+       call displayMessage(report)
+       write (label,'(e24.16)') timeEnd-timeStart
+       report='Δt = '//label//' Gyr'
+       call displayMessage(report)
+       call displayUnindent('done')
+    else
+       ! Timestep was limited by the ODE solver.
+       report='Cause: ODE solver'
+       call displayIndent(report)
+       report=var_str('name of limiting property    = ')//propertyName
+       call displayMessage(report)
+       report=var_str('number of failed evaluations = ')//countEvaluations
+       call displayMessage(report)
+       if (interrupted) then
+          report='evolution was interrupted'
+       else
+          report='evolution was not interrupted'
+       end if
+       call displayMessage(report)
+       report=var_str('value / rate / scale / error = ')
+       write (label,'(e24.16)') propertyValue(propertyIndex)
+       report=report//trim(label)//' / '
+       write (label,'(e24.16)') propertyRate (propertyIndex)
+       report=report//trim(label)//' / '
+       write (label,'(e24.16)') propertyScale(propertyIndex)
+       report=report//trim(label)//' / '
+       write (label,'(e24.16)') propertyError(propertyIndex)
+       report=report//trim(label)
+       call displayMessage(report)
+       call displayUnindent('done')
+    end if
+    call displayUnindent('done')
+    return
+  end subroutine tinyStepsProfile

--- a/source/merger_trees.node_evolver.standard.F90
+++ b/source/merger_trees.node_evolver.standard.F90
@@ -91,7 +91,7 @@
           &                                                                              odeTolerancesInactiveRelative                , odeTolerancesInactiveAbsolute
      logical                                                                          :: profileOdeEvolver                            , reuseODEStepSize
      integer         (kind=kind_int8                     )                            :: activeTreeIndex
-     type            (treeNode                           ), pointer                   :: activeNode
+     type            (treeNode                           ), pointer                   :: activeNode                          => null()
      integer                                                                          :: trialCount                                   , propertyTypeODE              , &
           &                                                                              propertyTypeIntegrator
      logical                                                                          :: interruptFirstFound
@@ -1159,7 +1159,7 @@ contains
        propertyName="unknown"
     end if
     ! Serialize rates.
-    call standardSelf%activeNode%deserializeRates(rate,standardSelf%propertyTypeODE)
+    call standardSelf%activeNode%serializeRates(rate,standardSelf%propertyTypeODE)
     ! Profile the step.
     call standardSelf%mergerTreeEvolveProfiler_%profile(standardSelf%activeNode,time,timeStartSaved,timeEnd,timeStep,standardSelf%countEvaluationsToSuccess,standardSelf%interruptFirstFound,limitingProperty,propertyName,currentPropertyValue(1:standardSelf%propertyCountActive),rate,scale,currentPropertyError(1:standardSelf%propertyCountActive),standardSelf%stepTimer%report())
     ! Reset the count of steps to success.

--- a/source/numerical.ODE_solver.F90
+++ b/source/numerical.ODE_solver.F90
@@ -274,10 +274,11 @@ module Numerical_ODE_Solvers
 
   ! Error analyzer interface.
   abstract interface
-     subroutine errorAnalyzerTemplate(y,yerr,xStep,status)
+     subroutine errorAnalyzerTemplate(x,x1,y,yerr,xStep,status)
        import c_int, c_double
        real   (c_double), intent(in   ), dimension(*) :: y     , yerr
-       real   (c_double), intent(in   ), value        :: xStep
+       real   (c_double), intent(in   ), value        :: x     , x1  , &
+            &                                            xStep
        integer(c_int   ), intent(in   ), value        :: status
      end subroutine errorAnalyzerTemplate
   end interface


### PR DESCRIPTION
Provides additional information to profilers. Adds a new `mergerTreeEvolveProfilerTinySteps` class which profiles the causes of tiny timesteps.