### PR TITLE
Allow intergalactic background radiation to be fully specified in the parameter file

### DIFF
--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -39,8 +39,11 @@
   <componentSpin              value="vector" />
   
   <!-- Intergalactic background radiation -->
-  <radiationFieldIntergalacticBackground value="intergalacticBackgroundFile">
-    <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+  <radiationFieldIntergalacticBackground value="summation">
+    <radiationField value="cosmicMicrowaveBackground"/>
+    <radiationField value="intergalacticBackgroundFile">
+      <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+    </radiationField>
   </radiationFieldIntergalacticBackground>
 
   <!-- Halo accretion options -->

--- a/source/nodes.operators.physics.CGM.chemistry.F90
+++ b/source/nodes.operators.physics.CGM.chemistry.F90
@@ -28,7 +28,7 @@
   use :: Cosmology_Functions                   , only : cosmologyFunctionsClass
   use :: Dark_Matter_Halo_Scales               , only : darkMatterHaloScaleClass
   use :: Hot_Halo_Mass_Distributions           , only : hotHaloMassDistributionClass
-  use :: Radiation_Fields                      , only : radiationFieldClass                   , radiationFieldCosmicMicrowaveBackground, radiationFieldSummation, crossSectionFunctionTemplate
+  use :: Radiation_Fields                      , only : radiationFieldClass                   , crossSectionFunctionTemplate
   use :: Numerical_Constants_Physical          , only : plancksConstant                       , speedLight
   use :: Numerical_Constants_Units             , only : angstromsPerMeter                     , electronVolt
 
@@ -61,10 +61,10 @@
       zero.
     </description>
     <deepCopy>
-      <functionClass variables="radiation_, radiationCosmicMicrowaveBackground"/>
+      <functionClass variables="radiation_"/>
     </deepCopy>
     <stateStorable>
-      <functionClass variables="radiation_, radiationCosmicMicrowaveBackground"/>
+      <functionClass variables="radiation_"/>
     </stateStorable>
   </nodeOperator>
   !!]
@@ -81,9 +81,7 @@
      class           (darkMatterHaloScaleClass               ), pointer                   :: darkMatterHaloScale_               => null()
      class           (cosmologyFunctionsClass                ), pointer                   :: cosmologyFunctions_                => null()
      class           (hotHaloMassDistributionClass           ), pointer                   :: hotHaloMassDistribution_           => null()
-     type            (radiationFieldSummation                ), pointer                   :: radiation_                         => null()
-     type            (radiationFieldCosmicMicrowaveBackground), pointer                   :: radiationCosmicMicrowaveBackground => null()
-     class           (radiationFieldClass                    ), pointer                   :: radiationIntergalacticBackground   => null()
+     class           (radiationFieldClass                    ), pointer                   :: radiation_                         => null()
      logical                                                  , allocatable, dimension(:) :: maskAnalytic
      integer                                                                              :: atomicHydrogenIndex                         , atomicHydrogenCationIndex, &
           &                                                                                  electronIndex
@@ -135,7 +133,7 @@ contains
     Constructor for the {\normalfont \ttfamily cgmChemistry} node operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
-    use :: Radiation_Fields, only : radiationFieldIntergalacticBackground
+    use :: Radiation_Fields, only : radiationFieldNull
     implicit none
     type            (nodeOperatorCGMChemistry              )                :: self
     type            (inputParameters                       ), intent(inout) :: parameters
@@ -145,7 +143,7 @@ contains
     class           (chemicalReactionRateClass             ), pointer       :: chemicalReactionRate_
     class           (darkMatterHaloScaleClass              ), pointer       :: darkMatterHaloScale_
     class           (cosmologyFunctionsClass               ), pointer       :: cosmologyFunctions_
-    class           (radiationFieldClass                   ), pointer       :: radiationIntergalacticBackground
+    class           (radiationFieldClass                   ), pointer       :: radiation_
     class           (hotHaloMassDistributionClass          ), pointer       :: hotHaloMassDistribution_
     double precision                                                        :: fractionTimescaleEquilibrium
 
@@ -166,24 +164,24 @@ contains
     !!]
     if (parameters%isPresent('radiationFieldIntergalacticBackground',searchInParents=.true.)) then
        !![
-       <objectBuilder class="radiationField" name="radiationIntergalacticBackground" parameterName="radiationFieldIntergalacticBackground" source="parameters"/>
+       <objectBuilder class="radiationField" name="radiation_" parameterName="radiationFieldIntergalacticBackground" source="parameters"/>
        !!]
