### PR TITLE
Fix a segfault associated with output of `rank?VarLen` datasets

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10561,6 +10561,7 @@ jobs:
              Regressions-Tree-With-Initial-Satellite-In-Progenitorless-Host,
              Regressions-Tree-With-No-Primary-Progenitor,
              Regressions-Bar-Instability-FPE,
+             Regressions-Output-Rank2VarLen-SegFault,
              Test-Methods-01,
              Test-Methods-02,
              Test-Methods-03,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8815,6 +8815,42 @@ jobs:
           ./Galacticus.exe testSuite/regressions/treeWithNoPrimaryProgenitor.xml 2>&1 | tee test.log
           ! grep -q FAIL test.log
       - run: echo "This job's status is ${{ job.status }}."
+  Regressions-Output-Rank2VarLen-SegFault:
+    runs-on: ubuntu-latest
+    container: ghcr.io/galacticusorg/buildenv:latest
+    needs: Build-Executable-Linux
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server."
+      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Check out repository datasets
+        uses: actions/checkout@v4      
+        with:
+          repository: galacticusorg/datasets
+          path: datasets
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
+      - name: Download executables
+        uses: actions/download-artifact@v3
+        with:
+          name: galacticus-exec
+      - name: Create test suite output directory
+        run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
+      - name: Run test
+        run: |
+          cd $GALACTICUS_EXEC_PATH
+          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+          chmod u=wrx ./Galacticus.exe
+          mkdir -p testSuite/outputs/regressions
+          set -o pipefail
+          ./Galacticus.exe testSuite/regressions/outputRank2ExtendSegFault.xml 2>&1 | tee test.log
+          ! grep -q FAIL test.log
+      - run: echo "This job's status is ${{ job.status }}."
   Regressions-Bar-Instability-FPE:
     runs-on: ubuntu-latest
     container: ghcr.io/galacticusorg/buildenv:latest

--- a/source/merger_trees.outputter.standard.F90
+++ b/source/merger_trees.outputter.standard.F90
@@ -477,7 +477,7 @@ contains
           doubleArray =extractor_%extract       (node,time,instance)
           do i=1,+extractor_%elementCount(                  time)
              if (     allocated(self%doubleProperty (doubleProperty +i)%scalar))                          deallocate(self%doubleProperty (doubleProperty +i)%scalar)
-             if (     allocated(self%doubleProperty (doubleProperty +i)%rank1 )) then
+             if (     allocated(self%doubleProperty (doubleProperty +i)%rank1 )) then 
                 if (size(self%doubleProperty (doubleProperty +i)%rank1,dim=1) /= size(doubleArray,dim=1)) deallocate(self%doubleProperty (doubleProperty +i)%rank1 )
              end if
              if (.not.allocated(self%doubleProperty (doubleProperty +i)%rank1)) allocate(self%doubleProperty (doubleProperty +i)%rank1(size(doubleArray,dim=1),self%doubleBufferSize))
@@ -513,7 +513,11 @@ contains
              if (     allocated(self%doubleProperty (doubleProperty +i)%rank1VarLen))                          deallocate(self%doubleProperty (doubleProperty +i)%rank1VarLen)
              if (.not.allocated(self%doubleProperty (doubleProperty +i)%rank2VarLen)) allocate(self%doubleProperty (doubleProperty +i)%rank2VarLen(self%doubleBufferSize))
              if (associated(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row)) then
-                if (size(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row) /= size(doubleArray2D,dim=1)) deallocate(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row)
+                if     (                                                                                                                            &
+                     &   size(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row,dim=1) /= size(doubleArray2D,dim=1) &
+                     &  .or.                                                                                                                        &
+                     &   size(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row,dim=2) /= size(doubleArray2D,dim=2) &
+                     & ) deallocate(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row)
              end if
              if (.not.associated(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row)) then
                 allocate(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row(size(doubleArray2D,dim=1),size(doubleArray2D,dim=2)))
@@ -573,7 +577,11 @@ contains
                 if (.not.allocated(self%doubleProperty(doubleProperty +i)%rank2VarLen)) allocate(self%doubleProperty (doubleProperty +i)%rank2VarLen(self%doubleBufferSize))
                 if (associated(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row)) then
                    shape_=doubleProperties(i)%shape()
