### PR TITLE
Refactor the supernovae type Ia delay time distribution class

### DIFF
--- a/doc/Galacticus.bib
+++ b/doc/Galacticus.bib
@@ -2645,6 +2645,27 @@ reviewed. The determination from the measurements from the literature is
 	year = {2010}
 },
 
+@article{freundlich_delay_2021,
+	title = {The delay time distribution of {Type}-{Ia} supernovae in galaxy clusters: the impact of extended star-formation histories},
+	volume = {502},
+	issn = {0035-8711, 1365-2966},
+	shorttitle = {The delay time distribution of {Type}-{Ia} supernovae in galaxy clusters},
+	url = {http://arxiv.org/abs/2012.00793},
+	doi = {10.1093/mnras/stab493},
+	abstract = {The delay time distribution (DTD) of Type-Ia supernovae (SNe Ia) is important for understanding chemical evolution, SN Ia progenitors, and SN Ia physics. Past estimates of the DTD in galaxy clusters have been deduced from SN Ia rates measured in cluster samples observed at various redshifts, corresponding to different time intervals after a presumed initial brief burst of star formation. A recent analysis of a cluster sample at \$z=1.13-1.75\$ confirmed indications from previous studies of lower-redshift clusters, that the DTD has a power-law form, \$\{{\textbackslash}rm DTD\}(t)=R\_1 (t/\{{\textbackslash}rm Gyr\}){\textasciicircum}{\textbackslash}alpha\$, with amplitude \$R\_1\$, at delay \$t=1{\textasciitilde}{\textbackslash}rm Gyr\$, several times higher than measured in field-galaxy environments. This implied that SNe Ia are somehow produced in larger numbers by the stellar populations in clusters. This conclusion, however, could have been affected by the implicit assumption that the stars were formed in a single brief starburst at high \$z\$. Here, we re-derive the DTD from the cluster SN Ia data, but relax the single-burst assumption. Instead, we allow for a range of star-formation histories and dust extinctions for each cluster. Via MCMC modeling, we simultaneously fit, using stellar population synthesis models and DTD models, the integrated galaxy-light photometry in several bands, and the SN Ia numbers discovered in each cluster. With these more-realistic assumptions, we find a best-fit DTD with power-law index \${\textbackslash}alpha=-1.09\_\{-0.12\}{\textasciicircum}\{+0.15\}\$, and amplitude \$R\_1=0.41\_\{-0.10\}{\textasciicircum}\{+0.12\}{\textbackslash}times 10{\textasciicircum}\{-12\}{\textasciitilde}\{{\textbackslash}rm yr\}{\textasciicircum}\{-1\}\{{\textbackslash}rm M\}\_{\textbackslash}odot{\textasciicircum}\{-1\}\$. We confirm a cluster-environment DTD with a larger amplitude than the field-galaxy DTD, by a factor \${\textbackslash}sim2-3\$ (at \$3.8{\textbackslash}sigma\$). Cluster and field DTDs have consistent slopes of \${\textbackslash}alpha{\textbackslash}approx-1.1\$.},
+	number = {4},
+	urldate = {2024-02-27},
+	journal = {Monthly Notices of the Royal Astronomical Society},
+	author = {Freundlich, Jonathan and Maoz, Dan},
+	month = mar,
+	year = {2021},
+	note = {arXiv:2012.00793 [astro-ph]},
+	keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Solar and Stellar Astrophysics},
+	pages = {5882--5895},
+	annote = {Comment: 14 pages, 4 figures, accepted by MNRAS},
+	file = {arXiv Fulltext PDF:/home/abensonca/.mozilla/firefox/f54gqgdx.default/zotero/storage/9T9G255D/Freundlich and Maoz - 2021 - The delay time distribution of Type-Ia supernovae .pdf:application/pdf;arXiv.org Snapshot:/home/abensonca/.mozilla/firefox/f54gqgdx.default/zotero/storage/86STTWMN/2012.html:text/html},
+}
+
 @article{gallazzi_ages_2005,
 	title = {The ages and metallicities of galaxies in the local universe},
 	volume = {362},

--- a/source/benchmarks.stellar_luminosities.F90
+++ b/source/benchmarks.stellar_luminosities.F90
@@ -107,8 +107,7 @@ program Benchmark_Stellar_Populations_Luminosities
        &                                                                                 stellarTracks_                      =stellarTracks_                                                                                                &
        &                                                                                )
   supernovaeTypeIa_                     =supernovaeTypeIaNagashima2005                  (                                                                                                                                                   &
-       &                                                                                 stellarAstrophysics_                =stellarAstrophysics_                                                                                        , &
-       &                                                                                 initialMassFunction_                =initialMassFunction_                                                                                          &
+       &                                                                                 stellarAstrophysics_                =stellarAstrophysics_                                                                                          &
        &                                                                                )
   supernovaePopulationIII_              =supernovaePopulationIIIHegerWoosley2002        (                                                                                                                                                   &
        &                                                                                 stellarAstrophysics_                =stellarAstrophysics_                                                                                          &

--- a/source/stellar_astrophysics.feedback.F90
+++ b/source/stellar_astrophysics.feedback.F90
@@ -25,6 +25,7 @@ module Stellar_Feedback
   !!{
   Implements a class that performs calculations of stellar feedback.
   !!}
+  use :: Stellar_Populations_Initial_Mass_Functions, only : initialMassFunctionClass
   implicit none
   private
 
@@ -41,7 +42,8 @@ module Stellar_Feedback
     <type>double precision</type>
     <pass>yes</pass>
     <selfTarget>yes</selfTarget>
-    <argument>double precision, intent(in   ) :: initialMass, age, metallicity</argument>
+    <argument>class           (initialMassFunctionClass), intent(inout) :: initialMassFunction_                  </argument>
+    <argument>double precision                          , intent(in   ) :: initialMass         , age, metallicity</argument>
    </method>
   </functionClass>
   !!]

--- a/source/stellar_astrophysics.feedback.instant_canonical.F90
+++ b/source/stellar_astrophysics.feedback.instant_canonical.F90
@@ -64,15 +64,17 @@ contains
     return
   end function instantCanonicalConstructorParameters
 
-  double precision function instantCanonicalEnergyInputCumulative(self,initialMass,age,metallicity)
+  double precision function instantCanonicalEnergyInputCumulative(self,initialMassFunction_,initialMass,age,metallicity)
     !!{
     Compute the cumulative energy input from a star of given {\normalfont \ttfamily initialMass}, {\normalfont \ttfamily age} and {\normalfont \ttfamily metallicity}.
     !!}
     implicit none
     class           (stellarFeedbackInstantCanonical), intent(inout), target :: self
-    double precision                                 , intent(in   )         :: age        , initialMass, &
+    class           (initialMassFunctionClass       ), intent(inout)         :: initialMassFunction_
+    double precision                                 , intent(in   )         :: age                 , initialMass, &
          &                                                                      metallicity
-
+    !$GLC attributes unused :: self, initialMassFunction_, initialMass, age, metallicity
+    
     instantCanonicalEnergyInputCumulative=feedbackEnergyInputAtInfinityCanonical
     return
   end function instantCanonicalEnergyInputCumulative

--- a/source/stellar_astrophysics.feedback.standard.F90
+++ b/source/stellar_astrophysics.feedback.standard.F90
@@ -151,18 +151,19 @@ contains
     return
   end subroutine standardDestructor
 
-  double precision function standardEnergyInputCumulative(self,initialMass,age,metallicity)
+  double precision function standardEnergyInputCumulative(self,initialMassFunction_,initialMass,age,metallicity)
     !!{
     Compute the cumulative energy input from a star of given {\normalfont \ttfamily initialMass}, {\normalfont \ttfamily age} and {\normalfont \ttfamily metallicity}.
     !!}
     use :: Numerical_Constants_Astronomical, only : metallicitySolar
     use :: Numerical_Integration           , only : integrator
     implicit none
-    class           (stellarFeedbackStandard), intent(inout), target :: self
-    double precision                         , intent(in   )         :: age                                                    , initialMass, metallicity
-    double precision                         , parameter             :: populationIIIMaximumMetallicity=1.0d-4*metallicitySolar
-    double precision                                                 :: energySNe                                              , energyWinds, lifetime
-    type            (integrator             )                        :: integrator_
+    class           (stellarFeedbackStandard ), intent(inout), target :: self
+    double precision                          , intent(in   )         :: age                                                    , initialMass, metallicity
+    class           (initialMassFunctionClass), intent(inout)         :: initialMassFunction_
+    double precision                          , parameter             :: populationIIIMaximumMetallicity=1.0d-4*metallicitySolar
+    double precision                                                  :: energySNe                                              , energyWinds, lifetime
+    type            (integrator              )                        :: integrator_
     
     ! Begin with zero energy input.
     standardEnergyInputCumulative=0.0d0
