### PR TITLE
Allow epochs to be specified as redshifts in the `outputTimesUniformSpacingInTime` class

### DIFF
--- a/source/output.times.uniform_spacing_in_time.F90
+++ b/source/output.times.uniform_spacing_in_time.F90
@@ -27,7 +27,8 @@
      Implementation of an output times class which generates a set of output times spaced uniformly in time.
      !!}
      private
-     double precision           :: timeMinimum, timeMaximum
+     double precision           :: timeMinimum    , timeMaximum    , &
+          &                        redshiftMinimum, redshiftMaximum
      integer         (c_size_t) :: countTimes
   end type outputTimesUniformSpacingInTime
 
@@ -46,30 +47,66 @@ contains
     Constructor for the {\normalfont \ttfamily uniformSpacingInTime} output times class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Error           , only : Error_Report
     implicit none
     type            (outputTimesUniformSpacingInTime)                :: self
     type            (inputParameters                ), intent(inout) :: parameters
     class           (cosmologyFunctionsClass        ), pointer       :: cosmologyFunctions_
-    double precision                                                 :: timeMinimum        , timeMaximum
+    double precision                                                 :: timeMinimum        , timeMaximum    , &
+         &                                                              redshiftMinimum    , redshiftMaximum
     integer         (c_size_t                       )                :: countTimes
