### PR TITLE
Do not attempt to use FFTW3 functions if FFTW is not available

### DIFF
--- a/scripts/build/useDependencies.pl
+++ b/scripts/build/useDependencies.pl
@@ -51,22 +51,26 @@ my %includeLibraries = (
     );
 # Parse the Makefile to find preprocessor macros that are set.
 my @preprocessorDirectives;
-my @conditionsStack;
-open(my $makefile,"Makefile");
-while ( my $line = <$makefile> ) {
-    # Build a stack of true/false values indicating whether the current line is active or not based on pre-processor arguments.
-    push(@conditionsStack,exists($ENV{$1}))
-	if ( $line =~ m/^ifdef ([A-Z]+)/ );
-    push(@conditionsStack,1)
-	if ( $line =~ m/^ifeq /          );
-    pop (@conditionsStack  )
-	if ( $line =~ m/^endif/          );
-    # If this line sets compiler flags, and no false entries exist in the preprocessor conditions stack, extract all preprocessor
-    # directives from the line.
-    push(@preprocessorDirectives,map {$_ =~ m/\-D([0-9A-Z]+)/ ? $1 : ()} split(" ",$line))
-	if ( ! grep {! $_} @conditionsStack && $line =~ m/^\s*FCFLAGS\s*\+??=/ );
+my @makefiles = ( "Makefile", glob($ENV{'BUILDPATH'}."/Makefile*") );
+foreach my $makefileName ( @makefiles ) { 
+    my @conditionsStack = ( 1 );;
+    open(my $makefile,$makefileName);
+    while ( my $line = <$makefile> ) {
+	# Build a stack of true/false values indicating whether the current line is active or not based on pre-processor arguments.
+	push(@conditionsStack,exists($ENV{$1}))
+	    if ( $line =~ m/^ifdef ([A-Z]+)/ );
+	push(@conditionsStack,1)
+	    if ( $line =~ m/^ifeq /          );
+	pop (@conditionsStack  )
+	    if ( $line =~ m/^endif/          );
+	# If this line sets compiler flags, and no false entries exist in the preprocessor conditions stack, extract all preprocessor
+	# directives from the line.    
+	push(@preprocessorDirectives,map {$_ =~ m/\-D([0-9A-Z]+)/ ? $1 : ()} split(" ",$line))
+		if ( ! grep {! $_} @conditionsStack && $line =~ m/^\s*FCFLAGS\s*\+??=/ );
+    }
+    close($makefile);
 }
-close($makefile);
+
 # Extract any preprocessor directives specified via the GALACTICUS_FCFLAGS environment variable.
 push(@preprocessorDirectives,map {$_ =~ m/\-D([0-9A-Z]+)/ ? $1 : ()} split(" ",$ENV{"GALACTICUS_FCFLAGS"}))
     if ( exists($ENV{"GALACTICUS_FCFLAGS"}) );
@@ -76,6 +80,7 @@ while ( my $line = <$compilerDefs> ) {
     my @columns = split(" ",$line);
     push(@preprocessorDirectives,$columns[1]);
 }
+
 # Initialize structure to hold record of directives from each source file.
 my $usesPerFile;
 my $havePerFile = -e $workDirectoryName."Makefile_Use_Dependencies.blob";

--- a/source/geometry.surveys.full_sky.F90
+++ b/source/geometry.surveys.full_sky.F90
@@ -224,9 +224,10 @@ contains
     !!{
     Compute the window function for the survey.
     !!}
+#ifdef FFTW3AVAIL
     use            :: FFTW3        , only : fftw_plan_dft_3d  , FFTW_FORWARD       , FFTW_ESTIMATE, fftw_execute_dft, &
          &                                  fftw_destroy_plan
-#ifdef FFTW3UNAVAIL
+#else
     use            :: Error        , only : Error_Report
 #endif
     use, intrinsic :: ISO_C_Binding, only : c_ptr             , c_double_complex

--- a/source/geometry.surveys.random_points.F90
+++ b/source/geometry.surveys.random_points.F90
@@ -84,8 +84,10 @@ contains
     !!{
     Compute the window function for the survey.
     !!}
+#ifdef FFTW3AVAIL
     use            :: FFTW3        , only : fftw_plan_dft_3d       , FFTW_FORWARD       , FFTW_ESTIMATE, fftw_execute_dft, &
          &                                  fftw_destroy_plan
+#endif
     use            :: Error        , only : Error_Report
     use, intrinsic :: ISO_C_Binding, only : c_double_complex       , c_ptr
     use            :: Meshes       , only : Meshes_Apply_Point     , cloudTypeTriangular

--- a/source/statistics.points.power_spectrum.F90
+++ b/source/statistics.points.power_spectrum.F90
@@ -35,8 +35,11 @@ contains
     Compute the power spectrum from a set of points in a periodic cube.
     !!}
     use            :: Display                 , only : displayMessage
-    use            :: FFTW3                   , only : FFTW_ESTIMATE     , FFTW_FORWARD        , FFTW_Wavenumber, fftw_destroy_plan, &
-          &                                            fftw_execute_dft  , fftw_plan_dft_3d
+    use            :: FFTW3                   , only : FFTW_Wavenumber
+#ifdef FFTW3AVAIL
+    use            :: FFTW3                   , only : FFTW_ESTIMATE     , FFTW_FORWARD        , fftw_destroy_plan, fftw_execute_dft, &
+          &                                            fftw_plan_dft_3d
+#endif
     use            :: Error                   , only : Error_Report
     use, intrinsic :: ISO_C_Binding           , only : c_double_complex  , c_ptr
     use            :: ISO_Varying_String      , only : varying_string


### PR DESCRIPTION
Moves the relevant module `use` statements inside preprocessor conditionals making use of the `FFTW3AVAIL` preprocessor macr,o,