### PR TITLE
Fix segfault during HDF5 close on error

### DIFF
--- a/source/error.F90
+++ b/source/error.F90
@@ -409,7 +409,7 @@ contains
     use    :: System_Output, only : stdOutIsATTY
     implicit none
 #ifdef USEMPI
-    integer            :: mpiRank
+    integer            :: mpiRank , error
     character(len=128) :: hostName
     logical            :: flag
 #endif
@@ -461,7 +461,7 @@ contains
     use    :: System_Output, only : stdOutIsATTY
     implicit none
 #ifdef USEMPI
-    integer            :: mpiRank
+    integer            :: mpiRank , error
     character(len=128) :: hostName
     logical            :: flag
 #endif
@@ -538,7 +538,7 @@ contains
     character(c_char), dimension(*) :: file       , reason
     integer  (c_int ), value        :: errorNumber, line
 #ifdef USEMPI
-    integer                         :: mpiRank
+    integer                         :: mpiRank    , error
     character(len=128)              :: hostName
     logical                         :: flag
 #endif

--- a/source/error.F90
+++ b/source/error.F90
@@ -103,12 +103,6 @@ contains
     !!{
     Display an error message.
     !!}
-#ifndef UNCLEANEXIT
-    use    :: HDF5_Access  , only : hdf5Access
-#endif
-#ifndef UNCLEANEXIT
-    use    :: HDF5         , only : H5Close_F
-#endif
 #ifdef USEMPI
     use    :: MPI          , only : MPI_Comm_Rank     , MPI_Comm_World
 #endif
@@ -117,7 +111,6 @@ contains
     use    :: System_Output, only : stdOutIsATTY
     implicit none
     character(len=*  ), intent(in   ) :: message
-    integer                           :: error
 #ifdef USEMPI
     integer                           :: mpiRank
     character(len=128)                :: hostName
@@ -141,11 +134,7 @@ contains
 #ifdef UNCLEANEXIT
     call Exit(1)
 #else
-    !$ if (.not.hdf5Access%ownedByThread()) &
-    !$      & call hdf5Access%set  (     )
-    call           H5Close_F       (error)
-    call           H5Close_C       (     )
-    !$ call        hdf5Access%unset(     )
+    call closeHDF5()
 #ifdef USEMPI
     call MPI_Initialized(flag,error)
     if (flag) then
@@ -256,12 +245,6 @@ contains
     !!{
     Handle {\normalfont \ttfamily SIGINT} signals, by flushing all data and then aborting.
     !!}
-#ifndef UNCLEANEXIT
-    use    :: HDF5_Access  , only : hdf5Access
-#endif
-#ifndef UNCLEANEXIT
-    use    :: HDF5         , only : H5Close_F
-#endif
 #ifdef USEMPI
     use    :: MPI_F08      , only : MPI_Comm_Rank     , MPI_Comm_World
 #endif
@@ -269,7 +252,6 @@ contains
     use    :: Display      , only : displayBold       , displayRed     , displayReset
     use    :: System_Output, only : stdOutIsATTY
     implicit none
-    integer            :: error
 #ifdef USEMPI
     integer            :: mpiRank
     character(len=128) :: hostName
@@ -287,11 +269,7 @@ contains
     !$    write (0,*) " => Error occurred in master thread"
     !$ end if
 #ifndef UNCLEANEXIT
-    !$ if (.not.hdf5Access%ownedByThread()) &
-    !$      & call hdf5Access%set  (     )
-    call           H5Close_F       (error)
-    call           H5Close_C       (     )
-    !$ call        hdf5Access%unset(     )
+    call closeHDF5()
 #endif
     call Warn_Review( )
     call BackTrace  ( )
@@ -319,12 +297,6 @@ contains
     !!{
     Handle {\normalfont \ttfamily SIGSEGV} signals, by flushing all data and then aborting.
     !!}
-#ifndef UNCLEANEXIT
-    use    :: HDF5_Access  , only : hdf5Access
-#endif
-#ifndef UNCLEANEXIT
-    use    :: HDF5         , only : H5Close_F
-#endif
 #ifdef USEMPI
     use    :: MPI_F08      , only : MPI_Comm_Rank     , MPI_Comm_World
 #endif
