### PR TITLE
Fix an issue that the progress bar is inaccurate when solving the excursion sets problem with MPI

### DIFF
--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
@@ -518,7 +518,7 @@ contains
           end if
 #endif
 #ifdef USEMPI
-          if (mpiSelf%isMaster() .or. .not.self%coordinatedMPI_) then
+          if (mpiSelf%isMaster() .and. self%coordinatedMPI_) then
              loopCountTotal=(int(self%countTime,kind=c_size_t)/int(mpiSelf%count(),kind=c_size_t)+1_c_size_t)*(int(self%countVariance-1,kind=c_size_t)*int(self%countVariance,kind=c_size_t))/2_c_size_t
           else
 #endif
@@ -1039,7 +1039,7 @@ contains
                   &         +int(self%countTimeRate,kind=c_size_t)*int(self%countVarianceCurrentRate           +1,kind=c_size_t)
           end if
 #ifdef USEMPI
-          if (mpiSelf%isMaster() .or. .not.self%coordinatedMPI_) then
+          if (mpiSelf%isMaster() .and. self%coordinatedMPI_) then
              loopCountTotal= loopCountTotal/int(mpiSelf%count(),kind=c_size_t)+1_c_size_t
           end if
 #endif

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.midpoint.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.midpoint.F90
@@ -237,7 +237,7 @@ contains
           end if
 #endif
 #ifdef USEMPI
-          if (mpiSelf%isMaster() .or. .not.self%coordinatedMPI_) then
+          if (mpiSelf%isMaster() .and. self%coordinatedMPI_) then
              loopCountTotal=(int(self%countTime,kind=c_size_t)/int(mpiSelf%count(),kind=c_size_t)+1_c_size_t)*(int(self%countVariance-1,kind=c_size_t)*int(self%countVariance,kind=c_size_t))/2_c_size_t
           else
 #endif
@@ -684,7 +684,7 @@ contains
                   &         +int(countTimeNew,kind=c_size_t)*int(self%countVarianceCurrentRate           +1,kind=c_size_t)
           end if
 #ifdef USEMPI
-          if (mpiSelf%isMaster() .or. .not.self%coordinatedMPI_) then
+          if (mpiSelf%isMaster() .and. self%coordinatedMPI_) then
              loopCountTotal=loopCountTotal/int(mpiSelf%count(),kind=c_size_t)+1_c_size_t
           end if
 #endif


### PR DESCRIPTION
The progress bar is inaccurate when we use multiple MPI processes and `self%coordinatedMPI_` is `.true.`.