### PR TITLE
Allow σ(M) integral to be split at local minima of the transfer function

### DIFF
--- a/scripts/build/libraryInterfaces.pl
+++ b/scripts/build/libraryInterfaces.pl
@@ -664,7 +664,7 @@ sub assignCAttributes {
  	push(@{$argument->{'fortran'}->{'attributes'}},"optional")
 	    if ( $argument->{'isOptional'}            );
 	## Transfer any dimension attributes.
-	push(@{$argument->{'fortran'}->{'attributes'}},grep {$_ =~ m/^dimension/} @{$argument->{'attributes'}});
+	push(@{$argument->{'fortran'}->{'attributes'}},grep {$_ =~ m/^dimension/ || $_ =~ m/^allocatable/} @{$argument->{'attributes'}});
 	## String argument passed as type "c_char_p" must be "dimension(*)" in Fortran.
  	push(@{$argument->{'fortran'}->{'attributes'}},"dimension(*)")
 	    if ( $argument->{'ctypes'}->{'type'} eq "c_char_p" );

--- a/source/structure_formation.transfer_function.AxionCAMB.F90
+++ b/source/structure_formation.transfer_function.AxionCAMB.F90
@@ -50,10 +50,11 @@
        <method description="Check that the provided wavenumber is within the tabulated range of the transfer function." method="checkRange" />
      </methods>
      !!]
-     final     ::                          axionCambDestructor
-     procedure :: checkRange            => axionCambCheckRange
-     procedure :: value                 => axionCambValue
-     procedure :: logarithmicDerivative => axionCambLogarithmicDerivative
+     final     ::                           axionCambDestructor
+     procedure :: checkRange             => axionCambCheckRange
+     procedure :: value                  => axionCambValue
+     procedure :: logarithmicDerivative  => axionCambLogarithmicDerivative
+     procedure :: wavenumbersLocalMinima => axionCambWavenumbersLocalMinima
   end type transferFunctionAxionCAMB
 
   interface transferFunctionAxionCAMB
@@ -229,3 +230,16 @@ contains
     axionCambLogarithmicDerivative=self%transferFunctionFileFuzzyDarkMatter%logarithmicDerivative(wavenumber)
     return
   end function axionCambLogarithmicDerivative
+
+  subroutine axionCambWavenumbersLocalMinima(self,wavenumbers)
+    !!{
+    Return a list of wavenumbers corresponding to local minima in the transfer function.
+    !!}
+    implicit none
+    class           (transferFunctionAxionCAMB), intent(inout)                            :: self
+    double precision                           , intent(  out), allocatable, dimension(:) :: wavenumbers
+
+    call self%checkRange(wavenumber=1.0d0)
+    wavenumbers=self%wavenumbersLocalMinima_
+    return
+  end subroutine axionCambWavenumbersLocalMinima

--- a/source/structure_formation.transfer_function.CAMB.F90
+++ b/source/structure_formation.transfer_function.CAMB.F90
@@ -50,10 +50,11 @@ Contains a module which implements a transfer function class using the CAMB code
        <method description="Check that the provided wavenumber is within the tabulated range of the transfer function." method="checkRange" />
      </methods>
      !!]
-     final     ::                          cambDestructor
-     procedure :: checkRange            => cambCheckRange
-     procedure :: value                 => cambValue
-     procedure :: logarithmicDerivative => cambLogarithmicDerivative
+     final     ::                           cambDestructor
+     procedure :: checkRange             => cambCheckRange
+     procedure :: value                  => cambValue
+     procedure :: logarithmicDerivative  => cambLogarithmicDerivative
+     procedure :: wavenumbersLocalMinima => cambWavenumbersLocalMinima
   end type transferFunctionCAMB
 
   interface transferFunctionCAMB
@@ -233,3 +234,16 @@ contains
     cambLogarithmicDerivative=self%transferFunctionFile%logarithmicDerivative(wavenumber)
     return
   end function cambLogarithmicDerivative
