### PR TITLE
Improvements to the Radial Range that Subhalo Density Profiles are Tabulated when Fitting TNFW Profile

### DIFF
--- a/source/nodes.property_extractor.tidally_truncated_NFW_fit.F90
+++ b/source/nodes.property_extractor.tidally_truncated_NFW_fit.F90
@@ -165,18 +165,21 @@ contains
     type            (multiCounter                               ), intent(inout), optional     :: instance
     class           (nodeComponentDarkMatterProfile             ), pointer                     :: darkMatterProfile
     class           (nodeComponentSatellite                     ), pointer                     :: satellite
-    double precision                                             , allocatable  , dimension(:) :: radii                     , fractionDensity
+    double precision                                             , allocatable  , dimension(:) :: radii                                          , fractionDensity
     type            (multiDMinimizer                            ), allocatable                 :: minimizer_
     double precision                                                            , dimension(1) :: locationMinimum
-    double precision                                             , parameter                   :: fractionRadiusOuter=0.95d0, fractionRadiusScale=0.1d0, &
-         &                                                                                        fractionMaximum    =0.10d0, fractionStep       =0.1d0
-    integer                                                      , parameter                   :: countRadiiPerDecade=10
-    integer                                                                                    :: countRadii                , i                        , &
-         &                                                                                        iteration
+    double precision                                             , parameter                   :: fractionRadiusScale                      =0.1d0, fractionMaximum=0.10d0, & 
+         &                                                                                        radiusMaximumFractionDensityVirialMinimum=0.1d0, fractionStep   =0.1d0 , &
+         &                                                                                        radiusMaximumScaleVirialMaximum          =1.0d1 
+    integer                                                      , parameter                   :: radiusMaximumCountRadiiPerDecade         =10   , countRadiiPerDecade=10  
+    integer                                                                                    :: countRadii                                     , i                     , &
+         &                                                                                        iteration                                      , n                     , &
+         &                                                                                        radiusMaxiumCountRadii
     logical                                                                                    :: converged
-    double precision                                                                           :: radiusOuter               , massTotal                , &
-         &                                                                                        radiusMinimum             , radiusMaximum            , &
-         &                                                                                        radiusScale               , radiusVirial
+    double precision                                                                           :: radiusOuter                                    , massTotal             , &
+         &                                                                                        radiusMinimum                                  , radiusMaximum         , &
+         &                                                                                        radiusScale                                    , radiusVirial          , &
+         &                                                                                        radiusMaximumFractionDensityVirial             , step
     !$GLC attributes unused :: instance
 
     allocate(tidallyTruncatedNFWFitExtract(3))
@@ -190,8 +193,20 @@ contains
        radiusScale  =  darkMatterProfile                     %scale              (                                              )
        radiusVirial =  self             %darkMatterHaloScale_%radiusVirial       (node                                          )
        ! Choose radii for fitting.
-       radiusMaximum=    fractionRadiusOuter*radiusOuter
-       radiusMinimum=min(fractionRadiusScale*radiusScale,fractionMaximum*radiusMaximum)
+       if (radiusOuter <= radiusVirial) then
+           radiusMaximum=radiusVirial
+       else
+           radiusMaxiumCountRadii=int(log10(radiusMaximumScaleVirialMaximum)*dble(radiusMaximumCountRadiiPerDecade)+1.0d0)
+           step                  =log10(radiusMaximumScaleVirialMaximum)/dble(radiusMaxiumCountRadii) 
+           do n=1,radiusMaxiumCountRadii
+             radiusMaximum                     =10**(log10(radiusVirial)+step*dble(i))
+             radiusMaximumFractionDensityVirial=+self%darkMatterProfileDMO_%density(node,radiusMaximum) &
+                    &                           /self%darkMatterProfileDMO_%density(node,radiusVirial )
+
+              if (radiusMaximumFractionDensityVirial < radiusMaximumFractionDensityVirialMinimum) exit
+           end do 
+       end if 
+       radiusMinimum=min(fractionRadiusScale*radiusScale,fractionMaximum*radiusMaximum,fractionMaximum*radiusOuter)
        countRadii   =int(log10(radiusMaximum/radiusMinimum)*dble(countRadiiPerDecade)+1.0d0)
        radii        =Make_Range(radiusMinimum,radiusMaximum,countRadii,rangeTypeLogarithmic)
        ! Tabulate the density ratio relative to an NFW profile.

--- a/source/nodes.property_extractor.tidally_truncated_NFW_fit.F90
+++ b/source/nodes.property_extractor.tidally_truncated_NFW_fit.F90
@@ -193,9 +193,8 @@ contains
        radiusScale  =  darkMatterProfile                     %scale              (                                              )
        radiusVirial =  self             %darkMatterHaloScale_%radiusVirial       (node                                          )
        ! Choose radii for fitting.
-       if (radiusOuter <= radiusVirial) then
-           radiusMaximum=radiusVirial
-       else
+       radiusMaximum=radiusVirial
+       if (radiusOuter > radiusVirial) then
            radiusMaxiumCountRadii=int(log10(radiusMaximumScaleVirialMaximum)*dble(radiusMaximumCountRadiiPerDecade)+1.0d0)
            step                  =log10(radiusMaximumScaleVirialMaximum)/dble(radiusMaxiumCountRadii) 
            do n=1,radiusMaxiumCountRadii


### PR DESCRIPTION
Changed the range of radii at which the density profile is tabulated at when fitting TNFW profiles. Before the density was tabulated to the outer radius (where the radius encloses the bound mass or the total mass (of the subhalo), whichever is smaller). This definition led to the maximum radius taking on very large values in some cases. To fix this, the following changes have been implemented: 
- Now the maximum tabulated radius is the virial radius if the outer radius is less than the virial radius
- If the outer radius is greater than the virial radius, the maximum radius is the radius at which the density drops to 1/10 the density at the virial radius or 10x the virial radius, whichever is smaller