### PR TITLE
Fix nBody operator

### DIFF
--- a/source/nBody.operator.potential_energy.F90
+++ b/source/nBody.operator.potential_energy.F90
@@ -193,6 +193,7 @@ contains
              ! Build octree.
              call octreePosition%build(positionRescaled,dble(selfBoundStatus(:,i)))
              !$omp parallel private(j)
+             !$omp do schedule(dynamic)
              do j=1,particleCount
                 if (selfBoundStatus(j,i) > 0 ) then
                    call octreePosition%traverseCompute(positionRescaled(:,j),dble(selfBoundStatus(j,i)),self%thetaTolerance,potentialEnergy(j,i),potentialEnergyPotential)
@@ -205,6 +206,7 @@ contains
                         &               /(dble(particleCount-1_c_size_t)-self%bootstrapSampleRate)
                 end if
              end do
+             !$omp end do
              !$omp end parallel
              ! Destroy the octree.
              call octreePosition%destroy()

--- a/source/nBody.operator.self_bound.Barnes_Hut.F90
+++ b/source/nBody.operator.self_bound.Barnes_Hut.F90
@@ -116,7 +116,8 @@ contains
     double precision                                 , pointer      , dimension(:,:) :: position                      , velocity              , &
          &                                                                              sampleWeight                  , sampleWeightPrevious
     integer         (c_size_t                       ), pointer      , dimension(:  ) :: particleIDs                   , particleIDsPrevious
-    double precision                                 , allocatable  , dimension(:,:) :: positionOffset                , positionRescaled
+    double precision                                 , allocatable  , dimension(:,:) :: positionOffset                , positionRescaled      , &
+         &                                                                              velocityRescaled
     double precision                                 , allocatable  , dimension(:,:) :: energyPotential               , velocityPotential     , &
          &                                                                              energyKinetic                 , sampleWeightActual
     double precision                                 , allocatable  , dimension(:,:) :: velocityCenterOfMass
@@ -131,8 +132,9 @@ contains
     logical                                          , allocatable  , dimension(:  ) :: isConverged
     integer         (c_size_t                       )                                :: representativeParticleCount
     integer                                                                          :: countIteration
-    double precision                                                                 :: lengthSoftening               , massParticle          , &
-         &                                                                              convergenceFactor             , weightRepresentative
+    double precision                                                                 :: lengthSoftening               , velocitySoftening     , &
+         &                                                                              massParticle                  , convergenceFactor     , &
+         &                                                                              weightRepresentative
     type            (varying_string                 )                                :: message
     character       (len=12                         )                                :: label
 
