### PR TITLE
Improve the calculation of radial velocity dispersion for heated dark matter profile

### DIFF
--- a/source/dark_matter_profiles_DMO.heated.F90
+++ b/source/dark_matter_profiles_DMO.heated.F90
@@ -369,7 +369,7 @@ contains
             &                     +1.0d0/radiusInitial                                       &
             &                     -2.0d0/gravitationalConstantGalacticus/mass*energySpecific &
             &                    )
-       ! If the radius found is negative, which means the intial shell has expanded to infinity, return the largest radius.
+       ! If the radius found is negative, which means the initial shell has expanded to infinity, return the largest radius.
        if (heatedRadiusEnclosingMass < 0.0d0) heatedRadiusEnclosingMass=radiusLarge
     end if
     return

--- a/source/dark_matter_profiles_DMO.heated.F90
+++ b/source/dark_matter_profiles_DMO.heated.F90
@@ -83,6 +83,8 @@
      procedure :: radiusCircularVelocityMaximum     => heatedRadiusCircularVelocityMaximum
      procedure :: circularVelocityMaximum           => heatedCircularVelocityMaximum
      procedure :: radialVelocityDispersion          => heatedRadialVelocityDispersion
+     procedure :: jeansEquationIntegrand            => heatedJeansEquationIntegrand
+     procedure :: jeansEquationRadius               => heatedJeansEquationRadius
      procedure :: radiusFromSpecificAngularMomentum => heatedRadiusFromSpecificAngularMomentum
      procedure :: rotationNormalization             => heatedRotationNormalization
      procedure :: energy                            => heatedEnergy
@@ -624,17 +626,71 @@ contains
        heatedRadialVelocityDispersion=self%darkMatterProfileDMO_%radialVelocityDispersion(node,radius)
     else if (self%velocityDispersionApproximate) then
        ! Use the approximate solution for velocity dispersion.
-       radiusInitial                 = self%radiusInitial                                               (node,radius                                  )
-       energySpecific                = self%darkMatterProfileHeating_%specificEnergy                    (node,radiusInitial,self%darkMatterProfileDMO_)
-       velocityDispersionSquare      =+self%darkMatterProfileDMO_    %radialVelocityDispersion          (node,radiusInitial                           )**2 &
+       radiusInitial                 = self%radiusInitial                                              (node,radius                                  )
+       energySpecific                = self%darkMatterProfileHeating_%specificEnergy                   (node,radiusInitial,self%darkMatterProfileDMO_)
+       velocityDispersionSquare      =+self%darkMatterProfileDMO_    %radialVelocityDispersion         (node,radiusInitial                           )**2 &
             &                         -2.0d0/3.0d0*energySpecific
        heatedRadialVelocityDispersion=sqrt(max(0.0d0,velocityDispersionSquare))
     else
        ! Use a numerical solution.
-       heatedRadialVelocityDispersion=+self                           %radialVelocityDispersionNumerical(node,radius                                  )
+       heatedRadialVelocityDispersion=+self                          %radialVelocityDispersionNumerical(node,radius                                  )
     end if
     return
   end function heatedRadialVelocityDispersion
+
+  double precision function heatedJeansEquationIntegrand(self,node,radius)
+    !!{
+    Integrand for generic dark matter profile Jeans equation. Here we do the integration with respect to the
+    initial radius $r_i$.
+    \begin{eqnarray}
+     \sigma_r(r) &=& \frac{1}{\rho(r)}\int_r^{r^{\mathrm{max}}} \rho(r) \frac{\mathrm{G} M(r)}{r^2} \mathrm{d} r \nonumber \\
+                 &=& \frac{1}{\rho(r)}\int_{r_i}^{r_{i}^{\mathrm{max}}} \rho_i(r_i) \frac{\mathrm{G} M(r_i)}{r_i^2}\left(\frac{r_i}{r}\right)^4 \mathrm{d} r_i.
+    \end{eqnarray}
+    Here $r$ can be written as a function of $r_i$
+    \begin{equation}
+     r=\frac{1}{1/r_i-2\epsilon(r_i)/(\mathrm{G}M(r_i))}.
+    \end{equation}
+    !!}
+    use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
+    implicit none
+    class           (darkMatterProfileDMOHeated), intent(inout) :: self
+    type            (treeNode                  ), intent(inout) :: node
+    double precision                            , intent(in   ) :: radius
+    double precision                                            :: radiusFinal , energySpecific, &
+         &                                                         enclosedMass
+
+    enclosedMass  =self%darkMatterProfileDMO_    %enclosedMass  (node,radius                           )
+    energySpecific=self%darkMatterProfileHeating_%specificEnergy(node,radius,self%darkMatterProfileDMO_)
+    radiusFinal   =+1.0d0                                                               &
+         &         /(                                                                   &
+         &           +1.0d0/radius                                                      &
+         &           -2.0d0*energySpecific/gravitationalConstantGalacticus/enclosedMass &
+         &          )
+    if (radiusFinal > 0.0d0) then
+       heatedJeansEquationIntegrand=+gravitationalConstantGalacticus                 &
+            &                       *enclosedMass                                    &
+            &                       *self%darkMatterProfileDMO_%density(node,radius) &
+            &                       / radius             **2                         &
+            &                       *(radius/radiusFinal)**4
+    else
+       heatedJeansEquationIntegrand=0.0d0
+    end if
+    return
+  end function heatedJeansEquationIntegrand
+
+  double precision function heatedJeansEquationRadius(self,node,radius)
+    !!{
+    Return the radius variable used in solving the Jeans equation that corresponds to a given physical radius.
+    Here we do the integration with respect to the initial radius, so return the initial radius.
+    !!}
+    implicit none
+    class           (darkMatterProfileDMOHeated), intent(inout) :: self
+    type            (treeNode                  ), intent(inout) :: node
+    double precision                            , intent(in   ) :: radius
+
+    heatedJeansEquationRadius=self%radiusInitial(node,radius)
+    return
+  end function heatedJeansEquationRadius
 
   double precision function heatedRadiusFromSpecificAngularMomentum(self,node,specificAngularMomentum)
     !!{


### PR DESCRIPTION
For heated dark matter profiles, the radius velocity dispersion is computed by numerically integrating the Jeans equation:

$\sigma_r(r) = \frac{1}{\rho(r)}\int_r^{r^{\mathrm{max}}} \rho(r) \frac{\mathrm{G} M(r)}{r^2} \mathrm{d} r.$

This is time consuming because one needs to solve for $\rho(r)$ frequently. If we do the above integration with respect to the initial radius $r_i$ which is related to $r$ by

$-\frac{G M}{2 r_i} + \Delta E_h(r_i) = -\frac{G M}{2 r},$

it will be much faster, i.e.

$\sigma_r(r) =\frac{1}{\rho(r)}\int_{r_i}^{r_{i}^{\mathrm{max}}} \rho_i(r_i) \frac{\mathrm{G} M(r_i)}{r_i^2}\left(\frac{r_i}{r}\right)^4 \mathrm{d} r_i$.

Here $\Delta E_h$ is the heating energy on a mass shell with initial radius $r_i$. Then one only needs to compute $\rho(r)$ once and $\rho_i(r_i)$ is usually very easy to calculate.

Computing time for running a merger tree with $M_{\rm host}=10^{13}M_{\odot}$ and $M_{\rm res}=2.4 \times 10^9 M_{\odot}$:
a) Orignial: 1154.31 seconds;
b) New: 137.74 seconds.