### PR TITLE
Avoid unnecessary divide/multiply in summation cooling function

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Parse/Declarations.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/Declarations.pm
@@ -185,7 +185,7 @@ sub AddDeclarations {
 	    parent     => $declarationsNode,
 	    firstChild => undef()
 	};
-	# Inert the node, after any module use node if one exists.
+	# Insert the node, after any module use node if one exists.
 	if ( $usesNode ) {
 	    &Galacticus::Build::SourceTree::InsertAfterNode ($usesNode            ,[$declarationsNode]);
 	} else {	

--- a/perl/Galacticus/Build/SourceTree/Process/ObjectBuilder.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/ObjectBuilder.pm
@@ -438,9 +438,10 @@ sub Process_ObjectBuilder {
 		my @declarations =
 		    (
 		     {
-			 intrinsic  => "integer"            ,
-			 variables  => [ "referenceCount_" ],
-			 attributes => [                   ]
+			 intrinsic     => "integer"            ,
+			 variables     => [ "referenceCount_" ],
+			 attributes    => [ "save"            ],
+			 threadprivate => 1
 		     }
 		    );
 		&Galacticus::Build::SourceTree::Parse::Declarations::AddDeclarations($node->{'parent'},\@declarations);

--- a/source/cooling.cooling_function.summation.F90
+++ b/source/cooling.cooling_function.summation.F90
@@ -256,7 +256,6 @@ contains
             &                    +coolingFunction
        coolingFunctionGradient  =+coolingFunctionGradient                                                       &
             &                    +coolingFunction                                                               &
-            &                    /numberDensityHydrogen                                                         &
             &                    *coolant%coolingFunction%coolingFunctionDensityLogSlope(                       &
             &                                                                            node                 , &
             &                                                                            numberDensityHydrogen, &
@@ -269,7 +268,6 @@ contains
     end do
     if (coolingFunctionCumulative /= 0.0d0) then
        summationCoolingFunctionDensityLogSlope=+coolingFunctionGradient   &
-            &                                  *numberDensityHydrogen     &
             &                                  /coolingFunctionCumulative
     else
        summationCoolingFunctionDensityLogSlope=0.0d0

--- a/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
+++ b/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
@@ -158,6 +158,7 @@ contains
     use :: Error                                 , only : Error_Report
     use :: Input_Paths                           , only : inputPath                                  , pathTypeDataStatic
     use :: Geometry_Surveys                      , only : surveyGeometryFullSky
+    use :: HDF5_Access                           , only : hdf5Access
     use :: IO_HDF5                               , only : hdf5Object
     use :: ISO_Varying_String                    , only : var_str                                    , varying_string
     use :: Node_Property_Extractors              , only : nodePropertyExtractorMassHalo              , nodePropertyExtractorMassStellar
@@ -283,6 +284,7 @@ contains
     </referenceConstruct>
     !!]
     ! Read observational data and convert masses to logarithmic.
+    !$ call hdf5Access%set()
     call fileData%openFile(char(inputPath(pathTypeDataStatic))//"observations/stellarHaloMassRelation/stellarHaloMassRelation_COSMOS_Leauthaud2012.hdf5")
     groupRedshiftName=var_str('redshiftInterval')//redshiftInterval
     groupRedshift=fileData%openGroup(char(groupRedshiftName))
@@ -290,6 +292,9 @@ contains
     call groupRedshift%readDataset('massHaloMean',massHaloMeanData)
     call groupRedshift%readDataset('massHaloLow' ,massHaloLowData )
     call groupRedshift%readDataset('massHaloHigh',massHaloHighData)
+    call groupRedshift%close      (                               )
+    call fileData     %close      (                               )
+    !$ call hdf5Access%unset()
     ! Create bins in halo mass.
     massHaloMinimum=massHaloMeanData(1                     )
     massHaloMaximum=massHaloMeanData(size(massHaloMeanData))

--- a/source/utility.MPI.F90
+++ b/source/utility.MPI.F90
@@ -2081,6 +2081,7 @@ contains
     self%countIncrementsHeld=self%countIncrementsHeld-1_c_size_t
     !$ call self%ompLock_%unset()
     ! Decrement the count of OpenMP threads waiting on the lock.
+    !$omp atomic
     self%countThreadsWaiting=self%countThreadsWaiting-1_c_size_t
 #else
     !$ call self%ompLock_%  set()


### PR DESCRIPTION
 When computing the logarithmic gradient of the cooling function with respect to density in the `coolingFunctionSummation` class we were doing: 


$$
\frac{\mathrm{d}\log \Lambda}{\mathrm{d}\log n} = \frac{n}{\Lambda} \sum \frac{\mathrm{d}\log \Lambda_i}{\mathrm{d}\log n} \frac{\Lambda_i}{n}
$$

But, since the density, $n$, is constant there's no need to do this, and we then also avoid floating point errors if the density is zero.
