### PR TITLE
Remove disk contribution to spheroid scales

### DIFF
--- a/source/merger_trees.node_evolver.standard.F90
+++ b/source/merger_trees.node_evolver.standard.F90
@@ -1033,18 +1033,18 @@ contains
     use, intrinsic :: ISO_C_Binding  , only : c_double           , c_int
     use            :: String_Handling, only : operator(//)
     implicit none
-    integer         (kind=c_int                   ), intent(in   )                                              :: status
-    real            (kind=c_double                ), intent(in   )                                              :: time
-    real            (kind=c_double                ), intent(in   ), dimension(:                               ) :: y
+    integer         (kind=c_int                   ), intent(in   )                                       :: status
+    real            (kind=c_double                ), intent(in   )                                       :: time
+    real            (kind=c_double                ), intent(in   ), dimension(:                        ) :: y
     real            (kind=c_double                )               , dimension(self_%propertyCountActive) :: dydt          , yError, &
-         &                                                                                                         yTolerance
-    type            (varying_string               )                                                             :: message       , line
-    integer                                                                                                     :: lengthMaximum
-    type            (enumerationVerbosityLevelType)                                                             :: verbosityLevel
-    integer         (c_size_t                     )                                                             :: i
-    character       (len =12                      )                                                             :: label
-    integer         (kind=c_int                   )                                                             :: odeStatus
-    double precision                                                                                            :: stepFactor
+         &                                                                                                  yTolerance
+    type            (varying_string               )                                                      :: message       , line
+    integer                                                                                              :: lengthMaximum
+    type            (enumerationVerbosityLevelType)                                                      :: verbosityLevel
+    integer         (c_size_t                     )                                                      :: i
+    character       (len =12                      )                                                      :: label
+    integer         (kind=c_int                   )                                                      :: odeStatus
+    double precision                                                                                     :: stepFactor
 
     ! Check if this is the final trial for this node.
     if (self_%trialCount == trialCountMaximum-1) then
@@ -1108,7 +1108,7 @@ contains
 
     forall(i=1:self_%propertyCountActive)
        standardODEStepTolerances(i)=+    self_%odeToleranceRelative     &
-            &                       *abs(propertyValues                   (i)) &
+            &                       *abs(      propertyValues      (i)) &
             &                       +    self_%odeToleranceAbsolute     &
             &                       *    self_%propertyScalesActive(i)
     end forall


### PR DESCRIPTION
Avoids inaccuracies in spheroid properties that can occur when a spheroid first begins to form in a disk.