### PR TITLE
Use `self` as the result object in all constructors

### DIFF
--- a/source/accretion_disks.spectra.file.F90
+++ b/source/accretion_disks.spectra.file.F90
@@ -63,12 +63,12 @@
 
 contains
 
-  function fileConstructorParameters(parameters)
+  function fileConstructorParameters(parameters) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily file} accretion disk spectra class which takes a parameter set as input.
     !!}
     implicit none
-    type(accretionDiskSpectraFile)                :: fileConstructorParameters
+    type(accretionDiskSpectraFile)                :: self
     type(inputParameters         ), intent(inout) :: parameters
     type(varying_string          )                :: fileName
 
@@ -79,14 +79,14 @@ contains
       <description>The name of a file from which to read tabulated spectra of accretion disks.</description>
     </inputParameter>
     !!]
-    fileConstructorParameters=fileConstructorInternal(char(fileName))
+    self=accretionDiskSpectraFile(char(fileName))
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function fileConstructorParameters
 
-  function fileConstructorInternal(fileName)
+  function fileConstructorInternal(fileName) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily file} accretion disk spectra class.
     !!}
@@ -94,7 +94,7 @@ contains
     use :: Error           , only : Component_List           , Error_Report
     use :: Galacticus_Nodes, only : defaultBlackHoleComponent
     implicit none
-    type     (accretionDiskSpectraFile)                :: fileConstructorInternal
+    type     (accretionDiskSpectraFile)                :: self
     character(len=*                   ), intent(in   ) :: fileName
 
     ! Ensure that the required methods are supported.
@@ -116,8 +116,8 @@ contains
             &  {introspection:location}                                                                                                &
             & )
     ! Load the file.
-    fileConstructorInternal%fileName=fileName
-    call fileConstructorInternal%loadFile(fileName)
+    self%fileName=fileName
+    call self%loadFile(fileName)
     return
   end function fileConstructorInternal
 

--- a/source/cosmology.parameters.simple.F90
+++ b/source/cosmology.parameters.simple.F90
@@ -54,21 +54,21 @@
 
 contains
 
-  function simpleConstructorParameters(parameters)
+  function simpleConstructorParameters(parameters) result(self)
     !!{
     Constructor for the simple cosmological parameters class which takes a parameter set as input.
     !!}
     use :: Display, only : displayMagenta, displayReset
     use :: Error  , only : Warn
     implicit none
-    type(cosmologyParametersSimple)                :: simpleConstructorParameters
+    type(cosmologyParametersSimple)                :: self
     type(inputParameters          ), intent(inout) :: parameters
 
     !![
     <inputParameter>
       <name>OmegaMatter</name>
       <source>parameters</source>
-      <variable>simpleConstructorParameters%OmegaMatterValue</variable>
+      <variable>self%OmegaMatterValue</variable>
       <defaultValue>0.3153d0</defaultValue>
       <defaultSource>(\citealt{planck_collaboration_planck_2018}; TT,TE,EE$+$lowE$+$lensing)</defaultSource>
       <description>The density of matter in the Universe in units of the critical density.</description>
@@ -76,7 +76,7 @@ contains
     <inputParameter>
       <name>OmegaBaryon</name>
       <source>parameters</source>
-      <variable>simpleConstructorParameters%OmegaBaryonValue</variable>
+      <variable>self%OmegaBaryonValue</variable>
       <defaultValue>0.04930d0</defaultValue>
       <defaultSource>(\citealt{planck_collaboration_planck_2018}; TT,TE,EE$+$lowE$+$lensing)</defaultSource>
       <description>The density of baryons in the Universe in units of the critical density.</description>
@@ -84,7 +84,7 @@ contains
     <inputParameter>
       <name>OmegaDarkEnergy</name>
       <source>parameters</source>
-      <variable>simpleConstructorParameters%OmegaDarkEnergyValue</variable>
+      <variable>self%OmegaDarkEnergyValue</variable>
       <defaultValue>0.6847d0</defaultValue>
       <defaultSource>(\citealt{planck_collaboration_planck_2018}; TT,TE,EE$+$lowE$+$lensing)</defaultSource>
       <description>The density of dark energy in the Universe in units of the critical density.</description>
@@ -92,7 +92,7 @@ contains
     <inputParameter>
       <name>temperatureCMB</name>
       <source>parameters</source>
-      <variable>simpleConstructorParameters%temperatureCMBValue</variable>
+      <variable>self%temperatureCMBValue</variable>
       <defaultValue>2.72548d0</defaultValue>
       <defaultSource>\citep{fixsen_temperature_2009}</defaultSource>
       <description>The present day temperature of the \gls{cmb} in units of Kelvin.</description>
@@ -100,36 +100,36 @@ contains
     <inputParameter>
       <name>HubbleConstant</name>
       <source>parameters</source>
-      <variable>simpleConstructorParameters%HubbleConstantValue</variable>
+      <variable>self%HubbleConstantValue</variable>
       <defaultValue>67.36d0</defaultValue>
       <defaultSource>(\citealt{planck_collaboration_planck_2018}; TT,TE,EE$+$lowE$+$lensing)</defaultSource>
       <description>The present day value of the Hubble parameter in units of km/s/Mpc.</description>
     </inputParameter>
     !!]
     ! Validate the input.
-    if (simpleConstructorParameters%HubbleConstantValue <= 0.0d0)                                                                                    &
-         & call Warn(displayMagenta()//"WARNING:"//displayReset()//" [cosmologyParametersSimple::simpleConstructorParameters]: H_0 ≤ 0 - are you sure this is what you wanted? "//{introspection:location})
+    if (self%HubbleConstantValue <= 0.0d0)                                                                                                       &
+         & call Warn(displayMagenta()//"WARNING:"//displayReset()//" H₀ ≤ 0 - are you sure this is what you wanted? "//{introspection:location})
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function simpleConstructorParameters
 
-  function simpleConstructorInternal(OmegaMatter,OmegaBaryon,OmegaDarkEnergy,temperatureCMB,HubbleConstant)
+  function simpleConstructorInternal(OmegaMatter,OmegaBaryon,OmegaDarkEnergy,temperatureCMB,HubbleConstant) result(self)
     !!{
     Internal constructor for the simple cosmological parameters class.
     !!}
     implicit none
-    type            (cosmologyParametersSimple)                :: simpleConstructorInternal
-    double precision                           , intent(in   ) :: HubbleConstant   , OmegaBaryon, &
-         &                                                        OmegaDarkEnergy  , OmegaMatter, &
+    type            (cosmologyParametersSimple)                :: self
+    double precision                           , intent(in   ) :: HubbleConstant , OmegaBaryon, &
+         &                                                        OmegaDarkEnergy, OmegaMatter, &
          &                                                        temperatureCMB
 
-    simpleConstructorInternal%OmegaMatterValue    =OmegaMatter
-    simpleConstructorInternal%OmegaBaryonValue    =OmegaBaryon
-    simpleConstructorInternal%OmegaDarkEnergyValue=OmegaDarkEnergy
-    simpleConstructorInternal%temperatureCMBValue =temperatureCMB
-    simpleConstructorInternal%HubbleConstantValue =HubbleConstant
+    self%OmegaMatterValue    =OmegaMatter
+    self%OmegaBaryonValue    =OmegaBaryon
+    self%OmegaDarkEnergyValue=OmegaDarkEnergy
+    self%temperatureCMBValue =temperatureCMB
+    self%HubbleConstantValue =HubbleConstant
     return
   end function simpleConstructorInternal
 

--- a/source/dark_matter.particle.cold_dark_matter.F90
+++ b/source/dark_matter.particle.cold_dark_matter.F90
@@ -45,16 +45,16 @@ Contains a module which implements a cold dark matter particle class.
 
 contains
 
-  function CDMConstructorParameters(parameters)
+  function CDMConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``{\normalfont \ttfamily CDM}'' dark matter particle class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(darkMatterParticleCDM)                :: CDMConstructorParameters
+    type(darkMatterParticleCDM)                :: self
     type(inputParameters      ), intent(inout) :: parameters
 
-    CDMConstructorParameters=darkMatterParticleCDM()
+    self=darkMatterParticleCDM()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/dark_matter_halos.spins.distributions.delta_function.F90
+++ b/source/dark_matter_halos.spins.distributions.delta_function.F90
@@ -39,7 +39,6 @@
      private
      double precision :: spin
    contains
-     final     ::                 deltaFunctionDestructor
      procedure :: sample       => deltaFunctionSample
      procedure :: distribution => deltaFunctionDistribution
   end type haloSpinDistributionDeltaFunction
@@ -55,14 +54,14 @@
 
 contains
 
-  function deltaFunctionConstructorParameters(parameters)
+  function deltaFunctionConstructorParameters(parameters) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily deltaFunction} dark matter halo spin
     distribution class which takes a parameter list as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(haloSpinDistributionDeltaFunction)                :: deltaFunctionConstructorParameters
+    type(haloSpinDistributionDeltaFunction)                :: self
     type(inputParameters                  ), intent(inout) :: parameters
 
     ! Check and read parameters.
@@ -70,7 +69,7 @@ contains
     <inputParameter>
       <name>spin</name>
       <source>parameters</source>
-      <variable>deltaFunctionConstructorParameters%spin</variable>
+      <variable>self%spin</variable>
       <defaultValue>0.03687d0</defaultValue>
       <defaultSource>\citep{bett_spin_2007}</defaultSource>
       <description>The fixed value of spin in a $\delta$-function spin distribution.</description>
@@ -80,31 +79,20 @@ contains
     return
   end function deltaFunctionConstructorParameters
 
-  function deltaFunctionConstructorInternal(spin)
+  function deltaFunctionConstructorInternal(spin) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily deltaFunction} dark matter halo spin
     distribution class.
     !!}
     implicit none