@@ -332,7 +304,6 @@ contains
     use    :: Display      , only : displayBold       , displayRed     , displayReset
     use    :: System_Output, only : stdOutIsATTY
     implicit none
-    integer            :: error
 #ifdef USEMPI
     integer            :: mpiRank
     character(len=128) :: hostName
@@ -350,11 +321,7 @@ contains
     !$    write (0,*) " => Error occurred in master thread"
     !$ end if
 #ifndef UNCLEANEXIT
-    !$ if (.not.hdf5Access%ownedByThread()) &
-    !$      & call hdf5Access%set  (     )
-    call           H5Close_F       (error)
-    call           H5Close_C       (     )
-    !$ call        hdf5Access%unset(     )
+    call closeHDF5()
 #endif
     call Warn_Review( )
     call BackTrace  ( )
@@ -382,12 +349,6 @@ contains
     !!{
     Handle {\normalfont \ttfamily SIGFPE} signals, by flushing all data and then aborting.
     !!}
-#ifndef UNCLEANEXIT
-    use    :: HDF5_Access  , only : hdf5Access
-#endif
-#ifndef UNCLEANEXIT
-    use    :: HDF5         , only : H5Close_F
-#endif
 #ifdef USEMPI
     use    :: MPI_F08      , only : MPI_Comm_Rank     , MPI_Comm_World
 #endif
@@ -395,7 +356,6 @@ contains
     use    :: Display      , only : displayBold       , displayRed     , displayReset
     use    :: System_Output, only : stdOutIsATTY
     implicit none
-    integer            :: error
 #ifdef USEMPI
     integer            :: mpiRank
     character(len=128) :: hostName
@@ -413,11 +373,7 @@ contains
     !$    write (0,*) " => Error occurred in master thread"
     !$ end if
 #ifndef UNCLEANEXIT
-    !$ if (.not.hdf5Access%ownedByThread()) &
-    !$      & call hdf5Access%set  (     )
-    call           H5Close_F       (error)
-    call           H5Close_C       (     )
-    !$ call        hdf5Access%unset(     )
+    call closeHDF5()
 #endif
     call Warn_Review( )
     call BackTrace  ( )
@@ -445,12 +401,6 @@ contains
     !!{
     Handle {\normalfont \ttfamily SIGBUS} signals, by flushing all data and then aborting.
     !!}
-#ifndef UNCLEANEXIT
-    use    :: HDF5_Access  , only : hdf5Access
-#endif
-#ifndef UNCLEANEXIT
-    use    :: HDF5         , only : H5Close_F
-#endif
 #ifdef USEMPI
     use    :: MPI_F08      , only : MPI_Comm_Rank     , MPI_Comm_World
 #endif
@@ -458,7 +408,6 @@ contains
     use    :: Display      , only : displayBold       , displayRed     , displayReset
     use    :: System_Output, only : stdOutIsATTY
     implicit none
-    integer            :: error
 #ifdef USEMPI
     integer            :: mpiRank
     character(len=128) :: hostName
@@ -476,11 +425,7 @@ contains
     !$    write (0,*) " => Error occurred in master thread"
     !$ end if
 #ifndef UNCLEANEXIT
-    !$ if (.not.hdf5Access%ownedByThread()) &
-    !$      & call hdf5Access%set  (     )
-    call           H5Close_F       (error)
-    call           H5Close_C       (     )
-    !$ call        hdf5Access%unset(     )
+    call closeHDF5()
 #endif
     call Warn_Review( )
     call BackTrace  ( )
@@ -508,12 +453,6 @@ contains
     !!{
     Handle {\normalfont \ttfamily SIGILL} signals, by flushing all data and then aborting.
     !!}
-#ifndef UNCLEANEXIT
-    use    :: HDF5_Access  , only : hdf5Access
-#endif
-#ifndef UNCLEANEXIT
-    use    :: HDF5         , only : H5Close_F
-#endif
 #ifdef USEMPI
     use    :: MPI_F08      , only : MPI_Comm_Rank     , MPI_Comm_World
 #endif
