### PR TITLE
Fix various issues related to non-instantaneous evolution of stellar populations

### DIFF
--- a/source/benchmarks.stellar_luminosities.F90
+++ b/source/benchmarks.stellar_luminosities.F90
@@ -107,7 +107,8 @@ program Benchmark_Stellar_Populations_Luminosities
        &                                                                                 stellarTracks_                      =stellarTracks_                                                                                                &
        &                                                                                )
   supernovaeTypeIa_                     =supernovaeTypeIaNagashima2005                  (                                                                                                                                                   &
-       &                                                                                 stellarAstrophysics_                =stellarAstrophysics_                                                                                          &
+       &                                                                                 stellarAstrophysics_                =stellarAstrophysics_                                                                                        , &
+       &                                                                                 initialMassFunction_                =initialMassFunction_                                                                                          &
        &                                                                                )
   supernovaePopulationIII_              =supernovaePopulationIIIHegerWoosley2002        (                                                                                                                                                   &
        &                                                                                 stellarAstrophysics_                =stellarAstrophysics_                                                                                          &

--- a/source/stellar_astrophysics.file.F90
+++ b/source/stellar_astrophysics.file.F90
@@ -72,9 +72,11 @@
      double precision                         , allocatable, dimension(:  ) :: massEjectedMassEjected           , massEjectedMass                , &
           &                                                                    massEjectedMetallicity
      double precision                         , allocatable, dimension(:  ) :: yieldMetals                      , yieldMetalsMass                , &
-          &                                                                    yieldMetalsMetallicity
+          &                                                                    yieldMetalsMetallicity           , yieldMetalsRangeMass           , &
+          &                                                                    yieldMetalsRangeMetallicity
      double precision                         , allocatable, dimension(:,:) :: yieldElement                     , yieldElementMass               , &
-          &                                                                    yieldElementMetallicity
+          &                                                                    yieldElementMetallicity          , yieldElementRangeMass          , &
+          &                                                                    yieldElementRangeMetallicity
      integer                                  , allocatable, dimension(:  ) :: atomIndexMap                     , countYieldElement
      integer                                                                :: countElement
      type            (interp2dIrregularObject)                              :: interpolationWorkspaceMassInitial, interpolationWorkspaceLifetime , &
@@ -161,10 +163,11 @@ contains
     !!{
     Read stellar astrophysics data. This is not done during object construction since it can be slow---we only perform the read if the data is actually needed.
     !!}
-    use :: Atomic_Data      , only : Atomic_Short_Label
-    use :: FoX_DOM          , only : destroy                          , node                        , extractDataContent
-    use :: Error            , only : Error_Report
-    use :: IO_XML           , only : XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList       ,  XML_Parse
+    use :: Atomic_Data   , only : Atomic_Short_Label
+    use :: FoX_DOM       , only : destroy                          , node                        , extractDataContent
+    use :: Error         , only : Error_Report
+    use :: IO_XML        , only : XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList       ,  XML_Parse
+    use :: File_Utilities, only : File_Name_Expand
     implicit none
     class           (stellarAstrophysicsFile), intent(inout)               :: self
     type            (node                   ), pointer                     :: doc              , datum                   , &
@@ -181,7 +184,7 @@ contains
     if (self%readDone) return
     !$omp critical (FoX_DOM_Access)
     ! Open the XML file containing stellar properties.
-    doc => XML_Parse(char(self%fileName),iostat=ioErr)
+    doc => XML_Parse(char(File_Name_Expand(char(self%fileName))),iostat=ioErr)
     if (ioErr /= 0) call Error_Report('Unable to parse stellar properties file'//{introspection:location})
     ! Check the file format version of the file.
     datum => XML_Get_First_Element_By_Tag_Name(doc,"fileFormat")
@@ -218,6 +221,10 @@ contains
     ! Find number of elements for which some yield data is available.
     self%countElement       =count (self%countYieldElement > 0)
     countYieldElementMaximum=maxval(self%countYieldElement    )
+    ! Validate.
+    if (countLifetime    <= 0) call Error_Report('star compilation provides no lifetimes'     //{introspection:location})
+    if (countMassEjected <= 0) call Error_Report('star compilation provides no ejected masses'//{introspection:location})
+    if (countYieldMetals <= 0) call Error_Report('star compilation provides no metal yields'  //{introspection:location})
     ! Create mapping of atomic index to our array space.
     mapToIndex=0
     do iElement=1,size(self%countYieldElement)
@@ -229,18 +236,22 @@ contains
        end if
     end do
     ! Allocate arrays to store stellar properties.
-    allocate(self%lifetimeLifetime          (countLifetime                             ))
-    allocate(self%lifetimeMass              (countLifetime                             ))
-    allocate(self%lifetimeMetallicity       (countLifetime                             ))
-    allocate(self%massEjectedMassEjected    (countMassEjected                          ))
-    allocate(self%massEjectedMass           (countMassEjected                          ))
-    allocate(self%massEjectedMetallicity    (countMassEjected                          ))
-    allocate(self%yieldMetals               (countYieldMetals                          ))
-    allocate(self%yieldMetalsMass           (countYieldMetals                          ))
-    allocate(self%yieldMetalsMetallicity    (countYieldMetals                          ))
-    allocate(self%yieldElement              (countYieldElementMaximum,self%countElement))
-    allocate(self%yieldElementMass          (countYieldElementMaximum,self%countElement))
-    allocate(self%yieldElementMetallicity   (countYieldElementMaximum,self%countElement))
+    allocate(self%lifetimeLifetime            (countLifetime                             ))
+    allocate(self%lifetimeMass                (countLifetime                             ))
+    allocate(self%lifetimeMetallicity         (countLifetime                             ))
+    allocate(self%massEjectedMassEjected      (countMassEjected                          ))
+    allocate(self%massEjectedMass             (countMassEjected                          ))
+    allocate(self%massEjectedMetallicity      (countMassEjected                          ))
+    allocate(self%yieldMetals                 (countYieldMetals                          ))
+    allocate(self%yieldMetalsMass             (countYieldMetals                          ))
+    allocate(self%yieldMetalsMetallicity      (countYieldMetals                          ))
+    allocate(self%yieldElement                (countYieldElementMaximum,self%countElement))
+    allocate(self%yieldElementMass            (countYieldElementMaximum,self%countElement))
+    allocate(self%yieldElementMetallicity     (countYieldElementMaximum,self%countElement))
+    allocate(self%yieldMetalsRangeMass        (2                                         ))
+    allocate(self%yieldMetalsRangeMetallicity (2                                         ))
+    allocate(self%yieldElementRangeMass       (2                       ,self%countElement))
+    allocate(self%yieldElementRangeMetallicity(2                       ,self%countElement))
     ! Loop over stars to process their properties.
     countLifetime         =0
     countMassEjected      =0
@@ -309,6 +320,15 @@ contains
     ! Destroy the document.
     call destroy(doc)
     !$omp end critical (FoX_DOM_Access)
+    ! Find ranges of each tabulated property.
+    self%yieldMetalsRangeMass       =[minval(self%yieldMetalsMass       ),maxval(self%yieldMetalsMass       )]
+    self%yieldMetalsRangeMetallicity=[minval(self%yieldMetalsMetallicity),maxval(self%yieldMetalsMetallicity)]
+    do iElement=1,size(self%countYieldElement)
+       if (self%atomIndexMap(iElement) > 0) then
+          self%yieldElementRangeMass       (:,self%atomIndexMap(iElement))=[minval(self%yieldElementMass       (1:self%countYieldElement(iElement),self%atomIndexMap(iElement))),maxval(self%yieldElementMass       (1:self%countYieldElement(iElement),self%atomIndexMap(iElement)))]
+          self%yieldElementRangeMetallicity(:,self%atomIndexMap(iElement))=[minval(self%yieldElementMetallicity(1:self%countYieldElement(iElement),self%atomIndexMap(iElement))),maxval(self%yieldElementMetallicity(1:self%countYieldElement(iElement),self%atomIndexMap(iElement)))]
+       end if
+    end do
     self%readDone=.true.
     return
   end subroutine fileRead
@@ -393,37 +413,58 @@ contains
     double precision                         , intent(in   )           :: massInitial , metallicity
     integer                                  , intent(in   ), optional :: atomIndex
     integer                                                            :: elementIndex
-
+    double precision                                                   :: metallicity_
+    
     call self%read()
     if (present(atomIndex)) then
        ! Compute the element mass yield.
        elementIndex =self%atomIndexMap(atomIndex)
-       fileMassYield=max(                                                                                                                       &
-            &            Interpolate_2D_Irregular(                                                                                              &
-            &                                           self%yieldElementMass               (1:self%countYieldElement(atomIndex),elementIndex), &
-            &                                           self%yieldElementMetallicity        (1:self%countYieldElement(atomIndex),elementIndex), &
-            &                                           self%yieldElement                   (1:self%countYieldElement(atomIndex),elementIndex), &
-            &                                                massInitial                                                                      , &
-            &                                                metallicity                                                                      , &
-            &                                           self%interpolationWorkspaceMassYield                                                  , &
-            &                                     reset=self%interpolationResetMassYield                                                        &
-            &                                    )                                                                                            , &
-            &            0.0d0                                                                                                                  &
-            &           )
+       ! Exclude initial masses outside of the available range of stars.
+       if     (                                                           &
+            &   massInitial >= self%yieldElementRangeMass(1,elementIndex) &
+            &  .and.                                                      &
+            &   massInitial <= self%yieldElementRangeMass(2,elementIndex) &
+            & ) then
+          metallicity_ =min(max(metallicity,self%yieldElementRangeMetallicity(1,elementIndex)),self%yieldElementRangeMetallicity(2,elementIndex))
+          fileMassYield=max(                                                                                                                       &
+               &            Interpolate_2D_Irregular(                                                                                              &
+               &                                           self%yieldElementMass               (1:self%countYieldElement(atomIndex),elementIndex), &
+               &                                           self%yieldElementMetallicity        (1:self%countYieldElement(atomIndex),elementIndex), &
+               &                                           self%yieldElement                   (1:self%countYieldElement(atomIndex),elementIndex), &
+               &                                                massInitial                                                                      , &
+               &                                                metallicity_                                                                     , &
+               &                                           self%interpolationWorkspaceMassYield                                                  , &
+               &                                     reset=self%interpolationResetMassYield                                                        &
+               &                                    )                                                                                            , &
+               &            0.0d0                                                                                                                  &
+               &           )
+       else
+          fileMassYield=0.0d0
+       end if
     else
        ! Compute the metal mass yield.
-       fileMassYield=max(                                                                     &
-            &            Interpolate_2D_Irregular(                                            &
-            &                                           self%yieldMetalsMass                , &
-            &                                           self%yieldMetalsMetallicity         , &
-            &                                           self%yieldMetals                    , &
-            &                                                massInitial                    , &
-            &                                                metallicity                    , &
-            &                                           self%interpolationWorkspaceMassYield, &
-            &                                     reset=self%interpolationResetMassYield      &
-            &                                    )                                          , &
-            &             0.0d0                                                               &
-            &            )
+       ! Exclude initial masses outside of the available range of stars.
+       if     (                                             &
+            &   massInitial >= self%yieldMetalsRangeMass(1) &
+            &  .and.                                        &
+            &   massInitial <= self%yieldMetalsRangeMass(2) &
+            & ) then
+          metallicity_ =min(max(metallicity,self%yieldMetalsRangeMetallicity(1)),self%yieldMetalsRangeMetallicity(2))          
+          fileMassYield=max(                                                                     &
+               &            Interpolate_2D_Irregular(                                            &
+               &                                           self%yieldMetalsMass                , &
+               &                                           self%yieldMetalsMetallicity         , &
+               &                                           self%yieldMetals                    , &
+               &                                                massInitial                    , &
+               &                                                metallicity_                   , &
+               &                                           self%interpolationWorkspaceMassYield, &
+               &                                     reset=self%interpolationResetMassYield      &
+               &                                    )                                          , &
+               &             0.0d0                                                               &
+               &            )
+       else
+          fileMassYield=0.0d0
+       end if
     end if
     return
   end function fileMassYield

--- a/source/stellar_astrophysics.supernovae_PopulationIII.zero.F90
+++ b/source/stellar_astrophysics.supernovae_PopulationIII.zero.F90
@@ -1,0 +1,78 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a Population III supernovae class with no population III supernovae.
+  !!}
+  
+  !![
+  <supernovaePopulationIII name="supernovaePopulationIIIZero">
+   <description>
+    A Population III supernovae class that has zero population III supernovae.
+   </description>
+  </supernovaePopulationIII>
+  !!]
+  type, extends(supernovaePopulationIIIClass) :: supernovaePopulationIIIZero
+     !!{
+     A Population III supernovae class that has zero population III supernovae.
+     !!}
+     private
+   contains
+     procedure :: energyCumulative => zeroEnergyCumulative
+  end type supernovaePopulationIIIZero
+
+  interface supernovaePopulationIIIZero
+     !!{
+     Constructors for the {\normalfont \ttfamily zero} Population III supernovae class.
+     !!}
+     module procedure zeroConstructorParameters
+  end interface supernovaePopulationIIIZero
+
+contains
+
+  function zeroConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily zero} Population III supernovae class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type(supernovaePopulationIIIZero)                :: self
+    type(inputParameters            ), intent(inout) :: parameters
+
+    self=supernovaePopulationIIIZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function zeroConstructorParameters
+
+  double precision function zeroEnergyCumulative(self,initialMass,age,metallicity) result(energy)
+    !!{
+    Compute the cumulative energy input from Population III supernovae - there are zero population III supernovae in this model,
+    so zero energy.    
+    !!}
+    implicit none
+    class           (supernovaePopulationIIIZero), intent(inout) :: self
+    double precision                             , intent(in   ) :: age        , initialMass, &
+         &                                                          metallicity
+    !$GLC attributes unused :: self, initialMass, age, metallicity
+    
+    energy=0.0d0
+    return
+  end function zeroEnergyCumulative

--- a/source/stellar_astrophysics.supernovae_type_Ia.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.F90
@@ -36,10 +36,18 @@ module Supernovae_Type_Ia
     Class providing models of supernovae type Ia, including the cumulative number occurring and metal yield.
    </description>
    <default>nagashima2005</default>
+   <method name="massInitialRange" >
+    <description>Return the range of initial stellar masses that contribute to the Type Ia population.</description>
+    <type>void</type>
+    <pass>yes</pass>
+    <argument>double precision, intent(in   ) :: age               , metallicity       </argument>
+    <argument>double precision, intent(  out) :: massInitialMinimum, massInitialMaximum</argument>
+   </method>
    <method name="number" >
     <description>Return the cumulative number of Type Ia supernovae from a stellar population of the given {\normalfont \ttfamily initialMass}, {\normalfont \ttfamily age}, and {\normalfont \ttfamily metallicity}.</description>
     <type>double precision</type>
     <pass>yes</pass>
+    <selfTarget>yes</selfTarget>
     <argument>double precision, intent(in   ) :: initialMass, age, metallicity</argument>
    </method>
    <method name="yield" >

--- a/source/stellar_astrophysics.supernovae_type_Ia.Nagashima2005.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.Nagashima2005.F90
@@ -21,8 +21,10 @@
   Implements a supernovae type Ia class based on \cite{nagashima_metal_2005}.
   !!}
 
-  use :: Stellar_Astrophysics, only : stellarAstrophysicsClass
-
+  use :: Stellar_Astrophysics                      , only : stellarAstrophysicsClass
+  use :: Stellar_Populations_Initial_Mass_Functions, only : initialMassFunctionClass
+  use :: Numerical_Integration                     , only : integrator
+  
   !![
   <supernovaeTypeIa name="supernovaeTypeIaNagashima2005">
    <description>
@@ -37,6 +39,8 @@
      !!}
      private
      class           (stellarAstrophysicsClass), pointer                   :: stellarAstrophysics_ => null()
+     class           (initialMassFunctionClass), pointer                   :: initialMassFunction_ => null()
+     type            (integrator              ), allocatable               :: integrator_
      double precision                                                      :: totalYield
      double precision                          , allocatable, dimension(:) :: elementYield
      logical                                                               :: initialized
@@ -46,10 +50,11 @@
        <method method="initialize" description="Initialize yield data."/>
      </methods>
      !!]
-     final     ::               nagashima2005Destructor
-     procedure :: number     => nagashima2005Number
-     procedure :: yield      => nagashima2005Yield
-     procedure :: initialize => nagashima2005Initialize
+     final     ::                     nagashima2005Destructor
+     procedure :: massInitialRange => nagashima2005MassInitialRange
+     procedure :: number           => nagashima2005Number
+     procedure :: yield            => nagashima2005Yield
+     procedure :: initialize       => nagashima2005Initialize
   end type supernovaeTypeIaNagashima2005
 
   interface supernovaeTypeIaNagashima2005
@@ -60,6 +65,16 @@
      module procedure nagashima2005ConstructorInternal
   end interface supernovaeTypeIaNagashima2005
 
+  ! Sub-module-scope variables used in integration.
+  class           (supernovaeTypeIaNagashima2005), pointer :: self_
+  double precision                                         :: massSecondary
+  !$omp threadprivate(self_,massSecondary)
+
+  ! Parameters of the distribution of binaries from Nagashima et al. (2005; MNRAS; 358; 1427; eqn. 17).
+  double precision, parameter :: primaryMassMaximum=6.0d0
+  double precision, parameter :: binaryMassMaximum =2.0d0*primaryMassMaximum, binaryMassMinimum  =3.00d0
+  double precision, parameter :: gamma             =2.0d0                   , typeIaNormalization=0.07d0
+  
 contains
 
   function nagashima2005ConstructorParameters(parameters) result(self)
@@ -71,30 +86,35 @@ contains
     type (supernovaeTypeIaNagashima2005)                :: self
     type (inputParameters              ), intent(inout) :: parameters
     class(stellarAstrophysicsClass     ), pointer       :: stellarAstrophysics_
+    class(initialMassFunctionClass     ), pointer       :: initialMassFunction_
 
     !![
     <objectBuilder class="stellarAstrophysics" name="stellarAstrophysics_" source="parameters"/>
+    <objectBuilder class="initialMassFunction" name="initialMassFunction_" source="parameters"/>
     !!]
-    self=supernovaeTypeIaNagashima2005(stellarAstrophysics_)
+    self=supernovaeTypeIaNagashima2005(stellarAstrophysics_,initialMassFunction_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="stellarAstrophysics_"/>
+    <objectDestructor name="initialMassFunction_"/>
     !!]
     return
   end function nagashima2005ConstructorParameters
 
-  function nagashima2005ConstructorInternal(stellarAstrophysics_) result(self)
+  function nagashima2005ConstructorInternal(stellarAstrophysics_,initialMassFunction_) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily nagashima2005} supernovae type Ia class.
     !!}
     implicit none
     type (supernovaeTypeIaNagashima2005)                        :: self
     class(stellarAstrophysicsClass     ), intent(in   ), target :: stellarAstrophysics_
