### PR TITLE
Add support for detailed debugging output

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -196,6 +196,33 @@ jobs:
           name: test-execs-MPI
           path: 'tests.*.exe'
       - run: echo "This job's status is ${{ job.status }}."
+  ### Executable debugging
+  Build-Executables-Debugging-Linux:
+    runs-on: ubuntu-latest
+    container: ghcr.io/galacticusorg/buildenv:latest
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server."
+      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
+          echo "GALACTICUS_FCFLAGS+=\ -DDEBUGGING" >> $GITHUB_ENV
+      - name: Build the code
+        run: |
+          cd $GALACTICUS_EXEC_PATH
+          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+          make -j2 Galacticus.exe tests.debugging.exe
+      - name: Upload test code executables
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-execs-debugging
+          path: 'tests.*.exe'
+      - run: echo "This job's status is ${{ job.status }}."
   ### Library
   Build-Library-Linux:
     runs-on: ubuntu-latest
@@ -5457,6 +5484,42 @@ jobs:
           chmod u=wrx ./tests.radiative_transfer.atomic_matter.state_solver.exe
           set -o pipefail
           mpirun -np 2 --allow-run-as-root ./tests.radiative_transfer.atomic_matter.state_solver.exe 2>&1 | tee test.log
+          ! grep -q FAIL test.log
+      - run: echo "This job's status is ${{ job.status }}."
+  ### Debugging Test Codes
+  Test-Debugging:
+    runs-on: ubuntu-latest
+    container: ghcr.io/galacticusorg/buildenv:latest
+    needs: Build-Executables-Debugging-Linux
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server."
+      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Check out repository datasets
+        uses: actions/checkout@v3      
+        with:
+          repository: galacticusorg/datasets
+          path: datasets
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
+      - name: Download executables
+        uses: actions/download-artifact@v3
+        with:
+          name: test-execs-debugging
+      - name: Create test suite output directory
+        run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
+      - name: Run test
+        run: |
+          cd $GALACTICUS_EXEC_PATH
+          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+          chmod u=wrx ./tests.debugging.exe
+          set -o pipefail
+          ./tests.debugging.exe 2>&1 | tee test.log
           ! grep -q FAIL test.log
       - run: echo "This job's status is ${{ job.status }}."
   ### Cosmology

--- a/scripts/analysis/debugAnalyzer.pl
+++ b/scripts/analysis/debugAnalyzer.pl
@@ -43,7 +43,7 @@ my $stepCount = $i+1;
 my @values = sort(keys(%{$data->{'properties'}}));
 my @rates;
 foreach my $property ( @values ) {
-    push(@rates,map {{property => $property, function => $_}} sort(keys($data->{'properties'}->{$property}->{'rate'})));
+    push(@rates,map {{property => $property, function => $_}} sort(keys(%{$data->{'properties'}->{$property}->{'rate'}})));
 }
 open(my $valueLog,">","debugValues.csv");
 print $valueLog "time , ".join(" , ",@values)."\n";