@@ -521,7 +460,6 @@ contains
     use    :: Display      , only : displayBold       , displayRed     , displayReset
     use    :: System_Output, only : stdOutIsATTY
     implicit none
-    integer            :: error
 #ifdef USEMPI
     integer            :: mpiRank
     character(len=128) :: hostName
@@ -539,11 +477,7 @@ contains
     !$    write (0,*) " => Error occurred in master thread"
     !$ end if
 #ifndef UNCLEANEXIT
-    !$ if (.not.hdf5Access%ownedByThread()) &
-    !$      & call hdf5Access%set  (     )
-    call           H5Close_F       (error)
-    call           H5Close_C       (     )
-    !$ call        hdf5Access%unset(     )
+    call closeHDF5()
 #endif
     call Warn_Review( )
     call BackTrace  ( )
@@ -571,16 +505,9 @@ contains
     !!{
     Handle {\normalfont \ttfamily SIGXCPU} signals, by flushing all data and then aborting.
     !!}
-#ifndef UNCLEANEXIT
-    use :: HDF5_Access  , only : hdf5Access
-#endif
-#ifndef UNCLEANEXIT
-    use :: HDF5         , only : H5Close_F
-#endif
     use :: Display      , only : displayBold , displayRed, displayReset
     use :: System_Output, only : stdOutIsATTY
     implicit none
-    integer :: error
 
     if (stdOutIsATTY()) then
        write (0,*) displayRed()//displayBold()//'Galacticus exceeded available CPU time - will try to flush data before exiting.'//displayReset()
@@ -589,11 +516,7 @@ contains
     end if
     call Flush(0)
 #ifndef UNCLEANEXIT
-    !$ if (.not.hdf5Access%ownedByThread()) &
-    !$      & call hdf5Access%set  (     )
-    call           H5Close_F       (error)
-    call           H5Close_C       (     )
-    !$ call        hdf5Access%unset(     )
+    call closeHDF5()
 #endif
     call Exit(errorStatusXCPU)
     return
@@ -603,12 +526,6 @@ contains
     !!{
     Handle errors from the GSL library, by flushing all data and then aborting.
     !!}
-#ifndef UNCLEANEXIT
-    use               :: HDF5_Access       , only : hdf5Access
-#endif
-#ifndef UNCLEANEXIT
-    use               :: HDF5              , only : H5Close_F
-#endif
     use   , intrinsic :: ISO_C_Binding     , only : c_char
     use               :: ISO_Varying_String, only : char
 #ifdef USEMPI
@@ -620,7 +537,6 @@ contains
     use               :: System_Output     , only : stdOutIsATTY
     character(c_char), dimension(*) :: file       , reason
     integer  (c_int ), value        :: errorNumber, line
-    integer                         :: error
 #ifdef USEMPI
     integer                         :: mpiRank
     character(len=128)              :: hostName
@@ -641,11 +557,7 @@ contains
        !$    write (0,*) " => Error occurred in master thread"
        !$ end if
 #ifndef UNCLEANEXIT
-       !$ if (.not.hdf5Access%ownedByThread()) &
-       !$      & call hdf5Access%set  (     )
-       call           H5Close_F       (error)
-       call           H5Close_C       (     )
-       !$ call        hdf5Access%unset(     )
+       call closeHDF5()
 #endif
        call Warn_Review( )
        call BackTrace  ( )
@@ -751,4 +663,26 @@ contains
     return
   end subroutine Error_Wait_Set
 
+#ifndef UNCLEANEXIT
+  subroutine closeHDF5()
+    !!{
+    Close HDF5 functionality on error.
+    !!}
+    use :: HDF5         , only : H5Close_F
+    use :: HDF5_Access  , only : hdf5Access, hdf5AccessInitialized
+    implicit none
+    integer :: error
+    
+    !$ if (hdf5AccessInitialized) then
+    !$    if (.not.hdf5Access%ownedByThread()) &
+    !$      & call hdf5Access%set  (     )
+    call           H5Close_F       (error)
+    call           H5Close_C       (     )
+    !$    if (hdf5AccessInitialized      ) &
+    !$      & call hdf5Access%unset(     )
+    !$ end if
+    return
+  end subroutine closeHDF5
+#endif
+  
 end module Error

