### PR TITLE
Add a reset method to MPI counters

### DIFF
--- a/source/tasks.evolve_forests.work_share.first_come_first_served.F90
+++ b/source/tasks.evolve_forests.work_share.first_come_first_served.F90
@@ -44,7 +44,8 @@
   end interface evolveForestsWorkShareFCFS
 
   ! Global counter of forests assigned.
-  type(mpiCounter) :: fcfsForestCounter
+  type   (mpiCounter) :: fcfsForestCounter
+  logical             :: fcfsForestCounterInitialized=.false.
 
 contains
 
@@ -92,7 +93,11 @@ contains
     integer                                                                    :: i
 #endif
     
-    fcfsForestCounter=mpiCounter()
+    if (.not.fcfsForestCounterInitialized) then
+       fcfsForestCounter=mpiCounter()
+       fcfsForestCounterInitialized=.true.
+    end if
+    call fcfsForestCounter%reset()
 #ifdef USEMPI
     if (present(activeProcessRanks)) then
        allocate(self%activeProcessRanks(size(activeProcessRanks)))


### PR DESCRIPTION
Avoids a segfault during finalization (possible compiler bug).