@@ -182,8 +183,8 @@ contains
        end if
     end if
     ! Add in contribution from Type Ia supernovae.
-    standardEnergyInputCumulative=+standardEnergyInputCumulative                                       &
-         &                        +self%supernovaeTypeIa_%number         (initialMass,age,metallicity) &
+    standardEnergyInputCumulative=+standardEnergyInputCumulative                                                            &
+         &                        +self%supernovaeTypeIa_%number         (initialMassFunction_,initialMass,age,metallicity) &
          &                        *self                  %supernovaEnergy
     ! Add in the contribution from stellar winds.
     self_                         =>  self

--- a/source/stellar_astrophysics.supernovae_type_Ia.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.F90
@@ -41,8 +41,9 @@ module Supernovae_Type_Ia
     <description>Return the range of initial stellar masses that contribute to the Type Ia population.</description>
     <type>void</type>
     <pass>yes</pass>
-    <argument>double precision, intent(in   ) :: age               , metallicity       </argument>
-    <argument>double precision, intent(  out) :: massInitialMinimum, massInitialMaximum</argument>
+    <argument>class           (initialMassFunctionClass), intent(inout) :: initialMassFunction_                    </argument>
+    <argument>double precision                          , intent(in   ) :: age                 , metallicity       </argument>
+    <argument>double precision                          , intent(  out) :: massInitialMinimum  , massInitialMaximum</argument>
    </method>
    <method name="number" >
     <description>Return the cumulative number of Type Ia supernovae from a stellar population of the given {\normalfont \ttfamily initialMass}, {\normalfont \ttfamily age}, and {\normalfont \ttfamily metallicity}.</description>

--- a/source/stellar_astrophysics.supernovae_type_Ia.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.F90
@@ -25,6 +25,7 @@ module Supernovae_Type_Ia
   !!{
   Implements a class for calculations of Type Ia supernovae.
   !!}
+  use :: Stellar_Populations_Initial_Mass_Functions, only : initialMassFunctionClass
   implicit none
   private
 
@@ -48,14 +49,16 @@ module Supernovae_Type_Ia
     <type>double precision</type>
     <pass>yes</pass>
     <selfTarget>yes</selfTarget>
-    <argument>double precision, intent(in   ) :: initialMass, age, metallicity</argument>
+    <argument>class           (initialMassFunctionClass), intent(inout), target :: initialMassFunction_                  </argument>
+    <argument>double precision                          , intent(in   )         :: initialMass         , age, metallicity</argument>
    </method>
    <method name="yield" >
     <description>Return the cumulative yield from Type Ia supernoave from a stellar population of the given {\normalfont \ttfamily initialMass}, {\normalfont \ttfamily age}, and {\normalfont \ttfamily metallicity}.</description>
     <type>double precision</type>
     <pass>yes</pass>
-    <argument>double precision, intent(in   )           :: initialMass, age, metallicity</argument>
-    <argument>integer         , intent(in   ), optional :: atomIndex</argument>
+    <argument>class           (initialMassFunctionClass), intent(inout)           :: initialMassFunction_                  </argument>
+    <argument>double precision                          , intent(in   )           :: initialMass         , age, metallicity</argument>
+    <argument>integer                                   , intent(in   ), optional :: atomIndex                             </argument>
    </method>
   </functionClass>
   !!]

--- a/source/stellar_astrophysics.supernovae_type_Ia.Nagashima2005.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.Nagashima2005.F90
@@ -32,27 +32,17 @@
    </description>
   </supernovaeTypeIa>
   !!]
-  type, extends(supernovaeTypeIaClass) :: supernovaeTypeIaNagashima2005
+  type, extends(supernovaeTypeIaFixedYield) :: supernovaeTypeIaNagashima2005
      !!{
      A supernovae type Ia class based on \cite{nagashima_metal_2005}.
      !!}
      private
-     class           (stellarAstrophysicsClass), pointer                   :: stellarAstrophysics_ => null()
-     type            (integrator              ), allocatable               :: integrator_
-     double precision                                                      :: totalYield
-     double precision                          , allocatable, dimension(:) :: elementYield
-     logical                                                               :: initialized
-   contains
-     !![
-     <methods>
-       <method method="initialize" description="Initialize yield data."/>
-     </methods>
-     !!]
+     class(stellarAstrophysicsClass), pointer     :: stellarAstrophysics_ => null()
+     type (integrator              ), allocatable :: integrator_
+   contains    
      final     ::                     nagashima2005Destructor
      procedure :: massInitialRange => nagashima2005MassInitialRange
      procedure :: number           => nagashima2005Number
-     procedure :: yield            => nagashima2005Yield
-     procedure :: initialize       => nagashima2005Initialize
   end type supernovaeTypeIaNagashima2005
 
   interface supernovaeTypeIaNagashima2005
@@ -125,64 +115,16 @@ contains
     return
   end subroutine nagashima2005Destructor
 
