### PR TITLE
Fix memory leaks

### DIFF
--- a/aux/words.dict
+++ b/aux/words.dict
@@ -342,6 +342,7 @@ deallocation
 declinations
 decrement
 dereference
+dereferenced
 descendantless
 deserialization
 deserialize

--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -1041,7 +1041,21 @@ CODE
 				    $allowedParametersCode     .= "     countNew=0\n";
 				    $allowedParametersCode     .= "     if (allocated(allowedParameters)) then\n";
 				    for(my $i=0;$i<$parameterCount;++$i) {
-					$allowedParametersCode .= "       if (.not.any(trim(allowedParameters) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."')) countNew=countNew+1\n";
+					# <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336">
+					#   <description>
+					#     Array constructors are not correctly finalized. So, avoid using thme
+					#   </description>
+					# $allowedParametersCode .= "       if (.not.any(trim(allowedParameters) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."')) countNew=countNew+1\n";
+					$allowedParametersCode .= "       isNew=.true.\n";
+					$allowedParametersCode .= "       do j=1,size(allowedParameters)\n";
+					$allowedParametersCode .= "          allowedParameter=trim(allowedParameters(j))\n";
+					$allowedParametersCode .= "          if (allowedParameter == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."') then\n";
+					$allowedParametersCode .= "             isNew=.false.\n";
+					$allowedParametersCode .= "             exit\n";
+					$allowedParametersCode .= "          end if\n";
+					$allowedParametersCode .= "       end do\n";
+					$allowedParametersCode .= "       if (isNew) countNew=countNew+1\n";
+					# </workaround>
 				    }
 				    $allowedParametersCode     .= "       if (countNew > 0) then\n";
 				    $allowedParametersCode     .= "         call move_alloc(allowedParameters,allowedParametersTmp)\n";
