### PR TITLE
Ensure that the preprocessor produces deterministic output

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -99,6 +99,16 @@ jobs:
         with:
           name: build-profile
           path: 'buildProfile.html'
+      - name: Test preprocessor determinism
+        run: |
+          # Test that the preprocessor produces deterministic output by re-preprocessing one file and checking that the results are unchanged.
+          cd $GALACTICUS_EXEC_PATH
+          cp work/build/mass_distributions.p.F90 work/build/mass_distributions.p.F90.prev
+          cp work/build/mass_distributions.spherical.Einasto.p.F90 work/build/mass_distributions.spherical.Einasto.p.F90.prev
+          touch source/mass_distributions.spherical.Einasto.F90
+          make -j16 work/build/mass_distributions.p.F90
+          cmp -s work/build/mass_distributions.p.F90 work/build/mass_distributions.p.F90.prev
+          cmp -s work/build/mass_distributions.spherical.Einasto.p.F90 work/build/mass_distributions.spherical.Einasto.p.F90.prev
       - run: echo "This job's status is ${{ job.status }}."
   ### Non-static executable
   Build-Executable-Linux-Non-Static:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -104,11 +104,11 @@ jobs:
           # Test that the preprocessor produces deterministic output by re-preprocessing one file and checking that the results are unchanged.
           cd $GALACTICUS_EXEC_PATH
           cp work/build/mass_distributions.p.F90 work/build/mass_distributions.p.F90.prev
-          cp work/build/mass_distributions.spherical.Einasto.p.F90 work/build/mass_distributions.spherical.Einasto.p.F90.prev
-          touch source/mass_distributions.spherical.Einasto.F90
+          cp work/build/mass_distributions.spherical.Sersic.p.F90 work/build/mass_distributions.spherical.Sersic.p.F90.prev
+          touch source/mass_distributions.spherical.Sersic.F90
           make -j16 work/build/mass_distributions.p.F90
           cmp -s work/build/mass_distributions.p.F90 work/build/mass_distributions.p.F90.prev
-          cmp -s work/build/mass_distributions.spherical.Einasto.p.F90 work/build/mass_distributions.spherical.Einasto.p.F90.prev
+          cmp -s work/build/mass_distributions.spherical.Sersic.p.F90 work/build/mass_distributions.spherical.Sersic.p.F90.prev
       - run: echo "This job's status is ${{ job.status }}."
   ### Non-static executable
   Build-Executable-Linux-Non-Static:

