### PR TITLE
Ensure that CosmicEmu power spectra files are read even if they pre-existed

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8848,6 +8848,43 @@ jobs:
           ./Galacticus.exe testSuite/regressions/barInstabilityFPE.xml 2>&1 | tee test.log
           ! grep -q FAIL test.log
       - run: echo "This job's status is ${{ job.status }}."
+  Regressions-CosmicEmu:
+    runs-on: ubuntu-latest
+    container: ghcr.io/galacticusorg/buildenv:latest
+    needs: Build-Executable-Linux
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server."
+      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Check out repository datasets
+        uses: actions/checkout@v4      
+        with:
+          repository: galacticusorg/datasets
+          path: datasets
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
+      - name: Download executables
+        uses: actions/download-artifact@v3
+        with:
+          name: galacticus-exec
+      - name: Create test suite output directory
+        run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
+      - name: Run test
+        run: |
+          cd $GALACTICUS_EXEC_PATH
+          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+          chmod u=wrx ./Galacticus.exe
+          mkdir -p testSuite/outputs/regressions
+          chmod u=wrx ./testSuite/regressions/cosmicEmu.pl
+          set -o pipefail
+          ./testSuite/regressions/cosmicEmu.pl 2>&1 | tee test.log
+          ! grep -q FAIL test.log
+      - run: echo "This job's status is ${{ job.status }}."
   ### Methods
   Test-Methods-01:
     runs-on: ubuntu-latest

