### PR TITLE
Use series solution for the radial velocity dispersion at large radii

### DIFF
--- a/source/dark_matter_profiles_DMO.Zhao1996.F90
+++ b/source/dark_matter_profiles_DMO.Zhao1996.F90
@@ -700,8 +700,8 @@ contains
     class           (darkMatterProfileDMOZhao1996  ), intent(inout) :: self
     type            (treeNode                      ), intent(inout) :: node
     double precision                                , intent(in   ) :: radius
-    double precision                                , parameter     :: radiusScaleFreeTiny               =1.0d-3
-    double precision                                                :: radiusScale                              , radiusScaleFree, &
+    double precision                                , parameter     :: radiusScaleFreeTiny               =1.0d-3, radiusScaleFreeLarge=1.0d2
+    double precision                                                :: radiusScale                              , radiusScaleFree           , &
          &                                                             velocityDispersionSquaredScaleFree
     
     select case (self%specialCase%ID)
@@ -711,12 +711,18 @@ contains
        radiusScale    = self%scaleRadius(node)
        radiusScaleFree=+     radius            &
             &          /     radiusScale
-       if (radiusScaleFree < radiusScaleFreeTiny) then
+       if      (radiusScaleFree < radiusScaleFreeTiny ) then
           ! Use series solution for small radii.
           velocityDispersionSquaredScaleFree=+11.0d0*Pi/15.0d0*radiusScaleFree**4                                                     &
                &                             +       Pi/ 6.0d0*radiusScaleFree**3*(-101.0d0+12.0d0*Pi**2-12.0d0*log(radiusScaleFree)) &
                &                             + 2.0d0*Pi/ 3.0d0*radiusScaleFree**2*(- 59.0d0+ 6.0d0*Pi**2- 6.0d0*log(radiusScaleFree)) &
                &                             +       Pi       *radiusScaleFree   *(- 23.0d0+ 2.0d0*Pi**2- 2.0d0*log(radiusScaleFree))