+    class(initialMassFunctionClass     ), intent(in   ), target :: initialMassFunction_
     !![
-    <constructorAssign variables="*stellarAstrophysics_"/>
+    <constructorAssign variables="*stellarAstrophysics_, *initialMassFunction_"/>
     !!]
 
-    self%initialized =.false.
+    self%initialized=.false.
+    self%integrator_=integrator(nagashima2005NumberIntegrand,toleranceRelative=1.0d-3)
     return
   end function nagashima2005ConstructorInternal
 
@@ -107,6 +127,7 @@ contains
 
     !![
     <objectDestructor name="self%stellarAstrophysics_"/>
+    <objectDestructor name="self%initialMassFunction_"/>
     !!]
     return
   end subroutine nagashima2005Destructor
@@ -160,48 +181,117 @@ contains
     self%initialized=.true.
     return
   end subroutine nagashima2005Initialize
+
+  subroutine nagashima2005MassInitialRange(self,age,metallicity,massInitialMinimum,massInitialMaximum)
+    !!{
+    Return the range of initial stellar masses contributing to the Type Ia population.
+    !!}
+    implicit none
+     class           (supernovaeTypeIaNagashima2005), intent(inout) :: self
+     double precision                               , intent(in   ) :: age               , metallicity
+     double precision                               , intent(  out) :: massInitialMinimum, massInitialMaximum
+
+     ! The minimum initial mass is set by the requirement that the secondary has evolved off of the main sequence at this age. The
+     ! maximum mass is the largest single-star mass for which the endpoint is a C-O white dwarf (Nagashima et al. 2005).
+     massInitialMinimum=self%stellarAstrophysics_%massInitial       (age,metallicity)
+     massInitialMaximum=                          primaryMassMaximum
+    return
+  end subroutine nagashima2005MassInitialRange
   
   double precision function nagashima2005Number(self,initialMass,age,metallicity)
     !!{
-    Compute the cumulative number of Type Ia supernovae originating per unit mass of stars that form with given {\normalfont \ttfamily
-    initialMass} and {\normalfont \ttfamily metallicity} after a time {\normalfont \ttfamily age}. The calculation is based on that of \cite{nagashima_metal_2005}. The
-    number returned here assumes a distribution of binary mass ratios and so only makes sense once it is integrated over an initial
-    mass function.
+    Compute the cumulative number of Type Ia supernovae originating per unit interval of secondary star mass with given
+    {\normalfont \ttfamily initialMass} and {\normalfont \ttfamily metallicity} after a time {\normalfont \ttfamily age}. The
+    calculation is based on that of \cite{nagashima_metal_2005}. This function is expected to be integrated over the initial mass
+    function of secondary stars.
     !!}
     implicit none
