### PR TITLE
Allow the `virialDensityContrastBryanNorman1998` class to work for arbitrary cosmologies

### DIFF
--- a/source/dark_matter_profiles.structure.concentration.MunozCuartas2011.F90
+++ b/source/dark_matter_profiles.structure.concentration.MunozCuartas2011.F90
@@ -120,6 +120,7 @@ contains
     <referenceConstruct owner="self" object="virialDensityContrastDefinition_">
      <constructor>
       virialDensityContrastBryanNorman1998              (                                                                            &amp;
+       &amp;                                             allowUnsupportedCosmology           =     .true.                          , &amp;
        &amp;                                             cosmologyParameters_                =self%cosmologyParameters_            , &amp;
        &amp;                                             cosmologyFunctions_                 =self%cosmologyFunctions_               &amp;
        &amp;                                            )

--- a/source/dark_matter_profiles.structure.concentration.Zhao2009.F90
+++ b/source/dark_matter_profiles.structure.concentration.Zhao2009.F90
@@ -132,6 +132,7 @@ contains
     <referenceConstruct owner="self" object="virialDensityContrastDefinition_">
      <constructor>
       virialDensityContrastBryanNorman1998              (                                                                            &amp;
+       &amp;                                             allowUnsupportedCosmology           =     .true.                          , &amp;
        &amp;                                             cosmologyParameters_                =self%cosmologyParameters_            , &amp;
        &amp;                                             cosmologyFunctions_                 =self%cosmologyFunctions_               &amp;
        &amp;                                            )

--- a/source/output.analyses.HI_vs_halo_mass_relation.ALFALFA_Padmanabhan_2017.F90
+++ b/source/output.analyses.HI_vs_halo_mass_relation.ALFALFA_Padmanabhan_2017.F90
@@ -346,11 +346,11 @@ contains
     ! lower by a factor Ωₘ^⅙ than they should be. We explicitly account for this factor when computing virial velocity below.
     allocate(virialDensityContrastData                             )
     !![
-    <referenceConstruct object="virialDensityContrastData"                              constructor="virialDensityContrastBryanNorman1998                  (cosmologyParametersData      ,cosmologyFunctionsData                              )"/>
+    <referenceConstruct object="virialDensityContrastData"                              constructor="virialDensityContrastBryanNorman1998                  (.false.,cosmologyParametersData      ,cosmologyFunctionsData                              )"/>
     !!]
     allocate(darkMatterHaloScaleData)
     !![
-    <referenceConstruct object="darkMatterHaloScaleData"                                constructor="darkMatterHaloScaleVirialDensityContrastDefinition    (cosmologyParametersData      ,cosmologyFunctionsData    ,virialDensityContrastData)"/>
+    <referenceConstruct object="darkMatterHaloScaleData"                                constructor="darkMatterHaloScaleVirialDensityContrastDefinition    (       cosmologyParametersData      ,cosmologyFunctionsData    ,virialDensityContrastData)"/>
     !!]
     ! Generate the target dataset.
     allocate(massHILogarithmicTarget          (massHaloCount              ))

--- a/source/satellites.merging.virial_orbits.Li2020.F90
+++ b/source/satellites.merging.virial_orbits.Li2020.F90
@@ -234,7 +234,15 @@ contains
     ! Create virial density contrast definition.
     allocate(self%virialDensityContrastDefinition_)
     !![
-    <referenceConstruct isResult="yes" owner="self" object="virialDensityContrastDefinition_" constructor="virialDensityContrastBryanNorman1998(self%cosmologyParameters_,self%cosmologyFunctions_)"/>
+    <referenceConstruct isResult="yes" owner="self" object="virialDensityContrastDefinition_">
+      <constructor>
+        virialDensityContrastBryanNorman1998(                                                     &amp;
+         &amp;                               allowUnsupportedCosmology=     .true.              , &amp;
+         &amp;                               cosmologyParameters_     =self%cosmologyParameters_, &amp;
+         &amp;                               cosmologyFunctions_      =self%cosmologyFunctions_   &amp;
+         &amp;                              )
+      </constructor>
+    </referenceConstruct>
     !!]
     return
   end function li2020ConstructorInternal