--- a/perl/Galacticus/Build/SourceTree.pm
+++ b/perl/Galacticus/Build/SourceTree.pm
@@ -162,7 +162,7 @@ sub BuildTree {
     # Run all defined parsers on the tree.
     my @unitParsers = ( "directives" );
     for(my $stage=0;$stage<2;++$stage) {
-	foreach my $parser ( keys(%Galacticus::Build::SourceTree::Hooks::parseHooks) ) {
+	foreach my $parser ( sort(keys(%Galacticus::Build::SourceTree::Hooks::parseHooks)) ) {
 	    next
 		if ( exists($options{'parsers'}) && ! grep {$_ eq $parser} @{$options{'parsers'}} );
 	    &{$Galacticus::Build::SourceTree::Hooks::parseHooks{$parser}}($tree)
@@ -183,7 +183,7 @@ sub ProcessTree {
     my @processors = sort(keys(%Galacticus::Build::SourceTree::Hooks::processHooks));
     # Perform a topological sort to enforce dependencies.
     my %dependencies;
-    foreach my $processor ( keys(%Galacticus::Build::SourceTree::Hooks::processDependencies) ) {
+    foreach my $processor ( sort(keys(%Galacticus::Build::SourceTree::Hooks::processDependencies)) ) {
 	foreach my $dependent ( @{$Galacticus::Build::SourceTree::Hooks::processDependencies{$processor}} ) {
 	    push(@{$dependencies{$dependent}},$processor);
 	}
@@ -265,7 +265,7 @@ sub Build_Children {
 	$lineNumber += $rawLine =~ tr/\n//;
 	# Check for unit opening.
 	my $unitFound;	
-	foreach my $unitType ( keys(%unitOpeners) ) {
+	foreach my $unitType ( sort(keys(%unitOpeners)) ) {
 	    if ( my @matches = ( $processedLine =~ $unitOpeners{$unitType}->{'regEx'} ) ) {		
 		# A match is found, extract the name of the unit, store current line number.
 		my $lineNumberOpener = $lineNumber;
@@ -700,7 +700,7 @@ sub SetVisibility {
     foreach ( 'private', 'public' ) {
 	if ( exists($visibilityNode->{'visibility'}->{$_}) ) {
 	    $newContent .= "  ".$_;
-	    $newContent .= " :: ".join(", ",keys(%{$visibilityNode->{'visibility'}->{$_}}))
+	    $newContent .= " :: ".join(", ",sort(keys(%{$visibilityNode->{'visibility'}->{$_}})))
 		if ( $visibilityNode->{'visibility'}->{$_} );
 	    $newContent .= "\n";
 	}

--- a/perl/Galacticus/Build/SourceTree/Analyze/UseDuplication.pm
+++ b/perl/Galacticus/Build/SourceTree/Analyze/UseDuplication.pm
@@ -32,20 +32,20 @@ sub Analyze_UseDuplication {
 		    my $nodeChild = $nodeParent->{'firstChild'};
 		    while ( $nodeChild ) {
 			if ( $nodeChild->{'type'} eq "moduleUse" ) {
-			    push(@usedModules,keys(%{$nodeChild->{'moduleUse'}}));
+			    push(@usedModules,sort(keys(%{$nodeChild->{'moduleUse'}})));
 			}
 			$nodeChild = $nodeChild->{'sibling'};
 		    }
 		    $nodeParent = $nodeParent->{'parent'};
 		}
-		foreach my $moduleName ( keys(%{$node->{'moduleUse'}}) ) {
+		foreach my $moduleName ( sort(keys(%{$node->{'moduleUse'}})) ) {
 		    if ( grep {$moduleName eq $_} @usedModules ) {
 			print "Warning: module '".$moduleName."' used in ".$node->{'parent'}->{'name'}."() was already used in container [file: ".$fileName."]\n";
 		    }
 		}
 	    }
 	    # Determine symbols used from each module.
-	    foreach my $module ( keys(%{$node->{'moduleUse'}}) ) {
+	    foreach my $module ( sort(keys(%{$node->{'moduleUse'}})) ) {
 		my @symbolsExported = &Fortran::Utils::moduleSymbols(lc($module));
 		my @symbolsUsed;
 		# Search through code looking for use of these symbols.
@@ -84,7 +84,7 @@ sub Analyze_UseDuplication {
 		    } else {
 			# Only specified symbols were imported. Check for those which were not needed.
 			my @symbolsNonRequired;
-			foreach my $symbolImported ( keys(%{$node->{'moduleUse'}->{$module}->{'only'}}) ) {
+			foreach my $symbolImported ( sort(keys(%{$node->{'moduleUse'}->{$module}->{'only'}})) ) {
 			    push(@symbolsNonRequired,$symbolImported)
 				unless ( grep {$_ eq $symbolImported} @symbolsUsed );
 			}

--- a/perl/Galacticus/Build/SourceTree/Parse/Declarations.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/Declarations.pm
@@ -303,7 +303,7 @@ sub parseDeclaration {
     # Parse an individual declaration line.
     my $line = shift();
     my $declaration;
-    foreach ( keys(%Fortran::Utils::intrinsicDeclarations) ) {
+    foreach ( sort(keys(%Fortran::Utils::intrinsicDeclarations)) ) {
 	if ( my @matches = ( $line =~ $Fortran::Utils::intrinsicDeclarations{$_}->{'regEx'} ) ) {
 	    my $intrinsic  = $Fortran::Utils::intrinsicDeclarations{$_}->{'intrinsic'};
 	    my $type;

--- a/perl/Galacticus/Build/SourceTree/Parse/ModuleUses.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/ModuleUses.pm
@@ -215,7 +215,7 @@ sub AddUses {
     # adopt the most permissive of the possibilities (e.g. if the new module is OpenMP-only, but the existing module use is not
     # OpenMP, then we need to keep it as not-OpenMP - furthermore we need to do this on a per-symbol basis, requiring that we have
     # OpenMP and conditions status per symbol and reproduce this correctly when updating the code).
-    foreach my $moduleName ( keys(%{$moduleUses->{'moduleUse'}}) ) {
+    foreach my $moduleName ( sort(keys(%{$moduleUses->{'moduleUse'}})) ) {
 	push(@{$usesNode->{'moduleOrder'}},$moduleName)
 	    unless ( grep {$_ eq $moduleName} @{$usesNode->{'moduleOrder'}} );
 	$usesNode->{'moduleUse'}->{$moduleName}->{'openMP'    } = $moduleUses->{'moduleUse'}->{$moduleName}->{'openMP'    };
@@ -227,7 +227,7 @@ sub AddUses {
 		delete($usesNode->{'moduleUse'}->{$moduleName}->{'only'});
 	    } else {
 		$usesNode->{'moduleUse'}->{$moduleName}->{'only'}->{$_} = 1x2
-		    foreach ( keys(%{$moduleUses->{'moduleUse'}->{$moduleName}->{'only'}}) );
+		    foreach ( sort(keys(%{$moduleUses->{'moduleUse'}->{$moduleName}->{'only'}})) );
 	    }
 	}
     }
@@ -255,7 +255,7 @@ sub UpdateUses {
     # Determine name and column widths.
     my $nameLengthMax = 0;
     my @columnLengthMax = ( 0, 0, 0, 0 );
-    foreach my $moduleName ( keys(%{$usesNode->{'moduleUse'}}) ) {
+    foreach my $moduleName ( sort(keys(%{$usesNode->{'moduleUse'}})) ) {
 	$nameLengthMax = length($moduleName)
 	    if ( length($moduleName) > $nameLengthMax );
 	if ( $usesNode->{'moduleUse'}->{$moduleName}->{'only'} ) {

--- a/perl/Galacticus/Build/SourceTree/Parse/Visibilities.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/Visibilities.pm
@@ -129,7 +129,7 @@ sub UpdateVisibilities {
     foreach my $visibility ( "public", "private" ) {
 	next
 	    unless ( exists($visibilitiesNode->{'visibility'}->{$visibility}) && scalar(keys(%{$visibilitiesNode->{'visibility'}->{$visibility}})) );
-	$code .= $visibility." :: ".join(", ",keys(%{$visibilitiesNode->{'visibility'}->{$visibility}}))."\n";
+	$code .= $visibility." :: ".join(", ",sort(keys(%{$visibilitiesNode->{'visibility'}->{$visibility}})))."\n";
     }
     $visibilitiesNode->{'firstChild'}->{'content'} = $code;
 }

--- a/perl/Galacticus/Build/SourceTree/Process/ClassDocumentation.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/ClassDocumentation.pm
@@ -176,7 +176,7 @@ sub Process_ClassDocumentation {
 	open(my $classFile,">",$classFileName);
 	print $classFile $xml->XMLout($classes,RootName => "classes",NoAttr => 1);
 	close($classFile);
-	push(@outputPrevious,keys(%{$classes}));
+	push(@outputPrevious,sort(keys(%{$classes})));
     }
 }
 

--- a/perl/Galacticus/Build/SourceTree/Process/Dependencies.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/Dependencies.pm
@@ -31,7 +31,7 @@ sub Process_Dependencies {
 	    }
 	    close($dependencyFile);
 	    # Generate code.
-	    my $code = join("\n",map {"call dependencies_%set(var_str('".$_."'),var_str('".$dependencies{$_}."'))"} keys(%dependencies))."\n";
+	    my $code = join("\n",map {"call dependencies_%set(var_str('".$_."'),var_str('".$dependencies{$_}."'))"} sort(keys(%dependencies)))."\n";
 	    # Insert our code.
 	    my $initializationNode =
 	    {

--- a/perl/Galacticus/Build/SourceTree/Process/EventHooks.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/EventHooks.pm
@@ -49,7 +49,7 @@ sub Process_EventHooks {
 		    open(my $declarations,"<",\$hook->{'interface'});
 		    while ( ! eof($declarations) ) {
 			&Fortran::Utils::Get_Fortran_Line($declarations,my $rawLine, my $processedLine, my $bufferedComments);
-			foreach my $declarator ( keys(%Fortran::Utils::intrinsicDeclarations) ) {
+			foreach my $declarator ( sort(keys(%Fortran::Utils::intrinsicDeclarations)) ) {
 			    if ( my @matches = ( $processedLine =~ $Fortran::Utils::intrinsicDeclarations{$declarator}->{'regEx'} ) ) {
 				push(@code::arguments,&Fortran::Utils::Extract_Variables($matches[$Fortran::Utils::intrinsicDeclarations{$declarator}->{'variables'}],keepQualifiers => 0));
 				last;

--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -424,7 +424,7 @@ sub Process_FunctionClass {
 		    $node = $node->{'type'} eq "contains" ? $node->{'firstChild'} : $node->{'sibling'};
 		}
 		# Validate sub-parameters.
-		foreach my $subParameterName ( keys(%subParameters) ) {
+		foreach my $subParameterName ( sort(keys(%subParameters)) ) {
 		    unless ( exists($subParameters{$subParameters{$subParameterName}->{'parent'}}) || $subParameters{$subParameterName}->{'parent'} eq "parameters" ) {
 			$supported = -7;
 			push(@failureMessage,"subparameter hierarchy failure");
@@ -450,7 +450,7 @@ sub Process_FunctionClass {
 			    # Get subparameters.
 			    $addSubParameters{'parameters'} = 1;
 			    $descriptorCode   .= "parameters=descriptor%subparameters('".$directive->{'name'}."')\n";
-			    foreach my $subParameterName (keys(%subParameters) ) {
+			    foreach my $subParameterName ( sort(keys(%subParameters)) ) {
 				$addSubParameters{$subParameterName} = 1;
 				$descriptorCode .= $subParameters{$subParameterName}->{'source'};
 			    }
@@ -711,7 +711,7 @@ CODE
 	    } else {
 		$descriptorCode  = " !\$GLC attributes unused :: descriptor, includeClass\n".$descriptorCode;
 	    }
- 	    $descriptorCode  = "type(inputParameters) :: ".join(",",keys(%addSubParameters))."\n".$descriptorCode
+ 	    $descriptorCode  = "type(inputParameters) :: ".join(",",sort(keys(%addSubParameters)))."\n".$descriptorCode
 		if ( %addSubParameters );
  	    $descriptorCode  = "character(len=18) :: parameterLabel\n".$descriptorCode
 		if ( $addLabel );
@@ -723,7 +723,7 @@ CODE
 		description => "Return an input parameter list descriptor which could be used to recreate this object.",
 		type        => "void",
 		pass        => "yes",
-		modules     => join(" ",keys(%descriptorModules)),
+		modules     => join(" ",sort(keys(%descriptorModules))),
 		argument    => [ "type(inputParameters), intent(inout) :: descriptor", "logical, intent(in   ), optional :: includeClass, includeFileModificationTimes" ],
 		code        => $descriptorCode
 	    };
@@ -964,7 +964,7 @@ CODE
 		    $allowedParametersCode .= "type is (".$className.")\n";
 		    # Include the class and all parent classes for which the parent class parameter constructor is called.
 		    while ( defined($className) ) {
-			foreach my $source ( keys(%{$allowedParameters->{$className}->{'parameters'}}) ) {
+			foreach my $source ( sort(keys(%{$allowedParameters->{$className}->{'parameters'}})) ) {
 			    $allowedParametersCode .= "  if (objectsOnly) then\n";
 			    {
 				my $parameterCount = exists($allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}) ? scalar(@{$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}}) : 0;
@@ -1241,7 +1241,7 @@ CODE
 		type        => "void",
 		recursive   => "yes",
 		pass        => "yes",
-		modules     => join(" ",keys(%{$deepCopy->{'modules'}})),
+		modules     => join(" ",sort(keys(%{$deepCopy->{'modules'}}))),
 		argument    => [ "class(".$directive->{'name'}."Class), intent(inout) :: destination" ],
 		code        => $deepCopy->{'code'}
 	    };
@@ -1261,9 +1261,9 @@ CODE
 		pass        => "yes",
 		code        => $deepCopy->{'finalizeCode'}
 	    };
-	    $methods{'deepCopyReset'   }->{'modules'} = join(" ",keys(%{$deepCopy->{'resetModules'   }}))
+	    $methods{'deepCopyReset'   }->{'modules'} = join(" ",sort(keys(%{$deepCopy->{'resetModules'   }})))
 		if ( scalar(keys(%{$deepCopy->{'resetModules'   }})) > 0 );
-	    $methods{'deepCopyFinalize'}->{'modules'} = join(" ",keys(%{$deepCopy->{'finalizeModules'}}))
+	    $methods{'deepCopyFinalize'}->{'modules'} = join(" ",sort(keys(%{$deepCopy->{'finalizeModules'}})))
 		if ( scalar(keys(%{$deepCopy->{'finalizeModules'}})) > 0 );
 	    # Add "stateStore" and "stateRestore" method.
 	    my $stateStores =
@@ -1358,7 +1358,7 @@ CODE
 		    (my $stateStoreExplicitInputCode, my $stateStoreExplicitOutputCode, my %stateStoreExplicitModules) = &stateStoreExplicitFunction($nonAbstractClass);
 		    $stateStore->{'inputCode'}  .= $stateStoreExplicitInputCode;
 		    $stateStore->{'outputCode'} .= $stateStoreExplicitOutputCode;
-		    foreach my $module ( keys(%stateStoreExplicitModules) ) {
+		    foreach my $module ( sort(keys(%stateStoreExplicitModules)) ) {
 			$stateStores->{'stateStoreModules'  }->{$module} = 1;
 			$stateStores->{'stateRestoreModules'}->{$module} = 1;
 		    }
@@ -1481,7 +1481,7 @@ CODE
 		description => "Store the state of this object to file.",
 		type        => "void",
 		pass        => "yes",
-		modules     => join(" ",keys(%{$stateStores->{'stateStoreModules'}})),
+		modules     => join(" ",sort(keys(%{$stateStores->{'stateStoreModules'}}))),
 		argument    => [ "integer, intent(in   ) :: stateFile", "type(c_ptr), intent(in   ) :: gslStateFile", "integer(c_size_t), intent(in   ) :: stateOperationID"  ],
 		code        => $stateStoreCode
 	    };
@@ -1498,7 +1498,7 @@ CODE
 		description => "Restore the state of this object from file.",
 		type        => "void",
 		pass        => "yes",
-		modules     => join(" ",keys(%{$stateStores->{'stateRestoreModules'}})),
+		modules     => join(" ",sort(keys(%{$stateStores->{'stateRestoreModules'}}))),
 		argument    => [ "integer, intent(in   ) :: stateFile", "type(c_ptr), intent(in   ) :: gslStateFile", "integer(c_size_t), intent(in   ) :: stateOperationID"  ],
 		code        => $stateRestoreCode
 	    };
@@ -1578,7 +1578,7 @@ CODE
 	    $modulePreContains->{'content'} .= "    !![\n";
 	    $modulePreContains->{'content'} .= "    <methods>\n";
 	    my $generics;
-            foreach my $methodName ( keys(%methods) ) {
+            foreach my $methodName ( sort(keys(%methods)) ) {
                 next
                     if ( $methodName eq "destructor" );
                 my $method = $methods{$methodName};
@@ -1593,7 +1593,7 @@ CODE
 		}
 		my $separator = "";
 		foreach my $argument ( @arguments ) {
-		    foreach my $intrinsic ( keys(%Fortran::Utils::intrinsicDeclarations) ) {
+		    foreach my $intrinsic ( sort(keys(%Fortran::Utils::intrinsicDeclarations)) ) {
 			my $declarator = $Fortran::Utils::intrinsicDeclarations{$intrinsic};
 			if ( my @matches = $argument =~ m/$declarator->{'regEx'}/ ) {
 			    my $intrinsicName =                          $declarator->{'intrinsic' }  ;
@@ -1670,7 +1670,7 @@ CODE
 		    align  => "left"
 		}
 		);
-            foreach ( keys(%methods) ) {
+            foreach ( sort(keys(%methods)) ) {
                 next
                     if ( $_ eq "destructor" );
                 my $method = $methods{$_};
@@ -2178,7 +2178,7 @@ CODE
 			    }
 			} elsif ( $classNode->{'type'} eq "visibility" ) {
 			    # Visibility statements must go in the module.
-			    push(@{$codeContent->{'submodule'}->{$class->{'type'}}->{'interfaces'}},map {lc($_)} keys(%{$classNode->{'visibility'}->{'public'}}));
+			    push(@{$codeContent->{'submodule'}->{$class->{'type'}}->{'interfaces'}},map {lc($_)} sort(keys(%{$classNode->{'visibility'}->{'public'}})));
 			    delete($classNode->{'visibility'}->{'private'})
 				if ( exists($classNode->{'visibility'}->{'private'}) );
 			    &Galacticus::Build::SourceTree::Parse::Visibilities::UpdateVisibilities($classNode);
@@ -2287,11 +2287,11 @@ CODE
 		@moduleSymbols = uniq(sort(map {lc($_)} @moduleSymbols));
 		foreach my $moduleUseNode ( @moduleUseNodes ) {
 		    # Remove symbols not used.
-		    foreach my $moduleName ( keys(%{$moduleUseNode->{'moduleUse'}}) ) {
+		    foreach my $moduleName ( sort(keys(%{$moduleUseNode->{'moduleUse'}})) ) {
 			if ( exists($moduleUseNode->{'moduleUse'}->{$moduleName}->{'all'}) ) {
 			    # All symbols imported - keep this module for now - in principle we would like to have no cases were all symbols are imported though!
 			} else {
-			    foreach my $symbolName ( keys(%{$moduleUseNode->{'moduleUse'}->{$moduleName}->{'only'}}) ) {
+			    foreach my $symbolName ( sort(keys(%{$moduleUseNode->{'moduleUse'}->{$moduleName}->{'only'}})) ) {
 				delete($moduleUseNode->{'moduleUse'}->{$moduleName}->{'only'}->{$symbolName})
 				    unless ( grep {$_ eq lc($symbolName)} @moduleSymbols );
 			    }
@@ -2319,7 +2319,7 @@ CODE
 	    };
             &Galacticus::Build::SourceTree::Parse::ModuleUses::AddUses($node->{'parent'},$bindingNode);
 	    # Create functions.
-	    foreach my $methodName ( keys(%methods) ) {
+	    foreach my $methodName ( sort(keys(%methods)) ) {
                 my $method = $methods{$methodName};
                 next
                     if ( exists($method->{'function'}) );
@@ -2678,7 +2678,7 @@ CODE
 	    &Galacticus::Build::SourceTree::InsertPreContains ($node->{'parent'}, $codeContent        ->{'module'}->{'interfaces'} );
 	    &Galacticus::Build::SourceTree::InsertPostContains($node->{'parent'},[$treePostcontainsTmp                            ]);	   
 	    # Generate submodule files.
-	    foreach my $className ( keys(%{$codeContent->{'submodule'}}) ) {
+	    foreach my $className ( sort(keys(%{$codeContent->{'submodule'}})) ) {
                 # Submodule names are just the class name with an underscore appended.
                 my $submoduleName = $className."_";
 		# Build a file node.

--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass/Utils.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass/Utils.pm
@@ -19,7 +19,7 @@ sub Class_Dependencies {
 	if ( $classNode->{'type'} eq $directiveName ) {
 	    $class->{'node'} = $classNode;
 	    $class->{$_    } = $classNode->{'directive'}->{$_}
-	        foreach ( keys(%{$classNode->{'directive'}}) );
+	        foreach ( sort(keys(%{$classNode->{'directive'}})) );
 	}
 	if ( $classNode->{'type'} eq "type" ) {
 	    # Parse class openers to find dependencies.

--- a/perl/Galacticus/Build/SourceTree/Process/Generics.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/Generics.pm
@@ -52,7 +52,7 @@ sub Process_Generics {
 				foreach my $element ( 'opener', 'closer', 'name' ) {
 				    if ( exists($copyNode->{$element}) ) {
 					$copyNode->{$element} = &ReplaceGeneric           ($copyNode->{$element},$node->{'directive'}->{'identifier'},$instance,$_)
-					    foreach ( keys(%{$instance}) );
+					    foreach ( sort(keys(%{$instance})) );
 					$copyNode->{$element} = &ReplaceGenericConditional($copyNode->{$element},$node->{'directive'}->{'identifier'},$instance   );
 				    }
 				}
@@ -62,7 +62,7 @@ sub Process_Generics {
 				    open(my $code,"<",\$copyNode->{'content'});
 				    while ( my $line = <$code> ) {
 					$line = &ReplaceGeneric           ($line,$node->{'directive'}->{'identifier'},$instance,$_)
-					    foreach ( keys(%{$instance}) );
+					    foreach ( sort(keys(%{$instance})) );
 					$line = &ReplaceGenericConditional($line,$node->{'directive'}->{'identifier'},$instance   );
 					$newCode .= $line;
 				    }
@@ -116,7 +116,7 @@ sub Process_Generics {
 				    foreach my $instance ( &List::ExtraUtils::as_array($node->{'directive'}->{'instance'}) ) {
 					my $copiedLine = $line;
 					$copiedLine = &ReplaceGeneric           ($copiedLine,$node->{'directive'}->{'identifier'},$instance,$_)
-					    foreach ( keys(%{$instance}) );
+					    foreach ( sort(keys(%{$instance})) );
 					$copiedLine = &ReplaceGenericConditional($copiedLine,$node->{'directive'}->{'identifier'},$instance   );
 					$newCode .= $copiedLine;
 				    }

--- a/perl/Galacticus/Build/SourceTree/Process/StateStorable.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/StateStorable.pm
@@ -75,7 +75,7 @@ sub Process_StateStorable {
 
     # Remove any type definitions which do not match the storable class.
     if ( scalar(@directiveNodes) > 0 ) {
-	foreach my $className ( keys(%classes) ) {
+	foreach my $className ( sort(keys(%classes)) ) {
 	    my $matched = 0;
 	    my $parentClassName = $className;
 	    while ( ! $matched ) {

--- a/perl/Sort/Topo.pm
+++ b/perl/Sort/Topo.pm
@@ -12,7 +12,7 @@ sub sort {
     my %dependencies = %{shift()};
     # First build an array of dependencies.
     my @dependency;
-    foreach my $object ( keys(%dependencies) ) {
+    foreach my $object ( sort(keys(%dependencies)) ) {
 	# Skip cases where the object is not present in the object list.
 	next
 	    unless ( grep {$_ eq $object} @objects );


### PR DESCRIPTION
In Perl, the `keys()` function returns keys in a random order. Wherever this is used in our build code we must use `sort(keys())` to ensure deterministic behavior.