### PR TITLE
Improvement to internal I/O thread safety

### DIFF
--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -9,7 +9,6 @@
   <componentBlackHole         value="standard" >
     <massSeed                                    value="100.0000"/>
     <heatsHotHalo                                value="true"    />
-    <efficiencyRadioMode                         value="  1.0000"/>
     <efficiencyWind                              value="  0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"    />
     <bondiHoyleAccretionEnhancementHotHalo       value="  6.0000"/>
@@ -84,7 +83,7 @@
 
   <coolingRadius value="simple"/>
   <coolingRate value="multiplier">
-    <multiplier  value="1.0"           />
+    <multiplier  value="0.5"           />
     <coolingRate value="whiteFrenk1991" >
       <velocityCutOff value="10000"/>
     </coolingRate>
@@ -93,34 +92,30 @@
     <degreesOfFreedom value="3.0"/>
   </coolingTime>
   <coolingTimeAvailable value="whiteFrenk1991">
-    <ageFactor value="0.0"/>
+    <ageFactor value="0"/>
   </coolingTimeAvailable>
   <!-- Hot halo ram pressure stripping options -->
   <hotHaloRamPressureStripping value="font2008"               />
   <hotHaloRamPressureForce     value="orbitalPosition"        />
   <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
   <!-- Galactic structure solver options -->
-  <galacticStructureSolver value="equilibrium">
-    <convergenceFailureIsFatal value="false"/>
-  </galacticStructureSolver>
+  <galacticStructureSolver value="equilibrium"/>
   <darkMatterProfile value="adiabaticGnedin2004">
-    <A                 value="0.73"   />
-    <omega             value="0.70"   />
-    <toleranceRelative value="1.00e-4"/>
+    <A     value="0.73"/>
+    <omega value="0.70"/>
   </darkMatterProfile>
   <!-- Star formation rate options -->
   <starFormationRateDisks               value="intgrtdSurfaceDensity"/>
   <starFormationRateSurfaceDensityDisks value="blitz2006"             >
-    <starFormationFrequencyNormalization value="2.0e-9"/>
-    <assumeMonotonicSurfaceDensity       value="true"  />
-    <assumeExponentialDisk               value="true"  />
-    <useTabulation                       value="true"  />
+    <assumeMonotonicSurfaceDensity value="true"/>
+    <assumeExponentialDisk         value="true"/>
+    <useTabulation                 value="true"/>
   </starFormationRateSurfaceDensityDisks>
   <starFormationRateSpheroids value="timescale">
     <starFormationTimescale value="dynamicalTime">
-      <efficiency       value="1.000"/>
+      <efficiency       value="0.040"/>
       <exponentVelocity value="2.000"/>
-      <timescaleMinimum value="0.010"/>
+      <timescaleMinimum value="0.001"/>
     </starFormationTimescale>
   </starFormationRateSpheroids>
 
@@ -137,7 +132,6 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"          />
@@ -197,9 +191,9 @@
     </nodeOperator>
     <nodeOperator value="satelliteDestructionMassThreshold">
       <!-- Subhalos will be removed if they fall below the merger tree mass resolution limit. -->
-      <massDestructionAbsolute           value="=[mergerTreeMassResolution::massResolutionMinimum]   "/>
-      <massDestructionMassTreeFraction   value="=[mergerTreeMassResolution::massResolutionFractional]"/>
-      <massDestructionMassInfallFraction value="0.0"                                                  />
+      <massDestructionAbsolute           value="=[mergerTreeMassResolution::massResolution]"/>
+      <massDestructionMassTreeFraction   value="0.0"                                        />
+      <massDestructionMassInfallFraction value="0.0"                                        />
     </nodeOperator>
     <!-- CGM -->
     <nodeOperator value="CGMChemistry">
@@ -211,16 +205,16 @@
     <!--Stellar feedback outflows-->
     <nodeOperator value="stellarFeedbackDisks">
       <stellarFeedbackOutflows value="rateLimit">
-        <timescaleOutflowFractionalMinimum value="0.01"/>
+        <timescaleOutflowFractionalMinimum value="0.001"/>
         <stellarFeedbackOutflows value="powerLaw">
-          <velocityCharacteristic value="135.83"/>
-          <exponent               value="  3.79"/>
+          <velocityCharacteristic value="250.0"/>
+          <exponent               value="  2.0"/>
         </stellarFeedbackOutflows>
       </stellarFeedbackOutflows>
     </nodeOperator>
     <nodeOperator value="stellarFeedbackSpheroids">
       <stellarFeedbackOutflows value="rateLimit">
-        <timescaleOutflowFractionalMinimum value="0.01"/>
+        <timescaleOutflowFractionalMinimum value="0.001"/>
         <stellarFeedbackOutflows value="powerLaw">
           <velocityCharacteristic value="100.0"/>
           <exponent               value="  2.0"/>
@@ -230,8 +224,8 @@
     <!-- Bar instability in galactic disks -->
     <nodeOperator value="barInstability">
       <galacticDynamicsBarInstability value="efstathiou1982">
-    	<stabilityThresholdGaseous value="0.7"/>
-    	<stabilityThresholdStellar value="1.1"/>
+	<stabilityThresholdGaseous value="0.7"/>
+	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="nodeFormationTimeMassFraction">
@@ -249,9 +243,9 @@
   </mergerTreeEvolver>
   <mergerTreeNodeEvolver value="standard">
     <!-- Standard node evolve with parameters chosen to (somewhat) optimize the evolution. -->
-    <odeToleranceAbsolute value="1.0e-4"/>
-    <odeToleranceRelative value="1.0e-4"/>
-    <reuseODEStepSize     value="false" />
+    <odeToleranceAbsolute value="0.01" />
+    <odeToleranceRelative value="0.01" />
+    <reuseODEStepSize     value="false"/>
   </mergerTreeNodeEvolver>
   <mergerTreeEvolveTimestep value="multi">
     <!-- Standard time-stepping rules -->
@@ -267,7 +261,7 @@
       <!-- This timestep rule is required to ensure that subhalos are removed when they meet the destruction criteria. -->
     </mergerTreeEvolveTimestep>
     <mergerTreeEvolveTimestep value="hostTidalMassLoss">
-      <!-- This timestep criterion makes sure that subsubhalos do not evolve too far ahead of their host subhalos when
+      <!-- This timestep criterion makes sure that subsubahlos do not evolve too far ahead of their host subhalos when
            the host density and mass change rapidly due to tidal effects. It also limits the evolution time of subhalos
            to the time at which the hosts first becomes subhalos. -->
       <timeStepRelative        value="0.1"/>

--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -9,6 +9,7 @@
   <componentBlackHole         value="standard" >
     <massSeed                                    value="100.0000"/>
     <heatsHotHalo                                value="true"    />
+    <efficiencyRadioMode                         value="  1.0000"/>
     <efficiencyWind                              value="  0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"    />
     <bondiHoyleAccretionEnhancementHotHalo       value="  6.0000"/>
@@ -83,7 +84,7 @@
 
   <coolingRadius value="simple"/>
   <coolingRate value="multiplier">
