### PR TITLE
Fix interface line numbering

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Parse/Declarations.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/Declarations.pm
@@ -50,8 +50,10 @@ sub Parse_Declarations {
 		# Accumulate raw text.
 		if ( $isDeclaration == 1 ) {
 		    $rawDeclaration .= $rawLine;
-		    push(@declarations,$declaration)
-			if ( $declaration );
+		    if ( $declaration ) {
+			$declaration->{'line'} = $lineNumber;
+			push(@declarations,$declaration);
+		    }
 		} else {
 		    $rawCode        .= $rawLine;
 		}

--- a/scripts/build/postprocess.pl
+++ b/scripts/build/postprocess.pl
@@ -122,13 +122,14 @@ while ( my $line = <STDIN> ) {
 	    last
 		if ( $_->{'lineOriginal'} > $lineOriginal );
 	    $source     = $_->{'source'};
-	    my $lineNumber;
+	    my $lineDescriptor;
 	    if ( $source =~ m/\(\)$/ ) {
-		$lineNumber = "meta";
+		$lineDescriptor = "auto-generated code (no line number)";
 	    } else {
-		$lineNumber = $lineOriginal-$_->{'lineOriginal'}+$_->{'line'};
+		my $lineNumber = $lineOriginal-$_->{'lineOriginal'}+$_->{'line'};
+		$lineDescriptor = "line ".$lineNumber;
 	    }
-    	    $line = $source.":".$lineNumber.":".$flag."\n";
+    	    $line = $source."; ".$lineDescriptor." [preprocessed line ".$lineOriginal."]; code ".$flag."\n";
 	}
 	print $buffer
 	    if ( $buffer );


### PR DESCRIPTION
- Add line numbers to individual declarations in the source tree
   - When building the tree representation of source code, add line numbers to individual declarations within a `declaration` node. This will allow more fine-grained reporting of line numbers in error messages.
- Refactor function class interface code to include line numbers for declarations
   - Function class modules contain interface definitions for functions in the associated submodules. These are now constructed to have line number information present before each declaration in the interface. This allows more accurate and fine-grained line number reporting in compiler error messages.
- Make post-processed compiler error messages more informative
   - Messages are now more clear about what is the line number and what is the error code, and also uses a more informative "auto-generated code" instead of "meta" to indicate code that did not originate from a source file.

