### PR TITLE
Correct a typo in the name of the `galacticStructure` parameter

### DIFF
--- a/source/galactic.structure.utilities.F90
+++ b/source/galactic.structure.utilities.F90
@@ -60,7 +60,7 @@ contains
     type (inputParameters)               , pointer :: parametersCurrent
 
     parametersCurrent => parameters
-    do while (.not.parametersCurrent%isPresent('galacticStructurw').and.associated(parametersCurrent%parent))
+    do while (.not.parametersCurrent%isPresent('galacticStructure').and.associated(parametersCurrent%parent))
        parametersCurrent => parametersCurrent%parent
     end do
     if (.not.parametersCurrent%isPresent('galacticStructure')) parametersCurrent => parameters


### PR DESCRIPTION
In the globally-callable constructor function for the `galacticStructure` class, the parameter name `galacticStructure` was misspelled. This could lead to the object being constructed from the wrong entry in the parameter file.