-    <multiplier  value="0.5"           />
+    <multiplier  value="1.0"           />
     <coolingRate value="whiteFrenk1991" >
       <velocityCutOff value="10000"/>
     </coolingRate>
@@ -92,30 +93,34 @@
     <degreesOfFreedom value="3.0"/>
   </coolingTime>
   <coolingTimeAvailable value="whiteFrenk1991">
-    <ageFactor value="0"/>
+    <ageFactor value="0.0"/>
   </coolingTimeAvailable>
   <!-- Hot halo ram pressure stripping options -->
   <hotHaloRamPressureStripping value="font2008"               />
   <hotHaloRamPressureForce     value="orbitalPosition"        />
   <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
   <!-- Galactic structure solver options -->
-  <galacticStructureSolver value="equilibrium"/>
+  <galacticStructureSolver value="equilibrium">
+    <convergenceFailureIsFatal value="false"/>
+  </galacticStructureSolver>
   <darkMatterProfile value="adiabaticGnedin2004">
-    <A     value="0.73"/>
-    <omega value="0.70"/>
+    <A                 value="0.73"   />
+    <omega             value="0.70"   />
+    <toleranceRelative value="1.00e-4"/>
   </darkMatterProfile>
   <!-- Star formation rate options -->
   <starFormationRateDisks               value="intgrtdSurfaceDensity"/>
   <starFormationRateSurfaceDensityDisks value="blitz2006"             >
-    <assumeMonotonicSurfaceDensity value="true"/>
-    <assumeExponentialDisk         value="true"/>
-    <useTabulation                 value="true"/>
+    <starFormationFrequencyNormalization value="2.0e-9"/>
+    <assumeMonotonicSurfaceDensity       value="true"  />
+    <assumeExponentialDisk               value="true"  />
+    <useTabulation                       value="true"  />
   </starFormationRateSurfaceDensityDisks>
   <starFormationRateSpheroids value="timescale">
     <starFormationTimescale value="dynamicalTime">
-      <efficiency       value="0.040"/>
+      <efficiency       value="1.000"/>
       <exponentVelocity value="2.000"/>
-      <timescaleMinimum value="0.001"/>
+      <timescaleMinimum value="0.010"/>
     </starFormationTimescale>
   </starFormationRateSpheroids>
 
@@ -132,6 +137,7 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"          />
@@ -191,9 +197,9 @@
     </nodeOperator>
     <nodeOperator value="satelliteDestructionMassThreshold">
       <!-- Subhalos will be removed if they fall below the merger tree mass resolution limit. -->
-      <massDestructionAbsolute           value="=[mergerTreeMassResolution::massResolution]"/>
-      <massDestructionMassTreeFraction   value="0.0"                                        />
-      <massDestructionMassInfallFraction value="0.0"                                        />
+      <massDestructionAbsolute           value="=[mergerTreeMassResolution::massResolutionMinimum]   "/>
+      <massDestructionMassTreeFraction   value="=[mergerTreeMassResolution::massResolutionFractional]"/>
+      <massDestructionMassInfallFraction value="0.0"                                                  />
     </nodeOperator>
     <!-- CGM -->
     <nodeOperator value="CGMChemistry">
@@ -205,16 +211,16 @@
     <!--Stellar feedback outflows-->
     <nodeOperator value="stellarFeedbackDisks">
       <stellarFeedbackOutflows value="rateLimit">
-        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <timescaleOutflowFractionalMinimum value="0.01"/>
         <stellarFeedbackOutflows value="powerLaw">
-          <velocityCharacteristic value="250.0"/>
-          <exponent               value="  2.0"/>
+          <velocityCharacteristic value="135.83"/>
+          <exponent               value="  3.79"/>
         </stellarFeedbackOutflows>
       </stellarFeedbackOutflows>
     </nodeOperator>
     <nodeOperator value="stellarFeedbackSpheroids">
       <stellarFeedbackOutflows value="rateLimit">
-        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <timescaleOutflowFractionalMinimum value="0.01"/>
         <stellarFeedbackOutflows value="powerLaw">
           <velocityCharacteristic value="100.0"/>
           <exponent               value="  2.0"/>
@@ -224,8 +230,8 @@
     <!-- Bar instability in galactic disks -->
     <nodeOperator value="barInstability">
       <galacticDynamicsBarInstability value="efstathiou1982">
-	<stabilityThresholdGaseous value="0.7"/>
-	<stabilityThresholdStellar value="1.1"/>
+    	<stabilityThresholdGaseous value="0.7"/>
+    	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="nodeFormationTimeMassFraction">
@@ -243,9 +249,9 @@
   </mergerTreeEvolver>
   <mergerTreeNodeEvolver value="standard">
     <!-- Standard node evolve with parameters chosen to (somewhat) optimize the evolution. -->
-    <odeToleranceAbsolute value="0.01" />
-    <odeToleranceRelative value="0.01" />
-    <reuseODEStepSize     value="false"/>
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+    <reuseODEStepSize     value="false" />
   </mergerTreeNodeEvolver>
   <mergerTreeEvolveTimestep value="multi">
     <!-- Standard time-stepping rules -->
@@ -261,7 +267,7 @@
       <!-- This timestep rule is required to ensure that subhalos are removed when they meet the destruction criteria. -->
     </mergerTreeEvolveTimestep>
     <mergerTreeEvolveTimestep value="hostTidalMassLoss">
-      <!-- This timestep criterion makes sure that subsubahlos do not evolve too far ahead of their host subhalos when
+      <!-- This timestep criterion makes sure that subsubhalos do not evolve too far ahead of their host subhalos when
            the host density and mass change rapidly due to tidal effects. It also limits the evolution time of subhalos
            to the time at which the hosts first becomes subhalos. -->
       <timeStepRelative        value="0.1"/>

--- a/perl/Galacticus/Build/SourceTree/Process/ThreadSafeIO.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/ThreadSafeIO.pm
@@ -26,10 +26,20 @@ sub Lock_IO {
     }
     return
 	unless ( $lock );
+    # Do not apply thread locking inside error reporting functions. These can be triggered from anywhere in the code - including
+    # within another I/O critical section which would then lead to deadlocking. Since at this point we are in an error condition
+    # anyway, we can just take our chances with thread race conditions.
+    my $depth  = 0;
+    my $module = $tree;
+    while ( $module ) {
+	return
+	    if ( $module->{'type'} eq "module" && $module->{'name'} eq "Error" );
+	$module = &Galacticus::Build::SourceTree::Walk_Tree($module,\$depth);
+    }
     # Walk the tree, looking for IO statements.
     my @ioStatements = ( 'open', 'close', 'read', 'write' );
