### PR TITLE
Fix uninitialized content in output of filter properties

### DIFF
--- a/source/instruments.filters.F90
+++ b/source/instruments.filters.F90
@@ -389,13 +389,19 @@ contains
     use :: IO_HDF5                  , only : hdf5Object
     use :: Numerical_Constants_Units, only : angstromsPerMeter
     implicit none
-    type(hdf5Object) :: filtersGroup, dataset
-
-    if (.not.allocated(filterResponses)) return
+    type            (hdf5Object) :: filtersGroup       , dataset
+    integer                      :: i
+    double precision             :: wavelengthEffective
+    
+    if (countFilterResponses == 0) return
+    ! Ensure effective wavelengths are set.
+    do i=1,countFilterResponses
+       wavelengthEffective=Filter_Wavelength_Effective(i)
+    end do
     !$ call hdf5Access%set()
     filtersGroup=outputFile%openGroup('Filters','Properties of filters used.')
-    call filtersGroup%writeDataset(filterResponses%name               ,'name'               ,'Filter name.'                                               )
-    call filtersGroup%writeDataset(filterResponses%wavelengthEffective,'wavelengthEffective','Effective wavelength of filter [Å].',datasetReturned=dataset)
+    call filtersGroup%writeDataset(filterResponses(1:countFilterResponses)%name               ,'name'               ,'Filter name.'                                               )
+    call filtersGroup%writeDataset(filterResponses(1:countFilterResponses)%wavelengthEffective,'wavelengthEffective','Effective wavelength of filter [Å].',datasetReturned=dataset)
     call dataset%writeAttribute("Angstroms [Å]"        ,"units"    )
     call dataset%writeAttribute(1.0d0/angstromsPerMeter,"unitsInSI")
     call dataset     %close()


### PR DESCRIPTION
When outputting filter information (names and effective wavelengths), we previously output the entirety of the allocated array, even if some parts of the array were unpopulated. This can happen as the array is dynamically expanded in size by a factor 2 as needed.

Additionally, this patch ensures that effective wavelengths for all filters have actually been computed before attempting to output them.