### PR TITLE
Allow reading of variable length string types from HDF5 attributes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -641,7 +641,6 @@ jobs:
         executable: [ tests.nodes.exe,
                       tests.parameters.exe,
                       tests.files.exe,
-                      tests.IO.HDF5.exe,
                       tests.IO.XML.exe,
                       tests.ODE_solver.exe,
                       tests.random.exe,
@@ -752,6 +751,15 @@ jobs:
     with:
       executable: ${{ matrix.executable }}
       artifact: test-execs
+    secrets: inherit
+  ### Test HDF5 IO
+  IO-HDF5:
+    needs: Build-Executable-Linux
+    uses: ./.github/workflows/testCode.yml
+    with:
+      executable: tests.IO.HDF5.exe
+      artifact: test-execs
+      requirePython: 1
     secrets: inherit
   ### Test Crash
   Crash:

--- a/.github/workflows/testCode.yml
+++ b/.github/workflows/testCode.yml
@@ -24,6 +24,10 @@ on:
         required: false
         default: 0
         type: string
+      requirePython: # Set to 0/1 to indicate if Python tools are required
+        required: false
+        default: 0
+        type: number
 defaults:
   run:
     shell: bash
@@ -52,6 +56,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact }}
+      - name: Install tools
+        if: ${{ format('{0}',inputs.requirePython) == '1' }}
+        run: |
+          apt -y update && apt -y upgrade
+          apt -y install python3-numpy python3-h5py
       - name: Create test suite output directory
         run: mkdir -p $GALACTICUS_EXEC_PATH/testSuite/outputs
       - name: Run test

--- a/source/hdf5_cFuncs.c
+++ b/source/hdf5_cFuncs.c
@@ -2,7 +2,7 @@
 
 #include "H5Tpublic.h"
 
-/* Return an ID for the basic C character string type */
+/* Call the H5close() function to completely shut down HDF5 */
 void H5Close_C(void)
 {
   herr_t error;  

--- a/source/hdf5_cTypes.c
+++ b/source/hdf5_cTypes.c
@@ -7,3 +7,8 @@ hid_t H5T_C_S1_Get(void)
 {
   return H5T_C_S1;
 }
+
+size_t H5T_Variable_Get(void)
+{
+  return H5T_VARIABLE;
+}

--- a/source/tests.IO.HDF5.F90
+++ b/source/tests.IO.HDF5.F90
@@ -27,6 +27,7 @@ program Tests_IO_HDF5
        &                            hdf5VarDouble2D
   use :: ISO_Varying_String, only : assignment(=)      , trim                  , varying_string
   use :: Kind_Numbers      , only : kind_int8
+  use :: System_Command    , only : System_Command_Do
   use :: Unit_Tests        , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
   implicit none
   type            (hdf5Object     ), target                                 :: datasetObject                  , fileObject           , &
@@ -865,6 +866,16 @@ program Tests_IO_HDF5
 
   ! Test identifying HDF5 file.
   call Assert("test if file is HDF5",IO_HDF5_Is_HDF5('testSuite/outputs/test.IO.HDF5.hdf5'),.true.)
+
+  ! Test of h5py compatibility.
+  call Unit_Tests_Begin_Group("h5py compatibility")
+  call System_Command_Do("./testSuite/scripts/generate_h5py.py")
+  call fileObject%openFile     ("testSuite/outputs/h5py.hdf5",overWrite=.false.             ,objectsOverwritable=.false.)
+  call fileObject%readAttribute("stringAttribute"            ,          characterValueReread                            )
+  call fileObject%close        (                                                                                        )
+  call fileObject%destroy      (                                                                                        )
+  call Assert("read h5py string attribute",characterValueReread,"this is a variable length string")
+  call Unit_Tests_End_Group()
 
   ! End unit tests.
   call Unit_Tests_End_Group()

--- a/testSuite/scripts/generate_h5py.py
+++ b/testSuite/scripts/generate_h5py.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import h5py
+
+# Generate an HDF5 file using h5py which contains a single string attribute. This is used to test reading of variable length
+# strings as written by h5py.
+f                          = h5py.File("testSuite/outputs/h5py.hdf5","w")
+f.attrs["stringAttribute"] = "this is a variable length string"
+


### PR DESCRIPTION
`h5py` writes strings in this way so it is useful to have this functionality.