--- a/source/structure_formation.power_spectrum.nonlinear.CosmicEmu.F90
+++ b/source/structure_formation.power_spectrum.nonlinear.CosmicEmu.F90
@@ -261,41 +261,41 @@ contains
           end if
           ! Generate the power spectrum.
           call System_Command_Do(inputPath(pathTypeDataDynamic)//"CosmicEmu_v1.1/emu.exe < "//parameterFile)
-          ! Read the data file.
-          self%wavenumberCount=Count_Lines_In_File(powerSpectrumFile,"#")
-          if (allocated(self%wavenumberTable   )) deallocate(self%wavenumberTable   )
-          if (allocated(self%powerSpectrumTable)) deallocate(self%powerSpectrumTable)
-          allocate(self%wavenumberTable   (self%wavenumberCount))
-          allocate(self%powerSpectrumTable(self%wavenumberCount))
-          open(newunit=powerSpectrumUnit,file=char(powerSpectrumFile),status='old',form='formatted')
-          iWavenumber=0
-          do while (iWavenumber < self%wavenumberCount)
-             read (powerSpectrumUnit,'(a)') powerSpectrumLine
-             if (powerSpectrumLine(1:1) == "#") then
-                if (powerSpectrumLine(1:33) == "# dimensionless Hubble parameter") then
-                   read (powerSpectrumLine(index(powerSpectrumLine,":")+1:),*) littleHubbleCMB
-                   if (Values_Differ(littleHubbleCMB,self%cosmologyParameters_%HubbleConstant(hubbleUnitsLittleH),relTol=1.0d-2)) &
-                        & call Error_Report(                                                                           &
-                        &                              'values of H₀ in Galacticus and CosmicEmu are significantly different' //  &
-                        &                               {introspection:location}                                                  &
-                        &                             )
-                end if
-             else
-                iWavenumber=iWavenumber+1
-                read (powerSpectrumLine,*) self%wavenumberTable(iWavenumber),self%powerSpectrumTable(iWavenumber)
-             end if
-          end do
-          close(powerSpectrumUnit)
-          ! Convert to logarithmic values.
-          self%wavenumberTable   =log(self%wavenumberTable   )
-          self%powerSpectrumTable=log(self%powerSpectrumTable)
-          ! Build the interpolator.
-          if (allocated(self%interpolator_)) deallocate(self%interpolator_)
-          allocate(self%interpolator_)
-          self%interpolator_=interpolator(self%wavenumberTable,self%powerSpectrumTable,extrapolationType=extrapolationTypeExtrapolate)
           ! Destroy the parameter file.
           call File_Remove(char(parameterFile))
        end if
+       ! Read the data file.
+       self%wavenumberCount=Count_Lines_In_File(powerSpectrumFile,"#")
+       if (allocated(self%wavenumberTable   )) deallocate(self%wavenumberTable   )
+       if (allocated(self%powerSpectrumTable)) deallocate(self%powerSpectrumTable)
+       allocate(self%wavenumberTable   (self%wavenumberCount))
+       allocate(self%powerSpectrumTable(self%wavenumberCount))
+       open(newunit=powerSpectrumUnit,file=char(powerSpectrumFile),status='old',form='formatted')
+       iWavenumber=0
+       do while (iWavenumber < self%wavenumberCount)
+          read (powerSpectrumUnit,'(a)') powerSpectrumLine
+          if (powerSpectrumLine(1:1) == "#") then
+             if (powerSpectrumLine(1:33) == "# dimensionless Hubble parameter") then
+                read (powerSpectrumLine(index(powerSpectrumLine,":")+1:),*) littleHubbleCMB
+                if (Values_Differ(littleHubbleCMB,self%cosmologyParameters_%HubbleConstant(hubbleUnitsLittleH),relTol=1.0d-2)) &
+                     & call Error_Report(                                                                                      &
+                     &                   'values of H₀ in Galacticus and CosmicEmu are significantly different'//              &
+                     &                    {introspection:location}                                                             &
+                     &                  )
+             end if
+          else
+             iWavenumber=iWavenumber+1
+             read (powerSpectrumLine,*) self%wavenumberTable(iWavenumber),self%powerSpectrumTable(iWavenumber)
+          end if
+       end do
+       close(powerSpectrumUnit)
+       ! Convert to logarithmic values.
+       self%wavenumberTable   =log(self%wavenumberTable   )
+       self%powerSpectrumTable=log(self%powerSpectrumTable)
+       ! Build the interpolator.
+       if (allocated(self%interpolator_)) deallocate(self%interpolator_)
+       allocate(self%interpolator_)
+       self%interpolator_=interpolator(self%wavenumberTable,self%powerSpectrumTable,extrapolationType=extrapolationTypeExtrapolate)
        call File_Unlock(self%fileLock)
     end if
     ! Interpolate in the tabulated data to get the power spectrum.

--- a/source/structure_formation.power_spectrum.nonlinear.CosmicEmu.F90
+++ b/source/structure_formation.power_spectrum.nonlinear.CosmicEmu.F90
@@ -255,7 +255,7 @@ contains
              end if
              ! Build the code.
              call displayMessage("compiling CosmicEmu code....",verbosityLevelWorking)
-             call System_Command_Do("cd "//inputPath(pathTypeDataDynamic)//"CosmicEmu_v1.1; sed -i~ -r s/""^(\s*gcc.*\-lm)\s*$""/""\1 \-I\`gsl\-config \-\-prefix\`\n\n%.o: %.c\n\tgcc -c \$< -o \$\*\.o \-I\`gsl\-config \-\-prefix\`\n""/ makefile; make");
+             call System_Command_Do("cd "//inputPath(pathTypeDataDynamic)//"CosmicEmu_v1.1; sed -i~ -r s/""^(\s*gcc.*\-lm)\s*$""/""\1 \-I\`gsl\-config \-\-prefix\`\n\n%.o: %.c\n\tgcc -c \$< -o \$\*\.o \-I\`gsl\-config \-\-prefix\`\n""/ makefile; sed -i~ -r s/""\-lgsl\s+\-lgslcblas\s+\-lm""/""\`gsl\-config \-\-libs\`""/ makefile; make");
              if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu_v1.1/emu.exe")) &
                   & call Error_Report("failed to build Cosmic_Emu code"//{introspection:location})
           end if

--- a/testSuite/regressions/cosmicEmu.pl
+++ b/testSuite/regressions/cosmicEmu.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use PDL;
+use PDL::IO::HDF5;
+
+# Run a power spectrum task using the CosmicEmu nonlinear power spectrum twice. This tests that a pre-computed power spectrum file
+# is correctly re-read on subsequent runs.
+# Andrew Benson (13-October-2023)
+
+# Run the model and check for successful completion.
+for(my $i=0;$i<2;++$i) {
+    system("./Galacticus.exe testSuite/regressions/cosmicEmu.xml");
+    die("FAILED: cosmicEmu.pl model failed to complete") 
+	unless ( $? == 0 );
+}
+
+exit;

--- a/testSuite/regressions/cosmicEmu.xml
+++ b/testSuite/regressions/cosmicEmu.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Parameters for tutorial on computing the power spectrum - https://github.com/galacticusorg/galacticus/wiki/Tutorial%3A-Power-spectra -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <version>0.9.4</version>
+
+  <!-- Specify tasks to perform -->
+  <task value="powerSpectra">
+    <includeNonLinear value="true"/>
+  </task>
+
+  <!-- Cosmological parameters -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.20000"/>
+    <OmegaMatter value=" 0.27250"/>
+    <OmegaDarkEnergy value=" 0.72750"/>
+    <OmegaBaryon value=" 0.04550"/>
+    <temperatureCMB value=" 2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+    <tolerance value="1.0e-3"/>
+  </cosmologicalMassVariance>
+  <powerSpectrumNonLinear value="cosmicEmmu"/>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/regressions/powerSpectrumCosmicEmu.hdf5"/>
+  <outputTimes value="list">
+    <redshifts value="0.0 1.0"/>
+  </outputTimes>
+
+</parameters>


### PR DESCRIPTION
Previously if the file already existed (from a previous run) it would not be read, leading to a segfault as the interpolator was uninitialized.