### PR TITLE
Remove unused variables, symbol imports, and mark known initialized variables

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -81,6 +81,9 @@ jobs:
           set +o pipefail
           chmod u=wrx ./scripts/build/buildProfiler.pl
           ./scripts/build/buildProfiler.pl build.log buildProfile.html --durationMinimum 20
+          ! grep -n Error: build.log
+          ! grep -n Warning: build.log
+          ! grep -v 'is up to date' build.log | grep -n -C 5 make:
       - name: Upload Galacticus executable
         uses: actions/upload-artifact@v4
         with:
@@ -125,8 +128,8 @@ jobs:
           set -o pipefail
           make -j2 Galacticus.exe 2>&1 | tee build.log
           set +o pipefail
-          ! grep -n -C 5 Error: build.log
-          ! grep -n -C 5 Warning: build.log
+          ! grep -n Error: build.log
+          ! grep -n Warning: build.log
           ! grep -v 'is up to date' build.log | grep -n -C 5 make:
       - name: Upload Galacticus executable
         uses: actions/upload-artifact@v4

--- a/source/black_holes.accretion_rates.standard.F90
+++ b/source/black_holes.accretion_rates.standard.F90
@@ -208,7 +208,6 @@ contains
          &                                                             temperatureHotHalo             , fractionHotMode         , &
          &                                                             lengthJeans                    , fractionColdMode        , &
          &                                                             efficiencyRadiative            , velocityRelative
-         &                                                             
 
     ! Get the host node.
     node          => blackHole%host()

--- a/source/dark_matter_profiles.adiabatic_Gnedin2004.F90
+++ b/source/dark_matter_profiles.adiabatic_Gnedin2004.F90
@@ -976,8 +976,7 @@ contains
     type            (treeNode                            )               , pointer :: nodeCurrent                    , nodeHost
     class           (nodeComponentBasic                  )               , pointer :: basic
     double precision                                                               :: massBaryonicSelfTotal          , massBaryonicTotal      , &
-         &                                                                            velocityCircularSquaredGradient, velocityCircularSquared, &
-         &                                                                            
+         &                                                                            velocityCircularSquaredGradient, velocityCircularSquared
 
     ! Set module-scope pointers to node and self.
     node_ => node

--- a/source/nodes.property_extractor.galaxy_major_merger_time.F90
+++ b/source/nodes.property_extractor.galaxy_major_merger_time.F90
@@ -101,6 +101,7 @@ contains
     class           (nodeComponentBasic                        )                , pointer     :: basic
     double precision                                            , dimension(:  ), allocatable :: times
     !$GLC attributes unused :: instance
+    !$GLC attributes initialized :: times
 
     basic => node %basic                    (                            )
     times =  basic%floatRank1MetaPropertyGet(self%galaxyMajorMergerTimeID)

--- a/source/nodes.property_extractor.jet_power_black_holes.F90
+++ b/source/nodes.property_extractor.jet_power_black_holes.F90
@@ -81,7 +81,6 @@ contains
     !!{
     Internal constructor for the {\normalfont \ttfamily jetPowerBlackHoles} node operator class.
     !!}
-    use :: Galacticus_Nodes, only : defaultBasicComponent
     implicit none
     type (nodePropertyExtractorJetPowerBlackHoles)                        :: self
     class(accretionDisksClass                    ), intent(in   ), target :: accretionDisks_

--- a/source/nodes.property_extractor.radiative_efficiency_black_holes.F90
+++ b/source/nodes.property_extractor.radiative_efficiency_black_holes.F90
@@ -81,7 +81,6 @@ contains
     !!{
     Internal constructor for the {\normalfont \ttfamily radiativeEfficiencyBlackHoles} node operator class.
     !!}
-    use :: Galacticus_Nodes, only : defaultBasicComponent
     implicit none
     type (nodePropertyExtractorRadiativeEfficiencyBlackHoles)                        :: self
     class(accretionDisksClass                               ), intent(in   ), target :: accretionDisks_

--- a/source/nodes.property_extractor.radius_black_holes.F90
+++ b/source/nodes.property_extractor.radius_black_holes.F90
@@ -74,7 +74,6 @@ contains
     !!{
     Internal constructor for the {\normalfont \ttfamily radiusBlackHoles} node operator class.
     !!}
-    use :: Galacticus_Nodes, only : defaultBasicComponent
     implicit none
     type (nodePropertyExtractorRadiusBlackHoles   )                        :: self
     class(blackHoleBinarySeparationGrowthRateClass), intent(in   ), target :: blackHoleBinarySeparationGrowthRate_

--- a/source/structure_formation.cosmological_density_field.F90
+++ b/source/structure_formation.cosmological_density_field.F90
@@ -539,6 +539,7 @@ contains
     class(  criticalOverdensityClass), intent(inout) :: self
     type   (treeNode                ), intent(inout) :: node
     integer(kind_int8               ), intent(in   ) :: uniqueID
+    !$GLC attributes unused :: node
 
     self%lastUniqueID=uniqueID
     return

--- a/source/tests.DiemerKravtsov2014_concentration.F90
+++ b/source/tests.DiemerKravtsov2014_concentration.F90
@@ -92,7 +92,7 @@ program Test_DiemerKravtsov2014_Concentration
           &        "http://www.benediktdiemer.com/wp-content/uploads/cM_WMAP7.txt",  &
           &        char(inputPath(pathTypeExec))                                  // &
           &        "testSuite/data/diemerKravtsov2014Concentration.txt"           ,  &
-          &        ioStatus                                                          &
+          &        status=ioStatus                                                   &
           &       )
      if (ioStatus /= 0 .or. .not.File_Exists(inputPath(pathTypeExec)//"testSuite/data/diemerKravtsov2014Concentration.txt")) &
           & call Error_Report('unable to retrieve reference dataset'//{introspection:location})


### PR DESCRIPTION
Also remove the context option from the `grep` commands used to search for related warnings and errors. The context option seem to prevent GitHub actions for recognizing a failed step (e.g. if such warnings are present).