### PR TITLE
Add further node labeling functionality

### DIFF
--- a/source/galactic.filters.any_descendant_node.F90
+++ b/source/galactic.filters.any_descendant_node.F90
@@ -1,0 +1,129 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which implements a galactic filter which applies another filter to all descendant nodes of the given node and passes if any descendant passes.
+!!}
+  
+  use :: Cosmology_Functions, only : cosmologyFunctionsClass
+
+  !![
+  <galacticFilter name="galacticFilterAnyDescendantNode">
+   <description>Applies a filter to all descendant nodes of the given node and passes if any descendant passes.</description>
+  </galacticFilter>
+  !!]
+  type, extends(galacticFilterClass) :: galacticFilterAnyDescendantNode
+     !!{
+     A galactic filter which applies another filter to all descendant nodes of the given node and passes if any descendant passes.
+     !!}
+     private
+     class  (galacticFilterClass), pointer :: galacticFilter_ => null()
+     logical                               :: allowSelf
+   contains
+     final     ::           anyDescendantNodeDestructor
+     procedure :: passes => anyDescendantNodePasses
+  end type galacticFilterAnyDescendantNode
+
+  interface galacticFilterAnyDescendantNode
+     !!{
+     Constructors for the ``anyDescendantNode'' galactic filter class.
+     !!}
+     module procedure anyDescendantNodeConstructorParameters
+     module procedure anyDescendantNodeConstructorInternal
+  end interface galacticFilterAnyDescendantNode
+
+contains
+
+  function anyDescendantNodeConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the ``anyDescendantNode'' galactic filter class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type   (galacticFilterAnyDescendantNode)                :: self
+    type   (inputParameters                ), intent(inout) :: parameters
+    class  (galacticFilterClass            ), pointer       :: galacticFilter_
+    logical                                                 :: allowSelf
+         
+    !![
+    <inputParameter>
+      <name>allowSelf</name>
+      <source>parameters</source>
+      <description>If true, the node itself is considered as a descendant, otherwise the node itself is excluded from the descendant node search.</description>
+    </inputParameter>
+    <objectBuilder class="galacticFilter" name="galacticFilter_" source="parameters"/>
+    !!]
+    self=galacticFilterAnyDescendantNode(allowSelf,galacticFilter_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="galacticFilter_"    />
+    !!]
+    return
+  end function anyDescendantNodeConstructorParameters
+  
+  function anyDescendantNodeConstructorInternal(allowSelf,galacticFilter_) result(self)
+    !!{
+    Internal constructor for the ``anyDescendantNode'' galactic filter class.
+    !!}
+    implicit none
+    type   (galacticFilterAnyDescendantNode)                        :: self
+    logical                                 , intent(in   )         :: allowSelf
+    class  (galacticFilterClass            ), intent(in   ), target :: galacticFilter_
+    !![
+    <constructorAssign variables="allowSelf, *galacticFilter_"/>
+    !!]
+
+    return
+  end function anyDescendantNodeConstructorInternal
+  
+  subroutine anyDescendantNodeDestructor(self)
+    !!{
+    Destructor for  the ``anyDescendantNode'' galactic filter class.
+    !!}
+    implicit none
+    type(galacticFilterAnyDescendantNode), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%galacticFilter_"/>
+    !!]
+    return
+  end subroutine anyDescendantNodeDestructor
+  
+  logical function anyDescendantNodePasses(self,node)
+    !!{
+    Implement a filter on descendant node properties.
+    !!}
+    implicit none
+    class(galacticFilterAnyDescendantNode), intent(inout)         :: self
+    type (treeNode                       ), intent(inout), target :: node
+    type (treeNode                       ), pointer               :: nodeDescendant
+
+    anyDescendantNodePasses=.false.
+    if (self%allowSelf) then
+       nodeDescendant => node
+    else
+       nodeDescendant => node%parent
+    end if
+    do while (associated(nodeDescendant))
+       anyDescendantNodePasses =  self          %galacticFilter_%passes(nodeDescendant)
+       nodeDescendant          => nodeDescendant%parent
+       if (anyDescendantNodePasses) exit
+    end do
+    return
+  end function anyDescendantNodePasses

