### PR TITLE
Correct numbering of lines in preprocessed source files

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Parse/Directives.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/Directives.pm
@@ -120,7 +120,9 @@ sub Parse_Directives {
 			type       => $directiveName              ,
 			directive  => $directive->{$directiveName},
 			line       => $node     ->{'line'        },
-			processed  => 0
+			processed  => 0                           ,
+			source     => $source                     ,
+			line       => $rawDirectiveLine
 		    };
 		    (my $rawCloser = $rawOpener) =~ s/\[/\]/;
 		    $rawDirective = $rawOpener.$rawDirective.$rawCloser;

--- a/perl/Galacticus/Build/SourceTree/Parse/ModuleUses.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/ModuleUses.pm
@@ -194,7 +194,9 @@ sub AddUses {
 	    type       => "moduleUse",
 	    sibling    => undef()    ,
 	    parent     => undef()    ,
-	    moduleUse  => undef()
+	    moduleUse  => undef()    ,
+	    source     => "Galacticus::Build::SourceTree::Parse::ModuleUses::AddUses()",
+	    line       => 1
 	};
 	$usesNode->{'firstChild'} =
 	{
@@ -202,7 +204,9 @@ sub AddUses {
 	    content    => ""       ,
 	    sibling    => undef()  ,
 	    parent     => $usesNode,
-	    firstChild => undef()
+	    firstChild => undef()  ,
+	    source     => "Galacticus::Build::SourceTree::Parse::ModuleUses::AddUses()",
+	    line       => 1
 	};
 	&Galacticus::Build::SourceTree::InsertBeforeNode($node->{'firstChild'},[$usesNode]);
     }

--- a/perl/Galacticus/Build/SourceTree/Parse/OpenMP.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/OpenMP.pm
@@ -137,8 +137,10 @@ sub Parse_OpenMP {
 		    if ( defined($rawCode) ) {
 			my $rawNode =
 			{
-			    type    => "code",
-			    content => $rawCode
+			    type    => "code"     ,
+			    content => $rawCode   ,
+			    source  => $source    ,
+			    line    => $lineNumber
 			};
 			undef($rawCode);
 			unshift(@newNodes,$rawNode);
@@ -154,12 +156,16 @@ sub Parse_OpenMP {
 		my $rawNode =
 		{
 		    type    => "code",
-		    content => $rawCode
+		    content => $rawCode   ,
+		    source  => $source    ,
+		    line    => $lineNumber
 		};
 		undef($rawCode);
 		push(@newNodesCombined,$rawNode);
 	    }
-	    &Galacticus::Build::SourceTree::ReplaceNode($node,\@newNodesCombined); 
+	    unless ( scalar(@newNodesCombined) == 1 && $newNodesCombined[0]->{'type'} eq "code" ) {
+		&Galacticus::Build::SourceTree::ReplaceNode($node,\@newNodesCombined);
+	    }
 	}
 	$node = &Galacticus::Build::SourceTree::Walk_Tree($node,\$depth);
     }    

--- a/perl/Galacticus/Build/SourceTree/Process/InputParametersValidate.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/InputParametersValidate.pm
@@ -121,7 +121,9 @@ sub Process_InputParametersValidate {
 		content    => $code            ,
 		sibling    => undef()          ,
 		parent     => $node->{'parent'},
-		firstChild => undef()
+		firstChild => undef()          ,
+		source     => "Galacticus::Build::SourceTree::Process::InputParametersValidate::Process_InputParametersValidate()",
+		line       => 1
 	    };
 	    &Galacticus::Build::SourceTree::InsertAfterNode($node,[$codeNode]);
 	}