-
+    
     !![
-    <inputParameter>
-      <name>timeMinimum</name>
-      <description>The minimum time at which to output.</description>
-      <source>parameters</source>
-    </inputParameter>
-    <inputParameter>
-      <name>timeMaximum</name>
-      <description>The maximum time at which to output.</description>
-      <source>parameters</source>
-    </inputParameter>
+    <objectBuilder class="cosmologyFunctions" name="cosmologyFunctions_" source="parameters"/>
+    !!]
+    if (parameters%isPresent('timeMinimum')) then
+       if (parameters%isPresent('redshiftMaximum')) call Error_Report("can not specify both 'timeMinimum' and 'redshiftMaximum'"//{introspection:location})
+       !![
+       <inputParameter>
+	 <name>timeMinimum</name>
+	 <description>The minimum time at which to output.</description>
+	 <source>parameters</source>
+       </inputParameter>
+       !!]
+    else if (parameters%isPresent('redshiftMaximum')) then
+       !![
+       <inputParameter>
+	 <name>redshiftMaximum</name>
+	 <description>The maximum redshift at which to output.</description>
+	 <source>parameters</source>
+       </inputParameter>
+       !!]
+       timeMinimum=cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(redshiftMaximum))
+    else
+       call Error_Report("must specify either 'timeMinimum' or 'redshiftMaximum'"//{introspection:location})
+    end if
+    if (parameters%isPresent('timeMaximum')) then
+       if (parameters%isPresent('redshiftMinimum')) call Error_Report("can not specify both 'timeMaximum' and 'redshiftMinimum'"//{introspection:location})
+       !![
+       <inputParameter>
+	 <name>timeMaximum</name>
+	 <description>The maximum time at which to output.</description>
+	 <source>parameters</source>
+       </inputParameter>
+       !!]
+    else if (parameters%isPresent('redshiftMinimum')) then
+       !![
+       <inputParameter>
+	 <name>redshiftMinimum</name>
+	 <description>The minimum redshift at which to output.</description>
+	 <source>parameters</source>
+       </inputParameter>
+       !!]
+       timeMaximum=cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(redshiftMinimum))
+    else
+       call Error_Report("must specify either 'timeMinimum' or 'redshiftMaximum'"//{introspection:location})
+    end if
+    !![
     <inputParameter>
       <name>countTimes</name>
       <description>The number of times at which to output.</description>
       <source>parameters</source>
     </inputParameter>
-    <objectBuilder class="cosmologyFunctions" name="cosmologyFunctions_" source="parameters"/>
     !!]
     self=outputTimesUniformSpacingInTime(timeMinimum,timeMaximum,countTimes,cosmologyFunctions_)
     !![
@@ -86,7 +123,7 @@ contains
     use :: Numerical_Ranges, only : Make_Range, rangeTypeLinear
     implicit none
     type            (outputTimesUniformSpacingInTime)                        :: self
-    double precision                                 , intent(in   )         :: timeMinimum, timeMaximum
+    double precision                                 , intent(in   )         :: timeMinimum        , timeMaximum
     integer         (c_size_t                       ), intent(in   )         :: countTimes
     class           (cosmologyFunctionsClass        ), intent(in   ), target :: cosmologyFunctions_
     integer         (c_size_t                       )                        :: i
@@ -100,5 +137,7 @@ contains
     do i=1,countTimes
        self%redshifts(i)=self%cosmologyFunctions_%redshiftFromExpansionFactor(self%cosmologyFunctions_%expansionFactor(self%times(i)))
     end do
+    self%redshiftMinimum=self%cosmologyFunctions_%redshiftFromExpansionFactor(self%cosmologyFunctions_%expansionFactor(self%timeMaximum))
+    self%redshiftMaximum=self%cosmologyFunctions_%redshiftFromExpansionFactor(self%cosmologyFunctions_%expansionFactor(self%timeMinimum))
     return
   end function uniformSpacingInTimeConstructorInternal

--- a/testSuite/test-methods.xml
+++ b/testSuite/test-methods.xml
@@ -1060,10 +1060,9 @@
     <formatVersion>2</formatVersion>
     <version>0.9.4</version>
     <componentBlackHole value="standard">
-    <efficiencyWindScalesWithEfficiencyRadiative value="false"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-  </componentBlackHole>
-
+      <efficiencyWindScalesWithEfficiencyRadiative value="false"/>
+      <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+    </componentBlackHole>
   </parameters>
 
   <!-- Hot halo ram pressure forces -->
@@ -2474,4 +2473,48 @@
     </nodeOperator>
   </parameters>
   
+  <!-- Output time options -->
+  <parameters>
+    <formatVersion>2</formatVersion>
+    <version>0.9.4</version>
+    <outputTimes value="list">
+      <redshifts value="0.0 0.2 0.4"/>
+    </outputTimes>
+    <outputTimes value="uniformSpacingInTime">
+      <timeMinimum value=" 1.0"/>
+      <timeMaximum value="13.0"/>
+      <countTimes  value=" 4  "/>
+    </outputTimes>
+    <outputTimes value="uniformSpacingInTime">
+      <timeMinimum     value="1.0"/>
+      <redshiftMinimum value="0.1"/>
+      <countTimes      value="4  "/>
+    </outputTimes>
+    <outputTimes value="uniformSpacingInTime">
+      <redshiftMaximum value=" 4.0"/>
+      <timeMaximum     value="13.0"/>
+      <countTimes      value=" 4  "/>
+    </outputTimes>
+    <outputTimes value="uniformSpacingInTime">
+      <redshiftMinimum value="0.1"/>
+      <redshiftMaximum value="4.0"/>
+      <countTimes      value="4  "/>
+    </outputTimes>
+    <outputTimes value="uniformSpacingInRedshift">
+      <redshiftMinimum value="0.1"/>
+      <redshiftMaximum value="4.0"/>
+      <countRedshifts  value="4  "/>
+    </outputTimes>
+    <outputTimes value="logarithmicSpacingInRedshift">
+      <redshiftMinimum value="0.1"/>
+      <redshiftMaximum value="4.0"/>
+      <countRedshifts  value="4  "/>
+    </outputTimes>
+    <outputTimes value="logarithmicSpacingInCriticalOverdensity">
+      <redshiftMinimum value="0.1"/>
+      <redshiftMaximum value="4.0"/>
+      <countRedshifts  value="4  "/>
+    </outputTimes>
+  </parameters>
+
 </parameterGrid>

--- a/testSuite/test-methods.xml
+++ b/testSuite/test-methods.xml
@@ -2513,7 +2513,7 @@
     <outputTimes value="logarithmicSpacingInCriticalOverdensity">
       <redshiftMinimum value="0.1"/>
       <redshiftMaximum value="4.0"/>
-      <countRedshifts  value="4  "/>
+      <countTimes      value="4  "/>
     </outputTimes>
   </parameters>
 


### PR DESCRIPTION
A mix of time/redshift is allowed for the min/max epoch.