### PR TITLE
Add a new fitting function of the mass-concentration relation for WDM

### DIFF
--- a/doc/Galacticus.bib
+++ b/doc/Galacticus.bib
@@ -4844,6 +4844,21 @@ mass-concentration-redshift relation, c(M, z), of dark matter haloes. Our simula
 	file = {NASA/ADS Full Text PDF:/home/abensonca/.mozilla/firefox/f54gqgdx.default/zotero/storage/GA2J7XH3/Ludlow et al. - 2016 - The mass-concentration-redshift relation of cold a.pdf:application/pdf}
 }
 
+@article{bose_copernicus_2016,
+        author = {Bose, Sownak and Hellwing, Wojciech A. and Frenk, Carlos S. and Jenkins, Adrian and Lovell, Mark R. and Helly, John C. and Li, Baojiu},
+        title = {The COpernicus COmplexio: Statistical Properties of Warm Dark Matter Haloes},
+        eprint = {1507.01998},
+        archivePrefix = {arXiv},
+        primaryClass = {astro-ph.CO},
+        doi = {10.1093/mnras/stv2294},
+        journal = {Mon. Not. Roy. Astron. Soc.},
+        volume = {455},
+        number = {1},
+        pages = {318--333},
+        year = {2016},
+        abstract={The recent detection of a 3.5 keV X-ray line from the centres of galaxies and clusters by \cite{2014ApJ...789...13B} and \cite{2014PhRvL.113y1301B} has been interpreted as emission from the decay of 7~keV sterile neutrinos which could make up the (warm) dark matter (WDM).  As part of the {\em COpernicus COmplexio} (\textsc{coco}) programme, we investigate the properties of dark matter haloes formed in a high-resolution cosmological $N$-body simulation from initial conditions similar to those expected in a universe in which the dark matter consists of 7~keV sterile neutrinos. This simulation and its cold dark matter (CDM) counterpart have $\sim13.4$bn particles, each of mass $\sim 10^5\,\Msun$, providing detailed information about halo structure and evolution down to dwarf galaxy mass scales.  Non-linear structure formation on small scales ($M_{200}\, \lsim\, 2 \times 10^9~h^{-1}\,M_\odot$) begins slightly later in \textsc{coco-warm} than in \textsc{coco-cold}.  The halo mass function at the present day in the WDM model begins to drop below its CDM counterpart at a mass $\sim 2 \times 10^{9}~h^{-1}\,M_\odot$ and declines very rapidly towards lower masses so that there are five times fewer haloes of mass $M_{200}= 10^{8}~h^{-1}\,M_\odot$ in \textsc{coco-warm} than in \textsc{coco-cold}.  Halo concentrations on dwarf galaxy scales are correspondingly smaller in \textsc{coco-warm}, and we provide a simple functional form that describes its evolution with redshift. The shapes of haloes are similar in the two cases, but the smallest haloes in \textsc{coco-warm} rotate slightly more slowly than their CDM counterparts.}
+}
+
 @article{madau_radiative_1995,
 	title = {Radiative transfer in a clumpy universe: The colors of high-redshift galaxies},
 	volume = {441},

--- a/source/dark_matter_profiles.structure.concentration.WDM.Bose2016.F90
+++ b/source/dark_matter_profiles.structure.concentration.WDM.Bose2016.F90
@@ -97,7 +97,7 @@ contains
 
   function wdmBose2016ConstructorInternal(cdmConcentration,transferFunction_,cosmologyFunctions_) result(self)
     !!{
-    Generic constructor for the \gls{wdmBose2016} dark matter halo concentration class.
+    Generic constructor for the {\normalfont \ttfamily wdmBose2016} dark matter halo concentration class.
     !!}
     implicit none
     type (darkMatterProfileConcentrationWDMBose2016)                        :: self

--- a/source/dark_matter_profiles.structure.concentration.WDM.Bose2016.F90
+++ b/source/dark_matter_profiles.structure.concentration.WDM.Bose2016.F90
@@ -1,0 +1,183 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by:  Xiaolong Du, Andrew Benson.
+
+  !!{
+  An implementation of warm dark matter halo profile concentrations using the
+  \cite{bose_copernicus_2016} modifier.
+  !!}
+
+  use :: Transfer_Functions , only : transferFunctionClass
+  use :: Cosmology_Functions, only : cosmologyFunctionsClass
+
+  !![
+  <darkMatterProfileConcentration name="darkMatterProfileConcentrationWDMBose2016">
+   <description>
+    A dark matter profile concentration class in which the concentration is computed by applying the correction factor of
+    \cite{bose_copernicus_2016}:
+    \begin{equation}
+    c_\mathrm{WDM} = c_\mathrm{CDM} \left( 1 + \gamma_1 {M_\mathrm{1/2} \over M_\mathrm{halo}} \right)^{-\gamma_2} (1+z)^{\beta(z)},
+    \end{equation}
+    where $\gamma_1=60$, $\gamma_2=0.17$, $M_\mathrm{1/2}$ is the mass corresponding to the wavenumber at which the WDM transfer
+    function is suppressed below the CDM transfer function by a factor of 2, $M_\mathrm{halo}$ is the mass of the dark matter
+    halo, and $\beta(z)=0.026 z-0.04$, to a CDM concentration algorithm as specified by {\normalfont \ttfamily [cdmConcentration]}.
+   </description>
+  </darkMatterProfileConcentration>
+  !!]
+  type, extends(darkMatterProfileConcentrationClass) :: darkMatterProfileConcentrationWDMBose2016
+     !!{
+     A dark matter halo profile concentration class implementing the modifier of
+     \cite{bose_copernicus_2016}.
+     !!}
+     private
+     class(darkMatterProfileConcentrationClass), pointer :: cdmConcentration    => null()
+     class(transferFunctionClass              ), pointer :: transferFunction_   => null()
+     class(cosmologyFunctionsClass            ), pointer :: cosmologyFunctions_ => null()
+   contains
+     final     ::                                   wdmBose2016Destructor
+     procedure :: concentration                  => wdmBose2016Concentration
+     procedure :: densityContrastDefinition      => wdmBose2016DensityContrastDefinition
+     procedure :: darkMatterProfileDMODefinition => wdmBose2016DarkMatterProfileDefinition
+  end type darkMatterProfileConcentrationWDMBose2016
+
+  interface darkMatterProfileConcentrationWDMBose2016
+     !!{
+     Constructors for the {\normalfont \ttfamily WDM} dark matter halo profile concentration
+     class.
+     !!}
+     module procedure wdmBose2016ConstructorParameters
+     module procedure wdmBose2016ConstructorInternal
+  end interface darkMatterProfileConcentrationWDMBose2016
+
+contains
+
+  function wdmBose2016ConstructorParameters(parameters) result(self)
+    !!{
+    Default constructor for the {\normalfont \ttfamily wdm} dark matter halo profile concentration class.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type (darkMatterProfileConcentrationWDMBose2016)                :: self
+    type (inputParameters                          ), intent(inout) :: parameters
+    class(darkMatterProfileConcentrationClass      ), pointer       :: cdmConcentration
+    class(transferFunctionClass                    ), pointer       :: transferFunction_
+    class(cosmologyFunctionsClass                  ), pointer       :: cosmologyFunctions_
+
+    !![
+    <objectBuilder class="darkMatterProfileConcentration" name="cdmConcentration"     source="parameters"/>
+    <objectBuilder class="transferFunction"               name="transferFunction_"    source="parameters"/>
+    <objectBuilder class="cosmologyFunctions"             name="cosmologyFunctions_"  source="parameters"/>
+    !!]
+    self=darkMatterProfileConcentrationWDMBose2016(cdmConcentration,transferFunction_,cosmologyFunctions_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="cdmConcentration"   />
+    <objectDestructor name="transferFunction_"  />
+    <objectDestructor name="cosmologyFunctions_"/>
+    !!]
+    return
+  end function wdmBose2016ConstructorParameters
+
+  function wdmBose2016ConstructorInternal(cdmConcentration,transferFunction_,cosmologyFunctions_) result(self)
+    !!{
+    Generic constructor for the \gls{wdmBose2016} dark matter halo concentration class.
+    !!}
+    implicit none
+    type (darkMatterProfileConcentrationWDMBose2016)                        :: self
+    class(darkMatterProfileConcentrationClass      ), intent(in   ), target :: cdmConcentration
+    class(transferFunctionClass                    ), intent(in   ), target :: transferFunction_
+    class(cosmologyFunctionsClass                  ), intent(in   ), target :: cosmologyFunctions_
+    !![
+    <constructorAssign variables="*cdmConcentration, *transferFunction_, *cosmologyFunctions_"/>
+    !!]
+
+    return
+  end function wdmBose2016ConstructorInternal
+
+  subroutine wdmBose2016Destructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily wdmBose2016} dark matter halo profile concentration class.
+    !!}
+    implicit none
+    type(darkMatterProfileConcentrationWDMBose2016), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%cdmConcentration"   />
+    <objectDestructor name="self%transferFunction_"  />
+    <objectDestructor name="self%cosmologyFunctions_"/>
+    !!]
+    return
+  end subroutine wdmBose2016Destructor
+
+  double precision function wdmBose2016Concentration(self,node)
+    !!{
+    Return the concentration of the dark matter halo profile of {\normalfont \ttfamily node}
+    using the warm dark matter modifier of \cite{bose_copernicus_2016}.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
+    implicit none
+    class           (darkMatterProfileConcentrationWDMBose2016), intent(inout), target  :: self
+    type            (treeNode                                 ), intent(inout), target  :: node
+    class           (nodeComponentBasic                       )               , pointer :: basic
+    ! Parameters of Bose et al. (2016)'s fitting formula.
+    double precision                                           , parameter              :: gamma1  =60.0d0, gamma2=0.17d0
+    double precision                                                                    :: redshift
+
+    ! Get required objects.
+    basic    => node %basic()
+    redshift =  1.0d0/self%cosmologyFunctions_%expansionFactor(basic%time())-1.0d0
+    ! Get WDM concentration
+    wdmBose2016Concentration=+self%cdmConcentration%concentration(node)              &
+         &                   /(                                                      &
+         &                     +1.0d0                                                &
+         &                     +gamma1                                               &
+         &                     *(self%transferFunction_%halfModeMass()/basic%mass()) &
+         &                    )**gamma2                                              &
+         &                   *(                                                      &
+         &                     1.0d0+redshift                                        &
+         &                    )**(0.026d0*redshift-0.04d0)
+    return
+  end function wdmBose2016Concentration
+
+  function wdmBose2016DensityContrastDefinition(self)
+    !!{
+    Return a virial density contrast object defining that used in the definition of
+    concentration in the warm dark matter modifier of \cite{bose_copernicus_2016}.
+    !!}
+    implicit none
+    class(virialDensityContrastClass               ), pointer       :: wdmBose2016DensityContrastDefinition
+    class(darkMatterProfileConcentrationWDMBose2016), intent(inout) :: self
+
+    wdmBose2016DensityContrastDefinition => self%cdmConcentration%densityContrastDefinition()
+    return
+  end function wdmBose2016DensityContrastDefinition
+
+  function wdmBose2016DarkMatterProfileDefinition(self)
+    !!{
+    Return a dark matter density profile object defining that used in the definition of concentration in the
+    warm dark matter modifier of \cite{bose_copernicus_2016}.
+    !!}
+    implicit none
+    class(darkMatterProfileDMOClass                ), pointer       :: wdmBose2016DarkMatterProfileDefinition
+    class(darkMatterProfileConcentrationWDMBose2016), intent(inout) :: self
+
+    wdmBose2016DarkMatterProfileDefinition => self%cdmConcentration%darkMatterProfileDMODefinition()
+    return
+  end function wdmBose2016DarkMatterProfileDefinition

--- a/source/dark_matter_profiles.structure.concentration.WDM.F90
+++ b/source/dark_matter_profiles.structure.concentration.WDM.F90
@@ -32,8 +32,7 @@
     A dark matter profile concentration class in which the concentration is computed by applying the correction factor of
     \cite{schneider_non-linear_2012}:
     \begin{equation}
-    c_\mathrm{WDM} = c_\mathrm{CDM} \left[ 1 + \gamma_1 \left( {M_\mathrm{1/2} \over M_\mathrm{halo}}
-    \right)^{\gamma_2}\right]^{-1},
+    c_\mathrm{WDM} = c_\mathrm{CDM} \left[ 1 + \gamma_1 {M_\mathrm{1/2} \over M_\mathrm{halo}}\right]^{-\gamma_2},
     \end{equation}
     where $\gamma_1=15$, $\gamma_2=0.3$, $M_\mathrm{1/2}$ is the mass corresponding to the wavenumber at which the WDM transfer
     function is suppressed below the CDM transfer function by a factor of 2, and $M_\mathrm{halo}$ is the mass of the dark


### PR DESCRIPTION
Implement the fitting function from Bose et al. 2016:

$c_\mathrm{WDM} = c_\mathrm{CDM} \left( 1 + \gamma_1 {M_\mathrm{1/2} \over M_\mathrm{halo}} \right)^{-\gamma_2} (1+z)^{\beta(z)},$

where $\gamma_1=60$, $\gamma_2=0.17$, $M_\mathrm{1/2}$ is the mass corresponding to the wavenumber at which the WDM transfer function is suppressed below the CDM transfer function by a factor of 2, $M_\mathrm{halo}$ is the mass of the dark matter halo, and $\beta(z)=0.026 z-0.04$.