### PR TITLE
Add labeling of progenitor halo origins when using the `singleStep` build controller

### DIFF
--- a/source/merger_trees.build.controller.F90
+++ b/source/merger_trees.build.controller.F90
@@ -89,8 +89,9 @@ module Merger_Tree_Build_Controllers
     <description>Alert the controller when new nodes are inserted into the tree.</description>
     <type>void</type>
     <pass>yes</pass>
-    <argument>type(treeNode), intent(inout)           :: nodeCurrent    , nodeProgenitor1</argument>
-    <argument>type(treeNode), intent(inout), optional :: nodeProgenitor2</argument>
+    <argument>type   (treeNode), intent(inout)           :: nodeCurrent    , nodeProgenitor1</argument>
+    <argument>type   (treeNode), intent(inout), optional :: nodeProgenitor2                 </argument>
+    <argument>logical          , intent(in   ), optional :: didBranch                       </argument>
    </method>
   </functionClass>
   !!]

--- a/source/merger_trees.build.controller.branchless.F90
+++ b/source/merger_trees.build.controller.branchless.F90
@@ -135,15 +135,16 @@ contains
     return
   end function branchlessBranchingProbabilityObject
 
-  subroutine branchlessNodesInserted(self,nodeCurrent,nodeProgenitor1,nodeProgenitor2)
+  subroutine branchlessNodesInserted(self,nodeCurrent,nodeProgenitor1,nodeProgenitor2,didBranch)
     !!{
     Act on the insertion of nodes into the merger tree.
     !!}
     implicit none
-    class(mergerTreeBuildControllerBranchless), intent(inout)           :: self
-    type (treeNode                           ), intent(inout)           :: nodeCurrent    , nodeProgenitor1
-    type (treeNode                           ), intent(inout), optional :: nodeProgenitor2
-    !$GLC attributes unused :: self, nodeCurrent, nodeProgenitor1, nodeProgenitor2
+    class  (mergerTreeBuildControllerBranchless), intent(inout)           :: self
+    type   (treeNode                           ), intent(inout)           :: nodeCurrent    , nodeProgenitor1
+    type   (treeNode                           ), intent(inout), optional :: nodeProgenitor2
+    logical                                     , intent(in   ), optional :: didBranch
+    !$GLC attributes unused :: self, nodeCurrent, nodeProgenitor1, nodeProgenitor2, didBranch
 
     ! Nothing to do.
     return

--- a/source/merger_trees.build.controller.constrained.F90
+++ b/source/merger_trees.build.controller.constrained.F90
@@ -444,18 +444,20 @@ contains
     return
   end function constrainedBranchingProbabilityObject
 
