### PR TITLE
Fix adapative star formation history lengths and times

### DIFF
--- a/perl/Galacticus/Build/Components/Classes/CreateDestroy.pm
+++ b/perl/Galacticus/Build/Components/Classes/CreateDestroy.pm
@@ -178,6 +178,11 @@ sub Class_Create_By_Interrupt {
 		 variables  => [ "self" ]
 	     },
 	     {
+		 intrinsic  => "double precision",
+		 attributes => [ "intent(in   )", "optional" ],
+		 variables  => [ "timeEnd" ]
+	     },
+	     {
 		 intrinsic  => "class",
 		 type       => "nodeComponent".ucfirst($code::class->{'name'}),
 		 attributes => [ "pointer" ],
@@ -208,7 +213,7 @@ CODE
 		);
 	    $function->{'content'} .= fill_in_string(<<'CODE', PACKAGE => 'code');
 type is (nodeComponent{ucfirst($code::class->{'name'}).ucfirst($code::member->{'name'})})
-   call {$createFunction}({$class->{'name'}})
+   call {$createFunction}({$class->{'name'}},timeEnd)
 CODE
 	}
 	$function->{'content'} .= fill_in_string(<<'CODE', PACKAGE => 'code');

--- a/perl/Galacticus/Build/Components/TreeNodes.pm
+++ b/perl/Galacticus/Build/Components/TreeNodes.pm
@@ -319,6 +319,11 @@ sub Insert_Interrupt_Interface {
 		 type       => "treeNode",
 		 attributes => [ "target", "intent(inout)" ],
 		 variables  => [ "node" ]
+	     },
+	     {
+		 intrinsic  => "double precision",
+		 attributes => [ "intent(in   )", "optional" ],
+		 variables  => [ "timeEnd" ]
 	     }
 	    ]		
     };    

--- a/source/merger_trees.evolver.standard.F90
+++ b/source/merger_trees.evolver.standard.F90
@@ -459,7 +459,7 @@ contains
                          ! Check for interrupt.
                          if (interrupted) then
                             ! If an interrupt occurred call the specified procedure to handle it.
-                            call interruptProcedure(node)
+                            call interruptProcedure(node,timeEnd)
                             ! Something happened so the tree is not deadlocked.
                             statusDeadlock=deadlockStatusIsNotDeadlocked
                          else

--- a/source/merger_trees.outputter.standard.F90
+++ b/source/merger_trees.outputter.standard.F90
@@ -1006,7 +1006,7 @@ contains
        self%doubleProperty (doubleProperty +1                                                                 )%name      =extractor_%name        (                       )
        self%doubleProperty (doubleProperty +1                                                                 )%comment   =extractor_%description (                       )
        self%doubleProperty (doubleProperty +1                                                                 )%unitsInSI =extractor_%unitsInSI   (                       )
-       call    extractor_%metaData(node  ,self%doubleProperty (doubleProperty +1)%metaDataRank0,self%doubleProperty (doubleProperty +1)%metaDataRank1)
+       call    extractor_%metaData(node      ,self%doubleProperty (doubleProperty +1)%metaDataRank0,self%doubleProperty (doubleProperty +1)%metaDataRank1)
        doubleProperty =doubleProperty +1
     class is (nodePropertyExtractorTuple        )
        ! Tuple property extractor - get the names, descriptions, and units.
@@ -1016,7 +1016,7 @@ contains
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                   time))%comment   =descriptionsTmp
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                   time))%unitsInSI =extractor_%unitsInSI   (                   time)
        do i=1,extractor_%elementCount(                   time)
-          call extractor_%metaData(node,i,self%doubleProperty (doubleProperty +i)%metaDataRank0,self%doubleProperty (doubleProperty +i)%metaDataRank1)
+          call extractor_%metaData(node,i     ,self%doubleProperty (doubleProperty +i)%metaDataRank0,self%doubleProperty (doubleProperty +i)%metaDataRank1)
        end do
        doubleProperty =doubleProperty +extractor_%elementCount(time)
        deallocate(namesTmp       )
@@ -1034,7 +1034,7 @@ contains
           call extractor_%columnDescriptions(self%doubleProperty(doubleProperty+i)%rank1Descriptors,self%doubleProperty(doubleProperty+i)%rank1DescriptorValues,self%doubleProperty(doubleProperty+i)%rank1DescriptorComment,self%doubleProperty(doubleProperty+i)%rank1DescriptorUnitsInSI,time)
        end do
        do i=1,extractor_%elementCount(                   time)
-          call extractor_%metaData(node,i,self%doubleProperty (doubleProperty +i)%metaDataRank0,self%doubleProperty (doubleProperty +1)%metaDataRank1)
+          call extractor_%metaData(node,i     ,self%doubleProperty (doubleProperty +i)%metaDataRank0,self%doubleProperty (doubleProperty +1)%metaDataRank1)
        end do
        doubleProperty =doubleProperty +extractor_%elementCount(time)
        deallocate(namesTmp       )
@@ -1046,7 +1046,7 @@ contains
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                       ))%name      =namesTmp
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                       ))%comment   =descriptionsTmp
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                       ))%unitsInSI =extractor_%unitsInSI  (                       )
-       call    extractor_%metaData(node  ,self%doubleProperty (doubleProperty +1)%metaDataRank0,self%doubleProperty (doubleProperty +1)%metaDataRank1)
+       call    extractor_%metaData(node            ,self%doubleProperty (doubleProperty +1)%metaDataRank0,self%doubleProperty (doubleProperty +1)%metaDataRank1)
        doubleProperty =doubleProperty +1
     class is (nodePropertyExtractorList2D       )
        ! 2D list property extractor - get the name, description, and units.