--- a/perl/Galacticus/Build/SourceTree/Process/ObjectBuilder.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/ObjectBuilder.pm
@@ -195,7 +195,9 @@ sub Process_ObjectBuilder {
 	    {
 		type       => "code"      ,
 		content    => $builderCode,
-		firstChild => undef()
+		firstChild => undef()     ,
+		source     => "Galacticus::Build::SourceTree::Process::ObjectBuilder::Process_ObjectBuilder()",
+		line       => 1
 	    };
 	    # Insert the node.
 	    &Galacticus::Build::SourceTree::InsertAfterNode($node,[$newNode]);
@@ -407,9 +409,11 @@ sub Process_ObjectBuilder {
 	    # Build a code node.
 	    my $newNode =
 	    {
-		type       => "code"      ,
+		type       => "code"         ,
 		content    => $destructorCode,
-		firstChild => undef()
+		firstChild => undef()        ,
+		source     => "Galacticus::Build::SourceTree::Process::ObjectBuilder::Process_ObjectBuilder()",
+		line       => 1
 	    };
 	    # Insert the node.
 	    &Galacticus::Build::SourceTree::InsertAfterNode($node,[$newNode]);
@@ -442,7 +446,7 @@ sub Process_ObjectBuilder {
 	    };
 	    if ( $debugging ) {
 		$usesNode->{'moduleUse'}->{'MPI_Utilities'     } = {intrinsic => 0, all => 1};
-		$usesNode->{'moduleUse'}->{'Display'} = {intrinsic => 0, all => 1};
+		$usesNode->{'moduleUse'}->{'Display'           } = {intrinsic => 0, all => 1};
 		$usesNode->{'moduleUse'}->{'String_Handling'   } = {intrinsic => 0, all => 1};
 		$usesNode->{'moduleUse'}->{'ISO_Varying_String'} = {intrinsic => 0, all => 1};
 		$usesNode->{'moduleUse'}->{'Function_Classes'  } = {intrinsic => 0, all => 1};
@@ -526,9 +530,11 @@ sub Process_ObjectBuilder {
 	    # Build a code node.
 	    my $newNode =
 	    {
-		type       => "code"      ,
+		type       => "code"        ,
 		content    => $incrementCode,
-		firstChild => undef()
+		firstChild => undef()       ,
+		source     => "Galacticus::Build::SourceTree::Process::ObjectBuilder::Process_ObjectBuilder()",
+		line       => 1
 	    };
 	    # Insert the node.
 	    &Galacticus::Build::SourceTree::InsertAfterNode($node,[$newNode]);
@@ -578,7 +584,9 @@ sub Process_ObjectBuilder {
 	    {
 		type       => "code"      ,
 		content    => $acquireCode,
-		firstChild => undef()
+		firstChild => undef()     ,
+		source     => "Galacticus::Build::SourceTree::Process::ObjectBuilder::Process_ObjectBuilder()",
+		line       => 1
 	    };
 	    # Insert the node.
 	    &Galacticus::Build::SourceTree::InsertAfterNode($node,[$newNode]);
@@ -677,9 +685,11 @@ sub Process_ObjectBuilder {
 	    }
 	    my $newNode =
 	    {
-		type       => "code"      ,
+		type       => "code"                        ,
 		content    => encode(q{utf8},$constructCode),
-		firstChild => undef()
+		firstChild => undef()                       ,
+		source     => "Galacticus::Build::SourceTree::Process::ObjectBuilder::Process_ObjectBuilder()",
+		line       => 1
 	    };
 	    # Insert the node.
 	    &Galacticus::Build::SourceTree::InsertAfterNode($node,[$newNode]);
@@ -757,9 +767,11 @@ sub Process_ObjectBuilder {
 	    # Build a code node.
 	    my $newNode =
 	    {
-		type       => "code"      ,
+		type       => "code"       ,
 		content    => $deepCopyCode,
-		firstChild => undef()
+		firstChild => undef()      ,
+		source     => "Galacticus::Build::SourceTree::Process::ObjectBuilder::Process_ObjectBuilder()",
+		line       => 1
 	    };
 	    # Insert the node.
 	    &Galacticus::Build::SourceTree::InsertAfterNode($node,[$newNode]);


### PR DESCRIPTION
This was broken by the recently-added preprocessing of `!$omp parallel` directives.

Also adds source location descriptors for other preprocessor directives.