### PR TITLE
Fix bugs in the calculations of tidal radius

### DIFF
--- a/source/satellites.tidal_stripping.radius.King1962.F90
+++ b/source/satellites.tidal_stripping.radius.King1962.F90
@@ -290,8 +290,9 @@ contains
        tidalFieldRadial                =+0.0d0
     end if
     ! If the tidal force is stretching (not compressing), compute the tidal radius.
+    tidalPull=frequencyAngular**2-tidalFieldRadial
     if     (                                                                          &
-         &   frequencyAngular**2                                   > tidalFieldRadial &
+         &   tidalPull                                             >  0.0d0           &
          &  .and.                                                                     &
          &   massSatellite                                         >  0.0d0           &
          &  .and.                                                                     &
@@ -300,7 +301,6 @@ contains
        ! Check if node differs from previous one for which we performed calculations.
        if (node%uniqueID() /= self%lastUniqueID) call self%calculationReset(node)
        ! Initial estimate of the tidal radius.
-       tidalPull=frequencyAngular**2-tidalFieldRadial
        if (self%radiusTidalPrevious <= 0.0d0) then
           self%radiusTidalPrevious=+sqrt(                                              &
                &                         +gravitationalConstantGalacticus              &

--- a/source/satellites.tidal_stripping.radius.King1962.F90
+++ b/source/satellites.tidal_stripping.radius.King1962.F90
@@ -280,7 +280,7 @@ contains
        call tidalTensorMatrix%eigenSystem(tidalTensorEigenVectors,tidalTensorEigenValues)
        tidalTensorEigenValueComponents = tidalTensorEigenValues
        tidalTensorEigenVectorComponents= tidalTensorEigenVectors
-       tidalFieldRadial                =-abs(tidalTensor%vectorProject(tidalTensorEigenVectorComponents(maxloc(tidalTensorEigenValueComponents,dim=1),:))) &
+       tidalFieldRadial                =-abs(tidalTensor%vectorProject(tidalTensorEigenVectorComponents(:,maxloc(tidalTensorEigenValueComponents,dim=1)))) &
             &                           *(                                                                                                                 &
             &                             +kilo                                                                                                            &
             &                             *gigaYear                                                                                                        &

--- a/source/satellites.tidal_stripping.radius.King1962.F90
+++ b/source/satellites.tidal_stripping.radius.King1962.F90
@@ -280,11 +280,11 @@ contains
        call tidalTensorMatrix%eigenSystem(tidalTensorEigenVectors,tidalTensorEigenValues)
        tidalTensorEigenValueComponents = tidalTensorEigenValues
        tidalTensorEigenVectorComponents= tidalTensorEigenVectors
-       tidalFieldRadial                =-abs(tidalTensor%vectorProject(tidalTensorEigenVectorComponents(:,maxloc(tidalTensorEigenValueComponents,dim=1)))) &
-            &                           *(                                                                                                                 &
-            &                             +kilo                                                                                                            &
-            &                             *gigaYear                                                                                                        &
-            &                             /megaParsec                                                                                                      &
+       tidalFieldRadial                =-tidalTensor%vectorProject(tidalTensorEigenVectorComponents(:,maxloc(tidalTensorEigenValueComponents,dim=1))) &
+            &                           *(                                                                                                            &
+            &                             +kilo                                                                                                       &
+            &                             *gigaYear                                                                                                   &
+            &                             /megaParsec                                                                                                 &
             &                            )**2
     else
        tidalFieldRadial                =+0.0d0

--- a/source/satellites.tidal_stripping.radius.King1962.F90
+++ b/source/satellites.tidal_stripping.radius.King1962.F90
@@ -220,7 +220,7 @@ contains
     class           (nodeComponentSatellite               ), pointer               :: satellite
     double precision                                       , dimension(3  )        :: position                               , velocity                        , &
          &                                                                            tidalTensorEigenValueComponents
-    double precision                                       , dimension(3,3)        :: tidalTensorComponents                  , tidalTensorEigenVectorComponents
+    double precision                                       , dimension(3,3)        :: tidalTensorComponents
     double precision                                       , parameter             :: radiusZero                      =0.0d+0
     double precision                                       , parameter             :: radiusTidalTinyFraction         =1.0d-6
     integer                                                                        :: status
@@ -266,11 +266,12 @@ contains
          &              *kilo                                                &
          &              *gigaYear                                            &
          &              /megaParsec
-    ! Find the maximum of the tidal field over all directions in the satellite. To compute this we multiply the a unit vector by
+    ! Find the maximum of the tidal field over all directions in the satellite. To compute this we multiply a unit vector by
     ! the tidal tensor, which gives the vector tidal acceleration for displacements along that direction. We then take the dot
-    ! product with that same unit vector to get the magnitude of this acceleration in the that direction. This magnitude is
-    ! maximized for a vector coinciding with the eigenvector of the tidal tensor with the largest eigenvalue. For spherical mass
-    ! distributions this reduces to:
+    ! product with that same unit vector to get the acceleration in that direction. This acceleration is maximized for a vector
+    ! coinciding with the eigenvector of the tidal tensor with the largest eigenvalue. Since the acceleration in the direction
+    ! of the eigenvector is exactly the eigenvalue corresponding to that eigenvector, we simply take the largest eigenvalue.
+    ! For spherical mass distributions this reduces to:
     !
     ! -2GM(r)r⁻³ - 4πGρ(r)
     if (associated(nodeHost)) then
@@ -279,12 +280,11 @@ contains
        tidalTensorMatrix               = tidalTensorComponents
        call tidalTensorMatrix%eigenSystem(tidalTensorEigenVectors,tidalTensorEigenValues)
        tidalTensorEigenValueComponents = tidalTensorEigenValues
-       tidalTensorEigenVectorComponents= tidalTensorEigenVectors
-       tidalFieldRadial                =-tidalTensor%vectorProject(tidalTensorEigenVectorComponents(:,maxloc(tidalTensorEigenValueComponents,dim=1))) &
-            &                           *(                                                                                                            &
-            &                             +kilo                                                                                                       &
-            &                             *gigaYear                                                                                                   &
-            &                             /megaParsec                                                                                                 &
+       tidalFieldRadial                =-maxval(tidalTensorEigenValueComponents) &
+            &                           *(                                       &
+            &                             +kilo                                  &
+            &                             *gigaYear                              &
+            &                             /megaParsec                            &
             &                            )**2
     else
        tidalFieldRadial                =+0.0d0


### PR DESCRIPTION
When calculating the tidal radius, Galacticus will compute the eigenvectors of the tidal tensor and project the tidal acceleration in the direction of the eigenvector with the largest eigenvalue.

```
       tidalFieldRadial                =-abs(tidalTensor%vectorProject(tidalTensorEigenVectorComponents(maxloc(tidalTensorEigenValueComponents,dim=1),:))) &
            &                           *(                                                                                                                 &
            &                             +kilo                                                                                                            &
            &                             *gigaYear                                                                                                        &
            &                             /megaParsec                                                                                                      &
            &                            )**2
```

There are three issues:
1) Different eigenvectors are stored in different columns of the matrix `tidalTensorEigenVectorComponents`. See the documentation of the function [`GSL_Eigen_SymmV`](https://www.gnu.org/software/gsl/doc/html/eigen.html). So we should take the column that corresponding to the largest eigenvalue, not the row unless the matrix `tidalTensorEigenVectorComponents` is symmetric (usually it is not).

2) In some special cases, the tidal force can be compressive. In such cases, the projection of the tidal tensor becomes negative. If we take the absolute value and multiply it by `-1` as shown above, `tidalFieldRadial` is always negative. So even when the tidal force is compressive, we will get a non-zero tidal mass loss rate.

3) The projection of the tidal tensor in the direction of a eigenvector is exactly the eigenvalue corresponding to that eigenvector, so we can simply use the eigenvalue instead of computing the projection. 