+       else if (radiusScaleFree > radiusScaleFreeLarge) then
+          ! Use series solution for large radii.
+          velocityDispersionSquaredScaleFree=+Pi*(- 3.0d0+  4.0d0*log(radiusScaleFree))/(   4.0d0*radiusScaleFree   ) &
+               &                             +Pi*( 69.0d0+ 20.0d0*log(radiusScaleFree))/(  50.0d0*radiusScaleFree**2) &
+               &                             +Pi*(-97.0d0- 60.0d0*log(radiusScaleFree))/( 300.0d0*radiusScaleFree**3) &
+               &                             +Pi*(284.0d0+420.0d0*log(radiusScaleFree))/(3675.0d0*radiusScaleFree**4)
        else
           ! Use full solution.
           velocityDispersionSquaredScaleFree=+(                                                                                                 &
@@ -764,13 +770,19 @@ contains
        radiusScale    = self%scaleRadius(node)
        radiusScaleFree=+     radius            &
             &          /     radiusScale
-       if (radiusScaleFree < radiusScaleFreeTiny) then
+       if      (radiusScaleFree < radiusScaleFreeTiny ) then
           ! Use series solution for small radii.
           velocityDispersionSquaredScaleFree=+(119.0d0*Pi-12.0d0*Pi**3)/ 6.0d0                    &
                &                             +(119.0d0*Pi-12.0d0*Pi**3)/ 2.0d0*radiusScaleFree    &
                &                             +(353.0d0*Pi-36.0d0*Pi**3)/ 6.0d0*radiusScaleFree**2 &
                &                             +(121.0d0*Pi-12.0d0*Pi**3)/ 6.0d0*radiusScaleFree**3 &
                &                                         - 9.0d0*Pi**4 /20.0d0*radiusScaleFree**4
+       else if (radiusScaleFree > radiusScaleFreeLarge) then
+          ! Use series solution for large radii.
+          velocityDispersionSquaredScaleFree=+Pi*(  -5.0d0+  4.0d0*log(radiusScaleFree))/(    4.0d0*radiusScaleFree    ) &
+               &                             +Pi*( 177.0d0+  60.0d0*log(radiusScaleFree))/(  100.0d0*radiusScaleFree**2) &
+               &                             +Pi*(-157.0d0-  60.0d0*log(radiusScaleFree))/(  300.0d0*radiusScaleFree**3) &
+               &                             +Pi*(5857.0d0+1260.0d0*log(radiusScaleFree))/(14700.0d0*radiusScaleFree**4)
        else
           ! Use full solution.
           velocityDispersionSquaredScaleFree=+(                                                                                    &
@@ -812,12 +824,18 @@ contains
        radiusScale    = self%scaleRadius(node)
        radiusScaleFree=+     radius            &
             &          /     radiusScale
-       if (radiusScaleFree < radiusScaleFreeTiny) then
+       if      (radiusScaleFree < radiusScaleFreeTiny ) then
           ! Use series solution for small radii.
           velocityDispersionSquaredScaleFree=+16.0d0*Pi/  3.0d0*sqrt(radiusScaleFree      )*(- 11.0d0+  16.0d0*log(2.0d0)) &
                &                             +16.0d0*Pi/ 15.0d0*     radiusScaleFree**1.5d0*(-139.0d0+ 200.0d0*log(2.0d0)) &
                &                             + 2.0d0*Pi/  7.0d0*     radiusScaleFree**2.5d0*(-387.0d0+ 560.0d0*log(2.0d0)) &
                &                             + 4.0d0*Pi/189.0d0*     radiusScaleFree**3.5d0*(-887.0d0+1260.0d0*log(2.0d0))
+       else if (radiusScaleFree > radiusScaleFreeLarge) then
+          ! Use series solution for large radii.
+          velocityDispersionSquaredScaleFree=+Pi*(-29.0d0+ 24.0d0*log(2.0d0)+ 12.0d0*log(radiusScaleFree))/(  12.0d0*radiusScaleFree   ) &
+               &                             +Pi*(107.0d0+120.0d0*log(2.0d0)+ 60.0d0*log(radiusScaleFree))/( 120.0d0*radiusScaleFree**2) &
+               &                             +Pi*(-11.0d0- 40.0d0*log(2.0d0)- 20.0d0*log(radiusScaleFree))/(  96.0d0*radiusScaleFree**3) &
+               &                             +Pi*( 57.0d0+280.0d0*log(2.0d0)+140.0d0*log(radiusScaleFree))/(1344.0d0*radiusScaleFree**4)
        else
           ! Use full solution.
           velocityDispersionSquaredScaleFree=+(                                                             &
@@ -866,12 +884,18 @@ contains
        radiusScale    = self%scaleRadius(node)
        radiusScaleFree=+     radius            &
             &          /     radiusScale
-       if (radiusScaleFree < radiusScaleFreeTiny) then
+       if      (radiusScaleFree < radiusScaleFreeTiny ) then
           ! Use series solution for small radii.
           velocityDispersionSquaredScaleFree=+8.0d0*Pi/   3.0d0*sqrt(radiusScaleFree       )                                                                 &
                &                             -      Pi/3150.0d0*     radiusScaleFree**3.5d0 *(-19861.0d0+60480.0d0*log(2.0d0)-7560.0d0*log(radiusScaleFree)) &
                &                             -      Pi/ 175.0d0*     radiusScaleFree**2.5d0 *(- 8683.0d0+13440.0d0*log(2.0d0)-1680.0d0*log(radiusScaleFree)) &
                &                             -4.0d0*Pi/  75.0d0*     radiusScaleFree**1.5d0 *(-  817.0d0+  960.0d0*log(2.0d0)- 120.0d0*log(radiusScaleFree))
+       else if (radiusScaleFree > radiusScaleFreeLarge) then
+          ! Use series solution for large radii.
+          velocityDispersionSquaredScaleFree=+Pi*(-   7.0d0+   8.0d0*log(2.0d0)+   4.0d0*log(radiusScaleFree))/(    4.0d0*radiusScaleFree   ) &
+               &                             +Pi*(  147.0d0+ 120.0d0*log(2.0d0)+  60.0d0*log(radiusScaleFree))/(  200.0d0*radiusScaleFree**2) &
+               &                             +Pi*(-  79.0d0- 840.0d0*log(2.0d0)- 420.0d0*log(radiusScaleFree))/( 2400.0d0*radiusScaleFree**3) &
+               &                             +Pi*(-3589.0d0+7560.0d0*log(2.0d0)+3780.0d0*log(radiusScaleFree))/(33600.0d0*radiusScaleFree**4)
        else
           ! Use full solution.
           velocityDispersionSquaredScaleFree=+(                                                                     &

--- a/source/tests.dark_matter_profiles.Zhao1996.F90
+++ b/source/tests.dark_matter_profiles.Zhao1996.F90
@@ -57,8 +57,8 @@ program Test_Dark_Matter_Profiles_Zhao1996
   class           (nodeComponentDarkMatterProfile                                ), pointer               :: darkMatterProfile_
   type            (inputParameters                                               )                        :: parameters
   double precision                                                                , parameter             :: concentration                        =+8.0d0, massVirial        =+1.0d12
-  integer                                                                         , parameter             :: countRadii                           =10
-  double precision                                                                , parameter             :: radiiMinimum                         =1.0d-6, radiiMaximum      =+1.0d01
+  integer                                                                         , parameter             :: countRadii                           =20
+  double precision                                                                , parameter             :: radiiMinimum                         =1.0d-6, radiiMaximum      =+1.0d03
   double precision                                                                , dimension(countRadii) :: massNumerical                               , mass                                 , &
        &                                                                                                     velocityDispersionNumerical                 , velocityDispersion                   , &
        &                                                                                                     radii


### PR DESCRIPTION
For certain combinations of $\alpha$, $\beta$ and $\gamma$, the radial velocity dispersion of the `darkMatterProfileDMOZhao1996` class can be computed analytically. However, the calculations can be inefficient. More importantly, at large radii, computing the analytic formula with machine accuracy may produce large round off errors and sometimes lead to floating-point errors. To solve this issue, we can use series solution at large radii.