### PR TITLE
`satellite` components must be back-propagated during node promotion

### DIFF
--- a/source/merger_trees.construct.read.F90
+++ b/source/merger_trees.construct.read.F90
@@ -1619,6 +1619,7 @@ contains
          &                                                                                     nodeNew
     class           (nodeComponentBasic       ), pointer                                    :: basic
     integer         (c_size_t                 )                                             :: iNode
+    integer                                                                                 :: i
     logical                                                                                 :: isolatedProgenitorExists, nodeIsMostMassive, &
          &                                                                                     progenitorIsIsolated
     type            (progenitorIterator       )                                             :: progenitors
@@ -1672,6 +1673,12 @@ contains
                    if (isolatedProgenitorExists) then
                       allocate(nodeNew)
                       call nodeList(descendantNode%isolatedNodeIndex)%node%copyNodeTo(nodeNew)
+                      if (nodeNew%satelliteCount() > 0) then
+                         ! Remove any satellite component from the copied node - each branch should have only a single satellite.
+                         do i=nodeNew%satelliteCount(),1,-1
+                            call nodeNew%satelliteRemove(i)
+                         end do
+                      end if
                       nodeNew                                         %sibling        => nodeList(descendantNode%isolatedNodeIndex)%node%firstChild
                       nodeNew                                         %parent         => nodeList(descendantNode%isolatedNodeIndex)%node
                       nodeNew                                         %firstSatellite => null()

--- a/source/merger_trees.operators.prune_by_mass_and_time.F90
+++ b/source/merger_trees.operators.prune_by_mass_and_time.F90
@@ -136,9 +136,10 @@ contains
     ! Get the final output time.
     timeFinal=self%outputTimes_%time(self%outputTimes_%count())    
     ! Walk the trees.
-    treeWalker   =  mergerTreeWalkerIsolatedNodes(tree,spanForest=.true.)
-    nodesRemain  =  treeWalker%next(node)
-    nodeRootHead => null()
+    treeWalker      =  mergerTreeWalkerIsolatedNodes(tree,spanForest=.true.)
+    nodesRemain     =  treeWalker%next(node)
+    nodeRootHead    => null()
+    nodeRootCurrent => null()
     do while (nodesRemain)
        nodesRemain=treeWalker%next(nodeNext)
        ! Skip nodes with no child

--- a/source/merger_trees.pruning.utilities.F90
+++ b/source/merger_trees.pruning.utilities.F90
@@ -61,48 +61,55 @@ contains
     return
   end subroutine Merger_Tree_Prune_Clean_Branch
 