--- a/source/structure_formation.virial_density_contrast.Bryan_Norman.F90
+++ b/source/structure_formation.virial_density_contrast.Bryan_Norman.F90
@@ -37,10 +37,17 @@
   !![
   <virialDensityContrast name="virialDensityContrastBryanNorman1998">
    <description>
-    A dark matter halo virial density contrast class using the fitting functions given by \cite{bryan_statistical_1998}. As
-    such, it is valid only for $\Omega_\Lambda=0$ or $\Omega_\mathrm{M}+\Omega_\Lambda=1$ cosmologies and will abort on other
-    cosmologies.
+    A dark matter halo virial density contrast class using the fitting functions given by \cite{bryan_statistical_1998}. As such,
+    it is valid only for $\Omega_\Lambda=0$ or $\Omega_\mathrm{M}+\Omega_\Lambda=1$ cosmologies and will either abort on other
+    cosmologies (if {\normalfont \ttfamily [allowUnsupportedCosmology]=false}), or revert to a numerical solution from top-hat
+    collapse (if {\normalfont \ttfamily [allowUnsupportedCosmology]=true}).
    </description>
+   <deepCopy>
+     <functionClass variables="virialDensityContrastTopHat_"/>
+   </deepCopy>
+   <stateStorable>
+     <functionClass variables="virialDensityContrastTopHat_"/>
+   </stateStorable>
   </virialDensityContrast>
   !!]
   type, extends(virialDensityContrastClass) :: virialDensityContrastBryanNorman1998
@@ -48,9 +55,11 @@
      A dark matter halo virial density contrast class using the fitting functions of \cite{bryan_statistical_1998}.
      !!}
      private
-     class(cosmologyParametersClass         ), pointer :: cosmologyParameters_ => null()
-     class(cosmologyFunctionsClass          ), pointer :: cosmologyFunctions_  => null()
-     type (enumerationBryanNorman1998FitType)          :: fitType
+     class  (cosmologyParametersClass                                      ), pointer :: cosmologyParameters_         => null()
+     class  (cosmologyFunctionsClass                                       ), pointer :: cosmologyFunctions_          => null()
+     type   (virialDensityContrastSphericalCollapseClsnlssMttrCsmlgclCnstnt), pointer :: virialDensityContrastTopHat_ => null()
+     type   (enumerationBryanNorman1998FitType                             )          :: fitType
+     logical                                                                          :: useFittingFunction                    , allowUnsupportedCosmology
    contains
      final     ::                                bryanNorman1998Destructor
      procedure :: densityContrast             => bryanNorman1998DensityContrast
@@ -74,16 +83,23 @@ contains
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type (virialDensityContrastBryanNorman1998)                :: self
-    type (inputParameters                     ), intent(inout) :: parameters
-    class(cosmologyParametersClass            ), pointer       :: cosmologyParameters_
-    class(cosmologyFunctionsClass             ), pointer       :: cosmologyFunctions_
+    type   (virialDensityContrastBryanNorman1998)                :: self
+    type   (inputParameters                     ), intent(inout) :: parameters
+    class  (cosmologyParametersClass            ), pointer       :: cosmologyParameters_
+    class  (cosmologyFunctionsClass             ), pointer       :: cosmologyFunctions_
+    logical                                                      :: allowUnsupportedCosmology
 
     !![
+    <inputParameter>
+      <name>allowUnsupportedCosmology</name>
+      <defaultValue>.false.</defaultValue>
+      <source>parameters</source>
+      <description>If true, unsupported cosmologies revert to using a numerical solution from the top-hat collapse model. Otherwise, unsupported cosmologies result in an error.</description>
+    </inputParameter>
     <objectBuilder class="cosmologyParameters" name="cosmologyParameters_" source="parameters"/>
     <objectBuilder class="cosmologyFunctions"  name="cosmologyFunctions_"  source="parameters"/>
     !!]
-    self=virialDensityContrastBryanNorman1998(cosmologyParameters_,cosmologyFunctions_)
+    self=virialDensityContrastBryanNorman1998(allowUnsupportedCosmology,cosmologyParameters_,cosmologyFunctions_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyParameters_"/>
@@ -92,25 +108,40 @@ contains
     return
   end function bryanNorman1998ConstructorParameters
 
-  function bryanNorman1998ConstructorInternal(cosmologyParameters_,cosmologyFunctions_) result(self)
+  function bryanNorman1998ConstructorInternal(allowUnsupportedCosmology,cosmologyParameters_,cosmologyFunctions_) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily bryanNorman1998} dark matter halo virial density contrast class.
     !!}
     use :: Error               , only : Error_Report
     use :: Numerical_Comparison, only : Values_Differ
     implicit none
