### PR TITLE
Allow `nodePropertyExtractorArray` objects to specify numerical column values

### DIFF
--- a/source/merger_trees.outputter.buffer_types.F90
+++ b/source/merger_trees.outputter.buffer_types.F90
@@ -59,6 +59,9 @@ module Merger_Tree_Outputter_Buffer_Types
      double precision                              , allocatable, dimension(:,:) :: rank1
      type            (hdf5VarDouble               ), allocatable, dimension(:  ) :: rank1VarLen
      type            (varying_string              ), allocatable, dimension(:  ) :: rank1Descriptors
+     double precision                              , allocatable, dimension(:  ) :: rank1DescriptorValues
+     type            (varying_string               )                             :: rank1DescriptorComment
+     double precision                                                            :: rank1DescriptorUnitsInSI
   end type outputPropertyDouble
 
 end module Merger_Tree_Outputter_Buffer_Types

--- a/source/merger_trees.outputter.standard.F90
+++ b/source/merger_trees.outputter.standard.F90
@@ -1017,7 +1017,8 @@ contains
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                   time))%comment   =descriptionsTmp
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                   time))%unitsInSI =extractor_%unitsInSI   (                   time)
        do i=1,extractor_%elementCount(time)
-          if (allocated(self%doubleProperty(doubleProperty+i)%rank1Descriptors)) deallocate(self%doubleProperty(doubleProperty+i)%rank1Descriptors)
+          if (allocated(self%doubleProperty(doubleProperty+i)%rank1Descriptors     )) deallocate(self%doubleProperty(doubleProperty+i)%rank1Descriptors     )
+          if (allocated(self%doubleProperty(doubleProperty+i)%rank1DescriptorValues)) deallocate(self%doubleProperty(doubleProperty+i)%rank1DescriptorValues)
           call extractor_%columnDescriptions(self%doubleProperty(doubleProperty+i)%rank1Descriptors,self%doubleProperty(doubleProperty+i)%rank1DescriptorValues,self%doubleProperty(doubleProperty+i)%rank1DescriptorComment,self%doubleProperty(doubleProperty+i)%rank1DescriptorUnitsInSI,time)
        end do
        do i=1,extractor_%elementCount(                   time)
@@ -1067,7 +1068,8 @@ contains
              call extractor_%metaData(elementTypeDouble,time,i,self%doubleProperty (doubleProperty +i)%metaData)
           end do
           do i=1,extractor_%elementCount(elementTypeDouble,time)
-             if (allocated(self%doubleProperty(doubleProperty+i)%rank1Descriptors)) deallocate(self%doubleProperty(doubleProperty+i)%rank1Descriptors)
+             if (allocated(self%doubleProperty(doubleProperty+i)%rank1Descriptors     )) deallocate(self%doubleProperty(doubleProperty+i)%rank1Descriptors     )
+             if (allocated(self%doubleProperty(doubleProperty+i)%rank1DescriptorValues)) deallocate(self%doubleProperty(doubleProperty+i)%rank1DescriptorValues)
              call extractor_%columnDescriptions(elementTypeDouble,i,time,self%doubleProperty(doubleProperty+i)%rank1Descriptors,self%doubleProperty(doubleProperty+i)%rank1DescriptorValues,self%doubleProperty(doubleProperty+i)%rank1DescriptorComment,self%doubleProperty(doubleProperty+i)%rank1DescriptorUnitsInSI)
           end do
           doubleProperty =doubleProperty +extractor_%elementCount(elementTypeDouble ,time)

--- a/source/merger_trees.outputter.standard.F90
+++ b/source/merger_trees.outputter.standard.F90
@@ -763,12 +763,23 @@ contains
                 call     dataset%writeAttribute(self%doubleProperty(iProperty)%metaData%value(iMetaDatum),char(self%doubleProperty(iProperty)%metaData%key(iMetaDatum)))
              end do
              call        dataset%close         (                                                                   )
