### PR TITLE
Reset satellite timescales when a subhalo is promoted to an isolated halo

### DIFF
--- a/source/events.subhalo_promotion.F90
+++ b/source/events.subhalo_promotion.F90
@@ -36,7 +36,7 @@ contains
     Promotes a subhalo to be an isolated node.
     !!}
     use :: Display                            , only : displayMessage               , displayVerbosity             , verbosityLevelInfo
-    use :: Galacticus_Nodes                   , only : nodeEvent                    , treeNode
+    use :: Galacticus_Nodes                   , only : nodeEvent                    , treeNode                     , nodeComponentSatellite
     use :: ISO_Varying_String                 , only : assignment(=)                , operator(//)                 , varying_string
     use :: Merger_Trees_Evolve_Deadlock_Status, only : deadlockStatusIsNotDeadlocked, enumerationDeadlockStatusType
     use :: String_Handling                    , only : operator(//)
@@ -45,6 +45,7 @@ contains
     type     (treeNode                     ), intent(inout), pointer :: node
     type     (enumerationDeadlockStatusType), intent(inout)          :: deadlockStatus
     type     (treeNode                     )               , pointer :: nodePromotion
+    class    (nodeComponentSatellite       )               , pointer :: satellite
     type     (varying_string               )                         :: message
     character(len=12                       )                         :: label
 
@@ -66,6 +67,11 @@ contains
     ! Remove the subhalo from its host.
     call node%removeFromHost  ()
     call node%removeFromMergee()
+    ! Reset the merging and destruction times of the satellite component to ensure no merging or destruction can occur (now that
+    ! this node is no longer a satellite).
+    satellite => node%satellite()
+    call satellite%timeOfMergingSet  (huge( 0.0d0))
+    call satellite%destructionTimeSet(     -1.0d0 )
     ! Make node the primary progenitor of the target node.
     node         %parent     => nodePromotion
     node         %sibling    => null()

--- a/source/merger_trees.evolve.timesteps.multi.F90
+++ b/source/merger_trees.evolve.timesteps.multi.F90
@@ -151,7 +151,8 @@ contains
     procedure       (timestepTask                     )               , pointer           :: task_
     class           (*                                )               , pointer           :: taskSelf_
     type            (treeNode                         )               , pointer           :: lockNode_
-    type            (varying_string                   )                                   :: lockType_
+    type            (varying_string                   ), save                             :: lockType_
+    !$omp threadprivate(lockType_)
     double precision                                                                      :: timeEvolveTo
 
     multiTimeEvolveTo               =  huge(0.0d0)


### PR DESCRIPTION
In this case, we set the merging time back to infinity, and the time until destruction to a negative value such that neither merging nor destruction can occur for such a halo (as these are not defined processes for isolated halos).