-       select type (radiationIntergalacticBackground)
-       class is (radiationFieldIntergalacticBackground)
-          ! This is as expected.
-       class default
-          call Error_Report('radiation field is not of the intergalactic background class'//{introspection:location})
-       end select
     else
-       radiationIntergalacticBackground => null()
+       allocate(radiationFieldNull :: radiation_)
+       select type (radiation_)
+       type is (radiationFieldNull)
+          !![
+	  <referenceConstruct object="radiation_" constructor="radiationFieldNull()"/>
+          !!]
+       end select
     end if
-    self=nodeOperatorCGMChemistry(fractionTimescaleEquilibrium,atomicIonizationRateCollisional_,atomicRecombinationRateRadiative_,atomicCrossSectionIonizationPhoto_,chemicalReactionRate_,darkMatterHaloScale_,cosmologyFunctions_,hotHaloMassDistribution_,radiationIntergalacticBackground)
+    self=nodeOperatorCGMChemistry(fractionTimescaleEquilibrium,atomicIonizationRateCollisional_,atomicRecombinationRateRadiative_,atomicCrossSectionIonizationPhoto_,chemicalReactionRate_,darkMatterHaloScale_,cosmologyFunctions_,hotHaloMassDistribution_,radiation_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="chemicalReactionRate_"             />
     <objectDestructor name="darkMatterHaloScale_"              />
     <objectDestructor name="cosmologyFunctions_"               />
-    <objectDestructor name="radiationIntergalacticBackground"  />
+    <objectDestructor name="radiation_"                        />
     <objectDestructor name="atomicIonizationRateCollisional_"  />
     <objectDestructor name="atomicRecombinationRateRadiative_" />
     <objectDestructor name="atomicCrossSectionIonizationPhoto_"/>
@@ -192,27 +190,25 @@ contains
     return
   end function cgmChemistryConstructorParameters
 
-  function cgmChemistryConstructorInternal(fractionTimescaleEquilibrium,atomicIonizationRateCollisional_,atomicRecombinationRateRadiative_,atomicCrossSectionIonizationPhoto_,chemicalReactionRate_,darkMatterHaloScale_,cosmologyFunctions_,hotHaloMassDistribution_,radiationIntergalacticBackground) result(self)
+  function cgmChemistryConstructorInternal(fractionTimescaleEquilibrium,atomicIonizationRateCollisional_,atomicRecombinationRateRadiative_,atomicCrossSectionIonizationPhoto_,chemicalReactionRate_,darkMatterHaloScale_,cosmologyFunctions_,hotHaloMassDistribution_,radiation_) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily cgmChemistry} node operator class.
     !!}
-    use :: Radiation_Fields             , only : radiationFieldList
-    use :: Chemical_Abundances_Structure, only : Chemicals_Index   , Chemicals_Property_Count
+    use :: Chemical_Abundances_Structure, only : Chemicals_Index, Chemicals_Property_Count
     implicit none
