### PR TITLE
Report the path to a parameter when resporting an unknown parameter name

### DIFF
--- a/testSuite/test-allowed-parameters.pl
+++ b/testSuite/test-allowed-parameters.pl
@@ -16,7 +16,7 @@ use List::Uniq ':all';
 my @disallowed;
 open(my $log,"outputs/test-allowed-parameters.log");
 while ( my $line = <$log> ) {
-    if ( $line =~ m/unrecognized parameter \[([a-zA-Z0-9\-]+)\]/ ) {
+    if ( $line =~ m/unrecognized parameter \[([a-zA-Z0-9\-]+) in [a-zA-Z\/]+\]/ ) {
 	push(@disallowed,$1);
     }
 }


### PR DESCRIPTION
Makes it easier to track down where the problem is in the parameter file.