-                   if (size(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row) /= shape_(1)) deallocate(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row)
+                   if     (                                                                                                            &
+                        &   size(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row,dim=1) /= shape_(1) &
+                        &  .or.                                                                                                        &
+                        &   size(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row,dim=2) /= shape_(2) &
+                        & ) deallocate(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row)
                    deallocate(shape_)
                 end if
                 if (.not.associated(self%doubleProperty (doubleProperty +i)%rank2VarLen (self%doubleBufferCount )%row)) then
@@ -828,28 +836,52 @@ contains
     !!{
     Extend the size of the double buffer.
     !!}
+    use :: IO_HDF5, only : hdf5VarDouble , hdf5VarDouble2D
     implicit none
     class           (mergerTreeOutputterStandard), intent(inout)                 :: self
     double precision                             , allocatable  , dimension(:  ) :: scalarTemporary
     double precision                             , allocatable  , dimension(:,:) :: rank1Temporary
-    integer                                                                      :: i
+    type            (hdf5VarDouble              ), allocatable  , dimension(:  ) :: rank1VarLenTemporary
+    type            (hdf5VarDouble2D            ), allocatable  , dimension(:  ) :: rank2VarLenTemporary
+    integer                                                                      :: i                   , j
 
     do i=1,size(self%doubleProperty)
-       if (allocated(self%doubleProperty(i)%scalar)) then
-          call move_alloc(self%doubleProperty(i)%scalar,scalarTemporary)
-          allocate(self%doubleProperty(i)%scalar(                           self%doubleBufferSize+standardBufferSizeIncrement))
-          self%doubleProperty(i)%scalar(  1:self%doubleBufferSize)=scalarTemporary
+       if (allocated(self%doubleProperty(i)%scalar    )) then
+          call move_alloc(self%doubleProperty(i)%scalar    ,scalarTemporary)
+          allocate(self%doubleProperty(i)%scalar    (                           self%doubleBufferSize+standardBufferSizeIncrement))
+          self%doubleProperty(i)%scalar    (  1:self%doubleBufferSize)=scalarTemporary
           deallocate(scalarTemporary)
        end if
-       if (allocated(self%doubleProperty(i)%rank1 )) then
-          call move_alloc(self%doubleProperty(i)%rank1 ,rank1Temporary )
-          allocate(self%doubleProperty(i)%rank1 (size(rank1Temporary,dim=1),self%doubleBufferSize+standardBufferSizeIncrement))
-          self%doubleProperty(i)%rank1 (:,1:self%doubleBufferSize)=rank1Temporary
+       if (allocated(self%doubleProperty(i)%rank1     )) then
+          call move_alloc(self%doubleProperty(i)%rank1     ,rank1Temporary )
+          allocate(self%doubleProperty(i)%rank1     (size(rank1Temporary,dim=1),self%doubleBufferSize+standardBufferSizeIncrement))
+          self%doubleProperty(i)%rank1     (:,1:self%doubleBufferSize)=rank1Temporary
           deallocate(rank1Temporary )
+       end if
+       if (allocated(self%doubleProperty(i)%rank1VarLen)) then
+          call move_alloc(self%doubleProperty(i)%rank1VarLen,rank1VarLenTemporary)
+          allocate(self%doubleProperty(i)%rank1VarLen(                           self%doubleBufferSize+standardBufferSizeIncrement))
+          self%doubleProperty(i)%rank1VarLen(  1:self%doubleBufferSize)=rank1VarLenTemporary
+          ! Nullify row pointers in the temporary array to avoid the associated data being destroyed when our temporary array is
+          ! deallocated.
+          do j=1,size(rank1VarLenTemporary)
+             rank1VarLenTemporary(j)%row => null()
+          end do
+          deallocate(rank1VarLenTemporary)
+       end if
+       if (allocated(self%doubleProperty(i)%rank2VarLen)) then
+          call move_alloc(self%doubleProperty(i)%rank2VarLen,rank2VarLenTemporary)
+          allocate(self%doubleProperty(i)%rank2VarLen(                           self%doubleBufferSize+standardBufferSizeIncrement))
+          self%doubleProperty(i)%rank2VarLen(  1:self%doubleBufferSize)=rank2VarLenTemporary
+          ! Nullify row pointers in the temporary array to avoid the associated data being destroyed when our temporary array is
+          ! deallocated.
+          do j=1,size(rank2VarLenTemporary)
+             rank2VarLenTemporary(j)%row => null()
+          end do
+          deallocate(rank2VarLenTemporary)
        end if
     end do
     self%doubleBufferSize=self%doubleBufferSize+standardBufferSizeIncrement
