### PR TITLE
On recent MacOS must include `stdlib.h` prior to `malloc.h`

### DIFF
--- a/source/utility.memory_reporting.mallinfo2.c
+++ b/source/utility.memory_reporting.mallinfo2.c
@@ -20,6 +20,7 @@
 //% Implements Fortran-callable wrappers around the Linux mallinfo2() function.
 
 #ifdef __APPLE__
+#include <stdlib.h>
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>


### PR DESCRIPTION
Failure to do so results in a problem in the pre-processor due to an undefined macro.