-  subroutine nagashima2005Initialize(self)
-    !!{
-    Read data for the {\normalfont \ttfamily nagashima2005} supernovae type Ia class.
-    !!}
-    use :: Atomic_Data      , only : Atom_Lookup                   , Atomic_Data_Atoms_Count
-    use :: FoX_dom          , only : destroy                       , node                             , extractDataContent
-    use :: Error            , only : Error_Report
-    use :: Input_Paths      , only : inputPath                     , pathTypeDataStatic
-    use :: IO_XML           , only : XML_Count_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList, &
-         &                           XML_Parse
-    implicit none
-    class           (supernovaeTypeIaNagashima2005), intent(inout)               :: self
-    type            (node                         ), pointer                     :: doc         , atom        , &
-         &                                                                          isotope     , yield
-    type            (xmlNodeList                  ), allocatable  , dimension(:) :: isotopesList
-    integer                                                                      :: atomicIndex , atomicNumber, &
-         &                                                                          iIsotope    , ioErr
-    double precision                                                             :: isotopeYield
-    
-    if (self%initialized) return
-    ! Allocate an array to store individual element yields.
-    allocate(self%elementYield(Atomic_Data_Atoms_Count()))
-    self%elementYield=0.0d0
-    self%totalYield  =0.0d0
-    ! Read in Type Ia yields.
-    !$omp critical (FoX_DOM_Access)
-    ! Open the XML file containing yields.
-    doc => XML_Parse(char(inputPath(pathTypeDataStatic))//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml',iostat=ioErr)
-    if (ioErr /= 0) call Error_Report('Unable to parse yields file'//{introspection:location})
-    ! Get a list of all isotopes.
-    call XML_Get_Elements_By_Tag_Name(doc,"isotope",isotopesList)
-    ! Loop through isotopes and compute the net metal yield.
-    do iIsotope=0,size(isotopesList)-1
-       isotope  => isotopesList(iIsotope)%element
-       if (XML_Count_Elements_By_Tag_Name(isotope,"yield") /= 1) call Error_Report('isotope must have precisely one yield'//{introspection:location})
-       yield => XML_Get_First_Element_By_Tag_Name(isotope,"yield")
-       call extractDataContent(yield,isotopeYield)
-       self%totalYield=self%totalYield+isotopeYield
-       if (XML_Count_Elements_By_Tag_Name(isotope,"atomicNumber") /= 1) call Error_Report('isotope must have precisely one atomic number'//{introspection:location})
-       atom => XML_Get_First_Element_By_Tag_Name(isotope,"atomicNumber")
-       call extractDataContent(atom,atomicNumber)
-       atomicIndex=Atom_Lookup(atomicNumber=atomicNumber)
-       self%elementYield(atomicIndex)=self%elementYield(atomicIndex)+isotopeYield
-    end do
-    call destroy(doc)
-    !$omp end critical (FoX_DOM_Access)
-    self%initialized=.true.
-    return
-  end subroutine nagashima2005Initialize
-
-  subroutine nagashima2005MassInitialRange(self,age,metallicity,massInitialMinimum,massInitialMaximum)
+  subroutine nagashima2005MassInitialRange(self,initialMassFunction_,age,metallicity,massInitialMinimum,massInitialMaximum)
     !!{
     Return the range of initial stellar masses contributing to the Type Ia population.
     !!}
     implicit none
      class           (supernovaeTypeIaNagashima2005), intent(inout) :: self
-     double precision                               , intent(in   ) :: age               , metallicity
-     double precision                               , intent(  out) :: massInitialMinimum, massInitialMaximum
+     class           (initialMassFunctionClass     ), intent(inout) :: initialMassFunction_
+     double precision                               , intent(in   ) :: age                 , metallicity
+     double precision                               , intent(  out) :: massInitialMinimum  , massInitialMaximum
+     !$GLC attributes unused :: initialMassFunction_
 
      ! The minimum initial mass is set by the requirement that the secondary has evolved off of the main sequence at this age. The
      ! maximum mass is the largest single-star mass for which the endpoint is a C-O white dwarf (Nagashima et al. 2005).
@@ -278,31 +220,3 @@ contains
     end function massFractionDistribution
 
   end function nagashima2005NumberIntegrand
-
-  double precision function nagashima2005Yield(self,initialMassFunction_,initialMass,age,metallicity,atomIndex)
-    !!{
-    Compute the cumulative yield from Type Ia supernovae originating per unit interval of secondary star mass with given
-    {\normalfont \ttfamily initialMass} and {\normalfont \ttfamily metallicity} after a time {\normalfont \ttfamily age}. The
-    calculation is based on that of \cite{nagashima_metal_2005} with Type Ia yields from \cite{nomoto_nucleosynthesis_1997}. The
-    number returned here assumes a distribution of binary mass ratios and so only makes sense once it is integrated over an
-    initial mass function.
-    !!}
-    implicit none
-    class           (supernovaeTypeIaNagashima2005), intent(inout)           :: self
-    class           (initialMassFunctionClass     ), intent(inout)           :: initialMassFunction_
-    double precision                               , intent(in   )           :: age                 , initialMass, &
-         &                                                                      metallicity
-    integer                                        , intent(in   ), optional :: atomIndex
-    double precision                                                         :: yield
-
-    call self%initialize()
-    if (present(atomIndex)) then
-       ! Return yield for requested atomic index.
-       yield=self%elementYield(atomIndex)
-    else
-       ! No atomic index given, therefore return total metal yield.
-       yield=self%totalYield
-    end if
-    nagashima2005Yield=self%number(initialMassFunction_,initialMass,age,metallicity)*yield
-    return
-  end function nagashima2005Yield

--- a/source/stellar_astrophysics.supernovae_type_Ia.differential_delay_time_distribution.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.differential_delay_time_distribution.F90
@@ -1,0 +1,127 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a supernovae type Ia class which operates through the differential delay time distribution.
+  !!}
+
+  !![
+  <supernovaeTypeIa name="supernovaeTypeIaDifferentialDTD" abstract="yes">
+   <description>
+    A supernovae type Ia class which operates through the differential delay time distribution.
+   </description>
+  </supernovaeTypeIa>
+  !!]
+  type, abstract, extends(supernovaeTypeIaMassIndependentDTD) :: supernovaeTypeIaDifferentialDTD
+     !!{
+     A supernovae type Ia class which operates through the differential delay time distribution.
+     !!}
+     private
+   contains
+     !![
+     <methods>
+       <method method="numberDifferential" description="Return the number of type Ia supernovae per Solar mass of stars formed per unit time at a given population age and metallicity."/>
+       <method method="timeDelayMinimum"   description="Return the minimum time in the type Ia supernovae delay time distribution."                                                     />
+       <method method="timeDelayMaximum"   description="Return the maximum time in the type Ia supernovae delay time distribution."                                                     />
+     </methods>
+     !!]
+     procedure                                       :: numberCumulative   => differentialDTDNumberCumulative
+     procedure(numberDifferentialTemplate), deferred :: numberDifferential
+     procedure                                       :: timeDelayMinimum   => differentialDTTimeDelayMinimum
+     procedure                                       :: timeDelayMaximum   => differentialDTTimeDelayMaximum
+  end type supernovaeTypeIaDifferentialDTD
+
+  abstract interface
+     double precision function numberDifferentialTemplate(self,age,metallicity)
+       !!{
+       Interface for differential number of Type Ia SNe.
+       !!}
+       import supernovaeTypeIaDifferentialDTD
+       class           (supernovaeTypeIaDifferentialDTD), intent(inout) :: self
+       double precision                                 , intent(in   ) :: age , metallicity
+     end function numberDifferentialTemplate
+  end interface
+
+contains
+  
+  double precision function differentialDTTimeDelayMinimum(self) result(time)
+    !!{
+    Compute the minimum time in the type Ia supernovae delay time distribution.
+    !!}
+    implicit none
+    class(supernovaeTypeIaDifferentialDTD), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    time=0.0d0
+    return
+  end function differentialDTTimeDelayMinimum
+  
+  double precision function differentialDTTimeDelayMaximum(self) result(time)
+    !!{
+    Compute the maximum time in the type Ia supernovae delay time distribution.
+    !!}
+    implicit none
+    class(supernovaeTypeIaDifferentialDTD), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    time=huge(0.0d0)
+    return
+  end function differentialDTTimeDelayMaximum
+  
+  double precision function differentialDTDNumberCumulative(self,age,metallicity) result(number)
+    !!{
+    Compute the cumulative number of Type Ia supernovae originating per unit interval of secondary star mass with given
+    {\normalfont \ttfamily initialMass} and {\normalfont \ttfamily metallicity} after a time {\normalfont \ttfamily age}. Here we
+    assume that the total number of Type Ias is specified independent of secondary star mass.
+    !!}
+    use :: Numerical_Integration, only : integrator
+    implicit none
+    class           (supernovaeTypeIaDifferentialDTD), intent(inout)         :: self
+    double precision                                 , intent(in   )         :: age        , metallicity
+    type            (integrator                     ), allocatable  , save   :: integrator_
+    !$omp threadprivate(integrator_)
+
+    if (age < self%timeDelayMinimum()) then
+       ! The minimum time in the delay time distribution has not yet been reached.
+       number=0.0d0
+    else
+       ! Integrate to find the cumulative number of type Ia supernovae at this time.
+       if (.not.allocated(integrator_)) then
+          allocate(integrator_)
+          integrator_=integrator(timeDelayDistributionDifferential,toleranceRelative=1.0d-3)
+       end if
+       number=integrator_%integrate(self%timeDelayMinimum(),min(age,self%timeDelayMaximum()))       
+    end if
+    return
+    
+  contains
+    
+    double precision function timeDelayDistributionDifferential(time)
+      !!{
+      Integrand used to compute the cumulative number of type Ia supernovae occuring by a given time.
+      !!}
+      implicit none
+      double precision, intent(in   ) :: time
+      
+      timeDelayDistributionDifferential=self%numberDifferential(time,metallicity)
+      return
+    end function timeDelayDistributionDifferential
+    
+  end function differentialDTDNumberCumulative
+  

--- a/source/stellar_astrophysics.supernovae_type_Ia.fixed_yield.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.fixed_yield.F90
@@ -1,0 +1,126 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a supernovae type Ia class in which the yield is independent of progenitor.
+  !!}
+  
+  !![
+  <supernovaeTypeIa name="supernovaeTypeIaFixedYield" abstract="yes">
+   <description>
+    A supernovae type Ia class in which the yield is independent of progenitor.
+   </description>
+  </supernovaeTypeIa>
+  !!]
+  type, abstract, extends(supernovaeTypeIaClass) :: supernovaeTypeIaFixedYield
+     !!{
+     A supernovae type Ia class in which the yield is independent of progenitor.
+     !!}
+     private
+     double precision                            :: totalYield
+     double precision, allocatable, dimension(:) :: elementYield
+     logical                                     :: initialized
+   contains
+     !![
+     <methods>
+       <method method="initialize" description="Initialize yield data."/>
+     </methods>
+     !!]
+     procedure :: yield            => fixedYieldYield
+     procedure :: initialize       => fixedYieldInitialize
+  end type supernovaeTypeIaFixedYield
+
+contains
+
+  subroutine fixedYieldInitialize(self)
+    !!{
+    Read data for the {\normalfont \ttfamily fixedYield} supernovae type Ia class.
+    !!}
+    use :: Atomic_Data, only : Atom_Lookup                   , Atomic_Data_Atoms_Count
+    use :: FoX_dom    , only : destroy                       , node                             , extractDataContent
+    use :: Error      , only : Error_Report
+    use :: Input_Paths, only : inputPath                     , pathTypeDataStatic
+    use :: IO_XML     , only : XML_Count_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList, &
+         &                     XML_Parse
+    implicit none
+    class           (supernovaeTypeIaFixedYield), intent(inout)               :: self
+    type            (node                      ), pointer                     :: doc         , atom        , &
+         &                                                                       isotope     , yield
+    type            (xmlNodeList               ), allocatable  , dimension(:) :: isotopesList
+    integer                                                                   :: atomicIndex , atomicNumber, &
+         &                                                                       iIsotope    , ioErr
+    double precision                                                          :: isotopeYield
+    
+    if (self%initialized) return
+    ! Allocate an array to store individual element yields.
+    allocate(self%elementYield(Atomic_Data_Atoms_Count()))
+    self%elementYield=0.0d0
+    self%totalYield  =0.0d0
+    ! Read in Type Ia yields.
+    !$omp critical (FoX_DOM_Access)
+    ! Open the XML file containing yields.
+    doc => XML_Parse(char(inputPath(pathTypeDataStatic))//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml',iostat=ioErr)
+    if (ioErr /= 0) call Error_Report('Unable to parse yields file'//{introspection:location})
+    ! Get a list of all isotopes.
+    call XML_Get_Elements_By_Tag_Name(doc,"isotope",isotopesList)
+    ! Loop through isotopes and compute the net metal yield.
+    do iIsotope=0,size(isotopesList)-1
+       isotope  => isotopesList(iIsotope)%element
+       if (XML_Count_Elements_By_Tag_Name(isotope,"yield") /= 1) call Error_Report('isotope must have precisely one yield'//{introspection:location})
+       yield => XML_Get_First_Element_By_Tag_Name(isotope,"yield")
+       call extractDataContent(yield,isotopeYield)
+       self%totalYield=self%totalYield+isotopeYield
+       if (XML_Count_Elements_By_Tag_Name(isotope,"atomicNumber") /= 1) call Error_Report('isotope must have precisely one atomic number'//{introspection:location})
+       atom => XML_Get_First_Element_By_Tag_Name(isotope,"atomicNumber")
+       call extractDataContent(atom,atomicNumber)
+       atomicIndex=Atom_Lookup(atomicNumber=atomicNumber)
+       self%elementYield(atomicIndex)=self%elementYield(atomicIndex)+isotopeYield
+    end do
+    call destroy(doc)
+    !$omp end critical (FoX_DOM_Access)
+    self%initialized=.true.
+    return
+  end subroutine fixedYieldInitialize
+
+  double precision function fixedYieldYield(self,initialMassFunction_,initialMass,age,metallicity,atomIndex) result(yield)
+    !!{
+    Compute the cumulative yield from Type Ia supernovae originating per unit interval of secondary star mass with given
+    {\normalfont \ttfamily initialMass} and {\normalfont \ttfamily metallicity} after a time {\normalfont \ttfamily age}. The
+    calculation is based on that of \cite{nagashima_metal_2005} with Type Ia yields from \cite{nomoto_nucleosynthesis_1997}. The
+    number returned here assumes a distribution of binary mass ratios and so only makes sense once it is integrated over an
+    initial mass function.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaFixedYield), intent(inout)           :: self
+    class           (initialMassFunctionClass  ), intent(inout)           :: initialMassFunction_
+    double precision                            , intent(in   )           :: age                 , initialMass, &
+         &                                                                   metallicity
+    integer                                     , intent(in   ), optional :: atomIndex
+
+    call self%initialize()
+    if (present(atomIndex)) then
+       ! Return yield for requested atomic index.
+       yield=self%elementYield(atomIndex)
+    else
+       ! No atomic index given, therefore return total metal yield.
+       yield=self%totalYield
+    end if
+    yield=self%number(initialMassFunction_,initialMass,age,metallicity)*yield
+    return
+  end function fixedYieldYield

--- a/source/stellar_astrophysics.supernovae_type_Ia.mass_independent_delay_time_distribution.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.mass_independent_delay_time_distribution.F90
@@ -1,0 +1,92 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a supernovae type Ia class for delay time distributions that are independent of progenitor mass.
+  !!}
+  
+  !![
+  <supernovaeTypeIa name="supernovaeTypeIaMassIndependentDTD" abstract="yes">
+   <description>
+    A supernovae type Ia class for delay time distributions that are independent of progenitor mass.
+   </description>
+  </supernovaeTypeIa>
+  !!]
+  type, abstract, extends(supernovaeTypeIaFixedYield) :: supernovaeTypeIaMassIndependentDTD
+     !!{
+     A supernovae type Ia class for delay time distributions that are independent of progenitor mass.
+     !!}
+     private
+   contains    
+     !![
+     <methods>
+       <method method="numberCumulative" description="Return the cumulative number of type Ia supernovae per Solar mass of stars formed at a given population age and metallicity."/>
+     </methods>
+     !!]
+     procedure                                     :: massInitialRange => massIndependentDTDMassInitialRange
+     procedure                                     :: number           => massIndependentDTDNumber
+     procedure(numberCumulativeTemplate), deferred :: numberCumulative
+  end type supernovaeTypeIaMassIndependentDTD
+
+  abstract interface
+     double precision function numberCumulativeTemplate(self,age,metallicity)
+       !!{
+       Interface for cumulative number of Type Ia SNe.
+       !!}
+       import supernovaeTypeIaMassIndependentDTD
+       class           (supernovaeTypeIaMassIndependentDTD), intent(inout) :: self
+       double precision                                    , intent(in   ) :: age , metallicity
+     end function numberCumulativeTemplate
+  end interface
+
+contains
+
+  subroutine massIndependentDTDMassInitialRange(self,initialMassFunction_,age,metallicity,massInitialMinimum,massInitialMaximum)
+    !!{
+    Return the range of initial stellar masses contributing to the Type Ia population.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaMassIndependentDTD), intent(inout) :: self
+    class           (initialMassFunctionClass          ), intent(inout) :: initialMassFunction_
+    double precision                                    , intent(in   ) :: age                 , metallicity
+    double precision                                    , intent(  out) :: massInitialMinimum  , massInitialMaximum
+    !$GLC attributes unused :: self, age, metallicity
+    
+    massInitialMinimum=initialMassFunction_%massMinimum()
+    massInitialMaximum=initialMassFunction_%massMaximum()
+    return
+  end subroutine massIndependentDTDMassInitialRange
+  
+  double precision function massIndependentDTDNumber(self,initialMassFunction_,initialMass,age,metallicity) result(number)
+    !!{
+    Compute the cumulative number of Type Ia supernovae originating per unit interval of secondary star mass with given
+    {\normalfont \ttfamily initialMass} and {\normalfont \ttfamily metallicity} after a time {\normalfont \ttfamily age}. Here we
+    assume that the total number of Type Ias is specified independent of secondary star mass.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaMassIndependentDTD), intent(inout), target :: self
+    class           (initialMassFunctionClass          ), intent(inout), target :: initialMassFunction_
+    double precision                                    , intent(in   )         :: age                 , initialMass, &
+         &                                                                         metallicity
+    !$GLC attributes unused :: initialMass
+
+    number=self%numberCumulative(age,metallicity)/initialMassFunction_%numberCumulative(initialMassFunction_%massMinimum(),initialMassFunction_%massMaximum())
+    return
+  end function massIndependentDTDNumber
+  

--- a/source/stellar_astrophysics.supernovae_type_Ia.power_law_delay_time_distribution.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.power_law_delay_time_distribution.F90
@@ -1,0 +1,130 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a supernovae type Ia class with a power-law delay time distribution.
+  !!}
+
+  !![
+  <supernovaeTypeIa name="supernovaeTypeIaPowerLawDTD">
+   <description>
+    A supernovae type Ia class with a power-law delay time distribution.
+   </description>
+  </supernovaeTypeIa>
+  !!]
+  type, extends(supernovaeTypeIaMassIndependentDTD) :: supernovaeTypeIaPowerLawDTD
+     !!{
+     A supernovae type Ia class with a power-law delay time distribution.
+     !!}
+     private
+     double precision :: timeMinimum  , exponent, &
+          &              normalization
+   contains    
+     procedure :: numberCumulative => powerLawDTDNumberCumulative
+  end type supernovaeTypeIaPowerLawDTD
+
+  interface supernovaeTypeIaPowerLawDTD
+     !!{
+     Constructors for the {\normalfont \ttfamily powerLawDTD} supernovae type Ia class.
+     !!}
+     module procedure powerLawDTDConstructorParameters
+     module procedure powerLawDTDConstructorInternal
+  end interface supernovaeTypeIaPowerLawDTD
+
+contains
+
+  function powerLawDTDConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily powerLawDTD} supernovae type Ia class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (supernovaeTypeIaPowerLawDTD)                :: self
+    type            (inputParameters            ), intent(inout) :: parameters
+    double precision                                             :: timeMinimum  , exponent, &
+          &                                                         normalization
+
+    !![
+    <inputParameter>
+      <name>timeMinimum</name>
+      <source>parameters</source>
+      <defaultValue>40.0d-3</defaultValue>
+      <defaultSource>\citep[][field galaxy DTD]{freundlich_delay_2021}</defaultSource>
+      <description>The minimum time before which the delay time distribution is zero.</description>
+    </inputParameter>
+    <inputParameter>
+      <name>exponent</name>
+      <source>parameters</source>
+      <defaultValue>-1.07d0</defaultValue>
+      <defaultSource>\citep[][field galaxy DTD]{freundlich_delay_2021}</defaultSource>
+      <description>The exponent $\alpha$ in the delay time distribution.</description>
+    </inputParameter>
+    <inputParameter>
+      <name>normalization</name>
+      <source>parameters</source>
+      <defaultValue>0.21d-3</defaultValue>
+      <defaultSource>\citep[][field galaxy DTD]{freundlich_delay_2021}</defaultSource>
+      <description>The normalization $R_1$ of the delay time distribution at 1~Gyr in units of Gyr$^{-1}\,\mathrm{M}_\odot^{-1}$.</description>
+    </inputParameter>
+    !!]
+    self=supernovaeTypeIaPowerLawDTD(timeMinimum,exponent,normalization)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function powerLawDTDConstructorParameters
+
+  function powerLawDTDConstructorInternal(timeMinimum,exponent,normalization) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily powerLawDTD} supernovae type Ia class.
+    !!}
+    implicit none
+    type            (supernovaeTypeIaPowerLawDTD)                :: self
+    double precision                             , intent(in   ) :: timeMinimum  , exponent, &
+          &                                                         normalization
+    !![
+    <constructorAssign variables="timeMinimum, exponent, normalization"/>
+    !!]
+    
+    self%initialized=.false.
+    return
+  end function powerLawDTDConstructorInternal
+  
+  double precision function powerLawDTDNumberCumulative(self,age,metallicity) result(number)
+    !!{
+    Compute the cumulative number of Type Ia SNe assuming a power-law delay time distribution.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaPowerLawDTD), intent(inout) :: self
+    double precision                             , intent(in   ) :: age , metallicity
+    !$GLC attributes unused :: metallicity
+    
+    if (age > self%timeMinimum) then
+       number =+  self%normalization                        &
+            &  /                      (1.0d0+self%exponent) &
+            &  *(                                           &
+            &    +     age          **(1.0d0+self%exponent) &
+            &    -self%timeMinimum  **(1.0d0+self%exponent) &
+            &   )
+    else
+       number=+0.0d0
+    end if
+    return
+  end function powerLawDTDNumberCumulative
+  

--- a/source/stellar_astrophysics.supernovae_type_Ia.power_law_delay_time_distribution_differential.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.power_law_delay_time_distribution_differential.F90
@@ -1,0 +1,137 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a supernovae type Ia class with a power-law delay time distribution.
+  !!}
+
+  !![
+  <supernovaeTypeIa name="supernovaeTypeIaPowerLawDTDDifferential">
+   <description>
+    A supernovae type Ia class with a power-law delay time distribution. This class implements the differential form of the delay time distribution and is intended primarily for testing.
+   </description>
+  </supernovaeTypeIa>
+  !!]
+  type, extends(supernovaeTypeIaDifferentialDTD) :: supernovaeTypeIaPowerLawDTDDifferential
+     !!{
+     A supernovae type Ia class with a power-law delay time distribution.
+     !!}
+     private
+     double precision :: timeMinimum  , exponent, &
+          &              normalization
+   contains    
+     procedure :: numberDifferential => powerLawDTDDifferentialNumberDifferential
+  end type supernovaeTypeIaPowerLawDTDDifferential
+
+  interface supernovaeTypeIaPowerLawDTDDifferential
+     !!{
+     Constructors for the {\normalfont \ttfamily powerLawDTDDifferential} supernovae type Ia class.
+     !!}
+     module procedure powerLawDTDDifferentialConstructorParameters
+     module procedure powerLawDTDDifferentialConstructorInternal
+  end interface supernovaeTypeIaPowerLawDTDDifferential
+
+contains
+
+  function powerLawDTDDifferentialConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily powerLawDTDDifferential} supernovae type Ia class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (supernovaeTypeIaPowerLawDTDDifferential)                :: self
+    type            (inputParameters                        ), intent(inout) :: parameters
+    double precision                                                         :: timeMinimum  , exponent, &
+          &                                                                     normalization
+
+    !![
+    <inputParameter>
+      <name>timeMinimum</name>
+      <source>parameters</source>
+      <defaultValue>40.0d-3</defaultValue>
+      <defaultSource>\citep[][field galaxy DTD]{freundlich_delay_2021}</defaultSource>
+      <description>The minimum time before which the delay time distribution is zero.</description>
+    </inputParameter>
+    <inputParameter>
+      <name>exponent</name>
+      <source>parameters</source>
+      <defaultValue>-1.07d0</defaultValue>
+      <defaultSource>\citep[][field galaxy DTD]{freundlich_delay_2021}</defaultSource>
+      <description>The exponent $\alpha$ in the delay time distribution.</description>
+    </inputParameter>
+    <inputParameter>
+      <name>normalization</name>
+      <source>parameters</source>
+      <defaultValue>0.21d-3</defaultValue>
+      <defaultSource>\citep[][field galaxy DTD]{freundlich_delay_2021}</defaultSource>
+      <description>The normalization $R_1$ of the delay time distribution at 1~Gyr in units of Gyr$^{-1}\,\mathrm{M}_\odot^{-1}$.</description>
+    </inputParameter>
+    !!]
+    self=supernovaeTypeIaPowerLawDTDDifferential(timeMinimum,exponent,normalization)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function powerLawDTDDifferentialConstructorParameters
+
+  function powerLawDTDDifferentialConstructorInternal(timeMinimum,exponent,normalization) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily powerLawDTDDifferential} supernovae type Ia class.
+    !!}
+    implicit none
+    type            (supernovaeTypeIaPowerLawDTDDifferential)                :: self
+    double precision                                         , intent(in   ) :: timeMinimum  , exponent, &
+          &                                                                     normalization
+    !![
+    <constructorAssign variables="timeMinimum, exponent, normalization"/>
+    !!]
+    
+    self%initialized=.false.
+    return
+  end function powerLawDTDDifferentialConstructorInternal
+  
+  double precision function powerLawDTDDifferentialTimeDelayMinimum(self) result(time)
+    !!{
+    Compute the minimum time in the type Ia supernovae delay time distribution.
+    !!}
+    implicit none
+    class(supernovaeTypeIaPowerLawDTDDifferential), intent(inout) :: self
+
+    time=self%timeMinimum
+    return
+  end function powerLawDTDDifferentialTimeDelayMinimum
+  
+  double precision function powerLawDTDDifferentialNumberDifferential(self,age,metallicity) result(number)
+    !!{
+    Compute the differential number of Type Ia SNe assuming a power-law delay time distribution.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaPowerLawDTDDifferential), intent(inout) :: self
+    double precision                                         , intent(in   ) :: age , metallicity
+    !$GLC attributes unused :: metallicity
+    
+    if (age > self%timeMinimum) then
+       number=+self%normalization                &
+            & *     age          **self%exponent
+    else
+       number=+0.0d0
+    end if
+    return
+  end function powerLawDTDDifferentialNumberDifferential
+  