-    type (virialDensityContrastBryanNorman1998)                        :: self
-    class(cosmologyParametersClass            ), intent(in   ), target :: cosmologyParameters_
-    class(cosmologyFunctionsClass             ), intent(in   ), target :: cosmologyFunctions_
+    type   (virialDensityContrastBryanNorman1998)                        :: self
+    class  (cosmologyParametersClass            ), intent(in   ), target :: cosmologyParameters_
+    class  (cosmologyFunctionsClass             ), intent(in   ), target :: cosmologyFunctions_
+    logical                                      , intent(in   )         :: allowUnsupportedCosmology
     !![
-    <constructorAssign variables="*cosmologyParameters_, *cosmologyFunctions_"/>
+    <constructorAssign variables="allowUnsupportedCosmology, *cosmologyParameters_, *cosmologyFunctions_"/>
     !!]
 
     ! Check that fitting formulae are applicable to this cosmology.
+    self%useFittingFunction=.true.
     if (self%cosmologyParameters_%OmegaDarkEnergy() == 0.0d0) then
        self%fitType=bryanNorman1998FitZeroLambda
     else if (.not.Values_Differ(self%cosmologyParameters_%OmegaMatter()+self%cosmologyParameters_%OmegaDarkEnergy(),1.0d0,absTol=1.0d-6)) then
        self%fitType=bryanNorman1998FitFlatUniverse
+    else if (self%allowUnsupportedCosmology) then
+       self%useFittingFunction=.false.
+       allocate(self%virialDensityContrastTopHat_)
+       !![
+       <referenceConstruct isResult="yes" owner="self" object="virialDensityContrastTopHat_">
+	 <constructor>
+	   virialDensityContrastSphericalCollapseClsnlssMttrCsmlgclCnstnt(                                              &amp;
+	    &amp;                                                         tableStore         =.true.                  , &amp;
+	    &amp;                                                         cosmologyFunctions_=self%cosmologyFunctions_  &amp;
+	    &amp;                                                        )
+	 </constructor>
+       </referenceConstruct>
+       !!]
     else
        call Error_Report('no fitting formula available for this cosmology'//{introspection:location})
     end if
@@ -128,6 +159,11 @@ contains
     <objectDestructor name="self%cosmologyParameters_" />
     <objectDestructor name="self%cosmologyFunctions_"  />
     !!]
+    if (.not.self%useFittingFunction) then
+       !![
+       <objectDestructor name="self%virialDensityContrastTopHat_" />
+       !!]
+    end if
     return
   end subroutine bryanNorman1998Destructor
 
@@ -143,18 +179,21 @@ contains
     double precision                                      , intent(in   ), optional :: time      , expansionFactor
     logical                                               , intent(in   ), optional :: collapsing
     double precision                                                                :: x
-    !$GLC attributes unused :: mass
 
