### PR TITLE
Allow download of Cloudy from `old/` subdirectory if main directory fails

### DIFF
--- a/source/interface.Cloudy.F90
+++ b/source/interface.Cloudy.F90
@@ -69,7 +69,11 @@ contains
           if (.not.File_Exists(cloudyPath//".tar.gz")) then
              call displayMessage("downloading Cloudy code....",verbosityLevelWorking)
              call download('"http://data.nublado.org/cloudy_releases/c'//char(cloudyVersionMajor)//'/'//char(cloudyVersion)//'.tar.gz"',char(cloudyPath)//'.tar.gz',status=status)
-             if (status /= 0) call Error_Report("failed to download Cloudy code"//{introspection:location})
+             if (status /= 0) then
+                ! Try the "old/" subdirectory. Sometimes the source is moved to this path prior to a new release.
+                call download('"http://data.nublado.org/cloudy_releases/c'//char(cloudyVersionMajor)//'/old/'//char(cloudyVersion)//'.tar.gz"',char(cloudyPath)//'.tar.gz',status=status)
+                if (status /= 0) call Error_Report("failed to download Cloudy code"//{introspection:location})
+             end if
           end if
           ! Unpack and patch the code.
           call displayMessage("unpacking and patching Cloudy code....",verbosityLevelWorking)

--- a/source/system.downloader.F90
+++ b/source/system.downloader.F90
@@ -112,7 +112,7 @@ contains
        end if
        tries=tries+1
        if (File_Exists(outputFileName)) call File_Remove(outputFileName)
-       call sleep(retryWait)
+       call sleep(retryWait_)
     end do
     if (     present(status)                   )  status=status_
     if (.not.present(status) .and. status_ /= 0) call Error_Report('failed to download "'//trim(url)//'"'//{introspection:location})


### PR DESCRIPTION
Useful as sometimes the source is moved to `old/` several days before the new release source is available.