-    type            (nodeOperatorCGMChemistry              )                         :: self
-    double precision                                        , intent(in   )          :: fractionTimescaleEquilibrium
-    class           (atomicIonizationRateCollisionalClass  ), intent(in   ), target  :: atomicIonizationRateCollisional_
-    class           (atomicRecombinationRateRadiativeClass ), intent(in   ), target  :: atomicRecombinationRateRadiative_
-    class           (atomicCrossSectionIonizationPhotoClass), intent(in   ), target  :: atomicCrossSectionIonizationPhoto_
-    class           (chemicalReactionRateClass             ), intent(in   ), target  :: chemicalReactionRate_
-    class           (darkMatterHaloScaleClass              ), intent(in   ), target  :: darkMatterHaloScale_
-    class           (cosmologyFunctionsClass               ), intent(in   ), target  :: cosmologyFunctions_
-    class           (hotHaloMassDistributionClass          ), intent(in   ), target  :: hotHaloMassDistribution_
-    class           (radiationFieldClass                   ), intent(in   ), pointer :: radiationIntergalacticBackground
-    type            (radiationFieldList                    )               , pointer :: radiationFieldList_
+    type            (nodeOperatorCGMChemistry              )                        :: self
+    double precision                                        , intent(in   )         :: fractionTimescaleEquilibrium
+    class           (atomicIonizationRateCollisionalClass  ), intent(in   ), target :: atomicIonizationRateCollisional_
+    class           (atomicRecombinationRateRadiativeClass ), intent(in   ), target :: atomicRecombinationRateRadiative_
+    class           (atomicCrossSectionIonizationPhotoClass), intent(in   ), target :: atomicCrossSectionIonizationPhoto_
+    class           (chemicalReactionRateClass             ), intent(in   ), target :: chemicalReactionRate_
+    class           (darkMatterHaloScaleClass              ), intent(in   ), target :: darkMatterHaloScale_
+    class           (cosmologyFunctionsClass               ), intent(in   ), target :: cosmologyFunctions_
+    class           (hotHaloMassDistributionClass          ), intent(in   ), target :: hotHaloMassDistribution_
+    class           (radiationFieldClass                   ), intent(in   ), target :: radiation_
     !$GLC attributes initialized :: radiationIntergalacticBackground
     !![
-    <constructorAssign variables="fractionTimescaleEquilibrium, *atomicIonizationRateCollisional_, *atomicRecombinationRateRadiative_, *atomicCrossSectionIonizationPhoto_, *chemicalReactionRate_, *darkMatterHaloScale_, *cosmologyFunctions_, *hotHaloMassDistribution_, *radiationIntergalacticBackground"/>
+    <constructorAssign variables="fractionTimescaleEquilibrium, *atomicIonizationRateCollisional_, *atomicRecombinationRateRadiative_, *atomicCrossSectionIonizationPhoto_, *chemicalReactionRate_, *darkMatterHaloScale_, *cosmologyFunctions_, *hotHaloMassDistribution_, *radiation_"/>
     !!]
 
     ! Determine if chemicals are being solved for.
@@ -228,22 +224,6 @@ contains
     self%maskAnalytic(self%atomicHydrogenIndex      )=.true.
     self%maskAnalytic(self%atomicHydrogenCationIndex)=.true.
     self%maskAnalytic(self%electronIndex            )=.true.
-    ! Create radiation fields.
-    allocate(radiationFieldList_                    )
-    allocate(self%radiation_                        )
-    allocate(self%radiationCosmicMicrowaveBackground)
-    !![
-    <referenceConstruct owner="self" object="radiationCosmicMicrowaveBackground" constructor="radiationFieldCosmicMicrowaveBackground(cosmologyFunctions_)"/>
-    !!]
-    radiationFieldList_%radiationField_ => self%radiationCosmicMicrowaveBackground
-    if (associated(radiationIntergalacticBackground)) then
-       allocate(radiationFieldList_%next)
-       radiationFieldList_%next%radiationField_ => radiationIntergalacticBackground
-    end if
-    !![
-    <referenceConstruct owner="self" object="radiation_" constructor="radiationFieldSummation(radiationFieldList_)"/>
-    !!]
-    nullify(radiationFieldList_)
     return
   end function cgmChemistryConstructorInternal
   
@@ -259,8 +239,6 @@ contains
     <objectDestructor name="self%darkMatterHaloScale_"              />
     <objectDestructor name="self%cosmologyFunctions_"               />
     <objectDestructor name="self%radiation_"                        />
-    <objectDestructor name="self%radiationCosmicMicrowaveBackground"/>
-    <objectDestructor name="self%radiationIntergalacticBackground"  />
     <objectDestructor name="self%atomicIonizationRateCollisional_"  />
     <objectDestructor name="self%atomicRecombinationRateRadiative_" />
     <objectDestructor name="self%atomicCrossSectionIonizationPhoto_"/>
@@ -429,7 +407,6 @@ contains
     use :: Chemical_Abundances_Structure    , only : chemicalAbundances 
     use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Density_Conversion
     use :: Galacticus_Nodes                 , only : nodeComponentBasic                   , nodeComponentHotHalo
-    use :: Radiation_Fields                 , only : radiationFieldIntergalacticBackground
     implicit none
     class           (nodeOperatorCGMChemistry), intent(inout)           :: self
     type            (treeNode                ), intent(inout)           :: node
@@ -449,13 +426,7 @@ contains
     ! Get the temperature of the CGM.
     temperature=self%darkMatterHaloScale_%temperatureVirial(node)
     ! Set the radiation background.