@@ -1055,14 +1055,14 @@ contains
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                       ))%name      =namesTmp
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                       ))%comment   =descriptionsTmp
        self%doubleProperty (doubleProperty +1:doubleProperty +extractor_%elementCount(                       ))%unitsInSI =extractor_%unitsInSI  (                       )
-       call    extractor_%metaData(node  ,self%doubleProperty (doubleProperty +1)%metaDataRank0,self%doubleProperty (doubleProperty +1)%metaDataRank1)
+       call    extractor_%metaData(node  ,time,self%doubleProperty (doubleProperty +1)%metaDataRank0,self%doubleProperty (doubleProperty +1)%metaDataRank1)
        doubleProperty =doubleProperty +1
     class is (nodePropertyExtractorIntegerScalar)
        ! Integer scalar property extractor - get the name, description, and units.
        self%integerProperty(integerProperty+1                                                                 )%name     =extractor_%name        (                       )
        self%integerProperty(integerProperty+1                                                                 )%comment  =extractor_%description (                       )
        self%integerProperty(integerProperty+1                                                                 )%unitsInSI=extractor_%unitsInSI   (                       )
-       call    extractor_%metaData(node  ,self%integerProperty(integerProperty+1)%metaDataRank0,self%integerProperty(integerProperty+1)%metaDataRank1)
+       call    extractor_%metaData(node       ,self%integerProperty(integerProperty+1)%metaDataRank0,self%integerProperty(integerProperty+1)%metaDataRank1)
        integerProperty=integerProperty+1
     class is (nodePropertyExtractorIntegerTuple )
        ! Integer tuple property extractor - get the names, descriptions, and units.
@@ -1072,7 +1072,7 @@ contains
        self%integerProperty(integerProperty+1:integerProperty+extractor_%elementCount(                   time))%comment  =descriptionsTmp
        self%integerProperty(integerProperty+1:integerProperty+extractor_%elementCount(                   time))%unitsInSI=extractor_%unitsInSI   (                   time)
        do i=1,extractor_%elementCount(                   time)
-          call extractor_%metaData(node,i,self%integerProperty(integerProperty+i)%metaDataRank0,self%integerProperty(integerProperty+1)%metaDataRank1)
+          call extractor_%metaData(node,i     ,self%integerProperty(integerProperty+i)%metaDataRank0,self%integerProperty(integerProperty+1)%metaDataRank1)
        end do
        integerProperty=integerProperty+extractor_%elementCount(time)
        deallocate(namesTmp       )

--- a/source/nodes.operators.analyses.node_formation_time.Cole2000.F90
+++ b/source/nodes.operators.analyses.node_formation_time.Cole2000.F90
@@ -171,11 +171,13 @@ contains
     return
   end subroutine nodeFormationTimeCole2000DifferentialEvolution
 
-  subroutine reformOnInterrupt(node)
+  subroutine reformOnInterrupt(node,timeEnd)
     !!{
     Wrapper function to perform node reformation during interrupt of differential evolution.
     !!}
-    type(treeNode), intent(inout), target :: node
+    type            (treeNode), intent(inout), target   :: node
+    double precision          , intent(in   ), optional :: timeEnd
+    !$GLC attributes unused :: timeEnd
 
     call self_%reform(node)
     return

--- a/source/nodes.operators.physics.position.interpolated.F90
+++ b/source/nodes.operators.physics.position.interpolated.F90
@@ -377,11 +377,13 @@ contains
     return
   end subroutine positionInterpolatedNodePromote
 
-  subroutine positionInterpolatedComputeInterpolation_(node)
+  subroutine positionInterpolatedComputeInterpolation_(node,timeEnd)
     !!{
     Interrupt function to recompute interpolation.
     !!}
-    type(treeNode), intent(inout), target :: node
+    type            (treeNode), intent(inout), target   :: node
+    double precision          , intent(in   ), optional :: timeEnd
+    !$GLC attributes unused :: timeEnd
     
     call self_%computeInterpolation(node)
     return

--- a/source/nodes.operators.physics.satellite_destruction.mass_threshold.F90
+++ b/source/nodes.operators.physics.satellite_destruction.mass_threshold.F90
@@ -142,7 +142,7 @@ contains
     return
   end subroutine satelliteDestructionMassThresholdDifferentialEvolution
   
-  subroutine destructionTrigger(node)
+  subroutine destructionTrigger(node,timeEnd)
     !!{
     Trigger destruction of the satellite by setting the time until destruction to zero.
     !!}
@@ -150,9 +150,11 @@ contains
     use :: Display         , only : displayBlue           , displayYellow, displayGreen, displayReset
     use :: Error           , only : Error_Report
     implicit none
-    type (treeNode              ), intent(inout), target  :: node
-    class(nodeComponentSatellite)               , pointer :: satellite
-
+    type            (treeNode              ), intent(inout), target   :: node
+    double precision                        , intent(in   ), optional :: timeEnd
+    class           (nodeComponentSatellite)               , pointer  :: satellite
+    !$GLC attributes unused :: timeEnd
+    
     satellite => node%satellite()
     if (satellite%boundMass() < self_%massDestroy(node)) then
        if (satellite%destructionTime() >= 0.0d0)                                                                                                                                                                               &

--- a/source/nodes.operators.physics.satellite_merging.radius_trigger.F90
+++ b/source/nodes.operators.physics.satellite_merging.radius_trigger.F90
@@ -153,15 +153,17 @@ contains
     return
   end subroutine satelliteMergingRadiusTriggerDifferentialEvolution
 