--- a/source/stellar_astrophysics.supernovae_type_Ia.zero.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.zero.F90
@@ -65,15 +65,16 @@ contains
     return
   end function zeroConstructorParameters
 
-  subroutine zeroMassInitialRange(self,age,metallicity,massInitialMinimum,massInitialMaximum)
+  subroutine zeroMassInitialRange(self,initialMassFunction_,age,metallicity,massInitialMinimum,massInitialMaximum)
     !!{
     Return the range of initial stellar masses contributing to the Type Ia population.
     !!}
     implicit none
-     class           (supernovaeTypeIaZero), intent(inout) :: self
-     double precision                      , intent(in   ) :: age               , metallicity
-     double precision                      , intent(  out) :: massInitialMinimum, massInitialMaximum
-     !$GLC attributes unused :: self, age, metallicity
+     class           (supernovaeTypeIaZero    ), intent(inout) :: self
+     class           (initialMassFunctionClass), intent(inout) :: initialMassFunction_
+     double precision                          , intent(in   ) :: age                 , metallicity
+     double precision                          , intent(  out) :: massInitialMinimum  , massInitialMaximum
+     !$GLC attributes unused :: self, initialMassFunction_, age, metallicity
 
      ! The range is arbitrary as we have no Type Ias.
      massInitialMinimum=1.0d0