@@ -1049,7 +1063,21 @@ CODE
 				    $allowedParametersCode     .= "         allowedParameters(1:size(allowedParametersTmp))=allowedParametersTmp\n";
 				    $allowedParametersCode     .= "         deallocate(allowedParametersTmp)\n";
 				    for(my $i=0;$i<$parameterCount;++$i) {
-					$allowedParametersCode .= "         if (.not.any(trim(allowedParameters(1:size(allowedParameters)-countNew)) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."')) then\n";
+					# <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336">
+					#   <description>
+					#     Array constructors are not correctly finalized. So, avoid using thme
+					#   </description>
+					# $allowedParametersCode .= "         if (.not.any(trim(allowedParameters(1:size(allowedParameters)-countNew)) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."')) then\n";
+					$allowedParametersCode .= "       isNew=.true.\n";
+					$allowedParametersCode .= "       do j=1,size(allowedParameters)-countNew\n";
+					$allowedParametersCode .= "          allowedParameter=trim(allowedParameters(j))\n";
+					$allowedParametersCode .= "          if (allowedParameter == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."') then\n";
+					$allowedParametersCode .= "             isNew=.false.\n";
+					$allowedParametersCode .= "             exit\n";
+					$allowedParametersCode .= "          end if\n";
+					$allowedParametersCode .= "       end do\n";
+					$allowedParametersCode .= "       if (isNew) then\n";
+					# </workaround>
 					$allowedParametersCode .= "           countNew=countNew-1\n";
 					$allowedParametersCode .= "           allowedParameters(size(allowedParameters)-countNew)='".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."'\n";
 					$allowedParametersCode .= "         end if\n";
@@ -1073,7 +1101,20 @@ CODE
 				    $allowedParametersCode     .= "     countNew=0\n";
 				    $allowedParametersCode     .= "     if (allocated(allowedParameters)) then\n";
 				    for(my $i=0;$i<$parameterCount;++$i) {
-					$allowedParametersCode .= "       if (.not.any(trim(allowedParameters) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'all'}->[$i]."')) countNew=countNew+1\n";
+					# <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336">
+					#   <description>
+					#     Array constructors are not correctly finalized. So, avoid using thme
+					#   </description>
+					# $allowedParametersCode .= "       if (.not.any(trim(allowedParameters) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'all'}->[$i]."')) countNew=countNew+1\n";
+					$allowedParametersCode .= "       isNew=.true.\n";
+					$allowedParametersCode .= "       do j=1,size(allowedParameters)\n";
+					$allowedParametersCode .= "          allowedParameter=trim(allowedParameters(j))\n";
+					$allowedParametersCode .= "          if (allowedParameter == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."') then\n";
+					$allowedParametersCode .= "             isNew=.false.\n";
+					$allowedParametersCode .= "             exit\n";
+					$allowedParametersCode .= "          end if\n";
+					$allowedParametersCode .= "       end do\n";
+					$allowedParametersCode .= "       if (isNew) countNew=countNew+1\n";
 				    }	
 				    $allowedParametersCode     .= "       if (countNew > 0) then\n";
 				    $allowedParametersCode     .= "         call move_alloc(allowedParameters,allowedParametersTmp)\n";
@@ -1081,7 +1122,21 @@ CODE
 				    $allowedParametersCode     .= "         allowedParameters(1:size(allowedParametersTmp))=allowedParametersTmp\n";
 				    $allowedParametersCode     .= "         deallocate(allowedParametersTmp)\n";
 				    for(my $i=0;$i<$parameterCount;++$i) {
-					$allowedParametersCode .= "         if (.not.any(trim(allowedParameters(1:size(allowedParameters)-countNew)) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'all'}->[$i]."')) then\n";
+					# <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336">
+					#   <description>
+					#     Array constructors are not correctly finalized. So, avoid using thme
+					#   </description>
+					# $allowedParametersCode .= "         if (.not.any(trim(allowedParameters(1:size(allowedParameters)-countNew)) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'all'}->[$i]."')) then\n";
+					$allowedParametersCode .= "       isNew=.true.\n";
+					$allowedParametersCode .= "       do j=1,size(allowedParameters)-countNew\n";
+					$allowedParametersCode .= "          allowedParameter=trim(allowedParameters(j))\n";
+					$allowedParametersCode .= "          if (allowedParameter == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."') then\n";
+					$allowedParametersCode .= "             isNew=.false.\n";
+					$allowedParametersCode .= "             exit\n";
+					$allowedParametersCode .= "          end if\n";
+					$allowedParametersCode .= "       end do\n";
+					$allowedParametersCode .= "       if (isNew) then\n";
+					# </workaround>
 					$allowedParametersCode .= "           countNew=countNew-1\n";
 					$allowedParametersCode .= "           allowedParameters(size(allowedParameters)-countNew)='".$allowedParameters->{$className}->{'parameters'}->{$source}->{'all'}->[$i]."'\n";
 					$allowedParametersCode .= "         end if\n";
@@ -1118,8 +1173,10 @@ CODE
 	    }
 	    $allowedParametersCode .= "end select\n";
 	    if ( $parametersPresent ) {
-		$allowedParametersCode = "type  (varying_string), allocatable, dimension(:) :: allowedParametersTmp\n".$directive->{'name'}."DsblVldtn=".$directive->{'name'}."DsblVldtn\n".$allowedParametersCode;
-		$allowedParametersCode = "integer                                           :: countNew\n"                                                                                 .$allowedParametersCode;
+		$allowedParametersCode = "type   (varying_string), allocatable, dimension(:) :: allowedParametersTmp\n".$directive->{'name'}."DsblVldtn=".$directive->{'name'}."DsblVldtn\n".$allowedParametersCode;
+		$allowedParametersCode = "integer                                            :: countNew, j\n"                                                                              .$allowedParametersCode;
+		$allowedParametersCode = "logical                                            :: isNew\n"                                                                                    .$allowedParametersCode;
+		$allowedParametersCode = "type   (varying_string)                            :: allowedParameter\n"                                                                         .$allowedParametersCode;
 	    } else {
 		$allowedParametersCode = "!\$GLC attributes unused :: self, allowedParameters, sourceName\n".$directive->{'name'}."DsblVldtn=".$directive->{'name'}."DsblVldtn\n";
 	    }

--- a/source/models.likelihoods.base_parameters.F90
+++ b/source/models.likelihoods.base_parameters.F90
@@ -73,7 +73,7 @@ contains
     integer                                                                           :: i                     , j                       , &
          &                                                                               instance              , indexElement            , &
          &                                                                               parameterCount
-    type     (inputParameters                        )                                :: parameters_           , subParameters_
+    type     (inputParameters                        ), pointer                       :: parameters_           , subParameters_
     character(len=10                                 )                                :: labelIndex
 
     ! On first call we must build pointers to all parameter nodes which will be modified as a function of chain state.
@@ -83,6 +83,7 @@ contains
           parameterCount=String_Count_Words(char(modelParametersActive_(i)%modelParameter_%name()),"::")
           allocate(parameterNames(parameterCount))
           call String_Split_Words(parameterNames,char(modelParametersActive_(i)%modelParameter_%name()),"::")
+          allocate(parameters_)
           parameters_=inputParameters(self%parametersModel)
           do j=1,parameterCount
              instance    =1
@@ -104,10 +105,15 @@ contains
                 self%modelParametersActive_(i)%indexElement =  indexElement
              else
                 ! This is an intermediate parameter, get the appropriate sub-parameters.
+                allocate  (subParameters_)
                 subParameters_                              =  parameters_%subParameters(char(parameterNames(j)),requireValue=.false.,copyInstance=instance)
+                deallocate(   parameters_)
+                allocate  (   parameters_)
                 parameters_                                 =  inputParameters(subParameters_)
+                deallocate(subParameters_)
              end if
           end do
+          deallocate(parameters_   )
           deallocate(parameterNames)
        end do
     end if
@@ -117,6 +123,7 @@ contains
           parameterCount=String_Count_Words(char(modelParametersInactive_(i)%modelParameter_%name()),"::")
           allocate(parameterNames(parameterCount))
           call String_Split_Words(parameterNames,char(modelParametersInactive_(i)%modelParameter_%name()),"::")
+          allocate(parameters_)
           parameters_=inputParameters(self%parametersModel)
           do j=1,parameterCount
              instance    =1
@@ -138,10 +145,15 @@ contains
                 self%modelParametersInactive_(i)%indexElement =  indexElement
              else
                 ! This is an intermediate parameter, get the appropriate sub-parameters.
+                allocate  (subParameters_)
                 subParameters_                                =  parameters_   %subParameters(char(parameterNames(j)),requireValue=.false.,copyInstance=instance)
+                deallocate(   parameters_)
+                allocate  (   parameters_)
                 parameters_                                   =  inputParameters(subParameters_)
+                deallocate(subParameters_)
              end if
           end do
+          deallocate(parameters_   )
           deallocate(parameterNames)
        end do
     end if

--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -1784,10 +1784,10 @@ contains
     logical                                          , intent(in   ), optional :: hashed
     type   (node                                    ), pointer                 :: node_
     type   (inputParameter                          ), pointer                 :: currentParameter
+    type   (inputParameters                         ), allocatable             :: subParameters
     type   (enumerationInputParameterErrorStatusType)                          :: errorStatus
-    type   (varying_string                          )                          :: parameterValue  , nodeName
+    type   (varying_string                          )                          :: parameterValue                  , nodeName
     logical                                                                    :: firstParameter
-    type   (inputParameters                         )                          :: subParameters
     !![
     <optionalArgument name="hashed" defaultsTo=".false." />
     !!]
@@ -1810,11 +1810,13 @@ contains
           !$omp critical (FoX_DOM_Access)
           nodeName=getNodeName(node_)
           !$omp end critical (FoX_DOM_Access)
+          allocate(subParameters)
           subParameters=self%subParameters(char(nodeName))
           if (associated(subParameters%parameters%firstChild)) inputParametersSerializeToString=inputParametersSerializeToString // &
                &                                                                                "{"                              // &
                &                                                                                subParameters%serializeToString()// &
                &                                                                                "}"
+          deallocate(subParameters)
           firstParameter=.false.
        end if
        currentParameter => currentParameter%sibling


### PR DESCRIPTION
Fixes memory leaks due to:

* Traversal of sub-parameters;
* Use of array constructors.

Both are workarounds until finalization is fully implemented.