### PR TITLE
Account for hot halo density profile in molecular hydrogen calculations

### DIFF
--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -40,7 +40,7 @@
   
   <!-- Intergalactic background radiation -->
   <radiationFieldIntergalacticBackground value="intergalacticBackgroundFile">
-    <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_Haardt_Madau_2012_Quasars_Galaxies.xml"/>
+    <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.xml"/>
   </radiationFieldIntergalacticBackground>
 
   <!-- Halo accretion options -->

--- a/source/chemical.reaction_rates.F90
+++ b/source/chemical.reaction_rates.F90
@@ -45,6 +45,7 @@ module Chemical_Reaction_Rates
     <selfTarget>yes</selfTarget>
     <argument>double precision                     , intent(in   ) :: lengthColumn   , temperature</argument>
     <argument>type            (chemicalAbundances ), intent(in   ) :: chemicalDensity             </argument>
+    <argument>double precision                     , intent(in   ) :: factorClumping              </argument>
     <argument>class           (radiationFieldClass), intent(inout) :: radiation                   </argument>
     <argument>type            (chemicalAbundances ), intent(inout) :: chemicalRates               </argument>
     <argument>type            (treeNode           ), intent(inout) :: node                        </argument>

--- a/source/chemical.reaction_rates.zero.F90
+++ b/source/chemical.reaction_rates.zero.F90
@@ -63,18 +63,19 @@ contains
     return
   end function zeroConstructorParameters
 
-  subroutine zeroRates(self,lengthColumn,temperature,chemicalDensity,radiation,chemicalRates,node)
+  subroutine zeroRates(self,lengthColumn,temperature,chemicalDensity,factorClumping,radiation,chemicalRates,node)
     !!{
     Return zero rates of chemical reactions.
     !!}
     implicit none
     class           (chemicalReactionRateZero), intent(inout), target :: self
     type            (chemicalAbundances      ), intent(in   )         :: chemicalDensity
-    double precision                          , intent(in   )         :: lengthColumn   , temperature
+    double precision                          , intent(in   )         :: lengthColumn   , temperature, &
+         &                                                               factorClumping
     class           (radiationFieldClass     ), intent(inout)         :: radiation
     type            (chemicalAbundances      ), intent(inout)         :: chemicalRates
     type            (treeNode                ), intent(inout)         :: node
-    !$GLC attributes unused :: self, chemicalDensity, lengthColumn, temperature, radiation, node
+    !$GLC attributes unused :: self, chemicalDensity, lengthColumn, temperature, factorClumping, radiation, node
 
     call chemicalRates%reset()
     return

--- a/source/hot_halo.mass_distribution.F90
+++ b/source/hot_halo.mass_distribution.F90
@@ -65,11 +65,18 @@ module Hot_Halo_Mass_Distributions
     <argument>double precision          , intent(in   )         :: radius</argument>
    </method>
    <method name="radialMoment" >
-    <description>Return the density of the hot halo at the given {\normalfont \ttfamily radius}.</description>
+    <description>Return the specified radial{\normalfont \ttfamily moment} of the density of the hot halo at the given {\normalfont \ttfamily radius}.</description>
     <type>double precision</type>
     <pass>yes</pass>
     <argument>type            (treeNode), intent(inout) :: node</argument>
     <argument>double precision          , intent(in   ) :: moment, radius</argument>
+   </method>
+   <method name="densitySquaredIntegral" >
+    <description>Return the integral of the square of the density of the hot halo from zero to the given {\normalfont \ttfamily radius}.</description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>type            (treeNode), intent(inout) :: node</argument>
+    <argument>double precision          , intent(in   ) :: radius</argument>
    </method>
    <method name="rotationNormalization" >
     <description>Returns the relation between specific angular momentum and rotation velocity (assuming a rotation velocity that is constant in radius) for {\normalfont \ttfamily node}. Specifically, the normalization, $A$, returned is such that $V_\mathrm{rot} = A J/M$.</description>