-    call self%radiationCosmicMicrowaveBackground%timeSet(basic%time())
-    if (associated(self%radiationIntergalacticBackground)) then
-       select type (radiationIntergalacticBackground => self%radiationIntergalacticBackground)
-       class is (radiationFieldIntergalacticBackground)
-          call radiationIntergalacticBackground%timeSet(basic%time())
-       end select
-    end if
+    call self%radiation_%timeSet(basic%time())
     ! Get the masses of chemicals.
     chemicalMasses=hotHalo%chemicals()
     ! Truncate masses to zero to avoid unphysical behavior.

--- a/source/objects.nodes.components.hot_halo.standard.F90
+++ b/source/objects.nodes.components.hot_halo.standard.F90
@@ -40,7 +40,7 @@ module Node_Component_Hot_Halo_Standard
   use :: Hot_Halo_Ram_Pressure_Stripping           , only : hotHaloRamPressureStrippingClass
   use :: Hot_Halo_Ram_Pressure_Stripping_Timescales, only : hotHaloRamPressureTimescaleClass
   use :: Kind_Numbers                              , only : kind_int8
-  use :: Radiation_Fields                          , only : radiationFieldClass                , radiationFieldCosmicMicrowaveBackground, radiationFieldList, radiationFieldSummation
+  use :: Radiation_Fields                          , only : radiationFieldClass
   implicit none
   private
   public :: Node_Component_Hot_Halo_Standard_Initialize  , Node_Component_Hot_Halo_Standard_Thread_Initialize  , &
@@ -267,11 +267,8 @@ module Node_Component_Hot_Halo_Standard
        &                                                                 massHeatingRateRemaining                   , outerRadiusGrowthRateStored
   !$omp threadprivate(gotCoolingRate,gotAngularMomentumCoolingRate,gotOuterRadiusGrowthRate,rateCooling,massHeatingRateRemaining,angularMomentumHeatingRateRemaining,outerRadiusGrowthRateStored,uniqueIDPrevious)
   ! Radiation structure.
-  type           (radiationFieldSummation                ), pointer   :: radiation
-  type           (radiationFieldCosmicMicrowaveBackground), pointer   :: radiationCosmicMicrowaveBackground
-  class          (radiationFieldClass                    ), pointer   :: radiationIntergalacticBackground
-  type           (radiationFieldList                     ), pointer   :: radiationFieldList_
-  !$omp threadprivate(radiation,radiationCosmicMicrowaveBackground,radiationIntergalacticBackground,radiationFieldList_)
+  class           (radiationFieldClass                   ), pointer   :: radiation
+  !$omp threadprivate(radiation)
 
   ! Tracked properties control.
   logical                                                             :: trackStrippedGas
@@ -472,12 +469,12 @@ contains
     !!{
     Initializes the tree node hot halo methods module.
     !!}
-    use :: Events_Hooks    , only : nodePromotionEvent                   , satelliteMergerEvent    , postEvolveEvent   , openMPThreadBindingAtLevel, &
-         &                          dependencyRegEx                      , dependencyDirectionAfter, haloFormationEvent
+    use :: Events_Hooks    , only : nodePromotionEvent     , satelliteMergerEvent    , postEvolveEvent   , openMPThreadBindingAtLevel, &
+         &                          dependencyRegEx        , dependencyDirectionAfter, haloFormationEvent
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : defaultHotHaloComponent
-    use :: Input_Parameters, only : inputParameter                       , inputParameters
-    use :: Radiation_Fields, only : radiationFieldIntergalacticBackground
+    use :: Input_Parameters, only : inputParameter         , inputParameters
+    use :: Radiation_Fields, only : radiationFieldNull
     implicit none
     type(inputParameters), intent(inout) :: parameters
     type(dependencyRegEx), dimension(1)  :: dependencies
@@ -507,32 +504,19 @@ contains
        call satelliteMergerEvent%attach(thread,satelliteMerger,openMPThreadBindingAtLevel,label='nodeComponentHotHaloStandard',dependencies=dependencies)
        call postEvolveEvent     %attach(thread,postEvolve     ,openMPThreadBindingAtLevel,label='nodeComponentHotHaloStandard'                          )
        call haloFormationEvent  %attach(thread,haloFormation  ,openMPThreadBindingAtLevel,label='nodeComponentHotHaloStandard'                          )
