### PR TITLE
Fix broken regex behavior

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Process/DeepCopyActions.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/DeepCopyActions.pm
@@ -37,10 +37,21 @@ sub Process_DeepCopyActions {
 	# Capture derived type definitions.
 	if ( $node->{'type'} eq "type" ) {
 	    # Parse class openers to find dependencies.
-	    if ( $node->{'opener'} =~ m/^\s*type\s*(,\s*(abstract)\s*|,\s*public\s*|,\s*private\s*|,\s*extends\s*\(([a-zA-Z0-9_]+)\)\s*)*(::)??\s*([a-z0-9_]+)\s*$/i ) {
-		my $type     = $5;
-		my $extends  = $3;
-		my $abstract = defined($2);
+	    if ( my @matches = $node->{'opener'} =~ m/^\s*type\s*((,\s*abstract\s*|,\s*public\s*|,\s*private\s*|,\s*extends\s*\([a-zA-Z0-9_]+\)\s*)*)(::)??\s*([a-zA-Z0-9_]+)\s*$/i ) {
+		my $type     = $4;
+		$matches[0] =~ s/^\s*,\s*//;
+		$matches[0] =~ s/\s*$//;
+		my @attributes = split(/\s*,\s*/,$matches[0]);
+		my $extends;
+		my $abstract = 0;
+		foreach my $attribute ( @attributes ) {
+		    if ( $attribute eq "abstract" ) {
+			$abstract = 1;
+		    }
+		    if ( $attribute =~ m/extends\(([a-zA-Z0-9_]+)\)/ ) {
+			$extends  = $1;
+		    }
+		}
 		$classes{$type} =
 		{
 		     node     => $node   ,

--- a/perl/Galacticus/Build/SourceTree/Process/StateStorable.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/StateStorable.pm
@@ -44,10 +44,21 @@ sub Process_StateStorable {
 	# Capture derived type definitions.
 	if ( $node->{'type'} eq "type" ) {
 	    # Parse class openers to find dependencies.
-	    if ( $node->{'opener'} =~ m/^\s*type\s*(,\s*(abstract)\s*|,\s*public\s*|,\s*private\s*|,\s*extends\s*\(([a-zA-Z0-9_]+)\)\s*)*(::)??\s*([a-z0-9_]+)\s*$/i ) {
-		my $type     = $5;
-		my $extends  = $3;
-		my $abstract = defined($2);
+	    if ( my @matches = $node->{'opener'} =~ m/^\s*type\s*((,\s*abstract\s*|,\s*public\s*|,\s*private\s*|,\s*extends\s*\([a-zA-Z0-9_]+\)\s*)*)(::)??\s*([a-zA-Z0-9_]+)\s*$/i ) {
+		my $type     = $4;
+		$matches[0] =~ s/^\s*,\s*//;
+		$matches[0] =~ s/\s*$//;
+		my @attributes = split(/\s*,\s*/,$matches[0]);
+		my $extends;
+		my $abstract = 0;
+		foreach my $attribute ( @attributes ) {
+		    if ( $attribute eq "abstract" ) {
+			$abstract = 1;
+		    }
+		    if ( $attribute =~ m/extends\(([a-zA-Z0-9_]+)\)/ ) {
+			$extends  = $1;
+		    }
+		}
 		$classes{$type} =
 		{
 		     node     => $node   ,

--- a/scripts/build/libraryInterfaces.pl
+++ b/scripts/build/libraryInterfaces.pl
@@ -188,7 +188,10 @@ foreach my $className ( sort(keys(%{$code})) ) {
 $python->{'units'}->{'init'}->{'content'} = fill_in_string(<<'CODE', PACKAGE => 'ext');
 from ctypes import *
 # Load the shared library into ctypes.
-libname = "./galacticus/lib/libgalacticus.so"
+import os
+# Load the shared library into ctypes.
+cwd = os.getcwd()
+libname = os.path.join(cwd,"galacticus/lib/libgalacticus.so")
 c_lib = CDLL(libname)
 c_lib.libGalacticusInitL()
 CODE


### PR DESCRIPTION
Perl v38 (which now ships with GitHub MacOS runners) has a subtle change in behavior for regexes using grouped alternative matches with sub-matches. This broke behavior in identifying abstract classes in a couple cases. A more robust approach that avoids sub-matches in this case.