### PR TITLE
Generate custom equality operator for each enumeration

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Process/Enumeration.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/Enumeration.pm
@@ -37,6 +37,9 @@ sub Process_Enumerations {
 	    my $i                 = $indexing-1;
 	    $enumerationSource .= "  ! Auto-generated enumeration\n";
 	    $enumerationSource .= "  type, extends(enumerationType) :: enumeration".$node->{'directive'}->{'name'}."Type\n";
+	    $enumerationSource .= "  contains\n";
+	    $enumerationSource .= "    procedure ::                  enumeration".$node->{'directive'}->{'name'}."IsEqual\n";
+	    $enumerationSource .= "    generic   :: operator(==) =>  enumeration".$node->{'directive'}->{'name'}."IsEqual\n";
 	    $enumerationSource .= "  end type enumeration".$node->{'directive'}->{'name'}."Type\n";
 	    $enumerationSource .= "  type(enumeration".$node->{'directive'}->{'name'}."Type), parameter, ".$visibility." :: ".$node->{'directive'}->{'name'}.ucfirst($_->{'label'})."=enumeration".$node->{'directive'}->{'name'}."Type(".++$i.")\n"
 		foreach ( &List::ExtraUtils::as_array($node->{'directive'}->{'entry'}) );
@@ -65,6 +68,25 @@ sub Process_Enumerations {
 	    my $enumerationTree = &Galacticus::Build::SourceTree::ParseCode($enumerationSource,"Galacticus::Build::SourceTree::Process::Enumeration()");
 	    my @enumerationNodes = &Galacticus::Build::SourceTree::Children($enumerationTree);
 	    &Galacticus::Build::SourceTree::InsertAfterNode($node,\@enumerationNodes);
+	    # Construct equality operator.
+	    my $functionName = "enumeration".ucfirst($node->{'directive'}->{'name'})."IsEqual";
+	    my $equalityFunction;
+	    $equalityFunction .= "\n";
+	    $equalityFunction .= "  ! Auto-generated enumeration function\n";
+	    $equalityFunction .= "  pure elemental logical function ".$functionName."(enumerationA,enumerationB) result(isEqual)\n";
+	    $equalityFunction .= "    !!{\n";
+	    $equalityFunction .= "    Validate a {\\normalfont \\ttfamily ".$node->{'directive'}->{'name'}."} enumeration value.\n";
+	    $equalityFunction .= "    !!}\n";
+	    $equalityFunction .= "    implicit none\n\n";
+	    $equalityFunction .= "    class(enumeration".$node->{'directive'}->{'name'}."Type), intent(in   ) :: enumerationA, enumerationB\n";
+	    $equalityFunction .= "    isEqual=enumerationA%ID == enumerationB%ID\n";
+	    $equalityFunction .= "    return\n";
+	    $equalityFunction .= "  end function ".$functionName."\n";
+	    $equalityFunction .= "  ! End auto-generated enumeration function\n";
+	    # Insert into the module.
+	    my $equalityTree = &Galacticus::Build::SourceTree::ParseCode($equalityFunction,"Galacticus::Build::SourceTree::Process::Enumeration()");
+	    my @equalityNodes = &Galacticus::Build::SourceTree::Children($equalityTree);
+	    &Galacticus::Build::SourceTree::InsertPostContains($node->{'parent'},\@equalityNodes);
 	    # Construct validator function as necessary.
 	    if ( $validator eq "yes" ) {
 		# Generate function code.

--- a/perl/Galacticus/Build/SourceTree/Process/Enumeration.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/Enumeration.pm
@@ -38,6 +38,11 @@ sub Process_Enumerations {
 	    $enumerationSource .= "  ! Auto-generated enumeration\n";
 	    $enumerationSource .= "  type, extends(enumerationType) :: enumeration".$node->{'directive'}->{'name'}."Type\n";
 	    $enumerationSource .= "  contains\n";
+	    $enumerationSource .= "    !![\n";
+	    $enumerationSource .= "    <methods>\n";
+	    $enumerationSource .= "      <method method=\"operator(==)\" description=\"Test the equality of two members of the enumeration.\"/>\n";
+	    $enumerationSource .= "    </methods>\n";
+	    $enumerationSource .= "    !!]\n";
 	    $enumerationSource .= "    procedure ::                  enumeration".$node->{'directive'}->{'name'}."IsEqual\n";
 	    $enumerationSource .= "    generic   :: operator(==) =>  enumeration".$node->{'directive'}->{'name'}."IsEqual\n";
 	    $enumerationSource .= "  end type enumeration".$node->{'directive'}->{'name'}."Type\n";

--- a/source/objects.enumeration.F90
+++ b/source/objects.enumeration.F90
@@ -37,7 +37,6 @@ module Enumerations
    contains
      !![
      <methods>
-       <method description="Test if two enumeration entries are equal."                   method="operator(==)"  />
        <method description="Test if two enumeration entries are not equal."               method="operator(/=)"  />
        <method description="Test if one enumeration is less than another."                method="operator(&lt;)" />
        <method description="Test if one enumeration is less or equal tothan another."     method="operator(&lt;=)"/>

--- a/source/objects.enumeration.F90
+++ b/source/objects.enumeration.F90
@@ -46,14 +46,12 @@ module Enumerations
        <method description="Subtract an integer from an enumeration member."              method="subtract"       />
      </methods>
      !!]
-     procedure ::                 enumerationIsEqual
      procedure ::                 enumerationIsNotEqual
      procedure ::                 enumerationLessThan
      procedure ::                 enumerationLessThanOrEqual
      procedure ::                 enumerationGreaterThan
      procedure ::                 enumerationGreaterThanOrEqual
      procedure ::                 enumerationSubtractionInteger
-     generic   :: operator(==) => enumerationIsEqual
      generic   :: operator(/=) => enumerationIsNotEqual
      generic   :: operator(< ) => enumerationLessThan
      generic   :: operator(<=) => enumerationLessThanOrEqual
@@ -63,21 +61,6 @@ module Enumerations
   end type enumerationType
 
 contains
-
-  elemental logical function enumerationIsEqual(enumerationA,enumerationB)
-    !!{
-    Return true if {\normalfont \ttfamily enumerationA} is equal to {\normalfont \ttfamily enumerationB}.
-    !!}
-    implicit none
-    class(enumerationType), intent(in   ) :: enumerationA, enumerationB
-
-    if (.not.same_type_as(enumerationA,enumerationB)) then
-       enumerationIsEqual=.false.
-    else
-       enumerationIsEqual=enumerationA%ID == enumerationB%ID
-    end if
-    return
-  end function enumerationIsEqual
 
   elemental logical function enumerationIsNotEqual(enumerationA,enumerationB)
     !!{


### PR DESCRIPTION
This avoids the need for any `same_type_as()` function - it makes no sense to test equality of different enumerations anyway, so this gives some modest speed up.