--- a/source/hot_halo.mass_distribution.beta_profile.F90
+++ b/source/hot_halo.mass_distribution.beta_profile.F90
@@ -53,13 +53,14 @@ An implementation of the hot halo mass distribution class for $\beta$-profile di
        <method description="Initialize the $\beta$-profile density hot halo mass distribution for the given {\normalfont \ttfamily node}." method="initialize" />
      </methods>
      !!]
-     final     ::                          betaProfileDestructor
-     procedure :: initialize            => betaProfileInitialize
-     procedure :: density               => betaProfileDensity
-     procedure :: densityLogSlope       => betaProfileDensityLogSlope
-     procedure :: enclosedMass          => betaProfileEnclosedMass
-     procedure :: radialMoment          => betaProfileRadialMoment
-     procedure :: rotationNormalization => betaProfileRotationNormalization
+     final     ::                           betaProfileDestructor
+     procedure :: initialize             => betaProfileInitialize
+     procedure :: density                => betaProfileDensity
+     procedure :: densityLogSlope        => betaProfileDensityLogSlope
+     procedure :: enclosedMass           => betaProfileEnclosedMass
+     procedure :: radialMoment           => betaProfileRadialMoment
+     procedure :: densitySquaredIntegral => betaProfileDensitySquaredIntegral
+     procedure :: rotationNormalization  => betaProfileRotationNormalization
   end type hotHaloMassDistributionBetaProfile
 
   interface hotHaloMassDistributionBetaProfile
@@ -270,6 +271,32 @@ contains
          &                      )
     return
   end function betaProfileRadialMoment