--- a/scripts/analysis/debugAnalyzer.pl
+++ b/scripts/analysis/debugAnalyzer.pl
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Data::Dumper;
+
+# Extract information from debug logs and export to CSV for further analysis.
+# Andrew Benson (22-August-2023)
+
+# Get the name of the debug log file.
+die("Usage: debugAnalyzer.pl <debugFile>")
+    unless ( scalar(@ARGV) == 1 );
+my $debugFileName = $ARGV[0];
+
+# Initialize step counter and data.
+my $i = -1;
+my $data;
+
+# Open and parse the debug log file.
+open(my $debugLog,$debugFileName);
+while ( my $line = <$debugLog> ) {
+    if ( $line =~ m/^\s*step:\s+([0-9\.eE\+\-]+)/ ) {
+	++$i;
+	$data->{'time'}->[$i] = $1;
+    } elsif ( $line =~ m/^\s*value:\s+([a-zA-Z:]+)\s+([\d\.eE\+\-]+)/ ) {
+	$data->{'properties'}->{$1}->{'value'}      ->[$i] = $2;
+    } elsif ( $line =~ m/^\s*rate:\s+\(([a-zA-Z0-9_]+)\)\s+([a-zA-Z:\d\[\]]+)\s+([\d\.eE\+\-]+)/ ) {
+	$data->{'properties'}->{$2}->{'rate' }->{$1}->[$i] = $3;
+    } else {
+	print $line;
+	die("failed to parse line");
+    }
+
+
+    ## AJB HACK
+    last
+	if ( $i > 10 );
+
+}
+close($debugLog);
+my $stepCount = $i+1;
+
+# Output values and rates.
+my @values = sort(keys(%{$data->{'properties'}}));
+my @rates;
+foreach my $property ( @values ) {
+    push(@rates,map {{property => $property, function => $_}} sort(keys($data->{'properties'}->{$property}->{'rate'})));
+}
+open(my $valueLog,">","debugValues.csv");
+print $valueLog "time , ".join(" , ",@values)."\n";
+for(my $j=0;$j<$stepCount;++$j) {
+    print $valueLog $data->{'time'}->[$j]." , ".join(" , ",map {defined($data->{'properties'}->{$_}->{'value'}->[$j]) ? $data->{'properties'}->{$_}->{'value'}->[$j] : "0.000000E+00"} @values)."\n";
+}
+close($valueLog);
+open(my $ratesLog,">","debugRates.csv");
+print $ratesLog "time , ".join(" , ",map {$_->{'property'}.":".$_->{'function'}} @rates)."\n";
+for(my $j=0;$j<$stepCount;++$j) {
+    print $ratesLog $data->{'time'}->[$j]." , ".join(" , ",map {my $rate = $data->{'properties'}->{$_->{'property'}}->{'rate'}->{$_->{'function'}}->[$j]; defined($rate) ? $rate : "0.000000E+00"} @rates)."\n";
+}
+close($ratesLog);
+exit;

--- a/scripts/build/libraryDependencies.pl
+++ b/scripts/build/libraryDependencies.pl
@@ -142,7 +142,8 @@ print
     join(" ",map {"-l".$_} @sortedLibraries).
     $staticOptions.
     $osOptions.
-    ((grep {$_ eq "blas"} @sortedLibraries) ? " -fexternal-blas" : "").
-    ($linkLibRT                             ? " -lrt"            : "").
+    ((grep {$_ eq "-DDEBUGGING"} @compilerOptions) ? " -rdynamic"       : "").
+    ((grep {$_ eq "blas"       } @sortedLibraries) ? " -fexternal-blas" : "").
+    ($linkLibRT                                    ? " -lrt"            : "").
     "\n";
 exit;

--- a/source/backtrace.c
+++ b/source/backtrace.c
@@ -1,0 +1,28 @@
+#include <execinfo.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+void getCallerC (int callerSize,char *caller) {
+  void *array[10];
+  char **strings;
+  int size, i;
+
+  size = backtrace (array, 10);
+  strings = backtrace_symbols (array, size);
+  if (size >= 4 ) {
+    i = 3;
+    /* Skip over unnamed functions. */
+    while ( i < size && strstr(strings[i],"()") ) {
+	++i;
+      }
+      if ( i < size ) {
+	strncpy(caller,strings[i],callerSize);
+      } else {
+	caller = "unknown";
+      }
+  } else {
+    caller = "unknown";
+  }
+  free (strings);
+}

--- a/source/merger_trees.node_evolver.standard.F90
+++ b/source/merger_trees.node_evolver.standard.F90
@@ -468,7 +468,7 @@ contains
              deallocate(self%odeTolerancesInactiveAbsolute)
           end if
           allocate(self%propertyValuesActive         (self%propertyCountAll))
-          allocate(self%propertyValuesActiveSaved  (self%propertyCountAll))
+          allocate(self%propertyValuesActiveSaved    (self%propertyCountAll))
           allocate(self%propertyValuesInactive       (self%propertyCountAll))
           allocate(self%propertyValuesInactiveSaved  (self%propertyCountAll))
           allocate(self%propertyScalesActive         (self%propertyCountAll))
@@ -794,19 +794,29 @@ contains
     !!{
     Function which evaluates the set of ODEs for the evolution of a specific node.
     !!}
+#ifdef DEBUGGING
+    use :: Debugging             , only : isDebugging    , debugLog
+    use :: ISO_Varying_String    , only : varying_string , assignment(=)
+    use :: Galacticus_Nodes      , only : propertyTypeAll
+#endif
     use :: Error                 , only : errorStatusXCPU
     use :: Galacticus_Nodes      , only : interruptTask  , nodeComponentBasic
     use :: Interface_GSL         , only : GSL_Success
     use :: ODE_Solver_Error_Codes, only : interruptedAtX , odeSolverInterrupt
     implicit none