@@ -159,8 +161,9 @@ contains
        call Error_Report('either 1 or 2 simulations (labelled "active" and "previous" in the case of 2 simulations) should be provided'//{introspection:location})
     end if
     ! Get simulation attributes.
-    lengthSoftening=simulations(current)%attributesReal%value('lengthSoftening')
-    massParticle   =simulations(current)%attributesReal%value('massParticle'   )
+    lengthSoftening  =simulations(current)%attributesReal%value('lengthSoftening')
+    massParticle     =simulations(current)%attributesReal%value('massParticle'   )
+    velocitySoftening=sqrt(gravitationalConstantGalacticus*massParticle/lengthSoftening)
     ! Get particle data.
     position    => simulations(current)%propertiesRealRank1%value('position'  )
     velocity    => simulations(current)%propertiesRealRank1%value('velocity'  )
@@ -178,6 +181,7 @@ contains
     allocate(velocityCenterOfMass  (3_c_size_t              ,self%bootstrapSampleCount))
     allocate(positionOffset        (3_c_size_t,particleCount                          ))
     allocate(positionRescaled      (3_c_size_t,particleCount                          ))
+    allocate(velocityRescaled      (3_c_size_t,particleCount                          ))
     allocate(boundStatus           (           particleCount,self%bootstrapSampleCount))
     allocate(indexSorted           (           particleCount                          ))
     allocate(countBound            (                         self%bootstrapSampleCount))
@@ -228,6 +232,7 @@ contains
     isConverged = .false.
     ! Rescale the particle coordinates by the softening length.
     positionRescaled=position/lengthSoftening
+    velocityRescaled=velocity/velocitySoftening
     call displayIndent('Performing self-bound analysis on bootstrap samples')
     do iSample=1,self%bootstrapSampleCount
        ! Initialize count of bound particles.
@@ -263,7 +268,7 @@ contains
        ! Build octrees.
        call displayIndent('build octrees')
        call octreePosition%build(positionRescaled,sampleWeightActual(:,iSample))
-       call octreeVelocity%build(velocity        ,sampleWeightActual(:,iSample))
+       call octreeVelocity%build(velocityRescaled,sampleWeightActual(:,iSample))
        call displayUnindent('done')
        ! Begin iterations.
        countIteration=0
@@ -275,7 +280,7 @@ contains
              ! Skip particles we do not need to analyze.
              if (.not.isBound(i,iSample)) cycle
              call octreePosition%traverseCompute(positionRescaled(:,i),sampleWeightActual(i,iSample),self%thetaTolerance,energyPotential  (i,iSample),selfBoundBarnesHutPotential)
-             call octreeVelocity%traverseCompute(velocity        (:,i),sampleWeightActual(i,iSample),self%thetaTolerance,velocityPotential(i,iSample),selfBoundBarnesHutPotential)
+             call octreeVelocity%traverseCompute(velocityRescaled(:,i),sampleWeightActual(i,iSample),self%thetaTolerance,velocityPotential(i,iSample),selfBoundBarnesHutPotential)
           end do
           !$omp end do
           !$omp workshare
@@ -363,7 +368,7 @@ contains
              do i=1,particleCount
                 if (isRemoved(i,iSample)) then
                    call octreePosition%removeParticle(positionRescaled(:,i),sampleWeight(i,iSample))
-                   call octreeVelocity%removeParticle(velocity        (:,i),sampleWeight(i,iSample))
+                   call octreeVelocity%removeParticle(velocityRescaled(:,i),sampleWeight(i,iSample))
                 end if
              end do
              ! Update bound status.
@@ -426,6 +431,7 @@ contains
     nullify   (indexVelocityMostBound )
     deallocate(positionOffset         )
     deallocate(positionRescaled       )
+    deallocate(velocityRescaled       )
     deallocate(countBound             )
     deallocate(countBoundPrevious     )
     deallocate(weightBound            )

--- a/source/nBody.operator.self_bound.F90
+++ b/source/nBody.operator.self_bound.F90
@@ -194,8 +194,9 @@ contains
     logical                                 , allocatable  , dimension(:  )          :: isConverged
     integer         (c_size_t              )                                         :: representativeParticleCount
     integer                                                                          :: addSubtract                   , countIteration
-    double precision                                                                 :: lengthSoftening               , massParticle          , &
-         &                                                                              convergenceFactor             , weightRepresentative
+    double precision                                                                 :: lengthSoftening               , velocitySoftening     , &
+         &                                                                              massParticle                  , convergenceFactor     , &
+         &                                                                              weightRepresentative
     type            (varying_string        )                                         :: message
     character       (len=12                )                                         :: label
 
@@ -222,8 +223,9 @@ contains
        call Error_Report('either 1 or 2 simulations (labelled "active" and "previous" in the case of 2 simulations) should be provided'//{introspection:location})
     end if
     ! Get simulation attributes.
-    lengthSoftening=simulations(current)%attributesReal%value('lengthSoftening')
-    massParticle   =simulations(current)%attributesReal%value('massParticle'   )
+    lengthSoftening  =simulations(current)%attributesReal%value('lengthSoftening')
+    massParticle     =simulations(current)%attributesReal%value('massParticle'   )
+    velocitySoftening=sqrt(gravitationalConstantGalacticus*massParticle/lengthSoftening)
     ! Get particle data.
     position    => simulations(current)%propertiesRealRank1%value('position'  )
     velocity    => simulations(current)%propertiesRealRank1%value('velocity'  )
@@ -369,7 +371,8 @@ contains
              end where
           end forall
           where(computeActual(i+1:particleCount))
-             separationSquared(i+1:particleCount)=+sum (positionRelative (:,i+1:particleCount)**2,dim=1)
+             separationSquared(i+1:particleCount)=+sum (positionRelative (:,i+1:particleCount)**2,dim=1) &
+                  &                               /velocitySoftening**2
              separation       (i+1:particleCount)=+sqrt(separationSquared(  i+1:particleCount)         )
              ! Compute potentials.
              potential        (i+1:particleCount)=+selfBoundPotential(                                      &


### PR DESCRIPTION
Fix two issues:
1. When doing self-bound analysis, the most-bound particle in velocity space is found by searching for the minimum of potential in velocity space (similar to the calculation of gravitational potential in position space). In the current version of Galacticus, the softening velocity (similar to the definition of softening length) is fixed at 1 km/s by default. But this default value may be too large for small halos with typical particle velocity smaller than 1km/s. Instead, we can define a softening velocity as
$v_{\rm softening} = \sqrt{G m_p/r_{\rm softening}},$
where $m_p$ is the particle mass, $r_{\rm softening}$ is the softening length.

2.  When computing the gravitational potential at particle positions, a "omp do" directive is missing, which lead to incorrect results.