### PR TITLE
Fixes to input parameter handling

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Process/ObjectBuilder.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/ObjectBuilder.pm
@@ -182,7 +182,7 @@ sub Process_ObjectBuilder {
 		$builderCode .= "      call ".$node->{'directive'}->{'name'}."%autoHook()\n";
 		$builderCode .= $debugMessage;
 		$builderCode .= $copyLoopClose;
-		$builderCode .= "      call Warn('Using default class for parameter ''['//char(parametersCurrent%path())//'".$parameterName."]''')\n";
+		$builderCode .= "      if (mpiSelf%isMaster()) call Warn('Using default class for parameter ''['//char(parametersCurrent%path())//'".$parameterName."]''')\n";
 		$builderCode .= "   end if\n";
 	    }
 	    if ( exists($node->{'directive'}->{'parameterName'}) ) {
@@ -201,6 +201,22 @@ sub Process_ObjectBuilder {
 	    };
 	    # Insert the node.
 	    &Galacticus::Build::SourceTree::InsertAfterNode($node,[$newNode]);
+	    # Use the MPI module.
+	    if ( $defaultName ) {
+		my $mpiNode =
+		{
+		    type      => "moduleUse",
+		    moduleUse =>
+		    {
+			"MPI_Utilities"   =>
+			{
+			    intrinsic => 0,
+			    only      => {mpiSelf => 1}
+			}
+		    }
+		};
+		&Galacticus::Build::SourceTree::Parse::ModuleUses::AddUses($node->{'parent'},$mpiNode);
+	    }
 	    # Add the required module.
 	    if ( exists($stateStorables->{'functionClasses'}->{$node->{'directive'}->{'class'}."Class"}->{'module'}) ) {
 		my $searchNode  = $tree;


### PR DESCRIPTION
First, warnings about default parameters are now issued only from the master process when running under MPI (to avoid large numbers of duplicated messages). Second, an access to the FoX library that occured outside of a required OpenMP critical section is now placed within such a critical section.