--- a/source/error.F90
+++ b/source/error.F90
@@ -112,7 +112,7 @@ contains
     implicit none
     character(len=*  ), intent(in   ) :: message
 #ifdef USEMPI
-    integer                           :: mpiRank
+    integer                           :: mpiRank , error
     character(len=128)                :: hostName
     logical                           :: flag
 #endif
@@ -253,7 +253,7 @@ contains
     use    :: System_Output, only : stdOutIsATTY
     implicit none
 #ifdef USEMPI
-    integer            :: mpiRank
+    integer            :: mpiRank , error
     character(len=128) :: hostName
     logical            :: flag
 #endif
@@ -305,7 +305,7 @@ contains
     use    :: System_Output, only : stdOutIsATTY
     implicit none
 #ifdef USEMPI
-    integer            :: mpiRank
+    integer            :: mpiRank , error
     character(len=128) :: hostName
     logical            :: flag
 #endif
@@ -357,7 +357,7 @@ contains
     use    :: System_Output, only : stdOutIsATTY
     implicit none
 #ifdef USEMPI
-    integer            :: mpiRank
+    integer            :: mpiRank , error
     character(len=128) :: hostName
     logical            :: flag
 #endif

--- a/source/merger_trees.construct.fully_specified.F90
+++ b/source/merger_trees.construct.fully_specified.F90
@@ -217,7 +217,7 @@ contains
     if (ioErr /= 0) then
        message=var_str("unable to read or parse fully-specified merger tree file ")//"'"//self%fileName//"'"
        if (File_Exists(self%fileName)) then
-          message=message//char(10)//displayGreen()//"HELP:"//displayReset()//" check that the XML in this file is valid (e.g. `xmllint --nout "//self%fileName//"` will display any XML errors"
+          message=message//char(10)//displayGreen()//"HELP:"//displayReset()//" check that the XML in this file is valid (e.g. `xmllint --noout "//self%fileName//"` will display any XML errors"
        else
           message=message//" - file does not exist"
        end if

--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -313,6 +313,7 @@ contains
     Constructor for the {\normalfont \ttfamily inputParameters} class from an XML file
     specified as a character variable.
     !!}
+    use :: Display       , only : displayGreen                     , displayReset
     use :: File_Utilities, only : File_Exists
     use :: FoX_dom       , only : node
     use :: Error         , only : Error_Report
@@ -333,9 +334,16 @@ contains
     doc => XML_Parse(fileName,iostat=errorStatus)
     if (errorStatus /= 0) then
        if (File_Exists(fileName)) then
-          call Error_Report('Unable to parse parameter file: "'//trim(fileName)//'"'//{introspection:location})
+          call Error_Report(                                                                                                                                                                &
+               &            'Unable to parse parameter file: "'//trim(fileName)//'"'//char(10)//                                                                                            &
+               &            displayGreen()//"HELP:"//displayReset()//" check that the XML in this file is valid (e.g. `xmllint --noout "//trim(fileName)//"` will display any XML errors"// &
+               &            {introspection:location}                                                                                                                                        &
+               &           )
        else
-          call Error_Report('Unable to find parameter file: "' //trim(fileName)//'"'//{introspection:location})
+          call Error_Report(                                                                                                                                                                &
+               &            'Unable to find parameter file: "' //trim(fileName)//'"'//                                                                                                      &
+               &            {introspection:location}                                                                                                                                        &
+               &           )
        end if
     end if
     parameterNode => XML_Get_First_Element_By_Tag_Name(              &


### PR DESCRIPTION
When an error occurs we attempt to close down the HDF5 subsystem. This requires obtaining a lock on the HDF5 subsystem. But, if an error occurs before the lock was initialized then this could cause a segfault due to attempting to access the uninitialized lock. We now check the initialization status before attempting to lock. This could potentially result in a race condition, but since this is already occurring during error, there's only so much that we can do.

Also adds a more useful error message for unparseable parameter files.