### PR TITLE
Improve latency of MPI counters

### DIFF
--- a/source/tasks.evolve_forests.F90
+++ b/source/tasks.evolve_forests.F90
@@ -572,8 +572,6 @@ contains
           end if
           ! Iterate evolving the tree until no more outputs are required.
           treeEvolveLoop : do while (iOutput <= self%outputTimes_%count())
-             ! Ping the work-share object.
-             call self%evolveForestsWorkShare_%ping()
              ! For single forest evolution, maximum evolution time is determined by the master thread only.
              singleForestMaximumTime : if (OMP_Get_Thread_Num() == 0 .or. .not.self%evolveSingleForest) then
                 ! We want to find the maximum time to which we can evolve this tree. This will be the minimum of the next output

--- a/source/tasks.evolve_forests.work_share.F90
+++ b/source/tasks.evolve_forests.work_share.F90
@@ -42,14 +42,6 @@ module Task_Evolve_Forests_Work_Shares
     <pass>yes</pass>
     <argument>logical, intent(in   ) :: utilizeOpenMPThreads</argument>
    </method>
-   <method name="ping" >
-    <description>Pings the work-share object (useful to allow synchronization).</description>
-    <type>void</type>
-    <pass>yes</pass>
-    <code>
-     !$GLC attributes unused :: self
-    </code>
-   </method>
    <method name="workerID" >
     <description>Return a unique worker ID.</description>
     <type>integer</type>

--- a/source/tasks.evolve_forests.work_share.first_come_first_served.F90
+++ b/source/tasks.evolve_forests.work_share.first_come_first_served.F90
@@ -32,7 +32,6 @@
      integer(c_size_t), allocatable, dimension(:) :: activeProcessRanks
    contains
      procedure :: forestNumber => fcfsForestNumber
-     procedure :: ping         => fcfsPing
   end type evolveForestsWorkShareFCFS
 
   interface evolveForestsWorkShareFCFS
@@ -136,25 +135,3 @@ contains
 #endif
     return
   end function fcfsForestNumber
-
-  subroutine fcfsPing(self)
-    !!{
-    Return the number of the next forest to process.
-    !!}
-#ifdef USEMPI
-    use :: MPI_Utilities, only : mpiSelf
-#endif
-    implicit none
-    class  (evolveForestsWorkShareFCFS), intent(inout) :: self
-#ifdef USEMPI
-    integer(c_size_t                  )                :: forestNumber
-#endif
-    !$GLC attributes unused :: self
-
-#ifdef USEMPI
-    !$omp master
-    if (mpiSelf%rank() == 0) forestNumber=fcfsForestCounter%get()
-    !$omp end master
-#endif
-    return
-  end subroutine fcfsPing


### PR DESCRIPTION
Where possible, the counter is incremented by the number of OpenMP threads waiting to increment in a single MPI call. The resulting set of increments are then handed out to each OpenMP process. This reduces the volume of MPI RMA calls, thereby improving latency.