### PR TITLE
Remove some OpenMP critical sections

### DIFF
--- a/source/merger_trees.operators.augment.F90
+++ b/source/merger_trees.operators.augment.F90
@@ -427,14 +427,12 @@ contains
              end do
              ! Accumulate the histogram of rescalings.
              if (nodeBranches) then
-                !$omp critical (Augment_Statistics)
                 self        %retryHistogram(min(rescaleCount,ubound(self%retryHistogram)))= &
                      & +self%retryHistogram(min(rescaleCount,ubound(self%retryHistogram)))  &
                      & +1
                 self        %trialCount    (min(rescaleCount,ubound(self%retryHistogram)))= &
                      & +self%trialCount    (min(rescaleCount,ubound(self%retryHistogram)))  &
                      & +max(1,1+retryCount)
-                !$omp end critical (Augment_Statistics)
              end if
              ! Clean up the best tree if one exists.
              if (associated(treeBest%nodeBase)) then

--- a/source/merger_trees.operators.export.F90
+++ b/source/merger_trees.operators.export.F90
@@ -302,9 +302,7 @@ contains
        end if
        if (self%snapshotsRequired) call mergerTrees%setProperty(propertyTypeSnapshot,nodeSnapshot)
        ! Write the tree to file.
-       !$omp critical (Merger_Tree_Write)
        call mergerTrees%export(char(self%outputFileName),self%exportFormat,hdfChunkSize,hdfCompressionLevel,append=.true.)
-       !$omp end critical (Merger_Tree_Write)
        ! Deallocate arrays.
        deallocate(treeIndex      )
        deallocate(treeWeight     )

--- a/source/objects.merger_tree_data.F90
+++ b/source/objects.merger_tree_data.F90
@@ -1503,8 +1503,9 @@ contains
     !!{
     Output a set of merger trees to an HDF5 file.
     !!}
-    use :: Error, only : Error_Report
-    use :: HDF5 , only : hsize_t
+    use :: Error         , only : Error_Report
+    use :: HDF5          , only : hsize_t
+    use :: File_Utilities, only : lockDescriptor, File_Lock, File_Unlock
     implicit none
     integer  (kind=hsize_t                   ), intent(in   )           :: hdfChunkSize
     integer                                   , intent(in   )           :: hdfCompressionLevel
@@ -1512,6 +1513,7 @@ contains
     class    (mergerTreeData                 ), intent(inout)           :: mergerTrees
     character(len=*                          ), intent(in   )           :: outputFileName
     logical                                   , intent(in   ), optional :: append
+    type     (lockDescriptor                 )                          :: fileLock
 
     ! Validate the merger tree.
     call Merger_Tree_Data_Validate_Trees            (mergerTrees)
@@ -1519,6 +1521,7 @@ contains
     ! If we have most-bound particle indices and particle data has been read, construct arrays giving position of particle data for each node.
     call Merger_Tree_Data_Construct_Particle_Indices(mergerTrees)
 
+    call File_Lock(outputFileName,fileLock,lockIsShared=.false.)
     select case (outputFormat%ID)
     case (mergerTreeFormatGalacticus%ID)
        call Merger_Tree_Data_Structure_Export_Galacticus(mergerTrees,outputFileName,hdfChunkSize,hdfCompressionLevel,append)
@@ -1527,6 +1530,7 @@ contains
     case default
        call Error_Report('output format is not recognized'//{introspection:location})
     end select
+    call File_Unlock(fileLock)
     return
   end subroutine Merger_Tree_Data_Structure_Export
 


### PR DESCRIPTION
In one case this is no longer needed (now that the relevant code is object-oriented). In the other a file lock is a better solution.