-             if (allocated(self%doubleProperty(iProperty)%rank1Descriptors) .and. size(self%doubleProperty(iProperty)%rank1Descriptors) > 0)                        &
-                  & call self%outputGroups(indexOutput)%nodeDataGroup%writeDataset(                                                                                 &
-                  &                                                                     self%doubleProperty(iProperty)%rank1Descriptors                           , &
-                  &                                                                trim(self%doubleProperty(iProperty)%name            )//"Columns"               , &
-                  &                                                                trim(self%doubleProperty(iProperty)%comment         )//" (column descriptions)"  &
-                  &                                                               )
+             if (allocated(self%doubleProperty(iProperty)%rank1Descriptors     ) .and. size(self%doubleProperty(iProperty)%rank1Descriptors     ) > 0) then
+                call self%outputGroups(indexOutput)%nodeDataGroup%writeDataset(                                                                                       &
+                     &                                                              self%doubleProperty(iProperty)%rank1Descriptors                                 , &
+                     &                                                         trim(self%doubleProperty(iProperty)%name                  )//"Columns"               , &
+                     &                                                         trim(self%doubleProperty(iProperty)%comment               )//" (column descriptions)"  &
+                     &                                                        )
+             end if
+             if (allocated(self%doubleProperty(iProperty)%rank1DescriptorValues) .and. size(self%doubleProperty(iProperty)%rank1DescriptorValues) > 0) then
+                call self%outputGroups(indexOutput)%nodeDataGroup%writeDataset(                                                                                       &
+                     &                                                              self%doubleProperty(iProperty)%rank1DescriptorValues                            , &
+                     &                                                         trim(self%doubleProperty(iProperty)%name                  )//"ColumnValues"          , &
+                     &                                                         char(self%doubleProperty(iProperty)%rank1DescriptorComment)                            &
+                     &                                                        )
+             dataset=self%outputGroups(indexOutput)%nodeDataGroup%openDataset(trim(self%doubleProperty(iProperty)%name)//"ColumnValues")
+             call dataset%writeAttribute(self%doubleProperty(iProperty)%rank1DescriptorUnitsInSI,"unitsInSI")
+             call dataset%close()
+             end if
           end if
        end do
        self%doublePropertiesWritten=self%doublePropertiesWritten+self%doubleBufferCount
@@ -1005,7 +1016,7 @@ contains
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                   time))%unitsInSI =extractor_%unitsInSI   (                   time)
        do i=1,extractor_%elementCount(time)
           if (allocated(self%doubleProperty(doubleProperty+i)%rank1Descriptors)) deallocate(self%doubleProperty(doubleProperty+i)%rank1Descriptors)
-          call extractor_%columnDescriptions(self%doubleProperty(doubleProperty+i)%rank1Descriptors,time)
+          call extractor_%columnDescriptions(self%doubleProperty(doubleProperty+i)%rank1Descriptors,self%doubleProperty(doubleProperty+i)%rank1DescriptorValues,self%doubleProperty(doubleProperty+i)%rank1DescriptorComment,self%doubleProperty(doubleProperty+i)%rank1DescriptorUnitsInSI,time)
        end do
        do i=1,extractor_%elementCount(                   time)
           call extractor_%metaData(i,self%doubleProperty (doubleProperty +i)%metaData)
@@ -1053,7 +1064,7 @@ contains
           end do
           do i=1,extractor_%elementCount(elementTypeDouble,time)
              if (allocated(self%doubleProperty(doubleProperty+i)%rank1Descriptors)) deallocate(self%doubleProperty(doubleProperty+i)%rank1Descriptors)
-             call extractor_%columnDescriptions(elementTypeDouble,i,time,self%doubleProperty(doubleProperty+i)%rank1Descriptors)
+             call extractor_%columnDescriptions(elementTypeDouble,i,time,self%doubleProperty(doubleProperty+i)%rank1Descriptors,self%doubleProperty(doubleProperty+i)%rank1DescriptorValues,self%doubleProperty(doubleProperty+i)%rank1DescriptorComment,self%doubleProperty(doubleProperty+i)%rank1DescriptorUnitsInSI)
           end do
           doubleProperty =doubleProperty +extractor_%elementCount(elementTypeDouble ,time)
           deallocate(namesTmp       )

--- a/source/nodes.property_extractor.SED.F90
+++ b/source/nodes.property_extractor.SED.F90
@@ -412,7 +412,7 @@ contains
 
   function sedWavelengths(self,time)
     !!{
-    Return column descriptions of the {\normalfont \ttfamily sed} property.
+    Return wavelengths at which the SED is tabulated.
     !!}
     use :: Error, only : Error_Report
     implicit none
@@ -461,25 +461,31 @@ contains
     return
   end function sedWavelengths
 
-  subroutine sedColumnDescriptions(self,descriptions,time)
+  subroutine sedColumnDescriptions(self,descriptions,values,valuesDescription,valuesUnitsInSI,time)
     !!{
     Return column descriptions of the {\normalfont \ttfamily sed} property.
     !!}