-    x=self%cosmologyFunctions_%omegaMatterEpochal(time,expansionFactor,collapsing)-1.0d0
-    select case (self%fitType%ID)
-    case (bryanNorman1998FitZeroLambda  %ID)
-       bryanNorman1998DensityContrast=(18.0d0*Pi**2+60.0d0*x-32.0d0*x**2)/(x+1.0d0)
-    case (bryanNorman1998FitFlatUniverse%ID)
-       bryanNorman1998DensityContrast=(18.0d0*Pi**2+82.0d0*x-39.0d0*x**2)/(x+1.0d0)
-    case default
-       bryanNorman1998DensityContrast=0.0d0
-       call Error_Report('invalid fit type'//{introspection:location})
-    end select
+    if (self%useFittingFunction) then
+       x=self%cosmologyFunctions_%omegaMatterEpochal(time,expansionFactor,collapsing)-1.0d0
+       select case (self%fitType%ID)
+       case (bryanNorman1998FitZeroLambda  %ID)
+          bryanNorman1998DensityContrast=(18.0d0*Pi**2+60.0d0*x-32.0d0*x**2)/(x+1.0d0)
+       case (bryanNorman1998FitFlatUniverse%ID)
+          bryanNorman1998DensityContrast=(18.0d0*Pi**2+82.0d0*x-39.0d0*x**2)/(x+1.0d0)
+       case default
+          bryanNorman1998DensityContrast=0.0d0
+          call Error_Report('invalid fit type'//{introspection:location})
+       end select
+    else
+       bryanNorman1998DensityContrast=self%virialDensityContrastTopHat_%densityContrast(mass,time,expansionFactor,collapsing)
+    end if
     return
   end function bryanNorman1998DensityContrast
 
@@ -170,32 +209,35 @@ contains
     double precision                                      , intent(in   ), optional :: time      , expansionFactor
     logical                                               , intent(in   ), optional :: collapsing
     double precision                                                                :: x
-    !$GLC attributes unused :: mass
 
-    x=self%cosmologyFunctions_%omegaMatterEpochal(time,expansionFactor,collapsing)-1.0d0
-    select case (self%fitType%ID)
-    case (bryanNorman1998FitZeroLambda  %ID)
-       bryanNorman1998DensityContrastRateOfChange=                                               &
-            & (                                                                                  &
-            &  +(            +60.0d0  -64.0d0*x   )                                              &
-            &  -(18.0d0*Pi**2+60.0d0*x-32.0d0*x**2)                                              &
-            &  /(x+1.0d0)                                                                        &
-            & )                                                                                  &
-            & *self%cosmologyFunctions_%omegaMatterRateOfChange(time,expansionFactor,collapsing) &
-            & / (x+1.0d0)
-    case (bryanNorman1998FitFlatUniverse%ID)
-       bryanNorman1998DensityContrastRateOfChange=                                               &
-            & (                                                                                  &
-            &  +(            +82.0d0  -78.0d0*x   )                                              &
-            &  -(18.0d0*Pi**2+82.0d0*x-39.0d0*x**2)                                              &
-            &  /(x+1.0d0)                                                                        &
-            & )                                                                                  &
-            & *self%cosmologyFunctions_%omegaMatterRateOfChange(time,expansionFactor,collapsing) &
-            & / (x+1.0d0)
-    case default
-       bryanNorman1998DensityContrastRateOfChange=0.0d0
-       call Error_Report('invalid fit type'//{introspection:location})
-    end select
+    if (self%useFittingFunction) then
+       x=self%cosmologyFunctions_%omegaMatterEpochal(time,expansionFactor,collapsing)-1.0d0
+       select case (self%fitType%ID)
+       case (bryanNorman1998FitZeroLambda  %ID)
+          bryanNorman1998DensityContrastRateOfChange=                                               &
+               & (                                                                                  &
+               &  +(            +60.0d0  -64.0d0*x   )                                              &
+               &  -(18.0d0*Pi**2+60.0d0*x-32.0d0*x**2)                                              &
+               &  /(x+1.0d0)                                                                        &
+               & )                                                                                  &
+               & *self%cosmologyFunctions_%omegaMatterRateOfChange(time,expansionFactor,collapsing) &
+               & / (x+1.0d0)
+       case (bryanNorman1998FitFlatUniverse%ID)
+          bryanNorman1998DensityContrastRateOfChange=                                               &
+               & (                                                                                  &
+               &  +(            +82.0d0  -78.0d0*x   )                                              &
+               &  -(18.0d0*Pi**2+82.0d0*x-39.0d0*x**2)                                              &
+               &  /(x+1.0d0)                                                                        &
+               & )                                                                                  &
+               & *self%cosmologyFunctions_%omegaMatterRateOfChange(time,expansionFactor,collapsing) &
+               & / (x+1.0d0)
+       case default
+          bryanNorman1998DensityContrastRateOfChange=0.0d0
+          call Error_Report('invalid fit type'//{introspection:location})
+       end select
+    else
+       bryanNorman1998DensityContrastRateOfChange=self%virialDensityContrastTopHat_%densityContrastRateOfChange(mass,time,expansionFactor,collapsing)
+    end if
     return
   end function bryanNorman1998DensityContrastRateOfChange
 
@@ -209,10 +251,13 @@ contains
     double precision                                      , intent(in   )           :: mass
     double precision                                      , intent(in   ), optional :: time      , expansionFactor
     logical                                               , intent(in   ), optional :: collapsing
-    !$GLC attributes unused :: self, mass, time, expansionFactor, collapsing
 
-    ! In simple cosmological constant dark energy universes, this ratio is always precisely 2 (e.g. Percival 2005;
-    ! http://adsabs.harvard.edu/abs/2005A%26A...443..819P)
-    bryanNorman1998TurnAroundOverVirialRadii=2.0d0
+    if (self%useFittingFunction) then
+       ! In simple cosmological constant dark energy universes, this ratio is always precisely 2 (e.g. Percival 2005;
+       ! http://adsabs.harvard.edu/abs/2005A%26A...443..819P)
+       bryanNorman1998TurnAroundOverVirialRadii=2.0d0
+    else
+       bryanNorman1998TurnAroundOverVirialRadii=self%turnAroundOverVirialRadii(mass,time,expansionFactor,collapsing)
+    end if
     return
   end function bryanNorman1998TurnAroundOverVirialRadii


### PR DESCRIPTION
If the option `allowUnsupportedCosmology` is set to `true` then cosmologies for which [Brayn & Norman (1998)](https://ui.adsabs.harvard.edu/abs/1998ApJ...495...80B/abstract) do not provide a fitting function revert to using the numerical solutions for the spherical top-hat collapse model.