### PR TITLE
Avoid memory leaks with interpolators and matrices

### DIFF
--- a/source/mass_distributions.Gaussian_ellipsoid.F90
+++ b/source/mass_distributions.Gaussian_ellipsoid.F90
@@ -45,7 +45,7 @@
           &                                                           scaleLengthMaximum
      integer                              , dimension(3          ) :: axesMapIn                        , axesMapOut
      double precision                     , dimension(2          ) :: axisRatio
-     type            (matrix)                                      :: rotationIn                       , rotationOut
+     type            (matrix), allocatable                         :: rotationIn                       , rotationOut
      double precision                     , dimension(3)           :: axis1                            , axis2                                 , &
           &                                                           axis3
    contains
@@ -245,6 +245,10 @@ contains
             &            /self%scaleLengthMaximum
     end do
     ! Compute rotation matrices required to rotate the ellipsoid to be aligned with the principle Cartesian axes, and back again.
+    if (allocated(self%rotationIn )) deallocate(self%rotationIn )
+    if (allocated(self%rotationOut)) deallocate(self%rotationOut)
+    allocate(self%rotationIn )
+    allocate(self%rotationOut)
     if (present(axes)) then
        self%axis1      =axes(1)
        self%axis2      =axes(2)

--- a/source/mass_distributions.spherical.Sersic.F90
+++ b/source/mass_distributions.spherical.Sersic.F90
@@ -434,13 +434,13 @@ contains
     type            (rootFinder            ), save                    :: finder
     logical                                 , save                    :: finderConstructed      =.false.
     !$omp threadprivate(finder,finderConstructed)
+    type            (interpolator          ), allocatable             :: interpolator_
     logical                                                           :: rebuildTable                   , tableHasSufficientExtent
     integer                                                           :: iRadius
     double precision                                                  :: deltaRadius                    , integrand                , &
          &                                                               massPrevious                   , previousIntegrand        , &
          &                                                               radiusActual                   , radiusInfinity
     type            (integrator            )                          :: integrator_
-    type            (interpolator          )                          :: interpolator_
 
     ! Check if a radius was specified. Use it if so, otherwise use a midpoint radius.
     if (present(radius)) then
@@ -523,11 +523,13 @@ contains
           self%tableDensity     =self%tableDensity     /self%tableEnclosedMass(self%tableCount)
           self%tableEnclosedMass=self%tableEnclosedMass/self%tableEnclosedMass(self%tableCount)
           ! Find the half mass radius.
+          allocate(interpolator_)
           interpolator_             =interpolator(                                                                &
                &                                  self%tableEnclosedMass(1:maxloc(self%tableEnclosedMass,dim=1)), &
                &                                  self%tableRadius      (1:maxloc(self%tableEnclosedMass,dim=1))  &
                &                                 )
           self%table3dRadiusHalfMass=interpolator_%interpolate(0.5d0)
+          deallocate(interpolator_)
           ! Scale radii and densities to be in units of the 3D half mass radius.
           self%tableRadius =self%tableRadius /self%table3dRadiusHalfMass
           self%tableDensity=self%tableDensity*self%table3dRadiusHalfMass**3

--- a/source/math.linear_algebra.F90
+++ b/source/math.linear_algebra.F90
@@ -1258,7 +1258,8 @@ contains
     implicit none
     type            (matrix)                                :: matrixRotation
     type            (vector), intent(in   ), dimension(3  ) :: points           , pointsRotated
-    type            (matrix)                                :: P                , Q
+    type            (matrix)                                :: P                , Q            , &
+         &                                                     Pinverse
     double precision                       , dimension(3,3) :: matrixComponents
 
     matrixComponents(:,1)=points          (1)
@@ -1269,7 +1270,8 @@ contains
     matrixComponents(:,2)=pointsRotated   (2)
     matrixComponents(:,3)=pointsRotated   (3)
     Q                    =matrix(matrixComponents)
-    matrixRotation       =Q*P%inverse()
+    Pinverse             =P%inverse()
+    matrixRotation       =Q*Pinverse
     return
   end function matrixRotation
 


### PR DESCRIPTION
We do this by explicitly allocating and deallocating, and by not using function results in expressions (but instead assigning them to variables first). These approaches should no longer be necessary when gfortran finalization is fully implemented.