+    use :: Numerical_Constants_Units, only : angstromsPerMeter
     implicit none
     class           (nodePropertyExtractorSED), intent(inout)                            :: self
     double precision                          , intent(in   ), optional                  :: time
     type            (varying_string          ), intent(inout), dimension(:), allocatable :: descriptions
+    double precision                          , intent(inout), dimension(:), allocatable :: values 
+    type            (varying_string          ), intent(  out)                            :: valuesDescription
+    double precision                          , intent(  out)                            :: valuesUnitsInSI
     double precision                          , dimension(:) , allocatable               :: wavelengths
     integer         (c_size_t                )                                           :: i
     character       (len=18                  )                                           :: label
     
     allocate(descriptions(self%size(time)))
-    allocate(wavelengths (self%size(time)))
-    wavelengths=self%wavelengths(time)
+    allocate(values      (self%size(time)))
+    values=self%wavelengths(time)
     do i=1,size(descriptions)      
-       write (label,'(a2,1x,e12.6,1x,a1)') "λ=",wavelengths(i),"Å"
+       write (label,'(a2,1x,e12.6,1x,a1)') "λ=",values(i),"Å"
        descriptions(i)=trim(label)
     end do
+    valuesDescription=var_str('Wavelengths at which the SED is tabulated [in units of Å].')
+    valuesUnitsInSI  =1.0d0/angstromsPerMeter
     return
   end subroutine sedColumnDescriptions
 

--- a/source/nodes.property_extractor.array.F90
+++ b/source/nodes.property_extractor.array.F90
@@ -42,7 +42,7 @@
        <method method="metaData"           description="Populate a hash with meta-data for the property."                   />
      </methods>
      !!]
-     procedure(arrayDescriptions), deferred :: columnDescriptions
+     procedure(arrayColumns     ), deferred :: columnDescriptions
      procedure(arraySize        ), deferred :: size
      procedure(arrayElementCount), deferred :: elementCount
      procedure(arrayExtract     ), deferred :: extract
@@ -88,6 +88,21 @@
        double precision                            , intent(in   ), optional                  :: time
        type            (varying_string            ), intent(inout), allocatable, dimension(:) :: descriptions
     end subroutine arrayDescriptions
+  end interface
+
+  abstract interface
+     subroutine arrayColumns(self,descriptions,values,valuesDescription,valuesUnitsInSI,time)
+       !!{
+       Interface for array column descriptions.
+       !!}
+       import varying_string, nodePropertyExtractorArray
+       class           (nodePropertyExtractorArray), intent(inout)                            :: self
+       double precision                            , intent(in   ), optional                  :: time
+       type            (varying_string            ), intent(inout), allocatable, dimension(:) :: descriptions
+       double precision                            , intent(inout), allocatable, dimension(:) :: values
+       type            (varying_string            ), intent(  out)                            :: valuesDescription
+       double precision                            , intent(  out)                            :: valuesUnitsInSI
+     end subroutine arrayColumns
   end interface
 
   abstract interface

--- a/source/nodes.property_extractor.density.F90
+++ b/source/nodes.property_extractor.density.F90
@@ -293,18 +293,24 @@ contains
     return
   end subroutine densityProfileDescriptions
 
-  subroutine densityProfileColumnDescriptions(self,descriptions,time)
+  subroutine densityProfileColumnDescriptions(self,descriptions,values,valuesDescription,valuesUnitsInSI,time)
     !!{
     Return column descriptions of the {\normalfont \ttfamily densityProfile} property.
     !!}
     implicit none
-    class           (nodePropertyExtractorDensityProfile), intent(inout)                             :: self
-    double precision                                     , intent(in   ), optional                   :: time
-    type            (varying_string                     ), intent(inout), dimension(:) , allocatable :: descriptions
+    class           (nodePropertyExtractorDensityProfile), intent(inout)                            :: self
+    double precision                                     , intent(in   ), optional                  :: time
+    type            (varying_string                     ), intent(inout), dimension(:), allocatable :: descriptions
+    double precision                                     , intent(inout), dimension(:), allocatable :: values 
+    type            (varying_string                     ), intent(  out)                            :: valuesDescription
+    double precision                                     , intent(  out)                            :: valuesUnitsInSI
     !$GLC attributes unused :: time
 
     allocate(descriptions(self%radiiCount))