-  subroutine mergerTrigger(node)
+  subroutine mergerTrigger(node,timeEnd)
     !!{
     Trigger a merger of the satellite by setting the time until merging to zero.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentSatellite, nodeComponentBasic, treeNode
     implicit none
-    type (treeNode              ), intent(inout), target  :: node
-    class(nodeComponentBasic    )               , pointer :: basic
-    class(nodeComponentSatellite)               , pointer :: satellite
+    type            (treeNode              ), intent(inout), target   :: node
+    double precision                        , intent(in   ), optional :: timeEnd
+    class           (nodeComponentBasic    )               , pointer  :: basic
+    class           (nodeComponentSatellite)               , pointer  :: satellite
+    !$GLC attributes unused :: timeEnd
 
     basic     => node%basic    ()
     satellite => node%satellite()

--- a/source/nodes.operators.physics.subsubhalo_promotion.F90
+++ b/source/nodes.operators.physics.subsubhalo_promotion.F90
@@ -147,14 +147,16 @@ contains
     return
   end subroutine subsubhaloPromotionDifferentialEvolution
   
-  subroutine subsubhaloPromotionPromote(node)
+  subroutine subsubhaloPromotionPromote(node,timeEnd)
     !!{
     Promote a sub-sub-halo into its host's host.
     !!}
     use :: Satellite_Promotion, only : Satellite_Move_To_New_Host
     implicit none
-    type(treeNode), intent(inout), target  :: node
-
+    type            (treeNode), intent(inout), target   :: node
+    double precision          , intent(in   ), optional :: timeEnd
+    !$GLC attributes unused :: timeEnd
+    
     ! Move the sub-sub-halo into its host's host.
     call Satellite_Move_To_New_Host(node,node%parent%parent)
     return

--- a/source/nodes.property_extractor.list2D.F90
+++ b/source/nodes.property_extractor.list2D.F90
@@ -107,16 +107,17 @@
 
 contains
   
-  subroutine list2DMetaData(self,node,metaDataRank0,metaDataRank1)
+  subroutine list2DMetaData(self,node,time,metaDataRank0,metaDataRank1)
     !!{
     Interface for list2D property meta-data.
     !!}
     implicit none
-    class(nodePropertyExtractorList2D), intent(inout) :: self
-    type (treeNode                   ), intent(inout) :: node
-    type (doubleHash                 ), intent(inout) :: metaDataRank0
-    type (rank1DoubleHash            ), intent(inout) :: metaDataRank1
-    !$GLC attributes unused :: self, node, metaDataRank0, metaDataRank1
+    class           (nodePropertyExtractorList2D), intent(inout) :: self
+    type            (treeNode                   ), intent(inout) :: node
+    double precision                             , intent(in   ) :: time
+    type            (doubleHash                 ), intent(inout) :: metaDataRank0
+    type            (rank1DoubleHash            ), intent(inout) :: metaDataRank1
+    !$GLC attributes unused :: self, node, time, metaDataRank0, metaDataRank1
     
     return
   end subroutine list2DMetaData

--- a/source/nodes.property_extractor.multi.F90
+++ b/source/nodes.property_extractor.multi.F90
@@ -823,7 +823,7 @@ contains
        class is (nodePropertyExtractorList2D       )
           if (elementType == elementTypeDouble ) then
              elementCount=extractor_%elementCount()
-             if (offset+1 <= iProperty .and. offset+elementCount >= iProperty) call extractor_%metaData(node                                  ,metaDataRank0,metaDataRank1)
+             if (offset+1 <= iProperty .and. offset+elementCount >= iProperty) call extractor_%metaData(node            ,time                 ,metaDataRank0,metaDataRank1)
           end if
        class is (nodePropertyExtractorMulti        )
           elementCount=extractor_%elementCount(elementType,time)

--- a/source/nodes.property_extractor.star_formation_history_masses.F90
+++ b/source/nodes.property_extractor.star_formation_history_masses.F90
@@ -93,7 +93,7 @@ contains
     !!{
     Internal constructor for the {\normalfont \ttfamily starFormationHistoryMass} property extractor class.
     !!}
-    use :: Galactic_Structure_Options, only : componentTypeDisk, componentTypeSpheroid
+    use :: Galactic_Structure_Options, only : componentTypeDisk, componentTypeSpheroid, componentTypeAll
     use :: Error                     , only : Error_Report
     implicit none
     type (nodePropertyExtractorStarFormationHistoryMass)                        :: self
@@ -104,11 +104,13 @@ contains
     <constructorAssign variables="component, *starFormationHistory_, *outputTimes_"/>
     !!]
     