--- a/source/stellar_astrophysics.supernovae_type_Ia.zero.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.zero.F90
@@ -81,30 +81,32 @@ contains
     return
   end subroutine zeroMassInitialRange
   
-  double precision function zeroNumber(self,initialMass,age,metallicity) result(number)
+  double precision function zeroNumber(self,initialMassFunction_,initialMass,age,metallicity) result(number)
     !!{
     Compute the cumulative number of Type Ia supernovae which is always zero.
     !!}
     implicit none
-    class           (supernovaeTypeIaZero), intent(inout), target :: self
-    double precision                      , intent(in   )         :: age        , initialMass, &
-         &                                                           metallicity
-    !$GLC attributes unused :: self, initialMass, age, metallicity
+    class           (supernovaeTypeIaZero    ), intent(inout), target :: self
+    class           (initialMassFunctionClass), intent(inout), target :: initialMassFunction_
+    double precision                          , intent(in   )         :: age                 , initialMass, &
+         &                                                               metallicity
+    !$GLC attributes unused :: self, initialMassFunction_, initialMass, age, metallicity
     
     number=0.0d0
     return
   end function zeroNumber
 
-  double precision function zeroYield(self,initialMass,age,metallicity,atomIndex) result(yield)
+  double precision function zeroYield(self,initialMassFunction_,initialMass,age,metallicity,atomIndex) result(yield)
     !!{
     Compute the cumulative yield from Type Ia supernovae which is always zero.
     !!}
     implicit none