-    descriptions=self%radii%name
+    allocate(values      (              0))
+    valuesDescription=var_str('')
+    valuesUnitsInSI  =0.0d0
+    descriptions     =self%radii%name
     return
   end subroutine densityProfileColumnDescriptions
 

--- a/source/nodes.property_extractor.density_contrasts.F90
+++ b/source/nodes.property_extractor.density_contrasts.F90
@@ -312,8 +312,8 @@ contains
     !$GLC attributes unused :: time
 
     allocate(descriptions(self%elementCount_))
-       descriptions(1)='Radius enclosing a given density contrast [Mpc].'
-       descriptions(2)='Mass within a given density contrast [M☉].'
+    descriptions(1)='Radius enclosing a given density contrast [Mpc].'
+    descriptions(2)='Mass within a given density contrast [M☉].'
     return
   end subroutine densityContrastsDescriptions
 
@@ -325,10 +325,10 @@ contains
     class           (nodePropertyExtractorDensityContrasts), intent(inout)                            :: self
     double precision                                       , intent(in   ), optional                  :: time
     type            (varying_string                       ), intent(inout), dimension(:), allocatable :: descriptions
+    double precision                                       , intent(inout), dimension(:), allocatable :: values
     type            (varying_string                       ), intent(  out)                            :: valuesDescription
     double precision                                       , intent(  out)                            :: valuesUnitsInSI
     character       (len=32                               )                                           :: label
-    double precision                                       , intent(inout), dimension(:), allocatable :: values
     integer         (c_size_t                             )                                           :: i
     !$GLC attributes unused :: time
 

--- a/source/nodes.property_extractor.density_contrasts.F90
+++ b/source/nodes.property_extractor.density_contrasts.F90
@@ -317,23 +317,29 @@ contains
     return
   end subroutine densityContrastsDescriptions
 
-  subroutine densityContrastsColumnDescriptions(self,descriptions,time)
+  subroutine densityContrastsColumnDescriptions(self,descriptions,values,valuesDescription,valuesUnitsInSI,time)
     !!{
     Return column descriptions of the {\normalfont \ttfamily densityContrasts} property.
     !!}
     implicit none
-    class           (nodePropertyExtractorDensityContrasts), intent(inout)                             :: self
-    double precision                                       , intent(in   ), optional                   :: time
-    type            (varying_string                       ), intent(inout), dimension(:) , allocatable :: descriptions
-    character       (len=32                               )                                            :: label
-    integer         (c_size_t                             )                                            :: i
+    class           (nodePropertyExtractorDensityContrasts), intent(inout)                            :: self
+    double precision                                       , intent(in   ), optional                  :: time
+    type            (varying_string                       ), intent(inout), dimension(:), allocatable :: descriptions
+    type            (varying_string                       ), intent(  out)                            :: valuesDescription
+    double precision                                       , intent(  out)                            :: valuesUnitsInSI
+    character       (len=32                               )                                           :: label
+    double precision                                       , intent(inout), dimension(:), allocatable :: values
+    integer         (c_size_t                             )                                           :: i
     !$GLC attributes unused :: time
 
     allocate(descriptions(self%countDensityContrasts))
+    allocate(values      (                         0))
     do i=1,self%countDensityContrasts
        write (label,'(a2,f9.4)') 'Δ=',self%densityContrasts(i)
        descriptions(i)=trim(label)
     end do
+    valuesDescription=var_str('')
+    valuesUnitsInSI  =0.0d0
     return
   end subroutine densityContrastsColumnDescriptions
 

--- a/source/nodes.property_extractor.mass_profile.F90
+++ b/source/nodes.property_extractor.mass_profile.F90
@@ -288,18 +288,24 @@ contains
     return
   end subroutine massProfileDescriptions
 
-  subroutine massProfileColumnDescriptions(self,descriptions,time)
+  subroutine massProfileColumnDescriptions(self,descriptions,values,valuesDescription,valuesUnitsInSI,time)
     !!{
     Return column descriptions of the {\normalfont \ttfamily massProfile} property.
     !!}
     implicit none
