### PR TITLE
Avoid a possible race condition when computing linear growth factors

### DIFF
--- a/source/structure_formation.linear_growth.baryons_darkMatter.F90
+++ b/source/structure_formation.linear_growth.baryons_darkMatter.F90
@@ -309,7 +309,7 @@ contains
        ! Iterate over wavenumber.
        !$ call OMP_Init_Lock(lockBaryons   )
        !$ call OMP_Init_Lock(lockDarkMatter)
-       !$omp parallel private(i,j,wavenumberLogarithmic,growthFactorDerivativeDarkMatter,growthFactorDerivativeBaryons,timeNow,growthFactorODEVariables,solver,linearGrowthFactorPresent)
+       !$omp parallel private(i,j,wavenumberLogarithmic,growthFactorDerivativeDarkMatter,growthFactorDerivativeBaryons,timeNow,growthFactorODEVariables,solver)
        allocate(cosmologyFunctions_      ,mold=self%cosmologyFunctions_      )
        allocate(intergalacticMediumState_,mold=self%intergalacticMediumState_)
        !$omp critical(linearGrowthBaryonsDrkMttrDeepCopy)
@@ -352,12 +352,14 @@ contains
        <objectDestructor name="cosmologyFunctions_"      />
        <objectDestructor name="intergalacticMediumState_"/>
        !!]
-       !$omp do
+       !$omp barrier
+       !$omp single
        ! Get present day growth factor at every wavenumber.
        do j=1,countWavenumbers
           linearGrowthFactorPresent(j)=self%growthFactor%interpolate(timePresent,self%growthFactor%y(j))
        end do
-       !$omp end do
+       !$omp end single
+       !$omp barrier
        !$omp do
        do j=1,countWavenumbers
           ! Normalize to growth factor of unity at present day.

--- a/source/structure_formation.linear_growth.baryons_darkMatter.F90
+++ b/source/structure_formation.linear_growth.baryons_darkMatter.F90
@@ -231,7 +231,7 @@ contains
   subroutine baryonsDarkMatterRetabulate(self,time,wavenumber)
     !!{
     Returns the linear growth factor $D(a)$ for expansion factor {\normalfont \ttfamily aExpansion}, normalized such that
-    $D(1)=1$ for a baryonsDarkMatter matter plus cosmological constant cosmology.
+    $D(1)=1$ for a baryons plus dark matter plus cosmological constant cosmology.
     !!}
     use    :: File_Utilities       , only : File_Lock                       , File_Unlock
     use    :: Error                , only : Error_Report
@@ -242,23 +242,23 @@ contains
     use    :: Table_Labels         , only : extrapolationTypeAbort          , extrapolationTypeFix
     use    :: Tables               , only : table1DGeneric
     implicit none
-    class           (linearGrowthBaryonsDarkMatter), intent(inout)           :: self
-    double precision                               , intent(in   )           :: time
-    double precision                               , intent(in   ), optional :: wavenumber
-    double precision                               , parameter               :: odeToleranceAbsolute          =   1.0d-10, odeToleranceRelative                = 1.0d-10
-    integer                                        , parameter               :: growthTablePointsPerDecadeTime=1000      , growthTablePointsPerDecadeWavenumber=100
-    double precision                               , dimension(4)            :: growthFactorODEVariables
-    double precision                               , dimension(2)            :: redshiftsInitial                         , timesInitial
-    integer                                                                  :: i                                        , j
-    double precision                                                         :: growthFactorDerivativeBaryons            , growthFactorDerivativeDarkMatter             , &
-         &                                                                      timeNow                                  , linearGrowthFactorPresent                    , &
-         &                                                                      timePresent                              , timeBigCrunch                                , &
-         &                                                                      wavenumberLogarithmic
-    integer                                                                  :: growthTableNumberPoints
-    type            (odeSolver                    )                          :: solver
-    type            (table1DGeneric               )                          :: transferFunctionDarkMatter               , transferFunctionBaryons
-    integer                                                                  :: countWavenumbers
-    !$ integer      (omp_lock_kind                )                          :: lockBaryons                              , lockDarkMatter
+    class           (linearGrowthBaryonsDarkMatter), intent(inout)              :: self
+    double precision                               , intent(in   )              :: time
+    double precision                               , intent(in   ), optional    :: wavenumber
+    double precision                               , parameter                  :: odeToleranceAbsolute          =   1.0d-10, odeToleranceRelative                = 1.0d-10
+    integer                                        , parameter                  :: growthTablePointsPerDecadeTime=1000      , growthTablePointsPerDecadeWavenumber=100
+    double precision                               , dimension(4)               :: growthFactorODEVariables
+    double precision                               , dimension(2)               :: redshiftsInitial                         , timesInitial
+    double precision                               , dimension(:) , allocatable :: linearGrowthFactorPresent
+    integer                                                                     :: i                                        , j
+    double precision                                                            :: growthFactorDerivativeBaryons            , growthFactorDerivativeDarkMatter             , &
+         &                                                                         timeNow                                  , wavenumberLogarithmic                        , &
+         &                                                                         timePresent                              , timeBigCrunch
+    integer                                                                     :: growthTableNumberPoints
+    type            (odeSolver                    )                             :: solver
+    type            (table1DGeneric               )                             :: transferFunctionDarkMatter               , transferFunctionBaryons
+    integer                                                                     :: countWavenumbers
+    !$ integer      (omp_lock_kind                )                             :: lockBaryons                              , lockDarkMatter
 
     ! Check if we need to recompute our table.
     if (self%remakeTable(time)) then