+
+  subroutine cambWavenumbersLocalMinima(self,wavenumbers)
+    !!{
+    Return a list of wavenumbers corresponding to local minima in the transfer function.
+    !!}
+    implicit none
+    class           (transferFunctionCAMB), intent(inout)                            :: self
+    double precision                      , intent(  out), allocatable, dimension(:) :: wavenumbers
+
+    call self%checkRange(wavenumber=1.0d0)
+    wavenumbers=self%wavenumbersLocalMinima_
+    return
+  end subroutine cambWavenumbersLocalMinima

--- a/source/structure_formation.transfer_function.CLASS_CDM.F90
+++ b/source/structure_formation.transfer_function.CLASS_CDM.F90
@@ -50,10 +50,11 @@ Contains a module which implements a transfer function class using the CLASS cod
        <method description="Check that the provided wavenumber is within the tabulated range of the transfer function." method="checkRange" />
      </methods>
      !!]
-     final     ::                          classCDMDestructor
-     procedure :: checkRange            => classCDMCheckRange
-     procedure :: value                 => classCDMValue
-     procedure :: logarithmicDerivative => classCDMLogarithmicDerivative
+     final     ::                           classCDMDestructor
+     procedure :: checkRange             => classCDMCheckRange
+     procedure :: value                  => classCDMValue
+     procedure :: logarithmicDerivative  => classCDMLogarithmicDerivative
+     procedure :: wavenumbersLocalMinima => classCDMWavenumbersLocalMinima
   end type transferFunctionCLASSCDM
 
   interface transferFunctionCLASSCDM
@@ -233,3 +234,16 @@ contains
     classCDMLogarithmicDerivative=self%transferFunctionFile%logarithmicDerivative(wavenumber)
     return
   end function classCDMLogarithmicDerivative
+
+  subroutine classCDMWavenumbersLocalMinima(self,wavenumbers)
+    !!{
+    Return a list of wavenumbers corresponding to local minima in the transfer function.
+    !!}
+    implicit none
+    class           (transferFunctionCLASSCDM), intent(inout)                            :: self
+    double precision                          , intent(  out), allocatable, dimension(:) :: wavenumbers
+
+    call self%checkRange(wavenumber=1.0d0)
+    wavenumbers=self%wavenumbersLocalMinima_
+    return
+  end subroutine classCDMWavenumbersLocalMinima

--- a/source/structure_formation.transfer_function.F90
+++ b/source/structure_formation.transfer_function.F90
@@ -47,6 +47,15 @@ module Transfer_Functions
     <pass>yes</pass>
     <argument>double precision, intent(in   ) :: wavenumber</argument>
    </method>
+   <method name="wavenumbersLocalMinima" >
+    <description>Return an array of wavenumbers at which the transfer function reaches a local minimum. (Or a zero-length array if no such local minima exist.)</description>
+    <type>void</type>
+    <pass>yes</pass>
+    <argument>double precision, intent(  out), allocatable, dimension(:) :: wavenumbers</argument>
+    <code>
+      allocate(wavenumbers(0))
+    </code>
+   </method>
    <method name="epochTime" >
     <description>Return the cosmic time corresponding to the epoch for which this transfer function is defined.</description>
     <type>double precision</type>

--- a/source/structure_formation.transfer_function.file.F90
+++ b/source/structure_formation.transfer_function.file.F90
@@ -364,6 +364,7 @@ contains
                &   transferLogarithmic(i) < transferLogarithmic(i+1) &
                & ) countLocalMinima=countLocalMinima+1
        end do
+       if (allocated(self%wavenumbersLocalMinima_)) deallocate(self%wavenumbersLocalMinima_)
        allocate(self%wavenumbersLocalMinima_(countLocalMinima))
        countLocalMinima=0
        do i=2,size(transferLogarithmic)-1


### PR DESCRIPTION
This makes integration more robust for oscillating transfer functions for example.