-       allocate(radiation                         )
-       allocate(radiationFieldList_               )
-       allocate(radiationCosmicMicrowaveBackground)
-       !![
-       <referenceConstruct object="radiationCosmicMicrowaveBackground" constructor="radiationFieldCosmicMicrowaveBackground(cosmologyFunctions_)"/>
-       !!]
-       radiationFieldList_%radiationField_ => radiationCosmicMicrowaveBackground
        if (parameters%isPresent('radiationFieldIntergalacticBackground')) then
           !![
-          <objectBuilder class="radiationField" name="radiationIntergalacticBackground" parameterName="radiationFieldIntergalacticBackground" source="parameters"/>
+          <objectBuilder class="radiationField" name="radiation" parameterName="radiationFieldIntergalacticBackground" source="parameters"/>
           !!]
-          select type (radiationIntergalacticBackground)
-          class is (radiationFieldIntergalacticBackground)
-             ! This is as expected.
-          class default
-             call Error_Report('radiation field is not of the intergalactic background class'//{introspection:location})
-          end select
-          allocate(radiationFieldList_%next)
-          radiationFieldList_%next%radiationField_ => radiationIntergalacticBackground
        else
-          radiationIntergalacticBackground => null()
+          allocate(radiationFieldNull :: radiation)
+          select type (radiation)
+          type is (radiationFieldNull)
+             !![
+	     <referenceConstruct object="radiation" constructor="radiationFieldNull()"/>
+             !!]
+          end select
        end if
-       !![
-       <referenceConstruct object="radiation" constructor="radiationFieldSummation(radiationFieldList_)"/>
-       !!]
-       nullify(radiationFieldList_)
     end if
     return
   end subroutine Node_Component_Hot_Halo_Standard_Thread_Initialize
@@ -564,8 +548,6 @@ contains
        <objectDestructor name="hotHaloRamPressureTimescale_"      />
        <objectDestructor name="hotHaloOutflowReincorporation_"    />
        <objectDestructor name="coolingRate_"                      />
-       <objectDestructor name="radiationIntergalacticBackground"  />
-       <objectDestructor name="radiationCosmicMicrowaveBackground"/>
        <objectDestructor name="radiation"                         />
        <objectDestructor name="galacticStructure_"                />
        !!]
@@ -1072,7 +1054,6 @@ contains
     use :: Galacticus_Nodes                 , only : interruptTask                        , nodeComponentHotHalo, nodeComponentHotHaloStandard, nodeComponentBasic, &
          &                                           treeNode
     use :: Numerical_Constants_Atomic       , only : atomicMassHydrogen
-    use :: Radiation_Fields                 , only : radiationFieldIntergalacticBackground
     implicit none
     class           (nodeComponentHotHalo), intent(inout)                    :: self
     double precision                      , intent(in   )                    :: rate
@@ -1115,13 +1096,7 @@ contains
           temperature            =darkMatterHaloScale_%temperatureVirial(node)
           numberDensityHydrogen  =hydrogenByMass*self%outflowedMass()*massToDensityConversion/atomicMassHydrogen
           ! Set the radiation field.
-          call radiationCosmicMicrowaveBackground%timeSet(basic%time())
-          if (associated(radiationIntergalacticBackground)) then
-             select type (radiationIntergalacticBackground)
-             class is (radiationFieldIntergalacticBackground)
-                call radiationIntergalacticBackground%timeSet(basic%time())
-             end select
-          end if
+          call radiation%timeSet(basic%time())
           ! Get the chemical densities.
           call chemicalState_%chemicalDensities(chemicalDensities,numberDensityHydrogen,temperature,outflowedAbundances,radiation)
           ! Convert from densities to mass rates.
@@ -2103,13 +2078,12 @@ contains
     !!{
     Updates the hot halo gas distribution at a formation event, if requested.
     !!}
-    use :: Abundances_Structure                 , only : abundances                           , zeroAbundances
-    use :: Chemical_Abundances_Structure        , only : chemicalAbundances                   , zeroChemicalAbundances
+    use :: Abundances_Structure                 , only : abundances                          , zeroAbundances
+    use :: Chemical_Abundances_Structure        , only : chemicalAbundances                  , zeroChemicalAbundances
     use :: Chemical_Reaction_Rates_Utilities    , only : Chemicals_Mass_To_Density_Conversion