-  subroutine constrainedNodesInserted(self,nodeCurrent,nodeProgenitor1,nodeProgenitor2)
+  subroutine constrainedNodesInserted(self,nodeCurrent,nodeProgenitor1,nodeProgenitor2,didBranch)
     !!{
     Act on the insertion of nodes into the merger tree.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic
     implicit none
-    class (mergerTreeBuildControllerConstrained), intent(inout)           :: self
-    type  (treeNode                            ), intent(inout)           :: nodeCurrent     , nodeProgenitor1
-    type  (treeNode                            ), intent(inout), optional :: nodeProgenitor2
-    class (nodeComponentBasic                  ), pointer                 :: basicCurrent    , basicProgenitor1, &
-         &                                                                   basicProgenitor2
-    logical                                                               :: isConstrained
+    class  (mergerTreeBuildControllerConstrained), intent(inout)           :: self
+    type   (treeNode                            ), intent(inout)           :: nodeCurrent     , nodeProgenitor1
+    type   (treeNode                            ), intent(inout), optional :: nodeProgenitor2
+    logical                                      , intent(in   ), optional :: didBranch
+    class  (nodeComponentBasic                  ), pointer                 :: basicCurrent    , basicProgenitor1, &
+         &                                                                    basicProgenitor2
+    logical                                                                :: isConstrained
+    !$GLC attributes unused :: didBranch
 
     basicCurrent     => nodeCurrent    %basic                      (                    )
     basicProgenitor1 => nodeProgenitor1%basic                      (                    )

--- a/source/merger_trees.build.controller.subsample.F90
+++ b/source/merger_trees.build.controller.subsample.F90
@@ -257,15 +257,16 @@ contains
     return
   end function subsampleBranchingProbabilityObject
 
-  subroutine subsampleNodesInserted(self,nodeCurrent,nodeProgenitor1,nodeProgenitor2)
+  subroutine subsampleNodesInserted(self,nodeCurrent,nodeProgenitor1,nodeProgenitor2,didBranch)
     !!{
     Act on the insertion of nodes into the merger tree.
     !!}
     implicit none
-    class(mergerTreeBuildControllerSubsample), intent(inout)           :: self
-    type (treeNode                          ), intent(inout)           :: nodeCurrent    , nodeProgenitor1
-    type (treeNode                          ), intent(inout), optional :: nodeProgenitor2
-    !$GLC attributes unused :: self, nodeCurrent, nodeProgenitor1, nodeProgenitor2
+    class  (mergerTreeBuildControllerSubsample), intent(inout)           :: self
+    type   (treeNode                          ), intent(inout)           :: nodeCurrent    , nodeProgenitor1
+    type   (treeNode                          ), intent(inout), optional :: nodeProgenitor2
+    logical                                    , intent(in   ), optional :: didBranch
+    !$GLC attributes unused :: self, nodeCurrent, nodeProgenitor1, nodeProgenitor2, didBranch
 
     ! Nothing to do.
     return

--- a/source/merger_trees.build.controller.uncontrolled.F90
+++ b/source/merger_trees.build.controller.uncontrolled.F90
@@ -126,15 +126,16 @@ contains
     return
   end function uncontrolledBranchingProbabilityObject
 
-  subroutine uncontrolledNodesInserted(self,nodeCurrent,nodeProgenitor1,nodeProgenitor2)
+  subroutine uncontrolledNodesInserted(self,nodeCurrent,nodeProgenitor1,nodeProgenitor2,didBranch)
     !!{
     Act on the insertion of nodes into the merger tree.
     !!}
     implicit none
-    class(mergerTreeBuildControllerUncontrolled), intent(inout)           :: self
-    type (treeNode                             ), intent(inout)           :: nodeCurrent     , nodeProgenitor1
-    type (treeNode                             ), intent(inout), optional :: nodeProgenitor2
-    !$GLC attributes unused :: self, nodeCurrent, nodeProgenitor1, nodeProgenitor2
+    class  (mergerTreeBuildControllerUncontrolled), intent(inout)           :: self
+    type   (treeNode                             ), intent(inout)           :: nodeCurrent     , nodeProgenitor1
+    type   (treeNode                             ), intent(inout), optional :: nodeProgenitor2
+    logical                                       , intent(in   ), optional :: didBranch
+    !$GLC attributes unused :: self, nodeCurrent, nodeProgenitor1, nodeProgenitor2, didBranch
 
     ! Nothing to do.
     return

--- a/source/merger_trees.construct.builder.Cole2000.F90
+++ b/source/merger_trees.construct.builder.Cole2000.F90
@@ -570,6 +570,8 @@ contains
                 ! Compute the critical overdensity corresponding to this new node.
                 deltaCritical1=self_%criticalOverdensityUpdate(branchDeltaCriticalCurrent,branchMassCurrent,nodeMass1,nodeNew1)
                 call basicNew1%timeSet(deltaCritical1)
+                ! Inform the build controller of this new node.
+                call self_%workers(numberWorker)%mergerTreeBuildController_%nodesInserted(nodeCurrent,nodeNew1)
                 ! Create links from old to new node and vice-versa.
                 nodeCurrent%firstChild => nodeNew1
                 nodeNew1%parent => nodeCurrent
@@ -613,6 +615,8 @@ contains
                 ! Set properties of the new node.
                 call basicNew1%massSet(nodeMass1     )
                 call basicNew1%timeSet(deltaCritical1)
+                ! Inform the build controller of this new node.
+                call self_%workers(numberWorker)%mergerTreeBuildController_%nodesInserted(nodeCurrent,nodeNew1)
                 ! Create links from old to new node and vice-versa.
                 nodeCurrent%firstChild => nodeNew1
                 nodeNew1   %parent     => nodeCurrent
@@ -797,7 +801,7 @@ contains
                       call basicNew2%massSet(nodeMass2     )
                       call basicNew2%timeSet(deltaCritical2)
                       ! Inform the build controller of these new nodes.
-                      call self_%workers(numberWorker)%mergerTreeBuildController_%nodesInserted(nodeCurrent,nodeNew1,nodeNew2)
+                      call self_%workers(numberWorker)%mergerTreeBuildController_%nodesInserted(nodeCurrent,nodeNew1,nodeNew2,didBranch=.true.)
                       ! Create links from old to new nodes and vice-versa. (Ensure that the first child node is the more massive progenitor.)
                       if (nodeMass2 > nodeMass1) then
                          nodeCurrent%firstChild => nodeNew2
@@ -813,7 +817,7 @@ contains
                    else
                       ! Second branch would be subresolution - do not create it.
                       ! Inform the build controller of the new node.
-                      call self_%workers(numberWorker)%mergerTreeBuildController_%nodesInserted(nodeCurrent,nodeNew1)
+                      call self_%workers(numberWorker)%mergerTreeBuildController_%nodesInserted(nodeCurrent,nodeNew1         ,didBranch=.true.)
                       ! Create links from old to new nodes and vice-versa.
                       nodeCurrent   %firstChild => nodeNew1
                       nodeNew1      %sibling    => null()


### PR DESCRIPTION
Halos are labeled as `primary` (sampled directly from the progenitor mass function), `secondary` (inserted to ensure mass conservation in a binary split), or `smooth` (resulting from smooth accretion, i.e. no branching).