### PR TITLE
Catch disks with tiny gas densities

### DIFF
--- a/source/star_formation.rate_surface_density.disks.Krumholz2009.F90
+++ b/source/star_formation.rate_surface_density.disks.Krumholz2009.F90
@@ -327,9 +327,10 @@ contains
     class           (starFormationRateSurfaceDensityDisksKrumholz2009), intent(inout) :: self
     type            (treeNode                                        ), intent(inout) :: node
     double precision                                                  , intent(in   ) :: radius
-    double precision                                                                  :: surfaceDensityFactor, molecularFraction             , &
-         &                                                                               s                   , sigmaMolecularComplex         , &
-         &                                                                               surfaceDensityGas   , surfaceDensityGasDimensionless
+    double precision                                                  , parameter     :: surfaceDensityGasTiny=1.0d-100
+    double precision                                                                  :: surfaceDensityFactor          , molecularFraction             , &
+         &                                                                               s                             , sigmaMolecularComplex         , &
+         &                                                                               surfaceDensityGas             , surfaceDensityGasDimensionless
     
     ! Compute factors.
     call self%computeFactors(node)
@@ -349,7 +350,7 @@ contains
        ! Get surface density and related quantities.
        call self%surfaceDensityFactors(node,radius,surfaceDensityGas,surfaceDensityGasDimensionless)
        ! Check for non-positive gas mass.
-       if (surfaceDensityGas <= 0.0d0) then
+       if (surfaceDensityGas <= surfaceDensityGasTiny) then
           krumholz2009Rate=0.0d0
        else
           ! Compute the molecular fraction.


### PR DESCRIPTION
These caused floating point exceptions. Now the star formation rate is simply set to zero in such cases.