-    double precision                    , intent(in   )               :: time
-    double precision                    , intent(in   ), dimension(:) :: y
-    double precision                    , intent(  out), dimension(:) :: dydt
-    logical                                                           :: interrupt
-    procedure       (interruptTask     ), pointer                     :: functionInterrupt
-    class           (nodeComponentBasic), pointer                     :: basic
-    integer         (kind_int8         )                              :: systemClockCount
- 
+    double precision                    , intent(in   )                                       :: time
+    double precision                    , intent(in   ), dimension(:                        ) :: y
+    double precision                    , intent(  out), dimension(:                        ) :: dydt
+    logical                                                                                   :: interrupt
+    procedure       (interruptTask     ), pointer                                             :: functionInterrupt
+    class           (nodeComponentBasic), pointer                                             :: basic
+    integer         (kind_int8         )                                                      :: systemClockCount
+#ifdef DEBUGGING
+    integer         (c_size_t          )                                                      :: iProperty
+    character       (len=32            )                                                      :: label
+    type            (varying_string    )                                                      :: message
+    double precision                                   , dimension(self_%propertyCountActive) :: valuesDebug, ratesDebug
+#endif
     ! Check for exceeding wall time.
     if (self_%systemClockMaximum > 0_kind_int8) then
        call System_Clock(systemClockCount)
@@ -839,6 +849,13 @@ contains
        dydt=0.0d0
        return
     end if
+#ifdef DEBUGGING
+    if (isDebugging()) then
+       write (label,'(f9.4)') time
+       message="step: "//trim(adjustl(label))
+       call debugLog(message)
+    end if
+#endif
     ! Set derivatives to zero initially.
     call self_%activeNode%odeStepRatesInitialize()
     if (self_%interruptFirstFound .and. time >= self_%timeInterruptFirst) then
@@ -871,6 +888,20 @@ contains
           end if
        end select
     end if
+#ifdef DEBUGGING
+    if (isDebugging()) then
+       call self_%activeNode%serializeValues(valuesDebug,self_%propertyTypeODE)
+       call self_%activeNode%serializeRates (ratesDebug ,self_%propertyTypeODE)
+       do iProperty=1,self_%propertyCountActive
+          write (label,'(e12.6)') valuesDebug(iProperty)
+          message="  value: "        //self_%activeNode%nameFromIndex(int(iProperty),self_%propertyTypeODE)//" "//trim(adjustl(label))
+          call debugLog(message)          
+          write (label,'(e12.6)') ratesDebug(iProperty)
+          message="   rate: (total) "//self_%activeNode%nameFromIndex(int(iProperty),self_%propertyTypeODE)//" "//trim(adjustl(label))
+          call debugLog(message)          
+       end do
+    end if
+#endif
     return
   end function standardODEs
 

--- a/source/tests.debugging.F90
+++ b/source/tests.debugging.F90
@@ -1,0 +1,54 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a program to test debugging tools.
+!!}
+
+program Test_Debugging
+  !!{
+  Contains a program to test debugging tools.
+  !!}
+  use :: Display                 , only : displayVerbositySet, verbosityLevelStandard
+  use :: Test_Debugging_Functions, only : dummyCaller
+  use :: ISO_Varying_String      , only : varying_string     , char                  , var_str
+#ifdef DEBUGGING
+  use :: Unit_Tests              , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
+#else
+  use :: Unit_Tests              , only : Skip               , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
+#endif  
+  implicit none
+#ifdef DEBUGGING
+  type(varying_string) :: caller
+#endif
+
+  ! Set verbosity level.
+  call displayVerbositySet(verbosityLevelStandard)
+  ! Begin unit tests.
+  call Unit_Tests_Begin_Group("Debugging")
+#ifdef DEBUGGING
+  call dummyCaller(caller)
+  call Assert("Identify calling function",caller,var_str("main")      )
+#else
+  call Skip  ("Identify calling function","not compiled for debugging")
+#endif
+  ! End unit tests.
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Finish   ()
+end program Test_Debugging

