### PR TITLE
Fix bugs in the implementation of pre-infall evolution

### DIFF
--- a/source/nodes.operators.physics.satellite.heating.tidal.F90
+++ b/source/nodes.operators.physics.satellite.heating.tidal.F90
@@ -148,6 +148,7 @@ contains
        do while (nodeHost%isPrimaryProgenitor())
           nodeHost => nodeHost%parent
        end do
+       nodeHost  => nodeHost%parent%firstChild
        ! Follow that node back through descendants until we find the node at the corresponding time.
        basic     => node    %basic()
        basicHost => nodeHost%basic()

--- a/source/nodes.operators.physics.satellite_orbits.F90
+++ b/source/nodes.operators.physics.satellite_orbits.F90
@@ -171,7 +171,7 @@ contains
     time               =  basicHost     %time       (                 )
     ! Integrate the orbit backward in time to each progenitor halo.
     allocate(solver)
-    solver         =  odeSolver(6_c_size_t,orbitalODEs,toleranceRelative=1.0d-3)
+    solver         =  odeSolver(6_c_size_t,orbitalODEs,toleranceRelative=1.0d-3,toleranceAbsolute=1.0d-6)
     self_          => self
     do while (associated(nodeProgenitor))
        basicProgenitor     => nodeProgenitor %basic             (                 )

--- a/source/nodes.operators.physics.satellite_orbits.F90
+++ b/source/nodes.operators.physics.satellite_orbits.F90
@@ -254,6 +254,7 @@ contains
     do while (nodeHost%isPrimaryProgenitor())
        nodeHost => nodeHost%parent
     end do
+    nodeHost        => nodeHost%parent%firstChild
     basicProgenitor => nodeHost%basic()
     do while (associated(nodeHost) .and. basicProgenitor%time() > time)
        nodeHost => nodeHost%firstChild

--- a/source/satellites.tidal_stripping.radius.King1962.F90
+++ b/source/satellites.tidal_stripping.radius.King1962.F90
@@ -245,6 +245,7 @@ contains
        do while (nodeHost%isPrimaryProgenitor())
           nodeHost => nodeHost%parent
        end do
+       nodeHost  => nodeHost%parent%firstChild
        ! Follow that node back through descendants until we find the node at the corresponding time.
        basic     => node    %basic()
        basicHost => nodeHost%basic()


### PR DESCRIPTION
When doing pre-infall evolution of a halo, accounting for the orbit evolution, tidal mass loss and heating, one needs to find the host halo at the corresponding time (before infall). In Galacticus, it walks up a branch in the merge tree to find the host node:

```
    nodeHost => nodeProgenitor
    do while (nodeHost%isPrimaryProgenitor())
       nodeHost => nodeHost%parent
    end do
    basicProgenitor => nodeHost%basic()
    do while (associated(nodeHost) .and. basicProgenitor%time() > time)
       nodeHost => nodeHost%firstChild
       if (associated(nodeHost)) basicProgenitor => nodeHost%basic()
    end do
```

There is a bug in the above code. For example, if we have a merger tree like the one in the attached plot. For `nodeProgenitor => node6`, the code give `nodeHost => node6`, this is incorrect. The host of `node6` at time `t` should be `node5`. On the other hand, for `node5`, which is the primary progenitor of `node4`, the host at `t` should be `node3`.

Modifying the above code as follows solves the issue:

```
    nodeHost => nodeProgenitor
    do while (nodeHost%isPrimaryProgenitor())
       nodeHost => nodeHost%parent
    end do
    nodeHost        => nodeHost%parent%firstChild
    basicProgenitor => nodeHost%basic()
    do while (associated(nodeHost) .and. basicProgenitor%time() > time)
       nodeHost => nodeHost%firstChild
       if (associated(nodeHost)) basicProgenitor => nodeHost%basic()
    end do
```

![tree 001](https://github.com/galacticusorg/galacticus/assets/33205087/bac66d03-4ea8-4e1d-a2bc-f9f0e0a1e532)
