### PR TITLE
Ensure stellar histories are zeroed when zeroing stellar mass due to ODE solver failure

### DIFF
--- a/source/objects.nodes.components.disk.standard.F90
+++ b/source/objects.nodes.components.disk.standard.F90
@@ -490,6 +490,7 @@ contains
     use :: Error                         , only : Error_Report
     use :: Galacticus_Nodes              , only : defaultDiskComponent, nodeComponentDisk  , nodeComponentDiskStandard, nodeComponentSpin, &
           &                                       treeNode            , nodeComponentBasic
+    use :: Histories                     , only : history
     use :: Interface_GSL                 , only : GSL_Success         , GSL_Continue
     use :: ISO_Varying_String            , only : assignment(=)       , operator(//)       , varying_string
     use :: Stellar_Luminosities_Structure, only : abs                 , stellarLuminosities
@@ -509,7 +510,9 @@ contains
     !$omp threadprivate(message)
     type            (stellarLuminosities), save                   :: luminositiesStellar
     !$omp threadprivate(luminositiesStellar)
-
+    type            (history            ), save                   :: historyStellar
+    !$omp threadprivate(historyStellar)
+    
     ! Return immediately if this class is not in use.
     if (.not.defaultDiskComponent%standardIsActive()) return
     ! Get the disk component.
@@ -558,6 +561,12 @@ contains
              specificAngularMomentum=0.0d0
              call disk%        massStellarSet(                  0.0d0)
              call disk%  abundancesStellarSet(         zeroAbundances)
+             historyStellar=disk%starFormationHistory    ()
+             call historyStellar%reset()
+             call disk         %starFormationHistorySet     (historyStellar)
+             historyStellar=disk%stellarPropertiesHistory()
+             call historyStellar%reset()
+             call disk          %stellarPropertiesHistorySet(historyStellar)
              ! We need to reset the stellar luminosities to zero. We can't simply use the "zeroStellarLuminosities" instance since
              ! our luminosities may have been truncated. If we were to use "zeroStellarLuminosities" then the number of stellar
              ! luminosities associated with the disk would change - but we are in the middle of differential evolution here and we
@@ -620,10 +629,16 @@ contains
              specificAngularMomentum=disk%angularMomentum()/massDisk
              if (specificAngularMomentum < 0.0d0) specificAngularMomentum=disk%radius()*disk%velocity()
           end if
-          ! Reset the stellar, abundances and angular momentum of the disk.
+          ! Reset the stellar mass, abundances and angular momentum of the disk.
           call disk%      massStellarSet(                                 0.0d0)
           call disk%abundancesStellarSet(                        zeroAbundances)
           call disk%  angularMomentumSet(specificAngularMomentum*disk%massGas())
+          historyStellar=disk%starFormationHistory    ()
+          call historyStellar%reset()
+          call disk         %starFormationHistorySet     (historyStellar)
+          historyStellar=disk%stellarPropertiesHistory()
+          call historyStellar%reset()
+          call disk          %stellarPropertiesHistorySet(historyStellar)
           ! Indicate that ODE evolution should continue after this state change.
           if (status == GSL_Success) status=GSL_Continue
        end if

--- a/source/objects.nodes.components.disk.very_simple.F90
+++ b/source/objects.nodes.components.disk.very_simple.F90
@@ -763,17 +763,19 @@ contains
     use :: Abundances_Structure            , only : zeroAbundances
     use :: Error                           , only : Error_Report
     use :: Galacticus_Nodes                , only : nodeComponentDisk      , nodeComponentDiskVerySimple, nodeComponentSpheroid           , treeNode
+    use :: Histories                       , only : history
     use :: Satellite_Merging_Mass_Movements, only : destinationMergerDisk  , destinationMergerSpheroid  , enumerationDestinationMergerType
     use :: Stellar_Luminosities_Structure  , only : zeroStellarLuminosities
     implicit none
-    class  (*                              ), intent(inout) :: self
-    type   (treeNode                       ), intent(inout) :: node
-    type   (treeNode                       ), pointer       :: nodeHost
-    class  (nodeComponentDisk              ), pointer       :: diskHost               , disk
-    class  (nodeComponentSpheroid          ), pointer       :: spheroidHost
-    type  (enumerationDestinationMergerType)                :: destinationGasSatellite, destinationGasHost       , &
-         &                                                     destinationStarsHost   , destinationStarsSatellite
-    logical                                                 :: mergerIsMajor
+    class  (*                               ), intent(inout) :: self
+    type   (treeNode                        ), intent(inout) :: node
+    type   (treeNode                        ), pointer       :: nodeHost
+    class  (nodeComponentDisk               ), pointer       :: diskHost               , disk
+    class  (nodeComponentSpheroid           ), pointer       :: spheroidHost
+    type   (enumerationDestinationMergerType)                :: destinationGasSatellite, destinationGasHost       , &
+         &                                                      destinationStarsHost   , destinationStarsSatellite
+    type   (history                         )                :: historyHost            , historyNode
+    logical                                                  :: mergerIsMajor
     !$GLC attributes unused :: self
 
     ! Check that the disk is of the verySimple class.
@@ -838,7 +840,14 @@ contains
                &                                    diskHost    %luminositiesStellar() &
                &                                   +disk        %luminositiesStellar() &
                &                                  )
