### PR TITLE
Fix build of FSPS on Apple M1/M2 chips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ $(BUILDPATH)/%.o : $(BUILDPATH)/%.p.F90 $(BUILDPATH)/%.m $(BUILDPATH)/%.d $(BUIL
 
 # Rule for building include file with preprocessor directives to detect OS. For some reason gfortran does not define these automatically.
 $(BUILDPATH)/os.inc:
-	$(CCOMPILER) -dM -E - < /dev/null | grep -e __APPLE__ -e __linux__ > $(BUILDPATH)/os.inc
+	$(CCOMPILER) -dM -E - < /dev/null | grep -e __APPLE__ -e __linux__ -e __aarch64__ > $(BUILDPATH)/os.inc
 
 # Rules for building HDF5 C interoperability types data file.
 $(BUILDPATH)/hdf5FCInterop.dat  : $(BUILDPATH)/hdf5FCInterop.exe $(BUILDPATH)/hdf5FCInteropC.exe


### PR DESCRIPTION
When building FSPS we usually include the compiler option [`-mcmodel=medium`](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html) to support a larger memory model for some of the very large static arrays used by FSPS. Arm64 architectures do not have this option, but their [default memory model](https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html) is sufficient anyway. So, simply disable this option when compiling on Arm64.
