### PR TITLE
Add a validation test for baryonic suppression of structure formation

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -743,6 +743,17 @@ jobs:
       uploadFile: ./testSuite/outputs/*.json
       uploadName: validate-PonosV
     secrets: inherit
+  Validate-Baryonic-Suppression:
+    needs: Build-Executable-Linux
+    uses: ./.github/workflows/testModel.yml
+    with:
+      file: validate-baryonicSuppression.pl
+      artifact: galacticus-exec
+      runPath: ./testSuite
+      cacheData: 0
+      uploadFile: ./testSuite/outputs/*.json
+      uploadName: validate-baryonicSuppression
+    secrets: inherit
   Validate-Idealized-Subhalo-Simulations:
     needs: Build-Executable-Linux
     uses: ./.github/workflows/testModel.yml
@@ -1342,7 +1353,7 @@ jobs:
   # Validate, deploy and update
   Validate:
     runs-on: ubuntu-latest
-    needs: [ Benchmark-Dark-Matter-Only-Subhalos, Benchmark-Milky-Way-Model, Validate-Dark-Matter-Only-Subhalos, Validate-Milky-Way-Model, Validate-PonosV, Validate-Idealized-Subhalo-Simulations ]
+    needs: [ Benchmark-Dark-Matter-Only-Subhalos, Benchmark-Milky-Way-Model, Validate-Dark-Matter-Only-Subhalos, Validate-Milky-Way-Model, Validate-PonosV, Validate-Baryonic-Suppression, Validate-Idealized-Subhalo-Simulations ]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -1454,6 +1465,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: validate-PonosV
+      - name: Download artifacts (validate-baryonicSuppression)
+        uses: actions/download-artifact@v4
+        with:
+          name: validate-baryonicSuppression
       - name: Download artifacts (build-profile)
         uses: actions/download-artifact@v4
         with:
@@ -1468,10 +1483,11 @@ jobs:
           mv results_darkMatterOnlySubhalos.json       dev/valid/darkMatterOnlySubhalos/results.json
           mv results_milkyWayModel.json                dev/valid/milkyWayModel/results.json
           mv results_PonosV.json                       dev/valid/strongLensing/results_PonosV.json
+          mv results_baryonicSuppression.json          dev/valid/baryonicSuppression/results_baryonicSuppression.json
           mv results_idealizedSubhaloSimulation_*.json dev/valid/idealizedSubhaloSimulations/
           git config --local user.email "github@users.noreply.github.com"
           git config --local user.name "github-action-validate"
-          git add dev/valid/darkMatterOnlySubhalos/results.json dev/valid/milkyWayModel/results.json dev/valid/strongLensing/results_PonosV.json dev/valid/idealizedSubhaloSimulations/results_idealizedSubhaloSimulation_*.json
+          git add dev/valid/darkMatterOnlySubhalos/results.json dev/valid/milkyWayModel/results.json dev/valid/strongLensing/results_PonosV.json dev/valid/baryonicSuppression/results_baryonicSuppression.json dev/valid/idealizedSubhaloSimulations/results_idealizedSubhaloSimulation_*.json
           git commit -m "Update validation results"
           git push --set-upstream origin gh-pages
           git checkout -

--- a/source/radiation.switch_on.F90
+++ b/source/radiation.switch_on.F90
@@ -1,0 +1,171 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a class that switches on a radiation field at a specified time.
+  !!}
+
+  use :: Cosmology_Functions, only : cosmologyFunctionsClass
+
+  !![
+  <radiationField name="radiationFieldSwitchOn">
+   <description>
+    A radiation field class that switches on another radiation field at a specified time.
+   </description>
+  </radiationField>
+  !!]
+  type, extends(radiationFieldIntergalacticBackground) :: radiationFieldSwitchOn
+     !!{
+     A radiation field class that switches on another radiation field at a specified time.
+     !!}
+     private
+     class           (cosmologyFunctionsClass), pointer :: cosmologyFunctions_ => null()
+     class           (radiationFieldClass    ), pointer :: radiationField_     => null()
+     double precision                                   :: redshiftSwitchOn             , timeSwitchOn, &
+          &                                                time_
+   contains
+     final     ::                      switchOnDestructor
+     procedure :: flux              => switchOnFlux
+     procedure :: time              => switchOnTime
+     procedure :: timeSet           => switchOnTimeSet
+     procedure :: timeDependentOnly => switchOnTimeDependentOnly
+  end type radiationFieldSwitchOn
+
+  interface radiationFieldSwitchOn
+     !!{
+     Constructors for the {\normalfont \ttfamily switchOn} radiation field class.
+     !!}
+     module procedure switchOnConstructorParameters
+     module procedure switchOnConstructorInternal
+  end interface radiationFieldSwitchOn
+
+contains
+
+  function switchOnConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily switchOn} radiation field class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (radiationFieldSwitchOn )                :: self
+    type            (inputParameters        ), intent(inout) :: parameters
+    class           (cosmologyFunctionsClass), pointer       :: cosmologyFunctions_
+    class           (radiationFieldClass    ), pointer       :: radiationField_
+    double precision                                         :: redshiftSwitchOn
+
+    !![
+    <inputParameter>
+      <name>redshiftSwitchOn</name>
+      <description>The redshift at which to switch on the radiation field.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="cosmologyFunctions" name="cosmologyFunctions_" source="parameters"/>
+    <objectBuilder class="radiationField"     name="radiationField_"     source="parameters"/>
+    !!]
+    self=radiationFieldSwitchOn(cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(redshiftSwitchOn)),radiationField_,cosmologyFunctions_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="cosmologyFunctions_"/>
+    <objectDestructor name="radiationField_"    />
+    !!]
+    return
+  end function switchOnConstructorParameters
+
+  function switchOnConstructorInternal(timeSwitchOn,radiationField_,cosmologyFunctions_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily switchOn} radiation field class.
+    !!}
+    implicit none
+    type            (radiationFieldSwitchOn )                        :: self
+    double precision                         , intent(in   )         :: timeSwitchOn
+    class           (cosmologyFunctionsClass), intent(in   ), target :: cosmologyFunctions_
+    class           (radiationFieldClass    ), intent(in   ), target :: radiationField_
+    !![
+    <constructorAssign variables="timeSwitchOn, *radiationField_, *cosmologyFunctions_"/>
+    !!]
+
+    self%redshiftSwitchOn=self%cosmologyFunctions_%redshiftFromExpansionFactor(self%cosmologyFunctions_%expansionFactor(timeSwitchOn))
+    return
+  end function switchOnConstructorInternal
+
+  subroutine switchOnDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily switchOn} radiation field class.
+    !!}
+    implicit none
+    type(radiationFieldSwitchOn), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%cosmologyFunctions_"/>
+    <objectDestructor name="self%radiationField_"    />
+    !!]
+    return
+  end subroutine switchOnDestructor
+
+  double precision function switchOnFlux(self,wavelength,node)
+    !!{
+    Return the flux in the radiation field.
+    !!}
+    implicit none
+    class           (radiationFieldSwitchOn), intent(inout)  :: self
+    double precision                        , intent(in   )  :: wavelength
+    type            (treeNode              ), intent(inout)  :: node
+
+    if (self%time_ < self%timeSwitchOn) then
+       switchOnFlux=0.0d0
+    else
+       switchOnFlux=self%radiationField_%flux(wavelength,node)
+    end if
+    return
+  end function switchOnFlux
+
+  double precision function switchOnTime(self)
+    !!{
+    Set the time of the radiation field.
+    !!}
+    implicit none
+    class(radiationFieldSwitchOn), intent(inout) :: self
+
+    switchOnTime=self%time_
+    return
+  end function switchOnTime
+
+  subroutine switchOnTimeSet(self,time)
+    !!{
+    Set the time of the radiation field.
+    !!}
+    implicit none
+    class           (radiationFieldSwitchOn), intent(inout) :: self
+    double precision                        , intent(in   ) :: time
+
+    self%time_=time
+    call self%radiationField_%timeSet(time)
+    return
+  end subroutine switchOnTimeSet
+
+  logical function switchOnTimeDependentOnly(self)
+    !!{
+    Return whether the radiation field in this class depends only on time.
+    !!}
+    implicit none
+    class(radiationFieldSwitchOn), intent(inout) :: self
+
+    switchOnTimeDependentOnly=self%radiationField_%timeDependentOnly()
+    return
+  end function switchOnTimeDependentOnly

--- a/source/structure_formation.linear_growth.baryons_darkMatter.F90
+++ b/source/structure_formation.linear_growth.baryons_darkMatter.F90
@@ -45,26 +45,26 @@
      of radiation perturbations.
      !!}
      private
-     logical                                                    :: tableInitialized                 =  .false.
-     double precision                                           :: tableTimeMinimum                           , tableTimeMaximum      , &
-          &                                                        tableWavenumberMinimum                     , tableWavenumberMaximum, &
-          &                                                        fractionDarkMatter                         , fractionBaryons       , &
-          &                                                        normalizationMatterDominated               , redshiftInitial       , &
+     logical                                                    :: tableInitialized                 =  .false., darkMatterOnlyInitialConditions
+     double precision                                           :: tableTimeMinimum                           , tableTimeMaximum                               , &
+          &                                                        tableWavenumberMinimum                     , tableWavenumberMaximum                         , &
+          &                                                        fractionDarkMatter                         , fractionBaryons                                , &
+          &                                                        normalizationMatterDominated               , redshiftInitial                                , &
           &                                                        redshiftInitialDelta
      integer                                                    :: cambCountPerDecade
      type            (table2DLogLogLin               )          :: growthFactor
      type            (varying_string                 )          :: fileName
-     class           (cosmologyParametersClass       ), pointer :: cosmologyParameters_             => null()
+     class           (cosmologyParametersClass       ), pointer :: cosmologyParameters_             => null() , cosmologyParametersInitialConditions_ => null()
      class           (cosmologyFunctionsClass        ), pointer :: cosmologyFunctions_              => null()
      class           (intergalacticMediumStateClass  ), pointer :: intergalacticMediumState_        => null()
      type            (linearGrowthCollisionlessMatter), pointer :: linearGrowthCollisionlessMatter_ => null()
    contains
      !![
      <methods>
-       <method description="Tabulate linear growth factor." method="retabulate" />
-       <method description="Read the tabulated mass variance from file." method="fileWrite" />
-       <method description="Read the tabulated mass variance from file." method="fileRead" />
-       <method description="Return true if the table must be remade." method="remakeTable" />
+       <method description="Tabulate linear growth factor."              method="retabulate" />
+       <method description="Read the tabulated mass variance from file." method="fileWrite"  />
+       <method description="Read the tabulated mass variance from file." method="fileRead"   />
+       <method description="Return true if the table must be remade."    method="remakeTable"/>
      </methods>
      !!]
      final     ::                                         baryonsDarkMatterDestructor
@@ -116,11 +116,12 @@ contains
     implicit none
     type            (linearGrowthBaryonsDarkMatter)                :: self
     type            (inputParameters              ), intent(inout) :: parameters
-    class           (cosmologyParametersClass     ), pointer       :: cosmologyParameters_
+    class           (cosmologyParametersClass     ), pointer       :: cosmologyParameters_           , cosmologyParametersInitialConditions_
     class           (cosmologyFunctionsClass      ), pointer       :: cosmologyFunctions_
     class           (intergalacticMediumStateClass), pointer       :: intergalacticMediumState_
-    double precision                                               :: redshiftInitial          , redshiftInitialDelta
+    double precision                                               :: redshiftInitial                , redshiftInitialDelta
     integer                                                        :: cambCountPerDecade
+    logical                                                        :: darkMatterOnlyInitialConditions
 
     !![
     <inputParameter>
@@ -141,21 +142,37 @@ contains
       <defaultValue>0</defaultValue>
       <description>The number of points per decade of wavenumber to compute in the CAMB transfer function. A value of 0 allows CAMB to choose what it considers to be optimal spacing of wavenumbers.</description>
     </inputParameter>
-    <objectBuilder class="cosmologyParameters"      name="cosmologyParameters_"      source="parameters"/>
-    <objectBuilder class="cosmologyFunctions"       name="cosmologyFunctions_"       source="parameters"/>
-    <objectBuilder class="intergalacticMediumState" name="intergalacticMediumState_" source="parameters"/>
+    <inputParameter>
+      <name>darkMatterOnlyInitialConditions</name>
+      <source>parameters</source>
+      <defaultValue>.false.</defaultValue>
+      <description>If true, set the initial conditions for baryonic modes using the dark matter mode initial conditions.</description>
+    </inputParameter>
+    <objectBuilder    class="cosmologyParameters"      name="cosmologyParameters_"                  source="parameters"                                                     />
+    <objectBuilder    class="cosmologyFunctions"       name="cosmologyFunctions_"                   source="parameters"                                                     />
+    <objectBuilder    class="intergalacticMediumState" name="intergalacticMediumState_"             source="parameters"                                                     />
     !!]
-    self=baryonsDarkMatterConstructorInternal(redshiftInitial,redshiftInitialDelta,cambCountPerDecade,cosmologyParameters_,cosmologyFunctions_,intergalacticMediumState_)
+    if (parameters%isPresent('cosmologyParametersInitialConditions')) then
+       !![
+       <objectBuilder class="cosmologyParameters"      name="cosmologyParametersInitialConditions_" source="parameters" parameterName="cosmologyParametersInitialConditions"/>
+       !!]
+    else
+       !![
+       <objectBuilder class="cosmologyParameters"      name="cosmologyParametersInitialConditions_" source="parameters"                                                     />
+       !!]
+    end if
+    self=baryonsDarkMatterConstructorInternal(redshiftInitial,redshiftInitialDelta,cambCountPerDecade,darkMatterOnlyInitialConditions,cosmologyParameters_,cosmologyParametersInitialConditions_,cosmologyFunctions_,intergalacticMediumState_)
     !![
     <inputParametersValidate source="parameters"/>
-    <objectDestructor name="cosmologyParameters_"     />
-    <objectDestructor name="cosmologyFunctions_"      />
-    <objectDestructor name="intergalacticMediumState_"/>
+    <objectDestructor name="cosmologyParameters_"                 />
+    <objectDestructor name="cosmologyParametersInitialConditions_"/>
+    <objectDestructor name="cosmologyFunctions_"                  />
+    <objectDestructor name="intergalacticMediumState_"            />
     !!]
     return
   end function baryonsDarkMatterConstructorParameters
 
-  function baryonsDarkMatterConstructorInternal(redshiftInitial,redshiftInitialDelta,cambCountPerDecade,cosmologyParameters_,cosmologyFunctions_,intergalacticMediumState_) result(self)
+  function baryonsDarkMatterConstructorInternal(redshiftInitial,redshiftInitialDelta,cambCountPerDecade,darkMatterOnlyInitialConditions,cosmologyParameters_,cosmologyParametersInitialConditions_,cosmologyFunctions_,intergalacticMediumState_) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily baryonsDarkMatter} linear growth class.
     !!}
@@ -164,14 +181,15 @@ contains
     use :: Input_Paths   , only : inputPath     , pathTypeDataDynamic
     implicit none
     type            (linearGrowthBaryonsDarkMatter)                           :: self
-    double precision                                          , intent(in   ) :: redshiftInitial          , redshiftInitialDelta
+    double precision                                          , intent(in   ) :: redshiftInitial                , redshiftInitialDelta
     integer                                                   , intent(in   ) :: cambCountPerDecade
-    class           (cosmologyParametersClass     ), target   , intent(in   ) :: cosmologyParameters_
+    logical                                                   , intent(in   ) :: darkMatterOnlyInitialConditions
+    class           (cosmologyParametersClass     ), target   , intent(in   ) :: cosmologyParameters_           , cosmologyParametersInitialConditions_
     class           (cosmologyFunctionsClass      ), target   , intent(in   ) :: cosmologyFunctions_
     class           (intergalacticMediumStateClass), target   , intent(in   ) :: intergalacticMediumState_
-    double precision                                                          :: timeBigCrunch            , timeNow
+    double precision                                                          :: timeBigCrunch                  , timeNow
     !![
-    <constructorAssign variables="redshiftInitial, redshiftInitialDelta, cambCountPerDecade, *cosmologyParameters_, *cosmologyFunctions_, *intergalacticMediumState_"/>
+    <constructorAssign variables="redshiftInitial, redshiftInitialDelta, cambCountPerDecade, *cosmologyParameters_, *cosmologyParametersInitialConditions_, *cosmologyFunctions_, *intergalacticMediumState_"/>
     !!]
 
     self%tableInitialized      =.false.
@@ -219,10 +237,11 @@ contains
     type (linearGrowthBaryonsDarkMatter), intent(inout) :: self
 
     !![
-    <objectDestructor name="self%cosmologyParameters_"            />
-    <objectDestructor name="self%cosmologyFunctions_"             />
-    <objectDestructor name="self%intergalacticMediumState_"       />
-    <objectDestructor name="self%linearGrowthCollisionlessMatter_"/>
+    <objectDestructor name="self%cosmologyParameters_"                 />
+    <objectDestructor name="self%cosmologyParametersInitialConditions_"/>
+    <objectDestructor name="self%cosmologyFunctions_"                  />
+    <objectDestructor name="self%intergalacticMediumState_"            />
+    <objectDestructor name="self%linearGrowthCollisionlessMatter_"     />
     !!]
     call self%growthFactor%destroy()
     return
@@ -297,7 +316,7 @@ contains
        ! Get the initial conditions from CAMB.
        call transferFunctionDarkMatter%destroy()
        call transferFunctionBaryons   %destroy()
-       call Interface_CAMB_Transfer_Function(self%cosmologyParameters_,redshiftsInitial,self%tableWavenumberMaximum,self%tableWavenumberMaximum,countPerDecade=self%cambCountPerDecade,transferFunctionDarkMatter=transferFunctionDarkMatter,transferFunctionBaryons=transferFunctionBaryons)
+       call Interface_CAMB_Transfer_Function(self%cosmologyParametersInitialConditions_,redshiftsInitial,self%tableWavenumberMaximum,self%tableWavenumberMaximum,countPerDecade=self%cambCountPerDecade,transferFunctionDarkMatter=transferFunctionDarkMatter,transferFunctionBaryons=transferFunctionBaryons)
        ! Determine number of points to tabulate.
        growthTableNumberPoints=int(log10(self%tableTimeMaximum/self%tableTimeMinimum)*dble(growthTablePointsPerDecadeTime))
        ! Destroy current table.
@@ -326,13 +345,18 @@ contains
           wavenumberLogarithmic=log(wavenumber_)
           ! Solve ODE to get corresponding expansion factors. Initialize with solution from CAMB.
           !$ call OMP_Set_Lock  (lockDarkMatter)
-          call self%growthFactor%populate(exp(transferFunctionDarkMatter%interpolate(wavenumberLogarithmic,table=1)),1,j,table=indexDarkMatter)
+          call    self%growthFactor%populate(exp(transferFunctionDarkMatter%interpolate(wavenumberLogarithmic,table=1)),1,j,table=indexDarkMatter)
           growthFactorDerivativeDarkMatter=(transferFunctionDarkMatter%interpolate(wavenumberLogarithmic,table=2)-transferFunctionDarkMatter%interpolate(wavenumberLogarithmic,table=1))*exp(transferFunctionDarkMatter%interpolate(wavenumberLogarithmic,table=1))/(timesInitial(2)-timesInitial(1))
           !$ call OMP_Unset_Lock(lockDarkMatter)
-          !$ call OMP_Set_Lock  (lockBaryons   )
-          call self%growthFactor%populate(exp(transferFunctionBaryons   %interpolate(wavenumberLogarithmic,table=1)),1,j,table=indexBaryons   )
-          growthFactorDerivativeBaryons   =(transferFunctionBaryons   %interpolate(wavenumberLogarithmic,table=2)-transferFunctionBaryons   %interpolate(wavenumberLogarithmic,table=1))*exp(transferFunctionBaryons   %interpolate(wavenumberLogarithmic,table=1))/(timesInitial(2)-timesInitial(1))
-          !$ call OMP_Unset_Lock(lockBaryons   )
+          if (self%darkMatterOnlyInitialConditions) then
+             call self%growthFactor%populate(exp(transferFunctionDarkMatter%interpolate(wavenumberLogarithmic,table=1)),1,j,table=indexDarkMatter)
+             growthFactorDerivativeBaryons=(transferFunctionDarkMatter%interpolate(wavenumberLogarithmic,table=2)-transferFunctionDarkMatter%interpolate(wavenumberLogarithmic,table=1))*exp(transferFunctionDarkMatter%interpolate(wavenumberLogarithmic,table=1))/(timesInitial(2)-timesInitial(1))
+          else
+             !$ call OMP_Set_Lock  (lockBaryons   )
+             call self%growthFactor%populate(exp(transferFunctionBaryons   %interpolate(wavenumberLogarithmic,table=1)),1,j,table=indexBaryons   )
+             growthFactorDerivativeBaryons=(transferFunctionBaryons   %interpolate(wavenumberLogarithmic,table=2)-transferFunctionBaryons   %interpolate(wavenumberLogarithmic,table=1))*exp(transferFunctionBaryons   %interpolate(wavenumberLogarithmic,table=1))/(timesInitial(2)-timesInitial(1))
+             !$ call OMP_Unset_Lock(lockBaryons   )
+          end if
           solver=odeSolver(4_c_size_t,growthFactorODEs,toleranceAbsolute=odeToleranceAbsolute,toleranceRelative=odeToleranceRelative)    
           do i=2,growthTableNumberPoints
              timeNow                    =self%growthFactor                    %x(i-1                        )

--- a/testSuite/parameters/validate_baryonicSuppression_IGM_evolution.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_IGM_evolution.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Baryonic suppression validation model - reference IGM evolution. -->
+<parameters>
+  <version>0.9.4</version>
+  <formatVersion>2</formatVersion>
+  <verbosityLevel value="working"/>
+
+  <!-- Random number generation -->
+  <randomNumberGenerator value="GSL">
+    <seed value="8122"/>
+  </randomNumberGenerator>
+
+  <!-- Task -->
+  <task value="evolveForests"/>
+  <evolveForestsWorkShare value="cyclic"/>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="null"/>
+  <componentHotHalo value="standard"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="null"/>
+  <componentSpin value="null"/>
+
+  <!-- Dark matter properties -->
+  <darkMatterParticle value="CDM"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="67.36000"/>	<!-- Planck 2018; https://ui.adsabs.harvard.edu/abs/2018arXiv180706211P -->
+    <OmegaMatter value=" 0.31530"/>	<!-- Planck 2018; https://ui.adsabs.harvard.edu/abs/2018arXiv180706211P -->
+    <OmegaDarkEnergy value=" 0.68470"/>	<!-- Planck 2018; https://ui.adsabs.harvard.edu/abs/2018arXiv180706211P -->
+    <OmegaBaryon value=" 0.04930"/>	<!-- Planck 2018; https://ui.adsabs.harvard.edu/abs/2018arXiv180706211P -->
+    <temperatureCMB value=" 2.72548"/>
+  </cosmologyParameters>
+
+
+  <!-- Power spectrum options -->
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8                           value="0.8111"/> <!-- Planck 2018; https://ui.adsabs.harvard.edu/abs/2018arXiv180706211P -->
+    <tolerance                         value="3.0e-4"/>
+    <toleranceTopHat                   value="3.0e-4"/>
+    <nonMonotonicIsFatal               value="false" />
+    <monotonicInterpolation            value="true"  />
+    <powerSpectrumWindowFunction value="topHat"/>
+  </cosmologicalMassVariance>
+  <transferFunction                   value="CAMB"     >
+    <redshift value="100.0"/>
+  </transferFunction>
+  <powerSpectrumPrimordial            value="powerLaw" >
+    <index               value="0.9649"/> <!-- Planck 2018; https://ui.adsabs.harvard.edu/abs/2018arXiv180706211P -->
+    <wavenumberReference value="1.0000"/>
+    <running             value="0.0000"/> <!-- Planck 2018; https://ui.adsabs.harvard.edu/abs/2018arXiv180706211P -->
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"  />
+
+  <!-- Structure formation options -->
+  <linearGrowth          value="collisionlessMatter"                      />
+  <criticalOverdensity   value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <haloMassFunction      value="shethTormen"                           >
+    <a             value="0.791"/> <!-- Best fit values from Benson, Ludlow, & Cole (2019). -->
+    <normalization value="0.302"/>
+    <p             value="0.218"/>
+  </haloMassFunction>
+
+  <!-- Merger tree building options --> 
+  <mergerTreeConstructor value="build">
+    <redshiftBase value="0.0"/>
+  </mergerTreeConstructor>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="  0.1"/>
+    <mergeProbability value="  0.1"/>
+    <redshiftMaximum value="100.0"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="fixedMass">
+    <massTree value="1.0e10"/>
+    <treeCount value="1"/>
+  </mergerTreeBuildMasses>
+
+  <!-- Halo mass resolution -->
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e9"/>
+  </mergerTreeMassResolution>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentration">
+    <correctForConcentrationDefinition value="true"/>
+    <darkMatterProfileConcentration value="diemerJoyce2019"/>
+  </darkMatterProfileScaleRadius>
+ 
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0"/>
+  </coolingTimeAvailable>
+  <hotHaloRamPressureStripping value="virialRadius"/>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"/>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <!-- Tree evolution -->
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.00"/>
+    <timestepHostRelative value="0.10"/>
+    <fractionTimestepSatelliteMinimum value="0.75"/>
+    <backtrackToSatellites value="true"/>
+  </mergerTreeEvolver>
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+    <reuseODEStepSize value="false"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolveTimestep value="simple">
+    <timeStepAbsolute value="1.000"/>
+    <timeStepRelative value="0.100"/>
+  </mergerTreeEvolveTimestep>
+  
+  <!-- Include reionization -->
+  <!-- IGM evolver -->
+  <intergalacticMediumState value="internal"/>
+  <universeOperator value="intergalacticMediumStateEvolve">
+    <timeCountPerDecade value=" 30  "/>
+    <redshiftMaximum    value="150.0"/>
+  </universeOperator>    
+
+  <!-- Background radiation -->
+  <radiationFieldIntergalacticBackground value="switchOn">
+    <redshiftSwitchOn value="6.0"/>
+    <radiationField value="intergalacticBackgroundFile">
+      <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_Haardt_Madau_2005_Quasars_Galaxies.hdf5"/>
+    </radiationField>
+  </radiationFieldIntergalacticBackground>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="naozBarkana2007"/>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/validate_baryonicSuppression_IGM_evolution.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <redshifts value="0.0"/>
+  </outputTimes>
+
+</parameters>

--- a/testSuite/parameters/validate_baryonicSuppression_baryonicPhysics.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_baryonicPhysics.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Baryonic parameters for the baryonic suppression validation model. -->
+<parameters>
+  <formatVersion>2</formatVersion>
+
+  <!-- Intergalactic background radiation -->
+  <radiationFieldIntergalacticBackground value="summation">
+    <radiationField value="cosmicMicrowaveBackground"/>
+    <radiationField value="intergalacticBackgroundFile">
+      <fileName value="%DATASTATICPATH%/radiation/Cosmic_Background_Radiation_Haardt_Madau_2005_Quasars_Galaxies.hdf5"/>
+    </radiationField>
+  </radiationFieldIntergalacticBackground>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="naozBarkana2007">
+    <rateAdjust value="3.0"/>
+  </accretionHalo>
+
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution           value="betaProfile"       />
+  <hotHaloTemperatureProfile         value="virial"            />
+  <hotHaloMassDistributionCoreRadius value="virialFraction"     >
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum     value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation       value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0.0"/>
+  </coolingTimeAvailable>
+  
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008">
+    <solverFailureIsFatal value="false"/>
+  </hotHaloRamPressureStripping>
+  <hotHaloRamPressureForce     value="font2008       "        />
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  
+  <!-- Galactic structure solver options -->
+  <galacticStructureSolver value="equilibrium"/>
+  <darkMatterProfile value="adiabaticGnedin2004">
+    <A     value="0.73"/>
+    <omega value="0.70"/>
+  </darkMatterProfile>
+  
+  <!-- Galaxy merger options -->
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="disk"/>
+    <massRatioMajorMerger      value="2.0" />
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1.0"/>
+  </mergerRemnantSize>
+  
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"        />
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Spins are computed using the angular momentum random walk model of Benson, Behrens, & Lu     -->
+    <!-- (2020; MNRAS; 496; 3371; http://adsabs.harvard.edu/abs/2020MNRAS.496.3371B).                 -->
+    <!-- The best fit-value for the mass exponent is taken from here                                  -->
+    <!-- https://github.com/galacticusorg/galacticus/wiki/Constraints:-Halo-spins-and-concentrations. -->
+    <!-- and is offset for fix to Keplerian orbit propagation                                         -->
+    <nodeOperator value="haloAngularMomentumVitvitska2002">
+      <exponentMass                    value="1.92527794238468"/>
+      <angularMomentumVarianceSpecific value="0.00100000000000"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+  </nodeOperator>
+
+  <!-- Merger tree evolution -->
+  <mergerTreeEvolver value="standard">
+    <!-- Standard merger tree evolver with parameters chosen to (somewhat) optimize the evolution. -->
+    <timestepHostAbsolute             value="1.00"/>
+    <timestepHostRelative             value="0.10"/>
+    <fractionTimestepSatelliteMinimum value="0.75"/>
+    <backtrackToSatellites            value="true"/>
+  </mergerTreeEvolver>
+  <mergerTreeNodeEvolver value="standard">
+    <!-- Standard node evolve with parameters chosen to (somewhat) optimize the evolution. -->
+    <odeToleranceAbsolute value="0.01" />
+    <odeToleranceRelative value="0.01" />
+    <reuseODEStepSize     value="false"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolveTimestep value="multi">
+    <!-- Standard time-stepping rules -->
+    <mergerTreeEvolveTimestep value="simple">
+      <timeStepAbsolute value="1.000"/>
+      <timeStepRelative value="0.100"/>
+    </mergerTreeEvolveTimestep>
+    <mergerTreeEvolveTimestep value="satellite">
+      <timeOffsetMaximumAbsolute value="0.010"/>
+      <timeOffsetMaximumRelative value="0.001"/>
+    </mergerTreeEvolveTimestep>
+  </mergerTreeEvolveTimestep>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard"/>
+  <outputTimes value="list">
+    <redshifts value="0.00 3.06 5.72 9.27"/>
+  </outputTimes>
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="nodeIndices"/>
+    <nodePropertyExtractor value="indicesTree"/>
+    <nodePropertyExtractor value="treeWeight" />
+    <nodePropertyExtractor value="massHalo"    >
+      <virialDensityContrastDefinition value="fixed">
+	<densityContrastValue value="200.0"/>
+	<densityType          value="mean" />
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+  </nodePropertyExtractor>
+
+</parameters>

--- a/testSuite/parameters/validate_baryonicSuppression_cosmology.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_cosmology.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Cosmological parameters for the baryonic suppression validation model.
+     Taken from Zheng et al. (2024; https://ui.adsabs.harvard.edu/abs/2024arXiv240317044Z) -->
+<parameters>
+  <formatVersion>2</formatVersion>
+
+  <!-- Dark matter properties -->
+  <darkMatterParticle value="CDM"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions  value="matterLambda"/>
+  <cosmologyParameters value="simple"       >
+    <HubbleConstant  value="67.77000"/>
+    <OmegaMatter     value=" 0.30700"/>
+    <OmegaDarkEnergy value=" 0.69300"/>
+    <OmegaBaryon     value=" 0.04825"/>
+    <temperatureCMB  value=" 2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <cosmologicalMassVariance value="filteredPower">
+    <tolerance                   value="1.0e-2"/>
+    <toleranceTopHat             value="1.0e-2"/>
+    <nonMonotonicIsFatal         value="false" />
+    <monotonicInterpolation      value="true"  />
+    <powerSpectrumWindowFunction value="topHat"/>
+    <wavenumberReference         value="1.0d0" />
+    <reference>
+      <cosmologicalMassVariance value="filteredPower">
+	<sigma_8                     value="0.8288"/>
+	<tolerance                   value="1.0e-2"/>
+	<toleranceTopHat             value="1.0e-2"/>
+	<nonMonotonicIsFatal         value="false" />
+	<monotonicInterpolation      value="true"  />
+	<powerSpectrumWindowFunction value="topHat"/>
+      </cosmologicalMassVariance>
+      <powerSpectrumPrimordialTransferred value="simple"/>
+      <powerSpectrumPrimordial value="powerLaw">
+	<index               value="0.9611"/>
+	<wavenumberReference value="1.0000"/>
+	<running             value="0.0000"/>
+      </powerSpectrumPrimordial>
+      <linearGrowth          value="collisionlessMatter"/>
+    </reference>
+  </cosmologicalMassVariance>
+  <transferFunction value="CAMB">
+    <redshift value="100.0"/>  
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index               value="0.9611"/>
+    <wavenumberReference value="1.0000"/>
+    <running             value="0.0000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+
+</parameters>

--- a/testSuite/parameters/validate_baryonicSuppression_evolve_withBaryons.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_evolve_withBaryons.xml
@@ -21,7 +21,9 @@
   <!-- Structure formation options -->
   <linearGrowth value="baryonsDarkMatter" >
     <cambCountPerDecade                   value="100"   />
+    <!-- Use pure dark matter initial conditions as used in the target hydro simulation -->
     <darkMatterOnlyInitialConditions      value="true"  />
+    <!-- Use a small baryon fraction here to approximate pure dark matter initial conditions as used in the target hydro simulation -->
     <cosmologyParametersInitialConditions value="simple" >
       <HubbleConstant  value="67.77000"/>
       <OmegaMatter     value=" 0.30700"/>

--- a/testSuite/parameters/validate_baryonicSuppression_evolve_withBaryons.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_evolve_withBaryons.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Baryonic suppression validation model - case including baryonic suppression. -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <verbosityLevel value="working"/>
+
+  <!-- Include cosmological parameters -->
+  <xi:include href="validate_baryonicSuppression_cosmology.xml"       xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Include merger tree parameters -->
+  <xi:include href="validate_baryonicSuppression_mergerTrees.xml"     xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Include baryonic physics parameters -->
+  <xi:include href="validate_baryonicSuppression_baryonicPhysics.xml" xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Random number generation -->
+  <randomNumberGenerator value="GSL">
+    <seed value="8122"/>
+  </randomNumberGenerator>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="baryonsDarkMatter" >
+    <cambCountPerDecade                   value="100"   />
+    <darkMatterOnlyInitialConditions      value="true"  />
+    <cosmologyParametersInitialConditions value="simple" >
+      <HubbleConstant  value="67.77000"/>
+      <OmegaMatter     value=" 0.30700"/>
+      <OmegaDarkEnergy value=" 0.69300"/>
+      <OmegaBaryon     value=" 0.01000"/>
+      <temperatureCMB  value=" 2.72548"/>
+    </cosmologyParametersInitialConditions>
+  </linearGrowth>
+  <criticalOverdensity   value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
+  <virialDensityContrast value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
+  <haloMassFunction      value="shethTormen"                           >
+    <a             value="0.791"/> <!-- Best fit values from Benson, Ludlow, & Cole (2019). -->
+    <normalization value="0.302"/>
+    <p             value="0.218"/>
+  </haloMassFunction>
+
+  <!-- Intergalactic medium evolution -->
+  <intergalacticMediumFilteringMass value="gnedin2000">
+    <timeTooEarlyIsFatal value="false"/>
+  </intergalacticMediumFilteringMass>
+  <intergalacticMediumState value="file">
+    <fileName value="testSuite/outputs/validate_baryonicSuppression_IGM.hdf5"/>
+  </intergalacticMediumState>
+
+  <!-- Cooling rate -->
+  <coolingRate value="multiplier">
+    <multiplier  value="0.5"           />
+    <coolingRate value="whiteFrenk1991" >
+      <velocityCutOff value="10000"/>
+    </coolingRate>
+  </coolingRate>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/validate_baryonicSuppression_evolve_withBaryonsAJB.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/validate_baryonicSuppression_evolve_withBaryons_noReionization.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_evolve_withBaryons_noReionization.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Baryonic suppression validation model - case including baryonic suppression but no reionization. -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <verbosityLevel value="working"/>
+
+  <!-- Include cosmological parameters -->
+  <xi:include href="validate_baryonicSuppression_cosmology.xml"       xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Include merger tree parameters -->
+  <xi:include href="validate_baryonicSuppression_mergerTrees.xml"     xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Include baryonic physics parameters -->
+  <xi:include href="validate_baryonicSuppression_baryonicPhysics.xml" xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Random number generation -->
+  <randomNumberGenerator value="GSL">
+    <seed value="8122"/>
+  </randomNumberGenerator>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="baryonsDarkMatter" >
+    <cambCountPerDecade                   value="100"   />
+    <darkMatterOnlyInitialConditions      value="true"  />
+    <cosmologyParametersInitialConditions value="simple" >
+      <HubbleConstant  value="67.77000"/>
+      <OmegaMatter     value=" 0.30700"/>
+      <OmegaDarkEnergy value=" 0.69300"/>
+      <OmegaBaryon     value=" 0.01000"/>
+      <temperatureCMB  value=" 2.72548"/>
+    </cosmologyParametersInitialConditions>
+  </linearGrowth>
+  <criticalOverdensity   value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
+  <virialDensityContrast value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
+  <haloMassFunction      value="shethTormen"                           >
+    <a             value="0.791"/> <!-- Best fit values from Benson, Ludlow, & Cole (2019). -->
+    <normalization value="0.302"/>
+    <p             value="0.218"/>
+  </haloMassFunction>
+
+  <!-- Intergalactic medium evolution -->
+  <intergalacticMediumFilteringMass value="gnedin2000">
+    <timeTooEarlyIsFatal value="false"/>
+  </intergalacticMediumFilteringMass>
+  <intergalacticMediumState value="recFast"/>
+
+  <!-- Cooling rate -->
+  <coolingRate value="zero"/>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/validate_baryonicSuppression_evolve_withBaryons_noReionization.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/validate_baryonicSuppression_evolve_withBaryons_noReionization.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_evolve_withBaryons_noReionization.xml
@@ -21,7 +21,9 @@
   <!-- Structure formation options -->
   <linearGrowth value="baryonsDarkMatter" >
     <cambCountPerDecade                   value="100"   />
+    <!-- Use pure dark matter initial conditions as used in the target hydro simulation -->
     <darkMatterOnlyInitialConditions      value="true"  />
+    <!-- Use a small baryon fraction here to approximate pure dark matter initial conditions as used in the target hydro simulation -->
     <cosmologyParametersInitialConditions value="simple" >
       <HubbleConstant  value="67.77000"/>
       <OmegaMatter     value=" 0.30700"/>

--- a/testSuite/parameters/validate_baryonicSuppression_evolve_withoutBaryons.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_evolve_withoutBaryons.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Baryonic suppression validation model - case excluding baryonic suppression. -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <verbosityLevel value="working"/>
+
+  <!-- Include cosmological parameters -->
+  <xi:include href="validate_baryonicSuppression_cosmology.xml"       xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Include merger tree parameters -->
+  <xi:include href="validate_baryonicSuppression_mergerTrees.xml"     xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Include baryonic physics parameters -->
+  <xi:include href="validate_baryonicSuppression_baryonicPhysics.xml" xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Random number generation -->
+  <randomNumberGenerator value="GSL">
+    <seed value="8122"/>
+  </randomNumberGenerator>
+
+  <!-- Structure formation options -->
+  <linearGrowth          value="collisionlessMatter"                      />
+  <criticalOverdensity   value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <haloMassFunction      value="shethTormen"                           >
+    <a             value="0.791"/> <!-- Best fit values from Benson, Ludlow, & Cole (2019). -->
+    <normalization value="0.302"/>
+    <p             value="0.218"/>
+  </haloMassFunction>
+
+  <!-- Cooling rate -->
+  <coolingRate value="zero"/>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/validate_baryonicSuppression_evolve_withoutBaryons.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/validate_baryonicSuppression_mergerTrees.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_mergerTrees.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Merger tree parameters for the baryonic suppression validation model. -->
+<parameters>
+  <formatVersion>2</formatVersion>
+
+  <!-- Task -->
+  <task value="multi">
+    <task value="haloMassFunction"  >
+      <haloMassMinimum value="1.0e05"/>
+      <haloMassMaximum value="1.0e12"/>
+      <pointsPerDecade value="10"    />
+    </task>
+    <task value="evolveForests"/>
+  </task>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard">
+    <fractionLossAngularMomentum value="0.3"/>
+    <starveSatellites value="false"/>
+    <efficiencyStrippingOutflow value="0.1"/>
+    <trackStrippedGas value="true"/>
+  </componentHotHalo>
+  <componentSatellite value="orbiting"/>
+  <componentSpheroid value="null"/>
+  <componentSpin value="vector"/>
+
+  <!-- Merger tree building options --> 
+  <mergerTreeConstructor value="build">
+    <redshiftBase value="0.0"/>
+  </mergerTreeConstructor>
+  <mergerTreeBuilder     value="cole2000">
+    <!-- The Cole et al. (2000) merger tree building algorithm is used. The "interval stepping" optimization from Appendix A -->
+    <!-- of Benson, Ludlow, & Cole (2019, MNRAS, 485, 5010; https://ui.adsabs.harvard.edu/abs/2019MNRAS.485.5010B) is used   -->
+    <!-- to speed up tree building.                                                                                          -->
+    <accretionLimit     value="  0.1"/>
+    <mergeProbability   value="  0.1"/>
+    <redshiftMaximum    value="100.0"/>
+    <branchIntervalStep value="true" />
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="PCHPlus">
+    <!-- Merger tree branching rates are computed using the PCH+ algorithm, with parameters constrained to match progenitor -->
+    <!-- mass functions in the MDPL simulation suite.                                                                       -->
+    <!-- See: https://github.com/galacticusorg/galacticus/wiki/Constraints:-Dark-matter-progenitor-halo-mass-functions      -->
+    <!-- CDM assumptions are used here to speed up tree construction.                                                       -->
+    <G0                 value="+1.1425468378985500"/>
+    <gamma1             value="-0.3273597030267590"/>
+    <gamma2             value="+0.0587448775510245"/>
+    <gamma3             value="+0.6456170934757410"/>
+    <accuracyFirstOrder value="+0.1000000000000000"/>
+    <cdmAssumptions     value="true"               />
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMinimum value="1.0e4"/>
+    <massTreeMaximum value="1.0e9"/>
+    <treesPerDecade  value="200"  />
+  </mergerTreeBuildMasses>
+  <mergerTreeBuildMassDistribution value="powerLaw">
+    <exponent value="1.0"/>
+  </mergerTreeBuildMassDistribution>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="0.5e4"/>
+  </mergerTreeMassResolution>
+  
+  <!-- Dark matter profile scale radii model -->
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <!-- Limit scale radii to keep concentrations within a reasonable range. -->
+    <concentrationMinimum value="  3.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="johnson2021">
+      <!-- Scale radii are computed using the energy random walk model of Johnson, Benson, & Grin (2021; ApJ; 908; 33; http://adsabs.harvard.edu/abs/2021ApJ...908...33J). -->
+      <!-- Best-fit values of the parameters are taken from https://github.com/galacticusorg/galacticus/wiki/Constraints:-Halo-spins-and-concentrations.                   -->
+      <energyBoost      value="0.797003643180003"/>
+      <massExponent     value="2.168409985653090"/>
+      <unresolvedEnergy value="0.550000000000000"/>
+      <darkMatterProfileScaleRadius value="ludlow2016"          >
+	<C                                  value="700.27000"    /> <!-- Best fit values from Johnson, Benson, & Grin (2020). -->
+	<f                                  value="  0.07534"    />
+	<timeFormationSeekDelta             value="  0.00000"    />
+	<darkMatterProfileScaleRadius value="concentration" >
+	  <correctForConcentrationDefinition    value="true"              />
+	  <darkMatterProfileConcentration value="diemerJoyce2019">
+	    <!-- Use the Diemer & Joyce (2019; ApJ; 871; 168; http://adsabs.harvard.edu/abs/2019ApJ...871..168D) model for concentrations. -->
+	  </darkMatterProfileConcentration>
+	</darkMatterProfileScaleRadius>
+      </darkMatterProfileScaleRadius>
+    </darkMatterProfileScaleRadius>
+  </darkMatterProfileScaleRadius>
+
+  <!-- Dark matter halo spin -->
+  <haloSpinDistribution value="bett2007">
+    <!-- For leaf nodes in the tree we fall back to drawing spins from the distribution function given by -->
+    <!-- Benson (2017; MNRAS; 471; 2871; http://adsabs.harvard.edu/abs/2017MNRAS.471.2871B).              -->
+    <!-- Best fit paramter values are taken from that paper.                                              -->
+    <alpha   value="1.7091800"/>
+    <lambda0 value="0.0420190"/>
+  </haloSpinDistribution>
+
+  <!-- Satellite orbit options -->
+  <virialOrbit value="spinCorrelated">
+    <!-- Best fit value for correlation with host spin from https://github.com/galacticusorg/galacticus/wiki/Constraints:-Halo-spins-and-concentrations. -->
+    <alpha value="0.155573112534425" />
+    <virialOrbit value="jiang2014" >
+      <!-- Best fit value from Benson, Behrens, & Lu (2020) -->
+      <bRatioHigh             value="+2.88333 +4.06371 +3.86726"/>
+      <bRatioIntermediate     value="+1.05361 +1.56868 +2.89027"/>
+      <bRatioLow              value="+0.07432 +0.54554 +1.04721"/>
+      <gammaRatioHigh         value="+0.07124 +0.04737 -0.01913"/>
+      <gammaRatioIntermediate value="+0.10069 +0.07821 +0.04231"/>
+      <gammaRatioLow          value="+0.10866 +0.11260 +0.11698"/>
+      <muRatioHigh            value="+1.10168 +1.09639 +1.09819"/>
+      <muRatioIntermediate    value="+1.18205 +1.19573 +1.24581"/>
+      <muRatioLow             value="+1.22053 +1.22992 +1.25528"/>
+      <sigmaRatioHigh         value="+0.09244 +0.14335 +0.21079"/>
+      <sigmaRatioIntermediate value="+0.07397 +0.09590 +0.10941"/>
+      <sigmaRatioLow          value="+0.07458 +0.09040 +0.06981"/>
+    </virialOrbit>
+  </virialOrbit>
+ 
+</parameters>

--- a/testSuite/validate-baryonicSuppression.pl
+++ b/testSuite/validate-baryonicSuppression.pl
@@ -1,0 +1,297 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib $ENV{'GALACTICUS_EXEC_PATH'         }."/perl";
+use lib $ENV{'GALACTICUS_ANALYSIS_PERL_PATH'}."/perl";
+use PDL;
+use PDL::NiceSlice;
+use PDL::IO::HDF5;
+use PDL::Constants qw(PI);
+use JSON::PP;
+use Git;
+use Stats::Histograms;
+
+# Run models to validate suppression of the halo mass function by baryons.
+# Andrew Benson (01-April-2024)
+
+# Define the target data for the mass function suppression. This was read from Figure 2 of Zheng et al. (2024;
+# https://ui.adsabs.harvard.edu/abs/2024arXiv240317044Z).
+#
+# * 'withBaryons' corresponds to the "RI" model of Zheng et al.
+# * 'withBaryons_noReionization' corresponds to the "NR" model of Zheng et al.
+#
+# Array indices correspond to redshift:
+#
+# * 4 ==> z = 9.27
+# * 3 ==> z = 5.72
+# * 2 ==> z = 3.06
+# * 1 ==> z = 0.00
+my @redshifts = ( "", "9.27", "5.72", "3.06", "0.00" );
+my $target;
+$target->{'withBaryons'               }->[4] =
+    pdl [
+	0.7115384615384613,
+	0.6961538461538460,
+	0.7576923076923074,
+	0.6961538461538460,
+	0.7730769230769230,
+	0.7346153846153844,
+	0.6423076923076921,
+	0.9500000000000000
+    ];
+$target->{'withBaryons_noReionization'}->[4] =
+    pdl [
+	0.7346153846153844,
+	0.7423076923076921,
+	0.8269230769230768,
+	0.9038461538461537,
+	0.9423076923076922,
+	1.0346153846153845,
+	0.9038461538461537,
+	0.9807692307692306
+    ];
+$target->{'withBaryons'               }->[3] =
+    pdl [
+	0.6750000000000000,
+	0.7321428571428572,
+	0.6821428571428573,
+	0.7392857142857143,
+	0.5607142857142857,
+	0.7464285714285716,
+	0.9964285714285716,
+	1.0000000000000000
+    ];
+$target->{'withBaryons_noReionization'}->[3] =
+    pdl [
+	0.7321428571428572,
+	0.7678571428571429,
+	0.8250000000000001,
+	0.9464285714285715,
+	0.8964285714285715,
+	0.9892857142857143,
+	0.9964285714285716,
+	1.0000000000000000
+    ];
+$target->{'withBaryons'               }->[2] =
+    pdl [
+	0.6685714285714284,
+	0.7028571428571427,
+	0.6876190476190476,
+	0.7371428571428571,
+	0.6609523809523808,
+	0.9885714285714284,
+	0.9885714285714284,
+	1.0000000000000000
+    ];
+$target->{'withBaryons_noReionization'}->[2] =
+    pdl [
+	0.6723809523809523,
+	0.7104761904761904,
+	0.8247619047619046,
+	0.9314285714285714,
+	0.9466666666666665,
+	0.9999999999999999,
+	0.9885714285714284,
+	1.0000000000000000
+    ];
+$target->{'withBaryons'               }->[1] =
+    pdl [
+	0.6756756756756757,
+	0.6540540540540540,
+	0.7261261261261260,
+	1.0000000000000000,
+	1.0072072072072071,
+	1.0000000000000000,
+	1.0072072072072071,
+	1.0000000000000000
+    ];
+$target->{'withBaryons_noReionization'}->[1] =
+    pdl [
+	0.6756756756756757,
+	0.6612612612612612,
+	0.7333333333333334,
+	1.0000000000000000,
+	0.9927927927927928,
+	1.0000000000000000,
+	1.0000000000000000,
+	1.0072072072072071
+    ];
+
+# Define χ² targets for each dataset.
+my $chiSquaredTarget;
+$chiSquaredTarget->{'withBaryons'               }->[1] = 6.0;
+$chiSquaredTarget->{'withBaryons_noReionization'}->[1] = 2.0;
+$chiSquaredTarget->{'withBaryons'               }->[2] = 3.0;
+$chiSquaredTarget->{'withBaryons_noReionization'}->[2] = 1.0;
+$chiSquaredTarget->{'withBaryons'               }->[3] = 3.0;
+$chiSquaredTarget->{'withBaryons_noReionization'}->[3] = 1.0;
+$chiSquaredTarget->{'withBaryons'               }->[4] = 2.0;
+$chiSquaredTarget->{'withBaryons_noReionization'}->[4] = 1.0;
+
+# Make output directory.
+system("mkdir -p outputs/");
+
+# Run the validate model.
+system("cd ..; ./Galacticus.exe testSuite/parameters/validate_baryonicSuppression_IGM_evolution.xml");
+unless ( $? == 0 ) {
+  print "FAIL: baryonic suppression (IGM evolution) validation model failed to run\n";
+  exit;
+}
+
+# Read data and repackage into a file suitable for re-reading by other models.
+my $model         = new PDL::IO::HDF5( "outputs/validate_baryonicSuppression_IGM_evolution.hdf5");
+my $igmFile       = new PDL::IO::HDF5(">outputs/validate_baryonicSuppression_IGM.hdf5"          );
+my $data;
+my $igmProperties = $model        ->group  ('igmProperties')       ;
+$data->{$_}       = $igmProperties->dataset($_             )->get()
+    foreach ( 'redshift', 'temperature', 'densityHydrogen1', 'densityHydrogen2', 'densityHelium1', 'densityHelium2', 'densityHelium3' );
+$data->{'hIonizedFraction' } =  $data->{'densityHydrogen2'}                                                         /($data->{'densityHydrogen1'}+$data->{'densityHydrogen2'}                          );
+$data->{'heIonizedFraction'} = ($data->{'densityHelium2'  }+$data->{'densityHelium3'}                              )/($data->{'densityHelium1'  }+$data->{'densityHelium2'  }+$data->{'densityHelium3'});
+$data->{'electronFraction' } = ($data->{'densityHydrogen2'}+$data->{'densityHelium2'}+2.0*$data->{'densityHelium3'})/($data->{'densityHydrogen1'}+$data->{'densityHydrogen2'}                          );
+$igmFile->dataset('redshift'         )->set($data->{'redshift'         });
+$igmFile->dataset('matterTemperature')->set($data->{'temperature'      });
+$igmFile->dataset('hIonizedFraction' )->set($data->{'hIonizedFraction' });
+$igmFile->dataset('heIonizedFraction')->set($data->{'heIonizedFraction'});
+$igmFile->dataset('electronFraction' )->set($data->{'electronFraction' });
+$igmFile->attrSet(extrapolationAllowed => pdl long 1);
+$igmFile->attrSet(fileFormat           => pdl long 1);
+
+# Establish bins in halo mass.
+my $massHaloLogarithmicBins = pdl sequence(8)/7.0*3.5+4.0;
+my $haloMassFunction;
+
+# Run models with and without baryonic suppression.
+foreach my $suffix ( "withoutBaryons", "withBaryons", "withBaryons_noReionization" ) {
+    print "Running model: '".$suffix."'\n";
+    system("cd ..; ./Galacticus.exe testSuite/parameters/validate_baryonicSuppression_evolve_".$suffix.".xml");
+    unless ( $? == 0 ) {
+    	print "FAIL: baryonic suppression (evolve: '".$suffix."') validation model failed to run\n";
+    	exit;
+    }
+    my $model                          = new PDL::IO::HDF5("outputs/validate_baryonicSuppression_evolve_".$suffix.".hdf5");
+    my $cosmology                      = $model    ->group  ('Parameters/cosmologyParameters');
+    (my $OmegaMatter, my $OmegaBaryon) = $cosmology->attrGet('OmegaMatter','OmegaBaryon');
+    my $fractionDarkMatter             = ($OmegaMatter-$OmegaBaryon)/$OmegaMatter;
+    # Iterate over outputs.
+    for(my $outputIndex=1;$outputIndex<=4;++$outputIndex) {
+	print "\tProcessing output: ".$outputIndex."\n";
+	# Read all required data.
+	my $output = $model ->group('Outputs/Output'.$outputIndex);
+	my $nodes  = $output->group('nodeData'                   );
+	my $data;
+	$data->{$_} = $nodes->dataset($_)->get()
+	    foreach ( 'nodeIsIsolated', 'mergerTreeIndex', 'nodeIndex', 'parentIndex', 'hotHaloMass', 'diskMassGas', 'massHaloEnclosedCurrent', 'basicMass', 'nodeIsIsolated', 'mergerTreeWeight' );
+	# Identify isolated and subhalos.
+	(my $isolated, my $subhalo) = which_both($data->{'nodeIsIsolated'} == 1);
+	# Build an index mapping each halo to its host halo. We take advantage here of the depth-first ordering of the outputs.
+	my $index = pdl zeros(nelem($data->{'nodeIsIsolated'}));
+	for(my $i=0;$i<nelem($isolated);++$i) {
+	    my $indexStart                   = $i == 0 ? 0: $isolated->(($i-1))+1;
+	    my $indexEnd                     =              $isolated->(($i  ))  ;
+	    $index->($indexStart:$indexEnd) .=              $isolated->(($i  ))  ;
+	}
+	# Accumulate masses of isolated halos.
+	my $massHalo;
+	if ( $suffix eq "withoutBaryons" ) {
+	    # In models without baryons, the halo mass is just the dark matter mass.
+	    $massHalo            = +$data->{'massHaloEnclosedCurrent'};
+	} else {
+	    # In models with baryons we assume that the hot gas of the host is distributed as the dark matter, so compute a
+	    # correction factor to account for the differing virial density contrast definitions in Galacticus and Zheng et
+	    # al. Gas in the disk is assumed to always be included within the virial radius.
+	    my $correctionFactor = +$data->{'massHaloEnclosedCurrent'}
+	                           /$data->{'basicMass'              };
+	    $massHalo            = +$data->{'massHaloEnclosedCurrent'}*$fractionDarkMatter
+		                   +$data->{'hotHaloMass'            }*$correctionFactor
+		                   +$data->{'diskMassGas'            };
+	    # Accumulate masses of subhalos halos. We assume that these are also distributed as the dark matter of the host and so
+	    # apply the same correction factor.
+	    $massHalo->($index->($subhalo)) += $data->{'hotHaloMass'}->($subhalo)*$correctionFactor->($index->($subhalo));
+	    $massHalo->($index->($subhalo)) += $data->{'diskMassGas'}->($subhalo)*$correctionFactor->($index->($subhalo));
+	}
+	# Construct final quantities needed for the mass function.
+	my $weight              = $data    ->{'mergerTreeWeight'}->($isolated)         ;
+	my $massHaloLogarithmic = $massHalo                      ->($isolated)->log10();
+	# Construct the mass function.
+	($haloMassFunction->{$suffix}->[$outputIndex]->{'massFunction'}, $haloMassFunction->{$suffix}->[$outputIndex]->{'massFunctionError'})
+	    = &Stats::Histograms::Histogram($massHaloLogarithmicBins,$massHaloLogarithmic,$weight,differential => 1);
+    }
+}
+
+# Compute ratios of mass functions with the dark matter only model mass function.
+my $output;
+my $chiSquared;
+for(my $outputIndex=1;$outputIndex<=4;++$outputIndex) {
+    foreach my $suffix ( "withBaryons", "withBaryons_noReionization" ) {
+	$haloMassFunction->{$suffix}->[$outputIndex]->{'ratio'     } = $haloMassFunction->{$suffix}->[$outputIndex]->{'massFunction'}/$haloMassFunction->{'withoutBaryons'}->[$outputIndex]->{'massFunction'};
+	$haloMassFunction->{$suffix}->[$outputIndex]->{'ratioError'} =
+	    +sqrt(
+	          +(
+		    +$haloMassFunction->{$suffix         }->[$outputIndex]->{'massFunctionError'}
+		    /$haloMassFunction->{$suffix         }->[$outputIndex]->{'massFunction'     }
+		   )**2
+		  +(
+		    +$haloMassFunction->{'withoutBaryons'}->[$outputIndex]->{'massFunctionError'}
+		    /$haloMassFunction->{'withoutBaryons'}->[$outputIndex]->{'massFunction'     }
+		   )**2
+	         )
+	    *        $haloMassFunction->{$suffix         }->[$outputIndex]->{'ratio'            };
+	$chiSquared->{$suffix}->[$outputIndex] =
+	    +sum  (
+	           +(
+		     +$haloMassFunction->{$suffix}->[$outputIndex]->{'ratio'     }
+		     -$target          ->{$suffix}->[$outputIndex]
+		    )		                                                  **2
+		   /  $haloMassFunction->{$suffix}->[$outputIndex]->{'ratioError'}**2
+	          )
+	    /nelem(   $target          ->{$suffix}->[$outputIndex]);
+	delete($haloMassFunction->{$suffix         }->[$outputIndex]->{'massFunction'     });
+	delete($haloMassFunction->{$suffix         }->[$outputIndex]->{'massFunctionError'});
+	@{$output->{'model'}->{$suffix         }->[$outputIndex]->{'ratio'     }} = $haloMassFunction->{$suffix         }->[$outputIndex]->{'ratio'     }->list();
+	@{$output->{'model'}->{$suffix         }->[$outputIndex]->{'ratioError'}} = $haloMassFunction->{$suffix         }->[$outputIndex]->{'ratioError'}->list();	
+	# Report.
+	my $status     = $chiSquared->{$suffix}->[$outputIndex] < $chiSquaredTarget->{$suffix}->[$outputIndex] ? "SUCCESS" : "FAILED";
+	my $inequality = $chiSquared->{$suffix}->[$outputIndex] < $chiSquaredTarget->{$suffix}->[$outputIndex] ? "<"       : "≥"     ;
+	print $status.": model '".$suffix.(" " x (length("withBaryons_noReionization")-length($suffix)))."' at z=".$redshifts[$outputIndex]." validation (χ² = ".sprintf("%5.3f",$chiSquared->{$suffix}->[$outputIndex])." ".$inequality." ".sprintf("%5.3f",$chiSquaredTarget->{$suffix}->[$outputIndex]).")\n";
+    }
+    delete($haloMassFunction->{'withoutBaryons'}->[$outputIndex]->{'massFunction'     });
+    delete($haloMassFunction->{'withoutBaryons'}->[$outputIndex]->{'massFunctionError'});
+}
+
+# Interface with git.
+my $repo         = Git->repository(Directory => $ENV{'GALACTICUS_EXEC_PATH'});
+my $lastRevision = $repo->command_oneline( [ 'rev-list', '--all' ], STDERR => 0 );
+(my $authorName  = $repo->command_oneline( [ 'show', '-s', '--format="%an"', $lastRevision ], STDERR => 0 )) =~ s/"//g;
+(my $authorEmail = $repo->command_oneline( [ 'show', '-s', '--format="%ae"', $lastRevision ], STDERR => 0 )) =~ s/"//g;
+(my $authorDate  = $repo->command_oneline( [ 'show', '-s', '--format="%aD"', $lastRevision ], STDERR => 0 )) =~ s/"//g;
+(my $message     = $repo->command_oneline( [ 'show', '-s', '--format="%s"' , $lastRevision ], STDERR => 0 )) =~ s/"//g;
+
+# Generate content for the validation metrics page.
+$output->{'repoUrl'      } = "https://github.com/galacticusorg/galacticus";
+$output->{'parameterFile'} = "testSuite/parameters/validate_baryonicSuppression_evolve_withBaryons.xml";
+$output->{'commit'       } =
+{
+    author =>
+    {
+    	    name  => $authorName,
+    	    email => $authorEmail
+    },
+    id        => $lastRevision,
+    message   => $message,
+    timestamp => $authorDate,
+    url       => "https://github.com/galacticusorg/galacticus/commit/".$lastRevision
+};
+foreach my $suffix ( "withBaryons", "withBaryons_noReionization" ) {
+    for(my $outputIndex=1;$outputIndex<=4;++$outputIndex) {
+	@{$output->{'target'}->{$suffix}->[$outputIndex]} = $target->{$suffix}->[$outputIndex]->list();
+    }
+}
+@{$output->{'redshift'}} = @redshifts;
+@{$output->{'massHalo'}} = $massHaloLogarithmicBins->list();
+my $json = JSON::PP->new()->pretty()->encode($output);
+open(my $reportFile,">","outputs/results_baryonicSuppression.json");
+print $reportFile "window.BARYONICSUPPRESSION_DATA = ";
+print $reportFile $json;
+close($reportFile);
+
+exit;


### PR DESCRIPTION
Adds a test to validate the behavior of [Galacticus](https://github.com/galacticusorg/galacticus) in calculations related to the suppression of structure growth by baryonic physics. Specifically, the ratio of the halo mass function in models with baryons to a model without baryons (dark matter only) is computed and compared to the hydrodynamical simulations of [Zheng et al. (2024)](https://ui.adsabs.harvard.edu/abs/2024arXiv240317044Z).