### PR TITLE
Update the URL for SDSS DR7 geometry data file

### DIFF
--- a/scripts/aux/archive.pl
+++ b/scripts/aux/archive.pl
@@ -1,0 +1,86 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use JSON;
+use File::Find;
+
+# Retrieve and archive copies of all run-time downloaded data files for Galacticus.
+# Andrew Benson (19-April-2024)
+
+# Get arguments.
+die("Usage: archive.pl <galacticusPath> <archivePath> <slackToken>")
+    unless ( scalar(@ARGV) == 3 );
+my $galacticusPath = $ARGV[0];
+my $archivePath    = $ARGV[1];
+my $slackToken     = $ARGV[2];
+
+# Parse the dependencies file.
+my $dependencies;
+open(my $dependenciesFile,$galacticusPath."/aux/dependencies.yml");
+while ( my $line = <$dependenciesFile> ) {
+    if ( $line =~ m/^(.*):\s+([\d\.]+)/ ) {
+	my $code    = $1;
+	my $version = $2;
+	my @versions = split(/\./,$version);
+	$dependencies->{$code} =
+	{
+	    version      => $version    ,
+	    versionMajor => $versions[0]
+	};
+    }
+}
+close($dependenciesFile);
+
+# Scan the source directory for files
+my @directories = ($galacticusPath."/source");
+my @links;
+find(\&linkFinder,@directories);
+
+# Retrieve links.
+my $report;
+foreach my $link ( @links ) {
+    if ( $link =~ m/^https??:\/\/(.+)\/(.+)/ ) {
+	my $path = $1;
+	my $file = $2;
+	system("mkdir -p ".$archivePath."/".$path);
+	my $fileName = $archivePath."/".$path."/".$file;
+	unless ( -e $fileName ) {
+	    $report->{'report'} .= "RETRIEVING: ".$link."\n";
+	    system("wget ".$link." -O ".$fileName);
+	    unless ( $? == 0 ) {
+		$report->{'report'} .= "\tFAILED: ".$link."\n";
+	    }
+	} else {
+	    $report->{'report'} .= "SKIPPING: (already archived) ".$link."\n";
+	}
+    }
+}
+
+# Report the results.
+system("curl -X POST -H 'Content-type: application/json' --data '".encode_json($report)."' https://hooks.slack.com/triggers/".$slackToken);
+
+exit;
+
+sub linkFinder {
+    # Find links that may be downloaded at run-time.
+    my $fileName = $_;
+    my $fullName = $File::Find::name;
+    return
+        unless ( $fileName =~ m/\.(F90|Inc)$/ );
+    open(my $file,$fileName);
+    while ( my $line = <$file> ) {
+        if ( $line =~ m/^\s*call\s+download\s*\(\s*(["'][^,]+)/ ) {
+	    my $link = $1;
+	    $link =~ s/["']//g;
+	    # Replace dependencies with the actual version number here. Handle the "cloudyVersion" case as a special instance as
+	    # we have to insert a "c" prefix.
+	    $link =~ s/\/\/char\(([a-zA-Z]+)VersionMajor\)\/\//$dependencies->{$1}->{'versionMajor'}/g;
+	    $link =~ s/\/\/char\(cloudyVersion\)\/\//c$dependencies->{'cloudy'}->{'version'}/g;
+	    $link =~ s/\/\/char\(([a-zA-Z]+)Version\)\/\//$dependencies->{$1}->{'version'}/g;
+	    # Add the link to the list to retrieve. We skip the "backup" ("old") Cloudy path here.
+	    push(@links,$link)
+		unless ( $link =~ m/cloudy_releases\/c\d+\/old\// );
+        }
+    }
+    close($file);
+}

--- a/source/geometry.surveys.Bernardi-2013-SDSS.F90
+++ b/source/geometry.surveys.Bernardi-2013-SDSS.F90
@@ -29,7 +29,7 @@ Implements the geometry of the SDSS survey used by \cite{bernardi_massive_2013}.
     
     For the angular mask, we make use of the \gls{mangle} polygon file provided by the \gls{mangle}
     project\footnote{Specifically,
-    \href{http://space.mit.edu/~molly/mangle/download/data/sdss_dr72safe0_res6d.pol.gz}{http://space.mit.edu/~molly/mangle/download/data/sdss\_dr72safe0\_res6d.pol.gz}.}
+    \href{https://zenodo.org/records/10998446/files/sdss_dr72safe0_res6d.pol.gz}{https://zenodo.org/records/10998446/files/sdss\_dr72safe0\_res6d.pol.gz}.}
     The solid angle of this mask, computed using the \gls{mangle} {\normalfont \ttfamily harmonize} command is
     2.232262776405~sr.
     
@@ -169,13 +169,13 @@ contains
     !!{
     Return the path to the directory containing \gls{mangle} files.
     !!}
-    use :: Input_Paths, only : inputPath, pathTypeDataStatic
+    use :: Input_Paths, only : inputPath, pathTypeDataDynamic
     implicit none
     class(surveyGeometryBernardi2013SDSS), intent(inout) :: self
     type (varying_string                )                :: bernardi2013SDSSMangleDirectory
     !$GLC attributes unused :: self
 
-    bernardi2013SDSSMangleDirectory=inputPath(pathTypeDataStatic)//"surveyGeometry/SDSS/"
+    bernardi2013SDSSMangleDirectory=inputPath(pathTypeDataDynamic)//"surveyGeometry/SDSS/"
     return
   end function bernardi2013SDSSMangleDirectory
 
@@ -183,7 +183,8 @@ contains
     !!{
     Return a list of \gls{mangle} files.
     !!}
-    use :: File_Utilities , only : File_Exists      , File_Lock, File_Unlock, lockDescriptor
+    use :: File_Utilities , only : File_Exists      , File_Lock, File_Unlock, lockDescriptor, &
+         &                         Directory_Make
     use :: Error          , only : Error_Report
     use :: System_Download, only : download
     use :: System_Command , only : System_Command_Do
@@ -199,9 +200,10 @@ contains
          &       self%mangleDirectory()//"sdss_dr72safe0_res6d.pol" &
          &      ]
     if (.not.File_Exists(mangleFiles(1))) then
+       call Directory_Make(self%mangleDirectory())
        call File_Lock  (char(mangleFiles(1)),lock,lockIsShared=.false.)
        if (.not.File_Exists(mangleFiles(1))) then
-          call download("http://space.mit.edu/~molly/mangle/download/data/sdss_dr72safe0_res6d.pol.gz",char(mangleFiles(1))//".gz",status=status)
+          call download("https://zenodo.org/records/10998446/files/sdss_dr72safe0_res6d.pol.gz",char(mangleFiles(1))//".gz",status=status)
           if (status /= 0 .or. .not.File_Exists(char(mangleFiles(1))//".gz")) &
                & call Error_Report('failed to download mangle polygon file'//{introspection:location})
           call System_Command_Do("gunzip "//mangleFiles(1)//".gz",status)

--- a/source/geometry.surveys.Li-White-2009-SDSS.F90
+++ b/source/geometry.surveys.Li-White-2009-SDSS.F90
@@ -279,14 +279,14 @@ contains
          &                                                                        i             , randomUnit
     double precision                                                           :: rightAscension, declination
     type            (varying_string               )                            :: message
-    type   (lockDescriptor                )                                           :: lock
+    type            (lockDescriptor               )                            :: lock
     integer                                                                    :: status
 
     ! Randoms file obtained from:  http://sdss.physics.nyu.edu/lss/dr72/random/
     if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"surveyGeometry/lss_random-0.dr72.dat")) then
        call Directory_Make(inputPath(pathTypeDataDynamic)//"surveyGeometry")
-       call File_Lock  (char(mangleFiles(1)),lock,lockIsShared=.false.)
-       if (.not.File_Exists(mangleFiles(1))) then
+       call File_Lock  (char(inputPath(pathTypeDataDynamic)//"surveyGeometry/lss_random-0.dr72.dat"),lock,lockIsShared=.false.)
+       if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"surveyGeometry/lss_random-0.dr72.dat")) then
           call download("https://zenodo.org/records/10257229/files/lss_random-0.dr72.dat",char(inputPath(pathTypeDataDynamic))//"surveyGeometry/lss_random-0.dr72.dat",status=status)
           if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeDataDynamic)//"surveyGeometry/lss_random-0.dr72.dat")) call Error_Report('unable to download SDSS survey geometry randoms file'//{introspection:location})
        end if

--- a/source/geometry.surveys.Li-White-2009-SDSS.F90
+++ b/source/geometry.surveys.Li-White-2009-SDSS.F90
@@ -264,9 +264,10 @@ contains
     Compute the window function for the survey.
     !!}
     use :: Display                 , only : displayMessage
-    use :: File_Utilities          , only : Count_Lines_In_File    , Directory_Make     , File_Exists
+    use :: File_Utilities          , only : Count_Lines_In_File, Directory_Make     , File_Exists, File_Lock, &
+         &                                  File_Unlock        , lockDescriptor
     use :: Error                   , only : Error_Report
-    use :: Input_Paths             , only : inputPath              , pathTypeDataDynamic
+    use :: Input_Paths             , only : inputPath          , pathTypeDataDynamic
     use :: ISO_Varying_String      , only : varying_string
     use :: Numerical_Constants_Math, only : Pi
     use :: String_Handling         , only : operator(//)
@@ -278,13 +279,18 @@ contains
          &                                                                        i             , randomUnit
     double precision                                                           :: rightAscension, declination
     type            (varying_string               )                            :: message
+    type   (lockDescriptor                )                                           :: lock
     integer                                                                    :: status
 
     ! Randoms file obtained from:  http://sdss.physics.nyu.edu/lss/dr72/random/
     if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"surveyGeometry/lss_random-0.dr72.dat")) then
        call Directory_Make(inputPath(pathTypeDataDynamic)//"surveyGeometry")
-       call download("https://zenodo.org/records/10257229/files/lss_random-0.dr72.dat",char(inputPath(pathTypeDataDynamic))//"surveyGeometry/lss_random-0.dr72.dat",status=status)
-       if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeDataDynamic)//"surveyGeometry/lss_random-0.dr72.dat")) call Error_Report('unable to download SDSS survey geometry randoms file'//{introspection:location})
+       call File_Lock  (char(mangleFiles(1)),lock,lockIsShared=.false.)
+       if (.not.File_Exists(mangleFiles(1))) then
+          call download("https://zenodo.org/records/10257229/files/lss_random-0.dr72.dat",char(inputPath(pathTypeDataDynamic))//"surveyGeometry/lss_random-0.dr72.dat",status=status)
+          if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeDataDynamic)//"surveyGeometry/lss_random-0.dr72.dat")) call Error_Report('unable to download SDSS survey geometry randoms file'//{introspection:location})
+       end if
+       call File_Unlock(                     lock                     )
     end if
     randomsCount=Count_Lines_In_File(inputPath(pathTypeDataDynamic)//"surveyGeometry/lss_random-0.dr72.dat")
     allocate(self%randomTheta(randomsCount))


### PR DESCRIPTION
- The old [site](https://space.mit.edu/~molly/mangle/download/data/sdss_dr72safe0_res6d.pol.gz) no longer exists.
- Also moves the SDSS DR7 geometry data file download to the dynamic datasets path.
- Also adds a ock on the geometry file for the `surveyGeometryLiWhite2009SDSS` class during download to avoid conflicts