@@ -305,6 +305,7 @@ contains
        ! Create table.
        countWavenumbers=int(dble(growthTablePointsPerDecadeWavenumber)*log10(self%tableWavenumberMaximum/self%tableWavenumberMinimum))+1
        call self%growthFactor%create(self%tableTimeMinimum,self%tableTimeMaximum,growthTableNumberPoints,self%tableWavenumberMinimum,self%tableWavenumberMaximum,countWavenumbers,tableCount=2,extrapolationTypeX=extrapolationTypeAbort,extrapolationTypeY=extrapolationTypeFix)
+       allocate(linearGrowthFactorPresent(countWavenumbers))
        ! Iterate over wavenumber.
        !$ call OMP_Init_Lock(lockBaryons   )
        !$ call OMP_Init_Lock(lockDarkMatter)
@@ -321,7 +322,7 @@ contains
        !$omp end critical(linearGrowthBaryonsDrkMttrDeepCopy)
        !$omp do
        do j=1,countWavenumbers
-          wavenumber_=self%growthFactor%y(j)
+          wavenumber_          =self%growthFactor%y(j)
           wavenumberLogarithmic=log(wavenumber_)
           ! Solve ODE to get corresponding expansion factors. Initialize with solution from CAMB.
           !$ call OMP_Set_Lock  (lockDarkMatter)
@@ -352,12 +353,17 @@ contains
        <objectDestructor name="intergalacticMediumState_"/>
        !!]
        !$omp do
+       ! Get present day growth factor at every wavenumber.
+       do j=1,countWavenumbers
+          linearGrowthFactorPresent(j)=self%growthFactor%interpolate(timePresent,self%growthFactor%y(j))
+       end do
+       !$omp end do
+       !$omp do
        do j=1,countWavenumbers
           ! Normalize to growth factor of unity at present day.
-          linearGrowthFactorPresent=self%growthFactor%interpolate(timePresent,self%growthFactor%y(j))
           do i=1,growthTableNumberPoints
-             call self%growthFactor%populate(self%growthFactor%z(i,j,table=indexDarkMatter)/linearGrowthFactorPresent,i,j,table=indexDarkMatter)
-             call self%growthFactor%populate(self%growthFactor%z(i,j,table=indexBaryons   )/linearGrowthFactorPresent,i,j,table=indexBaryons   )
+             call self%growthFactor%populate(self%growthFactor%z(i,j,table=indexDarkMatter)/linearGrowthFactorPresent(j),i,j,table=indexDarkMatter)
+             call self%growthFactor%populate(self%growthFactor%z(i,j,table=indexBaryons   )/linearGrowthFactorPresent(j),i,j,table=indexBaryons   )
           end do
        end do
        !$omp end do
@@ -485,7 +491,7 @@ contains
     else
        wavenumber_=wavenumberReference
     end if
-    ! Interpolate to get the expansion factor.
+    ! Interpolate to get the linear growth factor.
     baryonsDarkMatterValue=self%growthFactor%interpolate(time_,wavenumber_,table=indexDarkMatter)
     ! Normalize.
     select case (normalize_%ID)


### PR DESCRIPTION
This patch is intended to fix an intermittent problem in computing the linear growth factor accounting for baryons. Occasionally this calculation would fail its test with an error messages:
```
M: -> Linear growth: Einstein-de Sitter with baryons
M:      passed: dark matter linear growth factor [k ⟶ ∞ ; z =    0.0]
M:      FAILED: dark matter linear growth factor [k ⟶ 0 ; z =    0.0] [. :0.30554764E+03 ≉ 0.10000000E+01]
M:      passed: dark matter linear growth factor [k ⟶ ∞ ; z =    1.0]
M:      FAILED: dark matter linear growth factor [k ⟶ 0 ; z =    1.0] [. :0.15277382E+03 ≉ 0.50000000E+00]
M:      passed: dark matter linear growth factor [k ⟶ ∞ ; z =    3.0]
M:      FAILED: dark matter linear growth factor [k ⟶ 0 ; z =    3.0] [. :0.76386718E+02 ≉ 0.25000000E+00]
M:      passed: dark matter linear growth factor [k ⟶ ∞ ; z =    9.0]
M:      FAILED: dark matter linear growth factor [k ⟶ 0 ; z =    9.0] [. :0.30554372E+02 ≉ 0.10000000E+00]
M:      passed: dark matter linear growth factor [k ⟶ ∞ ; z =   30.0]
M:      FAILED: dark matter linear growth factor [k ⟶ 0 ; z =   30.0] [. :0.98543877E+01 ≉ 0.32258065E-01]
M: <-
```
The intermittent nature suggests a problem with OpenMP parallelism. Upon investigation, the loop which normalizes the growth factor (as a function of wavenumber) to 1 at the present day was both interpolating in the growth factor table and updating that table. Race conditions could then (in principle) lead to interpolation between elements of the table that had/had not already been normalized, leading to undefined results.

This patch separates the two stages: we first interpolate in the table to find the (unnormalized) growth factor at the present day at each wavenumber, and then (in a second loop) do the normalization, thereby avoiding the race condition.