-    if     (                                                                                                    &
-         &   component /= componentTypeDisk                                                                     &
-         &  .and.                                                                                               &
-         &   component /= componentTypeSpheroid                                                                 &
-         & ) call Error_Report("only 'disk' and 'spheroid' components are supported"//{introspection:location})    
+    if     (                                                                                                            &
+         &   component /= componentTypeDisk                                                                             &
+         &  .and.                                                                                                       &
+         &   component /= componentTypeSpheroid                                                                         &
+         &  .and.                                                                                                       &
+         &   component /= componentTypeAll                                                                              &
+         & ) call Error_Report("only 'disk', 'spheroid', and 'all' components are supported"//{introspection:location})    
     return
   end function starFormationHistoryMassConstructorInternal
 
@@ -142,7 +144,7 @@ contains
     Implement a {\normalfont \ttfamily starFormationHistoryMass} property extractor.
     !!}
     use :: Galacticus_Nodes          , only : nodeComponentDisk, nodeComponentSpheroid
-    use :: Galactic_Structure_Options, only : componentTypeDisk, componentTypeSpheroid
+    use :: Galactic_Structure_Options, only : componentTypeDisk, componentTypeSpheroid, componentTypeAll
     use :: Histories                 , only : history
     implicit none
     double precision                                               , dimension(:,: ,: ), allocatable :: starFormationHistoryMassExtract
@@ -151,8 +153,9 @@ contains
     type            (multiCounter                                 ), intent(inout)     , optional    :: instance
     class           (nodeComponentDisk                            )                    , pointer     :: disk
     class           (nodeComponentSpheroid                        )                    , pointer     :: spheroid
-    type            (history                                      )                                  :: starFormationHistory
-    !$GLC attributes unustarFormationHistoryMass :: instance
+    type            (history                                      )                                  :: starFormationHistory        , starFormationHistoryDisk, &
+         &                                                                                              starFormationHistorySpheroid
+    !$GLC attributes unused :: instance
 
     ! Get the relevant star formation history.
     select case (self%component%ID)
@@ -162,6 +165,21 @@ contains
     case (componentTypeSpheroid%ID)
        spheroid             => node    %spheroid            ()
        starFormationHistory =  spheroid%starFormationHistory()
+    case (componentTypeAll     %ID)
+       spheroid                     => node    %spheroid            ()
+       disk                         => node    %disk                ()
+       starFormationHistoryDisk     =  disk    %starFormationHistory()
+       starFormationHistorySpheroid =  spheroid%starFormationHistory()
+       if (starFormationHistoryDisk%exists()) then
+          if (starFormationHistorySpheroid%exists()) then
+             starFormationHistory= starFormationHistoryDisk     &
+                  &               +starFormationHistorySpheroid
+          else
+             starFormationHistory=starFormationHistoryDisk
+          end if
+       else
+          starFormationHistory=starFormationHistorySpheroid
+       end if
     end select
     if (starFormationHistory%exists()) then
        allocate(starFormationHistoryMassExtract(size(starFormationHistory%data,dim=1),size(starFormationHistory%data,dim=2),1))
@@ -214,24 +232,23 @@ contains
     return
   end function starFormationHistoryMassUnitsInSI
   
-  subroutine starFormationHistoryMassMetaData(self,node,metaDataRank0,metaDataRank1)
+  subroutine starFormationHistoryMassMetaData(self,node,time,metaDataRank0,metaDataRank1)
     !!{
     Return metadata associated with the {\normalfont \ttfamily starFormationHistoryMass} properties.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic
     implicit none
-    class  (nodePropertyExtractorStarFormationHistoryMass), intent(inout) :: self
-    type   (treeNode                                     ), intent(inout) :: node
-    type   (doubleHash                                   ), intent(inout) :: metaDataRank0
-    type   (rank1DoubleHash                              ), intent(inout) :: metaDataRank1
-    class  (nodeComponentBasic                           ), pointer       :: basic
-    integer(c_size_t                                     )                :: indexOutput
+    class           (nodePropertyExtractorStarFormationHistoryMass), intent(inout) :: self
+    type            (treeNode                                     ), intent(inout) :: node
+    double precision                                               , intent(in   ) :: time
+    type            (doubleHash                                   ), intent(inout) :: metaDataRank0
+    type            (rank1DoubleHash                              ), intent(inout) :: metaDataRank1
+    integer         (c_size_t                                     )                :: indexOutput
     !$GLC attributes unused :: metaDataRank0
 
     call    metaDataRank1%set('metallicity',self%starFormationHistory_%metallicityBoundaries(           ))
     if (self%starFormationHistory_%perOutputTabulationIsStatic()) then
-       basic       => node             %basic(                               )
-       indexOutput =  self%outputTimes_%index(basic%time(),findClosest=.true.)
+       indexOutput =  self%outputTimes_%index(time,findClosest=.true.)
        call metaDataRank1%set('time'       ,self%starFormationHistory_%times                (indexOutput))
     end if
     return

--- a/source/objects.nodes.components.black_hole.non_central.F90
+++ b/source/objects.nodes.components.black_hole.non_central.F90
@@ -329,20 +329,22 @@ contains
     return
   end subroutine Node_Component_Black_Hole_Noncentral_Scale_Set
 
-  subroutine Node_Component_Black_Hole_Noncentral_Merge_Black_Holes(node)
+  subroutine Node_Component_Black_Hole_Noncentral_Merge_Black_Holes(node,timeEnd)
     !!{
     Merge two black holes.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBlackHole, treeNode
     implicit none
-    type            (treeNode              ), intent(inout), target  :: node
-    class           (nodeComponentBlackHole)               , pointer :: blackHole1      , blackHole2        , &
-         &                                                              blackHolePrimary, blackHoleSecondary
-    double precision                                                 :: massBlackHoleNew, spinBlackHoleNew  , &
-         &                                                              massBlackHole1  , massBlackHole2    , &
-         &                                                              velocityRecoil  , spinBlackHole1    , &
-         &                                                              spinBlackHole2
-
+    type            (treeNode              ), intent(inout), target   :: node
+    double precision                        , intent(in   ), optional :: timeEnd
+    class           (nodeComponentBlackHole)               , pointer  :: blackHole1      , blackHole2        , &
+         &                                                               blackHolePrimary, blackHoleSecondary
+    double precision                                                  :: massBlackHoleNew, spinBlackHoleNew  , &
+         &                                                               massBlackHole1  , massBlackHole2    , &
+         &                                                               velocityRecoil  , spinBlackHole1    , &
+         &                                                               spinBlackHole2
+    !$GLC attributes unused :: timeEnd
+    
     ! Get the black holes.
     blackHole1 => node%blackHole(instance=              1)
     blackHole2 => node%blackHole(instance=mergingInstance)
@@ -381,24 +383,25 @@ contains
     return
   end subroutine Node_Component_Black_Hole_Noncentral_Merge_Black_Holes
 
-  subroutine Node_Component_Black_Hole_Noncentral_Triple_Interaction(node)
+  subroutine Node_Component_Black_Hole_Noncentral_Triple_Interaction(node,timeEnd)
     !!{
     Handles triple black holes interactions, using conditions similar to those of \cite{volonteri_assembly_2003}.
     !!}
     use :: Galacticus_Nodes            , only : nodeComponentBasic             , nodeComponentBlackHole, treeNode
     use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
     implicit none
-    type            (treeNode              ), intent(inout), target  :: node
-    class           (nodeComponentBasic    )               , pointer :: basic
-    class           (nodeComponentBlackHole)               , pointer :: blackHoleBinary          , blackHoleCentral           , &
-         &                                                              ejectedBlackHoleComponent, newBinaryBlackHoleComponent, &
-         &                                                              tripleBlackHoleComponent
-    integer                                                          :: ejectedInstance          , newBinaryInstance
-    double precision                                                 :: bindingEnergy            , kineticEnergyChange        , &
-         &                                                              massBinary               , massEjected                , &
-         &                                                              massRatioIntruder        , newRadius                  , &
-         &                                                              velocityBinary           , velocityEjected
-    logical                                                          :: removeBinary             , removeEjected
+    type            (treeNode              ), intent(inout), target   :: node
+    double precision                        , intent(in   ), optional :: timeEnd
+    class           (nodeComponentBasic    )               , pointer  :: basic
+    class           (nodeComponentBlackHole)               , pointer  :: blackHoleBinary          , blackHoleCentral           , &
+         &                                                               ejectedBlackHoleComponent, newBinaryBlackHoleComponent, &
+         &                                                               tripleBlackHoleComponent
+    integer                                                           :: ejectedInstance          , newBinaryInstance
+    double precision                                                  :: bindingEnergy            , kineticEnergyChange        , &
+         &                                                               massBinary               , massEjected                , &
+         &                                                               massRatioIntruder        , newRadius                  , &
+         &                                                               velocityBinary           , velocityEjected
+    logical                                                           :: removeBinary             , removeEjected
 
     ! Get the basic component.
     basic            => node%basic    (                       )

--- a/source/objects.nodes.components.black_hole.non_central.F90
+++ b/source/objects.nodes.components.black_hole.non_central.F90
@@ -402,6 +402,7 @@ contains
          &                                                               massRatioIntruder        , newRadius                  , &
          &                                                               velocityBinary           , velocityEjected
     logical                                                           :: removeBinary             , removeEjected
+    !$GLC attributes unused :: timeEnd
 
     ! Get the basic component.
     basic            => node%basic    (                       )

--- a/source/objects.nodes.components.black_hole.simple.F90
+++ b/source/objects.nodes.components.black_hole.simple.F90
@@ -374,15 +374,17 @@ contains
     return
   end subroutine satelliteMerger
 
-  subroutine Node_Component_Black_Hole_Simple_Create(node)
+  subroutine Node_Component_Black_Hole_Simple_Create(node,timeEnd)
     !!{
     Creates a simple black hole component for {\normalfont \ttfamily node}.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBlackHole, treeNode
     implicit none
-    type (treeNode              ), intent(inout), target  :: node
-    class(nodeComponentBlackHole)               , pointer :: blackHole
-
+    type            (treeNode              ), intent(inout), target   :: node
+    double precision                        , intent(in   ), optional :: timeEnd
+    class           (nodeComponentBlackHole)               , pointer  :: blackHole
+    !$GLC attributes unused :: timeEnd
+    
     ! Create the component.
     blackHole => node%blackHole(autoCreate=.true.)
     ! Set the seed mass.

--- a/source/objects.nodes.components.black_hole.standard.F90
+++ b/source/objects.nodes.components.black_hole.standard.F90
@@ -636,15 +636,17 @@ contains
     return
   end function Node_Component_Black_Hole_Standard_Recoil_Escapes
 
-  subroutine Node_Component_Black_Hole_Standard_Create(node)
+  subroutine Node_Component_Black_Hole_Standard_Create(node,timeEnd)
     !!{
     Creates a black hole component for {\normalfont \ttfamily node}.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBlackHole, treeNode
     implicit none
-    type (treeNode              ), intent(inout), target  :: node
-    class(nodeComponentBlackHole)               , pointer :: blackHole
-
+    type            (treeNode              ), intent(inout), target   :: node
+    double precision                        , intent(in   ), optional :: timeEnd
+    class           (nodeComponentBlackHole)               , pointer  :: blackHole
+    !$GLC attributes unused :: timeEnd
+    
     ! Create the black hole.
     blackHole => node%blackHole(autoCreate=.true.)
     ! Set to the seed mass.

--- a/source/objects.nodes.components.hot_halo.standard.F90
+++ b/source/objects.nodes.components.hot_halo.standard.F90
@@ -2077,15 +2077,17 @@ contains
     return
   end subroutine Node_Component_Hot_Halo_Standard_Create
 
-  subroutine Node_Component_Hot_Halo_Standard_Initializor(self)
+  subroutine Node_Component_Hot_Halo_Standard_Initializor(self,timeEnd)
     !!{
     Initializes a standard hot halo component.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentHotHaloStandard, treeNode
     implicit none
-    type (nodeComponentHotHaloStandard)          :: self
-    type (treeNode                    ), pointer :: node
-
+    type            (nodeComponentHotHaloStandard), intent(inout)           :: self
+    double precision                              , intent(in   ), optional :: timeEnd
+    type            (treeNode                    ), pointer                 :: node
+    !$GLC attributes unused :: timeEnd
+    
     ! Return if already initialized.
     if (self%isInitialized()) return
     ! Get the hosting node.

--- a/source/objects.nodes.components.satellite.orbiting.F90
+++ b/source/objects.nodes.components.satellite.orbiting.F90
@@ -365,13 +365,15 @@ contains
     return
   end subroutine Node_Component_Satellite_Orbiting_Scale_Set
 
-  subroutine Node_Component_Satellite_Orbiting_Initializor(self)
+  subroutine Node_Component_Satellite_Orbiting_Initializor(self,timeEnd)
     !!{
     Initializes an orbiting satellite component.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentSatelliteOrbiting
     implicit none
-    type(nodeComponentSatelliteOrbiting) :: self
+    type            (nodeComponentSatelliteOrbiting), intent(inout)           :: self
+    double precision                                , intent(in   ), optional :: timeEnd
+    !$GLC attributes unused :: timeEnd
 
     call Node_Component_Satellite_Orbiting_Create(self%hostNode)
     return

--- a/source/objects.nodes.components.satellite.preset.F90
+++ b/source/objects.nodes.components.satellite.preset.F90
@@ -434,7 +434,7 @@ contains
     return
   end subroutine Node_Component_Satellite_Preset_Rate_Compute
 
-  subroutine Node_Component_Satellite_Preset_Orphanize(node)
+  subroutine Node_Component_Satellite_Preset_Orphanize(node,timeEnd)
     !!{
     Handle orphanization of a preset satellite component. The satellite should be moved to the branch of its target node.
     !!}
@@ -443,12 +443,14 @@ contains
     use :: ISO_Varying_String, only : operator(//)      , var_str               , varying_string
     use :: String_Handling   , only : operator(//)
     implicit none
-    type (treeNode              ), intent(inout), target  :: node
-    type (treeNode              )               , pointer :: nodeHost
-    class(nodeComponentBasic    )               , pointer :: basic    , basicHost
-    class(nodeComponentSatellite)               , pointer :: satellite
-    type (varying_string        )                         :: message
-
+    type            (treeNode              ), intent(inout), target   :: node
+    double precision                        , intent(in   ), optional :: timeEnd
+    type            (treeNode              )               , pointer  :: nodeHost
+    class           (nodeComponentBasic    )               , pointer  :: basic    , basicHost
+    class           (nodeComponentSatellite)               , pointer  :: satellite
+    type            (varying_string        )                          :: message
+    !$GLC attributes unused :: timeEnd
+    
     satellite => node    %satellite  ()
     call satellite%isOrphanSet(.true.)
     nodeHost  => node    %mergeTarget

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -1393,21 +1393,22 @@ contains
     return
   end subroutine Node_Component_Spheroid_Standard_Radius_Solver
 
-  subroutine Node_Component_Spheroid_Standard_Initializor(self)
+  subroutine Node_Component_Spheroid_Standard_Initializor(self,timeEnd)
     !!{
     Initializes a standard spheroid component.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic, nodeComponentDisk, nodeComponentSpheroidStandard, treeNode
     use :: Histories       , only : history
     implicit none
-    type            (nodeComponentSpheroidStandard)          :: self
-    type            (treeNode                     ), pointer :: node
-    class           (nodeComponentDisk            ), pointer :: disk
-    class           (nodeComponentBasic           ), pointer :: basic
-    type            (history                      )          :: historyStarFormation        , stellarPropertiesHistory      , &
-         &                                                      diskStarFormationHistory
-    logical                                                  :: createStarFormationHistory  , createStellarPropertiesHistory
-    double precision                                         :: timeBegin
+    type            (nodeComponentSpheroidStandard), intent(inout)           :: self
+    double precision                               , intent(in   ), optional :: timeEnd
+    type            (treeNode                     ), pointer                 :: node
+    class           (nodeComponentDisk            ), pointer                 :: disk
+    class           (nodeComponentBasic           ), pointer                 :: basic
+    type            (history                      )                          :: historyStarFormation        , stellarPropertiesHistory      , &
+         &                                                                      diskStarFormationHistory
+    logical                                                                  :: createStarFormationHistory  , createStellarPropertiesHistory
+    double precision                                                         :: timeBegin
 
     ! Return if already initialized.
     if (self%isInitialized()) return
@@ -1435,24 +1436,26 @@ contains
           basic    => node %basic()
           timeBegin = basic%time ()
        end if
-       call starFormationHistory_%create                 (node,historyStarFormation,timeBegin)
-       call self                 %starFormationHistorySet(     historyStarFormation          )
+       call starFormationHistory_%create                 (node,historyStarFormation,timeBegin,timeEnd)
+       call self                 %starFormationHistorySet(     historyStarFormation                  )
     end if
     ! Record that the spheroid has been initialized.
     call self%isInitializedSet(.true.)
     return
   end subroutine Node_Component_Spheroid_Standard_Initializor
 
-  subroutine Node_Component_Spheroid_Standard_Star_Formation_History_Extend(node)
+  subroutine Node_Component_Spheroid_Standard_Star_Formation_History_Extend(node,timeEnd)
     !!{
     Extend the range of a star formation history in a standard spheroid component for {\normalfont \ttfamily node}.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentSpheroid, treeNode
     implicit none
-    type (treeNode             ), intent(inout), target  :: node
-    class(nodeComponentSpheroid)               , pointer :: spheroid
-    type (history              )                         :: historyStarFormation
-
+    type            (treeNode             ), intent(inout), target   :: node
+    double precision                       , intent(in   ), optional :: timeEnd
+    class           (nodeComponentSpheroid)               , pointer  :: spheroid
+    type            (history              )                          :: historyStarFormation
+    !$GLC attributes unused :: timeEnd
+    
     ! Get the spheroid component.
     spheroid => node%spheroid()
     ! Extend the range as necessary.
@@ -1462,16 +1465,18 @@ contains
     return
   end subroutine Node_Component_Spheroid_Standard_Star_Formation_History_Extend
 
-  subroutine Node_Component_Spheroid_Standard_Stellar_Prprts_History_Extend(node)
+  subroutine Node_Component_Spheroid_Standard_Stellar_Prprts_History_Extend(node,timeEnd)
     !!{
     Extend the range of a stellar properties history in a standard spheroid component for {\normalfont \ttfamily node}.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentSpheroid, treeNode
     implicit none
-    type (treeNode             ), intent(inout), target  :: node
-    class(nodeComponentSpheroid)               , pointer :: spheroid
-    type (history              )                         :: stellarPropertiesHistory
-
+    type            (treeNode             ), intent(inout), target   :: node
+    double precision                       , intent(in   ), optional :: timeEnd
+    class           (nodeComponentSpheroid)               , pointer  :: spheroid
+    type            (history              )                          :: stellarPropertiesHistory
+    !$GLC attributes unused :: timeEnd
+    
     ! Get the spheroid component.
     spheroid => node%spheroid()
     ! Extend the range as necessary.

--- a/source/star_formation.histories.F90
+++ b/source/star_formation.histories.F90
@@ -47,9 +47,10 @@ module Star_Formation_Histories
     <description>Create the star formation history object.</description>
     <type>void</type>
     <pass>yes</pass>
-    <argument>type            (treeNode), intent(inout) :: node</argument>
-    <argument>type            (history ), intent(inout) :: historyStarFormation</argument>
-    <argument>double precision          , intent(in   ) :: timeBegin</argument>
+    <argument>type            (treeNode), intent(inout)           :: node</argument>
+    <argument>type            (history ), intent(inout)           :: historyStarFormation</argument>
+    <argument>double precision          , intent(in   )           :: timeBegin</argument>
+    <argument>double precision          , intent(in   ), optional :: timeEnd</argument>
    </method>
    <method name="scales" >
     <description>Set ODE solver absolute scales for a star formation history object.</description>

--- a/source/star_formation.histories.adaptive.F90
+++ b/source/star_formation.histories.adaptive.F90
@@ -371,24 +371,29 @@ contains
     return
   end subroutine adaptiveDestructor
 
-  subroutine adaptiveCreate(self,node,historyStarFormation,timeBegin)
+  subroutine adaptiveCreate(self,node,historyStarFormation,timeBegin,timeEnd)
     !!{
     Create the history required for storing star formation history.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic
     implicit none
-    class           (starFormationHistoryAdaptive), intent(inout) :: self
-    type            (treeNode                    ), intent(inout) :: node
-    type            (history                     ), intent(inout) :: historyStarFormation
-    double precision                              , intent(in   ) :: timeBegin
-    class           (nodeComponentBasic          ), pointer       :: basic
-    integer         (c_size_t                    )                :: indexOutput
-    double precision                                              :: timeNext
+    class           (starFormationHistoryAdaptive), intent(inout)           :: self
+    type            (treeNode                    ), intent(inout)           :: node
+    type            (history                     ), intent(inout)           :: historyStarFormation
+    double precision                              , intent(in   )           :: timeBegin
+    double precision                              , intent(in   ), optional :: timeEnd
+    class           (nodeComponentBasic          ), pointer                 :: basic
+    integer         (c_size_t                    )                          :: indexOutput
+    double precision                                                        :: timeNext
     !$GLC attributes unused :: timeBegin
 
     ! Get the time and index of the next output
-    basic    => node             %basic   (                                                )
-    timeNext =  self%outputTimes_%timeNext(timeCurrent=basic%time(),indexOutput=indexOutput)
+    if (present(timeEnd)) then
+       indexOutput=self%outputTimes_%index(timeEnd)
+    else
+       basic    => node             %basic   (                                                )
+       timeNext =  self%outputTimes_%timeNext(timeCurrent=basic%time(),indexOutput=indexOutput)
+    end if
     ! Create the appropriate history.
     call historyStarFormation%create(int(self%countMetallicities+1),size(self%intervals(indexOutput)%time))
     historyStarFormation%time=self%intervals(indexOutput)%time

--- a/source/star_formation.histories.in_situ.F90
+++ b/source/star_formation.histories.in_situ.F90
@@ -156,24 +156,26 @@ contains
     return
   end subroutine inSituDestructor
 
-  subroutine inSituCreate(self,node,historyStarFormation,timeBegin)
+  subroutine inSituCreate(self,node,historyStarFormation,timeBegin,timeEnd)
     !!{
     Create the history required for storing star formation history.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
     implicit none
-    class           (starFormationHistoryInSitu), intent(inout) :: self
-    type            (treeNode                  ), intent(inout) :: node
-    type            (history                   ), intent(inout) :: historyStarFormation
-    double precision                            , intent(in   ) :: timeBegin
-    class           (nodeComponentBasic        ), pointer       :: basic
-    double precision                                            :: timeBeginActual     , timeEnd
-
+    class           (starFormationHistoryInSitu), intent(inout)           :: self
+    type            (treeNode                  ), intent(inout)           :: node
+    type            (history                   ), intent(inout)           :: historyStarFormation
+    double precision                            , intent(in   )           :: timeBegin
+    double precision                            , intent(in   ), optional :: timeEnd
+    class           (nodeComponentBasic        ), pointer                 :: basic
+    double precision                                                      :: timeBeginActual     , timeEnd_
+    !$GLC attributes unused :: timeEnd
+    
     ! Find the start and end times for this history.
     basic           =>               node %basic()
     timeBeginActual =  min(timeBegin,basic%time ())
-    timeEnd         =  self%outputTimes_%timeNext(timeBegin)
-    call self%make(historyStarFormation,timeBeginActual,timeEnd)
+    timeEnd_        =  self%outputTimes_%timeNext(timeBegin)
+    call self%make(historyStarFormation,timeBeginActual,timeEnd_)
     return
   end subroutine inSituCreate
 

--- a/source/star_formation.histories.metallicity_split.F90
+++ b/source/star_formation.histories.metallicity_split.F90
@@ -248,23 +248,25 @@ contains
     return
   end subroutine metallicitySplitDestructor
 
-  subroutine metallicitySplitCreate(self,node,historyStarFormation,timeBegin)
+  subroutine metallicitySplitCreate(self,node,historyStarFormation,timeBegin,timeEnd)
     !!{
     Create the history required for storing star formation history.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
     implicit none
-    class           (starFormationHistoryMetallicitySplit), intent(inout) :: self
-    type            (treeNode                            ), intent(inout) :: node
-    type            (history                             ), intent(inout) :: historyStarFormation
-    double precision                                      , intent(in   ) :: timeBegin
-    class           (nodeComponentBasic                  ), pointer       :: basic
-    double precision                                                      :: timeBeginActual     , timeEnd
-
+    class           (starFormationHistoryMetallicitySplit), intent(inout)           :: self
+    type            (treeNode                            ), intent(inout)           :: node
+    type            (history                             ), intent(inout)           :: historyStarFormation
+    double precision                                      , intent(in   )           :: timeBegin
+    double precision                                      , intent(in   ), optional :: timeEnd
+    class           (nodeComponentBasic                  ), pointer                 :: basic
+    double precision                                                                :: timeBeginActual     , timeEnd_
+    !$GLC attributes unused :: timeEnd
+    
     basic           => node%basic()
     timeBeginActual =  min(timeBegin,basic%time())
-    timeEnd         =  self%outputTimes_%timeNext(basic%time())
-    call self%make(historyStarFormation,timeBeginActual,timeEnd)
+    timeEnd_        =  self%outputTimes_%timeNext(basic%time())
+    call self%make(historyStarFormation,timeBeginActual,timeEnd_)
     return
   end subroutine metallicitySplitCreate
 

--- a/source/star_formation.histories.null.F90
+++ b/source/star_formation.histories.null.F90
@@ -63,16 +63,17 @@ contains
     return
   end function nullConstructorParameters
 
-  subroutine nullCreate(self,node,historyStarFormation,timeBegin)
+  subroutine nullCreate(self,node,historyStarFormation,timeBegin,timeEnd)
     !!{
     Create the history required for storing star formation history.
     !!}
     implicit none
-    class           (starFormationHistoryNull), intent(inout) :: self
-    type            (treeNode                ), intent(inout) :: node
-    type            (history                 ), intent(inout) :: historyStarFormation
-    double precision                          , intent(in   ) :: timeBegin
-    !$GLC attributes unused :: self, node, historyStarFormation, timeBegin
+    class           (starFormationHistoryNull), intent(inout)           :: self
+    type            (treeNode                ), intent(inout)           :: node
+    type            (history                 ), intent(inout)           :: historyStarFormation
+    double precision                          , intent(in   )           :: timeBegin
+    double precision                          , intent(in   ), optional :: timeEnd
+    !$GLC attributes unused :: self, node, historyStarFormation, timeBegin, timeEnd
 
     ! Do nothing.
     return

--- a/testSuite/regressions/adaptiveSFHLengths.xml
+++ b/testSuite/regressions/adaptiveSFHLengths.xml
@@ -97,7 +97,7 @@
     <treeCount value="1"/>
   </mergerTreeBuildMasses>
   <mergerTreeMassResolution value="fixed">
-    <massResolution value="1.0e10"/>
+    <massResolution value="1.0e7"/>
   </mergerTreeMassResolution>
   
   <mergerTreeOperator value="sequence">
@@ -477,8 +477,16 @@
   <diskLuminositiesStellarInactive value="true"/>
   <spheroidLuminositiesStellarInactive value="true"/>
 
-  <nodePropertyExtractor value="starFormationHistory">
-    <component value="disk"/>
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="starFormationHistory">
+      <component value="disk"/>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="starFormationHistory">
+      <component value="spheroid"/>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="starFormationHistory">
+      <component value="all"/>
+    </nodePropertyExtractor>
   </nodePropertyExtractor>
 
   <elementsToTrack value="Fe"/>


### PR DESCRIPTION
- Correct times output by the `nodePropertyExtractorStarFormationHistoryMasses` class
   - Previously these were always the times corresponding to the final output time. They now correspond to the actual time of each output.
- Allows selection of the "all" component, allowing the summed star formation history of disk and spheroid to be output.
- Ensure that adaptive star formation histories are always created with the correct length
   - Previously, if a spheroid was created via interrupt at precisely the next output time, the star formation history (created by the `starFormationHistoryAdaptive` class) would be created with times appropriate to the subsequent output time. This resulted in mismatches between the lengths (and times) of star formation histories for some galaxies.
- Expand the test of adaptive star formation histories
   - Now additionally checks the lengths of spheroid star formation histories are identical, checks that disk and spheroid star formation histories are of the same lengths, and that the times at which the star formation histories are tabulated are consistent with the output 

