### PR TITLE
Fix static builds of FSPS and CLASS

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -362,6 +362,12 @@ jobs:
           forutilsVersion=`awk '{if ($1 == "forutils:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
           fspsVersion=`awk '{if ($1 == "fsps:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
           cloudyVersion=`awk '{if ($1 == "cloudy:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
+          # Check that executables were statically linked
+          ! ldd dynamic/CAMB-${cambVersion}/fortran/camb
+          ! ldd dynamic/AxionCAMB/camb
+          ! ldd dynamic/class_public-${classVersion}/class
+          ! ldd dynamic/RecFast/recfast.exe
+          ! ldd dynamic/fsps-${fspsVersion}/src/autosps.exe
           tar cfj tools.tar.bz2 \
             dynamic/CAMB-${cambVersion}/fortran/camb \
             dynamic/AxionCAMB/camb \

--- a/source/interface.CLASS.F90
+++ b/source/interface.CLASS.F90
@@ -103,7 +103,7 @@ contains
        call displayMessage("compiling CLASS code",verbosityLevelWorking)
        command='cd '//classPath//'; cp Makefile Makefile.tmp; '
        ! Include Galacticus compilation flags here.
-       command=command//'sed -E -i~ s/"^CC[[:space:]]+=[[:space:]]+gcc"/"CC='//char(compiler(languageC))//'"/ Makefile.tmp; sed -E -i~ s/"^CCFLAG = "/"CCFLAG = '//char(stringSubstitute(compilerOptions(languageC),"/","\/"))
+       command=command//'sed -E -i~ s/"^CC[[:space:]]+=[[:space:]]+gcc"/"CC='//char(compiler(languageC))//'"/ Makefile.tmp; sed -E -i~ s/"^(CC|LD)FLAG = "/"\1FLAG = '//char(stringSubstitute(compilerOptions(languageC),"/","\/"))
        if (static_) command=command//' -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive'
        command=command//' "/ Makefile.tmp; make -f Makefile.tmp -j1 class'
        call System_Command_Do(char(command),status);

--- a/source/interface.FSPS.F90
+++ b/source/interface.FSPS.F90
@@ -109,10 +109,11 @@ contains
        end if
        call displayMessage("compiling autosps.exe code",verbosityLevelWorking)
        if (static_) then
-          call System_Command_Do("cd "//fspsPath//"/src; sed -i~ -E s/'^(F90FLAGS = .*)'/'\1 \-static'/g Makefile")
+          call System_Command_Do("cd "//fspsPath//"/src; grep -P '^F90FLAGS := ' Makefile && sed -i~ -E s/'^(F90FLAGS := [^#]*)'/'\1 \-static'/g Makefile"               ,status)
        else
-          call System_Command_Do("cd "//fspsPath//"/src; sed -i~ -E s/'^(F90FLAGS = .*)[[:space:]]*\-static(.*)'/'\1 \2'/g Makefile")
+          call System_Command_Do("cd "//fspsPath//"/src; grep -P '^F90FLAGS := ' Makefile && sed -i~ -E s/'^(F90FLAGS := .*)[[:space:]]*\-static(.*)'/'\1 \2'/g Makefile",status)
        end if
+       if (status /= 0) call Error_Report("failed to patch FSPS file 'Makefile' for static/dynamic build"//{introspection:location})
        call System_Command_Do(                                                                                                                                                &
             &                 "cd "//fspsPath//"/src; export SPS_HOME="//fspsPath//'; export F90FLAGS="'                                                                   // &
 #ifndef __aarch64__

--- a/source/interface.FSPS.F90
+++ b/source/interface.FSPS.F90
@@ -109,9 +109,23 @@ contains
        end if
        call displayMessage("compiling autosps.exe code",verbosityLevelWorking)
        if (static_) then
-          call System_Command_Do("cd "//fspsPath//"/src; grep -P '^F90FLAGS := ' Makefile && sed -i~ -E s/'^(F90FLAGS := [^#]*)'/'\1 \-static'/g Makefile"               ,status)
+          call System_Command_Do(                                                                                &
+               &                 "cd "//fspsPath//"/src; "                                                    // &
+#ifndef __APPLE__
+               &                 "grep -P '^F90FLAGS := ' Makefile && "                                       // &
+#endif
+               &                 "sed -i~ -E s/'^(F90FLAGS := [^#]*)'/'\1 \-static'/g Makefile"               ,  &
+               &                 status                                                                          &
+               &                )
        else
-          call System_Command_Do("cd "//fspsPath//"/src; grep -P '^F90FLAGS := ' Makefile && sed -i~ -E s/'^(F90FLAGS := .*)[[:space:]]*\-static(.*)'/'\1 \2'/g Makefile",status)
+          call System_Command_Do(                                                                                &
+               &                 "cd "//fspsPath//"/src; "                                                    // &
+#ifndef __APPLE__
+               &                 "grep -P '^F90FLAGS := ' Makefile && "                                       // &
+#endif
+               &                 "sed -i~ -E s/'^(F90FLAGS := .*)[[:space:]]*\-static(.*)'/'\1 \2'/g Makefile",  &
+               &                 status                                                                          &
+               &                )
        end if
        if (status /= 0) call Error_Report("failed to patch FSPS file 'Makefile' for static/dynamic build"//{introspection:location})
        call System_Command_Do(                                                                                                                                                &


### PR DESCRIPTION
For FSPS, the `Makefile` syntax had changed meaning that our patch for force static builds failed. This is now fixed and we include some level of checking that our patch applied correctly.

For CLASS, the `-static` flag was not being correctly applied to the `LDFLAGS` variable used when linking the code.

The CI/CD workflow now includes checks that these codes are statically linked.