--- a/source/galactic.filters.labelled.F90
+++ b/source/galactic.filters.labelled.F90
@@ -1,0 +1,101 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Implements a galactic filter which tests whether the given node has a specified label.
+!!}
+  
+  !![
+  <galacticFilter name="galacticFilterLabelled">
+   <description>Tests whether the given node has a specified label.</description>
+  </galacticFilter>
+  !!]
+  type, extends(galacticFilterClass) :: galacticFilterLabelled
+     !!{
+     Tests whether the given node has a specified label.
+     !!}
+     private
+     type   (varying_string) :: label
+     integer                 :: labelID
+   contains
+     procedure :: passes => labelledPasses
+  end type galacticFilterLabelled
+
+  interface galacticFilterLabelled
+     !!{
+     Constructors for the ``labelled'' galactic filter class.
+     !!}
+     module procedure labelledConstructorParameters
+     module procedure labelledConstructorInternal
+  end interface galacticFilterLabelled
+
+contains
+
+  function labelledConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the ``labelled'' galactic filter class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type(galacticFilterLabelled)                :: self
+    type(inputParameters       ), intent(inout) :: parameters
+    type(varying_string        )                :: label
+
+    !![
+    <inputParameter>
+      <name>label</name>
+      <source>parameters</source>
+      <description>The label upon which to filter.</description>
+    </inputParameter>
+    !!]
+    self=galacticFilterLabelled(label)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function labelledConstructorParameters
+  
+  function labelledConstructorInternal(label) result(self)
+    !!{
+    Internal constructor for the ``labelled'' galactic filter class.
+    !!}
+    use :: Nodes_Labels, only : nodeLabelRegister
+    implicit none
+    type(galacticFilterLabelled)                :: self
+    type(varying_string        ), intent(inout) :: label
+    !![
+    <constructorAssign variables="label"/>
+    !!]
+
+    self%labelID=nodeLabelRegister(char(label))
+    return
+  end function labelledConstructorInternal
+
+  logical function labelledPasses(self,node)
+    !!{
+    Implement a filter on node labels.
+    !!}
+    use :: Nodes_Labels, only : nodeLabelIsPresent
+    implicit none
+    class(galacticFilterLabelled), intent(inout)         :: self
+    type (treeNode              ), intent(inout), target :: node
+
+    labelledPasses=nodeLabelIsPresent(self%labelID,node)
+    return
+  end function labelledPasses

--- a/source/nodes.operators.metadata.label.F90
+++ b/source/nodes.operators.metadata.label.F90
@@ -1,0 +1,123 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Implements a node operator class that applies labels to nodes during tree initialization based on a \refClass{galacticFilter}.
+!!}
+
+  use :: Galactic_Filters, only : galacticFilterClass
+
+  !![
+  <nodeOperator name="nodeOperatorLabel">
+   <description>A node operator class that applies labels to nodes during tree initialization based on a \refClass{galacticFilter}.</description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorLabel
+     !!{
+     A node operator class that applies labels to nodes during tree initialization based on a \refClass{galacticFilter}.
+     !!}
+     private
+     type   (varying_string     )          :: label
+     integer                               :: labelID
+     class  (galacticFilterClass), pointer :: galacticFilter_ => null()
+   contains
+     final     ::                       labelDestructor
+     procedure :: nodeTreeInitialize => labelTreeInitialize
+  end type nodeOperatorLabel
+
+  interface nodeOperatorLabel
+     !!{
+     Constructors for the {\normalfont \ttfamily label} node operator class.
+     !!}
+     module procedure labelConstructorParameters
+     module procedure labelConstructorInternal
+  end interface nodeOperatorLabel
+
+contains
+
+  function labelConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily label} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type (nodeOperatorLabel  )                :: self
+    type (inputParameters    ), intent(inout) :: parameters
+    class(galacticFilterClass), pointer       :: galacticFilter_
+    type (varying_string     )                :: label
+
+    !![
+    <inputParameter>
+      <name>label</name>
+      <source>parameters</source>
+      <description>The label to apply.</description>
+    </inputParameter>
+    <objectBuilder class="galacticFilter" name="galacticFilter_" source="parameters"/>
+    !!]    
+    self=nodeOperatorLabel(label,galacticFilter_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="galacticFilter_"/>
+    !!]
+    return
+  end function labelConstructorParameters
+
+  function labelConstructorInternal(label,galacticFilter_) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily label} node operator class which takes a parameter set as input.
+    !!}
+    use :: Nodes_Labels, only : nodeLabelRegister
+    implicit none
+    type (nodeOperatorLabel  )                        :: self
+    type (varying_string     ), intent(inout)         :: label
+    class(galacticFilterClass), intent(in   ), target :: galacticFilter_
+    !![
+    <constructorAssign variables="label, *galacticFilter_"/>
+    !!]
+
+    self%labelID=nodeLabelRegister(char(label))
+    return
+  end function labelConstructorInternal
+  
+  subroutine labelDestructor(self)
+    !!{
+    Destructor for  the ``label'' galactic filter class.
+    !!}[<0;149;44m
+    implicit none
+    type(nodeOperatorLabel), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%galacticFilter_"/>
+    !!]
+    return
+  end subroutine labelDestructor
+
+  subroutine labelTreeInitialize(self,node)
+    !!{
+    Initialize node branch tip indices.
+    !!}
+    use :: Nodes_Labels, only : nodeLabelSet
+    implicit none
+    class(nodeOperatorLabel), intent(inout), target  :: self
+    type (treeNode         ), intent(inout), target  :: node
+
+    if (self%galacticFilter_%passes(node)) &
+         & call nodeLabelSet(self%labelID,node)
+    return
+  end subroutine labelTreeInitialize

