### PR TITLE
Copy element index in to OpenMP parallel region

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6745,6 +6745,44 @@ jobs:
           ./test-mass-host-maximum.pl 2>&1 | tee test.log
           ! grep -q FAIL test.log
       - run: echo "This job's status is ${{ job.status }}."
+  Test-Noninstantaneous-Recycling:
+    runs-on: ubuntu-latest
+    container: ghcr.io/galacticusorg/buildenv:latest
+    needs: Build-Executable-Linux
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server."
+      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Check out repository datasets
+        uses: actions/checkout@v4      
+        with:
+          repository: galacticusorg/datasets
+          path: datasets
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
+          echo "GALACTICUS_ANALYSIS_PERL_PATH=$GITHUB_WORKSPACE/analysis-perl" >> $GITHUB_ENV
+      - name: Download executables
+        uses: actions/download-artifact@v3
+        with:
+          name: galacticus-exec
+      - name: Create test suite output directory
+        run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
+      - name: Run test
+        run: |
+          cd $GALACTICUS_EXEC_PATH
+          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+          chmod u=wrx ./Galacticus.exe
+          cd testSuite
+          chmod u=wrx ./test-noninstantaneous_recycling.pl
+          set -o pipefail
+          ./test-noninstantaneous_recycling.pl 2>&1 | tee test.log
+          ! grep -q FAIL test.log
+      - run: echo "This job's status is ${{ job.status }}."
   Test-Satellite-Distance-Minimum:
     runs-on: ubuntu-latest
     container: ghcr.io/galacticusorg/buildenv:latest
@@ -10405,6 +10443,7 @@ jobs:
              Test-Inactive-Luminosities,
              Test-Interoutput-Star-Formation-Rate,
              Test-Mass-Host-Maximum,
+             Test-Noninstantaneous_Recycling,
              Test-Satellite-Distance-Minimum,
              Test-Tree-Filter-Labels,
              Test-Constrained-Merger-Trees,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10443,7 +10443,7 @@ jobs:
              Test-Inactive-Luminosities,
              Test-Interoutput-Star-Formation-Rate,
              Test-Mass-Host-Maximum,
-             Test-Noninstantaneous_Recycling,
+             Test-Noninstantaneous-Recycling,
              Test-Satellite-Distance-Minimum,
              Test-Tree-Filter-Labels,
              Test-Constrained-Merger-Trees,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6778,9 +6778,9 @@ jobs:
           git config --global --add safe.directory $GALACTICUS_EXEC_PATH
           chmod u=wrx ./Galacticus.exe
           cd testSuite
-          chmod u=wrx ./test-noninstantaneous_recycling.pl
+          chmod u=wrx ./test-noninstantaneous-recycling.pl
           set -o pipefail
-          ./test-noninstantaneous_recycling.pl 2>&1 | tee test.log
+          ./test-noninstantaneous-recycling.pl 2>&1 | tee test.log
           ! grep -q FAIL test.log
       - run: echo "This job's status is ${{ job.status }}."
   Test-Satellite-Distance-Minimum:

--- a/source/stellar_astrophysics.tracks.file.F90
+++ b/source/stellar_astrophysics.tracks.file.F90
@@ -445,7 +445,7 @@ contains
           interpolationFactorsMass(iMetallicity,:)=[0.0d0,1.0d0]
           massOutOfRange=.true.
        else
-          call self%interpolatorMass(iMetallicity)%linearFactors(initialMass,interpolationIndicesMass(iMetallicity,1),interpolationFactorsMass(iMetallicity,:))
+          call self%interpolatorMass(jMetallicity)%linearFactors(initialMass,interpolationIndicesMass(iMetallicity,1),interpolationFactorsMass(iMetallicity,:))
           interpolationIndicesMass(iMetallicity,2)=interpolationIndicesMass(iMetallicity,1)+1
        end if
        ! Loop over masses.

--- a/source/stellar_populations.standard.F90
+++ b/source/stellar_populations.standard.F90
@@ -190,6 +190,7 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter>
+
       <name>metalYield</name>
       <defaultValue>0.0d0</defaultValue>
       <description>The metal yield to use in the instantaneous stellar evolution approximation. (If not specified it will be computed internally.)</description>
@@ -376,7 +377,7 @@ contains
     type            (integratorCompositeGaussKronrod1D)                        :: integrator_
     integer                                                                    :: fileFormat        , iAge            , &
          &                                                                        iMetallicity      , loopCount       , &