-    class           (supernovaeTypeIaZero), intent(inout)           :: self
-    double precision                      , intent(in   )           :: age        , initialMass, &
-         &                                                             metallicity
-    integer                               , intent(in   ), optional :: atomIndex
-    !$GLC attributes unused :: self, initialMass, age, metallicity, atomIndex
+    class           (supernovaeTypeIaZero    ), intent(inout)           :: self
+    class           (initialMassFunctionClass), intent(inout)           :: initialMassFunction_
+    double precision                          , intent(in   )           :: age                 , initialMass, &
+         &                                                                 metallicity
+    integer                                   , intent(in   ), optional :: atomIndex
+    !$GLC attributes unused :: self, initialMassFunction_, initialMass, age, metallicity, atomIndex
     
     yield=0.0d0    
     return

--- a/source/stellar_populations.initial_mass_functions.Chabrier2001.F90
+++ b/source/stellar_populations.initial_mass_functions.Chabrier2001.F90
@@ -48,11 +48,12 @@
           &              massCharacteristic      , sigma                 , &
           &              normalizationExponential, normalizationLogNormal
    contains
-     procedure :: massMinimum => chabrier2001MassMinimum
-     procedure :: massMaximum => chabrier2001MassMaximum
-     procedure :: phi         => chabrier2001Phi
-     procedure :: tabulate    => chabrier2001Tabulate
-     procedure :: label       => chabrier2001Label
+     procedure :: massMinimum      => chabrier2001MassMinimum
+     procedure :: massMaximum      => chabrier2001MassMaximum
+     procedure :: phi              => chabrier2001Phi
+     procedure :: numberCumulative => chabrier2001NumberCumulative
+     procedure :: tabulate         => chabrier2001Tabulate
+     procedure :: label            => chabrier2001Label
   end type initialMassFunctionChabrier2001
 
   interface initialMassFunctionChabrier2001
@@ -263,6 +264,44 @@ contains
     end if
     return
   end function chabrier2001Phi
