### PR TITLE
Improve efficiency of non-inactive evolution

### DIFF
--- a/source/nodes.operators.physics.star_formation.disks.F90
+++ b/source/nodes.operators.physics.star_formation.disks.F90
@@ -223,9 +223,15 @@ contains
     
     ! Check for a realistic disk, return immediately if disk is unphysical.
     disk => node%disk()
-    if     (     disk%angularMomentum() < 0.0d0 &
-         &  .or. disk%radius         () < 0.0d0 &
-         &  .or. disk%massGas        () < 0.0d0 &
+    if     (     disk%angularMomentum() < 0.0d0      &
+         &  .or. disk%radius         () < 0.0d0      &
+         &  .or. disk%massGas        () < 0.0d0      &
+         &  .or.                                     &
+         &   (                                       &
+         &          propertyInactive(propertyType)   &
+         &    .and.                                  & 
+         &     .not.self%luminositiesStellarInactive &
+         &   )                                       &
          & ) return
     if (propertyInactive(propertyType)) then
        ! For inactive property solution make use of the "massStellarFormed" property to determine the star formation rate.

--- a/source/nodes.operators.physics.star_formation.spheroids.F90
+++ b/source/nodes.operators.physics.star_formation.spheroids.F90
@@ -177,7 +177,13 @@ contains
     if     (     spheroid%angularMomentum() < angularMomentumMinimum &
          &  .or. spheroid%radius         () <          radiusMinimum &
          &  .or. spheroid%massGas        () <            massMinimum &
-         & ) return
+         &  .or.                                                     &
+         &   (                                                       &
+         &          propertyInactive(propertyType)                   &
+         &    .and.                                                  & 
+         &     .not.self%luminositiesStellarInactive                 &
+         &   )                                                       &
+        & ) return
     if (propertyInactive(propertyType)) then
        ! For inactive property solution make use of the "massStellarFormed" property to determine the star formation rate.
        rateStarFormation=spheroid%massStellarFormedRateGet()

--- a/source/nodes.operators.physics.star_formation.spheroids.F90
+++ b/source/nodes.operators.physics.star_formation.spheroids.F90
@@ -40,8 +40,9 @@
      class  (starFormationHistoryClass       ), pointer :: starFormationHistory_        => null()
      logical                                            :: luminositiesStellarInactive
    contains
-     final     ::                          starFormationSpheroidsDestructor
-     procedure :: differentialEvolution => starFormationSpheroidsDifferentialEvolution
+     final     ::                                   starFormationSpheroidsDestructor
+     procedure :: differentialEvolutionAnalytics => starFormationSpheroidsDifferentialEvolutionAnalytics
+     procedure :: differentialEvolution          => starFormationSpheroidsDifferentialEvolution
   end type nodeOperatorStarFormationSpheroids
   
   interface nodeOperatorStarFormationSpheroids
@@ -120,6 +121,30 @@ contains
     return
   end subroutine starFormationSpheroidsDestructor
 
+  subroutine starFormationSpheroidsDifferentialEvolutionAnalytics(self,node)
+    !!{
+    Initialize the mass transfer fraction.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentSpheroid
+    implicit none
+    class(nodeOperatorStarFormationSpheroids), intent(inout) :: self
+    type (treeNode                          ), intent(inout) :: node
+    class(nodeComponentSpheroid             ), pointer       :: spheroid
+
+    ! Mark the formed stellar mass as analytically-solvable (it is always zero) if we are not solving for luminosities as inactive
+    ! properties.
+    if (.not.self%luminositiesStellarInactive) then
+       spheroid => node%spheroid()
+       select type (spheroid)
+       type is (nodeComponentSpheroid)
+          ! Spheroid does not yet exist.
+       class default
+          call spheroid%massStellarFormedAnalytic()
+       end select
+    end if
+    return
+  end subroutine starFormationSpheroidsDifferentialEvolutionAnalytics
+
   subroutine starFormationSpheroidsDifferentialEvolution(self,node,interrupt,functionInterrupt,propertyType)
     !!{
     Perform star formation in a spheroid.
@@ -161,7 +186,7 @@ contains
        ! of stars formed as a function of time. This differs from the stellar mass due to recycling, and possibly transfer of
        ! stellar mass to other components.
        rateStarFormation=self%starFormationRateSpheroids_%rate(node)   
-       call spheroid%massStellarFormedRate(rateStarFormation)
+       if (self%luminositiesStellarInactive) call spheroid%massStellarFormedRate(rateStarFormation)
     end if
     ! Compute abundances of star forming gas.
     massFuel      =spheroid%massGas      ()


### PR DESCRIPTION
When _not_ solving for luminosities as inactive properties, their are various properties (mass of stars formed, fraction of disk mass retained) that are not used. These are now marked as analytically-solvable (and then simply left at zero) so that they do not get included in the ODE solver.