+
+  double precision function betaProfileDensitySquaredIntegral(self,node,radius)
+    !!{
+    Return the integral of the square of the density profile of the hot halo to the given {\normalfont \ttfamily radius}.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentHotHalo, treeNode
+    implicit none
+    class           (hotHaloMassDistributionBetaProfile), intent(inout) :: self
+    type            (treeNode                          ), intent(inout) :: node
+    double precision                                    , intent(in   ) :: radius
+    class           (nodeComponentHotHalo              ), pointer       :: hotHalo
+
+    call self%initialize(node)
+    hotHalo                => node%hotHalo()
+    betaProfileDensitySquaredIntegral=                                      &
+         & self%                                                            &
+         &  distribution%                                                   &
+         &   densitySquareIntegral(                                         &
+         &                         radiusMinimum=0.0d0                    , &
+         &                         radiusMaximum=min(                       &
+         &                                           radius               , &
+         &                                           hotHalo%outerRadius()  &
+         &                                          )                       &
+         &                         )
+    return
+  end function betaProfileDensitySquaredIntegral
 
   double precision function betaProfileRotationNormalization(self,node)
     !!{

--- a/source/mass_distributions.F90
+++ b/source/mass_distributions.F90
@@ -103,6 +103,13 @@ module Mass_Distributions
     <argument>double precision, intent(in   ), optional :: radiusMinimum, radiusMaximum</argument>
     <argument>logical         , intent(  out), optional :: isInfinite</argument>
    </method>
+   <method name="densitySquareIntegral" >
+    <description>Return the integral over the square of the density of the distribution.</description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>double precision, intent(in   ), optional :: radiusMinimum, radiusMaximum</argument>
+    <argument>logical         , intent(  out), optional :: isInfinite                  </argument>
+   </method>
    <method name="positionSample" >
     <description>Return a position sampled from the distribution.</description>
     <type>double precision, dimension(3)</type>

--- a/source/objects.nodes.components.hot_halo.standard.F90
+++ b/source/objects.nodes.components.hot_halo.standard.F90
@@ -244,7 +244,6 @@ module Node_Component_Hot_Halo_Standard
   class(coolingInfallRadiusClass           ), pointer :: coolingInfallRadius_
   class(hotHaloMassDistributionClass       ), pointer :: hotHaloMassDistribution_
   class(accretionHaloClass                 ), pointer :: accretionHalo_
-  class(chemicalReactionRateClass          ), pointer :: chemicalReactionRate_
   class(hotHaloRamPressureStrippingClass   ), pointer :: hotHaloRamPressureStripping_
   class(hotHaloRamPressureTimescaleClass   ), pointer :: hotHaloRamPressureTimescale_
   class(hotHaloOutflowReincorporationClass ), pointer :: hotHaloOutflowReincorporation_
@@ -252,7 +251,7 @@ module Node_Component_Hot_Halo_Standard
   class(coolingRateClass                   ), pointer :: coolingRate_
   class(cosmologyParametersClass           ), pointer :: cosmologyParameters_
   class(galacticStructureClass             ), pointer :: galacticStructure_
-  !$omp threadprivate(cosmologyFunctions_,darkMatterHaloScale_,coolingSpecificAngularMomentum_,coolingInfallRadius_,hotHaloMassDistribution_,accretionHalo_,chemicalReactionRate_,chemicalState_,hotHaloRamPressureStripping_,hotHaloRamPressureTimescale_,coolingRate_,cosmologyParameters_,hotHaloOutflowReincorporation_,galacticStructure_)
+  !$omp threadprivate(cosmologyFunctions_,darkMatterHaloScale_,coolingSpecificAngularMomentum_,coolingInfallRadius_,hotHaloMassDistribution_,accretionHalo_,chemicalState_,hotHaloRamPressureStripping_,hotHaloRamPressureTimescale_,coolingRate_,cosmologyParameters_,hotHaloOutflowReincorporation_,galacticStructure_)
 
   ! Internal count of abundances and chemicals.
   integer                                                             :: abundancesCount                            , chemicalsCount
@@ -493,7 +492,6 @@ contains
        <objectBuilder class="coolingInfallRadius"            name="coolingInfallRadius_"            source="subParameters"/>
        <objectBuilder class="hotHaloMassDistribution"        name="hotHaloMassDistribution_"        source="subParameters"/>
        <objectBuilder class="accretionHalo"                  name="accretionHalo_"                  source="subParameters"/>
-       <objectBuilder class="chemicalReactionRate"           name="chemicalReactionRate_"           source="subParameters"/>
        <objectBuilder class="chemicalState"                  name="chemicalState_"                  source="subParameters"/>
        <objectBuilder class="hotHaloRamPressureStripping"    name="hotHaloRamPressureStripping_"    source="subParameters"/>
        <objectBuilder class="hotHaloRamPressureTimescale"    name="hotHaloRamPressureTimescale_"    source="subParameters"/>
@@ -557,7 +555,6 @@ contains
        <objectDestructor name="coolingInfallRadius_"              />
        <objectDestructor name="hotHaloMassDistribution_"          />
        <objectDestructor name="accretionHalo_"                    />
-       <objectDestructor name="chemicalReactionRate_"             />
        <objectDestructor name="chemicalState_"                    />
        <objectDestructor name="hotHaloRamPressureStripping_"      />
        <objectDestructor name="hotHaloRamPressureTimescale_"      />
@@ -2205,7 +2202,7 @@ contains
 
     call displayMessage('Storing state for: componentHotHalo -> standard',verbosity=verbosityLevelInfo)
     !![
-    <stateStore variables="cosmologyFunctions_ darkMatterHaloScale_ coolingSpecificAngularMomentum_ coolingInfallRadius_ hotHaloMassDistribution_ accretionHalo_ chemicalReactionRate_ chemicalState_ hotHaloRamPressureStripping_ hotHaloRamPressureTimescale_ coolingRate_ cosmologyParameters_ hotHaloOutflowReincorporation_ galacticStructure_"/>
+    <stateStore variables="cosmologyFunctions_ darkMatterHaloScale_ coolingSpecificAngularMomentum_ coolingInfallRadius_ hotHaloMassDistribution_ accretionHalo_ chemicalState_ hotHaloRamPressureStripping_ hotHaloRamPressureTimescale_ coolingRate_ cosmologyParameters_ hotHaloOutflowReincorporation_ galacticStructure_"/>
     !!]
     return
   end subroutine Node_Component_Hot_Halo_Standard_State_Store
@@ -2228,7 +2225,7 @@ contains
 
     call displayMessage('Retrieving state for: componentHotHalo -> standard',verbosity=verbosityLevelInfo)
     !![
-    <stateRestore variables="cosmologyFunctions_ darkMatterHaloScale_ coolingSpecificAngularMomentum_ coolingInfallRadius_ hotHaloMassDistribution_ accretionHalo_ chemicalReactionRate_ chemicalState_ hotHaloRamPressureStripping_ hotHaloRamPressureTimescale_ coolingRate_ cosmologyParameters_ hotHaloOutflowReincorporation_ galacticStructure_"/>
+    <stateRestore variables="cosmologyFunctions_ darkMatterHaloScale_ coolingSpecificAngularMomentum_ coolingInfallRadius_ hotHaloMassDistribution_ accretionHalo_ chemicalState_ hotHaloRamPressureStripping_ hotHaloRamPressureTimescale_ coolingRate_ cosmologyParameters_ hotHaloOutflowReincorporation_ galacticStructure_"/>
     !!]
     return
   end subroutine Node_Component_Hot_Halo_Standard_State_Restore

--- a/source/tests.mass_distributions.F90
+++ b/source/tests.mass_distributions.F90
@@ -133,18 +133,42 @@ program Test_Mass_Distributions
   class is (massDistributionSpherical)
      position    =[1.0d0,0.0d0,0.0d0]
      positionZero=[0.0d0,0.0d0,0.0d0]
-     call Assert(                                                        &
-          &      "Mass within scale radius"                            , &
-          &      +massDistribution_%massEnclosedBySphere(1.0d0       ), &
-          &      +(4.0d0-Pi)*Pi                                        , &
-          &      absTol=1.0d-6                                           &
+     call Assert(                                                              &
+          &      "Mass within scale radius"                                  , &
+          &      +massDistribution_%massEnclosedBySphere (1.0d0             ), &
+          &      +(4.0d0-Pi)*Pi                                              , &
+          &      absTol=1.0d-6                                                 &
           &     )
-     call Assert(                                                        &
-          &      "Potential at scale radius"                           , &
-          &      +massDistribution_%potential           (position    )  &
-          &      -massDistribution_%potential           (positionZero), &
-          &      +Pi*(Pi+log(4.0d0)-4.0d0)                             , &
-          &      absTol=1.0d-6                                           &
+     call Assert(                                                              &
+          &      "Potential at scale radius"                                 , &
+          &      +massDistribution_%potential            (position          )  &
+          &      -massDistribution_%potential            (positionZero      ), &
+          &      +Pi*(Pi+log(4.0d0)-4.0d0)                                   , &
+          &      absTol=1.0d-6                                                 &
+          &     )
+     call Assert(                                                              &
+          &      "Radial moment, m=1"                                        , &
+          &      +massDistribution_%densityRadialMoment  (1.0d0,0.0d0,1.0d0) , &
+          &      +0.3465735902799727d0                                       , &
+          &      absTol=1.0d-6                                                 &
+          &     )
+     call Assert(                                                              &
+          &      "Radial moment, m=2"                                        , &
+          &      +massDistribution_%densityRadialMoment  (2.0d0,0.0d0,1.0d0) , &
+          &      +0.2146018366025517d0                                       , &
+          &      absTol=1.0d-6                                                 &
+          &     )
+     call Assert(                                                              &
+          &      "Radial moment, m=3"                                        , &
+          &      +massDistribution_%densityRadialMoment  (3.0d0,0.0d0,1.0d0) , &
+          &      +0.1534264097200273d0                                       , &
+          &      absTol=1.0d-6                                                 &
+          &     )
+     call Assert(                                                              &
+          &      "Square integral"                                           , &
+          &      +massDistribution_%densitySquareIntegral(      0.0d0,1.0d0) , &
+          &      +1.793209546954886d0                                        , &
+          &      absTol=1.0d-6                                                 &
           &     )
   end select
   ! Ensure that a dimensionful profile produces the correct mass inside of its outer radius.


### PR DESCRIPTION
Computes an estimate of the "clumping factor" boost to two-body reaction rates based on the hot halo density profile. Also accounts for the density profile when estimating column densities for self-shielding calculations.

Also, switch to using the more up to date Faucher-Giguere (2020) model for the intergalactic background radiation.