-    use :: Galacticus_Nodes                     , only : nodeComponentBasic                   , nodeComponentHotHalo  , nodeComponentHotHaloStandard, treeNode
+    use :: Galacticus_Nodes                     , only : nodeComponentBasic                  , nodeComponentHotHalo  , nodeComponentHotHaloStandard, treeNode
     use :: Node_Component_Hot_Halo_Standard_Data, only : outflowReturnOnFormation
     use :: Numerical_Constants_Atomic           , only : atomicMassHydrogen
-    use :: Radiation_Fields                     , only : radiationFieldIntergalacticBackground
     implicit none
     class           (*                   ), intent(inout) :: self
     type            (treeNode            ), intent(inout) :: node
@@ -2145,13 +2119,7 @@ contains
           numberDensityHydrogen=hydrogenByMass*hotHalo%outflowedMass()*massToDensityConversion/atomicMassHydrogen
           ! Set the radiation field.
           basic => node%basic()
-          call radiationCosmicMicrowaveBackground%timeSet(basic%time())
-          if (associated(radiationIntergalacticBackground)) then
-             select type (radiationIntergalacticBackground)
-             class is (radiationFieldIntergalacticBackground)
-                call radiationIntergalacticBackground%timeSet(basic%time())
-             end select
-          end if
+          call radiation%timeSet(basic%time())
            ! Get the chemical densities.
           call chemicalState_%chemicalDensities(chemicalDensities,numberDensityHydrogen,temperature,outflowedAbundances,radiation)
           ! Convert from densities to masses.

--- a/source/universe.operators.intergalactic_medium_state_evolve.F90
+++ b/source/universe.operators.intergalactic_medium_state_evolve.F90
@@ -157,12 +157,6 @@ contains
     <objectBuilder class="intergalacticMediumState"                name="intergalacticMediumState_"                source="parameters"                                                      />
     <objectBuilder class="radiationField"                          name="radiationField_"                          source="parameters" parameterName="radiationFieldIntergalacticBackground"/>
     !!]
-    select type (radiationField_)
-    class is (radiationFieldIntergalacticBackground)
-       ! This is as expected.
-    class default
-       call Error_Report('radiation field is not of the intergalactic background class'//{introspection:location})
-    end select
     timeMinimum=cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(redshiftMaximum))
     timeMaximum=cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(redshiftMinimum))
     self=universeOperatorIntergalacticMediumStateEvolve(timeMinimum,timeMaximum,timeCountPerDecade,cosmologyParameters_,cosmologyFunctions_,linearGrowth_,cosmologicalMassVariance_,outputTimes_,gauntFactor_,atomicCrossSectionIonizationPhoto_,atomicIonizationPotential_,atomicRecombinationRateDielectronic_,atomicRecombinationRateRadiative_,atomicRecombinationRateRadiativeCooling_,atomicIonizationRateCollisional_,atomicExcitationRateCollisional_,intergalacticMediumState_,radiationField_)
@@ -739,10 +733,7 @@ contains
               recombinationDielectronicRateTo  =+0.0d0
            end if
            ! Set the epoch for the intergalactic background radiation field.
-           select type (radiationField_ => self_%radiationField_)
-           class is (radiationFieldIntergalacticBackground)
-              call radiationField_%timeSet(time)
-           end select
+           call self_%radiationField_%timeSet(time)
            ! Compute rate of photoionizations from this ion.
            if (electronNumber  > 0) then
               ! Set the ground state for this photoionization calculation.

--- a/testSuite/parameters/checkpointingCheckpoints.xml
+++ b/testSuite/parameters/checkpointingCheckpoints.xml
@@ -35,10 +35,13 @@
   </spheroidMassDistribution>
 
   <!-- Intergalactic background radiation -->
-  <radiationFieldIntergalacticBackground value="intergalacticBackgroundFile">
-    <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+  <radiationFieldIntergalacticBackground value="summation">
+    <radiationField value="cosmicMicrowaveBackground"/>
+    <radiationField value="intergalacticBackgroundFile">
+      <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+    </radiationField>
   </radiationFieldIntergalacticBackground>
-
+  
   <!-- Dark matter particle type -->
   <darkMatterParticle value="CDM"/>
 

--- a/testSuite/parameters/checkpointingNoCheckpoints.xml
+++ b/testSuite/parameters/checkpointingNoCheckpoints.xml
@@ -34,8 +34,11 @@
   </spheroidMassDistribution>
 
   <!-- Intergalactic background radiation -->
