### PR TITLE
Make integration of σ(M) more robust

### DIFF
--- a/source/structure_formation.cosmological_mass_variance.filtered_power_spectrum.F90
+++ b/source/structure_formation.cosmological_mass_variance.filtered_power_spectrum.F90
@@ -368,10 +368,10 @@ contains
                &                   )**(1.0d0/3.0d0)                              &
                &                  *Pi
        else
-          self%wavenumberHalfMode=huge(0.0d0)/5.0d0
+          self%wavenumberHalfMode=-1.0d0
        end if
     else
-       self%wavenumberHalfMode=huge(0.0d0)/5.0d0
+       self%wavenumberHalfMode=-1.0d0
     end if
     return
   end function filteredPowerConstructorInternal
@@ -508,14 +508,22 @@ contains
     use :: Display                 , only : displayGreen, displayBlue, displayYellow, displayReset
     use :: Error                   , only : Error_Report
     use :: Numerical_Constants_Math, only : Pi
+    use :: HDF5_Access             , only : hdf5Access
+    use :: IO_HDF5                 , only : hdf5Object
+    use :: String_Handling         , only : operator(//)
     implicit none
     class           (cosmologicalMassVarianceFilteredPower), intent(inout) :: self
-    double precision                                       , intent(in   ) :: mass        , time
-    double precision                                       , intent(  out) :: rootVariance, rootVarianceLogarithmicGradient
-    double precision                                                       :: wavenumber  , rootVarianceGradient           , &
-         &                                                                    interpolant , h
-    integer                                                                :: i           , j
-
+    double precision                                       , intent(in   ) :: mass         , time
+    double precision                                       , intent(  out) :: rootVariance , rootVarianceLogarithmicGradient
+    type            (hdf5Object                           ), save          :: errorFile
+    type            (varying_string                       ), save          :: errorFileName
+    !$omp threadprivate(errorFile,errorFileName)
+    character       (len=1                                )                :: label
+    double precision                                                       :: wavenumber   , rootVarianceGradient           , &
+         &                                                                    interpolant  , h                              , &
+         &                                                                    linearGrowth
+    integer                                                                :: i            , j
+    
     call self%retabulate(mass,time)
     if (self%growthIsMassDependent_) then
        call self%interpolantsTime(time,i,h)
@@ -569,7 +577,37 @@ contains
        ! Logarithmic gradient is positive, which should not happen.
        if (self%monotonicInterpolation) then
           ! Monotonic interpolation is being used - a positive logarithmic gradient should be impossible.
-          call Error_Report('dlogσ/dlogM > 0 detected, but monotonic interpolation was used - this should not happen'//{introspection:location})
+          ! Write a file with the interpolating data.
+          if (.not.self%powerSpectrumWindowFunction_%amplitudeIsMassIndependent()) then
+             errorFileName=self%fileName//".error."//GetPID()
+             !$ call hdf5Access%set()
+             call    errorFile%openFile(char(errorFileName),overWrite=.true.,objectsOverwritable=.true.)
+             call    errorFile%writeAttribute(mass                           ,'mass'                           )
+             call    errorFile%writeAttribute(rootVariance                   ,'rootVariance'                   )
+             call    errorFile%writeAttribute(rootVarianceGradient           ,'rootVarianceGradient'           )
+             call    errorFile%writeAttribute(rootVarianceLogarithmicGradient,'rootVarianceLogarithmicGradient')
+             if (.not.self%growthIsMassDependent_) then
+                linearGrowth=self%linearGrowth_%value(time)
+                call errorFile%writeAttribute(linearGrowth                   ,'linearGrowth'                   )
+             end if
+             do j=i,i+1
+                if (j == i) then
+                   interpolant=1.0d0-h
+                else
+                   interpolant=      h
+                end if
+                if (interpolant == 0.0d0) cycle
+                write (label,'(i1)') j-i+1
+                rootVarianceGradient=self%rootVarianceTable(j)%interpolateGradient(mass)
+                call errorFile%writeAttribute(     interpolant                 ,'interpolant'         //trim(adjustl(label)))
+                call errorFile%writeAttribute(     rootVarianceGradient        ,'rootVarianceGradient'//trim(adjustl(label)))
+                call errorFile%writeDataset  (self%rootVarianceTable   (j)%xs(),'massTable'           //trim(adjustl(label)))
+                call errorFile%writeDataset  (self%rootVarianceTable   (j)%ys(),'rootVarianceTable'   //trim(adjustl(label)))
+             end do
+          end if
+          call errorFile%close()
+          !$ call hdf5Access%unset()
+          call Error_Report('dlogσ/dlogM > 0 detected, but monotonic interpolation was used - this should not happen'//char(10)//'  table data written to:'//char(10)//'    '//char(errorFileName)//{introspection:location})
        else
           ! Recommend that monotonic interpolation be used.
           call Error_Report(                                                                                                                                                                                                                  &
@@ -935,15 +973,19 @@ contains
       use :: Interface_GSL           , only : GSL_EBadTol      , GSL_ETol  , GSL_ERound, GSL_Success
       use :: Numerical_Constants_Math, only : Pi
       use :: Numerical_Integration   , only : GSL_Integ_Gauss15, integrator
+      use :: Sorting, only : sort
       implicit none
-      double precision            , intent(in   ) :: time_
-      logical                     , intent(in   ) :: useTopHat
-      double precision            , parameter     :: wavenumberBAO    =5.0d0 ! The wavenumber above which baryon acoustic oscillations are small - used to split the integral allowing the oscillating part to be handled robustly.
-      double precision                            :: topHatRadius           , wavenumberMaximum     , &
-           &                                         wavenumberMinimum      , integrandLow          , &
-           &                                         integrandMedium        , integrandHigh
-      integer                                     :: status
-      type            (integrator)                :: integrator_            , integratorLogarithmic_
+      double precision                         , intent(in   ) :: time_
+      logical                                  , intent(in   ) :: useTopHat
+      double precision                         , parameter     :: wavenumberBAO    =5.0d0 ! The wavenumber above which baryon acoustic oscillations are small - used to split the integral allowing the oscillating part to be handled robustly.
+      double precision            , allocatable, dimension(:)  :: wavenumbers            , wavenumbersRestricted
+      double precision                                         :: wavenumberMinimum      , wavenumberMaximum     , &
+           &                                                      integrand              , integrandInterval     , &
+           &                                                      wavenumberLower        , wavenumberUpper       , &
+           &                                                      topHatRadius
+      integer                                                  :: i                      , status
+      logical                                                  :: computeLogarithmically
+      type            (integrator)                             :: integrator_            , integratorLogarithmic_
 
       filteredPowerTime=time_
       topHatRadius     =(                                             &
@@ -956,113 +998,99 @@ contains
            &             /self%cosmologyParameters_%OmegaMatter    () &
            &             /self%cosmologyParameters_%densityCritical() &
            &            )**(1.0d0/3.0d0)
+      ! Find the minimum wavenumber for the integral.
       if (self%truncateAtParticleHorizon) then
          wavenumberMinimum=+1.0d0                                                                                                &
               &            /self%cosmologyFunctions_%distanceParticleHorizonComoving(self%cosmologyFunctions_%cosmicTime(1.0d0))
       else
          wavenumberMinimum=+0.0d0
       end if
-      ! The integral over the power spectrum is split at a wavenumber corresponding to the smallest scale at which BAO features
-      ! are significant (unless the upper limit of the integral is already below that wavenumber). This allows the oscillatory
-      ! part of the integral to be computed more accurately, without affecting the non-oscillatory part at larger wavenumbers, and
-      ! leads to an overall more accurate and robust determination of σ(M).
-      ! For non-cold dark matter models with suppressed power spectrum on small scales, another splitting is done around the
-      ! half-mode wavenumber so that σ(M) is better resolved near the saturation value. This is particularly useful if the transfer
-      ! function oscillates on small scales.
+      ! Find the maximum wavenumber for the integral (and establish the integrator).
       if (useTopHat) then
-         integrator_=integrator(varianceIntegrandTopHat,toleranceRelative=+self%tolerance,integrationRule=GSL_Integ_Gauss15)
-         wavenumberMaximum=min(1.0d3/topHatRadius,self%powerSpectrumWindowFunctionTopHat_%wavenumberMaximum(smoothingMass))
-         if      (                                                   &
-              &    wavenumberMaximum > 3.0d0*self%wavenumberHalfMode &
-              &   .and.                                              &
-              &    wavenumberBAO     < 3.0d0*self%wavenumberHalfMode &
-              &  ) then
-            integrandLow   =   integrator_%integrate(wavenumberMinimum            ,           wavenumberBAO     )
-            integrandMedium=   integrator_%integrate(wavenumberBAO                ,3.0d0*self%wavenumberHalfMode)
-            integrandHigh  =   integrator_%integrate(3.0d0*self%wavenumberHalfMode,           wavenumberMaximum )
-            rootVariance   =+(                                                            &
-                 &            +integrandLow                                               &
-                 &            +integrandMedium                                            &
-                 &            +integrandHigh                                              &
-                 &           )                                                            &
-                 &          /2.0d0                                                        &
-                 &          /Pi**2
-         else if (wavenumberMaximum > wavenumberBAO) then
-            integrandLow   =   integrator_%integrate(wavenumberMinimum,wavenumberBAO    )
-            integrandHigh  =   integrator_%integrate(wavenumberBAO    ,wavenumberMaximum)
-            rootVariance   =+(                                                            &
-                 &            +integrandLow                                               &
-                 &            +integrandHigh                                              &
-                 &           )                                                            &
-                 &          /2.0d0                                                        &
-                 &          /Pi**2
-         else
-            rootVariance =+  integrator_%integrate(wavenumberMinimum,wavenumberMaximum) &
-                 &       /2.0d0                                                         &
-                 &       /Pi**2
-         end if
+         wavenumberMaximum     =min(1.0d3/topHatRadius,self%powerSpectrumWindowFunctionTopHat_%wavenumberMaximum(smoothingMass))
+         integrator_           =integrator(varianceIntegrandTopHat           ,toleranceRelative=+self%toleranceTopHat,integrationRule=GSL_Integ_Gauss15)
+         integratorLogarithmic_=integrator(varianceIntegrandTopHatLogarithmic,toleranceRelative=+self%toleranceTopHat,integrationRule=GSL_Integ_Gauss15)
       else
-         integrator_=integrator(varianceIntegrand,toleranceRelative=+self%tolerance,integrationRule=GSL_Integ_Gauss15)
-         wavenumberMaximum=min(1.0d3/topHatRadius,self%powerSpectrumWindowFunction_      %wavenumberMaximum(smoothingMass))
-         if      (                                                   &
-              &    wavenumberMaximum > 3.0d0*self%wavenumberHalfMode &
-              &   .and.                                              &
-              &    wavenumberBAO     < 3.0d0*self%wavenumberHalfMode &
-              &  ) then
-            integrandLow   =   integrator_%integrate(           wavenumberMinimum ,           wavenumberBAO     )
-            integrandMedium=   integrator_%integrate(           wavenumberBAO     ,3.0d0*self%wavenumberHalfMode)
-            integrandHigh  =   integrator_%integrate(3.0d0*self%wavenumberHalfMode,           wavenumberMaximum )
-            if (integrandHigh <= 0.0d0) then
-               ! If there is no power in the high wavenumber integral this may be because the upper limit is large and the power
-               ! is confined to small wavenumbers near the lower limit. This can happen, for example, if attempting to compute
-               ! σ(M) for mass scales far below the cut off for power spectra with a small-scale cut off. In such cases attempt to
-               ! evaluate the integral again, but integrating over log(wavenumber) such that more points in the integrand are
-               ! placed at small wavenumber.
-               integratorLogarithmic_=integrator(varianceIntegrandLogarithmic,toleranceRelative=+self%tolerance,integrationRule=GSL_Integ_Gauss15)
-               integrandHigh         =integratorLogarithmic_%integrate(log(wavenumberBAO),log(wavenumberMaximum))
-               if (integrandHigh <= 0.0d0) call Error_Report('no power above BAO scale - unexpected'//{introspection:location})
-            end if
-            rootVariance   =+(                                                            &
-                 &            +integrandLow                                               &
-                 &            +integrandMedium                                            &
-                 &            +integrandHigh                                              &
-                 &           )                                                            &
-                 &          /2.0d0                                                        &
-                 &          /Pi**2
-         else if (wavenumberMaximum > wavenumberBAO) then
-            integrandLow =   integrator_%integrate(wavenumberMinimum,wavenumberBAO                  )
-            integrandHigh=   integrator_%integrate(wavenumberBAO    ,wavenumberMaximum,status=status)
-            if     (                       &
-                 &   status == GSL_EBadTol &
-                 &  .or.                   &
-                 &   status == GSL_ETol    &
-                 &  .or.                   &
-                 &   status == GSL_ERound  &
-                 & ) then
-               ! If there is no power in the high wavenumber integral this may be because the upper limit is large and the power
-               ! is confined to small wavenumbers near the lower limit. This can happen, for example, if attempting to compute
-               ! σ(M) for mass scales far below the cut off for power spectra with a small-scale cut off. In such cases attempt to
-               ! evaluate the integral again, but integrating over log(wavenumber) such that more points in the integrand are
-               ! placed at small wavenumber.
-               integratorLogarithmic_=integrator(varianceIntegrandLogarithmic,toleranceRelative=+self%tolerance,integrationRule=GSL_Integ_Gauss15)
-               integrandHigh         =integratorLogarithmic_%integrate(log(wavenumberBAO),log(wavenumberMaximum))
-               if (integrandHigh <= 0.0d0) call Error_Report('no power above BAO scale - unexpected'//{introspection:location})
-            else if (status /= GSL_Success) then
-               call Error_Report('integration above the BAO scale failed'//{introspection:location})
-            end if
-            rootVariance =+(                                                            &
-                 &          +integrandLow                                               &
-                 &          +integrandHigh                                              &
-                 &         )                                                            &
-                 &        /2.0d0                                                        &
-                 &        /Pi**2
-         else
-            rootVariance =+  integrator_%integrate(wavenumberMinimum,wavenumberMaximum) &
-                 &        /2.0d0                                                        &
-                 &        /Pi**2
-         end if
+         wavenumberMaximum     =min(1.0d3/topHatRadius,self%powerSpectrumWindowFunction_      %wavenumberMaximum(smoothingMass))
+         integrator_           =integrator(varianceIntegrand                 ,toleranceRelative=+self%tolerance     ,integrationRule=GSL_Integ_Gauss15)
+         integratorLogarithmic_=integrator(varianceIntegrandLogarithmic      ,toleranceRelative=+self%tolerance     ,integrationRule=GSL_Integ_Gauss15)
       end if
-      rootVariance=sqrt(rootVariance)
+      ! Split the integral into subsets of the wavenumber range
+      !
+      !!  1. The integral over the power spectrum is split at a wavenumber corresponding to the smallest scale at which BAO
+      !!  features are significant (unless the upper limit of the integral is already below that wavenumber). This allows the
+      !!  oscillatory part of the integral to be computed more accurately, without affecting the non-oscillatory part at larger
+      !!  wavenumbers, and leads to an overall more accurate and robust determination of σ(M).
+      !!
+      !!  2. The integral is split at a modest multiple of the inverse top hat radius. We would expect the window function to cut
+      !!  off above this scale, so it is useful to have a split just above this cut off.
+      !!
+      !!  3. For non-cold dark matter models with suppressed power spectrum on small scales, another splitting is done around the
+      !!  half-mode wavenumber so that σ(M) is better resolved near the saturation value. This is particularly useful if the
+      !!  transfer function oscillates on small scales.
+      wavenumbers=[                                &
+           &                   wavenumberMinimum , &
+           &       +3.0d0*self%wavenumberHalfMode, &
+           &       +3.0d0/     topHatRadius      , &
+           &                   wavenumberBAO       &
+           &      ]
+      ! Restrict the intervals to those between the minimum and maxmimum wavenumbers, and then sort them.
+      wavenumbersRestricted=pack(wavenumbers,wavenumbers >= wavenumberMinimum .and. wavenumbers < wavenumberMaximum)
+      call sort(wavenumbersRestricted)
+      ! Iterate over intervals, accumulation the integral.
+      integrand=0.0d0
+      do i=1,size(wavenumbersRestricted)
+         wavenumberLower=wavenumbersRestricted(i)
+         if (i < size(wavenumbersRestricted)) then
+            wavenumberUpper=wavenumbersRestricted(i+1)
+         else
+            wavenumberUpper=wavenumberMaximum
+         end if
+         integrandInterval=integrator_%integrate(wavenumberLower,wavenumberUpper,status=status)
+         ! Decide if we need to try a logarithmic integral instead.
+         if     (                       &
+              &   (&
+              &     status == GSL_EBadTol &
+              &    .or.                   &
+              &     status == GSL_ETol    &
+              &    .or.                   &
+              &     status == GSL_ERound  &
+              &   )&
+              &  .and.&
+              &   wavenumberLower > 0.0d0 &
+              & ) then
+            ! The integration failed numerically, and the lower limit is non-zero, so try a logarithmic integral instead.
+            computeLogarithmically=.true.
+         else if (status /= GSL_Success) then
+            ! Integration failed for some other reason, report an error.
+            computeLogarithmically=.false.
+            call Error_Report('integration over interval failed'//{introspection:location})
+         else if (integrandInterval <= 0.0d0 .and. wavenumberLower > 0.0d0) then
+            ! Integration gave a zero result, and the lower limit is non-zero. This may be because the upper limit is large and
+            ! the power is confined to small wavenumbers near the lower limit. This can happen, for example, if attempting to
+            ! compute σ(M) for mass scales far below the cut off for power spectra with a small-scale cut off. In such cases
+            ! attempt to evaluate the integral again, but integrating over log(wavenumber) such that more points in the integrand
+            ! are placed at small wavenumber.
+            computeLogarithmically=.true.
+         else
+            ! The integration was successful, no need to try a logarithmic integral.
+            computeLogarithmically=.false.
+         end if
+         ! Recompue the integral using a logarithmic integral if necessary.
+         if (computeLogarithmically) then
+            integrandInterval=integratorLogarithmic_%integrate(log(wavenumberLower),log(wavenumberUpper))
+            ! Check for zero power.
+            if (integrandInterval <= 0.0d0) call Error_Report('no power in interval integrand - unexpected'//{introspection:location})
+         end if
+         ! Accumulate the integral from this region.
+         integrand=+integrand         &
+              &    +integrandInterval
+      end do
+      ! Apply factors of 2 and π to compute the root variance.
+      rootVariance=+integrand          &
+           &       /2.0d0              &
+           &       /Pi**2
+      rootVariance=+sqrt(rootVariance)
       return
     end function rootVariance
 
@@ -1085,7 +1113,8 @@ contains
 
     double precision function varianceIntegrandLogarithmic(wavenumberLogarithmic)
       !!{
-      Integrand function used in computing the variance in (real space) top-hat spheres from the power spectrum. This version integrates with respect to $\log(k)$.
+      Integrand function used in computing the variance in (real space) top-hat spheres from the power spectrum. This version
+      integrates with respect to $\log(k)$.
       !!}
       implicit none
       double precision, intent(in   ) :: wavenumberLogarithmic
@@ -1119,6 +1148,26 @@ contains
            &                   )**2
       return
     end function varianceIntegrandTopHat
+
+    double precision function varianceIntegrandTopHatLogarithmic(wavenumberLogarithmic)
+      !!{
+      Integrand function used in computing the variance in (real space) top-hat spheres from the power spectrum.
+      !!}
+      implicit none
+      double precision, intent(in   ) :: wavenumberLogarithmic
+      double precision                :: wavenumber
+
+      ! Return power spectrum multiplied by window function and volume element in k-space. Factors of 2 and π are included
+      ! elsewhere.
+      wavenumber                        =+exp(wavenumberLogarithmic)
+      varianceIntegrandTopHatLogarithmic=+  self%powerSpectrumPrimordialTransferred_%power(wavenumber,filteredPowerTime) &
+           &                             *(                                                                              &
+           &                               +self%powerSpectrumWindowFunctionTopHat_ %value(wavenumber,smoothingMass    ) &
+           &                               *                                               wavenumber                    &
+           &                              )**2                                                                           &
+           &                             *                                                 wavenumber
+      return
+    end function varianceIntegrandTopHatLogarithmic
 
   end subroutine filteredPowerRetabulate
 

--- a/source/structure_formation.cosmological_mass_variance.filtered_power_spectrum.F90
+++ b/source/structure_formation.cosmological_mass_variance.filtered_power_spectrum.F90
@@ -1048,15 +1048,15 @@ contains
          end if
          integrandInterval=integrator_%integrate(wavenumberLower,wavenumberUpper,status=status)
          ! Decide if we need to try a logarithmic integral instead.
-         if     (                       &
-              &   (&
+         if     (                         &
+              &   (                       &
               &     status == GSL_EBadTol &
               &    .or.                   &
               &     status == GSL_ETol    &
               &    .or.                   &
               &     status == GSL_ERound  &
-              &   )&
-              &  .and.&
+              &   )                       &
+              &  .and.                    &
               &   wavenumberLower > 0.0d0 &
               & ) then
             ! The integration failed numerically, and the lower limit is non-zero, so try a logarithmic integral instead.

--- a/testSuite/parameters/constrainHaloMassFunction.xml
+++ b/testSuite/parameters/constrainHaloMassFunction.xml
@@ -24,9 +24,9 @@
 
   <!-- Power spectrum options -->
   <cosmologicalMassVariance value="filteredPower">
-    <sigma_8 value="0.8228"/>
-    <tolerance value="4.0e-4"/>
-    <toleranceTopHat value="2.0e-4"/>
+    <sigma_8         value="0.8228"/>
+    <tolerance       value="1.0e-6"/>
+    <toleranceTopHat value="1.0e-6"/>
   </cosmologicalMassVariance>
   <transferFunction value="CAMB"/>
   <powerSpectrumPrimordial value="powerLaw">


### PR DESCRIPTION
Adds a further split in the integral for σ(M) at a wavenumber corresponding to a few times the inverse of the top-hat radius. Since window functions are expected to cut off above this wavenumber this can help to capture the peak in the integrand (which, otherwise, was very occassionally not captured). As this results is multiple different wavenumber splits for these integrals, we now handle this in a more general way, first generating a list of wavenumbers at which to split, sorting these, and integrating each resulting interval individually.