### PR TITLE
Support installation of the IRATE toolkit for validation of test model outputs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -860,6 +860,7 @@ jobs:
       artifact: galacticus-exec
       runPath: ./testSuite
       options: "--launchMethod local --threadMaximum 1 --ompThreads 4"
+      needsIRATE: 1
     secrets: inherit
   ## Model Integration
   Model-Integration:
@@ -887,7 +888,6 @@ jobs:
                 test-bar-instability.pl,
                 test-transfer-functions-axion.pl,
                 test-mass-definitions.pl,
-                test-Bolshoi-tree-builder.pl,
                 test-branchlessTrees.pl,
                 test-branchSubsampling.pl,
                 test-CGM-mass-cooled.pl,
@@ -904,7 +904,6 @@ jobs:
                 test-noninstantaneous-recycling.pl,
                 test-satellite-distance-minimum.pl,
                 test-treeFilterLabels.pl,
-                test-Millennium-tree-builder.pl,
                 test-output.pl,
                 test-output-tree-contiguousity.pl,
                 test-parameter-validation.pl,
@@ -927,6 +926,21 @@ jobs:
       file: ${{ matrix.file }}
       artifact: galacticus-exec
       runPath: ./testSuite
+    secrets: inherit
+  Miscellaneous-IRATE:
+    needs: Build-Executable-Linux
+    strategy:
+      # Ensure all jobs are run, even if some fail.
+      fail-fast: false
+      matrix:
+        file: [ test-Bolshoi-tree-builder.pl,
+                test-Millennium-tree-builder.pl ]
+    uses: ./.github/workflows/testModel.yml
+    with:
+      file: ${{ matrix.file }}
+      artifact: galacticus-exec
+      runPath: ./testSuite
+      needsIRATE: 1
     secrets: inherit
   Miscellaneous-Deep:
     needs: Build-Executable-Linux
@@ -1531,6 +1545,7 @@ jobs:
              Model-Integration,
              Miscellaneous,
              Miscellaneous-Cached,
+             Miscellaneous-IRATE,
              Miscellaneous-Deep,
              Miscellaneous-Models,
              Outputs,

--- a/.github/workflows/testModel.yml
+++ b/.github/workflows/testModel.yml
@@ -102,7 +102,11 @@ jobs:
         if: ${{ format('{0}',inputs.needsIRATE) == '1' }}
         run: |
           apt -y update && apt -y upgrade
-          apt -y install python-numpy python-h5py cython
+          apt -y install python2-minimal hdf5 curl 
+          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+          python2 get-pip.py
+          pip2 install numpy h5py
+          pip2 install Cython --install-option="--no-cython-compile"
       - name: Check out repository IRATE
         if: ${{ format('{0}',inputs.needsIRATE) == '1' }}
         uses: actions/checkout@v4      
@@ -113,7 +117,7 @@ jobs:
         if: ${{ format('{0}',inputs.needsIRATE) == '1' }}
         run: |
           cd irate-format
-          python setup.py install
+          python2 setup.py install
           cd -
       - name: Mark time for cache accesses
         if: ${{ format('{0}',inputs.cacheData) == '1' }}

--- a/.github/workflows/testModel.yml
+++ b/.github/workflows/testModel.yml
@@ -98,26 +98,24 @@ jobs:
         run: |
           apt -y update && apt -y upgrade
           apt -y install ${{ inputs.install }}
-      - name: Install IRATE prerequisites
+      - name: Install IRATE
         if: ${{ format('{0}',inputs.needsIRATE) == '1' }}
         run: |
           apt -y update && apt -y upgrade
-          apt -y install python2-minimal hdf5 curl 
+          apt -y install python2-minimal python2-dev python-setuptools libhdf5-dev curl libntirpc-dev
           curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
           python2 get-pip.py
           pip2 install numpy h5py
           pip2 install Cython --install-option="--no-cython-compile"
-      - name: Check out repository IRATE
-        if: ${{ format('{0}',inputs.needsIRATE) == '1' }}
-        uses: actions/checkout@v4      
-        with:
-          repository: galacticusorg/irate-format
-          path: irate-format
-      - name: Install IRATE
-        if: ${{ format('{0}',inputs.needsIRATE) == '1' }}
-        run: |
+          eval `ssh-agent -s`
+          ssh-add - <<< '${{ secrets.IRATE_DEPLOY_PRIVATE_KEY }}'
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git clone git@github.com:galacticusorg/irate-format.git
           cd irate-format
-          python2 setup.py install
+          # For some reason install fails on the first attempt - so try twice.
+          CFLAGS=-I/usr/include/ntirpc/ python2 setup.py install || true
+          CFLAGS=-I/usr/include/ntirpc/ python2 setup.py install
           cd -
       - name: Mark time for cache accesses
         if: ${{ format('{0}',inputs.cacheData) == '1' }}

--- a/.github/workflows/testModel.yml
+++ b/.github/workflows/testModel.yml
@@ -45,6 +45,10 @@ on:
       install: # Specify packages to install
         required: false
         type: string
+      needsIRATE: # Set to 0/1 to indicate if the IRATE package should be installed
+        required: false
+        default: 0
+        type: string
 defaults:
   run:
     shell: bash
@@ -94,6 +98,23 @@ jobs:
         run: |
           apt -y update && apt -y upgrade
           apt -y install ${{ inputs.install }}
+      - name: Install IRATE prerequisites
+        if: ${{ format('{0}',inputs.needsIRATE) == '1' }}
+        run: |
+          apt -y update && apt -y upgrade
+          apt -y install python-numpy python-h5py cython
+      - name: Check out repository IRATE
+        if: ${{ format('{0}',inputs.needsIRATE) == '1' }}
+        uses: actions/checkout@v4      
+        with:
+          repository: galacticusorg/irate-format
+          path: irate-format
+      - name: Install IRATE
+        if: ${{ format('{0}',inputs.needsIRATE) == '1' }}
+        run: |
+          cd irate-format
+          python setup.py install
+          cd -
       - name: Mark time for cache accesses
         if: ${{ format('{0}',inputs.cacheData) == '1' }}
         run: |

--- a/.github/workflows/testModel.yml
+++ b/.github/workflows/testModel.yml
@@ -109,9 +109,7 @@ jobs:
           pip2 install Cython --install-option="--no-cython-compile"
           eval `ssh-agent -s`
           ssh-add - <<< '${{ secrets.IRATE_DEPLOY_PRIVATE_KEY }}'
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git clone git@github.com:galacticusorg/irate-format.git
+          GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new" git clone git@github.com:galacticusorg/irate-format.git
           cd irate-format
           # For some reason install fails on the first attempt - so try twice.
           CFLAGS=-I/usr/include/ntirpc/ python2 setup.py install || true


### PR DESCRIPTION
This allows import and installation of the IRATE toolkit from a private repo (as the package is no longer officially maintained).