-    class           (supernovaeTypeIaNagashima2005), intent(inout) :: self
-    double precision                               , intent(in   ) :: age                     , initialMass               , &
-         &                                                            metallicity
-    double precision                                               :: dyingStarMass           , muMinimum
-    ! Parameters of the distribution of binaries from Nagashima et al. (2005; MNRAS; 358; 1427; eqn. 17).
-    double precision                               , parameter     :: binaryMassMaximum=12.0d0, binaryMassMinimum  =3.00d0
-    double precision                               , parameter     :: gamma            = 2.0d0, typeIaNormalization=0.07d0
-
-    ! Check if initial mass is within the range of binary masses that lead to Type Ia supernovae.
-    if (initialMass > binaryMassMinimum .and. initialMass < binaryMassMaximum) then
-       ! Get the initial mass of a star which is just dying at this age.
-       dyingStarMass=self%stellarAstrophysics_%massInitial(age,metallicity)
-       ! Compute the cumulative number of Type Ia supernovae originating from stars of this mass.
-       muMinimum=max(dyingStarMass/initialMass,(1.0d0-binaryMassMaximum/2.0d0/initialMass))
-       if (muMinimum < 0.5d0) then
-          nagashima2005Number=typeIaNormalization*(1.0d0-(2.0d0*muMinimum)**(1.0d0+gamma))
-       else
-          nagashima2005Number=0.0d0
-       end if
+    class           (supernovaeTypeIaNagashima2005), intent(inout), target :: self
+    double precision                               , intent(in   )         :: age                         , initialMass, &
+         &                                                                    metallicity
+    double precision                                                       :: massFractionSecondaryMinimum
+    
+    ! Check if the secondary has evolved off of the main sequence at this age.
+    if (initialMass > self%stellarAstrophysics_%massInitial(age,metallicity)) then
+       ! The secondary has evolved off of the main sequence. Integrate over all possible secondary mass fractions, μ=m₂/m_b. The
+       ! minimum secondary mass fraction is determined by the maximum possible primary mass (i.e. the maximum mass in the initial
+       ! mass function).
+       self_                        => self
+       massSecondary                =  initialMass
+       massFractionSecondaryMinimum =  +1.0d0                                       &
+            &                          /(                                           &
+            &                            +1.0d0                                     &
+            &                            +self%initialMassFunction_%massMaximum  () &
+            &                            /                          massSecondary   &
+            &                           )
+       nagashima2005Number          =  self%integrator_%integrate(massFractionSecondaryMinimum,0.5d0)       
     else