+
+  double precision function chabrier2001NumberCumulative(self,massLower,massUpper) result(number)
+    !!{
+    Evaluate a piecewise power-law stellar initial mass function.
+    !!}
+    use :: Numerical_Constants_Math, only : Pi
+    implicit none
+    class           (initialMassFunctionChabrier2001), intent(inout) :: self
+    double precision                                 , intent(in   ) :: massLower , massUpper
+    double precision                                                 :: massLower_, massUpper_
+
+    number=0.0d0
+    ! Gaussian piece.
+    massLower_=max(massLower,self%massLower     )
+    massUpper_=min(massUpper,self%massTransition)
+    if (massUpper_ > massLower_)                                                           &
+         & number=+number                                                                  &
+         &        +sqrt(Pi/ 2.0d0)                                                         &
+         &        *log (   10.0d0)                                                         &
+         &        *self%sigma                                                              &
+         &        *self%normalizationLogNormal                                             &
+         &        *(                                                                       &
+         &          +erf(log10(massUpper_/self%massCharacteristic)/sqrt(2.0d0)/self%sigma) &
+         &          -erf(log10(massLower_/self%massCharacteristic)/sqrt(2.0d0)/self%sigma) &
+         &        )
+    ! Power-law piece.
+    massLower_=max(massLower,self%massTransition)
+    massUpper_=min(massUpper,self%massUpper     )
+    if (massUpper_ > massLower_)                       &
+         & number=+     number                         &
+         &        +self%normalizationExponential       &
+         &        /              (1.0d0+self%exponent) &
+         &        *(                                   &
+         &          +massUpper_**(1.0d0+self%exponent) &
+         &          +massLower_**(1.0d0+self%exponent) &
+         &         )
+    return
+  end function chabrier2001NumberCumulative
 
   subroutine chabrier2001Tabulate(self,imfTable)
     !!{

--- a/source/stellar_populations.initial_mass_functions.F90
+++ b/source/stellar_populations.initial_mass_functions.F90
@@ -54,6 +54,12 @@ module Stellar_Populations_Initial_Mass_Functions
     <pass>yes</pass>
     <argument>double precision, intent(in   ) :: massInitial</argument>
    </method>
+   <method name="numberCumulative" >
+    <description>Return the integral of the initial mass function, $\int_{m_\mathrm{lower}}^{m_\mathrm{upper}} \phi(M) \mathrm{d}M$.</description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>double precision, intent(in   ) :: massLower, massUpper</argument>
+   </method>
    <method name="tabulate" >
     <description>Return the initial mass function, $\phi(M)=\mathrm{d}N/\mathrm{d}M$, at the given mass $M=${\normalfont \ttfamily initialMass}.</description>
     <type>void</type>

--- a/source/stellar_populations.initial_mass_functions.piecewise_power_law.F90
+++ b/source/stellar_populations.initial_mass_functions.piecewise_power_law.F90
@@ -46,11 +46,12 @@
           &                                         massLower    , massUpper, &
           &                                         mass
    contains
-     procedure :: massMinimum => piecewisePowerLawMassMinimum
-     procedure :: massMaximum => piecewisePowerLawMassMaximum
-     procedure :: phi         => piecewisePowerLawPhi
-     procedure :: tabulate    => piecewisePowerLawTabulate
-     procedure :: label       => piecewisePowerLawLabel
+     procedure :: massMinimum      => piecewisePowerLawMassMinimum
+     procedure :: massMaximum      => piecewisePowerLawMassMaximum
+     procedure :: phi              => piecewisePowerLawPhi
+     procedure :: numberCumulative => piecewisePowerLawNumberCumulative
+     procedure :: tabulate         => piecewisePowerLawTabulate
+     procedure :: label            => piecewisePowerLawLabel
   end type initialMassFunctionPiecewisePowerLaw
 
   interface initialMassFunctionPiecewisePowerLaw
@@ -218,6 +219,32 @@ contains
     end do
     return
   end function piecewisePowerLawPhi
+
+  double precision function piecewisePowerLawNumberCumulative(self,massLower,massUpper) result(number)
+    !!{
+    Evaluate a piecewise power-law stellar initial mass function.
+    !!}
+    implicit none
+    class           (initialMassFunctionPiecewisePowerLaw), intent(inout) :: self
+    double precision                                      , intent(in   ) :: massLower , massUpper
+    double precision                                                      :: massLower_, massUpper_
+    integer                                                               :: i
+
+    number=0.0d0
+    do i=1,self%countPieces
+       massLower_=max(massLower,self%massLower(i))
+       massUpper_=min(massUpper,self%massUpper(i))
+       if (massUpper_ > massLower_)                               &
+            & number=+     number                                 &
+            &        +                     self%normalization(i)  &
+            &        /              (1.0d0+self%exponent     (i)) &
+            &        *(                                           &
+            &          +massUpper_**(1.0d0+self%exponent     (i)) &
+            &          -massLower_**(1.0d0+self%exponent     (i)) &
+            &        )
+    end do
+    return
+  end function piecewisePowerLawNumberCumulative
 
   subroutine piecewisePowerLawTabulate(self,imfTable)
     !!{

--- a/source/stellar_populations.standard.F90
+++ b/source/stellar_populations.standard.F90
@@ -628,9 +628,9 @@ contains
     select case (indexElement_)
     case (0)
        ! Total metallicity required.
-       yieldMass=supernovaeTypeIa_%yield(massInitial,sneIaLifetime,metallicity_              )
+       yieldMass=supernovaeTypeIa_%yield(initialMassFunction_,massInitial,sneIaLifetime,metallicity_              )
     case default
-       yieldMass=supernovaeTypeIa_%yield(massInitial,sneIaLifetime,metallicity_,indexElement_)
+       yieldMass=supernovaeTypeIa_%yield(initialMassFunction_,massInitial,sneIaLifetime,metallicity_,indexElement_)
     end select
     standardIntegrandYield=+standardIntegrandYield                &
          &                 +initialMassFunction_%phi(massInitial) &
@@ -659,8 +659,8 @@ contains
        ! In the standard calculation, simply use the current lifetime.
        lifetime=lifetime_
     end if
-    standardIntegrandEnergyOutput=+initialMassFunction_%phi                  (massInitial                      ) &
-         &                        *stellarFeedback_    %energyInputCumulative(massInitial,lifetime,metallicity_)
+    standardIntegrandEnergyOutput=+initialMassFunction_%phi                  (                     massInitial                      ) &
+         &                        *stellarFeedback_    %energyInputCumulative(initialMassFunction_,massInitial,lifetime,metallicity_)
     return
   end function standardIntegrandEnergyOutput
 

--- a/source/tests.initial_mass_functions.F90
+++ b/source/tests.initial_mass_functions.F90
@@ -150,7 +150,7 @@ program Test_Initial_Mass_Functions
   call Unit_Tests_Begin_Group('Type Ia SNe')
   call Unit_Tests_Begin_Group('Nagashima et al. (2005)')
   stellarAstrophysics_          =stellarAstrophysicsFile      ('%DATASTATICPATH%/stellarAstrophysics/stellarPropertiesPortinariChiosiBressan1998.xml')
-  supernovaeTypeIaNagashima2005_=supernovaeTypeIaNagashima2005(stellarAstrophysics_,imfPiecewisePowerLaw)
+  supernovaeTypeIaNagashima2005_=supernovaeTypeIaNagashima2005(stellarAstrophysics_)
   call integrator_%toleranceSet(1.0d-6,1.0d-6)
   call integrator_%integrandSet(numberTypeIaSNeIntegrand)
   do i=1,size(ageTypeIa)
@@ -192,8 +192,8 @@ contains
     implicit none
     double precision, intent(in   ) :: massSecondary
 
-    numberTypeIaSNeIntegrand=+supernovaeTypeIaNagashima2005_%number(massSecondary,ageTypeIa(i),metallicitySolar)  &
-         &                   *imfPiecewisePowerLaw              %phi   (massSecondary                )
+    numberTypeIaSNeIntegrand=+supernovaeTypeIaNagashima2005_%number(imfPiecewisePowerLaw,massSecondary,ageTypeIa(i),metallicitySolar)  &
+         &                   *imfPiecewisePowerLaw          %phi   (                     massSecondary                              )
     return
   end function numberTypeIaSNeIntegrand
 

--- a/source/tests.initial_mass_functions.F90
+++ b/source/tests.initial_mass_functions.F90
@@ -28,32 +28,48 @@ program Test_Initial_Mass_Functions
   use :: Display                                   , only : displayVerbositySet             , verbosityLevelStandard
   use :: Numerical_Integration2                    , only : integratorCompositeTrapezoidal1D
   use :: NUmerical_Constants_Astronomical          , only : metallicitySolar
-  use :: Stellar_Populations_Initial_Mass_Functions, only : initialMassFunctionBPASS        , initialMassFunctionBaugh2005TopHeavy, initialMassFunctionChabrier2001   , initialMassFunctionClass            , &
-          &                                                 initialMassFunctionKennicutt1983, initialMassFunctionKroupa2001       , initialMassFunctionMillerScalo1979, initialMassFunctionPiecewisePowerLaw, &
+  use :: Stellar_Populations_Initial_Mass_Functions, only : initialMassFunctionBPASS        , initialMassFunctionBaugh2005TopHeavy, initialMassFunctionChabrier2001        , initialMassFunctionClass            , &
+          &                                                 initialMassFunctionKennicutt1983, initialMassFunctionKroupa2001       , initialMassFunctionMillerScalo1979     , initialMassFunctionPiecewisePowerLaw, &
           &                                                 initialMassFunctionSalpeter1955 , initialMassFunctionScalo1986
-  use :: Supernovae_Type_Ia                        , only : supernovaeTypeIaNagashima2005
+  use :: Supernovae_Type_Ia                        , only : supernovaeTypeIaNagashima2005   , supernovaeTypeIaPowerLawDTD         , supernovaeTypeIaPowerLawDTDDifferential, supernovaeTypeIaClass
   use :: Stellar_Astrophysics                      , only : stellarAstrophysicsFile
-  use :: Unit_Tests                                , only : Assert                          , Unit_Tests_Begin_Group              , Unit_Tests_End_Group              , Unit_Tests_Finish
+  use :: Unit_Tests                                , only : Assert                          , Unit_Tests_Begin_Group              , Unit_Tests_End_Group                   , Unit_Tests_Finish
   implicit none
-  class           (initialMassFunctionClass            ), pointer      :: imf
-  type            (initialMassFunctionChabrier2001     ), target       :: imfChabrier2001
-  type            (initialMassFunctionPiecewisePowerLaw), target       :: imfPiecewisePowerLaw
-  type            (initialMassFunctionSalpeter1955     ), target       :: imfSalpeter1955
-  type            (initialMassFunctionBPASS            ), target       :: imfBPASS
-  type            (initialMassFunctionBaugh2005TopHeavy), target       :: imfBaugh2005TopHeavy
-  type            (initialMassFunctionKennicutt1983    ), target       :: imfKennicutt1983
-  type            (initialMassFunctionKroupa2001       ), target       :: imfKroupa2001
-  type            (initialMassFunctionMillerScalo1979  ), target       :: imfMillerScalo1979
-  type            (initialMassFunctionScalo1986        ), target       :: imfScalo1986
-  type            (stellarAstrophysicsFile             )               :: stellarAstrophysics_
-  type            (supernovaeTypeIaNagashima2005       )               :: supernovaeTypeIaNagashima2005_
-  type            (integratorCompositeTrapezoidal1D    )               :: integrator_
+  class           (initialMassFunctionClass               ), pointer      :: imf
+  type            (initialMassFunctionChabrier2001        ), target       :: imfChabrier2001
+  type            (initialMassFunctionPiecewisePowerLaw   ), target       :: imfPiecewisePowerLaw
+  type            (initialMassFunctionSalpeter1955        ), target       :: imfSalpeter1955
+  type            (initialMassFunctionBPASS               ), target       :: imfBPASS
+  type            (initialMassFunctionBaugh2005TopHeavy   ), target       :: imfBaugh2005TopHeavy
+  type            (initialMassFunctionKennicutt1983       ), target       :: imfKennicutt1983
+  type            (initialMassFunctionKroupa2001          ), target       :: imfKroupa2001
+  type            (initialMassFunctionMillerScalo1979     ), target       :: imfMillerScalo1979
+  type            (initialMassFunctionScalo1986           ), target       :: imfScalo1986
+  type            (stellarAstrophysicsFile                )               :: stellarAstrophysics_
+  type            (supernovaeTypeIaNagashima2005          ), target       :: supernovaeTypeIaNagashima2005_
+  type            (supernovaeTypeIaPowerLawDTD            ), target       :: supernovaeTypeIaPowerLawDTD_
+  type            (supernovaeTypeIaPowerLawDTDDifferential), target       :: supernovaeTypeIaPowerLawDTDDifferential_
+  class           (supernovaeTypeIaClass                  ), pointer      :: supernovaeTypeIa_
+  type            (integratorCompositeTrapezoidal1D       )               :: integrator_
   ! Values of the cumulative number of type Ia SNe read from Figure 6 of Nagashima et al (2005; MNRAS; 363; 31;
-  ! https://ui.adsabs.harvard.edu/abs/2005MNRAS.363L..31N) at 0.1, 1, and 10Gyr.
-  double precision                                      , dimension(3) :: ageTypeIa                     =[1.0d-1,1.0d+0,1.0d+1]                    , &
-       &                                                                  numberTypeIaSNeNagashima2005  =[6.0d-6,6.6d-4,2.2d-3]
-  double precision                                                     :: massInInitialMassFunction                            , numberTypeIaSNe   , &
-       &                                                                  massInitialMinimum                                   , massInitialMaximum
+  ! https://ui.adsabs.harvard.edu/abs/2005MNRAS.363L..31N) at 0.1, 1, and 10Gyr, and for a power-law delay time distribution.
+  double precision                                      , dimension(3) :: ageTypeIa                     =[                                          &
+       &                                                                                                  1.000000000000000d-1,                     &
+       &                                                                                                  1.000000000000000d+0,                     &
+       &                                                                                                  1.000000000000000d+1                      &
+       &                                                                                                 ]                    ,                     &
+       &                                                                  numberTypeIaSNeNagashima2005  =[                                          &
+       &                                                                                                  6.000000000000000d-6,                     &
+       &                                                                                                  6.600000000000000d-4,                     &
+       &                                                                                                  2.200000000000000d-3                      &
+       &                                                                                                 ]                    ,                     &
+       &                                                                  numberTypeIaSNePowerLawDTD    =[                                          &
+       &                                                                                                  2.334828201481421d-4,                     &
+       &                                                                                                  7.581754850034585d-4,                     &
+       &                                                                                                  1.204761370427590d-3                      &
+       &                                                                                                 ]
+  double precision                                                     :: massInInitialMassFunction                           , numberTypeIaSNe   , &
+       &                                                                  massInitialMinimum                                  , massInitialMaximum
   integer                                                              :: i
   character       (len=12                              )               :: label
   
@@ -149,12 +165,13 @@ program Test_Initial_Mass_Functions
   call Unit_Tests_End_Group()
   call Unit_Tests_Begin_Group('Type Ia SNe')
   call Unit_Tests_Begin_Group('Nagashima et al. (2005)')
-  stellarAstrophysics_          =stellarAstrophysicsFile      ('%DATASTATICPATH%/stellarAstrophysics/stellarPropertiesPortinariChiosiBressan1998.xml')
-  supernovaeTypeIaNagashima2005_=supernovaeTypeIaNagashima2005(stellarAstrophysics_)
+  stellarAstrophysics_           =  stellarAstrophysicsFile      ('%DATASTATICPATH%/stellarAstrophysics/stellarPropertiesPortinariChiosiBressan1998.xml')
+  supernovaeTypeIaNagashima2005_ =  supernovaeTypeIaNagashima2005(stellarAstrophysics_)
+  supernovaeTypeIa_              => supernovaeTypeIaNagashima2005_
   call integrator_%toleranceSet(1.0d-6,1.0d-6)
   call integrator_%integrandSet(numberTypeIaSNeIntegrand)
   do i=1,size(ageTypeIa)
-     call supernovaeTypeIaNagashima2005_%massInitialRange(ageTypeIa(i),metallicitySolar,massInitialMinimum,massInitialMaximum)
+     call supernovaeTypeIaNagashima2005_%massInitialRange(imfPiecewisePowerLaw,ageTypeIa(i),metallicitySolar,massInitialMinimum,massInitialMaximum)
      massInitialMinimum=max(massInitialMinimum,imfPiecewisePowerLaw%massMinimum())
      massInitialMaximum=min(massInitialMaximum,imfPiecewisePowerLaw%massMaximum())
      numberTypeIaSNe=integrator_%evaluate(                    &
@@ -165,6 +182,40 @@ program Test_Initial_Mass_Functions
      ! The tolerance for this test is (very) low. Nagashima et al. (2005) do not specify what they use for M(t) - the mass of a
      ! star leaving the main sequence at time t). Therefore, the best we can do is an approximate comparison.
      call Assert('Cumulative number of Type Ia SNe at age '//trim(label)//'Gyr',numberTypeIaSNe,numberTypeIaSNeNagashima2005(i),relTol=0.5d0)
+  end do
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Begin_Group('Power law delay time distribution')
+  supernovaeTypeIaPowerLawDTD_ =  supernovaeTypeIaPowerLawDTD(40.0d-3,-1.07d0,0.21d-3)
+  supernovaeTypeIa_            => supernovaeTypeIaPowerLawDTD_
+  call integrator_%toleranceSet(1.0d-6,1.0d-6)
+  call integrator_%integrandSet(numberTypeIaSNeIntegrand)
+  do i=1,size(ageTypeIa)
+     call supernovaeTypeIaPowerLawDTD_%massInitialRange(imfPiecewisePowerLaw,ageTypeIa(i),metallicitySolar,massInitialMinimum,massInitialMaximum)
+     massInitialMinimum=max(massInitialMinimum,imfPiecewisePowerLaw%massMinimum())
+     massInitialMaximum=min(massInitialMaximum,imfPiecewisePowerLaw%massMaximum())
+     numberTypeIaSNe=integrator_%evaluate(                    &
+          &                               massInitialMinimum, &
+          &                               massInitialMaximum  &
+          &                              )  
+     write (label,'(f4.1)') ageTypeIa(i)
+     call Assert('Cumulative number of Type Ia SNe at age '//trim(label)//'Gyr',numberTypeIaSNe,numberTypeIaSNePowerLawDTD(i),relTol=1.0d-3)
+  end do
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Begin_Group('Power law delay time distribution (differential)')
+  supernovaeTypeIaPowerLawDTDDifferential_ =  supernovaeTypeIaPowerLawDTDDifferential(40.0d-3,-1.07d0,0.21d-3)
+  supernovaeTypeIa_                        => supernovaeTypeIaPowerLawDTDDifferential_
+  call integrator_%toleranceSet(1.0d-6,1.0d-6)
+  call integrator_%integrandSet(numberTypeIaSNeIntegrand)
+  do i=1,size(ageTypeIa)
+     call supernovaeTypeIaPowerLawDTDDifferential_%massInitialRange(imfPiecewisePowerLaw,ageTypeIa(i),metallicitySolar,massInitialMinimum,massInitialMaximum)
+     massInitialMinimum=max(massInitialMinimum,imfPiecewisePowerLaw%massMinimum())
+     massInitialMaximum=min(massInitialMaximum,imfPiecewisePowerLaw%massMaximum())
+     numberTypeIaSNe=integrator_%evaluate(                    &
+          &                               massInitialMinimum, &
+          &                               massInitialMaximum  &
+          &                              )  
+     write (label,'(f4.1)') ageTypeIa(i)
+     call Assert('Cumulative number of Type Ia SNe at age '//trim(label)//'Gyr',numberTypeIaSNe,numberTypeIaSNePowerLawDTD(i),relTol=1.0d-3)
   end do
   call Unit_Tests_End_Group()
   call Unit_Tests_End_Group()
@@ -192,8 +243,8 @@ contains
     implicit none
     double precision, intent(in   ) :: massSecondary
 
-    numberTypeIaSNeIntegrand=+supernovaeTypeIaNagashima2005_%number(imfPiecewisePowerLaw,massSecondary,ageTypeIa(i),metallicitySolar)  &
-         &                   *imfPiecewisePowerLaw          %phi   (                     massSecondary                              )
+    numberTypeIaSNeIntegrand=+supernovaeTypeIa_   %number(imfPiecewisePowerLaw,massSecondary,ageTypeIa(i),metallicitySolar)  &
+         &                   *imfPiecewisePowerLaw%phi   (                     massSecondary                              )
     return
   end function numberTypeIaSNeIntegrand
 

--- a/source/tests.stellar_populations.F90
+++ b/source/tests.stellar_populations.F90
@@ -85,8 +85,7 @@ program Test_Stellar_Populations
        &                                                            stellarTracks_                       =stellarTracks_                                                                                       &
        &                                                           )
   supernovaeTypeIa_        =supernovaeTypeIaNagashima2005          (                                                                                                                                           &
-       &                                                            stellarAstrophysics_                 =stellarAstrophysics_                                                                               , &
-       &                                                            initialMassFunction_                 =initialMassFunction_                                                                                 &
+       &                                                            stellarAstrophysics_                 =stellarAstrophysics_                                                                                 &
        &                                                           )
   supernovaePopulationIII_ =supernovaePopulationIIIHegerWoosley2002(                                                                                                                                           &
        &                                                            stellarAstrophysics_                 =stellarAstrophysics_                                                                                 &

--- a/source/tests.stellar_populations.luminosities.F90
+++ b/source/tests.stellar_populations.luminosities.F90
@@ -137,8 +137,7 @@ call Directory_Make(char(inputPath(pathTypeDataDynamic))//'stellarPopulations/SS
        &                                                                                 stellarTracks_                       =stellarTracks_                                                                                               &
        &                                                                                )
   supernovaeTypeIa_                      =supernovaeTypeIaNagashima2005                 (                                                                                                                                                   &
-       &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_                                                                                       , &
-       &                                                                                 initialMassFunction_                 =initialMassFunction_                                                                                         &
+       &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_                                                                                         &
        &                                                                                )
   supernovaePopulationIII_               =supernovaePopulationIIIHegerWoosley2002       (                                                                                                                                                   &
        &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_                                                                                         &


### PR DESCRIPTION
* Provides a more flexible means of implementing delay time distributions. The top-level method, `number` still returns the cumulative number of type Ia SNe per secondary star mass interval.
* A new abstract class `supernovaeTypeIaFixedYield` is provided which assumes fixed yields per SNeIa, thereby avoiding the need to reimplement this in all other classes.
* The `supernovaeTypeIaNagashima2005` class now inherits from `supernovaeTypeIaFixedYield` but is otherwise unchanged.
* A new abstract class `supernovaeTypeIaMassIndependentDTD` (inhereting from `supernovaeTypeIaFixedYield`) is provided which assumes a delay time distribution that is independent of secondary star mass. It provides a deferred method `numberCumulative` that simply returns the cumulative number of SNeIa by a given age.
* A new `supernovaeTypeIaPowerLawDTD` class (inhereting from `supernovaeTypeIaMassIndependentDTD`) implements simple power-law models of the delay time distribution.
* A new abstract class `supernovaeTypeIaDifferentialDTD` class (inhereting from `supernovaeTypeIaMassIndependentDTD`) supports numerical integration over the differential delay time distribution (for cases where no analytic solution is available).
* A new `supernovaeTypeIaPowerLawDTDDifferential` class (inhereting from `supernovaeTypeIaDifferentialDTD`) implements the same simple power-law models of the delay time distribution as the `supernovaeTypeIaPowerLawDTD` class, but only in differential form (and is used as a test that the itegration provided by `supernovaeTypeIaDifferentialDTD` functions correctly).
    
    New tests of these classes are included.