-         &                                                                        loopCountTotal    , i
+          &                                                                        loopCountTotal    , i
     double precision                                                           :: maximumMass       , minimumMass     , &
          &                                                                        metallicity
     type            (hdf5Object                       )                        :: file              , dataset
@@ -450,7 +451,7 @@ contains
                &            *tableAgeCount
           loopCount      =   0
           self_          =>  self
-          !$omp parallel private (iAge,iMetallicity,progressMessage,minimumMass,maximumMass,integrator_) copyin(self_)
+          !$omp parallel private (iAge,iMetallicity,progressMessage,minimumMass,maximumMass,integrator_) copyin(self_,indexElement_)
           allocate(stellarAstrophysics_,mold=self%stellarAstrophysics_)
           allocate(initialMassFunction_,mold=self%initialMassFunction_)
           allocate(stellarFeedback_    ,mold=self%stellarFeedback_    )

--- a/testSuite/parameters/noninstantaneous_recycling.xml
+++ b/testSuite/parameters/noninstantaneous_recycling.xml
@@ -470,5 +470,5 @@
    <countRedshifts value="10"/>
  
 </outputTimes>
-  <outputFileName value="testSuite/outputs/noninstantaneoys_recycling.hdf5"/>
+  <outputFileName value="testSuite/outputs/noninstantaneous_recycling.hdf5"/>
 </parameters>