-       ! Mass is not in range - assume that no Type Ia SNe are produced.
+       ! Secondary has not yet evolved off of the main sequence - no SNIa occurs as yet.
        nagashima2005Number=0.0d0
     end if
     return
   end function nagashima2005Number
+  
+  double precision function nagashima2005NumberIntegrand(massFractionSecondary) result(integrand)
+    !!{
+    Integrand used in computing the number of Type Ia supernovae.
+    !!}
+    implicit none
+    double precision, intent(in   ) :: massFractionSecondary
+    double precision                :: massBinary           , massPrimary
+    
+    ! Check if the binary initial mass is within the range of binary masses that lead to Type Ia supernovae, and that the primary
+    ! mass is below the maximum single-star mass to produce a C-O white dwarf.
+    massBinary=+massSecondary         &
+         &     /massFractionSecondary
+    massPrimary=+massBinary           &
+         &      -massSecondary
+    if     (                                  &
+         &   massBinary  > binaryMassMinimum  &
+         &  .and.                             &
+         &   massBinary  < binaryMassMaximum  &
+         &  .and.                             &
+         &   massPrimary < primaryMassMaximum &
+         & ) then
+       ! Evaluate the integrand. Nagashima et al. (2005) give this integrand in the 2D space of (m_b,μ). Here, the quantity we
+       ! compute will be integrated over m₂, weighted by the initial mass function of for single-stars with masses corresponding
+       ! to our secondaries. As such, we must:
+       !   1. divide the integrand given by Nagashima et al. (2005) by φ(m₂) (as it will later be multiplied by it), and;
+       !   2. multiply the integrand by dm_b/dm₂ = 1/υ to convert from integration over m_b to integration over m₂.
+       integrand=+                           typeIaNormalization                             &
+            &    *self_%initialMassFunction_%phi                     (massBinary           ) &
+            &    /self_%initialMassFunction_%phi                     (massSecondary        ) &
+            &    *                           massFractionDistribution(massFractionSecondary) &
+            &    /                           massFractionSecondary
+    else
+       integrand=0.0d0
+    end if
+    return
+    
+  contains
+
+    double precision function massFractionDistribution(massFractionSecondary)
+      !!{
+      The distribution function for secondary mass fractions in binary star systems from \cite{nagashima_metal_2005}.
+      !!}
+      implicit none
+      double precision, intent(in   ) :: massFractionSecondary
+
+      massFractionDistribution=+2.0d0**(1.0d0+gamma)         &
+           &                   *       (1.0d0+gamma)         &
+           &                   *massFractionSecondary**gamma
+      return
+    end function massFractionDistribution
+
+  end function nagashima2005NumberIntegrand
 
   double precision function nagashima2005Yield(self,initialMass,age,metallicity,atomIndex)
     !!{
-    Compute the cumulative yield from Type Ia supernovae originating per unit mass of stars that form with given {\normalfont
-    \ttfamily initialMass} and {\normalfont \ttfamily metallicity} after a time {\normalfont \ttfamily age}. The calculation is
-    based on the Type Ia rate calculation of \cite{nagashima_metal_2005} and the Type Ia yields from
-    \cite{nomoto_nucleosynthesis_1997}. The number returned here assumes a distribution of binary mass ratios and so only makes
-    sense once it is integrated over an initial mass function.
+    Compute the cumulative yield from Type Ia supernovae originating per unit interval of secondary star mass with given
+    {\normalfont \ttfamily initialMass} and {\normalfont \ttfamily metallicity} after a time {\normalfont \ttfamily age}. The
+    calculation is based on that of \cite{nagashima_metal_2005} with Type Ia yields from \cite{nomoto_nucleosynthesis_1997}. The
+    number returned here assumes a distribution of binary mass ratios and so only makes sense once it is integrated over an
+    initial mass function.
     !!}
     implicit none
     class           (supernovaeTypeIaNagashima2005), intent(inout)           :: self

