### PR TITLE
Fix behavior of the `download()` function

### DIFF
--- a/source/accretion_disks.spectra.Hopkins2007.F90
+++ b/source/accretion_disks.spectra.Hopkins2007.F90
@@ -123,7 +123,7 @@ contains
     type            (hdf5Object                     )                              :: file                              , dataset
     integer                                                                        :: fileFormatCurrentFile             , sedUnit             , &
          &                                                                            i                                 , j                   , &
-         &                                                                            ioStatus                          , wavelengthCount
+         &                                                                            status                            , wavelengthCount
     character       (len= 16                        )                              :: label
     character       (len=256                        )                              :: line
     double precision                                                               :: frequencyLogarithmic              , spectrumLogarithmic
@@ -155,8 +155,8 @@ contains
        ! Download the AGN SED code.
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.c")) then
           call Directory_Make(inputPath(pathTypeDataDynamic)//"/AGN_Spectrum")
-          call download("http://www.tapir.caltech.edu/~phopkins/Site/qlf_files/agn_spectrum.c",char(inputPath(pathTypeDataStatic))//"aux/AGN_Spectrum/agn_spectrum.c",ioStatus)
-          if (ioStatus /= 0 .or. .not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.c")) call Error_Report('failed to download agn_spectrum.c'//{introspection:location})
+          call download("http://www.tapir.caltech.edu/~phopkins/Site/qlf_files/agn_spectrum.c",char(inputPath(pathTypeDataStatic))//"aux/AGN_Spectrum/agn_spectrum.c",status=status)
+          if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.c")) call Error_Report('failed to download agn_spectrum.c'//{introspection:location})
        end if
        ! Compile the AGN SED code.
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")) then
@@ -181,8 +181,8 @@ contains
           open(newUnit=sedUnit,file=char(inputPath(pathTypeDataStatic))//"aux/AGN_Spectrum/SED.txt",status="old",form="formatted")
           j=wavelengthCount+1
           do
-             read(sedUnit,'(a)',iostat=ioStatus) line
-             if (ioStatus             == iostat_end) exit
+             read(sedUnit,'(a)',iostat=status) line
+             if (status               == iostat_end) exit
              if (line(1:1)            == ";"       ) cycle
              read (line,*) frequencyLogarithmic,spectrumLogarithmic
              if (frequencyLogarithmic <  0.0d0     ) cycle

--- a/source/system.downloader.F90
+++ b/source/system.downloader.F90
@@ -63,16 +63,17 @@ contains
     return
   end subroutine downloadInitialize
   
-  subroutine downloadVarStr(url,outputFileName,status)
+  subroutine downloadVarStr(url,outputFileName,retries,retryWait,status)
     !!{
     Download content from the given {\normalfont url} to the given {\normalfont \ttfamily outputFileName}.
     !!}
     use :: ISO_Varying_String, only : char, varying_string
     implicit none
-    type   (varying_string), intent(in   )           :: url   , outputFileName
+    type   (varying_string), intent(in   )           :: url    , outputFileName
+    integer                , intent(in   ), optional :: retries, retryWait
     integer                , intent(  out), optional :: status
     
-    call download(char(url),char(outputFileName),status)
+    call download(char(url),char(outputFileName),retries,retryWait,status)
     return
   end subroutine downloadVarStr
 


### PR DESCRIPTION
Adds the retry options to the `varying_string` version of the `download()` function to match those of the `character` version.

Also adds a keyword to one call to `download()` to ensure that the status option is passed correctly.