--- a/source/tests.debugging.functions.F90
+++ b/source/tests.debugging.functions.F90
@@ -1,0 +1,46 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains functions used in debugging tests.
+!!}
+
+module Test_Debugging_Functions
+  !!{
+  Contains functions used in debugging tests.
+  !!}
+  private
+  public :: dummyCaller
+  
+contains
+
+  subroutine dummyCaller(caller)
+    !!{
+    Callable function to generate a backtrace.
+    !!}
+    use :: ISO_Varying_String, only : varying_string
+    use :: Debugging         , only : getCaller
+    implicit none
+    type(varying_string), intent(  out) :: caller
+
+    caller=getCaller()
+    return
+  end subroutine dummyCaller
+  
+end module Test_Debugging_Functions

--- a/source/utility.debugging.F90
+++ b/source/utility.debugging.F90
@@ -1,0 +1,134 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module that implements useful debugging utilities.
+!!}
+
+! Specify an explicit dependence on the backtrace.o object file.
+!: $(BUILDPATH)/backtrace.o
+  
+module Debugging
+  !!{
+  Implements useful debugging utilities.
+  !!}
+  use, intrinsic :: ISO_C_Binding, only : c_int, c_char
+  private
+  public :: debugLog , debugOn, debugOff, isDebugging, &
+       &    getCaller
+
+  ! Debugging status.
+  logical :: debugging_          =.false.
+  !$omp threadprivate(debugging_)
+  
+  ! File unit for output of debugging information.
+  logical :: debugFileInitialized=.false.
+  integer :: debugFile
+  !$omp threadprivate(debugFile,debugFileInitialized)
+
+  interface
+     subroutine getCallerC(callerSize,caller) bind(c,name='getCallerC')
+       !!{
+       Template for a C function that returns the name of the caller function.
+       !!}
+       import
+       integer  (kind=c_int ), value :: callerSize
+       character(kind=c_char)        :: caller    (callerSize)
+     end subroutine getCallerC
+  end interface
+
+contains
+
+  subroutine initialize()
+    !!{
+    Initialize debug output.
+    !!}
+    !$ use :: OMP_Lib, only : OMP_Get_Thread_Num
+    implicit none
+    character(len=32) :: fileName
+    
+    if (.not.debugFileInitialized) then
+       write    (fileName,'(a)'       ) 'debug.log'
+       !$ write (fileName,'(a,i4.4,a)') 'debug_thread',OMP_Get_Thread_Num(),'.log'
+       open(newUnit=debugFile,file='debug_thread.log',status='unknown',form='formatted')
+       debugFileInitialized=.true.
+    end if
+    return
+  end subroutine initialize
+
+  subroutine debugOn()
+    !!{
+    Switch debugging on.
+    !!}
+
+    debugging_=.true.
+    return
+  end subroutine debugOn
+
+  subroutine debugOff()
+    !!{
+    Switch debugging off.
+    !!}
+
+    debugging_=.false.
+    return
+  end subroutine debugOff
+
+  logical function isDebugging()
+    !!{
+    Return true if debugging is on.
+    !!}
+
+    isDebugging=debugging_
+    return
+  end function isDebugging
+  
+  subroutine debugLog(message)
+    !!{
+    Write a message to the debug log.
+    !!}
+    use :: ISO_Varying_String, only : varying_string, char
+    implicit none
+    type(varying_string), intent(in   ) :: message
+
+    call initialize()
+    write (debugFile,'(a)') char(message)
+    return
+  end subroutine debugLog
+  
+  function getCaller()
+    !!{
+    Return the name of the calling function.
+    !!}
+    use :: ISO_Varying_String, only : varying_string     , index, extract
+    use :: String_Handling   , only : String_C_to_Fortran
+    implicit none
+    type     (varying_string)                 :: getCaller , caller_
+    character(kind=c_char   ), dimension(256) :: caller
+    integer                                   :: indexStart, indexEnd
+
+    call getCallerC(256,caller)
+    caller_   =String_C_to_Fortran(caller)
+    indexStart=index(caller_,"(")
+    indexEnd  =index(caller_,"+")
+    getCaller=extract(caller_,indexStart+1,indexEnd-1)
+    return
+  end function getCaller
+  
+end module Debugging


### PR DESCRIPTION
If compiled with the option `-DDEBUGGING` then a call to `debugOn()` will result in detailed information being output to a debug file for every ODE step, including values of all properties, total rates of change, and rates of change contributed by individual functions. Calling `debugOff()` will suspend this output. 

A script `scripts/analysis/debugAnalyzer.pl` is provided to parse this output and format it as CSV files for easy plotting and further analysis.