-    class           (nodePropertyExtractorMassProfile), intent(inout)                             :: self
-    double precision                                  , intent(in   ), optional                   :: time
-    type            (varying_string                  ), intent(inout), dimension(:) , allocatable :: descriptions
+    class           (nodePropertyExtractorMassProfile), intent(inout)                            :: self
+    double precision                                  , intent(in   ), optional                  :: time
+    type            (varying_string                  ), intent(inout), dimension(:), allocatable :: descriptions
+    double precision                                  , intent(inout), dimension(:), allocatable :: values 
+    type            (varying_string                  ), intent(  out)                            :: valuesDescription
+    double precision                                  , intent(  out)                            :: valuesUnitsInSI
     !$GLC attributes unused :: time
 
     allocate(descriptions(self%radiiCount))
-    descriptions=self%radii%name
+    allocate(values      (              0))
+    valuesDescription=var_str('')
+    valuesUnitsInSI  =0.0d0
+    descriptions     =self%radii%name
     return
   end subroutine massProfileColumnDescriptions
 

--- a/source/nodes.property_extractor.multi.F90
+++ b/source/nodes.property_extractor.multi.F90
@@ -400,7 +400,7 @@ contains
     return
   end subroutine multiNames
 
-  subroutine multiColumnDescriptions(self,elementType,i,time,descriptions)
+  subroutine multiColumnDescriptions(self,elementType,i,time,descriptions,values,valuesDescription,valuesUnitsInSI)
     !!{
     Return column descriptions of the multiple properties.
     !!}
@@ -411,8 +411,11 @@ contains
     integer                                     , intent(in   )                             :: i
     double precision                            , intent(in   )                             :: time
     type            (varying_string            ), intent(  out), dimension(:) , allocatable :: descriptions
+    double precision                            , intent(  out), dimension(:) , allocatable :: values
+    type            (varying_string            ), intent(  out)                             :: valuesDescription
+    double precision                            , intent(  out)                             :: valuesUnitsInSI
     type            (multiExtractorList        ), pointer                                   :: extractor_
-    integer                                                                                 :: elementCount, offset
+    integer                                                                                 :: elementCount     , offset
 
     offset     =  0
     extractor_ => self%extractors
@@ -455,7 +458,7 @@ contains
           if (elementType == elementTypeDouble ) then
              elementCount=extractor_%elementCount(time)
              if (offset+elementCount >= i) then
-                call extractor_%columnDescriptions(descriptions,time)
+                call extractor_%columnDescriptions(descriptions,values,valuesDescription,valuesUnitsInSI,time)
                 return
              end if
           end if

--- a/source/nodes.property_extractor.projected_density.F90
+++ b/source/nodes.property_extractor.projected_density.F90
@@ -373,18 +373,24 @@ contains
     return
   end subroutine projectedDensityDescriptions
 
-  subroutine projectedDensityColumnDescriptions(self,descriptions,time)
+  subroutine projectedDensityColumnDescriptions(self,descriptions,values,valuesDescription,valuesUnitsInSI,time)
     !!{
     Return column descriptions of the {\normalfont \ttfamily projectedDensity} property.
     !!}
     implicit none
-    class           (nodePropertyExtractorProjectedDensity), intent(inout)                             :: self
-    double precision                                       , intent(in   ), optional                   :: time
-    type            (varying_string                       ), intent(inout), dimension(:) , allocatable :: descriptions
+    class           (nodePropertyExtractorProjectedDensity), intent(inout)                            :: self
+    double precision                                       , intent(in   ), optional                  :: time
+    type            (varying_string                       ), intent(inout), dimension(:), allocatable :: descriptions
+    double precision                                       , intent(inout), dimension(:), allocatable :: values
+    type            (varying_string                         ), intent(  out)                            :: valuesDescription
+    double precision                                         , intent(  out)                            :: valuesUnitsInSI
     !$GLC attributes unused :: time
 
     allocate(descriptions(self%radiiCount))
-    descriptions=self%radii%name
+    allocate(values      (              0))
+    valuesDescription=var_str('')
+    valuesUnitsInSI  =0.0d0
+    descriptions     =self%radii%name
     return
   end subroutine projectedDensityColumnDescriptions
 

--- a/source/nodes.property_extractor.projected_mass.F90
+++ b/source/nodes.property_extractor.projected_mass.F90
@@ -361,18 +361,25 @@ contains
     return
   end subroutine projectedMassDescriptions
 
-  subroutine projectedMassColumnDescriptions(self,descriptions,time)
+  subroutine projectedMassColumnDescriptions(self,descriptions,values,valuesDescription,valuesUnitsInSI,time)
     !!{
     Return column descriptions of the {\normalfont \ttfamily projectedMass} property.
     !!}
     implicit none