--- a/testSuite/parameters/noninstantaneous_recycling.xml
+++ b/testSuite/parameters/noninstantaneous_recycling.xml
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Galacticus model constrained to match baryonic physics data                        -->
+<!-- See https://github.com/galacticusorg/galacticus/wiki/Constraints:-Baryonic-Physics -->
+<!-- 30-November-2020                                                                   -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <version>0.9.4</version>
+
+
+<verbosityLevel value="working"/>
+
+  <!-- Task and work control -->
+  <task value="evolveForests">
+    <walltimeMaximum value="-1"/> 
+  </task>
+  <evolveForestsWorkShare value="cyclic"/>
+  
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard"/>
+  
+  <componentHotHalo value="coldMode"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard"/>
+  <spheroidMassDistribution value="hernquist">
+    <dimensionless value="true"/>
+  </spheroidMassDistribution>
+  <treeNodeMethodSpin3D value="vector"/>
+  
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.0"/>	
+    <OmegaMatter value=" 0.279000"/>	
+    <OmegaDarkEnergy value=" 0.721000"/>	
+    <OmegaBaryon value=" 0.046"/>	
+    <temperatureCMB value=" 2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.821"/> 	<!-- Planck 2018; arXiv:1807.06211 -->
+  </cosmologicalMassVariance>
+
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.9649"/> <!-- Planck 2018; arXiv:1807.06211 -->
+    <wavenumberReference value="1.0000"/>
+    <running value="0.0000"/> <!-- Planck 2018; arXiv:1807.06211 -->
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  
+  <!--Builds a merger tree of MW halo mass-->
+  <mergerTreeBuildMasses value="fixedMass">
+    <massTree value="1e12"/>
+    <treeCount value="1"/>
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e9"/>
+  </mergerTreeMassResolution>
+  
+  <mergerTreeOperator value="sequence">
+    <mergerTreeOperator value="massAccretionHistory"/>
+  </mergerTreeOperator>
+
+  
+  <luminosityFilter value="SDSS_g SDSS_r DES_g DES_r"/>
+
+  <luminosityPostprocessSet value="default recent unabsorbed recentUnabsorbed"/>
+
+  <luminosityRedshift value="0.0 0.0 0.0 0.0"/>
+
+  <luminosityType value="observed observed observed observed"/>
+
+  <stellarPopulationSpectraPostprocessorBuilder value="lookup">
+    <names value="default recent unabsorbed recentUnabsorbed"/>
+
+
+    <!-- default - includes absorption by the IGM -->
+
+    <stellarPopulationSpectraPostprocessor value="inoue2014" />
+
+    <!--recent - includes absorption by the IGM and includes only light from recently formed populations -->
+
+    <stellarPopulationSpectraPostprocessor value="sequence" >
+      <stellarPopulationSpectraPostprocessor value="inoue2014" />
+      <stellarPopulationSpectraPostprocessor value="recent" >
+	<timeLimit value="1.0e-2" /> <!-- t_{BC} of Charlot & Fall (2000; ApJ, 539, 718)-->
+      </stellarPopulationSpectraPostprocessor>
+    </stellarPopulationSpectraPostprocessor>
+
+    <!-- unabsorbed - includes all light, no absorption -->
+
+    <stellarPopulationSpectraPostprocessor value="identity" />
+
+    <stellarPopulationSpectraPostprocessor value="recent" >
+      <timeLimit value="1.0e-2" /> <!-- t_{BC} of Charlot & Fall (2000; ApJ, 539, 718)-->
+    </stellarPopulationSpectraPostprocessor>
+  </stellarPopulationSpectraPostprocessorBuilder>
+
+  <stellarSpectraDustAttenuation value="charlotFall2000"/>
+
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="indexLastHost"/>
+    <nodePropertyExtractor value="timeFirstInfall"/>
+
+    <nodePropertyExtractor value="virialProperties"/>
+    <nodePropertyExtractor value="mostMassiveProgenitor"/>
+    <nodePropertyExtractor value="starFormationRate">
+      <component value="disk"/>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="starFormationRate">
+      <component value="spheroid"/>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="velocityMaximum"/>
+    
+    <nodePropertyExtractor value="massHalo">
+      <virialDensityContrastDefinition value="fixed">
+	<densityContrastValue value="200"/>
+	<densityType value="critical"/>
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="massStellar"/>
+    <nodePropertyExtractor value="radiiHalfLightProperties"/>
+    <nodePropertyExtractor value="darkMatterProfileScaleRadius"/>
+    <nodePropertyExtractor value="indicesTree"/>
+    <nodePropertyExtractor value="massISM"/>
+    <nodePropertyExtractor value="nodeIndices"/>
+    <nodePropertyExtractor value="radiusHalfMass"/>
+    <nodePropertyExtractor value="time"/>
+    <nodePropertyExtractor value="densityContrasts">
+      <densityContrasts value="200.0"/>
+      <darkMatterOnly   value="true"/>
+    </nodePropertyExtractor>
+    
+  </nodePropertyExtractor>
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileConcentration value="gao2008"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+
+  <!-- Dark matter halo spin options -->
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="coldMode">
+    <redshiftReionization value="9.0"/>
+    <velocitySuppressionReionization value="25.0"/>
+    <thresholdStabilityShock value="0.0126"/>
+    <widthTransitionStabilityShock value="0.01"/>
+  </accretionHalo>
+  
+  <coldModeInfallRate value="dynamicalTime">
+  <dynamicalRateFraction value="2.0"/>
+  </coldModeInfallRate>
+  
+  <!-- CGM gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.142588563154576"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="7.84401490527569"/>
+  </hotHaloOutflowReincorporation>
+  
+  
+  <coolingFunction value="velocityCutOff">
+  <velocityCutOff value="19.0"/>
+  <redshiftCutOff value="1.0e6"/>
+  <whenCutOff value="after"/>
+  
+  
+  
+  <coolingFunction value="atomicCIECloudy"/>
+  
+  
+  
+  
+  </coolingFunction>
+  
+  <coolingRate value="multiplier">
+    <multiplier value="15"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  </coolingRate>
+  
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0.774282113742516"/>
+  </coolingTimeAvailable>
+  <hotHaloAngularMomentumLossFraction value="0.0871188291891892"/>
+  <starveSatellites value="false"/>
+
+  <!-- Hot halo ram pressure stripping options -->
+ 
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <hotHaloOutflowStrippingEfficiency value="0.1"/>
+  <hotHaloTrackStrippedGas value="true"/>
+  
+   <satelliteTidalField value="sphericalSymmetry"/>
+  <satelliteTidalStripping value="zentner2005"/>
+  
+  <!-- Galactic structure options -->
+  <diskMassDistribution value="exponentialDisk">
+    <dimensionless value="true"/>
+  </diskMassDistribution>
+  <galacticStructureSolver value="simple"/>
+  <darkMatterProfile value="darkMatterOnly"/>
+  <spheroidAngularMomentumAtScaleRadius value="0.50"/>
+
+  <!-- Star formation rate options -->
+    <starFormationRateSurfaceDensityDisks value="blitz2006">
+    <velocityDispersionDiskGas value="10.0"/>
+    <heightToRadialScaleDisk value="0.137"/>
+    <surfaceDensityCritical value="200.0"/>
+    <surfaceDensityExponent value="0.4"/>
+    <starFormationFrequencyNormalization value="5.25e-10"/>
+    <pressureCharacteristic value="4.54"/>
+    <pressureExponent value="0.92"/>
+    
+  </starFormationRateSurfaceDensityDisks>
+  
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.00415758894175098"/>
+      <exponentVelocity value="3.27016548773809"/>
+      <timescaleMinimum value="7.57979244540382"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+  
+ 
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="noninstantaneous">
+    <countHistoryTimes value="30"/>
+  </stellarPopulationProperties>
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+  <initialMassFunction value="chabrier2001"/>
+    <!-- <elementsToTrack    value="O"    /> -->
+ 
+
+  <!-- AGN feedback options -->
+  <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleHeatsHotHalo value="true"/>
+
+  <stellarWinds value="leitherer1992"/>
+  <initialMassForSupernovaTypeII value="8.0"/>
+  <supernovaeIa value="nagashima"/>
+  <supernovaePopIII value="Heger-Woosley2002"/>
+  <stellarFeedback value="standard"/>
+  
+  <!-- Black hole options -->
+  <blackHoleSeedMass value="100"/>
+  <blackHoleToSpheroidStellarGrowthRatio value="2.32959186797031"/>
+  <blackHoleHeatingEfficiency value="0.00140338137883176"/>
+  <blackHoleWindEfficiency value="0.211884639031352"/>
+  <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleEfficiency value="0.213288020410184"/>
+  <blackHoleJetFraction value="0.00657974778017468"/>
+
+  <!-- Satellite orbit options -->
+  <satelliteOrbitStoreOrbitalParameters value="true"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="li2020">
+    <darkMatterHaloScale   value="virialDensityContrastDefinition"/>
+    <virialDensityContrast value="bryanNorman1998"/>
+  </virialOrbit>
+  <satelliteMergingTimescales value="villalobos2013">
+    <exponent value="0.0949174380399185"/>
+    <satelliteMergingTimescales value="jiang2008">
+      <timescaleMultiplier value="5.49121979923864"/>
+    </satelliteMergingTimescales>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="dominant"/>
+    <destinationStarsMinorMerger value="dominant"/>
+    <massRatioMajorMerger value="0.207178360765429"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1.41586769307318"/>
+  </mergerRemnantSize>
+
+  <!-- Spheroid options -->
+  <spheroidEnergeticOutflowMassRate value="1.0e-2"/>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+
+    
+
+    
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"        />
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+
+        
+    <!-- Star formation options -->
+    <nodeOperator value="starFormationDisks">
+      <luminositiesStellarInactive value="true"/>
+    </nodeOperator>
+    <nodeOperator value="starFormationSpheroids">
+      <luminositiesStellarInactive value="true"/>
+    </nodeOperator>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.0127606668366045"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="160.019897613397"/><!--160.019897613397-->
+          <exponent value="1.7561921242039"/>
+        </stellarFeedbackOutflows>
+        
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.103745531708515"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="151.06489745284"/>
+          <exponent value="0.33561921242039"/><!--0.23561921242039-->
+        </stellarFeedbackOutflows>
+        
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="1.06448595007383"/>
+	<stabilityThresholdStellar value="1.198674706841"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+    
+    <nodeOperator value="ramPressureMassLossDisks">
+
+      <ramPressureStripping value="simpleCylindrical">
+	<beta value="1.00"/>
+      </ramPressureStripping>
+    </nodeOperator>
+    <nodeOperator value="ramPressureMassLossSpheroids">
+      <ramPressureStripping value="simpleSpherical">
+	<beta value="1.00"/>
+      </ramPressureStripping>
+    </nodeOperator>
+
+    <!-- Tidal pressure stripping -->
+
+    <nodeOperator value="tidalMassLossDisks">
+      <tidalStripping value="simple">
+	<beta value="0.01"/>
+      </tidalStripping>
+    </nodeOperator>
+
+    <nodeOperator value="tidalMassLossSpheroids">
+      <tidalStripping value="simple">
+	<beta value="0.01"/>
+     </tidalStripping>
+    </nodeOperator>
+
+    <nodeOperator value="indexShift"/>
+    <nodeOperator value="indexLastHost"/>
+    <nodeOperator value="timeFirstInfall"/>
+
+  </nodeOperator>
+  
+  <starFormationHistory value="adaptive">
+    <timeStepMinimum value="0.01"/>
+    <countTimeStepsMaximum value="390"/>
+    <countMetallicities value="0"/>
+    <countOutputBuffer value="100"/>
+  </starFormationHistory>
+  
+  <!-- Numerical tolerances -->
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0e+0"/>
+    <timestepHostRelative value="1.0e-1"/>
+    <fractionTimestepSatelliteMinimum value="0.75"/>
+    <backtrackToSatellites value="false"/>
+  </mergerTreeEvolver>
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+    <odeAlgorithm value="rungeKuttaCashKarp"/>
+    <reuseODEStepSize value="true"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolveTimestep value="multi">
+    <mergerTreeEvolveTimestep value="simple">
+      <timeStepAbsolute value="1.000"/>
+      <timeStepRelative value="0.100"/>
+    </mergerTreeEvolveTimestep>
+    <mergerTreeEvolveTimestep value="satellite">
+      <timeOffsetMaximumAbsolute value="0.010"/>
+      <timeOffsetMaximumRelative value="0.001"/>
+    </mergerTreeEvolveTimestep>
+  </mergerTreeEvolveTimestep>
+  <diskMassToleranceAbsolute value="1.0e-6"/>
+  <spheroidMassToleranceAbsolute value="1.0e-6"/>
+  <diskLuminositiesStellarInactive value="true"/>
+  <spheroidLuminositiesStellarInactive value="true"/>
+
+  
+
+   
+  
+  <elementsToTrack value="Fe"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  
+ <outputTimes value="uniformSpacingInRedshift">
+   <redshiftMinimum value="0.0"/>
+   <redshiftMaximum value="20.0"/>
+   <countRedshifts value="10"/>
+ 
+</outputTimes>
+  <outputFileName value="testSuite/outputs/noninstantaneoys_recycling.hdf5"/>
+</parameters>