--- a/source/stellar_astrophysics.supernovae_type_Ia.zero.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.zero.F90
@@ -1,0 +1,111 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a supernovae type Ia class with no supernovae.
+  !!}
+
+  !![
+  <supernovaeTypeIa name="supernovaeTypeIaZero">
+   <description>
+    A supernovae type Ia class which produces zero supernovae.
+   </description>
+  </supernovaeTypeIa>
+  !!]
+  type, extends(supernovaeTypeIaClass) :: supernovaeTypeIaZero
+     !!{
+     A supernovae type Ia class that produces zero supernovae.
+     !!}
+     private
+   contains
+     procedure :: massInitialRange => zeroMassInitialRange
+     procedure :: number           => zeroNumber
+     procedure :: yield            => zeroYield
+  end type supernovaeTypeIaZero
+
+  interface supernovaeTypeIaZero
+     !!{
+     Constructors for the {\normalfont \ttfamily zero} supernovae type Ia class.
+     !!}
+     module procedure zeroConstructorParameters
+  end interface supernovaeTypeIaZero
+
+contains
+
+  function zeroConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily zero} supernovae type Ia class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type(supernovaeTypeIaZero)                :: self
+    type(inputParameters     ), intent(inout) :: parameters
+
+   
+    self=supernovaeTypeIaZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function zeroConstructorParameters
+
+  subroutine zeroMassInitialRange(self,age,metallicity,massInitialMinimum,massInitialMaximum)
+    !!{
+    Return the range of initial stellar masses contributing to the Type Ia population.
+    !!}
+    implicit none
+     class           (supernovaeTypeIaZero), intent(inout) :: self
+     double precision                      , intent(in   ) :: age               , metallicity
+     double precision                      , intent(  out) :: massInitialMinimum, massInitialMaximum
+     !$GLC attributes unused :: self, age, metallicity
+
+     ! The range is arbitrary as we have no Type Ias.
+     massInitialMinimum=1.0d0
+     massInitialMaximum=2.0d0
+    return
+  end subroutine zeroMassInitialRange
+  
+  double precision function zeroNumber(self,initialMass,age,metallicity) result(number)
+    !!{
+    Compute the cumulative number of Type Ia supernovae which is always zero.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaZero), intent(inout), target :: self
+    double precision                      , intent(in   )         :: age        , initialMass, &
+         &                                                           metallicity
+    !$GLC attributes unused :: self, initialMass, age, metallicity
+    
+    number=0.0d0
+    return
+  end function zeroNumber
+
+  double precision function zeroYield(self,initialMass,age,metallicity,atomIndex) result(yield)
+    !!{
+    Compute the cumulative yield from Type Ia supernovae which is always zero.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaZero), intent(inout)           :: self
+    double precision                      , intent(in   )           :: age        , initialMass, &
+         &                                                             metallicity
+    integer                               , intent(in   ), optional :: atomIndex
+    !$GLC attributes unused :: self, initialMass, age, metallicity, atomIndex
+    
+    yield=0.0d0    
+    return
+  end function zeroYield

