### PR TITLE
fix: floating point exception in nodePropertyExtractorSatelliteDynamicalTime

### DIFF
--- a/source/nodes.property_extractor.satellite.dynamical_time.F90
+++ b/source/nodes.property_extractor.satellite.dynamical_time.F90
@@ -130,9 +130,11 @@ contains
     type            (multiCounter                               ), intent(inout), optional :: instance
     double precision                                                                       :: radiusTidal, massTidal
     !$GLC attributes unused :: instance
-
+    dynamicalTimeExtract  =-1.0d0
     radiusTidal           =self%satelliteTidalStrippingRadius_%radius      (node            )
-    massTidal             =self%galacticStructure_            %massEnclosed(node,radiusTidal)
+    if (radiusTidal <= 0.0d0) return
+    massTidal             =self%galacticStructure_            %massEnclosed(node,radiusTidal) 
+    if (massTidal <= 0.0d0) return
     dynamicalTimeExtract  =+sqrt(                                    &  
          &                       +Pi                             **2 &
          &                       /4.0d0                              &


### PR DESCRIPTION
Fixed floating point exception in nodePropertyExtractorSatelliteDynamicalTime. Check that both the tidal radius and tidal mass are non zero. If they are zero, return -1.0 to avoid divide by zero.