### PR TITLE
Add alternative specificiation of log-normal distribution parameters

### DIFF
--- a/source/structure_formation.halo_environment.lognormal.F90
+++ b/source/structure_formation.halo_environment.lognormal.F90
@@ -140,8 +140,8 @@ contains
     <referenceConstruct owner="self" isResult="yes" object="distributionDensityContrast">
      <constructor>
       distributionFunction1DLogNormal(                                                                    &amp;
-        &amp;                                    +densityContrastMean                                   , &amp;
-        &amp;                                    +self%variance                                         , &amp;
+        &amp;                         mean      =+densityContrastMean                                   , &amp;
+        &amp;                         variance  =+self%variance                                         , &amp;
         &amp;                         limitUpper=+1.0d0                                                   &amp;
         &amp;                                    +self%criticalOverdensity_%value(expansionFactor=1.0d0)  &amp;
         &amp;                        )


### PR DESCRIPTION
Can now specify the parameters directly instead of specifying the mean and variance.