--- a/source/tests.initial_mass_functions.F90
+++ b/source/tests.initial_mass_functions.F90
@@ -27,55 +27,69 @@ program Test_Initial_Mass_Functions
   !!}
   use :: Display                                   , only : displayVerbositySet             , verbosityLevelStandard
   use :: Numerical_Integration2                    , only : integratorCompositeTrapezoidal1D
+  use :: NUmerical_Constants_Astronomical          , only : metallicitySolar
   use :: Stellar_Populations_Initial_Mass_Functions, only : initialMassFunctionBPASS        , initialMassFunctionBaugh2005TopHeavy, initialMassFunctionChabrier2001   , initialMassFunctionClass            , &
           &                                                 initialMassFunctionKennicutt1983, initialMassFunctionKroupa2001       , initialMassFunctionMillerScalo1979, initialMassFunctionPiecewisePowerLaw, &
           &                                                 initialMassFunctionSalpeter1955 , initialMassFunctionScalo1986
+  use :: Supernovae_Type_Ia                        , only : supernovaeTypeIaNagashima2005
+  use :: Stellar_Astrophysics                      , only : stellarAstrophysicsFile
   use :: Unit_Tests                                , only : Assert                          , Unit_Tests_Begin_Group              , Unit_Tests_End_Group              , Unit_Tests_Finish
   implicit none
