### PR TITLE
Allow relative paths in input parameter evaluated expressions

### DIFF
--- a/source/tests.parameters.F90
+++ b/source/tests.parameters.F90
@@ -33,13 +33,14 @@ program Test_Parameters
   use :: Input_Parameters          , only : inputParameters         , inputParameter
   use :: Unit_Tests                , only : Assert                  , Unit_Tests_Begin_Group       , Unit_Tests_End_Group, Unit_Tests_Finish
   implicit none
-  type            (hdf5Object                   )          :: outputFile
-  type            (varying_string               )          :: parameterFile            , parameterValue
-  class           (cosmologyParametersClass     ), pointer :: cosmologyParameters_
-  class           (cosmologicalMassVarianceClass), pointer :: cosmologicalMassVariance_
-  type            (inputParameters              ), target  :: testParameters
-  type            (inputParameter               ), pointer :: testParameter
-  double precision                                         :: valueNumerical
+  type            (hdf5Object                   )              :: outputFile
+  type            (varying_string               )              :: parameterFile            , parameterValue
+  class           (cosmologyParametersClass     ), pointer     :: cosmologyParameters_
+  class           (cosmologicalMassVarianceClass), pointer     :: cosmologicalMassVariance_
+  type            (inputParameters              ), target      :: testParameters
+  type            (inputParameters              ), allocatable :: wrapper1                 ,  wrapper2
+  type            (inputParameter               ), pointer     :: testParameter
+  double precision                                             :: valueNumerical
   
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
@@ -86,6 +87,16 @@ program Test_Parameters
   call Assert('derived value'                        ,valueNumerical,+1.234000000d1,absTol=1.0d-6)
   call testParameters%value('derivedValue2',valueNumerical)
   call Assert('derived value [recursive]'            ,valueNumerical,-8.264825587d0,absTol=1.0d-6)
+  allocate(wrapper1)
+  allocate(wrapper2)
+  wrapper1=testParameters%subParameters('wrapper1')
+  wrapper2=wrapper1      %subParameters('wrapper2')
+  call wrapper1%value('derivedValue4',valueNumerical)
+  call Assert('derived value [relative]'             ,valueNumerical, 33.42d0,absTol=1.0d-6)
+  call wrapper2%value('derivedValue5',valueNumerical)
+  call Assert('derived value [relative]'             ,valueNumerical,118.08d0,absTol=1.0d-6)
+  deallocate(wrapper2)
+  deallocate(wrapper1)
   !! Reset the value of the fixed parameter.
   testParameter => testParameters%node('fixedValue')
   call testParameter %set  (2.468d0)

--- a/testSuite/parameters/testsParameters.xml
+++ b/testSuite/parameters/testsParameters.xml
@@ -53,5 +53,13 @@
   <derivedValue2 value="=2.3+[fixedValue]-[derivedValue2:derivedValue3]^2">
     <derivedValue3 value="=exp([fixedValue])"/>
   </derivedValue2>
+  <wrapper1 value="" ignoreWarnings="true">
+    <derivedValue4 value="=[.::fixedValue1]"/>
+    <fixedValue1 value="33.42"/>
+    <wrapper2 value="" ignoreWarnings="true">
+      <derivedValue5 value="=[.::fixedValue2]+[..::fixedValue1]+[.::..::wrapper2::fixedValue2]"/>
+      <fixedValue2 value="42.33"/>
+    </wrapper2>
+  </wrapper1>
 
 </parameters>


### PR DESCRIPTION
For example:

* "`.`" implies the current parameter - so `=[.::parameterName]` refers to a parameter named `parameterName` within the current parameter;

* "`..`" implies the parent parameter - so `=[..::parameterName]` refers to a parameter named `parameterName` in the parent of the current parameter.