-
     return
   end subroutine standardExtendDoubleBuffer
 

--- a/testSuite/regressions/outputRank2ExtendSegFault.xml
+++ b/testSuite/regressions/outputRank2ExtendSegFault.xml
@@ -1,0 +1,464 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Regression test for segfault resulting from extension of output buffers when rank-1 or rank-2 varlen outputs are used -->
+<!-- 14-December-2024                                  0                                                                   -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <version>0.9.4</version>
+  <!-- Task and work control -->
+  <task value="evolveForests">
+    <walltimeMaximum value="-1"/> 
+  </task>
+  <evolveForestsWorkShare value="cyclic"/>
+  
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard"/>
+
+  <componentHotHalo           value="standard"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard"/>
+
+  <diskMassDistribution value="exponentialDisk">
+    <dimensionless value="true"/>
+  </diskMassDistribution>
+  
+  <spheroidMassDistribution value="hernquist">
+    <dimensionless value="true"/>
+  </spheroidMassDistribution>
+
+  <treeNodeMethodSpin3D value="vector"/>
+  
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.0"/>	
+    <OmegaMatter value=" 0.279000"/>	
+    <OmegaDarkEnergy value=" 0.721000"/>	
+    <OmegaBaryon value=" 0.046"/>	
+    <temperatureCMB value=" 2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.821"/> 	<!-- Planck 2018; arXiv:1807.06211 -->
+  </cosmologicalMassVariance>
+
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.9649"/> <!-- Planck 2018; arXiv:1807.06211 -->
+    <wavenumberReference value="1.0000"/>
+    <running value="0.0000"/> <!-- Planck 2018; arXiv:1807.06211 -->
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build">
+    <!-- Merger trees are built starting from z=0.0 -->
+    <redshiftBase value="0.0"/>
+  </mergerTreeConstructor>
+  <mergerTreeBuilder value="cole2000">
+    <!-- The Cole et al. (2000) merger tree building algorithm is used. The "interval stepping" optimization from Appendix A -->
+    <!-- of Benson, Ludlow, & Cole (2019, MNRAS, 485, 5010; https://ui.adsabs.harvard.edu/abs/2019MNRAS.485.5010B) is used   -->
+    <!-- to speed up tree building.                                                                                          -->
+    <accretionLimit     value="  0.1"/>
+    <mergeProbability   value="  0.1"/>
+    <redshiftMaximum    value="100.0"/>
+    <branchIntervalStep value="true" />
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="PCHPlus">
+    <!-- Merger tree branching rates are computed using the PCH+ algorithm, with parameters constrained to match progenitor -->
+    <!-- mass functions in the MDPL simulation suite.                                                                       -->
+    <!-- See: https://github.com/galacticusorg/galacticus/wiki/Constraints:-Dark-matter-progenitor-halo-mass-functions      -->
+    <!-- CDM assumptions are used here to speed up tree construction.                                                       -->
+    <G0                 value="+1.1425468378985500"/>
+    <gamma1             value="-0.3273597030267590"/>
+    <gamma2             value="+0.0587448775510245"/>
+    <gamma3             value="+0.6456170934757410"/>
+    <accuracyFirstOrder value="+0.1000000000000000"/>
+    <cdmAssumptions     value="true"               />
+  </mergerTreeBranchingProbability>
+  
+  <!--Builds a merger tree of MW halo mass-->
+  <mergerTreeBuildMasses value="fixedMass">
+    <massTree value="1e12"/>
+    <treeCount value="1"/>
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e7"/>
+  </mergerTreeMassResolution>
+  
+  <mergerTreeOperator value="sequence">
+    <mergerTreeOperator value="massAccretionHistory"/>
+  </mergerTreeOperator>
+  <radiationFieldIntergalacticBackground value="intergalacticBackgroundFile">
+    <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+  </radiationFieldIntergalacticBackground>
+  
+  
+  <luminosityFilter value="SDSS_g SDSS_r DES_g DES_r"/>
+  <luminosityPostprocessSet value="default recent unabsorbed recentUnabsorbed"/>
+  <luminosityRedshift value="0.0 0.0 0.0 0.0"/>
+  <luminosityType value="observed observed observed observed"/>
+
+  <stellarPopulationSpectraPostprocessorBuilder value="lookup">
+    <names value="default recent unabsorbed recentUnabsorbed"/>
+    <!-- default - includes absorption by the IGM -->
+    <stellarPopulationSpectraPostprocessor value="inoue2014" />
+    <!--recent - includes absorption by the IGM and includes only light from recently formed populations -->
+    <stellarPopulationSpectraPostprocessor value="sequence" >
+      <stellarPopulationSpectraPostprocessor value="inoue2014" />
+      <stellarPopulationSpectraPostprocessor value="recent" >
+	<timeLimit value="1.0e-2" /> <!-- t_{BC} of Charlot & Fall (2000; ApJ, 539, 718)-->
+      </stellarPopulationSpectraPostprocessor>
+    </stellarPopulationSpectraPostprocessor>
+    <!-- unabsorbed - includes all light, no absorption -->
+    <stellarPopulationSpectraPostprocessor value="identity" />
+    <stellarPopulationSpectraPostprocessor value="recent" >
+      <timeLimit value="1.0e-2" /> <!-- t_{BC} of Charlot & Fall (2000; ApJ, 539, 718)-->
+    </stellarPopulationSpectraPostprocessor>
+  </stellarPopulationSpectraPostprocessorBuilder>
+
+  <stellarSpectraDustAttenuation value="charlotFall2000"/>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter only halo structure options -->
+  <darkMatterProfileDMO value="heated">
+    <!-- Dark matter only halo profiles are set to be heated NFW profiles. Where analytic solutions for heated halo -->
+    <!-- properties are not available, numerical solutions are selected.                                            -->
+    <darkMatterProfileDMO value="NFW"      />
+    <nonAnalyticSolver    value="numerical"/>
+    <toleranceRelativeVelocityDispersionMaximum value="0.1"/>
+  </darkMatterProfileDMO>
+  <darkMatterProfileHeating value="tidal">
+    <!-- The heating source for dark matter halos is set to be tidal heating from their host halo. Parameter values are based on
+         matching tidal tracks from Errani & Navarro (2021; MNRAS; 505; 18;
+         https://ui.adsabs.harvard.edu/abs/2021MNRAS.505...18E), as described in
+         https://hackmd.io/GAVyCqaKRoWvN_D9_B4qrg#New-Tidal-Heating-Model -->
+    <!--<coefficientSecondOrder    value="+0.406"/> -->
+    <coefficientSecondOrder0   value="+0.030"/>
+    <coefficientSecondOrder1   value="-0.320"/>
+    <correlationVelocityRadius value="-0.333"/>
+  </darkMatterProfileHeating>
+
+  <!-- Dark matter profile scale radii model -->
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <!-- Limit scale radii to keep concentrations within a reasonable range. -->
+    <concentrationMinimum value="  3.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="johnson2021">
+      <!-- Scale radii are computed using the energy random walk model of Johnson, Benson, & Grin (2021; ApJ; 908; 33; http://adsabs.harvard.edu/abs/2021ApJ...908...33J). -->
+      <!-- Best-fit values of the parameters are taken from https://github.com/galacticusorg/galacticus/wiki/Constraints:-Halo-spins-and-concentrations.                   -->
+      <energyBoost      value="0.797003643180003"/>
+      <massExponent     value="2.168409985653090"/>
+      <unresolvedEnergy value="0.550000000000000"/>
+      <!-- For leaf nodes in the tree we instead set scale radii using a concentration-mass-redshift model, with concentrations limited to a reasonable range. -->
+      <darkMatterProfileScaleRadius value="concentration"/>
+    </darkMatterProfileScaleRadius>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="diemerJoyce2019">
+    <!-- Use the Diemer & Joyce (2019; ApJ; 871; 168; http://adsabs.harvard.edu/abs/2019ApJ...871..168D) model for concentrations. -->
+  </darkMatterProfileConcentration>
+  
+  <!-- Dark matter halo spin options -->
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="naozBarkana2007"/>
+  <intergalacticMediumFilteringMass value="gnedin2000"/>
+  <intergalacticMediumState value="metallicityPolynomial">
+    <coefficients value="-1.3 -1.9"/>
+    <intergalacticMediumState value="instantReionization">
+      <electronScatteringOpticalDepth value="0.0633"/>
+      <reionizationTemperature value="2.0e4"/>
+      <presentDayTemperature value="1.0e3"/>
+      <intergalacticMediumState value="recFast"/>
+    </intergalacticMediumState>
+  </intergalacticMediumState>
+  
+  <coldModeInfallRate value="dynamicalTime">
+    <dynamicalRateFraction value="2.0"/>
+  </coldModeInfallRate>
+  
+  <!-- CGM gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.142588563154576"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="7.84401490527569"/>
+  </hotHaloOutflowReincorporation>
+  
+  <coolingFunction value="summation">
+    <coolingFunction value="atomicCIECloudy"/>
+    <coolingFunction value="CMBCompton"/>
+    <coolingFunction value="molecularHydrogenGalliPalla"/>
+  </coolingFunction>
+
+  <chemicalReactionRate value="hydrogenNetwork">
+    <fast value="true"/>
+    <includeSelfShielding value="true"/>
+  </chemicalReactionRate>
+  <chemicalsToTrack value="AtomicHydrogen AtomicHydrogenCation MolecularHydrogen Electron"/>
+  
+  <coolingRate value="multiplier">
+    <multiplier value="15"/>
+    <coolingRate value="whiteFrenk1991">
+      <velocityCutOff value="10000"/>
+    </coolingRate>
+  </coolingRate>
+  
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0.774282113742516"/>
+  </coolingTimeAvailable>
+  <hotHaloAngularMomentumLossFraction value="0.0871188291891892"/>
+  <starveSatellites value="false"/>
+
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <hotHaloOutflowStrippingEfficiency value="0.1"/>
+  <hotHaloTrackStrippedGas value="true"/>
+  
+  <satelliteTidalField value="sphericalSymmetry"/>
+  <satelliteTidalStripping value="zentner2005"/>
+  
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="simple"/>
+  <darkMatterProfile value="darkMatterOnly"/>
+  <spheroidAngularMomentumAtScaleRadius value="0.50"/>
+
+  <!-- Star formation rate options -->
+  <starFormationRateSurfaceDensityDisks value="blitz2006">
+    <velocityDispersionDiskGas value="10.0"/>
+    <heightToRadialScaleDisk value="0.137"/>
+    <surfaceDensityCritical value="200.0"/>
+    <surfaceDensityExponent value="0.4"/>
+    <starFormationFrequencyNormalization value="5.25e-10"/>
+    <pressureCharacteristic value="4.54"/>
+    <pressureExponent value="0.92"/>
+  </starFormationRateSurfaceDensityDisks>
+  
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.00415758894175098"/>
+      <exponentVelocity value="3.27016548773809"/>
+      <timescaleMinimum value="7.57979244540382"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="instantaneous"/>
+  
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+  <initialMassFunction value="chabrier2001"/>
+  <stellarPopulation value="standard">
+    <recycledFraction value="0.128400314266335"/>
+    <metalYield value="0.00721512185415169"/>
+  </stellarPopulation>
+
+  <!-- AGN feedback options -->
+  <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleHeatsHotHalo value="true"/>
+
+  <stellarWinds value="leitherer1992"/>
+  <initialMassForSupernovaTypeII value="8.0"/>
+  <supernovaeIa value="nagashima"/>
+  <supernovaePopIII value="Heger-Woosley2002"/>
+  <stellarFeedback value="standard"/>
+  
+  <!-- Black hole options -->
+  <blackHoleSeedMass value="100"/>
+  <blackHoleToSpheroidStellarGrowthRatio value="2.32959186797031"/>
+  <blackHoleHeatingEfficiency value="0.00140338137883176"/>
+  <blackHoleWindEfficiency value="0.211884639031352"/>
+  <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleEfficiency value="0.213288020410184"/>
+  <blackHoleJetFraction value="0.00657974778017468"/>
+
+  <!-- Satellite orbit options -->
+  <satelliteOrbitStoreOrbitalParameters value="true"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="li2020">
+    <darkMatterHaloScale   value="virialDensityContrastDefinition"/>
+    <virialDensityContrast value="bryanNorman1998"/>
+  </virialOrbit>
+  <satelliteMergingTimescales value="villalobos2013">
+    <exponent value="0.0949174380399185"/>
+    <satelliteMergingTimescales value="jiang2008">
+      <timescaleMultiplier value="5.49121979923864"/>
+    </satelliteMergingTimescales>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="dominant"/>
+    <destinationStarsMinorMerger value="dominant"/>
+    <massRatioMajorMerger value="0.207178360765429"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1.41586769307318"/>
+  </mergerRemnantSize>
+
+  <!-- Spheroid options -->
+  <spheroidEnergeticOutflowMassRate value="1.0e-2"/>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>    
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"        />
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <!-- Star formation options -->
+    <nodeOperator value="starFormationDisks">
+      <luminositiesStellarInactive value="true"/>
+    </nodeOperator>
+    <nodeOperator value="starFormationSpheroids">
+      <luminositiesStellarInactive value="true"/>
+    </nodeOperator>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.0127606668366045"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="160.019897613397"/><!--160.019897613397-->
+          <exponent value="1.7561921242039"/>
+        </stellarFeedbackOutflows>        
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.103745531708515"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="151.06489745284"/>
+          <exponent value="0.33561921242039"/><!--0.23561921242039-->
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="1.06448595007383"/>
+	<stabilityThresholdStellar value="1.198674706841"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="indexBranchTip"/>
+    <nodeOperator value="ramPressureMassLossDisks">
+      <ramPressureStripping value="simpleCylindrical">
+	<beta value="1.00"/>
+      </ramPressureStripping>
+    </nodeOperator>
+    <nodeOperator value="ramPressureMassLossSpheroids">
+      <ramPressureStripping value="simpleSpherical">
+	<beta value="1.00"/>
+      </ramPressureStripping>
+    </nodeOperator>
+    <!-- Tidal pressure stripping -->
+    <nodeOperator value="tidalMassLossDisks">
+      <tidalStripping value="simple">
+	<beta value="0.01"/>
+      </tidalStripping>
+    </nodeOperator>
+    <nodeOperator value="tidalMassLossSpheroids">
+      <tidalStripping value="simple">
+	<beta value="0.01"/>
+      </tidalStripping>
+    </nodeOperator>
+    <nodeOperator value="satelliteMassLoss">
+      <darkMatterHaloMassLossRate value="vanDenBosch"/>
+    </nodeOperator>
+    <nodeOperator value="indexShift"/>
+    <nodeOperator value="indexLastHost"/>
+    <nodeOperator value="timeFirstInfall"/>
+  </nodeOperator>
+  
+  <starFormationHistory value="adaptive">
+    <timeStepMinimum value="0.01"/>
+    <countTimeStepsMaximum value="390"/>
+    <countMetallicities value="0"/>
+    <countOutputBuffer value="100"/>
+  </starFormationHistory>
+  
+  <!-- Numerical tolerances -->
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0e+0"/>
+    <timestepHostRelative value="1.0e-1"/>
+    <fractionTimestepSatelliteMinimum value="0.75"/>
+    <backtrackToSatellites value="false"/>
+  </mergerTreeEvolver>
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+    <!--odeJacobianStepSizeRelative value="0.01"/>
+	<odeAlgorithm value="bdf"/>
+	<odeAlgorithmNonJacobian value="rungeKuttaCashKarp"/>
+	<odeLatentIntegratorType value="trapezoidal"/>
+	<odeLatentIntegratorIntervalsMaximum value="1000"/-->
+	<odeAlgorithm value="rungeKuttaCashKarp"/>
+	<reuseODEStepSize value="true"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolveTimestep value="multi">
+    <mergerTreeEvolveTimestep value="simple">
+      <timeStepAbsolute value="1.000"/>
+      <timeStepRelative value="0.100"/>
+    </mergerTreeEvolveTimestep>
+    <mergerTreeEvolveTimestep value="satellite">
+      <timeOffsetMaximumAbsolute value="0.010"/>
+      <timeOffsetMaximumRelative value="0.001"/>
+    </mergerTreeEvolveTimestep>
+  </mergerTreeEvolveTimestep>
+  <diskMassToleranceAbsolute value="1.0e-6"/>
+  <spheroidMassToleranceAbsolute value="1.0e-6"/>
+  <diskLuminositiesStellarInactive value="true"/>
+  <spheroidLuminositiesStellarInactive value="true"/>
+
+  <nodePropertyExtractor value="starFormationHistoryMass">
+    <component value="disk"/>
+  </nodePropertyExtractor>
+  
+  <elementsToTrack value="Fe"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="uniformSpacingInTime">
+    <timeMinimum value="0.04"/>
+    <timeMaximum value="0.54"/>
+    <countTimes value="6"/> 
+  </outputTimes>
+  
+  <outputFileName value="testSuite/outputs/regressions/outputRank2ExtendSegFault.hdf5"/>
+</parameters>


### PR DESCRIPTION
When the output buffers must be extended, the `rank1VarLen` and `rank2VarLen` arrays must be extended and their original content copied back in. The was previously not done, resulting in a segfault due to out-of-bounds array access.

Thanks @msbovill for finding this problem!