-  class           (initialMassFunctionClass            ), pointer :: imf
-  type            (initialMassFunctionChabrier2001     ), target  :: imfChabrier2001
-  type            (initialMassFunctionPiecewisePowerLaw), target  :: imfPiecewisePowerLaw
-  type            (initialMassFunctionSalpeter1955     ), target  :: imfSalpeter1955
-  type            (initialMassFunctionBPASS            ), target  :: imfBPASS
-  type            (initialMassFunctionBaugh2005TopHeavy), target  :: imfBaugh2005TopHeavy
-  type            (initialMassFunctionKennicutt1983    ), target  :: imfKennicutt1983
-  type            (initialMassFunctionKroupa2001       ), target  :: imfKroupa2001
-  type            (initialMassFunctionMillerScalo1979  ), target  :: imfMillerScalo1979
-  type            (initialMassFunctionScalo1986        ), target  :: imfScalo1986
-  type            (integratorCompositeTrapezoidal1D    )          :: integrator_
-  double precision                                                :: massInInitialMassFunction
-
+  class           (initialMassFunctionClass            ), pointer      :: imf
+  type            (initialMassFunctionChabrier2001     ), target       :: imfChabrier2001
+  type            (initialMassFunctionPiecewisePowerLaw), target       :: imfPiecewisePowerLaw
+  type            (initialMassFunctionSalpeter1955     ), target       :: imfSalpeter1955
+  type            (initialMassFunctionBPASS            ), target       :: imfBPASS
+  type            (initialMassFunctionBaugh2005TopHeavy), target       :: imfBaugh2005TopHeavy
+  type            (initialMassFunctionKennicutt1983    ), target       :: imfKennicutt1983
+  type            (initialMassFunctionKroupa2001       ), target       :: imfKroupa2001
+  type            (initialMassFunctionMillerScalo1979  ), target       :: imfMillerScalo1979
+  type            (initialMassFunctionScalo1986        ), target       :: imfScalo1986
+  type            (stellarAstrophysicsFile             )               :: stellarAstrophysics_
+  type            (supernovaeTypeIaNagashima2005       )               :: supernovaeTypeIaNagashima2005_
+  type            (integratorCompositeTrapezoidal1D    )               :: integrator_
+  ! Values of the cumulative number of type Ia SNe read from Figure 6 of Nagashima et al (2005; MNRAS; 363; 31;
+  ! https://ui.adsabs.harvard.edu/abs/2005MNRAS.363L..31N) at 0.1, 1, and 10Gyr.
+  double precision                                      , dimension(3) :: ageTypeIa                     =[1.0d-1,1.0d+0,1.0d+1]                    , &
+       &                                                                  numberTypeIaSNeNagashima2005  =[6.0d-6,6.6d-4,2.2d-3]
+  double precision                                                     :: massInInitialMassFunction                            , numberTypeIaSNe   , &
+       &                                                                  massInitialMinimum                                   , massInitialMaximum
+  integer                                                              :: i
+  character       (len=12                              )               :: label
+  
   call displayVerbositySet(verbosityLevelStandard)
   call Unit_Tests_Begin_Group("Stellar initial mass functions")
   call integrator_%initialize  (24           )
   call integrator_%toleranceSet(1.0d-7,1.0d-7)
   call integrator_%integrandSet(initialMassFunctionIntegrand)
   call Unit_Tests_Begin_Group("Normalization")
-  imfChabrier2001     =initialMassFunctionChabrier2001     (                                       &
-       &                                                    massLower         =+  0.10d0         , &
-       &                                                    massUpper         =+125.00d0         , &
-       &                                                    massTransition    =+  1.00d0         , &
-       &                                                    massCharacteristic=+  0.08d0         , &
-       &                                                    exponent          =-  2.30d0         , &
-       &                                                    sigma             =+  0.69d0           &
+  imfChabrier2001     =initialMassFunctionChabrier2001     (                                              &
+       &                                                    massLower         =+  0.10d0                , &
+       &                                                    massUpper         =+125.00d0                , &
+       &                                                    massTransition    =+  1.00d0                , &
+       &                                                    massCharacteristic=+  0.08d0                , &
+       &                                                    exponent          =-  2.30d0                , &
+       &                                                    sigma             =+  0.69d0                  &
        &                                                   )
-  imfPiecewisePowerLaw=initialMassFunctionPiecewisePowerLaw(                                       &
-       &                                                    mass              =[+0.10d0,+125.0d0], &
-       &                                                    exponent          =[-2.30d0         ]  &
+  ! This piecewise IMF is matched to the "Kennicutt IMF" used by Nagashima et al (2005; MNRAS; 363; 31;
+  ! https://ui.adsabs.harvard.edu/abs/2005MNRAS.363L..31N) in their Type Ia SNe calculations.
+  imfPiecewisePowerLaw=initialMassFunctionPiecewisePowerLaw(                                              &
+       &                                                    mass              =[+0.15d0,+1.0d0,+120.0d0], &
+       &                                                    exponent          =[-1.40d0,-2.5d0         ]  &
        &                                                   )
-  imfSalpeter1955     =initialMassFunctionSalpeter1955     (                                       &
+  imfSalpeter1955     =initialMassFunctionSalpeter1955     (                                              &
        &                                                   )
-  imfBPASS            =initialMassFunctionBPASS            (                                       &
+  imfBPASS            =initialMassFunctionBPASS            (                                              &
        &                                                   )
-  imfBaugh2005TopHeavy=initialMassFunctionBaugh2005TopHeavy(                                       &
+  imfBaugh2005TopHeavy=initialMassFunctionBaugh2005TopHeavy(                                              &
        &                                                   )
-  imfKennicutt1983    =initialMassFunctionKennicutt1983    (                                       &
+  imfKennicutt1983    =initialMassFunctionKennicutt1983    (                                              &
        &                                                   )
-  imfKroupa2001       =initialMassFunctionKroupa2001       (                                       &
+  imfKroupa2001       =initialMassFunctionKroupa2001       (                                              &
        &                                                   )
-  imfMillerScalo1979  =initialMassFunctionMillerScalo1979  (                                       &
+  imfMillerScalo1979  =initialMassFunctionMillerScalo1979  (                                              &
        &                                                   )
-  imfScalo1986        =initialMassFunctionScalo1986        (                                       &
+  imfScalo1986        =initialMassFunctionScalo1986        (                                              &
        &                                                   )
   imf                       => imfChabrier2001
   massInInitialMassFunction =  integrator_%evaluate(                   &
@@ -133,6 +147,27 @@ program Test_Initial_Mass_Functions
        &                                           )
   call Assert('Scalo (1986)'                 ,massInInitialMassFunction,1.0d0,relTol=1.0d-6)
   call Unit_Tests_End_Group()
+  call Unit_Tests_Begin_Group('Type Ia SNe')
+  call Unit_Tests_Begin_Group('Nagashima et al. (2005)')
+  stellarAstrophysics_          =stellarAstrophysicsFile      ('%DATASTATICPATH%/stellarAstrophysics/stellarPropertiesPortinariChiosiBressan1998.xml')
+  supernovaeTypeIaNagashima2005_=supernovaeTypeIaNagashima2005(stellarAstrophysics_,imfPiecewisePowerLaw)
+  call integrator_%toleranceSet(1.0d-6,1.0d-6)
+  call integrator_%integrandSet(numberTypeIaSNeIntegrand)
+  do i=1,size(ageTypeIa)
+     call supernovaeTypeIaNagashima2005_%massInitialRange(ageTypeIa(i),metallicitySolar,massInitialMinimum,massInitialMaximum)
+     massInitialMinimum=max(massInitialMinimum,imfPiecewisePowerLaw%massMinimum())
+     massInitialMaximum=min(massInitialMaximum,imfPiecewisePowerLaw%massMaximum())
+     numberTypeIaSNe=integrator_%evaluate(                    &
+          &                               massInitialMinimum, &
+          &                               massInitialMaximum  &
+          &                              )  
+     write (label,'(f4.1)') ageTypeIa(i)
+     ! The tolerance for this test is (very) low. Nagashima et al. (2005) do not specify what they use for M(t) - the mass of a
+     ! star leaving the main sequence at time t). Therefore, the best we can do is an approximate comparison.
+     call Assert('Cumulative number of Type Ia SNe at age '//trim(label)//'Gyr',numberTypeIaSNe,numberTypeIaSNeNagashima2005(i),relTol=0.5d0)
+  end do
+  call Unit_Tests_End_Group()
+  call Unit_Tests_End_Group()
   call Unit_Tests_End_Group()
   call Unit_Tests_Finish   ()
 
@@ -149,6 +184,18 @@ contains
          &                       *imf%phi(mass)
     return
   end function initialMassFunctionIntegrand
+
+  double precision function numberTypeIaSNeIntegrand(massSecondary)
+    !!{
+    Integrand used to find the cumulative number of Type Ia SNe.
+    !!}
+    implicit none
+    double precision, intent(in   ) :: massSecondary
+
+    numberTypeIaSNeIntegrand=+supernovaeTypeIaNagashima2005_%number(massSecondary,ageTypeIa(i),metallicitySolar)  &
+         &                   *imfPiecewisePowerLaw              %phi   (massSecondary                )
+    return
+  end function numberTypeIaSNeIntegrand
 
 end program Test_Initial_Mass_Functions
 

--- a/source/tests.stellar_populations.F90
+++ b/source/tests.stellar_populations.F90
@@ -85,7 +85,8 @@ program Test_Stellar_Populations
        &                                                            stellarTracks_                       =stellarTracks_                                                                                       &
        &                                                           )
   supernovaeTypeIa_        =supernovaeTypeIaNagashima2005          (                                                                                                                                           &
-       &                                                            stellarAstrophysics_                 =stellarAstrophysics_                                                                                 &
+       &                                                            stellarAstrophysics_                 =stellarAstrophysics_                                                                               , &
+       &                                                            initialMassFunction_                 =initialMassFunction_                                                                                 &
        &                                                           )
   supernovaePopulationIII_ =supernovaePopulationIIIHegerWoosley2002(                                                                                                                                           &
        &                                                            stellarAstrophysics_                 =stellarAstrophysics_                                                                                 &

--- a/source/tests.stellar_populations.luminosities.F90
+++ b/source/tests.stellar_populations.luminosities.F90
@@ -137,13 +137,14 @@ call Directory_Make(char(inputPath(pathTypeDataDynamic))//'stellarPopulations/SS
        &                                                                                 stellarTracks_                       =stellarTracks_                                                                                               &
        &                                                                                )
   supernovaeTypeIa_                      =supernovaeTypeIaNagashima2005                 (                                                                                                                                                   &
-       &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_                                                                                         &
+       &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_                                                                                       , &
+       &                                                                                 initialMassFunction_                 =initialMassFunction_                                                                                         &
        &                                                                                )
   supernovaePopulationIII_               =supernovaePopulationIIIHegerWoosley2002       (                                                                                                                                                   &
        &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_                                                                                         &
        &                                                                                )
   stellarFeedback_                       =stellarFeedbackStandard                       (                                                                                                                                                   &
-       &                                                                                 initialMassForSupernovaeTypeII        =8.0d00                                                                                                    , &
+       &                                                                                 initialMassForSupernovaeTypeII       =8.0d00                                                                                                     , &
        &                                                                                 supernovaEnergy                      =1.0d51                                                                                                     , &
        &                                                                                 supernovaeTypeIa_                    =supernovaeTypeIa_                                                                                          , &
        &                                                                                 supernovaePopulationIII_             =supernovaePopulationIII_                                                                                   , &
@@ -151,7 +152,7 @@ call Directory_Make(char(inputPath(pathTypeDataDynamic))//'stellarPopulations/SS
        &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_                                                                                         &
        &                                                                                )
   stellarPopulationSpectra_              =stellarPopulationSpectraFile                  (                                                                                                                                                   &
-       &                                                                                 forceZeroMetallicity                   =.false.                                                                                                  , &
+       &                                                                                 forceZeroMetallicity                 =.false.                                                                                                    , &
        &                                                                                 fileName                             =char(inputPath(pathTypeDataStatic))//'stellarPopulations/SSP_Spectra_BC2003_lowResolution_imfSalpeter.hdf5'  &
        &                                                                                )
   stellarPopulation_                     =stellarPopulationStandard                     (                                                                                                                                                   &


### PR DESCRIPTION
* Corrects the implementation of the Nagashima et al. (2005) model for the number of Type Ia SNe as a function of population age/metallicity. It correct the dependence on the initial mass function, adds a missing Jacobian term, and implements the upper limit on the primary.

* In the `stellarAstrophysicsFile` class, extrapolation in initial stellar mass is no longer performed - instead, for masses outside of the available range, stellar properties are truncated to zero. Additionally, no extrapolation in metallicity is made outside of the available range.

* Adds implementations of the `supernovaeTypeIa` and `supernovaePopulationIII` classes that assume zero contributions. This is useful to test the contribution of type Ia SNe to metal enrichment, and to disable Pop III contributions.