### PR TITLE
Optimize baryonic spherical collapse solvers

### DIFF
--- a/parameters/tutorials/darkMatterOnlySubHalos.xml
+++ b/parameters/tutorials/darkMatterOnlySubHalos.xml
@@ -73,7 +73,9 @@
   <powerSpectrumPrimordialTransferred value="simple"  />
 
   <!-- Structure formation options -->
-  <linearGrowth          value="baryonsDarkMatter"                    />
+  <linearGrowth          value="baryonsDarkMatter"                     >
+    <cambCountPerDecade value="100"/>
+  </linearGrowth>
   <criticalOverdensity   value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
   <virialDensityContrast value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
   <haloMassFunction      value="shethTormen"                           >

--- a/perl/Galacticus/Build/SourceTree/Process/Enumeration.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/Enumeration.pm
@@ -319,7 +319,7 @@ sub Process_Enumerations {
 		$descriptorFunction .= "    type(varying_string) :: description\n\n";
 		my $description      = "    description=var_str(char(10))//\"Enumeration '".$node->{'directive'}->{'name'}."' has the following members:\"\n";
 		my @entries       = &List::ExtraUtils::as_array($node->{'directive'}->{'entry'});
-		my $lengthMaximum = max map {length($_)} @entries;
+		my $lengthMaximum = max map {length($_->{'label'})} @entries;
 		for(my $i=0;$i<scalar(@entries);++$i) {
 		    my $entry     = $entries[$i];
 		    my $separator = $i == scalar(@entries)-1 ? "." : ";";

--- a/source/structure_formation.critical_overdensity.spherical_collapse_baryons_darkMatter_darkEnergy.F90
+++ b/source/structure_formation.critical_overdensity.spherical_collapse_baryons_darkMatter_darkEnergy.F90
@@ -24,7 +24,7 @@
   use :: Cosmology_Parameters                 , only : cosmologyParameters                               , cosmologyParametersClass
   use :: Dark_Matter_Particles                , only : darkMatterParticle                                , darkMatterParticleClass
   use :: Intergalactic_Medium_Filtering_Masses, only : intergalacticMediumFilteringMass                  , intergalacticMediumFilteringMassClass
-  use :: Spherical_Collapse_Solvers           , only : sphericalCollapseSolverBaryonsDarkMatterDarkEnergy
+  use :: Spherical_Collapse_Solvers           , only : sphericalCollapseSolverBaryonsDarkMatterDarkEnergy, enumerationCllsnlssMttrDarkEnergyFixedAtType
   use :: Tables                               , only : table1D
 
   !![
@@ -48,6 +48,7 @@
           &                                                                               tableUnclusteredTimeMinimum                 , tableUnclusteredTimeMaximum
      double precision                                                                  :: normalization
      logical                                                                           :: tableStore
+     type            (enumerationCllsnlssMttrDarkEnergyFixedAtType      )              :: energyFixedAt
      class           (table1D                                           ), allocatable :: overdensityCriticalClustered                , overdensityCriticalUnclustered
      class           (darkMatterParticleClass                           ), pointer     :: darkMatterParticle_               => null()
      class           (cosmologyParametersClass                          ), pointer     :: cosmologyParameters_              => null()
@@ -83,7 +84,8 @@ contains
     Constructor for the {\normalfont \ttfamily sphericalCollapseBrynsDrkMttrDrkEnrgy} critical overdensity class
     which takes a parameter set as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters          , only : inputParameter                                , inputParameters
+    use :: Spherical_Collapse_Solvers, only : enumerationCllsnlssMttrDarkEnergyFixedAtEncode
     implicit none
     type            (criticalOverdensitySphericalCollapseBrynsDrkMttrDrkEnrgy)                :: self
     type            (inputParameters                                         ), intent(inout) :: parameters
@@ -94,6 +96,7 @@ contains
     class           (intergalacticMediumFilteringMassClass                   ), pointer       :: intergalacticMediumFilteringMass_
     double precision                                                                          :: normalization
     logical                                                                                   :: tableStore
+    type            (varying_string                                          )                :: energyFixedAt
 
     !![
     <inputParameter>
@@ -108,13 +111,21 @@ contains
       <defaultValue>.true.</defaultValue>
       <description>If true, store/restore the tabulated solution to/from file when possible.</description>
     </inputParameter>
+    <inputParameter>
+      <name>energyFixedAt</name>
+      <defaultValue>var_str('turnaround')</defaultValue>
+      <description>Selects the epoch at which the energy of a spherical top hat perturbation in a dark energy cosmology should be
+        ``fixed'' for the purposes of computing virial density contrasts. (See the discussion in
+        \citealt{percival_cosmological_2005}; \S8.)</description>
+      <source>parameters</source>
+    </inputParameter>
     <objectBuilder class="cosmologyFunctions"               name="cosmologyFunctions_"               source="parameters"/>
     <objectBuilder class="cosmologyParameters"              name="cosmologyParameters_"              source="parameters"/>
     <objectBuilder class="cosmologicalMassVariance"         name="cosmologicalMassVariance_"         source="parameters"/>
     <objectBuilder class="darkMatterParticle"               name="darkMatterParticle_"               source="parameters"/>
     <objectBuilder class="intergalacticMediumFilteringMass" name="intergalacticMediumFilteringMass_" source="parameters"/>
     !!]
-    self=criticalOverdensitySphericalCollapseBrynsDrkMttrDrkEnrgy(cosmologyParameters_,cosmologyFunctions_,cosmologicalMassVariance_,darkMatterParticle_,intergalacticMediumFilteringMass_,tableStore,normalization)
+    self=criticalOverdensitySphericalCollapseBrynsDrkMttrDrkEnrgy(cosmologyParameters_,cosmologyFunctions_,cosmologicalMassVariance_,darkMatterParticle_,intergalacticMediumFilteringMass_,tableStore,enumerationCllsnlssMttrDarkEnergyFixedAtEncode(char(energyFixedAt),includesPrefix=.false.),normalization)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyParameters_"             />
@@ -126,13 +137,12 @@ contains
     return
   end function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorParameters
 
-  function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorInternal(cosmologyParameters_,cosmologyFunctions_,cosmologicalMassVariance_,darkMatterParticle_,intergalacticMediumFilteringMass_,tableStore,normalization) result(self)
+  function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorInternal(cosmologyParameters_,cosmologyFunctions_,cosmologicalMassVariance_,darkMatterParticle_,intergalacticMediumFilteringMass_,tableStore,energyFixedAt,normalization) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily sphericalCollapseBrynsDrkMttrDrkEnrgy} critical overdensity class.
     !!}
-    use :: Dark_Matter_Particles     , only : darkMatterParticleCDM
-    use :: Error                     , only : Error_Report
-    use :: Spherical_Collapse_Solvers, only : cllsnlssMttrDarkEnergyFixedAtUndefined
+    use :: Dark_Matter_Particles, only : darkMatterParticleCDM
+    use :: Error                , only : Error_Report
     implicit none
     type            (criticalOverdensitySphericalCollapseBrynsDrkMttrDrkEnrgy)                          :: self
     class           (cosmologyFunctionsClass                                 ), target  , intent(in   ) :: cosmologyFunctions_
@@ -141,18 +151,19 @@ contains
     class           (darkMatterParticleClass                                 ), target  , intent(in   ) :: darkMatterParticle_
     class           (intergalacticMediumFilteringMassClass                   ), target  , intent(in   ) :: intergalacticMediumFilteringMass_
     logical                                                                             , intent(in   ) :: tableStore
+    type            (enumerationCllsnlssMttrDarkEnergyFixedAtType            )          , intent(in   ) :: energyFixedAt
     double precision                                                          , optional, intent(in   ) :: normalization
     !![
     <optionalArgument name="normalization" defaultsTo="1.0d0" />
-    <constructorAssign variables="*cosmologyParameters_, *cosmologyFunctions_, *cosmologicalMassVariance_, *darkMatterParticle_, *intergalacticMediumFilteringMass_, tableStore, normalization"/>
+    <constructorAssign variables="*cosmologyParameters_, *cosmologyFunctions_, *cosmologicalMassVariance_, *darkMatterParticle_, *intergalacticMediumFilteringMass_, tableStore, energyFixedAt, normalization"/>
     !!]
 
     self%tableInitialized=.false.
     allocate(self%sphericalCollapseSolverClustered_  )
     allocate(self%sphericalCollapseSolverUnclustered_)
     !![
-    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverClustered_"   constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.true. ,cllsnlssMttrDarkEnergyFixedAtUndefined,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
-    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverUnclustered_" constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.false.,cllsnlssMttrDarkEnergyFixedAtUndefined,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
+    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverClustered_"   constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.true. ,self%energyFixedAt,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
+    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverUnclustered_" constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.false.,self%energyFixedAt,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
     !!]
     ! Require that the dark matter be cold dark matter.
     select type (darkMatterParticle_)

--- a/source/structure_formation.spherical_collapse.solver.baryons_darkMatter_darkEnergy.F90
+++ b/source/structure_formation.spherical_collapse.solver.baryons_darkMatter_darkEnergy.F90
@@ -171,31 +171,34 @@ contains
     use :: Root_Finder, only : rangeExpandMultiplicative, rangeExpandSignExpectNegative, rangeExpandSignExpectPositive, rootFinder
     use :: Tables     , only : table1DLogarithmicLinear
     implicit none
-    class           (sphericalCollapseSolverBaryonsDarkMatterDarkEnergy)             , intent(inout) :: self
-    double precision                                                                 , intent(in   ) :: time
-    type            (enumerationCllsnlssMttCsmlgclCnstntClcltnType     )             , intent(in   ) :: calculationType
-    class           (table1D                                           ), allocatable, intent(inout) :: sphericalCollapse_
-    class           (linearGrowthClass                                 ), pointer                    :: linearGrowth_                  => null()
-    double precision                                                    , parameter                  :: toleranceAbsolute              =  0.0d0  , toleranceRelative              =1.0d-12
-    double precision                                                    , dimension(2)               :: timeRange
-    type            (rootFinder                                        ), save                       :: finderPerturbationInitial                , finderExpansionMaximum
-    logical                                                             , save                       :: finderPerturbationConstructed  =  .false., finderExpansionConstructed     =.false.
+    class           (sphericalCollapseSolverBaryonsDarkMatterDarkEnergy)             , intent(inout)  :: self
+    double precision                                                                 , intent(in   )  :: time
+    type            (enumerationCllsnlssMttCsmlgclCnstntClcltnType     )             , intent(in   )  :: calculationType
+    class           (table1D                                           ), allocatable, intent(inout)  :: sphericalCollapse_
+    class           (linearGrowthClass                                 ), pointer                     :: linearGrowth_                  => null()
+    double precision                                                    , parameter                   :: toleranceAbsolute              =  0.0d0  , toleranceRelative              =1.0d-12
+    double precision                                                                 , dimension(2  ) :: timeRange
+    double precision                                                    , allocatable, dimension(:  ) :: timesPrevious
+    double precision                                                    , allocatable, dimension(:,:) :: valuesPrevious
+    type            (rootFinder                                        ), save                        :: finderPerturbationInitial                , finderExpansionMaximum
+    logical                                                             , save                        :: finderPerturbationConstructed  =  .false., finderExpansionConstructed     =.false.
     !$omp threadprivate(finderPerturbationInitial,finderExpansionMaximum,finderPerturbationConstructed,finderExpansionConstructed)
-    integer                                                                                          :: countTimes                               , iTime                                  , &
-         &                                                                                              iCount
-    double precision                                                                                 :: expansionFactor                          , epsilonPerturbation                    , &
-         &                                                                                              epsilonPerturbationMaximum               , epsilonPerturbationMinimum             , &
-         &                                                                                              densityContrastExpansionMaximum          , expansionFactorExpansionMaximum        , &
-         &                                                                                              radiusExpansionMaximum                   , timeExpansionMaximum                   , &
-         &                                                                                              normalization                            , q                                      , &
-         &                                                                                              timeEnergyFixed                          , timeInitial                            , &
-         &                                                                                              y                                        , timeMinimum                            , &
-         &                                                                                              timeMaximum                              , r                                      , &
-         &                                                                                              z                                        , fractionDarkMatter
-    double complex                                                                                   :: a                                        , b                                      , &
-         &                                                                                              x
-    type            (varying_string                                    )                             :: message
-    character       (len=13                                            )                             :: label
+    integer                                                                                           :: countTimes                               , iTime                                  , &
+         &                                                                                               iCount                                   , iTimeMinimum                           , &
+         &                                                                                               iTimeMaximum                             , countTimesEffective
+    double precision                                                                                  :: expansionFactor                          , epsilonPerturbation                    , &
+         &                                                                                               epsilonPerturbationMaximum               , epsilonPerturbationMinimum             , &
+         &                                                                                               densityContrastExpansionMaximum          , expansionFactorExpansionMaximum        , &
+         &                                                                                               radiusExpansionMaximum                   , timeExpansionMaximum                   , &
+         &                                                                                               normalization                            , q                                      , &
+         &                                                                                               timeEnergyFixed                          , timeInitial                            , &
+         &                                                                                               y                                        , timeMinimum                            , &
+         &                                                                                               timeMaximum                              , r                                      , &
+         &                                                                                               z                                        , fractionDarkMatter
+    double complex                                                                                    :: a                                        , b                                      , &
+         &                                                                                               x
+    type            (varying_string                                    )                              :: message
+    character       (len=13                                            )                              :: label
 
     ! Find minimum and maximum times to tabulate.
     if (allocated(sphericalCollapse_)) then
@@ -210,14 +213,28 @@ contains
     ! Expand the range to ensure the requested time is included.
     timeMinimum=min(timeMinimum,time/2.0d0)
     timeMaximum=max(timeMaximum,time*2.0d0)
+    ! Round to the nearest factor of 2.
+    timeMinimum=2.0d0**floor  (log(timeMinimum)/log(2.0d0))
+    timeMaximum=2.0d0**ceiling(log(timeMaximum)/log(2.0d0))
     ! Determine number of points to tabulate.
-    countTimes=int(log10(timeMaximum/timeMinimum)*dble(tablePointsPerDecade))
+    countTimes=nint(log(timeMaximum/timeMinimum)/log(2.0d0)*dble(tablePointsPerOctave))
     ! Copy baryon clustering option to module-scope.
     baryonsCluster=self%baryonsCluster
     ! Deallocate table if currently allocated.
     if (allocated(sphericalCollapse_)) then
+       ! Store the current solution.
+       timesPrevious      =sphericalCollapse_%xs()
+       valuesPrevious     =sphericalCollapse_%ys()
+       iTimeMinimum       =nint(log(timesPrevious(                 1 )/timeMinimum)/log(2.0d0)*tablePointsPerOctave)+1
+       iTimeMaximum       =nint(log(timesPrevious(size(timesPrevious))/timeMinimum)/log(2.0d0)*tablePointsPerOctave)+1
+       countTimesEffective=countTimes-(iTimeMaximum-iTimeMinimum+1)
+       ! Destroy the table.
        call sphericalCollapse_%destroy()
        deallocate(sphericalCollapse_)
+    else
+       iTimeMinimum       =+huge(0)
+       iTimeMaximum       =-huge(0)
+       countTimesEffective=countTimes
     end if
     allocate(table1DLogarithmicLinear :: sphericalCollapse_)
     select type (sphericalCollapse_)
@@ -226,6 +243,20 @@ contains
        call sphericalCollapse_%create(timeMinimum,timeMaximum,countTimes)
        ! Solve ODE to get corresponding overdensities.
        message="Solving spherical collapse model for baryons + dark matter + dark energy universe for "
+       select case (calculationType%ID)
+       case (cllsnlssMttCsmlgclCnstntClcltnCriticalOverdensity  %ID)
+          message=message//"critical overdensity"
+       case (cllsnlssMttCsmlgclCnstntClcltnVirialDensityContrast%ID)
+          message=message//"virial density contrast"
+       case (cllsnlssMttCsmlgclCnstntClcltnRadiusTurnaround     %ID)
+          message=message//"turnaround radius"
+       end select
+       if (baryonsCluster) then
+          message=message//" (baryons do cluster)"
+       else
+          message=message//" (baryons do not cluster)"
+       end if
+       message=message//" for "
        write (label,'(e12.6)') timeMinimum
        message=message//trim(adjustl(label))//" ≤ t/Gyr ≤ "
        write (label,'(e12.6)') timeMaximum
@@ -258,163 +289,170 @@ contains
        !$omp end critical(sphericalCollapseSolverBrynsDrkMttrDrkEnrgyDeepCopy)
        !$omp do schedule(dynamic)
        do iTime=1,countTimes
-          call displayCounter(                                              &
-               &              int(100.0d0*dble(iCount-1)/dble(countTimes)), &
-               &              isNew=.false.                               , &
-               &              verbosity=verbosityLevelWorking               &
-               &             )
-          ! Get the current expansion factor.
-          expansionFactor=cosmologyFunctions_%expansionFactor(sphericalCollapse_%x(iTime))
-          ! Initial guess for the range of the initial perturbation amplitude. Since we expect a collapsing perturbation to have
-          ! linear theory amplitude of order unity at the time of collapse, and since linear perturbations grow proportional to
-          ! the expansion factor in an Einstein-de Sitter universe with no baryons, we use an initial guess for the lower and
-          ! upper limits which are a multiple of our starting expansion factor.
-          epsilonPerturbationMinimum=1.0d-1*expansionFactorInitialFraction
-          epsilonPerturbationMaximum=1.0d+1*expansionFactorInitialFraction
-          ! Evaluate cosmological parameters at the present time.
-          OmegaMatterEpochal    =+     cosmologyFunctions_%omegaMatterEpochal     (expansionFactor=expansionFactor)
-          if (self%baryonsCluster) then
-             OmegaBaryonEpochal =+0.0d0
-          else
-             OmegaBaryonEpochal =+                          OmegaMatterEpochal                                      &
-                  &              *self%cosmologyParameters_%OmegaBaryon           (                               ) &
-                  &              /self%cosmologyParameters_%OmegaMatter           (                               )
-          end if
-          OmegaDarkEnergyEpochal=+     cosmologyFunctions_ %omegaDarkEnergyEpochal(expansionFactor=expansionFactor)
-          hubbleTimeEpochal     =+     cosmologyFunctions_ %expansionRate         (                expansionFactor)
-          time_                 =+     sphericalCollapse_  %x                     (                iTime          )
-          ! Check dark energy equation of state is within acceptable range.
-          if (cosmologyFunctions_%equationOfStateDarkEnergy(time=time_) >= -1.0d0/3.0d0) &
-               & call Error_Report('ω<-⅓ required'//{introspection:location})
-          ! Find the value of ε for which the perturbation just collapses at this time.
-          if (.not.finderPerturbationConstructed) then
-             finderPerturbationInitial=rootFinder(                                                                 &
-                  &                               rootFunction     =baryonsDarkMatterDarkEnergyRadiusPerturbation, &
-                  &                               toleranceAbsolute=toleranceAbsolute                            , &
-                  &                               toleranceRelative=toleranceRelative                            , &
-                  &                               rangeExpandUpward=2.0d0                                        , &
-                  &                               rangeExpandType  =rangeExpandMultiplicative                      &
-                  &                              )
-             finderPerturbationConstructed=.true.
-          end if
-          epsilonPerturbation=finderPerturbationInitial%find(rootRange=[epsilonPerturbationMinimum,epsilonPerturbationMaximum])
-          select case (calculationType%ID)
-          case (cllsnlssMttCsmlgclCnstntClcltnCriticalOverdensity%ID)
-             ! Critical linear overdensity.
-             normalization=+linearGrowth_%value                                                                                (time_) &
-                  &        /linearGrowth_%value(                                                                                       &
-                  &                             cosmologyFunctions_%cosmicTime(                                                        &
-                  &                                                            +expansionFactorInitialFraction                         &
-                  &                                                            *cosmologyFunctions_            %expansionFactor(time_) &
-                  &                                                           )                                                        &
-                  &                            )
-             call sphericalCollapse_%populate(                                   &
-                  &                           normalization*epsilonPerturbation, &
-                  &                           iTime                              &
+          if (iTime >= iTimeMinimum .and. iTime <= iTimeMaximum) then
+             call sphericalCollapse_%populate(                                        &
+                  &                           valuesPrevious(iTime-iTimeMinimum+1,1), &
+                  &                                          iTime                    &
                   &                          )
-          case (cllsnlssMttCsmlgclCnstntClcltnVirialDensityContrast%ID,cllsnlssMttCsmlgclCnstntClcltnRadiusTurnaround%ID)
-             ! Find the epoch of maximum expansion for the perturbation.
-             if (.not.finderExpansionConstructed) then
-                finderExpansionMaximum=rootFinder(                                                                   &
-                     &                            rootFunction=baryonsDarkMatterDarkEnergyExpansionRatePerturbation, &
-                     &                            toleranceAbsolute=toleranceAbsolute                              , &
-                     &                            toleranceRelative=toleranceRelative                                &
-                     &                           )
-                finderExpansionConstructed=.true.
-             end if
-             call finderExpansionMaximum%rangeExpand (                                                             &
-                  &                                   rangeExpandDownward          =1.0d0-1.0d-2                 , &
-                  &                                   rangeExpandUpward            =1.0d0+1.0d-2                 , &
-                  &                                   rangeExpandType              =rangeExpandMultiplicative    , &
-                  &                                   rangeUpwardLimit             =time_                        , &
-                  &                                   rangeExpandDownwardSignExpect=rangeExpandSignExpectPositive, &
-                  &                                   rangeExpandUpwardSignExpect  =rangeExpandSignExpectNegative  &
-                  &                                  )
-             amplitudePerturbation=epsilonPerturbation
-             ! Compute the corresponding time of maximum expansion.
-             timeInitial                    =cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactor(time_)*expansionFactorInitialFraction)
-             ! Guess that the time of maximum expansion occurred at close to half of the current time.
-             timeRange                      =[0.45d0,0.55d0]*time_
-             timeExpansionMaximum           =finderExpansionMaximum%find(rootRange=timeRange)
-             expansionFactorExpansionMaximum=cosmologyFunctions_%expansionFactor(timeExpansionMaximum)
-             ! Solve the dynamics of the perturbation to find the radius at the point of maximum expansion.
-             call baryonsDarkMatterDarkEnergyPerturbationDynamicsSolver(epsilonPerturbation,timeExpansionMaximum,radiusExpansionMaximum)
-             ! Compute the density contrast of the perturbation at maximum expansion.
-             densityContrastExpansionMaximum=(expansionFactorExpansionMaximum/expansionFactor/radiusExpansionMaximum)**3
-             ! Solve the cubic equation (Percival, 2005, A&A, 443, 819, eqn. 38; but modified to include the effects of baryons)
-             ! to give the ratio of virial to turnaround radii, x.
-             select case (self%energyFixedAt%ID)
-             case (cllsnlssMttrDarkEnergyFixedAtTurnaround   %ID)
-                timeEnergyFixed=timeExpansionMaximum
-             case (cllsnlssMttrDarkEnergyFixedAtVirialization%ID)
-                timeEnergyFixed=time_
-             case default
-                call Error_Report('unrecognized epoch'//{introspection:location})
-             end select
+          else
+             call displayCounter(                                                       &
+                  &              int(100.0d0*dble(iCount-1)/dble(countTimesEffective)), &
+                  &              isNew=.false.                                        , &
+                  &              verbosity=verbosityLevelWorking                        &
+                  &             )
+             ! Get the current expansion factor.
+             expansionFactor=cosmologyFunctions_%expansionFactor(sphericalCollapse_%x(iTime))
+             ! Initial guess for the range of the initial perturbation amplitude. Since we expect a collapsing perturbation to have
+             ! linear theory amplitude of order unity at the time of collapse, and since linear perturbations grow proportional to
+             ! the expansion factor in an Einstein-de Sitter universe with no baryons, we use an initial guess for the lower and
+             ! upper limits which are a multiple of our starting expansion factor.
+             epsilonPerturbationMinimum=1.0d-1*expansionFactorInitialFraction
+             epsilonPerturbationMaximum=1.0d+1*expansionFactorInitialFraction
+             ! Evaluate cosmological parameters at the present time.
+             OmegaMatterEpochal    =+     cosmologyFunctions_%omegaMatterEpochal     (expansionFactor=expansionFactor)
              if (self%baryonsCluster) then
-                q                 =     +cosmologyFunctions_%omegaDarkEnergyEpochal(time=timeExpansionMaximum) &
-                     &                  /cosmologyFunctions_%omegaMatterEpochal    (time=timeExpansionMaximum) &
-                     &                  /densityContrastExpansionMaximum
-                y                 =     +expansionFactorExpansionMaximum**cosmologyFunctions_%exponentDarkEnergy(time=timeExpansionMaximum) &
-                     &                  /expansionFactor                **cosmologyFunctions_%exponentDarkEnergy(time=time_               )
-                a                 =+1.0d0-(1.0d0+3.0d0*cosmologyFunctions_%equationOfStateDarkEnergy(time=timeEnergyFixed))*q/2.0d0
-                b                 =      +(1.0d0+3.0d0*cosmologyFunctions_%equationOfStateDarkEnergy(time=time_          ))*q/y
+                OmegaBaryonEpochal =+0.0d0
              else
-                fractionDarkMatter=+(                                         &
-                     &               +self%cosmologyParameters_%OmegaMatter() &
-                     &               -self%cosmologyParameters_%OmegaBaryon() &
-                     &              )                                         &
-                     &             /  self%cosmologyParameters_%OmegaMatter()
-                q                 =+cosmologyFunctions_%omegaDarkEnergyEpochal(time=timeExpansionMaximum) &
-                     &             /cosmologyFunctions_%omegaMatterEpochal    (time=timeExpansionMaximum) &
-                     &             /fractionDarkMatter                                                    &
-                     &             /densityContrastExpansionMaximum
-                y                 = expansionFactorExpansionMaximum**cosmologyFunctions_%exponentDarkEnergy(time=timeExpansionMaximum) &
-                     &             /expansionFactor                **cosmologyFunctions_%exponentDarkEnergy(time=time_               )
-                r                 =+  self%cosmologyParameters_%OmegaBaryon() &
-                     &             /(                                         &
-                     &               +self%cosmologyParameters_%OmegaMatter() &
-                     &               -self%cosmologyParameters_%OmegaBaryon() &
-                     &              )                                         &
-                     &             /densityContrastExpansionMaximum
-                z                 =+(                                    &
-                     &               +expansionFactorExpansionMaximum    &
-                     &               /expansionFactor                    &
-                     &              )**3
-                a                 =+1.0d0+r        -(1.0d0+3.0d0*cosmologyFunctions_%equationOfStateDarkEnergy(time=timeEnergyFixed))*q/2.0d0
-                b                 =      -r/z/2.0d0+(1.0d0+3.0d0*cosmologyFunctions_%equationOfStateDarkEnergy(time=time_          ))*q/y
+                OmegaBaryonEpochal =+                          OmegaMatterEpochal                                      &
+                     &              *self%cosmologyParameters_%OmegaBaryon           (                               ) &
+                     &              /self%cosmologyParameters_%OmegaMatter           (                               )
              end if
-             x      =+(0.0d0,0.5d0)*sqrt(3.0d0)                                                                          &
-                  &  *(                                                                                                  &
-                  &    +1.0d0/b*((54.0d0+6.0d0*sqrt(3.0d0)*sqrt((16.0d0*a**3+27.0d0*b)/b))*b**2)**(+1.0d0/3.0d0)/ 6.0d0  &
-                  &    +2.0d0*a*((54.0d0+6.0d0*sqrt(3.0d0)*sqrt((16.0d0*a**3+27.0d0*b)/b))*b**2)**(-1.0d0/3.0d0)         &
-                  &   )                                                                                                  &
-                  &  - (1.0d0/b*((54.0d0+6.0d0*sqrt(3.0d0)*sqrt((16.0d0*a**3+27.0d0*b)/b))*b**2)**(+1.0d0/3.0d0)/12.0d0) &
-                  &  + (      a*((54.0d0+6.0d0*sqrt(3.0d0)*sqrt((16.0d0*a**3+27.0d0*b)/b))*b**2)**(-1.0d0/3.0d0)       )
+             OmegaDarkEnergyEpochal=+     cosmologyFunctions_ %omegaDarkEnergyEpochal(expansionFactor=expansionFactor)
+             hubbleTimeEpochal     =+     cosmologyFunctions_ %expansionRate         (                expansionFactor)
+             time_                 =+     sphericalCollapse_  %x                     (                iTime          )
+             ! Check dark energy equation of state is within acceptable range.
+             if (cosmologyFunctions_%equationOfStateDarkEnergy(time=time_) >= -1.0d0/3.0d0) &
+                  & call Error_Report('ω<-⅓ required'//{introspection:location})
+             ! Find the value of ε for which the perturbation just collapses at this time.
+             if (.not.finderPerturbationConstructed) then
+                finderPerturbationInitial=rootFinder(                                                                 &
+                     &                               rootFunction     =baryonsDarkMatterDarkEnergyRadiusPerturbation, &
+                     &                               toleranceAbsolute=toleranceAbsolute                            , &
+                     &                               toleranceRelative=toleranceRelative                            , &
+                     &                               rangeExpandUpward=2.0d0                                        , &
+                     &                               rangeExpandType  =rangeExpandMultiplicative                      &
+                     &                              )
+                finderPerturbationConstructed=.true.
+             end if
+             epsilonPerturbation=finderPerturbationInitial%find(rootRange=[epsilonPerturbationMinimum,epsilonPerturbationMaximum])
              select case (calculationType%ID)
-             case (cllsnlssMttCsmlgclCnstntClcltnVirialDensityContrast%ID)
-                ! The density contrast calculated as Δ=1/(x Rmax)³ is Δ=ρvir/⟨ρDM⟩ - i.e. the density of the virialized dark
-                ! matter perturbation relative to the mean density of dark matter. However, what we want (for the definition used
-                ! by Galacticus) is the density of the perturbation relative to the total mean density. So we perform that
-                ! conversion here.
-                call sphericalCollapse_%populate(                                            &
-                     &                           +(                                          &
-                     &                             +self%cosmologyParameters_%OmegaMatter()  &
-                     &                             -self%cosmologyParameters_%OmegaBaryon()  &
-                     &                            )                                          &
-                     &                           /  self%cosmologyParameters_%OmegaMatter()  &
-                     &                           /(dble(x)*radiusExpansionMaximum)**3      , &
-                     &                           iTime                                       &
+             case (cllsnlssMttCsmlgclCnstntClcltnCriticalOverdensity%ID)
+                ! Critical linear overdensity.
+                normalization=+linearGrowth_%value                                                                                (time_) &
+                     &        /linearGrowth_%value(                                                                                       &
+                     &                             cosmologyFunctions_%cosmicTime(                                                        &
+                     &                                                            +expansionFactorInitialFraction                         &
+                     &                                                            *cosmologyFunctions_            %expansionFactor(time_) &
+                     &                                                           )                                                        &
+                     &                            )
+                call sphericalCollapse_%populate(                                   &
+                     &                           normalization*epsilonPerturbation, &
+                     &                           iTime                              &
                      &                          )
-             case (cllsnlssMttCsmlgclCnstntClcltnRadiusTurnaround    %ID)
-                call sphericalCollapse_%populate(                                            &
-                     &                           1.0d0/ dble(x)                            , &
-                     &                           iTime                                       &
-                     &                          )
+             case (cllsnlssMttCsmlgclCnstntClcltnVirialDensityContrast%ID,cllsnlssMttCsmlgclCnstntClcltnRadiusTurnaround%ID)
+                ! Find the epoch of maximum expansion for the perturbation.
+                if (.not.finderExpansionConstructed) then
+                   finderExpansionMaximum=rootFinder(                                                                   &
+                        &                            rootFunction=baryonsDarkMatterDarkEnergyExpansionRatePerturbation, &
+                        &                            toleranceAbsolute=toleranceAbsolute                              , &
+                        &                            toleranceRelative=toleranceRelative                                &
+                        &                           )
+                   finderExpansionConstructed=.true.
+                end if
+                call finderExpansionMaximum%rangeExpand (                                                             &
+                     &                                   rangeExpandDownward          =1.0d0-1.0d-2                 , &
+                     &                                   rangeExpandUpward            =1.0d0+1.0d-2                 , &
+                     &                                   rangeExpandType              =rangeExpandMultiplicative    , &
+                     &                                   rangeUpwardLimit             =time_                        , &
+                     &                                   rangeExpandDownwardSignExpect=rangeExpandSignExpectPositive, &
+                     &                                   rangeExpandUpwardSignExpect  =rangeExpandSignExpectNegative  &
+                     &                                  )
+                amplitudePerturbation=epsilonPerturbation
+                ! Compute the corresponding time of maximum expansion.
+                timeInitial                    =cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactor(time_)*expansionFactorInitialFraction)
+                ! Guess that the time of maximum expansion occurred at close to half of the current time.
+                timeRange                      =[0.45d0,0.55d0]*time_
+                timeExpansionMaximum           =finderExpansionMaximum%find(rootRange=timeRange)
+                expansionFactorExpansionMaximum=cosmologyFunctions_%expansionFactor(timeExpansionMaximum)
+                ! Solve the dynamics of the perturbation to find the radius at the point of maximum expansion.
+                call baryonsDarkMatterDarkEnergyPerturbationDynamicsSolver(epsilonPerturbation,timeExpansionMaximum,radiusExpansionMaximum)
+                ! Compute the density contrast of the perturbation at maximum expansion.
+                densityContrastExpansionMaximum=(expansionFactorExpansionMaximum/expansionFactor/radiusExpansionMaximum)**3
+                ! Solve the cubic equation (Percival, 2005, A&A, 443, 819, eqn. 38; but modified to include the effects of baryons)
+                ! to give the ratio of virial to turnaround radii, x.
+                select case (self%energyFixedAt%ID)
+                case (cllsnlssMttrDarkEnergyFixedAtTurnaround   %ID)
+                   timeEnergyFixed=timeExpansionMaximum
+                case (cllsnlssMttrDarkEnergyFixedAtVirialization%ID)
+                   timeEnergyFixed=time_
+                case default
+                   call Error_Report('unrecognized epoch'//{introspection:location})
+                end select
+                if (self%baryonsCluster) then
+                   q                 =     +cosmologyFunctions_%omegaDarkEnergyEpochal(time=timeExpansionMaximum) &
+                        &                  /cosmologyFunctions_%omegaMatterEpochal    (time=timeExpansionMaximum) &
+                        &                  /densityContrastExpansionMaximum
+                   y                 =     +expansionFactorExpansionMaximum**cosmologyFunctions_%exponentDarkEnergy(time=timeExpansionMaximum) &
+                        &                  /expansionFactor                **cosmologyFunctions_%exponentDarkEnergy(time=time_               )
+                   a                 =+1.0d0-(1.0d0+3.0d0*cosmologyFunctions_%equationOfStateDarkEnergy(time=timeEnergyFixed))*q/2.0d0
+                   b                 =      +(1.0d0+3.0d0*cosmologyFunctions_%equationOfStateDarkEnergy(time=time_          ))*q/y
+                else
+                   fractionDarkMatter=+(                                         &
+                        &               +self%cosmologyParameters_%OmegaMatter() &
+                        &               -self%cosmologyParameters_%OmegaBaryon() &
+                        &              )                                         &
+                        &             /  self%cosmologyParameters_%OmegaMatter()
+                   q                 =+cosmologyFunctions_%omegaDarkEnergyEpochal(time=timeExpansionMaximum) &
+                        &             /cosmologyFunctions_%omegaMatterEpochal    (time=timeExpansionMaximum) &
+                        &             /fractionDarkMatter                                                    &
+                        &             /densityContrastExpansionMaximum
+                   y                 = expansionFactorExpansionMaximum**cosmologyFunctions_%exponentDarkEnergy(time=timeExpansionMaximum) &
+                        &             /expansionFactor                **cosmologyFunctions_%exponentDarkEnergy(time=time_               )
+                   r                 =+  self%cosmologyParameters_%OmegaBaryon() &
+                        &             /(                                         &
+                        &               +self%cosmologyParameters_%OmegaMatter() &
+                        &               -self%cosmologyParameters_%OmegaBaryon() &
+                        &              )                                         &
+                        &             /densityContrastExpansionMaximum
+                   z                 =+(                                    &
+                        &               +expansionFactorExpansionMaximum    &
+                        &               /expansionFactor                    &
+                        &              )**3
+                   a                 =+1.0d0+r        -(1.0d0+3.0d0*cosmologyFunctions_%equationOfStateDarkEnergy(time=timeEnergyFixed))*q/2.0d0
+                   b                 =      -r/z/2.0d0+(1.0d0+3.0d0*cosmologyFunctions_%equationOfStateDarkEnergy(time=time_          ))*q/y
+                end if
+                x      =+(0.0d0,0.5d0)*sqrt(3.0d0)                                                                          &
+                     &  *(                                                                                                  &
+                     &    +1.0d0/b*((54.0d0+6.0d0*sqrt(3.0d0)*sqrt((16.0d0*a**3+27.0d0*b)/b))*b**2)**(+1.0d0/3.0d0)/ 6.0d0  &
+                     &    +2.0d0*a*((54.0d0+6.0d0*sqrt(3.0d0)*sqrt((16.0d0*a**3+27.0d0*b)/b))*b**2)**(-1.0d0/3.0d0)         &
+                     &   )                                                                                                  &
+                     &  - (1.0d0/b*((54.0d0+6.0d0*sqrt(3.0d0)*sqrt((16.0d0*a**3+27.0d0*b)/b))*b**2)**(+1.0d0/3.0d0)/12.0d0) &
+                     &  + (      a*((54.0d0+6.0d0*sqrt(3.0d0)*sqrt((16.0d0*a**3+27.0d0*b)/b))*b**2)**(-1.0d0/3.0d0)       )
+                select case (calculationType%ID)
+                case (cllsnlssMttCsmlgclCnstntClcltnVirialDensityContrast%ID)
+                   ! The density contrast calculated as Δ=1/(x Rmax)³ is Δ=ρvir/⟨ρDM⟩ - i.e. the density of the virialized dark
+                   ! matter perturbation relative to the mean density of dark matter. However, what we want (for the definition used
+                   ! by Galacticus) is the density of the perturbation relative to the total mean density. So we perform that
+                   ! conversion here.
+                   call sphericalCollapse_%populate(                                            &
+                        &                           +(                                          &
+                        &                             +self%cosmologyParameters_%OmegaMatter()  &
+                        &                             -self%cosmologyParameters_%OmegaBaryon()  &
+                        &                            )                                          &
+                        &                           /  self%cosmologyParameters_%OmegaMatter()  &
+                        &                           /(dble(x)*radiusExpansionMaximum)**3      , &
+                        &                           iTime                                       &
+                        &                          )
+                case (cllsnlssMttCsmlgclCnstntClcltnRadiusTurnaround    %ID)
+                   call sphericalCollapse_%populate(                                            &
+                        &                           1.0d0/ dble(x)                            , &
+                        &                           iTime                                       &
+                        &                          )
+                end select
              end select
-          end select
-          !$omp atomic
-          iCount=iCount+1
+             !$omp atomic
+             iCount=iCount+1
+          end if
        end do
        !$omp end do
        !![

--- a/source/structure_formation.spherical_collapse.solver.collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation.spherical_collapse.solver.collisionlessMatter_cosmologicalConstant.F90
@@ -77,6 +77,7 @@
 
   ! Resolution of tabulated solutions.
   integer         , parameter :: tablePointsPerDecade=1000
+  integer         , parameter :: tablePointsPerOctave= 300
 
   ! Variables used in root finding.
   double precision            :: OmegaDarkEnergyEpochal, OmegaMatterEpochal, &
@@ -165,20 +166,24 @@ contains
     !!{
     Compute the critical overdensity for collapse for the spherical collapse model.
     !!}
-    use :: Error , only : errorStatusSuccess
-    use :: Tables, only : table1D
+    use :: Error         , only : errorStatusSuccess
+    use :: File_Utilities, only : File_Lock         , File_Unlock, lockDescriptor
+    use :: Tables        , only : table1D
     implicit none
     class           (sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt)             , intent(inout) :: self
     double precision                                                               , intent(in   ) :: time
     logical                                                                        , intent(in   ) :: tableStore
     class           (table1D                                         ), allocatable, intent(inout) :: criticalOverdensity_
     integer                                                                                        :: status
+    type            (lockDescriptor                                  )                             :: fileLock
 
+    if (tableStore) call File_Lock(char(self%fileNameCriticalOverdensity),fileLock,lockIsShared=.true.)
     call    self%restoreTable(time,criticalOverdensity_,self%fileNameCriticalOverdensity                 ,tableStore,status)
     if (status /= errorStatusSuccess) then
        call self%tabulate    (time,criticalOverdensity_,cllsnlssMttCsmlgclCnstntClcltnCriticalOverdensity                  )
        call self%storeTable  (     criticalOverdensity_,self%fileNameCriticalOverdensity                 ,tableStore       )
     end if
+    if (tableStore) call File_Unlock(fileLock)
     return
   end subroutine cllsnlssMttCsmlgclCnstntCriticalOverdensity
 
@@ -186,20 +191,24 @@ contains
     !!{
     Tabulate the virial density contrast for the spherical collapse model.
     !!}
-    use :: Error , only : errorStatusSuccess
-    use :: Tables, only : table1D
+    use :: Error         , only : errorStatusSuccess
+    use :: File_Utilities, only : File_Lock         , File_Unlock, lockDescriptor
+    use :: Tables        , only : table1D
     implicit none
     class           (sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt)             , intent(inout) :: self
     double precision                                                               , intent(in   ) :: time
     logical                                                                        , intent(in   ) :: tableStore
     class           (table1D                                         ), allocatable, intent(inout) :: virialDensityContrast_
     integer                                                                                        :: status
+    type            (lockDescriptor                                  )                             :: fileLock
 
+    if (tableStore) call File_Lock(char(self%fileNameVirialDensityContrast),fileLock,lockIsShared=.true.)
     call    self%restoreTable(time,virialDensityContrast_,self%fileNameVirialDensityContrast                 ,tableStore,status)
     if (status /= errorStatusSuccess) then
        call self%tabulate    (time,virialDensityContrast_,cllsnlssMttCsmlgclCnstntClcltnVirialDensityContrast                  )
        call self%storeTable  (     virialDensityContrast_,self%fileNameVirialDensityContrast                 ,tableStore       )
     end if
+    if (tableStore) call File_Unlock(fileLock)
     return
   end subroutine cllsnlssMttCsmlgclCnstntVirialDensityContrast
 
@@ -207,20 +216,24 @@ contains
     !!{
     Tabulate the ratio of turnaround to virial radii for the spherical collapse model.
     !!}
-    use :: Error , only : errorStatusSuccess
-    use :: Tables, only : table1D
+    use :: Error         , only : errorStatusSuccess
+    use :: File_Utilities, only : File_Lock         , File_Unlock, lockDescriptor
+    use :: Tables        , only : table1D
     implicit none
     class           (sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt)             , intent(inout) :: self
     double precision                                                               , intent(in   ) :: time
     logical                                                                        , intent(in   ) :: tableStore
     class           (table1D                                         ), allocatable, intent(inout) :: radiusTurnaround_
     integer                                                                                        :: status
+    type            (lockDescriptor                                  )                             :: fileLock
 
+    if (tableStore) call File_Lock(char(self%fileNameRadiusTurnaround),fileLock,lockIsShared=.true.)
     call    self%restoreTable(time,radiusTurnaround_,self%fileNameRadiusTurnaround                 ,tableStore,status)
     if (status /= errorStatusSuccess) then
        call self%tabulate    (time,radiusTurnaround_,cllsnlssMttCsmlgclCnstntClcltnRadiusTurnaround                  )
        call self%storeTable  (     radiusTurnaround_,self%fileNameRadiusTurnaround                 ,tableStore       )
     end if
+    if (tableStore) call File_Unlock(fileLock)
     return
   end subroutine cllsnlssMttCsmlgclCnstntRadiusTurnaround
 
@@ -803,8 +816,8 @@ contains
     !!{
     Attempt to restore a table from file.
     !!}
-    use :: File_Utilities    , only : File_Exists    , File_Lock               , File_Unlock, lockDescriptor
     use :: Error             , only : errorStatusFail, errorStatusSuccess
+    use :: File_Utilities    , only : File_Exists
     use :: HDF5_Access       , only : hdf5Access
     use :: IO_HDF5           , only : hdf5Object
     use :: ISO_Varying_String, only : char           , varying_string
@@ -818,14 +831,11 @@ contains
     integer                                                                        , intent(  out) :: status
     type            (hdf5Object                                      )                             :: file
     double precision                                                  , allocatable, dimension(:)  :: timeTable    , valueTable
-    type            (lockDescriptor                                  )                             :: fileLock
     !$GLC attributes unused :: self
 
     status=errorStatusFail
     if (.not.tableStore) return
     if (File_Exists(fileName)) then
-       ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
-       call File_Lock(char(fileName),fileLock,lockIsShared=.true.)
        !$ call hdf5Access%set()
        call file%openFile(char(fileName))
        call file%readDataset('time',timeTable)
@@ -850,7 +860,6 @@ contains
        end if
        call file%close()
        !$ call hdf5Access%unset()
-       call File_Unlock(fileLock)
     end if
     return
   end subroutine cllsnlssMttCsmlgclCnstntRestoreTable
@@ -859,8 +868,7 @@ contains
     !!{
     Store a table to file.
     !!}
-    use :: File_Utilities    , only : Directory_Make, File_Lock     , File_Path, File_Unlock, &
-          &                           lockDescriptor
+    use :: File_Utilities    , only : Directory_Make, File_Path
     use :: HDF5_Access       , only : hdf5Access
     use :: IO_HDF5           , only : hdf5Object
     use :: ISO_Varying_String, only : char          , varying_string
@@ -871,19 +879,15 @@ contains
     type   (varying_string                                  ), intent(in   ) :: fileName
     logical                                                  , intent(in   ) :: tableStore
     type   (hdf5Object                                      )                :: file
-    type   (lockDescriptor                                  )                :: fileLock
     !$GLC attributes unused :: self
 
     if (.not.tableStore) return
     call Directory_Make(char(File_Path(char(fileName))))
-    ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
-    call File_Lock     (char(fileName),fileLock,lockIsShared=.false.)
     !$ call hdf5Access%set()
     call file%openFile    (char   (fileName                           )        ,overWrite=.true.,readOnly=.false.)
     call file%writeDataset(        storeTable%xs()                     ,'time'                                   )
     call file%writeDataset(reshape(storeTable%ys(),[storeTable%size()]),'value'                                  )
     call file%close       (                                                                                      )
     !$ call hdf5Access%unset()
-    call File_Unlock(fileLock)
     return
   end subroutine cllsnlssMttCsmlgclCnstntStoreTable

--- a/source/structure_formation.spherical_collapse.solver.collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation.spherical_collapse.solver.collisionlessMatter_cosmologicalConstant.F90
@@ -167,7 +167,8 @@ contains
     Compute the critical overdensity for collapse for the spherical collapse model.
     !!}
     use :: Error         , only : errorStatusSuccess
-    use :: File_Utilities, only : File_Lock         , File_Unlock, lockDescriptor
+    use :: File_Utilities, only : File_Lock         , File_Unlock, lockDescriptor, Directory_Make, &
+         &                        File_Path
     use :: Tables        , only : table1D
     implicit none
     class           (sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt)             , intent(inout) :: self
@@ -177,7 +178,10 @@ contains
     integer                                                                                        :: status
     type            (lockDescriptor                                  )                             :: fileLock
 
-    if (tableStore) call File_Lock(char(self%fileNameCriticalOverdensity),fileLock,lockIsShared=.true.)
+    if (tableStore) then
+       call Directory_Make(char(File_Path(char(self%fileNameCriticalOverdensity)))                             )
+       call File_Lock     (               char(self%fileNameCriticalOverdensity)  ,fileLock,lockIsShared=.true.)
+    end if
     call    self%restoreTable(time,criticalOverdensity_,self%fileNameCriticalOverdensity                 ,tableStore,status)
     if (status /= errorStatusSuccess) then
        call self%tabulate    (time,criticalOverdensity_,cllsnlssMttCsmlgclCnstntClcltnCriticalOverdensity                  )
@@ -192,7 +196,8 @@ contains
     Tabulate the virial density contrast for the spherical collapse model.
     !!}
     use :: Error         , only : errorStatusSuccess
-    use :: File_Utilities, only : File_Lock         , File_Unlock, lockDescriptor
+    use :: File_Utilities, only : File_Lock         , File_Unlock, lockDescriptor, Directory_Make, &
+         &                        File_Path
     use :: Tables        , only : table1D
     implicit none
     class           (sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt)             , intent(inout) :: self
@@ -202,7 +207,10 @@ contains
     integer                                                                                        :: status
     type            (lockDescriptor                                  )                             :: fileLock
 
-    if (tableStore) call File_Lock(char(self%fileNameVirialDensityContrast),fileLock,lockIsShared=.true.)
+    if (tableStore) then
+       call Directory_Make(char(File_Path(char(self%fileNameVirialDensityContrast)))                             )
+       call File_Lock     (               char(self%fileNameVirialDensityContrast)  ,fileLock,lockIsShared=.true.)
+    end if
     call    self%restoreTable(time,virialDensityContrast_,self%fileNameVirialDensityContrast                 ,tableStore,status)
     if (status /= errorStatusSuccess) then
        call self%tabulate    (time,virialDensityContrast_,cllsnlssMttCsmlgclCnstntClcltnVirialDensityContrast                  )
@@ -217,7 +225,8 @@ contains
     Tabulate the ratio of turnaround to virial radii for the spherical collapse model.
     !!}
     use :: Error         , only : errorStatusSuccess
-    use :: File_Utilities, only : File_Lock         , File_Unlock, lockDescriptor
+    use :: File_Utilities, only : File_Lock         , File_Unlock, lockDescriptor, Directory_Make, &
+         &                        File_Path
     use :: Tables        , only : table1D
     implicit none
     class           (sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt)             , intent(inout) :: self
@@ -227,7 +236,10 @@ contains
     integer                                                                                        :: status
     type            (lockDescriptor                                  )                             :: fileLock
 
-    if (tableStore) call File_Lock(char(self%fileNameRadiusTurnaround),fileLock,lockIsShared=.true.)
+    if (tableStore) then
+       call Directory_Make(char(File_Path(char(self%fileNameRadiusTurnaround)))                             )
+       call File_Lock     (               char(self%fileNameRadiusTurnaround)  ,fileLock,lockIsShared=.true.)
+    end if
     call    self%restoreTable(time,radiusTurnaround_,self%fileNameRadiusTurnaround                 ,tableStore,status)
     if (status /= errorStatusSuccess) then
        call self%tabulate    (time,radiusTurnaround_,cllsnlssMttCsmlgclCnstntClcltnRadiusTurnaround                  )

--- a/source/tests.spherical_collapse.baryons_dark_matter.F90
+++ b/source/tests.spherical_collapse.baryons_dark_matter.F90
@@ -183,6 +183,7 @@ program Tests_Spherical_Collapse_Baryons_Dark_Matter
           &                                                                                                                      darkMatterParticle_                =darkMatterParticleCDM_                     , &
           &                                                                                                                      intergalacticMediumFilteringMass_  =intergalacticMediumFilteringMassGnedin2000_, &
           &                                                                                                                      tableStore                         =.false.                                    , &
+          &                                                                                                                      energyFixedAt                      =cllsnlssMttrDarkEnergyFixedAtTurnaround    , &
           &                                                                                                                      normalization                      =1.0d0                                        &
           &                                                                                                                     )
      virialDensityContrastSphrclCllpsCllsnlssMttrCsmlgclCnstnt_ =virialDensityContrastSphericalCollapseClsnlssMttrCsmlgclCnstnt(                                                                                  &


### PR DESCRIPTION
* Force use of a finer-grained `CAMB` solution when solving for the linear growth of perturbations including baryons. This avoids problems in integrating over the power spectrum when a coarser-grained solution was used.
* Optimize retabulation of spherical collapse solution when including baryons. When retabulating these solutions, values from the prior solution (if available) are now re-used to avoid wasting time recomputing them.
* Avoid race conditions in file locking for spherical collapse solutions. Previously, testing for the existance/extent of a pre-existing solution file, and the subsequent (re)build of the solution were done within separate locks, allowing for a race condition.
* Allow specification of `energyFixedAt` for the critical overdensity when including baryons in large-scale structure calculations. This parameter is irrelevant to the critical overdensity calculation. However, by allowing it to be set, it will default to the same choice as used for the virial density contrast, which will permit some optimization.