-  <radiationFieldIntergalacticBackground value="intergalacticBackgroundFile">
-    <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+  <radiationFieldIntergalacticBackground value="summation">
+    <radiationField value="cosmicMicrowaveBackground"/>
+    <radiationField value="intergalacticBackgroundFile">
+      <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+    </radiationField>
   </radiationFieldIntergalacticBackground>
 
   <!-- Dark matter particle type -->

--- a/testSuite/parameters/checkpointingResume.xml
+++ b/testSuite/parameters/checkpointingResume.xml
@@ -34,8 +34,11 @@
   </spheroidMassDistribution>
 
   <!-- Intergalactic background radiation -->
-  <radiationFieldIntergalacticBackground value="intergalacticBackgroundFile">
-    <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+  <radiationFieldIntergalacticBackground value="summation">
+    <radiationField value="cosmicMicrowaveBackground"/>
+    <radiationField value="intergalacticBackgroundFile">
+      <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+    </radiationField>
   </radiationFieldIntergalacticBackground>
 
   <!-- Dark matter particle type -->

--- a/testSuite/regressions/adaptiveSFHLengths.xml
+++ b/testSuite/regressions/adaptiveSFHLengths.xml
@@ -105,8 +105,11 @@
   </mergerTreeOperator>
 
 
-  <radiationFieldIntergalacticBackground value="intergalacticBackgroundFile">
-    <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+  <radiationFieldIntergalacticBackground value="summation">
+    <radiationField value="cosmicMicrowaveBackground"/>
+    <radiationField value="intergalacticBackgroundFile">
+      <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+    </radiationField>
   </radiationFieldIntergalacticBackground>
 
   

--- a/testSuite/regressions/issue142.xml
+++ b/testSuite/regressions/issue142.xml
@@ -421,9 +421,12 @@
   </universeOperator>    
 
   <!-- Background radiation -->
-  <radiationFieldIntergalacticBackground value="intergalacticBackgroundInternal">
-    <wavelengthCountPerDecade value="50"/>
-    <timeCountPerDecade value="10"/>
+  <radiationFieldIntergalacticBackground value="summation">
+    <radiationField value="cosmicMicrowaveBackground"/>
+    <radiationField value="intergalacticBackgroundInternal">
+      <wavelengthCountPerDecade value="50"/>
+      <timeCountPerDecade value="10"/>
+    </radiationField>
   </radiationFieldIntergalacticBackground>
 
   <!-- Halo accretion options -->

--- a/testSuite/regressions/outputRank2ExtendSegFault.xml
+++ b/testSuite/regressions/outputRank2ExtendSegFault.xml
@@ -102,8 +102,11 @@
   <mergerTreeOperator value="sequence">
     <mergerTreeOperator value="massAccretionHistory"/>
   </mergerTreeOperator>
-  <radiationFieldIntergalacticBackground value="intergalacticBackgroundFile">
-    <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+  <radiationFieldIntergalacticBackground value="summation">
+    <radiationField value="cosmicMicrowaveBackground"/>
+    <radiationField value="intergalacticBackgroundFile">
+      <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_FG20.hdf5"/>
+    </radiationField>
   </radiationFieldIntergalacticBackground>
   
   

--- a/testSuite/test-methods.xml
+++ b/testSuite/test-methods.xml
@@ -1354,9 +1354,12 @@
       <redshiftMaximum value="150"/>
     </universeOperator>
     <!-- Background radiation -->
-    <radiationFieldIntergalacticBackground value="intergalacticBackgroundInternal">
-      <wavelengthCountPerDecade value="5"/>
-      <timeCountPerDecade value="2"/>
+    <radiationFieldIntergalacticBackground value="summation">
+      <radiationField value="cosmicMicrowaveBackground"/>
+      <radiationField value="intergalacticBackgroundInternal">
+	<wavelengthCountPerDecade value="5"/>
+	<timeCountPerDecade value="2"/>
+      </radiationField>
     </radiationFieldIntergalacticBackground>
     <!-- Halo mass ranges -->
     <mergerTreeBuildMasses value="sampledDistributionUniform">


### PR DESCRIPTION
Cosmic microwave background radiation is no longer added internally. This allows more flexibility - the CMB can still be included in the parameter file.