--- a/testSuite/test-noninstantaneous-recycling.pl
+++ b/testSuite/test-noninstantaneous-recycling.pl
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib $ENV{'GALACTICUS_EXEC_PATH'         }."/perl";
+use lib $ENV{'GALACTICUS_ANALYSIS_PERL_PATH'}."/perl";
+use PDL;
+use PDL::NiceSlice;
+use PDL::IO::HDF5;
+use File::Slurp qw(slurp);
+use System::Redirect;
+
+# Check calculations of noninstantaneous recycling.
+# Andrew Benson (23-September-2023)
+
+# Run the model.
+&System::Redirect::tofile("mkdir -p outputs; cd ..; ./Galacticus.exe testSuite/parameters/noninstantaneous_recycling.xml","outputs/noninstantaneous_recycling.log");
+unless ( $? == 0 ) {
+    print "FAILED:  model run:\n";
+    system("cat outputs/noninstantaneous_recycling.log");
+} else {
+    print "SUCCESS: model run\n";
+}
+# Read the model data and check for consistency.
+my $model   = new PDL::IO::HDF5("outputs/noninstantaneous_recycling.hdf5");
+my $outputs  = $model  ->group('Outputs' );
+my $output   = $outputs->group('Output10');
+my $nodeData = $output ->group('nodeData');
+my $data;
+$data->{$_} = $nodeData->dataset($_)->get()
+    foreach ( 
+	"spheroidAbundancesStellarMetals",
+	"spheroidAbundancesStellarFe"    ,
+	"diskAbundancesStellarMetals"    ,
+	"diskAbundancesStellarFe"
+    );
+my $massMetals = $data->{'spheroidAbundancesStellarMetals'}+$data->{'diskAbundancesStellarMetals'};
+my $massFe     = $data->{'spheroidAbundancesStellarFe'    }+$data->{'diskAbundancesStellarFe'    };
+my $nonZero    = which($massMetals > 1.0);
+my $ratio      = +$massFe    ->($nonZero)
+                 /$massMetals->($nonZero); 
+my $status = all($ratio < 0.16) ? "SUCCESS" : "FAILED";
+print $status.": Fe/Z ratio\n";
+exit 0;


### PR DESCRIPTION
When tabulating stellar population metal production, the element index is set outside of the OpenMP `parallel` region, so must be copied in to all threads to allow each thread to compute for the correct element.