-    class           (nodePropertyExtractorProjectedMass), intent(inout)                             :: self
-    double precision                                    , intent(in   ), optional                   :: time
-    type            (varying_string                    ), intent(inout), dimension(:) , allocatable :: descriptions
+    class           (nodePropertyExtractorProjectedMass), intent(inout)                            :: self
+    double precision                                    , intent(in   ), optional                  :: time
+    type            (varying_string                    ), intent(inout), dimension(:), allocatable :: descriptions
+    double precision                                    , intent(inout), dimension(:), allocatable :: values
+    type            (varying_string                    ), intent(  out)                            :: valuesDescription
+    double precision                                    , intent(  out)                            :: valuesUnitsInSI
+
     !$GLC attributes unused :: time
 
     allocate(descriptions(self%radiiCount))
-    descriptions=self%radii%name
+    allocate(values      (              0))
+    valuesDescription=var_str('')
+    valuesUnitsInSI  =0.0d0
+    descriptions     =self%radii%name
     return
   end subroutine projectedMassColumnDescriptions
 

--- a/source/nodes.property_extractor.rotation_curve.F90
+++ b/source/nodes.property_extractor.rotation_curve.F90
@@ -295,18 +295,24 @@ contains
     return
   end subroutine rotationCurveDescriptions
 
-  subroutine rotationCurveColumnDescriptions(self,descriptions,time)
+  subroutine rotationCurveColumnDescriptions(self,descriptions,values,valuesDescription,valuesUnitsInSI,time)
     !!{
     Return column descriptions of the {\normalfont \ttfamily rotationCurve} property.
     !!}
     implicit none
-    class           (nodePropertyExtractorRotationCurve), intent(inout)                             :: self
-    double precision                                    , intent(in   ), optional                   :: time
-    type            (varying_string                    ), intent(inout), dimension(:) , allocatable :: descriptions
+    class           (nodePropertyExtractorRotationCurve), intent(inout)                            :: self
+    double precision                                    , intent(in   ), optional                  :: time
+    type            (varying_string                    ), intent(inout), dimension(:), allocatable :: descriptions
+    double precision                                    , intent(inout), dimension(:), allocatable :: values
+    type            (varying_string                    ), intent(  out)                            :: valuesDescription
+    double precision                                    , intent(  out)                            :: valuesUnitsInSI
     !$GLC attributes unused :: time
 
     allocate(descriptions(self%radiiCount))
-    descriptions=self%radii%name
+    allocate(values      (              0))
+    valuesDescription=var_str('')
+    valuesUnitsInSI  =0.0d0
+    descriptions     =self%radii%name
     return
   end subroutine rotationCurveColumnDescriptions
 

--- a/source/nodes.property_extractor.velocity_dispersion.F90
+++ b/source/nodes.property_extractor.velocity_dispersion.F90
@@ -434,18 +434,24 @@ contains
     return
   end subroutine velocityDispersionDescriptions
 
-  subroutine velocityDispersionColumnDescriptions(self,descriptions,time)
+  subroutine velocityDispersionColumnDescriptions(self,descriptions,values,valuesDescription,valuesUnitsInSI,time)
     !!{
     Return column descriptions of the {\normalfont \ttfamily velocityDispersion} property.
     !!}
     implicit none
-    class           (nodePropertyExtractorVelocityDispersion), intent(inout)                             :: self
-    double precision                                         , intent(in   ), optional                   :: time
-    type            (varying_string                         ), intent(inout), dimension(:) , allocatable :: descriptions
+    class           (nodePropertyExtractorVelocityDispersion), intent(inout)                            :: self
+    double precision                                         , intent(in   ), optional                  :: time
+    type            (varying_string                         ), intent(inout), dimension(:), allocatable :: descriptions
+    double precision                                         , intent(inout), dimension(:), allocatable :: values
+    type            (varying_string                         ), intent(  out)                            :: valuesDescription
+    double precision                                         , intent(  out)                            :: valuesUnitsInSI
     !$GLC attributes unused :: time
 
     allocate(descriptions(self%radiiCount))
-    descriptions=self%radii%name
+    allocate(values      (              0))
+    valuesDescription=var_str('')
+    valuesUnitsInSI  =0.0d0
+    descriptions     =self%radii%name
     return
   end subroutine velocityDispersionColumnDescriptions
 


### PR DESCRIPTION
These can also be provided with a description and units information. The `mergerTreeOperatorStandard` class supports this new functionality and will output these numerical column values if they are provided.