### PR TITLE
Add OpenMP critical sections around accesses to the FoX library

### DIFF
--- a/source/objects.abundances.F90
+++ b/source/objects.abundances.F90
@@ -266,19 +266,27 @@ contains
     integer                                          :: i
 
     ! Get the metallicity.
+    !$omp critical (FoX_DOM_Access)
     call XML_Get_Elements_By_Tag_Name(abundancesDefinition,'metals',abundanceList)
+    !$omp end critical (FoX_DOM_Access)
     if (size(abundanceList) >  1) call Error_Report('multiple metallicity values specified'//{introspection:location})
     if (size(abundanceList) == 1) then
+       !$omp critical (FoX_DOM_Access)
        abundance => abundanceList(0)%element
        call extractDataContent(abundance,self%metallicityValue)
+       !$omp end critical (FoX_DOM_Access)
     end if
     if (elementsCount > 0) then
        do i=1,elementsCount
+          !$omp critical (FoX_DOM_Access)
           call XML_Get_Elements_By_Tag_Name(abundancesDefinition,trim(elementsToTrack(i)),abundanceList)
+          !$omp end critical (FoX_DOM_Access)
           if (size(abundanceList) >  1) call Error_Report('multiple '//trim(elementsToTrack(i))//' values specified'//{introspection:location})
           if (size(abundanceList) == 1) then
+             !$omp critical (FoX_DOM_Access)
              abundance => abundanceList(0)%element
              call extractDataContent(abundance,self%elementalValue(i))
+             !$omp end critical (FoX_DOM_Access)
           end if
        end do
     end if

--- a/source/objects.chemical_abundances.F90
+++ b/source/objects.chemical_abundances.F90
@@ -484,11 +484,15 @@ contains
 
     if (chemicalsCount > 0) then
        do i=1,chemicalsCount
+          !$omp critical (FoX_DOM_Access)
           call XML_Get_Elements_By_Tag_Name(chemicalsDefinition,char(chemicalsToTrack(i)),chemicalAbundanceList)
+          !$omp end critical (FoX_DOM_Access)
           if (size(chemicalAbundanceList) >  1) call Error_Report('multiple '//char(chemicalsToTrack(i))//' values specified'//{introspection:location})
           if (size(chemicalAbundanceList) == 1) then
+             !$omp critical (FoX_DOM_Access)
              chemical => chemicalAbundanceList(0)%element
              call extractDataContent(chemical,self%chemicalValue(i))
+             !$omp end critical (FoX_DOM_Access)
           end if
        end do
     end if

--- a/source/objects.kepler_orbits.F90
+++ b/source/objects.kepler_orbits.F90
@@ -237,15 +237,21 @@ contains
     double precision                                           :: massHost                                   , massSatellite   , &
          &                                                        propertyValue
     logical                                                    :: massHostSet                                , massSatelliteSet
-
+    character       (len=32     )                              :: nodeName
+    
     ! Get the radius.
     do i=1,size(propertyNames)
+       !$omp critical (FoX_DOM_Access)
        call XML_Get_Elements_By_Tag_Name(keplerOrbitDefinition,trim(propertyNames(i)),propertyList)
+       !$omp end critical (FoX_DOM_Access)
        if (size(propertyList) >  1) call Error_Report('multiple '//trim(propertyNames(i))//' values specified'//{introspection:location})
        if (size(propertyList) == 1) then
+          !$omp critical (FoX_DOM_Access)
           property => propertyList(0)%element
           call extractDataContent(property,propertyValue)
-          select case (getNodeName(property))
+          nodeName=getNodeName(property)
+          !$omp end critical (FoX_DOM_Access)
+          select case (trim(nodeName))
           case ( 'radius'             )
              call self%            radiusSet(propertyValue)
           case ( 'velocityRadial'     )

--- a/source/objects.stellar_luminosities.F90
+++ b/source/objects.stellar_luminosities.F90
@@ -477,11 +477,15 @@ contains
     integer                                                  :: i
 
     ! Get the luminosities.
+    !$omp critical (FoX_DOM_Access)
     call XML_Get_Elements_By_Tag_Name(stellarLuminositiesDefinition,'luminosity',luminosityList)
+    !$omp end critical (FoX_DOM_Access)
     if (luminosityCount > 0) then
        do i=0,luminosityCount-1
+          !$omp critical (FoX_DOM_Access)
           luminosity => luminosityList(i)%element
           call extractDataContent(luminosity,self%luminosityValue(i+1))
+          !$omp end critical (FoX_DOM_Access)
        end do
     end if
     return
@@ -1801,31 +1805,9 @@ contains
 
     call displayIndent  (var_str('storing state for "stellar luminosities" [position: ')//FTell(stateFile)//']',verbosity=verbosityLevelWorking)
     call displayMessage(var_str('storing "luminosityCount" [position: ')//FTell(stateFile)//']',verbosity=verbosityLevelWorking)
-    !![
-    <workaround type="gfortran" PR="92836" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=92836">
-     <description>Internal file I/O in gfortran can be non-thread safe.</description>
-    </workaround>
-    !!]
-#ifdef THREADSAFEIO
-    !$omp critical(gfortranInternalIO)
-#endif
     write (stateFile) luminosityCount
-#ifdef THREADSAFEIO
-    !$omp end critical(gfortranInternalIO)
-#endif
     call displayMessage(var_str('storing luminosities [position: ')//FTell(stateFile)//']',verbosity=verbosityLevelWorking)
-    !![
-    <workaround type="gfortran" PR="92836" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=92836">
-     <description>Internal file I/O in gfortran can be non-thread safe.</description>
-    </workaround>
-    !!]
-#ifdef THREADSAFEIO
-    !$omp critical(gfortranInternalIO)
-#endif
     write (stateFile) luminosityIndex,luminosityCosmicTime,luminosityRedshift,luminosityBandRedshift
-#ifdef THREADSAFEIO
-    !$omp end critical(gfortranInternalIO)
-#endif
     do i=1,luminosityCount
        call displayMessage(var_str('storing luminosity ')//i//' of '//luminosityCount//' [position: '//FTell(stateFile)//']',verbosity=verbosityLevelWorking)
        call luminosityName          (i)%stateStore(stateFile)
@@ -1872,18 +1854,7 @@ contains
     if (allocated(unitStellarLuminosities%luminosityValue)) deallocate(unitStellarLuminosities%luminosityValue)
     if (allocated(zeroStellarLuminosities%luminosityValue)) deallocate(zeroStellarLuminosities%luminosityValue)
     call displayMessage(var_str('restoring "luminosityCount" [position: ')//FTell(stateFile)//']',verbosity=verbosityLevelWorking)
-    !![
-    <workaround type="gfortran" PR="92836" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=92836">
-     <description>Internal file I/O in gfortran can be non-thread safe.</description>
-    </workaround>
-    !!]
-#ifdef THREADSAFEIO
-    !$omp critical(gfortranInternalIO)
-#endif
     read (stateFile) luminosityCount
-#ifdef THREADSAFEIO
-    !$omp end critical(gfortranInternalIO)
-#endif
     allocate(luminosityFilterIndex                  (luminosityCount))
     allocate(luminosityIndex                        (luminosityCount))
     allocate(luminosityPostprocessor                (luminosityCount))
@@ -1899,18 +1870,7 @@ contains
     unitStellarLuminosities%luminosityValue=1.0d0
     zeroStellarLuminosities%luminosityValue=0.0d0
     call displayMessage(var_str('restoring luminosities [position: ')//FTell(stateFile)//']',verbosity=verbosityLevelWorking)
-    !![
-    <workaround type="gfortran" PR="92836" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=92836">
-     <description>Internal file I/O in gfortran can be non-thread safe.</description>
-    </workaround>
-    !!]
-#ifdef THREADSAFEIO
-    !$omp critical(gfortranInternalIO)
-#endif
     read (stateFile) luminosityIndex,luminosityCosmicTime,luminosityRedshift,luminosityBandRedshift
-#ifdef THREADSAFEIO
-    !$omp end critical(gfortranInternalIO)
-#endif
     do i=1,luminosityCount
        call displayMessage(var_str('restoring luminosity ')//i//' of '//luminosityCount//' [position: '//FTell(stateFile)//']',verbosity=verbosityLevelWorking)
        call luminosityName          (i)%stateRestore(stateFile)

--- a/source/objects.tensors.rank2.dimension3.symmetric.F90
+++ b/source/objects.tensors.rank2.dimension3.symmetric.F90
@@ -86,23 +86,39 @@ contains
 
     ! Get the elements
     do i=1,6
+       !$omp critical (FoX_DOM_Access)
        call XML_Get_Elements_By_Tag_Name(tensorDefinition,elementNames(i),elementList)
+       !$omp end critical (FoX_DOM_Access)
        if (size(elementList) > 1) call Error_Report('multiple "'//elementNames(i)//'" values specified'//{introspection:location})
        if (size(elementList) < 1) call Error_Report('no "'//elementNames(i)//'" value specified'       //{introspection:location})
+       !$omp critical (FoX_DOM_Access)
        element => elementList(0)%element
+       !$omp end critical (FoX_DOM_Access)
        select case (elementNames(i))
        case ( 'x00' )
+          !$omp critical (FoX_DOM_Access)
           call extractDataContent(element,self%x00)
+          !$omp end critical (FoX_DOM_Access)
        case ( 'x01' )
+          !$omp critical (FoX_DOM_Access)
           call extractDataContent(element,self%x01)
+          !$omp end critical (FoX_DOM_Access)
        case ( 'x02' )
+          !$omp critical (FoX_DOM_Access)
           call extractDataContent(element,self%x02)
+          !$omp end critical (FoX_DOM_Access)
        case ( 'x11' )
+          !$omp critical (FoX_DOM_Access)
           call extractDataContent(element,self%x11)
+          !$omp end critical (FoX_DOM_Access)
        case ( 'x12' )
+          !$omp critical (FoX_DOM_Access)
           call extractDataContent(element,self%x12)
+          !$omp end critical (FoX_DOM_Access)
        case ( 'x22' )
+          !$omp critical (FoX_DOM_Access)
           call extractDataContent(element,self%x22)
+          !$omp end critical (FoX_DOM_Access)
        end select
     end do
     return


### PR DESCRIPTION
There were a handful of cases where this had been missing previously.