-    type(haloSpinDistributionDeltaFunction) :: deltaFunctionConstructorInternal
-    double precision, intent(in   ) :: spin
-
-    deltaFunctionConstructorInternal%spin=spin
+    type            (haloSpinDistributionDeltaFunction)                :: self
+    double precision                                   , intent(in   ) :: spin
+    !![
+    <constructorAssign variables="spin"/>
+    !!]
+    
     return
   end function deltaFunctionConstructorInternal
-
-  subroutine deltaFunctionDestructor(self)
-    !!{
-    Destructor for the {\normalfont \ttfamily deltaFunction} dark matter halo spin
-    distribution class.
-    !!}
-    implicit none
-    type(haloSpinDistributionDeltaFunction), intent(inout) :: self
-    !$GLC attributes unused :: self
-
-    ! Nothing to do.
-    return
-  end subroutine deltaFunctionDestructor
 
   double precision function deltaFunctionSample(self,node)
     !!{

--- a/source/galactic.filters.ISM_mass.F90
+++ b/source/galactic.filters.ISM_mass.F90
@@ -49,13 +49,13 @@ Contains a module which implements a galactic high-pass filter for total ISM mas
 
 contains
 
-  function ismMassConstructorParameters(parameters)
+  function ismMassConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``ismMass'' galactic filter class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(galacticFilterISMMass)                :: ismMassConstructorParameters
+    type(galacticFilterISMMass)                :: self
     type(inputParameters      ), intent(inout) :: parameters
 
     ! Check and read parameters.
@@ -63,7 +63,7 @@ contains
     <inputParameter>
       <name>massThreshold</name>
       <source>parameters</source>
-      <variable>ismMassConstructorParameters%massThreshold</variable>
+      <variable>self%massThreshold</variable>
       <description>The parameter $M_0$ (in units of $M_\odot$) appearing in the ISM mass threshold for the ISM mass galactic filter class.</description>
     </inputParameter>
     <inputParametersValidate source="parameters"/>
@@ -71,16 +71,17 @@ contains
     return
   end function ismMassConstructorParameters
 
-  function ismMassConstructorInternal(massThreshold)
+  function ismMassConstructorInternal(massThreshold) result(self)
     !!{
     Internal constructor for the ``ismMass'' galactic filter class.
     !!}
     implicit none
-    type            (galacticFilterISMMass)                :: ismMassConstructorInternal
+    type            (galacticFilterISMMass)                :: self
     double precision                       , intent(in   ) :: massThreshold
     !![
     <constructorAssign variables="massThreshold"/>
     !!]
+    
     return
   end function ismMassConstructorInternal
 

--- a/source/galactic.filters.always.F90
+++ b/source/galactic.filters.always.F90
@@ -44,16 +44,16 @@ Contains a module which implements a galactic filter which always passes.
 
 contains
 
-  function alwaysConstructorParameters(parameters)
+  function alwaysConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``always'' galactic filter class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(galacticFilterAlways)                :: alwaysConstructorParameters
+    type(galacticFilterAlways)                :: self
     type(inputParameters     ), intent(inout) :: parameters
 
-    alwaysConstructorParameters=galacticFilterAlways()
+    self=galacticFilterAlways()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/galactic.filters.basic_mass.F90
+++ b/source/galactic.filters.basic_mass.F90
@@ -49,13 +49,13 @@ Contains a module which implements a galactic high-pass filter for the default `
 
 contains
 
-  function basicMassConstructorParameters(parameters)
+  function basicMassConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``basicMass'' galactic filter class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(galacticFilterBasicMass)                :: basicMassConstructorParameters
+    type(galacticFilterBasicMass)                :: self
     type(inputParameters        ), intent(inout) :: parameters
 
     ! Check and read parameters.
@@ -63,7 +63,7 @@ contains
     <inputParameter>
       <name>massThreshold</name>
       <source>parameters</source>
-      <variable>basicMassConstructorParameters%massThreshold</variable>
+      <variable>self%massThreshold</variable>
       <description>The parameter $M_0$ (in units of $M_\odot$) appearing in the basic mass threshold for the basic mass galactic filter class.</description>
     </inputParameter>
     <inputParametersValidate source="parameters"/>
@@ -71,16 +71,17 @@ contains
     return
   end function basicMassConstructorParameters
 
-  function basicMassConstructorInternal(massThreshold)
+  function basicMassConstructorInternal(massThreshold) result(self)
     !!{
     Internal constructor for the ``basicMass'' galactic filter class.
     !!}
     implicit none
-    type            (galacticFilterBasicMass)                :: basicMassConstructorInternal
+    type            (galacticFilterBasicMass)                :: self
     double precision                         , intent(in   ) :: massThreshold
     !![
     <constructorAssign variables="massThreshold"/>
     !!]
+    
     return
   end function basicMassConstructorInternal
 

--- a/source/galactic.filters.stellar_mass.F90
+++ b/source/galactic.filters.stellar_mass.F90
@@ -49,13 +49,13 @@ Contains a module which implements a galactic high-pass filter for total stellar
 
 contains
 
-  function stellarMassConstructorParameters(parameters)
+  function stellarMassConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``stellarMass'' galactic filter class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(galacticFilterStellarMass)                :: stellarMassConstructorParameters
+    type(galacticFilterStellarMass)                :: self
     type(inputParameters          ), intent(inout) :: parameters
 
     ! Check and read parameters.
@@ -63,7 +63,7 @@ contains
     <inputParameter>
       <name>massThreshold</name>
       <source>parameters</source>
-      <variable>stellarMassConstructorParameters%massThreshold</variable>
+      <variable>self%massThreshold</variable>
       <description>The parameter $M_0$ (in units of $M_\odot$) appearing in the stellar mass threshold for the stellar mass galactic filter class.</description>
     </inputParameter>
     <inputParametersValidate source="parameters"/>
@@ -71,16 +71,17 @@ contains
     return
   end function stellarMassConstructorParameters
 
-  function stellarMassConstructorInternal(massThreshold)
+  function stellarMassConstructorInternal(massThreshold) result(self)
     !!{
     Internal constructor for the ``stellarMass'' galactic filter class.
     !!}
     implicit none
-    type            (galacticFilterStellarMass)                :: stellarMassConstructorInternal
+    type            (galacticFilterStellarMass)                :: self
     double precision                           , intent(in   ) :: massThreshold
     !![
     <constructorAssign variables="massThreshold"/>
     !!]
+    
     return
   end function stellarMassConstructorInternal
 

--- a/source/galactic.filters.stellar_mass_morphology.F90
+++ b/source/galactic.filters.stellar_mass_morphology.F90
@@ -50,21 +50,21 @@ Contains a module which implements a galactic high-pass filter for stellar mass-
 
 contains
 
-  function stellarMassMorphologyConstructorParameters(parameters)
+  function stellarMassMorphologyConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``stellarMassMorphology'' galactic filter class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(galacticFilterStellarMassMorphology)                :: stellarMassMorphologyConstructorParameters
-    type(inputParameters          ), intent(inout) :: parameters
+    type(galacticFilterStellarMassMorphology)                :: self
+    type(inputParameters                    ), intent(inout) :: parameters
 
     ! Check and read parameters.
     !![
     <inputParameter>
       <name>spheroidToTotalRatioThreshold</name>
       <source>parameters</source>
-      <variable>stellarMassMorphologyConstructorParameters%spheroidToTotalRatioThreshold</variable>
+      <variable>self%spheroidToTotalRatioThreshold</variable>
       <description>The parameter $R_0$ appearing in the stellar mass-weight morphology threshold for the stellar mass-weighted morphology galactic filter class.</description>
     </inputParameter>
     <inputParametersValidate source="parameters"/>
@@ -72,16 +72,17 @@ contains
     return
   end function stellarMassMorphologyConstructorParameters
 
-  function stellarMassMorphologyConstructorInternal(spheroidToTotalRatioThreshold)
+  function stellarMassMorphologyConstructorInternal(spheroidToTotalRatioThreshold) result(self)
     !!{
     Internal constructor for the ``stellarMassMorphology'' galactic filter class.
     !!}
     implicit none
-    type            (galacticFilterStellarMassMorphology)                :: stellarMassMorphologyConstructorInternal
+    type            (galacticFilterStellarMassMorphology)                :: self
     double precision                                     , intent(in   ) :: spheroidToTotalRatioThreshold
     !![
     <constructorAssign variables="spheroidToTotalRatioThreshold"/>
     !!]
+    
     return
   end function stellarMassMorphologyConstructorInternal
 

--- a/source/interface.AxionCAMB.F90
+++ b/source/interface.AxionCAMB.F90
@@ -489,11 +489,7 @@ contains
        ! Make sure that the transfer function is non-negative.
        transferFunctions=abs(transferFunctions)
        ! Remove temporary files.
-       command="rm -f "                    // &
-            &   parameterFile         //" "// &
-            &  "axionCamb_params.ini" //" "
-       call File_Remove(parameterFile         )
-       call File_Remove("axionCamb_params.ini")
+       call File_Remove(parameterFile)
        do i=1,countRedshiftsUnique
           call File_Remove('axionCamb_transfer_'   //trim(adjustl(redshiftLabelsCombined(i)))//'.dat')
           call File_Remove('axionCamb_matterpower_'//trim(adjustl(redshiftLabelsCombined(i)))//'.dat')

--- a/source/merger_trees.construct.build.mass_resolution.fixed.F90
+++ b/source/merger_trees.construct.build.mass_resolution.fixed.F90
@@ -49,13 +49,13 @@
 
 contains
 
-  function fixedConstructorParameters(parameters)
+  function fixedConstructorParameters(parameters) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily fixed} merger tree building mass resolution class which reads parameters from a
     provided parameter list.
     !!}
     implicit none
-    type(mergerTreeMassResolutionFixed)                :: fixedConstructorParameters
+    type(mergerTreeMassResolutionFixed)                :: self
     type(inputParameters              ), intent(inout) :: parameters
 
     ! Check and read parameters.
@@ -63,7 +63,7 @@ contains
     <inputParameter>
       <name>massResolution</name>
       <source>parameters</source>
-      <variable>fixedConstructorParameters%massResolution</variable>
+      <variable>self%massResolution</variable>
       <defaultValue>5.0d9</defaultValue>
       <description>The mass resolution to use when building merger trees.</description>
     </inputParameter>
@@ -72,15 +72,17 @@ contains
     return
   end function fixedConstructorParameters
 
-  function fixedConstructorInternal(massResolution)
+  function fixedConstructorInternal(massResolution) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily fixed} merger tree building mass resolution class.
     !!}
     implicit none
-    type            (mergerTreeMassResolutionFixed)                :: fixedConstructorInternal
+    type            (mergerTreeMassResolutionFixed)                :: self
     double precision                               , intent(in   ) :: massResolution
-
-    fixedConstructorInternal%massResolution=massResolution
+    !![
+    <constructorAssign variables="massResolution"/>
+    !!]
+    
     return
   end function fixedConstructorInternal
 

--- a/source/merger_trees.filter.always.F90
+++ b/source/merger_trees.filter.always.F90
@@ -44,16 +44,16 @@ Contains a module which implements a merger tree filter which always passes.
 
 contains
 
-  function alwaysConstructorParameters(parameters)
+  function alwaysConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``always'' merger tree filter class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(mergerTreeFilterAlways)                :: alwaysConstructorParameters
+    type(mergerTreeFilterAlways)                :: self
     type(inputParameters       ), intent(inout) :: parameters
 
-    alwaysConstructorParameters=mergerTreeFilterAlways()
+    self=mergerTreeFilterAlways()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/merger_trees.operators.deforest.F90
+++ b/source/merger_trees.operators.deforest.F90
@@ -44,16 +44,16 @@ Contains a module which implements a deforestation operator on merger trees (i.e
 
 contains
 
-  function deforestConstructorParameters(parameters)
+  function deforestConstructorParameters(parameters) result(self)
     !!{
     Constructor for the deforestation merger tree operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(mergerTreeOperatorDeforest)                :: deforestConstructorParameters
+    type(mergerTreeOperatorDeforest)                :: self
     type(inputParameters           ), intent(inout) :: parameters
 
-    deforestConstructorParameters=mergerTreeOperatorDeforest()
+    self=mergerTreeOperatorDeforest()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/merger_trees.operators.dump_to_GraphViz.F90
+++ b/source/merger_trees.operators.dump_to_GraphViz.F90
@@ -56,13 +56,13 @@ Contains a module which implements a dump to \gls{graphviz} operator on merger t
 
 contains
 
-  function dumpToGraphVizConstructorParameters(parameters)
+  function dumpToGraphVizConstructorParameters(parameters) result(self)
     !!{
     Constructor for the dump-to-\gls{graphviz} merger tree operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(mergerTreeOperatorDumpToGraphViz)                :: dumpToGraphVizConstructorParameters
+    type(mergerTreeOperatorDumpToGraphViz)                :: self
     type(inputParameters                 ), intent(inout) :: parameters
 
     !![
@@ -70,35 +70,35 @@ contains
       <name>path</name>
       <defaultValue>var_str('.')</defaultValue>
       <source>parameters</source>
-      <variable>dumpToGraphVizConstructorParameters%path</variable>
+      <variable>self%path</variable>
       <description>Specifies the directory to which merger tree structure should be dumped.</description>
     </inputParameter>
     <inputParameter>
       <name>massMinimum</name>
       <defaultValue>0.0d0</defaultValue>
       <source>parameters</source>
-      <variable>dumpToGraphVizConstructorParameters%massMinimum</variable>
+      <variable>self%massMinimum</variable>
       <description>Specifies the minimum root mass for which merger tree structure should be dumped.</description>
     </inputParameter>
     <inputParameter>
       <name>massMaximum</name>
       <defaultValue>huge(0.0d0)</defaultValue>
       <source>parameters</source>
-      <variable>dumpToGraphVizConstructorParameters%massMaximum</variable>
+      <variable>self%massMaximum</variable>
       <description>Specifies the minimum root mass for which merger tree structure should be dumped.</description>
     </inputParameter>
     <inputParameter>
       <name>scaleNodesByLogMass</name>
       <defaultValue>.true.</defaultValue>
       <source>parameters</source>
-      <variable>dumpToGraphVizConstructorParameters%scaleNodesByLogMass</variable>
+      <variable>self%scaleNodesByLogMass</variable>
       <description>Specifies whether or not node sizes should be scaled by the logarithm of their mass.</description>
     </inputParameter>
     <inputParameter>
       <name>edgeLengthsToTimes</name>
       <defaultValue>.true.</defaultValue>
       <source>parameters</source>
-      <variable>dumpToGraphVizConstructorParameters%edgeLengthsToTimes</variable>
+      <variable>self%edgeLengthsToTimes</variable>
       <description>Specifies whether or not the lengths of edges in the graph should be scaled to time differences between nodes.</description>
     </inputParameter>
     <inputParametersValidate source="parameters"/>
@@ -106,18 +106,18 @@ contains
     return
   end function dumpToGraphVizConstructorParameters
 
-  function dumpToGraphVizConstructorInternal(path,massMinimum,massMaximum)
+  function dumpToGraphVizConstructorInternal(path,massMinimum,massMaximum) result(self)
     !!{
     Internal constructor for the dump-to-\gls{graphviz} merger tree operator class.
     !!}
     implicit none
-    type            (mergerTreeOperatorDumpToGraphViz)                :: dumpToGraphVizConstructorInternal
+    type            (mergerTreeOperatorDumpToGraphViz)                :: self
     type            (varying_string                  ), intent(in   ) :: path
     double precision                                  , intent(in   ) :: massMinimum                      , massMaximum
-
-    dumpToGraphVizConstructorInternal%path       =path
-    dumpToGraphVizConstructorInternal%massMinimum=massMinimum
-    dumpToGraphVizConstructorInternal%massMaximum=massMaximum
+    !![
+    <constructorAssign variables="path, massMinimum, massMaximum"/>
+    !!]
+    
     return
   end function dumpToGraphVizConstructorInternal
 

--- a/source/merger_trees.operators.information_content.F90
+++ b/source/merger_trees.operators.information_content.F90
@@ -62,40 +62,40 @@
 
 contains
 
-  function informationContentConstructorParameters(parameters)
+  function informationContentConstructorParameters(parameters) result(self)
     !!{
     Constructor for the information content merger tree operator class which takes a parameter set as input.
     !!}
     implicit none
-    type   (mergerTreeOperatorInformationContent)                :: informationContentConstructorParameters
+    type   (mergerTreeOperatorInformationContent)                :: self
     type   (inputParameters                     ), intent(inout) :: parameters
 
     !![
     <inputParameter>
       <name>outputGroupName</name>
       <source>parameters</source>
-      <variable>informationContentConstructorParameters%outputGroupName</variable>
+      <variable>self%outputGroupName</variable>
       <defaultValue>var_str('treeInformationContent')</defaultValue>
       <description>The name of an \gls{hdf5} group to which tree information content should be written.</description>
     </inputParameter>
     !!]
-    informationContentConstructorParameters%treeCount=0_c_size_t
+    self%treeCount=0_c_size_t
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function informationContentConstructorParameters
 
-  function informationContentConstructorInternal(outputGroupName)
+  function informationContentConstructorInternal(outputGroupName) result(self)
     !!{
     Internal constructor for the information content merger tree operator class.
     !!}
     implicit none
-    type(mergerTreeOperatorInformationContent)                :: informationContentConstructorInternal
+    type(mergerTreeOperatorInformationContent)                :: self
     type(varying_string                      ), intent(in   ) :: outputGroupName
 
-    informationContentConstructorInternal%outputGroupName=outputGroupName
-    informationContentConstructorInternal%treeCount      =0_c_size_t
+    self%outputGroupName=outputGroupName
+    self%treeCount      =0_c_size_t
    return
   end function informationContentConstructorInternal
 

--- a/source/merger_trees.operators.monotonize_mass_growth.F90
+++ b/source/merger_trees.operators.monotonize_mass_growth.F90
@@ -49,17 +49,17 @@
 
 contains
 
-  function monotonizeMassGrowthConstructorParameters(parameters)
+  function monotonizeMassGrowthConstructorParameters(parameters) result(self)
     !!{
     Constructor for the mass growth monotonizing merger tree operator class which takes a
     parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(mergerTreeOperatorMonotonizeMassGrowth)                :: monotonizeMassGrowthConstructorParameters
+    type(mergerTreeOperatorMonotonizeMassGrowth)                :: self
     type(inputParameters                       ), intent(inout) :: parameters
 
-    monotonizeMassGrowthConstructorParameters=mergerTreeOperatorMonotonizeMassGrowth()
+    self=mergerTreeOperatorMonotonizeMassGrowth()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/merger_trees.operators.null.F90
+++ b/source/merger_trees.operators.null.F90
@@ -43,16 +43,16 @@ Contains a module which implements a null operator on merger trees.
 
 contains
 
-  function nullConstructorParameters(parameters)
+  function nullConstructorParameters(parameters) result(self)
     !!{
     Constructor for the null merger tree operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(mergerTreeOperatorNull)                :: nullConstructorParameters
+    type(mergerTreeOperatorNull)                :: self
     type(inputParameters       ), intent(inout) :: parameters
 
-    nullConstructorParameters=mergerTreeOperatorNull()
+    self=mergerTreeOperatorNull()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/merger_trees.operators.prune_by_mass.F90
+++ b/source/merger_trees.operators.prune_by_mass.F90
@@ -51,13 +51,13 @@ Contains a module which implements a pruning-by-mass operator on merger trees.
 
 contains
 
-  function pruneByMassConstructorParameters(parameters)
+  function pruneByMassConstructorParameters(parameters) result(self)
     !!{
     Constructor for the prune-by-mass merger tree operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(mergerTreeOperatorPruneByMass)                :: pruneByMassConstructorParameters
+    type(mergerTreeOperatorPruneByMass)                :: self
     type(inputParameters              ), intent(inout) :: parameters
 
     !![
@@ -65,14 +65,14 @@ contains
       <name>massThreshold</name>
       <source>parameters</source>
       <defaultValue>0.0d0</defaultValue>
-      <variable>pruneByMassConstructorParameters%massThreshold</variable>
+      <variable>self%massThreshold</variable>
       <description>Threshold mass below which merger tree branches should be pruned.</description>
     </inputParameter>
     <inputParameter>
       <name>preservePrimaryProgenitor</name>
       <source>parameters</source>
       <defaultValue>.true.</defaultValue>
-      <variable>pruneByMassConstructorParameters%preservePrimaryProgenitor</variable>
+      <variable>self%preservePrimaryProgenitor</variable>
       <description>If true, primary progenitor status is preserved even if the primary progenitor is pruned from the tree.</description>
     </inputParameter>
     <inputParametersValidate source="parameters"/>
@@ -80,17 +80,18 @@ contains
     return
   end function pruneByMassConstructorParameters
 
-  function pruneByMassConstructorInternal(massThreshold,preservePrimaryProgenitor)
+  function pruneByMassConstructorInternal(massThreshold,preservePrimaryProgenitor) result(self)
     !!{
     Internal constructor for the prune-by-mass merger tree operator class.
     !!}
     implicit none
-    type            (mergerTreeOperatorPruneByMass)                :: pruneByMassConstructorInternal
+    type            (mergerTreeOperatorPruneByMass)                :: self
     double precision                               , intent(in   ) :: massThreshold
     logical                                        , intent(in   ) :: preservePrimaryProgenitor
+    !![
+    <constructorAssign variables="massThreshold, preservePrimaryProgenitor"/>
+    !!]
 
-    pruneByMassConstructorInternal%massThreshold            =massThreshold
-    pruneByMassConstructorInternal%preservePrimaryProgenitor=preservePrimaryProgenitor
     return
   end function pruneByMassConstructorInternal
 

--- a/source/merger_trees.operators.prune_clones.F90
+++ b/source/merger_trees.operators.prune_clones.F90
@@ -44,16 +44,16 @@ Contains a module which implements a pruning-by-mass operator on merger trees.
 
 contains
 
-  function pruneClonesConstructorParameters(parameters)
+  function pruneClonesConstructorParameters(parameters) result(self)
     !!{
     Constructor for the clone pruning merger tree operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(mergerTreeOperatorPruneClones)                :: pruneClonesConstructorParameters
+    type(mergerTreeOperatorPruneClones)                :: self
     type(inputParameters              ), intent(inout) :: parameters
 
-    pruneClonesConstructorParameters=mergerTreeOperatorPruneClones()
+    self=mergerTreeOperatorPruneClones()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/merger_trees.operators.prune_hierarchy.F90
+++ b/source/merger_trees.operators.prune_hierarchy.F90
@@ -54,12 +54,12 @@
 
 contains
 
-  function pruneHierarchyConstructorParameters(parameters)
+  function pruneHierarchyConstructorParameters(parameters) result(self)
     !!{
     Constructor for the prune-hierarchy merger tree operator class which takes a parameter set as input.
     !!}
     implicit none
-    type   (mergerTreeOperatorPruneHierarchy)                :: pruneHierarchyConstructorParameters
+    type   (mergerTreeOperatorPruneHierarchy)                :: self
     type   (inputParameters                 ), intent(inout) :: parameters
     integer                                                  :: hierarchyDepth
 
@@ -71,24 +71,24 @@ contains
       <description>The depth in the substructure hierarchy at which to prune a tree.</description>
     </inputParameter>
     !!]
-    pruneHierarchyConstructorParameters=pruneHierarchyConstructorInternal(hierarchyDepth)
+    self=mergerTreeOperatorPruneHierarchy(hierarchyDepth)
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function pruneHierarchyConstructorParameters
 
-  function pruneHierarchyConstructorInternal(hierarchyDepth)
+  function pruneHierarchyConstructorInternal(hierarchyDepth) result(self)
     !!{
     Internal constructor for the prune-hierarchy merger tree operator class.
     !!}
     use :: Error, only : Error_Report
     implicit none
-    type   (mergerTreeOperatorPruneHierarchy)                :: pruneHierarchyConstructorInternal
+    type   (mergerTreeOperatorPruneHierarchy)                :: self
     integer                                  , intent(in   ) :: hierarchyDepth
 
     if (hierarchyDepth < 1) call Error_Report('[hierarchyDepth] > 0 is required'//{introspection:location})
-    pruneHierarchyConstructorInternal%hierarchyDepth=hierarchyDepth
+    self%hierarchyDepth=hierarchyDepth
     return
   end function pruneHierarchyConstructorInternal
 

--- a/source/merger_trees.operators.prune_non_essential.F90
+++ b/source/merger_trees.operators.prune_non_essential.F90
@@ -56,25 +56,25 @@
 
 contains
 
-  function pruneNonEssentialConstructorParameters(parameters)
+  function pruneNonEssentialConstructorParameters(parameters) result(self)
     !!{
     Constructor for the prune-non-essential merger tree operator class which takes a parameter set as input.
     !!}
     implicit none
-    type   (mergerTreeOperatorPruneNonEssential)                :: pruneNonEssentialConstructorParameters
+    type   (mergerTreeOperatorPruneNonEssential)                :: self
     type   (inputParameters                    ), intent(inout) :: parameters
 
     !![
     <inputParameter>
       <name>essentialNodeID</name>
       <source>parameters</source>
-      <variable>pruneNonEssentialConstructorParameters%essentialNodeID</variable>
+      <variable>self%essentialNodeID</variable>
       <description>ID of the essential node to avoid pruning.</description>
     </inputParameter>
     <inputParameter>
       <name>essentialNodeTime</name>
       <source>parameters</source>
-      <variable>pruneNonEssentialConstructorParameters%essentialNodeTime</variable>
+      <variable>self%essentialNodeTime</variable>
       <description>Time of the essential node to avoid pruning.</description>
     </inputParameter>
     <inputParametersValidate source="parameters"/>
@@ -82,17 +82,18 @@ contains
     return
   end function pruneNonEssentialConstructorParameters
 
-  function pruneNonEssentialConstructorInternal(essentialNodeID,essentialNodeTime)
+  function pruneNonEssentialConstructorInternal(essentialNodeID,essentialNodeTime) result(self)
     !!{
     Internal constructor for the prune-non-essential merger tree operator class.
     !!}
     implicit none
-    type            (mergerTreeOperatorPruneNonEssential)                :: pruneNonEssentialConstructorInternal
+    type            (mergerTreeOperatorPruneNonEssential)                :: self
     integer                                              , intent(in   ) :: essentialNodeID
     double precision                                     , intent(in   ) :: essentialNodeTime
-
-    pruneNonEssentialConstructorInternal%essentialNodeID  =essentialNodeID
-    pruneNonEssentialConstructorInternal%essentialNodeTime=essentialNodeTime
+    !![
+    <constructorAssign variables="essentialNodeID, essentialNodeTime"/>
+    !!]
+    
    return
   end function pruneNonEssentialConstructorInternal
 

--- a/source/merger_trees.operators.select_within_range.F90
+++ b/source/merger_trees.operators.select_within_range.F90
@@ -46,13 +46,13 @@ Contains a module which implements a select-within-range operator on the base no
 
 contains
 
-  function selectWithinRangeConstructorParameters(parameters)
+  function selectWithinRangeConstructorParameters(parameters) result(self)
     !!{
     Constructor for the select-within-range merger tree operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(mergerTreeOperatorSelectWithinRange)                :: selectWithinRangeConstructorParameters
+    type(mergerTreeOperatorSelectWithinRange)                :: self
     type(inputParameters                    ), intent(inout) :: parameters
 
     !![
@@ -60,14 +60,14 @@ contains
       <name>baseMassMinimum</name>
       <source>parameters</source>
       <defaultValue>0.0d0</defaultValue>
-      <variable>selectWithinRangeConstructorParameters%baseMassMinimum</variable>
+      <variable>self%baseMassMinimum</variable>
       <description>Base node mass below which trees should be ignored.</description>
     </inputParameter>
     <inputParameter>
       <name>baseMassMaximum</name>
       <source>parameters</source>
       <defaultValue>0.0d0</defaultValue>
-      <variable>selectWithinRangeConstructorParameters%baseMassMaximum</variable>
+      <variable>self%baseMassMaximum</variable>
       <description>Base node mass above which trees should be ignored.</description>
     </inputParameter>
     <inputParametersValidate source="parameters"/>
@@ -75,16 +75,17 @@ contains
     return
   end function selectWithinRangeConstructorParameters
 
-  function selectWithinRangeConstructorInternal(baseMassMinimum,baseMassMaximum)
+  function selectWithinRangeConstructorInternal(baseMassMinimum,baseMassMaximum) result(self)
     !!{
     Internal constructor for the select-within-range merger tree operator class.
     !!}
     implicit none
-    type            (mergerTreeOperatorSelectWithinRange)                :: selectWithinRangeConstructorInternal
-    double precision                                     , intent(in   ) :: baseMassMinimum                         , baseMassMaximum
-
-    selectWithinRangeConstructorInternal%baseMassMinimum=baseMassMinimum
-    selectWithinRangeConstructorInternal%baseMassMaximum=baseMassMaximum
+    type            (mergerTreeOperatorSelectWithinRange)                :: self
+    double precision                                     , intent(in   ) :: baseMassMinimum, baseMassMaximum
+    !![
+    <constructorAssign variables="baseMassMinimum, baseMassMaximum"/>
+    !!]
+ 
     return
   end function selectWithinRangeConstructorInternal
 

--- a/source/nodes.property_extractor.final_descendent.F90
+++ b/source/nodes.property_extractor.final_descendent.F90
@@ -46,16 +46,16 @@ Contains a module which implements an ISM mass output analysis property extracto
 
 contains
 
-  function finalDescendentConstructorParameters(parameters)
+  function finalDescendentConstructorParameters(parameters) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily finalDescendent} node property extractor class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(nodePropertyExtractorFinalDescendent)                :: finalDescendentConstructorParameters
+    type(nodePropertyExtractorFinalDescendent)                :: self
     type(inputParameters                     ), intent(inout) :: parameters
 
-    finalDescendentConstructorParameters=nodePropertyExtractorFinalDescendent()
+    self=nodePropertyExtractorFinalDescendent()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/nodes.property_extractor.mass_ISM.F90
+++ b/source/nodes.property_extractor.mass_ISM.F90
@@ -53,20 +53,20 @@ Contains a module which implements an ISM mass output analysis property extracto
 
 contains
 
-  function massISMConstructorParameters(parameters)
+  function massISMConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``massISM'' output analysis property extractor class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type (nodePropertyExtractorMassISM)                :: massISMConstructorParameters
+    type (nodePropertyExtractorMassISM)                :: self
     type (inputParameters             ), intent(inout) :: parameters
     class(galacticStructureClass      ), pointer       :: galacticStructure_
 
     !![
     <objectBuilder class="galacticStructure" name="galacticStructure_" source="parameters"/>
     !!]
-    massISMConstructorParameters=nodePropertyExtractorMassISM(galacticStructure_)
+    self=nodePropertyExtractorMassISM(galacticStructure_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="galacticStructure_"/>

--- a/source/nodes.property_extractor.mass_black_hole.F90
+++ b/source/nodes.property_extractor.mass_black_hole.F90
@@ -48,16 +48,16 @@ Contains a module which implements a black hole mass output analysis property ex
 
 contains
 
-  function massBlackHoleConstructorParameters(parameters)
+  function massBlackHoleConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``massBlackHole'' output analysis property extractor class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(nodePropertyExtractorMassBlackHole)                :: massBlackHoleConstructorParameters
+    type(nodePropertyExtractorMassBlackHole)                :: self
     type(inputParameters                   ), intent(inout) :: parameters
 
-    massBlackHoleConstructorParameters=nodePropertyExtractorMassBlackHole()
+    self=nodePropertyExtractorMassBlackHole()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/nodes.property_extractor.null.F90
+++ b/source/nodes.property_extractor.null.F90
@@ -44,16 +44,16 @@ Contains a module which implements a null output analysis class.
 
 contains
 
-  function nullConstructorParameters(parameters)
+  function nullConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``null'' output analysis property extractor class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(nodePropertyExtractorNull)                :: nullConstructorParameters
+    type(nodePropertyExtractorNull)                :: self
     type(inputParameters          ), intent(inout) :: parameters
 
-    nullConstructorParameters=nodePropertyExtractorNull()
+    self=nodePropertyExtractorNull()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/nodes.property_extractor.tree_indices.F90
+++ b/source/nodes.property_extractor.tree_indices.F90
@@ -46,16 +46,16 @@ Contains a module which implements an ISM mass output analysis property extracto
 
 contains
 
-  function indicesTreeConstructorParameters(parameters)
+  function indicesTreeConstructorParameters(parameters) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily indicesTree} node property extractor class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(nodePropertyExtractorIndicesTree)                :: indicesTreeConstructorParameters
+    type(nodePropertyExtractorIndicesTree)                :: self
     type(inputParameters                 ), intent(inout) :: parameters
 
-    indicesTreeConstructorParameters=nodePropertyExtractorIndicesTree()
+    self=nodePropertyExtractorIndicesTree()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/numerical.nearest_neighbors.F90
+++ b/source/numerical.nearest_neighbors.F90
@@ -120,7 +120,7 @@ module Nearest_Neighbors
 
 contains
 
-  function nearestNeighborsConstructor(points)
+  function nearestNeighborsConstructor(points) result(self)
     !!{
     Constructs a nearest neighor search object.
     !!}
@@ -128,14 +128,14 @@ contains
     use :: Error, only : Error_Report
 #endif
     implicit none
-    type            (nearestNeighbors)                                :: nearestNeighborsConstructor
+    type            (nearestNeighbors)                                :: self
     double precision                  , intent(in   ), dimension(:,:) :: points
 
 #ifdef ANNAVAIL
-    nearestNeighborsConstructor%ANNkd_tree=nearestNeighborsConstructorC(size(points,dim=1),size(points,dim=2),points)
+    self%ANNkd_tree=nearestNeighborsConstructorC(size(points,dim=1),size(points,dim=2),points)
 #else
     !$GLC attributes unused :: points
-    nearestNeighborsConstructor%ANNkd_tree=C_Null_Ptr
+    self%ANNkd_tree=C_Null_Ptr
     call Error_Report('ANN library is required but was not found'//{introspection:location})
 #endif
     return

--- a/source/objects.nodes.F90
+++ b/source/objects.nodes.F90
@@ -263,22 +263,22 @@ module Galacticus_Nodes
 
   !
   ! Functions for treeNode class.
-  function Tree_Node_Constructor(index,hostTree)
+  function Tree_Node_Constructor(index,hostTree) result(self)
     !!{
     Return a pointer to a newly created and initialized {\normalfont \ttfamily treeNode}.
     !!}
     use :: Error, only : Error_Report
     implicit none
-    type   (treeNode      ), pointer                         :: Tree_Node_Constructor
+    type   (treeNode      ), pointer                         :: self
     integer(kind=kind_int8), intent(in   ), optional         :: index
     type   (mergerTree    ), intent(in   ), optional, target :: hostTree
     integer                                                  :: allocErr
 
     ! Allocate the object.
-    allocate(Tree_Node_Constructor,stat=allocErr)
+    allocate(self,stat=allocErr)
     if (allocErr/=0) call Error_Report('unable to allocate node'//{introspection:location})
     ! Initialize the node.
-    call Tree_Node_Constructor%initialize(index,hostTree)
+    call self%initialize(index,hostTree)
     return
   end function Tree_Node_Constructor
 

--- a/source/output.analyses.null.F90
+++ b/source/output.analyses.null.F90
@@ -47,16 +47,16 @@ Contains a module which implements a null output analysis class.
 
 contains
 
-  function nullConstructorParameters(parameters)
+  function nullConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``null'' output analysis class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(outputAnalysisNull)                :: nullConstructorParameters
+    type(outputAnalysisNull)                :: self
     type(inputParameters   ), intent(inout) :: parameters
 
-    nullConstructorParameters=outputAnalysisNull()
+    self=outputAnalysisNull()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/output.analyses.property_operator.antiLog10.F90
+++ b/source/output.analyses.property_operator.antiLog10.F90
@@ -44,16 +44,16 @@ Contains a module which implements an anti-$\log_{10}()$ output analysis propert
 
 contains
 
-  function antiLog10ConstructorParameters(parameters)
+  function antiLog10ConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``antiLog10'' output analysis property operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(outputAnalysisPropertyOperatorAntiLog10)                :: antiLog10ConstructorParameters
+    type(outputAnalysisPropertyOperatorAntiLog10)                :: self
     type(inputParameters                        ), intent(inout) :: parameters
 
-    antiLog10ConstructorParameters=outputAnalysisPropertyOperatorAntiLog10()
+    self=outputAnalysisPropertyOperatorAntiLog10()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/output.analyses.property_operator.identity.F90
+++ b/source/output.analyses.property_operator.identity.F90
@@ -44,16 +44,16 @@ Contains a module which implements an identity output analysis property operator
 
 contains
 
-  function identityConstructorParameters(parameters)
+  function identityConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``identity'' output analysis property operateor class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(outputAnalysisPropertyOperatorIdentity)                :: identityConstructorParameters
+    type(outputAnalysisPropertyOperatorIdentity)                :: self
     type(inputParameters                       ), intent(inout) :: parameters
 
-    identityConstructorParameters=outputAnalysisPropertyOperatorIdentity()
+    self=outputAnalysisPropertyOperatorIdentity()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/output.analyses.property_operator.log10.F90
+++ b/source/output.analyses.property_operator.log10.F90
@@ -44,16 +44,16 @@ Contains a module which implements an log10 output analysis property operator cl
 
 contains
 
-  function log10ConstructorParameters(parameters)
+  function log10ConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``log10'' output analysis property operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(outputAnalysisPropertyOperatorLog10)                :: log10ConstructorParameters
+    type(outputAnalysisPropertyOperatorLog10)                :: self
     type(inputParameters                    ), intent(inout) :: parameters
 
-    log10ConstructorParameters=outputAnalysisPropertyOperatorLog10()
+    self=outputAnalysisPropertyOperatorLog10()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/output.analyses.property_operator.magnitude.F90
+++ b/source/output.analyses.property_operator.magnitude.F90
@@ -44,16 +44,16 @@ Contains a module which implements an output analysis property operator class wh
 
 contains
 
-  function magnitudeConstructorParameters(parameters)
+  function magnitudeConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``magnitude'' output analysis property operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(outputAnalysisPropertyOperatorMagnitude)                :: magnitudeConstructorParameters
+    type(outputAnalysisPropertyOperatorMagnitude)                :: self
     type(inputParameters                        ), intent(inout) :: parameters
 
-    magnitudeConstructorParameters=outputAnalysisPropertyOperatorMagnitude()
+    self=outputAnalysisPropertyOperatorMagnitude()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/output.analyses.property_operator.square.F90
+++ b/source/output.analyses.property_operator.square.F90
@@ -44,16 +44,16 @@ Contains a module which implements a square output analysis property operator cl
 
 contains
 
-  function squareConstructorParameters(parameters)
+  function squareConstructorParameters(parameters) result(self)
     !!{
     Constructor for the ``square'' output analysis property operateor class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(outputAnalysisPropertyOperatorSquare)                :: squareConstructorParameters
+    type(outputAnalysisPropertyOperatorSquare)                :: self
     type(inputParameters                     ), intent(inout) :: parameters
 
-    squareConstructorParameters=outputAnalysisPropertyOperatorSquare()
+    self=outputAnalysisPropertyOperatorSquare()
     !![
     <inputParametersValidate source="parameters"/>
     !!]

--- a/source/structure_formation.transfer_function.AxionCAMB.F90
+++ b/source/structure_formation.transfer_function.AxionCAMB.F90
@@ -40,10 +40,10 @@
      A transfer function class which utilizes the AxionCAMB code to compute transfer functions.
      !!}
      private
-     logical                                            :: initialized
-     double precision                                   :: wavenumberMaximum
-     logical                                            :: wavenumberMaximumReached
-     integer                                            :: axionCambCountPerDecade
+     logical          :: initialized
+     double precision :: wavenumberMaximum
+     logical          :: wavenumberMaximumReached
+     integer          :: axionCambCountPerDecade
    contains
      !![
      <methods>

--- a/source/structure_formation.unevolved_subhalo_mass_function.Giocoli2008.F90
+++ b/source/structure_formation.unevolved_subhalo_mass_function.Giocoli2008.F90
@@ -50,13 +50,13 @@ Contains a module which implements a \cite{giocoli_population_2008} unevolved da
 
 contains
 
-  function giocoli2008ConstructorParameters(parameters)
+  function giocoli2008ConstructorParameters(parameters) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily giocoli2008} halo mass function class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(unevolvedSubhaloMassFunctionGiocoli2008)                :: giocoli2008ConstructorParameters
+    type(unevolvedSubhaloMassFunctionGiocoli2008)                :: self
     type(inputParameters                        ), intent(inout) :: parameters
 
     ! Check and read parameters.
@@ -64,7 +64,7 @@ contains
     <inputParameter>
       <name>normalization</name>
       <source>parameters</source>
-      <variable>giocoli2008ConstructorParameters%normalization</variable>
+      <variable>self%normalization</variable>
       <defaultValue>0.21d0</defaultValue>
       <defaultSource>\cite{giocoli_population_2008}</defaultSource>
       <description>The parameter $N_0$ in the \cite{giocoli_population_2008} unevolved subhalo mass function fit.</description>
@@ -72,7 +72,7 @@ contains
     <inputParameter>
       <name>exponent</name>
       <source>parameters</source>
-      <variable>giocoli2008ConstructorParameters%exponent</variable>
+      <variable>self%exponent</variable>
       <defaultValue>0.8d0</defaultValue>
       <defaultSource>\cite{giocoli_population_2008}</defaultSource>
       <description>The parameter $\alpha$ in the \cite{giocoli_population_2008} unevolved subhalo mass function fit.</description>
@@ -82,16 +82,17 @@ contains
    return
   end function giocoli2008ConstructorParameters
 
-  function giocoli2008ConstructorInternal(normalization,exponent)
+  function giocoli2008ConstructorInternal(normalization,exponent) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily giocoli2008} halo mass function class.
     !!}
     implicit none
-    type            (unevolvedSubhaloMassFunctionGiocoli2008)                :: giocoli2008ConstructorInternal
-    double precision                                         , intent(in   ) :: normalization                 , exponent
+    type            (unevolvedSubhaloMassFunctionGiocoli2008)                :: self
+    double precision                                         , intent(in   ) :: normalization, exponent
+    !![
+    <constructorAssign variables="normalization, exponent"/>
+    !!]
 
-    giocoli2008ConstructorInternal%normalization=normalization
-    giocoli2008ConstructorInternal%exponent     =exponent
     return
   end function giocoli2008ConstructorInternal
 

--- a/source/utility.IO.IRATE.F90
+++ b/source/utility.IO.IRATE.F90
@@ -36,8 +36,8 @@ module IO_IRATE
      A class for interacting with \gls{irate} format files.
      !!}
      type (varying_string          )          :: fileName
-     class(cosmologyFunctionsClass ), pointer :: cosmologyFunctions_
-     class(cosmologyParametersClass), pointer :: cosmologyParameters_
+     class(cosmologyFunctionsClass ), pointer :: cosmologyFunctions_  => null()
+     class(cosmologyParametersClass), pointer :: cosmologyParameters_ => null()
    contains
      !![
      <methods>
@@ -65,20 +65,20 @@ module IO_IRATE
 
 contains
 
-  function irateConstructor(fileName,cosmologyParameters_,cosmologyFunctions_)
+  function irateConstructor(fileName,cosmologyParameters_,cosmologyFunctions_) result(self)
     !!{
     Constructor for \gls{irate} file interface class.
     !!}
     use :: ISO_Varying_String, only : assignment(=)
     implicit none
-    type     (irate                   )                        :: irateConstructor
+    type     (irate                   )                        :: self
     character(len=*                   ), intent(in   )         :: fileName
     class    (cosmologyFunctionsClass ), intent(in   ), target :: cosmologyFunctions_
     class    (cosmologyParametersClass), intent(in   ), target :: cosmologyParameters_
 
-    irateConstructor%cosmologyParameters_ => cosmologyParameters_
-    irateConstructor%cosmologyFunctions_  => cosmologyFunctions_
-    irateConstructor%fileName             =  trim(fileName)
+    self%cosmologyParameters_ => cosmologyParameters_
+    self%cosmologyFunctions_  => cosmologyFunctions_
+    self%fileName             =  trim(fileName)
     return
   end function irateConstructor
 

--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -298,7 +298,7 @@ contains
             &              )
     else
        self=inputParameters(                                                 &
-            &               xmlString                                      , &
+            &               char(xmlString)                                , &
             &               allowedParameterNames                          , &
             &               outputParametersGroup                          , &
             &               noOutput                                         &
@@ -306,28 +306,6 @@ contains
     end if
     return
   end function inputParametersConstructorVarStr
-
-  function inputParametersConstructorFileVarStr(fileName,allowedParameterNames,outputParametersGroup,noOutput) result(self)
-    !!{
-    Constructor for the {\normalfont \ttfamily inputParameters} class from an XML file
-    specified as a variable length string.
-    !!}
-    use :: ISO_Varying_String, only : char
-    implicit none
-    type     (inputParameters)                                           :: self
-    type     (varying_string    )              , intent(in   )           :: fileName
-    character(len=*             ), dimension(:), intent(in   ), optional :: allowedParameterNames
-    type     (hdf5Object        ), target      , intent(in   ), optional :: outputParametersGroup
-    logical                                    , intent(in   ), optional :: noOutput
-
-    self=inputParameters(                       &
-         &               char(fileName)       , &
-         &               allowedParameterNames, &
-         &               outputParametersGroup, &
-         &               noOutput               &
-         &              )
-    return
-  end function inputParametersConstructorFileVarStr
 
   function inputParametersConstructorFileChar(fileName,allowedParameterNames,outputParametersGroup,noOutput) result(self)
     !!{

--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -237,33 +237,33 @@ module Input_Parameters
 
 contains
 
-  function inputParametersConstructorNull()
+  function inputParametersConstructorNull() result(self)
     !!{
     Constructor for the {\normalfont \ttfamily inputParameters} class creating a null instance.
     !!}
     use :: FoX_dom, only : createDocument, getDocumentElement, getImplementation, setLiveNodeLists
     implicit none
-    type(inputParameters) :: inputParametersConstructorNull
+    type(inputParameters) :: self
 
-    allocate(inputParametersConstructorNull%warnedDefaults)
-    allocate(inputParametersConstructorNull%lock          )
-    inputParametersConstructorNull%document       => createDocument    (                                  &
-         &                                                              getImplementation()             , &
-         &                                                              qualifiedName      ="parameters", &
-         &                                                              docType            =null()        &
-         &                                                             )
-    inputParametersConstructorNull%rootNode       => getDocumentElement(inputParametersConstructorNull%document)
-    inputParametersConstructorNull%parameters     => null              (                                       )
-    inputParametersConstructorNull%warnedDefaults =  integerHash       (                                       )
-    inputParametersConstructorNull%lock           =  ompLock           (                                       )
-    inputParametersConstructorNull%isNull         = .true.
+    allocate(self%warnedDefaults)
+    allocate(self%lock          )
+    self%document       => createDocument    (                                  &
+         &                                    getImplementation()             , &
+         &                                    qualifiedName      ="parameters", &
+         &                                    docType            =null()        &
+         &                                   )
+    self%rootNode       => getDocumentElement(self%document)
+    self%parameters     => null              (             )
+    self%warnedDefaults =  integerHash       (             )
+    self%lock           =  ompLock           (             )
+    self%isNull         = .true.
     !$omp critical (FoX_DOM_Access)
-    call setLiveNodeLists(inputParametersConstructorNull%document,.false.)
+    call setLiveNodeLists(self%document,.false.)
     !$omp end critical (FoX_DOM_Access)
    return
   end function inputParametersConstructorNull
 
-  function inputParametersConstructorVarStr(xmlString,allowedParameterNames,outputParametersGroup,noOutput)
+  function inputParametersConstructorVarStr(xmlString,allowedParameterNames,outputParametersGroup,noOutput) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily inputParameters} class from an XML file
     specified as a variable length string.
@@ -274,7 +274,7 @@ contains
     use :: FoX_dom           , only : node
     use :: ISO_Varying_String, only : char, extract, operator(==)
     implicit none
-    type     (inputParameters)                                           :: inputParametersConstructorVarStr
+    type     (inputParameters)                                           :: self
     type     (varying_string    )              , intent(in   )           :: xmlString
     character(len=*             ), dimension(:), intent(in   ), optional :: allowedParameterNames
     type     (hdf5Object        ), target      , intent(in   ), optional :: outputParametersGroup
@@ -287,49 +287,49 @@ contains
        !$omp critical (FoX_DOM_Access)
        parameterNode => parseString(char(xmlString))
        !$omp end critical (FoX_DOM_Access)
-       inputParametersConstructorVarStr=inputParametersConstructorNode      (                                                 &
-            &                                                                XML_Get_First_Element_By_Tag_Name(               &
-            &                                                                                                  parameterNode, &
-            &                                                                                                  'parameters'   &
-            &                                                                                                 )             , &
-            &                                                                allowedParameterNames                          , &
-            &                                                                outputParametersGroup                          , &
-            &                                                                noOutput                                         &
-            &                                                               )
+       self=inputParameters(                                                 &
+            &               XML_Get_First_Element_By_Tag_Name(               &
+            &                                                 parameterNode, &
+            &                                                 'parameters'   &
+            &                                                )             , &
+            &               allowedParameterNames                          , &
+            &               outputParametersGroup                          , &
+            &               noOutput                                         &
+            &              )
     else
-       inputParametersConstructorVarStr=inputParametersConstructorFileVarStr(                                                 &
-            &                                                                xmlString                                      , &
-            &                                                                allowedParameterNames                          , &
-            &                                                                outputParametersGroup                          , &
-            &                                                                noOutput                                         &
-            &                                                               )
+       self=inputParameters(                                                 &
+            &               xmlString                                      , &
+            &               allowedParameterNames                          , &
+            &               outputParametersGroup                          , &
+            &               noOutput                                         &
+            &              )
     end if
     return
   end function inputParametersConstructorVarStr
 
-  function inputParametersConstructorFileVarStr(fileName,allowedParameterNames,outputParametersGroup,noOutput)
+  function inputParametersConstructorFileVarStr(fileName,allowedParameterNames,outputParametersGroup,noOutput) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily inputParameters} class from an XML file
     specified as a variable length string.
     !!}
     use :: ISO_Varying_String, only : char
     implicit none
-    type     (inputParameters)                                           :: inputParametersConstructorFileVarStr
+    type     (inputParameters)                                           :: self
     type     (varying_string    )              , intent(in   )           :: fileName
     character(len=*             ), dimension(:), intent(in   ), optional :: allowedParameterNames
     type     (hdf5Object        ), target      , intent(in   ), optional :: outputParametersGroup
     logical                                    , intent(in   ), optional :: noOutput
 
-    inputParametersConstructorFileVarStr=inputParametersConstructorFileChar(                       &
-         &                                                                  char(fileName)       , &
-         &                                                                  allowedParameterNames, &
-         &                                                                  outputParametersGroup, &
-         &                                                                  noOutput               &
-         &                                                                 )
+    self=inputParameters(                       &
+         &               char(fileName)       , &
+         &               allowedParameterNames, &
+         &               outputParametersGroup, &
+         &               noOutput               &
+         &              )
     return
   end function inputParametersConstructorFileVarStr
 
-  function inputParametersConstructorFileChar(fileName,allowedParameterNames,outputParametersGroup,noOutput)
+  function inputParametersConstructorFileChar(fileName,allowedParameterNames,outputParametersGroup,noOutput) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily inputParameters} class from an XML file
     specified as a character variable.
@@ -339,7 +339,7 @@ contains
     use :: Error         , only : Error_Report
     use :: IO_XML        , only : XML_Get_First_Element_By_Tag_Name, XML_Parse
     implicit none
-    type     (inputParameters)                                        :: inputParametersConstructorFileChar
+    type     (inputParameters)                                        :: self
     character(len=*          )              , intent(in   )           :: fileName
     character(len=*          ), dimension(:), intent(in   ), optional :: allowedParameterNames
     type     (hdf5Object     ), target      , intent(in   ), optional :: outputParametersGroup
@@ -360,43 +360,43 @@ contains
        end if
     end if
     !$omp end critical (FoX_DOM_Access)
-    inputParametersConstructorFileChar=inputParametersConstructorNode(                                                 &
-         &                                                            XML_Get_First_Element_By_Tag_Name(               &
-         &                                                                                              parameterNode, &
-         &                                                                                              'parameters'   &
-         &                                                                                             )             , &
-         &                                                            allowedParameterNames                          , &
-         &                                                            outputParametersGroup                          , &
-         &                                                            noOutput                                         &
-         &                                                           )
+    self=inputParameters(                                                 &
+         &               XML_Get_First_Element_By_Tag_Name(               &
+         &                                                 parameterNode, &
+         &                                                 'parameters'   &
+         &                                                )             , &
+         &               allowedParameterNames                          , &
+         &               outputParametersGroup                          , &
+         &               noOutput                                         &
+         &              )
     return
   end function inputParametersConstructorFileChar
 
-  function inputParametersConstructorCopy(parameters)
+  function inputParametersConstructorCopy(parameters) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily inputParameters} class from an existing parameters object.
     !!}
     implicit none
-    type (inputParameters)                :: inputParametersConstructorCopy
+    type (inputParameters)                :: self
     type (inputParameters), intent(in   ) :: parameters
 
-    inputParametersConstructorCopy            =  inputParameters(parameters%rootNode  ,noOutput=.true.,noBuild=.true.)
-    inputParametersConstructorCopy%parameters =>                 parameters%parameters
-    inputParametersConstructorCopy%parent     =>                 parameters%parent
+    self            =  inputParameters(parameters%rootNode  ,noOutput=.true.,noBuild=.true.)
+    self%parameters =>                 parameters%parameters
+    self%parent     =>                 parameters%parent
     if (allocated(parameters%warnedDefaults)) then
-       if (allocated(inputParametersConstructorCopy%warnedDefaults)) deallocate(inputParametersConstructorCopy%warnedDefaults)
-       allocate(inputParametersConstructorCopy%warnedDefaults)
-       inputParametersConstructorCopy%warnedDefaults=parameters%warnedDefaults
+       if (allocated(self%warnedDefaults)) deallocate(self%warnedDefaults)
+       allocate(self%warnedDefaults)
+       self%warnedDefaults=parameters%warnedDefaults
     end if
     if (associated(parameters%lock)) then
-       deallocate(inputParametersConstructorCopy%lock)
-       allocate(inputParametersConstructorCopy%lock)
-       inputParametersConstructorCopy%lock=ompLock()
+       deallocate(self%lock)
+       allocate  (self%lock)
+       self%lock=ompLock()
     end if
     return
   end function inputParametersConstructorCopy
 
-  function inputParametersConstructorNode(parametersNode,allowedParameterNames,outputParametersGroup,noOutput,noBuild)
+  function inputParametersConstructorNode(parametersNode,allowedParameterNames,outputParametersGroup,noOutput,noBuild) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily inputParameters} class from an FoX node.
     !!}
@@ -411,7 +411,7 @@ contains
     use :: IO_HDF5           , only : ioHDF5AccessInitialize
     use :: HDF5_Access       , only : hdf5Access
     implicit none
-    type     (inputParameters)                                        :: inputParametersConstructorNode
+    type     (inputParameters)                                        :: self
     type     (node           ), pointer     , intent(in   )           :: parametersNode
     character(len=*          ), dimension(:), intent(in   ), optional :: allowedParameterNames
     type     (hdf5Object     ), target      , intent(in   ), optional :: outputParametersGroup
@@ -427,53 +427,53 @@ contains
     !!]
 #include "os.inc"
 
-    allocate(inputParametersConstructorNode%warnedDefaults)
-    allocate(inputParametersConstructorNode%lock          )
-    inputParametersConstructorNode%isNull         =  .false.
-    inputParametersConstructorNode%document       => getOwnerDocument(parametersNode)
-    inputParametersConstructorNode%rootNode       =>                  parametersNode
-    inputParametersConstructorNode%parent         => null            (              )
-    inputParametersConstructorNode%warnedDefaults =  integerHash     (              )
-    inputParametersConstructorNode%lock           =  ompLock         (              )
+    allocate(self%warnedDefaults)
+    allocate(self%lock          )
+    self%isNull         =  .false.
+    self%document       => getOwnerDocument(parametersNode)
+    self%rootNode       =>                  parametersNode
+    self%parent         => null            (              )
+    self%warnedDefaults =  integerHash     (              )
+    self%lock           =  ompLock         (              )
     !$omp critical (FoX_DOM_Access)
-    call setLiveNodeLists(inputParametersConstructorNode%document,.false.)
+    call setLiveNodeLists(self%document,.false.)
     if (.not.noBuild_) then
-       allocate(inputParametersConstructorNode%parameters)
-       inputParametersConstructorNode%parameters%content    => null()
-       inputParametersConstructorNode%parameters%parent     => null()
-       inputParametersConstructorNode%parameters%firstChild => null()
-       inputParametersConstructorNode%parameters%sibling    => null()
-       inputParametersConstructorNode%parameters%referenced => null()
-       call inputParametersConstructorNode%buildTree        (inputParametersConstructorNode%parameters,parametersNode)
-       call inputParametersConstructorNode%resolveReferences(                                                        )
+       allocate(self%parameters)
+       self%parameters%content    => null()
+       self%parameters%parent     => null()
+       self%parameters%firstChild => null()
+       self%parameters%sibling    => null()
+       self%parameters%referenced => null()
+       call self%buildTree        (self%parameters,parametersNode)
+       call self%resolveReferences(                              )
     end if
     !$omp end critical (FoX_DOM_Access)
     ! Set a pointer to HDF5 object to which to write parameters.
     if (present(outputParametersGroup)) then
        !$ call hdf5Access%  set()
-       inputParametersConstructorNode%outputParameters         =outputParametersGroup%openGroup('Parameters')
-       inputParametersConstructorNode%outputParametersCopied   =.false.
-       inputParametersConstructorNode%outputParametersTemporary=.false.
+       self%outputParameters         =outputParametersGroup%openGroup('Parameters')
+       self%outputParametersCopied   =.false.
+       self%outputParametersTemporary=.false.
        !$ call hdf5Access%unset()
     else if (.not.noOutput_) then
        ! The HDF5 access lock may not yet have been initialized. Ensure it is before using it.
        call ioHDF5AccessInitialize()
        !$ call hdf5Access%  set()
-       call inputParametersConstructorNode%outputParametersContainer%openFile(                                      &
-            &                                                                 char(                                 &
-            &                                                                      File_Name_Temporary(             &
-            &                                                                                          'glcTmpPar', &
+       call self%outputParametersContainer%openFile(                                      &
+            &                                       char(                                 &
+            &                                            File_Name_Temporary(             &
+            &                                                                'glcTmpPar', &
 #ifdef __APPLE__
-            &                                                                                          '/tmp'       &
+            &                                                                '/tmp'       &
 #else
-            &                                                                                          '/dev/shm'   &
+            &                                                                '/dev/shm'   &
 #endif
-            &                                                                                         )             &
-            &                                                                      )                                &
-            &                                                                )
-       inputParametersConstructorNode%outputParameters         =inputParametersConstructorNode%outputParametersContainer%openGroup('Parameters')
-       inputParametersConstructorNode%outputParametersCopied   =.false.
-       inputParametersConstructorNode%outputParametersTemporary=.true.
+            &                                                               )             &
+            &                                            )                                &
+            &                                      )
+       self%outputParameters         =self%outputParametersContainer%openGroup('Parameters')
+       self%outputParametersCopied   =.false.
+       self%outputParametersTemporary=.true.
        !$ call hdf5Access%unset()
     end if
     ! Get allowed parameter names.
@@ -502,8 +502,8 @@ contains
     if (.not.allocated(allowedParameterNamesCombined)) allocate(allowedParameterNamesCombined(0))
     ! Check for version information.
     !$omp critical (FoX_DOM_Access)
-    if (XML_Path_Exists(inputParametersConstructorNode%rootNode,"version")) then
-       versionElement => XML_Get_First_Element_By_Tag_Name(inputParametersConstructorNode%rootNode,"version")
+    if (XML_Path_Exists(self%rootNode,"version")) then
+       versionElement => XML_Get_First_Element_By_Tag_Name(self%rootNode,"version")
        versionLabel=getTextContent(versionElement)
        if (String_Strip(versionLabel) /= "0.9.4") then
           message=displayGreen()//"HELP:"//displayReset()                           // &
@@ -518,7 +518,7 @@ contains
     end if
     !$omp end critical (FoX_DOM_Access)
     ! Check parameters.
-    call inputParametersConstructorNode%checkParameters(allowedParameterNamesCombined)
+    call self%checkParameters(allowedParameterNamesCombined)
     return
   end function inputParametersConstructorNode
 
@@ -1689,14 +1689,14 @@ contains
     return
   end subroutine inputParametersValueNode{Type¦label}
 
-  function inputParameterListConstructor()
+  function inputParameterListConstructor() result(self)
     !!{
     Construct an {\normalfont \ttfamily inputParameterList} object.
     !!}
     implicit none
-    type(inputParameterList) :: inputParameterListConstructor
+    type(inputParameterList) :: self
 
-    inputParameterListConstructor%count=0
+    self%count=0
     return
   end function inputParameterListConstructor
 

--- a/source/utility.regular_expressions.F90
+++ b/source/utility.regular_expressions.F90
@@ -92,15 +92,15 @@ module Regular_Expressions
 
 contains
 
-  function Regular_Expression_Constructor(regularExpression)
+  function Regular_Expression_Constructor(regularExpression) result(self)
     !!{
     Constructor for {\normalfont \ttfamily regEx} objects.
     !!}
     implicit none
-    type     (regEx)                :: Regular_Expression_Constructor
+    type     (regEx)                :: self
     character(len=*), intent(in   ) :: regularExpression
 
-    Regular_Expression_Constructor%r=Regular_Expression_Construct_C(trim(regularExpression)//char(0))
+    self%r=Regular_Expression_Construct_C(trim(regularExpression)//char(0))
     return
   end function Regular_Expression_Constructor
 


### PR DESCRIPTION
Also includes a few other clean-ups of constructors (formatting, using the `constructorAssign` directive, etc.).