-  subroutine Merger_Tree_Prune_Unlink_Parent(node,parentNode,parentWillBePruned,preservePrimaryProgenitor)
+  subroutine Merger_Tree_Prune_Unlink_Parent(node,nodeParent,parentWillBePruned,preservePrimaryProgenitor)
     !!{
     Unlink a parent node from a tree branch which is about to be pruned.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
     implicit none
-    type   (treeNode          ), intent(inout), pointer :: node              , parentNode
+    type   (treeNode          ), intent(inout), pointer :: node              , nodeParent
     logical                    , intent(in   )          :: parentWillBePruned, preservePrimaryProgenitor
-    type   (treeNode          ), pointer                :: newNode           , workNode
-    class  (nodeComponentBasic), pointer                :: newBasic
-
+    type   (treeNode          ), pointer                :: nodeNew           , nodeWork
+    class  (nodeComponentBasic), pointer                :: basicNew
+    integer                                             :: i
+    
     ! Check primary progenitor status.
-    if (node%isPrimaryProgenitorOf(parentNode)) then
+    if (node%isPrimaryProgenitorOf(nodeParent)) then
        ! Node is primary progenitor - we must check if the parent will be pruned also.
        if (parentWillBePruned.or..not.preservePrimaryProgenitor) then
           ! Parent will eventually be pruned - simply replace the current first child (about to pruned) with its
           ! sibling. Alternatively, we've been asked to not preserve primary progenitor status by inserting cloned nodes.
-          parentNode%firstChild => node%sibling
+          nodeParent%firstChild => node%sibling
        else
           ! Parent will not be pruned. Insert a clone of the parent as its own first progenitor to prevent any siblings of the
           ! to-be-pruned branch being misidentified as the primary progenitor.
-          allocate(newNode)
-          call parentNode%copyNodeTo(newNode)
-          newNode%sibling        => node%sibling
-          newNode%parent         => parentNode
-          parentNode%firstChild  => newNode
-          newNode%firstChild     => null()
-          newNode%event          => null()
-          newNode%firstSatellite => null()
-          newNode%firstMergee    => null()
-          newNode%mergeTarget    => null()
-          newNode%siblingMergee  => null()
-          newBasic               => newNode%basic()
-          call newBasic%timeSet(newBasic%time()*(1.0d0-1.0d-6))
+          allocate(nodeNew)
+          call nodeParent%copyNodeTo(nodeNew)
+          nodeNew%sibling        => node%sibling
+          nodeNew%parent         => nodeParent
+          nodeParent%firstChild  => nodeNew
+          nodeNew%firstChild     => null()
+          nodeNew%event          => null()
+          nodeNew%firstSatellite => null()
+          nodeNew%firstMergee    => null()
+          nodeNew%mergeTarget    => null()
+          nodeNew%siblingMergee  => null()
+          basicNew               => nodeNew%basic()
+          call basicNew%timeSet(basicNew%time()*(1.0d0-1.0d-6))
+          if (nodeNew%satelliteCount() > 0) then
+             ! Remove any satellite component from the copied node - each branch should have only a single satellite.
+             do i=nodeNew%satelliteCount(),1,-1
+                call nodeNew%satelliteRemove(i)
+             end do
+          end if          
        end if
     else
        ! Node to be pruned is not the primary progenitor - simply unlink it from its siblings.
-       workNode => parentNode%firstChild
-       do while (.not.associated(workNode%sibling,node))
-          workNode => workNode%sibling
+       nodeWork => nodeParent%firstChild
+       do while (.not.associated(nodeWork%sibling,node))
+          nodeWork => nodeWork%sibling
        end do
-       workNode%sibling => node%sibling
+       nodeWork%sibling => node%sibling
     end if
     return
   end subroutine Merger_Tree_Prune_Unlink_Parent

--- a/testSuite/validate-PonosV.pl
+++ b/testSuite/validate-PonosV.pl
@@ -18,8 +18,8 @@ system("mkdir -p outputs/");
 # Run the validate model.
 system("cd ..; export OMP_NUM_THREADS=2; ./Galacticus.exe testSuite/parameters/validate_PonosV.xml");
 unless ( $? == 0 ) {
-    print "FAIL: PonosV validation model failed to run\n";
-    exit;
+   print "FAIL: PonosV validation model failed to run\n";
+   exit;
 }
 
 # Read data.
@@ -140,8 +140,11 @@ my $statusSurfaceDensity = ($percentageAbove > 5.0 || $percentageBelow > 5.0) ? 
 print $statusSurfaceDensity.": Percentage of realizations above/below the PonosV subhalo surface density: ".sprintf("%5.1f",$percentageAbove)."/".sprintf("%5.1f",$percentageBelow)."\n";
 
 # Compute the mean slope of the subhalo mass function, and report.
-my $alpha = -log($subhaloSurfaceDensity8->average()         /$subhaloSurfaceDensity9->average()         )
-    /log(sqrt($massBoundMinimum8*$massBoundMaximum8)/sqrt($massBoundMinimum9*$massBoundMaximum9));
+# We exclude models for which there are no subhalos present in one of the mass cuts. This probably introduces some bias.
+my $nonZero     = which(($subhaloSurfaceDensity8 > 0.0) & ($subhaloSurfaceDensity9 > 0.0));
+my $alphas      = -log($subhaloSurfaceDensity8->($nonZero)        /$subhaloSurfaceDensity9->($nonZero)        )
+                  /log(sqrt($massBoundMinimum8*$massBoundMaximum8)/sqrt($massBoundMinimum9*$massBoundMaximum9));
+my $alpha       = $alphas->average();
 my $statusSlope = abs($alpha-$alphaPonosV) < 0.2 ? "SUCCESS" : "FAIL";
 print $statusSlope.": Projected subhalo mass function slope Galacticus/PonosV: ".sprintf("%4.2f",$alpha)."/".sprintf("%4.2f",$alphaPonosV)."\n";
 


### PR DESCRIPTION
This is necessary as some operators cause orbits to be assigned to non-primary progenitor halos. Without back-propagation of the `satellite` component those orbits (and other satellite properties) will be lost when the primary progenitor of the halo is promoted to it (and, typically, a new orbit is then assigned, which will break the expected correlations between subhalo orbits and any properties of the host halo that depend on them).