-    my $node  = $tree;
-    my $depth = 0;
+    my $node         = $tree;
+    $depth           = 0;
     while ( $node ) {
 	if ( $node->{'type'} eq "code" ) {
 	    my $newContent    ;
@@ -38,10 +48,17 @@ sub Lock_IO {
 	    open(my $content,"<",\$node->{'content'});
 	    while ( ! eof($content) ) {
 		&Fortran::Utils::Get_Fortran_Line($content,my $rawLine, my $processedLine, my $bufferedComments);
+		# Detect entry and exit to existing critical sections - we don't want to add locks inside such a section as that
+		# would result in deadlocks.
 		$inCritical = 1
 		    if ( $processedLine =~ m/^\s*!\$omp\s+critical\s*\(gfortranInternalIO\)\s*$/ );
 		$inCritical = 0
 		    if ( $processedLine =~ m/^\s*!\$omp\s+end\s+critical\s*\(gfortranInternalIO\)\s*$/ );
+		# Convert "FoX_DOM_Access" critical sections to "gfortranInternalIO". This still prevents multi-threaded access to
+		# the FoX library, but also restricts access to gfortran internal IO within the FoX library.
+		$rawLine =~ s/FoX_DOM_Access/gfortranInternalIO/
+		    if ( $rawLine =~ m/^\s*!\$omp\s+(end\s+)??critical\s*\(FoX_DOM_Access\)\s*$/ );
+		# Detect IO statements and lock if not already in a critical section.
 		my $isIO = 0;
 		foreach my $ioStatement ( @ioStatements ) {
 		    if ( $processedLine =~ m/^\s*(!\$)??\s*$ioStatement\s*\(/ ) {

--- a/source/atomic.data.F90
+++ b/source/atomic.data.F90
@@ -192,11 +192,11 @@ contains
     !!{
     Ensure that the module is initialized by reading in data.
     !!}
-    use :: FoX_dom           , only : destroy              , getElementsByTagname             , node
+    use :: FoX_dom           , only : destroy              , getElementsByTagname             , node                        , extractDataContent
     use :: Error             , only : Error_Report
     use :: Input_Paths       , only : inputPath            , pathTypeDataStatic
-    use :: IO_XML            , only : XML_Array_Read_Static, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, extractDataContent => extractDataContentTS, &
-         &                            xmlNodeList          , XML_Parse
+    use :: IO_XML            , only : XML_Array_Read_Static, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, XML_Parse         , &
+         &                            xmlNodeList
     use :: ISO_Varying_String, only : char
     use :: String_Handling   , only : String_Lower_Case    , char
     implicit none

--- a/source/interface.Local_Group_database.F90
+++ b/source/interface.Local_Group_database.F90
@@ -158,9 +158,10 @@ contains
     !!{
     Get a named text property from the Local Group database.
     !!}
-    use                      :: FoX_DOM           , only : getAttributeNode            , getTextContent                            , hasAttribute, setAttribute
+    use                      :: FoX_DOM           , only : getAttributeNode            , getTextContent                            , hasAttribute, setAttribute, &
+         &                                                 extractDataContent
     use                      :: Error             , only : Error_Report
-    use                      :: IO_XML            , only : XML_Get_Elements_By_Tag_Name, extractDataContent => extractDataContentTS
+    use                      :: IO_XML            , only : XML_Get_Elements_By_Tag_Name
     {Type¦match¦^VarStr$¦use :: ISO_Varying_String, only : varying_string              , assignment(=)¦}
     implicit none
     class           (localGroupDB            ), intent(inout)                                      :: self
@@ -342,13 +343,14 @@ contains
     !!{
     Update the database.
     !!}
-    use :: FoX_DOM                         , only : appendChild                 , createElementNS                            , setAttribute      , getAttributeNode, &
-         &                                          getNamespaceURI             , getTextContent                             , hasAttribute      , serialize
+    use :: FoX_DOM                         , only : appendChild                 , createElementNS    , setAttribute      , getAttributeNode, &
+         &                                          getNamespaceURI             , getTextContent     , hasAttribute      , serialize       , &
+         &                                          extractDataContent
     use :: Error                           , only : Error_Report
     use :: Input_Paths                     , only : inputPath                   , pathTypeDataStatic
-    use :: IO_XML                          , only : XML_Get_Elements_By_Tag_Name, extractDataContent  => extractDataContentTS
+    use :: IO_XML                          , only : XML_Get_Elements_By_Tag_Name
     use :: ISO_Varying_String              , only : char
-    use :: Numerical_Constants_Astronomical, only : arcminutesToDegrees         , arcsecondsToDegrees                        , degreesToRadians  , hoursToDegrees  , &
+    use :: Numerical_Constants_Astronomical, only : arcminutesToDegrees         , arcsecondsToDegrees, degreesToRadians  , hoursToDegrees  , &
           &                                         minutesToDegrees            , secondsToDegrees
     implicit none
     class           (localGroupDB  ), intent(inout)             :: self

--- a/source/merger_trees.construct.build.masses.read.XML.F90
+++ b/source/merger_trees.construct.build.masses.read.XML.F90
@@ -125,13 +125,7 @@ contains
     integer                                                                                  :: ioErr
 
     !$omp critical (FoX_DOM_Access)
-#ifdef THREADSAFEIO
-    !$omp critical(gfortranInternalIO)
-#endif
     doc => parseFile(char(File_Name_Expand(char(self%fileName))),iostat=ioErr)
-#ifdef THREADSAFEIO
-    !$omp end critical(gfortranInternalIO)
-#endif
     if (ioErr /= 0) call Error_Report('unable to read or parse merger tree root mass file'//{introspection:location})
     rootNode => getDocumentElement(doc)
     ! Read all tree masses.

--- a/source/merger_trees.construct.fully_specified.F90
+++ b/source/merger_trees.construct.fully_specified.F90
@@ -208,13 +208,7 @@ contains
     !$omp critical (FoX_DOM_Access)
     if (.not.associated(self%document)) allocate(self%document)
     ! Parse the merger tree file.
-#ifdef THREADSAFEIO
-       !$omp critical(gfortranInternalIO)
-#endif
     self%document%doc => parseFile(char(self%fileName),iostat=ioErr)
-#ifdef THREADSAFEIO
-       !$omp end critical(gfortranInternalIO)
-#endif
     if (ioErr /= 0) call Error_Report('unable to read or parse fully-specified merger tree file'//{introspection:location})
     self%document%copyCount = 1
     ! Get the list of trees.
@@ -362,9 +356,9 @@ contains
       !!{
       Extract and return an index from a node definition as used when constructing fully-specified merger trees.
       !!}
-      use :: FoX_Dom     , only : node
+      use :: FoX_Dom     , only : node                        , extractDataContent
       use :: Kind_Numbers, only : kind_int8
-      use :: IO_XML      , only : XML_Get_Elements_By_Tag_Name, extractDataContent => extractDataContentTS
+      use :: IO_XML      , only : XML_Get_Elements_By_Tag_Name
       use :: Error       , only : Error_Report
       implicit none
       integer  (kind=kind_int8)                             :: indexNode

--- a/source/meta.tree_processing_times.file.F90
+++ b/source/meta.tree_processing_times.file.F90
@@ -108,13 +108,7 @@ contains
     
     ! Parse the fit file.
     !$omp critical (FoX_DOM_Access)
-#ifdef THREADSAFEIO
-       !$omp critical(gfortranInternalIO)
-#endif
     doc => parseFile(char(fileName),iostat=ioStatus)
-#ifdef THREADSAFEIO
-       !$omp end critical(gfortranInternalIO)
-#endif
     if (ioStatus /= 0) call Error_Report('Unable to find or parse tree timing file'//{introspection:location})
     fit => XML_Get_First_Element_By_Tag_Name(doc,"fit")
     call XML_Array_Read_Static(fit,"coefficient",self%fitCoefficient)

--- a/source/objects.abundances.F90
+++ b/source/objects.abundances.F90
@@ -255,9 +255,9 @@ contains
     !!{
     Build a {\normalfont \ttfamily abundances} object from the given XML {\normalfont \ttfamily abundancesDefinition}.
     !!}
-    use :: FoX_DOM, only : node
+    use :: FoX_DOM, only : node                        , extractDataContent
     use :: Error  , only : Error_Report
-    use :: IO_XML , only : XML_Get_Elements_By_Tag_Name, xmlNodeList, extractDataContent => extractDataContentTS
+    use :: IO_XML , only : XML_Get_Elements_By_Tag_Name, xmlNodeList
     implicit none
     class  (abundances ), intent(inout)              :: self
     type   (node       ), intent(in   ), pointer     :: abundancesDefinition

--- a/source/objects.chemical_abundances.F90
+++ b/source/objects.chemical_abundances.F90
@@ -471,9 +471,9 @@ contains
     !!{
     Build a {\normalfont \ttfamily chemicalAbundances} object from the given XML {\normalfont \ttfamily chemicalsDefinition}.
     !!}
-    use :: FoX_DOM           , only : node
+    use :: FoX_DOM           , only : node                        , extractDataContent
     use :: Error             , only : Error_Report
-    use :: IO_XML            , only : XML_Get_Elements_By_Tag_Name, xmlNodeList, extractDataContent => extractDataContentTS
+    use :: IO_XML            , only : XML_Get_Elements_By_Tag_Name, xmlNodeList
     use :: ISO_Varying_String, only : char
     implicit none
     class  (chemicalAbundances), intent(inout)              :: self

--- a/source/objects.chemical_structure.F90
+++ b/source/objects.chemical_structure.F90
@@ -93,10 +93,10 @@ contains
     Initialize the chemical structure database by reading the atomic structure database. Note: this implementation is not
     fully compatible with chemical markup language (CML), but only a limited subset of it.
     !!}
-    use :: FoX_dom           , only : Node                        , destroy
+    use :: FoX_dom           , only : Node                        , destroy           , extractDataContent
     use :: Error             , only : Error_Report
     use :: Input_Paths       , only : inputPath                   , pathTypeDataStatic
-    use :: IO_XML            , only : XML_Get_Elements_By_Tag_Name, xmlNodeList       , XML_Parse, extractDataContent => extractDataContentTS
+    use :: IO_XML            , only : XML_Get_Elements_By_Tag_Name, xmlNodeList       , XML_Parse
     use :: ISO_Varying_String, only : char                        , assignment(=)
     implicit none
     type     (Node       ), pointer                   :: doc     , atom    , bond        , chemical, element

--- a/source/objects.kepler_orbits.F90
+++ b/source/objects.kepler_orbits.F90
@@ -217,9 +217,9 @@ contains
     !!{
     Build a {\normalfont \ttfamily keplerOrbit} object from the given XML {\normalfont \ttfamily keplerOrbitDefinition}.
     !!}
-    use :: FoX_DOM, only : getNodeName                 , node
+    use :: FoX_DOM, only : getNodeName                 , node       , extractDataContent
     use :: Error  , only : Error_Report
-    use :: IO_XML , only : XML_Get_Elements_By_Tag_Name, xmlNodeList, extractDataContent => extractDataContentTS
+    use :: IO_XML , only : XML_Get_Elements_By_Tag_Name, xmlNodeList
     implicit none
     class           (keplerOrbit), intent(inout)               :: self
     type            (node       ), pointer                     :: keplerOrbitDefinition

--- a/source/objects.stellar_luminosities.F90
+++ b/source/objects.stellar_luminosities.F90
@@ -466,9 +466,9 @@ contains
     !!{
     Build a {\normalfont \ttfamily stellarLuminosities} object from the given XML {\normalfont \ttfamily stellarLuminositiesDefinition}.
     !!}
-    use :: FoX_DOM, only : node
+    use :: FoX_DOM, only : node                        , extractDataContent
     use :: Error  , only : Error_Report
-    use :: IO_XML , only : XML_Get_Elements_By_Tag_Name, xmlNodeList, extractDataContent => extractDataContentTS
+    use :: IO_XML , only : XML_Get_Elements_By_Tag_Name, xmlNodeList
     implicit none
     class  (stellarLuminosities), intent(inout)              :: self
     type   (node               ), intent(in   ), pointer     :: stellarLuminositiesDefinition

--- a/source/objects.tensors.rank2.dimension3.symmetric.F90
+++ b/source/objects.tensors.rank2.dimension3.symmetric.F90
@@ -75,9 +75,9 @@ contains
     !!{
     Build a {\normalfont \ttfamily tensorRank2Dimension3Symmetric} object from the given XML {\normalfont \ttfamily tensorDefinition}.
     !!}
-    use :: FoX_DOM, only : node
+    use :: FoX_DOM, only : node                        , extractDataContent
     use :: Error  , only : Error_Report
-    use :: IO_XML , only : XML_Get_Elements_By_Tag_Name, xmlNodeList, extractDataContent => extractDataContentTS
+    use :: IO_XML , only : XML_Get_Elements_By_Tag_Name, xmlNodeList
     implicit none
     type     (node       )               , pointer     :: element
     type     (xmlNodeList), dimension(:) , allocatable :: elementList

--- a/source/output.times.simulation_snapshots.F90
+++ b/source/output.times.simulation_snapshots.F90
@@ -87,13 +87,7 @@ contains
     !!]
     
     !$omp critical (FoX_DOM_Access)
-#ifdef THREADSAFEIO
-       !$omp critical(gfortranInternalIO)
-#endif
     doc => parseFile(char(File_Name_Expand(char(self%fileName))),iostat=ioStatus)
-#ifdef THREADSAFEIO
-       !$omp end critical(gfortranInternalIO)
-#endif
     if (ioStatus /= 0) call Error_Report('unable to find or parse the simulation definition file'//{introspection:location})
     snapshots => XML_Get_First_Element_By_Tag_Name(doc,'snapshots')
     call XML_Array_Read(snapshots,'snapshot',self%redshifts)

--- a/source/output.version.F90
+++ b/source/output.version.F90
@@ -72,13 +72,13 @@ contains
     !!}
     use :: Dates_and_Times   , only : Formatted_Date_and_Time
     use :: File_Utilities    , only : File_Exists
-    use :: FoX_dom           , only : destroy                          , node
+    use :: FoX_dom           , only : destroy                          , node           , extractDataContent
     use :: FoX_utils         , only : generate_UUID
     use :: Error             , only : Error_Report
     use :: Output_HDF5       , only : outputFile
     use :: HDF5_Access       , only : hdf5Access
     use :: IO_HDF5           , only : hdf5Object
-    use :: IO_XML            , only : XML_Get_First_Element_By_Tag_Name, XML_Path_Exists, XML_Parse, extractDataContent => extractDataContentTS
+    use :: IO_XML            , only : XML_Get_First_Element_By_Tag_Name, XML_Path_Exists, XML_Parse
     use :: ISO_Varying_String, only : varying_string
     implicit none
     type     (Node          ), pointer :: doc            , emailNode, nameNode

--- a/source/stellar_astrophysics.file.F90
+++ b/source/stellar_astrophysics.file.F90
@@ -162,10 +162,9 @@ contains
     Read stellar astrophysics data. This is not done during object construction since it can be slow---we only perform the read if the data is actually needed.
     !!}
     use :: Atomic_Data      , only : Atomic_Short_Label
-    use :: FoX_DOM          , only : destroy                          , node
+    use :: FoX_DOM          , only : destroy                          , node                        , extractDataContent
     use :: Error            , only : Error_Report
-    use :: IO_XML           , only : XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList, extractDataContent => extractDataContentTS, &
-         &                           XML_Parse
+    use :: IO_XML           , only : XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList       ,  XML_Parse
     implicit none
     class           (stellarAstrophysicsFile), intent(inout)               :: self
     type            (node                   ), pointer                     :: doc              , datum                   , &

--- a/source/stellar_astrophysics.supernovae_PopulationIII.HegerWoosley2002.F90
+++ b/source/stellar_astrophysics.supernovae_PopulationIII.HegerWoosley2002.F90
@@ -102,13 +102,7 @@ contains
     ! Read in pair instability supernova energies.
     !$omp critical (FoX_DOM_Access)
     ! Open the XML file containing yields.
-#ifdef THREADSAFEIO
-       !$omp critical(gfortranInternalIO)
-#endif
     doc => parseFile(char(inputPath(pathTypeDataStatic))//'stellarAstrophysics/Supernovae_Pair_Instability_Heger_Woosley_1992.xml',iostat=ioErr)
-#ifdef THREADSAFEIO
-       !$omp end critical(gfortranInternalIO)
-#endif
     if (ioErr /= 0) call Error_Report('Unable to parse supernovae file'//{introspection:location})
     ! Get the mass and energy elements.
     massElement   => XML_Get_First_Element_By_Tag_Name(doc,"heliumCoreMass" )

--- a/source/stellar_astrophysics.supernovae_type_Ia.Nagashima2005.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.Nagashima2005.F90
@@ -81,11 +81,11 @@ contains
     Internal constructor for the {\normalfont \ttfamily nagashima2005} supernovae type Ia class.
     !!}
     use :: Atomic_Data      , only : Atom_Lookup                   , Atomic_Data_Atoms_Count
-    use :: FoX_dom          , only : destroy                       , node
+    use :: FoX_dom          , only : destroy                       , node                             , extractDataContent
     use :: Error            , only : Error_Report
     use :: Input_Paths      , only : inputPath                     , pathTypeDataStatic
-    use :: IO_XML           , only : XML_Count_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name                        , XML_Get_Elements_By_Tag_Name, xmlNodeList, &
-         &                           XML_Parse                     , extractDataContent                => extractDataContentTS
+    use :: IO_XML           , only : XML_Count_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name                    , XML_Get_Elements_By_Tag_Name, xmlNodeList, &
+         &                           XML_Parse
     implicit none
     type            (supernovaeTypeIaNagashima2005)                              :: self
     class           (stellarAstrophysicsClass     ), intent(in   ), target       :: stellarAstrophysics_

--- a/source/structure_formation.critical_overdensity.Marsh2016.FDM.F90
+++ b/source/structure_formation.critical_overdensity.Marsh2016.FDM.F90
@@ -178,13 +178,7 @@ contains
     if (.not.self%useFittingFunction) then
        ! Read in the tabulated critical overdensity scaling.
        !$omp critical (FoX_DOM_Access)
-#ifdef THREADSAFEIO
-       !$omp critical(gfortranInternalIO)
-#endif
        doc => parseFile(char(inputPath(pathTypeDataStatic))//"darkMatter/criticalOverdensityFuzzyDarkMatterMarsh.xml",iostat=ioStatus)
-#ifdef THREADSAFEIO
-       !$omp end critical(gfortranInternalIO)
-#endif
        if (ioStatus /= 0) call Error_Report('unable to find or parse the tabulated data'//{introspection:location})
        ! Extract the datum lists.
        element    => XML_Get_First_Element_By_Tag_Name(doc,"mass" )

--- a/source/structure_formation.critical_overdensity.warm_dark_matter.F90
+++ b/source/structure_formation.critical_overdensity.warm_dark_matter.F90
@@ -188,13 +188,7 @@ contains
     end select
     ! Read in the tabulated critical overdensity scaling.
     !$omp critical (FoX_DOM_Access)
-#ifdef THREADSAFEIO
-       !$omp critical(gfortranInternalIO)
-#endif
     doc => parseFile(char(inputPath(pathTypeDataStatic))//"darkMatter/criticalOverdensityWarmDarkMatterBarkana.xml",iostat=ioStatus)
-#ifdef THREADSAFEIO
-       !$omp end critical(gfortranInternalIO)
-#endif
     if (ioStatus /= 0) call Error_Report('unable to find or parse the tabulated data'//{introspection:location})
     ! Extract the datum lists.
     element    => XML_Get_First_Element_By_Tag_Name(doc,"mass" )

--- a/source/structure_formation.halo_mass_function.Tinker2008.F90
+++ b/source/structure_formation.halo_mass_function.Tinker2008.F90
@@ -157,13 +157,7 @@ contains
     parameterFileName=inputPath(pathTypeDataStatic)//"darkMatter/Halo_Mass_Function_Parameters_Tinker_2008.xml"
     if (.not.File_Exists(parameterFileName)) call Error_Report('Unable to find data file "'//parameterFileName//'"'//{introspection:location})
     !$omp critical (FoX_DOM_Access)
-#ifdef THREADSAFEIO
-       !$omp critical(gfortranInternalIO)
-#endif
     doc => parseFile(char(parameterFileName),ioStat=ioStatus)
-#ifdef THREADSAFEIO
-       !$omp end critical(gfortranInternalIO)
-#endif
     if (ioStatus /= 0) call Error_Report('Unable to parse data file "'//parameterFileName//'"'//{introspection:location})
     columnsElement => XML_Get_First_Element_By_Tag_Name(doc           ,"columns"        )
     columnElement  => XML_Get_First_Element_By_Tag_Name(columnsElement,"densityContrast")

--- a/source/tests.IO.XML.F90
+++ b/source/tests.IO.XML.F90
@@ -25,21 +25,14 @@ program Tests_IO_XML
   !!{
   Tests the XML I/O module.
   !!}
-  use            :: Display       , only : displayVerbositySet, verbosityLevelStandard
-  use            :: FoX_DOM       , only : destroy            , node                  , serialize
+  use            :: Unit_Tests    , only : Assert                        , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
+  use            :: IO_XML        , only : XML_Count_Elements_By_Tag_Name                        , XML_Array_Read      , XML_Array_Read_Static, XML_Get_First_Element_By_Tag_Name, &
+          &                                XML_Parse                                             , XML_Path_Exists     , xmlNodeList          , XML_Get_ELements_By_Tag_Name
+  use            :: Display       , only : displayVerbositySet           , verbosityLevelStandard
+  use            :: FoX_DOM       , only : destroy                       , node                  , serialize           , extractDataContent
   use            :: Error         , only : Error_Report
   use, intrinsic :: ISO_C_Binding , only : c_size_t
   use            :: System_Command, only : System_Command_Do
-  use            :: Unit_Tests    , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
-  use            :: IO_XML            , only : XML_Count_Elements_By_Tag_Name                       , XML_Array_Read        , XML_Array_Read_Static, XML_Get_First_Element_By_Tag_Name, &
-          &                                    XML_Parse                                            , XML_Path_Exists       , xmlNodeList          , XML_Get_ELements_By_Tag_Name     , &
-          &                                    extractDataContent            => extractDataContentTS
-  use            :: Display       , only : displayVerbositySet, verbosityLevelStandard
-  use            :: FoX_DOM       , only : destroy            , node                  , serialize
-  use            :: Error         , only : Error_Report
-  use, intrinsic :: ISO_C_Binding , only : c_size_t
-  use            :: System_Command, only : System_Command_Do
-  use            :: Unit_Tests    , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
   implicit none
   type            (node       )                           , pointer :: doc        , xmlElement
   type            (xmlNodeList), allocatable, dimension(:)          :: xmlElements

--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -1082,10 +1082,12 @@ contains
              end if
              ! Check for duplicated parameters.
              !$omp critical (FoX_DOM_Access)
-             if (parameterNamesSeen%exists(getNodeName(node_))) then
+             unknownName=getNodeName(node_)
+             !$omp end critical (FoX_DOM_Access)
+             if (parameterNamesSeen%exists(unknownName)) then
                 parameterMatched=.false.
                 if (present(allowedMultiParameterNames)) &
-                     & parameterMatched=any(getNodeName(node_) == allowedMultiParameterNames)
+                     & parameterMatched=any(unknownName == allowedMultiParameterNames)
                 if (.not.parameterMatched .and. .not.ignoreWarnings) then
                    if (.not.warningsFound.and.verbose) call displayIndent(displayMagenta()//'WARNING:'//displayReset()//' problems found with input parameters:')
                    warningsFound=.true.
@@ -1095,9 +1097,8 @@ contains
                    end if
                 end if
              else
-                call parameterNamesSeen%set(getNodeName(node_),1)
+                call parameterNamesSeen%set(unknownName,1)
              end if
-             !$omp end critical (FoX_DOM_Access)
           end if
           currentParameter => currentParameter%sibling
        end do

--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -269,10 +269,10 @@ contains
     specified as a variable length string.
     !!}
     use :: FoX_dom           , only : node
-    use :: ISO_Varying_String, only : char, extract, operator(==)
-    use :: IO_XML            , only : XML_Get_First_Element_By_Tag_Name, parseString => parseStringTS
-    use :: FoX_dom           , only : node
-    use :: ISO_Varying_String, only : char, extract, operator(==)
+    use :: ISO_Varying_String, only : char                             , extract    , operator(==)
+    use :: IO_XML            , only : XML_Get_First_Element_By_Tag_Name
+    use :: FoX_dom           , only : node                             , parseString
+    use :: ISO_Varying_String, only : char                             , extract    , operator(==)
     implicit none
     type     (inputParameters)                                           :: self
     type     (varying_string    )              , intent(in   )           :: xmlString
@@ -382,11 +382,11 @@ contains
     !!}
     use :: Display           , only : displayGreen                     , displayMessage , displayReset
     use :: File_Utilities    , only : File_Name_Temporary
-    use :: FoX_dom           , only : getOwnerDocument                 , node           , setLiveNodeLists
+    use :: FoX_dom           , only : getOwnerDocument                 , node           , setLiveNodeLists, getTextContent
     use :: Error             , only : Error_Report
-    use :: ISO_Varying_String, only : assignment(=)                    , char           , operator(//)                      , operator(/=)
+    use :: ISO_Varying_String, only : assignment(=)                    , char           , operator(//)    , operator(/=)
     use :: String_Handling   , only : String_Strip
-    use :: IO_XML            , only : XML_Get_First_Element_By_Tag_Name, XML_Path_Exists, getTextContent => getTextContentTS
+    use :: IO_XML            , only : XML_Get_First_Element_By_Tag_Name, XML_Path_Exists
     use :: Display           , only : displayMessage
     use :: IO_HDF5           , only : ioHDF5AccessInitialize
     use :: HDF5_Access       , only : hdf5Access
@@ -919,10 +919,9 @@ contains
     !!{
     Get the value of a parameter.
     !!}
-    use :: FoX_dom           , only : DOMException                      , getAttributeNode, getNodeName, hasAttribute, &
-          &                           inException                       , node
+    use :: FoX_dom           , only : DOMException , getAttributeNode, getNodeName   , hasAttribute, &
+          &                           inException  , node            , getTextContent
     use :: ISO_Varying_String, only : assignment(=)
-    use :: IO_XML            , only : getTextContent => getTextContentTS
     use :: Error             , only : Error_Report
     implicit none
     type   (varying_string)                :: inputParameterGet
@@ -1499,13 +1498,13 @@ contains
     !!{
     Return the value of the specified parameter.
     !!}
-    use :: FoX_dom           , only : DOMException                     , getAttributeNode  , getNodeName                        , hasAttribute                              , &
-          &                           inException                      , node
+    use :: FoX_dom           , only : DOMException                     , getAttributeNode  , getNodeName   , hasAttribute      , &
+          &                           inException                      , node              , getTextContent, extractDataContent
     use :: Error             , only : Error_Report
-    use :: ISO_Varying_String, only : assignment(=)                    , char              , operator(//)                       , operator(==)                              , &
+    use :: ISO_Varying_String, only : assignment(=)                    , char              , operator(//)  , operator(==)      , &
           &                           trim
     use :: String_Handling   , only : String_Count_Words               , String_Split_Words, operator(//)
-    use :: IO_XML            , only : XML_Get_First_Element_By_Tag_Name, XML_Path_Exists   , getTextContent  => getTextContentTS, extractDataContent => extractDataContentTS
+    use :: IO_XML            , only : XML_Get_First_Element_By_Tag_Name, XML_Path_Exists
     use :: HDF5_Access       , only : hdf5Access
     implicit none
     class           (inputParameters                         ), intent(inout), target      :: self

--- a/testSuite/parameters/bug1066052.xml
+++ b/testSuite/parameters/bug1066052.xml
@@ -51,7 +51,6 @@
     <angularMomentumAlwaysGrows value="true"/>
   </componentHotHalo>
 
-  <verbosityLevel value="standard"/>
   <nodePromotionIndexShift value="false"/>
   <outputTimes value="list">
     <redshifts value="0.000"/>

--- a/testSuite/parameters/bug745815.xml
+++ b/testSuite/parameters/bug745815.xml
@@ -9,151 +9,11 @@
     <OmegaBaryon value="0.0455"/>
     <temperatureCMB value="2.72548"/>
   </cosmologyParameters>
-  <accretionDisks value="ADAF">
-    <efficiencyRadiationType value="thinDisk"/>
-    <adiabaticIndex value="1.444"/>
-    <energyOption value="pureADAF"/>
-    <efficiencyRadiation value="0.01"/>
-    <viscosityOption value="fit"/>
-  </accretionDisks>
-  <accretionHalo value="simple">
-    <redshiftReionization value="9"/>
-    <velocitySuppressionReionization value="30"/>
-  </accretionHalo>
-  <accretionRateThinDiskMaximum value="0.30d0"/>
-  <accretionRateThinDiskMinimum value="0.01d0"/>
-  <darkMatterProfile value="adiabaticGnedin2004">
-    <A value="0.8"/>
-    <omega value="0.77"/>
-  </darkMatterProfile>
-
-  <blackHoleBinaryMergers value="rezzolla2008"/>
-  <coolingFunction value="atomicCIECloudy"/>
-  <coolingRadius value="simple"/>
-  <coolingRate value="whiteFrenk1991">
-    <velocityCutOff value="10000"/>
-  </coolingRate>
-  <coolingTimeAvailable value="whiteFrenk1991">
-    <ageFactor value="0"/>
-  </coolingTimeAvailable>
-  <coolingTime value="simple">
-    <degreesOfFreedom value="3.0"/>
-  </coolingTime>
-  <cosmologyFunctions value="matterLambda"/>
-  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
-  <darkMatterProfileConcentration value="gao2008"/>
-  <darkMatterProfileDMO value="NFW"/>
-  <darkMatterProfileScaleRadius value="concentrationLimiter">
-    <concentrationMinimum value="  4.0"/>
-    <concentrationMaximum value="100.0"/>
-    <darkMatterProfileScaleRadius value="concentration"/>
-  </darkMatterProfileScaleRadius>
-  <galacticStructureSolver value="equilibrium"/>
-  <haloMassFunction value="tinker2008"/>
-  <haloSpinDistribution value="bett2007">
-    <alpha value="2.509"/>
-    <lambda0 value="0.04326"/>
-  </haloSpinDistribution>
-  <hotHaloMassDistribution value="cored isothermal"/>
-  <hotHaloOutflowReincorporation value="haloDynamicalTime">
-    <multiplier value="1.26027"/>
-  </hotHaloOutflowReincorporation>
-
-  <hotHaloTemperatureProfile value="virial"/>
-  <stellarPopulation value="standard">
-    <recycledFraction value="0.39"/>
-    <metalYield value="0.02"/>
-  </stellarPopulation>
-  <initialMassFunction value="salpeter1955"/>
-  <stellarPopulationSelector value="fixed"/>
-  <hotHaloMassDistributionCoreRadius value="virialFraction">
-    <coreRadiusOverVirialRadius value="0.1"/>
-  </hotHaloMassDistributionCoreRadius>
-  <linearGrowth value="collisionlessMatter"/>
-  <mergerTreeBuilder value="cole2000">
-    <accretionLimit value="0.1"/>
-    <mergeProbability value="0.1"/>
-  </mergerTreeBuilder>
-  <mergerTreeMassResolution value="fixed">
-    <massResolution value="5000000000"/>
-  </mergerTreeMassResolution>
-  <mergerTreeBuildMasses value="sampledDistributionUniform">
-    <massTreeMaximum value="1e+12"/>
-    <massTreeMinimum value="10000000000"/>
-    <treesPerDecade value="5"/>
-  </mergerTreeBuildMasses>
-
-  <mergerTreeBuilder value="cole2000">
-    <accretionLimit value="0.1"/>
-    <mergeProbability value="0.1"/>
-  </mergerTreeBuilder>
-  <mergerTreeBuildTreesBaseRedshift value="0"/>
-  <mergerTreeBuildTreesBeginAtTree value="1"/>
-  <mergerTreeBuildMassDistribution value="uniform"/>
-  <mergerTreeBuildTreesHaloMassExponent value="1"/>
-  <mergerTreeConstructor value="build"/>
-  <mergerTreeNodeMerger value="single level hierarchy"/>
-  <mergerTreeNodeEvolver value="standard">
-    <odeToleranceAbsolute value="0.01"/>
-    <odeToleranceRelative value="0.01"/>
-  </mergerTreeNodeEvolver>
-
-  <outputTimes value="list">
-    <redshifts value="0"/>
-  </outputTimes>
-
-  <nodePropertyExtractor value="virialProperties"/>
-  <powerSpectrumPrimordial value="powerLaw">
-    <index value="0.961"/>
-    <wavenumberReference value="1.000"/>
-    <running value="0.000"/>
-  </powerSpectrumPrimordial>
+ 
   <randomNumberGenerator value="GSL">
     <seed value="228"/>
   </randomNumberGenerator>
-  <mergerMassMovements value="simple">
-    <massRatioMajorMerger value="0.1"/>
-    <destinationGasMinorMerger value="spheroid"/>
-  </mergerMassMovements>
-  <satelliteMergingTimescales value="jiang2008"/>
-  <mergerRemnantSize value="cole2000">
-    <energyOrbital value="1"/>
-  </mergerRemnantSize>
-  <cosmologicalMassVariance value="filteredPower">
-    <sigma_8 value="0.807"/>
-  </cosmologicalMassVariance>
-  <starFormationRateDisks value="timescale">
-    <starFormationTimescale value="dynamicalTime">
-      <efficiency value="0.1"/>
-      <exponentVelocity value="-1.5"/>
-      <timescaleMinimum value="0.001"/>
-    </starFormationTimescale>
-  </starFormationRateDisks>
 
-  <starFormationRateSpheroids value="timescale">
-    <starFormationTimescale value="dynamicalTime">
-      <efficiency value="0.1"/>
-      <exponentVelocity value="0"/>
-      <timescaleMinimum value="0.001"/>
-    </starFormationTimescale>
-  </starFormationRateSpheroids>
-  <stellarPopulationProperties value="instantaneous"/>
-  <stellarPopulationSpectra value="FSPS"/>
-  <mergerTreeEvolver value="standard">
-    <timestepHostAbsolute value="1"/>
-    <timestepHostRelative value="0.1"/>
-  </mergerTreeEvolver>
-
-  <transferFunction value="eisensteinHu1999">
-    <neutrinoNumberEffective value="3.04"/>
-    <neutrinoMassSummed value="0.0"/>
-  </transferFunction>
-  <mergerTreeBranchingProbability value="parkinsonColeHelly">
-    <G0 value="+0.57"/>
-    <gamma1 value="+0.38"/>
-    <gamma2 value="-0.01"/>
-    <accuracyFirstOrder value="+0.10"/>
-  </mergerTreeBranchingProbability>
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
     <massSeed value="100"/>
@@ -172,7 +32,7 @@
   <componentHotHalo value="standard">
     <starveSatellites value="true"/>
   </componentHotHalo>
-  <componentSatelliteOrbit value="simple"/>
+  <componentSatellite value="simple"/>
   <componentSpheroid value="standard">
     <efficiencyEnergeticOutflow value="1"/>
     <toleranceAbsoluteMass value="1e-06"/>
@@ -181,56 +41,6 @@
     </massDistributionSpheroid>
   </componentSpheroid>
   <componentSpin value="scalar"/>
-  <verbosityLevel value="standard"/>
-  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
-  <virialOrbit value="benson2005"/>
 
-  <!-- Node evolution and physics -->
-  <nodeOperator value="multi">
-    <!-- Cosmological epoch -->
-    <nodeOperator value="cosmicTime"/>
-    <!-- DMO evolution -->
-    <nodeOperator value="DMOInterpolate"/>
-    <!-- Halo concentrations -->
-    <nodeOperator value="darkMatterProfileScaleSet"/>
-    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
-    <!-- Halo spins -->
-    <nodeOperator value="haloAngularMomentumRandom">
-      <factorReset value="2.0"/>
-    </nodeOperator>
-    <nodeOperator value="haloAngularMomentumInterpolate"/>
-    <!-- Satellite evolution -->
-    <nodeOperator value="satelliteMergingTime"/>
-    <nodeOperator value="satelliteMassLoss"/>
-    <!-- Star formation -->
-    <nodeOperator value="starFormationDisks"/>
-    <nodeOperator value="starFormationSpheroids"/>
-    <!--Stellar feedback outflows-->
-    <nodeOperator value="stellarFeedbackDisks">
-      <stellarFeedbackOutflows value="rateLimit">
-        <timescaleOutflowFractionalMinimum value="0.001"/>
-        <stellarFeedbackOutflows value="powerLaw">
-          <velocityCharacteristic value="200.0"/>
-          <exponent value="2.0"/>
-        </stellarFeedbackOutflows>
-      </stellarFeedbackOutflows>
-    </nodeOperator>
-    <nodeOperator value="stellarFeedbackSpheroids">
-      <stellarFeedbackOutflows value="rateLimit">
-        <timescaleOutflowFractionalMinimum value="0.001"/>
-        <stellarFeedbackOutflows value="powerLaw">
-          <exponent value="2"/>
-          <velocityCharacteristic value="50"/>
-        </stellarFeedbackOutflows>
-      </stellarFeedbackOutflows>
-    </nodeOperator>
-    <!-- Bar instability in galactic disks -->
-    <nodeOperator value="barInstability">
-      <galacticDynamicsBarInstability value="efstathiou1982">
-	<stabilityThresholdGaseous value="0.9"/>
-	<stabilityThresholdStellar value="1.1"/>
-      </galacticDynamicsBarInstability>
-    </nodeOperator>
-  </nodeOperator>
 
 </parameters>

--- a/testSuite/parameters/massHostMaximum.xml
+++ b/testSuite/parameters/massHostMaximum.xml
@@ -71,9 +71,6 @@
   <!-- Substructure hierarchy options -->
   <mergerTreeNodeMerger value="singleLevelHierarchy"/>
 
-  <!-- Dark matter halo structure options -->
-  <darkMatterProfileDMO value="isothermal"/>
-
   <!-- Halo accretion options -->
   <accretionHalo value="zero"/>
 

--- a/testSuite/parameters/stellarMassWeightedAgesMerging.xml
+++ b/testSuite/parameters/stellarMassWeightedAgesMerging.xml
@@ -63,9 +63,6 @@
   <!-- Substructure hierarchy options -->
   <mergerTreeNodeMerger value="singleLevelHierarchy"/>
 
-  <!-- Dark matter halo structure options -->
-  <darkMatterProfileDMO value="isothermal"/>
-
   <!-- Halo accretion options -->
   <accretionHalo value="zero"/>
 

--- a/testSuite/regressions/initialSatelliteNoPrimaryProgenitor.xml
+++ b/testSuite/regressions/initialSatelliteNoPrimaryProgenitor.xml
@@ -132,7 +132,6 @@
   <mergerMassMovements value="verySimple"/>
   <haloMassFunction value="tinker2008"/>
   <componentSatellite value="preset"/>
-  <mergerTreeBuildMassDistribution value="uniform"/>
   <mergerRemnantSize value="null"/>
   <transferFunction value="eisensteinHu1999">
     <neutrinoNumberEffective value="3.04"/>
@@ -168,13 +167,6 @@
   <randomNumberGenerator value="GSL">
     <seed value="828"/>
   </randomNumberGenerator>
-  <starFormationRateDisks value="timescale">
-    <starFormationTimescale value="haloScaling">
-      <fraction value="1.0"/>
-      <exponentVelocity value="-3.0"/>
-      <exponentRedshift value="0.0"/>
-    </starFormationTimescale>
-  </starFormationRateDisks>
   <coolingRate value="simpleScaling">
     <timescale value="1.0"/>
     <massCutOff value="5.0e12"/>

--- a/testSuite/regressions/subhaloMergesAtFinalTimeOfTree.xml
+++ b/testSuite/regressions/subhaloMergesAtFinalTimeOfTree.xml
@@ -134,7 +134,6 @@
   <mergerMassMovements value="verySimple"/>
   <haloMassFunction value="tinker2008"/>
   <componentSatellite value="preset"/>
-  <mergerTreeBuildMassDistribution value="uniform"/>
   <mergerRemnantSize value="null"/>
   <transferFunction value="eisensteinHu1999">
     <neutrinoNumberEffective value="3.04"/>

--- a/testSuite/regressions/subhaloTwoConsecutiveMergers.xml
+++ b/testSuite/regressions/subhaloTwoConsecutiveMergers.xml
@@ -136,7 +136,6 @@
   <mergerMassMovements value="verySimple"/>
   <haloMassFunction value="tinker2008"/>
   <componentSatellite value="preset"/>
-  <mergerTreeBuildMassDistribution value="uniform"/>
   <mergerRemnantSize value="null"/>
   <transferFunction value="eisensteinHu1999">
     <neutrinoNumberEffective value="3.04"/>


### PR DESCRIPTION
This fix automates the application of OpenMP `gfortranInteralIO` critical sections around internal (and external) I/O when the `-DTHREADSAFEIO` compile option is specified. It also translates (in the preprocessor) `FoX_DOM_Access` critical sections to `gfortranInternalIO` critical sections when the `-DTHREADSAFEIO` compile option is specified since some internal I/O occurs in the FoX library also. (Note that this still ensures that the FoX library is accessed only by a single thread at a time, but now strengthens that protecting to avoid conflicts with other threads performing internal I/O).