--- a/source/nodes.property_extractor.labels.F90
+++ b/source/nodes.property_extractor.labels.F90
@@ -95,7 +95,8 @@ contains
     !!{
     Return the names of the {\normalfont \ttfamily labels} properties.
     !!}
-    use :: Nodes_Labels, only : nodeLabelNames
+    use :: Nodes_Labels   , only : nodeLabelNames
+    use :: String_Handling, only : String_Upper_Case_First
     implicit none
     class           (nodePropertyExtractorLabels), intent(inout)                             :: self
     double precision                             , intent(in   )                             :: time
@@ -105,7 +106,7 @@ contains
 
     call nodeLabelNames(names)
     do i=1,size(names)
-       names(i)="nodeLabel"//names(i)
+       names(i)="nodeLabel"//String_Upper_Case_First(char(names(i)))
     end do
     return
   end subroutine labelsNames

--- a/source/objects.nodes.labels.F90
+++ b/source/objects.nodes.labels.F90
@@ -55,6 +55,8 @@ contains
        do i=1,size(labels_)
           if (labels_(i) == label) then
              labelID=i
+             if (descriptions_(i) == '' .and. present(description)) &
+                  & descriptions_(i)=description
              exit
           end if
        end do

--- a/source/objects.nodes.labels.F90
+++ b/source/objects.nodes.labels.F90
@@ -67,6 +67,8 @@ contains
           call move_alloc(descriptions_,descriptionsTmp)
           allocate(labels_      (size(labelsTmp      )+1))
           allocate(descriptions_(size(descriptionsTmp)+1))
+          labels_      (1:size(labelsTmp      ))=labelsTmp
+          descriptions_(1:size(descriptionsTmp))=descriptionsTmp
        else
           allocate(labels_      (                      1))
           allocate(descriptions_(                      1))

--- a/source/objects.nodes.labels.F90
+++ b/source/objects.nodes.labels.F90
@@ -104,16 +104,12 @@ contains
     class  (nodeComponentBasic), pointer       :: basic, basicParent
     !$GLC attributes unused :: ID
 
-    basic       => node%basic()
-    basicParent => node%parent%basic()
-    label=basic%longIntegerRank0MetaPropertyGet(nodeLabelsID)
-    labelParent=basicParent%longIntegerRank0MetaPropertyGet(nodeLabelsID)
-labelCombined=ior(label,labelParent)
-    call basic%longIntegerRank0MetaPropertySet(                                                                     &
-         &                                                                                 nodeLabelsID           , &
-         &                                     labelCombined &
-         &                                    )
-
+    basic         => node              %basic                          (            )
+    basicParent   => node       %parent%basic                          (            )
+    label         =  basic             %longIntegerRank0MetaPropertyGet(nodeLabelsID)
+    labelParent   =  basicParent       %longIntegerRank0MetaPropertyGet(nodeLabelsID)
+    labelCombined =  ior(label,labelParent)
+    call basic%longIntegerRank0MetaPropertySet(nodeLabelsID,labelCombined)
     return
   end subroutine mergeLabels
 

--- a/testSuite/parameters/treeFilterLabels.xml
+++ b/testSuite/parameters/treeFilterLabels.xml
@@ -271,6 +271,28 @@
       <massDestructionMassInfallFraction value="0.0"/>
       <massDestructionMassTreeFraction   value="0.0"/>
     </nodeOperator>
+    <!-- Labels -->
+    <nodeOperator value="label">
+      <label value="memberLMC"/>
+      <galacticFilter value="anyDescendantNode">
+        <allowSelf value="false"/>
+        <galacticFilter value="labelled">
+          <label value="LMC"/>
+        </galacticFilter>
+      </galacticFilter>
+    </nodeOperator>
+    <nodeOperator value="label">
+      <label value="lateMerger"/>
+      <galacticFilter value="all">
+        <galacticFilter value="highPass">
+          <threshold value="11.8"/>
+          <nodePropertyExtractor value="time"/>
+        </galacticFilter>
+        <galacticFilter value="parentNode">
+          <galacticFilter value="mainBranch"/>
+        </galacticFilter>
+      </galacticFilter>
+    </nodeOperator>
   </nodeOperator>
   
   <!-- Numerical tolerances -->


### PR DESCRIPTION
Provides a `nodeOperator` to apply labels to nodes (based on a `galacticFilter`) during initialization. Also provides some new `galacticFilter`s to check for labels in other nodes, and to apply a filter to all descendant nodes.