-       case (destinationMergerSpheroid%ID)
+          ! Also add stellar properties histories.
+          historyNode=disk    %stellarPropertiesHistory()
+          historyHost=diskHost%stellarPropertiesHistory()
+          call historyHost%interpolatedIncrement      (historyNode)
+          call historyNode%reset                      (           )
+          call diskHost   %stellarPropertiesHistorySet(historyHost)
+          call disk       %stellarPropertiesHistorySet(historyNode)
+        case (destinationMergerSpheroid%ID)
           call spheroidHost%massStellarSet        (                                    &
                &                                    spheroidHost%  massStellar      () &
                &                                   +disk        %  massStellar      () &
@@ -851,6 +860,13 @@ contains
                &                                    spheroidHost%luminositiesStellar() &
                &                                   +disk        %luminositiesStellar() &
                &                                  )
+          ! Also add stellar properties histories.
+          historyNode=disk    %stellarPropertiesHistory()
+          historyHost=spheroidHost%stellarPropertiesHistory()
+          call historyHost %interpolatedIncrement      (historyNode)
+          call historyNode %reset                      (           )
+          call spheroidHost%stellarPropertiesHistorySet(historyHost)
+          call disk        %stellarPropertiesHistorySet(historyNode)
        case default
           call Error_Report(                                    &
                &            'unrecognized movesTo descriptor'// &

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -435,6 +435,7 @@ contains
     use :: Abundances_Structure          , only : abs                     , zeroAbundances
     use :: Display                       , only : displayMessage          , verbosityLevelWarn
     use :: Galacticus_Nodes              , only : defaultSpheroidComponent, nodeComponentSpheroid, nodeComponentSpheroidStandard, treeNode
+    use :: Histories                     , only : history
     use :: Interface_GSL                 , only : GSL_Success             , GSL_Continue
     use :: ISO_Varying_String            , only : assignment(=)           , operator(//)         , varying_string
     use :: Stellar_Luminosities_Structure, only : abs                     , stellarLuminosities
@@ -453,6 +454,8 @@ contains
     !$omp threadprivate(message)
     type            (stellarLuminosities  ), save                   :: luminositiesStellar
     !$omp threadprivate(luminositiesStellar)
+    type            (history              ), save                   :: historyStellar
+    !$omp threadprivate(historyStellar)
 
     ! Return immediately if this class is not in use.
     if (.not.defaultSpheroidComponent%standardIsActive()) return
@@ -502,6 +505,12 @@ contains
              specificAngularMomentum=0.0d0
              call spheroid%        massStellarSet(                  0.0d0)
              call spheroid%  abundancesStellarSet(         zeroAbundances)
+             historyStellar=spheroid%starFormationHistory    ()
+             call historyStellar%reset()
+             call spheroid      %starFormationHistorySet   (historyStellar)
+             historyStellar=spheroid%stellarPropertiesHistory()
+             call historyStellar%reset()
+             call spheroid      %stellarPropertiesHistorySet(historyStellar)
              ! We need to reset the stellar luminosities to zero. We can't simply use the "zeroStellarLuminosities" instance since
              ! our luminosities may have been truncated. If we were to use "zeroStellarLuminosities" then the number of stellar
              ! luminosities associated with the spheroid would change - but we are in the middle of differential evolution here and we
@@ -562,10 +571,16 @@ contains
           else
              specificAngularMomentum=spheroid%angularMomentum()/massSpheroid
           end if
-          ! Reset the stellar, abundances and angular momentum of the spheroid.
+          ! Reset the stellar mass, abundances and angular momentum of the spheroid.
           call spheroid%        massStellarSet(                                 0.0d0)
           call spheroid%  abundancesStellarSet(                        zeroAbundances)
           call spheroid%angularMomentumSet(specificAngularMomentum*spheroid%massGas())
+          historyStellar=spheroid%starFormationHistory    ()
+          call historyStellar%reset()
+          call spheroid      %starFormationHistorySet   (historyStellar)
+          historyStellar=spheroid%stellarPropertiesHistory()
+          call historyStellar%reset()
+          call spheroid      %stellarPropertiesHistorySet(historyStellar)
           ! Indicate that ODE evolution should continue after this state change.
           if (status == GSL_Success) status=GSL_Continue
        end if


### PR DESCRIPTION
Without this, the summed star formation history will not match the stellar mass.