### PR TITLE
fix: Remove `Method` suffix from parameter names in test suite parameter files

### DIFF
--- a/testSuite/parameters/concentrationDistributionLudlow2016.xml
+++ b/testSuite/parameters/concentrationDistributionLudlow2016.xml
@@ -19,12 +19,20 @@
     <HubbleConstant  value="70.400000"/>
     <OmegaMatter     value=" 0.272000"/>
     <OmegaDarkEnergy value=" 0.728000"/>
-    <OmegaBaryon     value=" 0.044550"/>
+    <OmegaBaryon     value=" 0.0000000"/>
     <temperatureCMB  value=" 2.725480"/>
   </cosmologyParameters>
 
   <!-- Power spectrum options -->
-  <transferFunction        value="CAMB"    />
+  <transferFunction        value="CAMB"     >
+    <cosmologyParameters value="simple">
+      <HubbleConstant  value="70.400000"/>
+      <OmegaMatter     value=" 0.272000"/>
+      <OmegaDarkEnergy value=" 0.728000"/>
+      <OmegaBaryon     value=" 0.044550"/>
+      <temperatureCMB  value=" 2.725480"/>
+    </cosmologyParameters>
+  </transferFunction>
   <powerSpectrumPrimordial value="powerLaw" >
     <index               value="0.967"/>
     <wavenumberReference value="1.000"/>

--- a/testSuite/parameters/concentrationDistributionLudlow2016.xml
+++ b/testSuite/parameters/concentrationDistributionLudlow2016.xml
@@ -24,24 +24,24 @@
   </cosmologyParameters>
 
   <!-- Power spectrum options -->
-  <transferFunctionMethod        value="CAMB"    />
-  <powerSpectrumPrimordialMethod value="powerLaw" >
+  <transferFunction        value="CAMB"    />
+  <powerSpectrumPrimordial value="powerLaw" >
     <index               value="0.967"/>
     <wavenumberReference value="1.000"/>
     <running             value="0.000"/>
-  </powerSpectrumPrimordialMethod>
-  <powerSpectrumPrimordialTransferredMethod value="simple"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
   <cosmologicalMassVariance value="filteredPower">
     <sigma_8 value="0.81"/>
   </cosmologicalMassVariance>
 
   <!-- Structure formation options -->
   <linearGrowth value="collisionlessMatter"/>
-  <haloMassFunctionMethod value="shethTormen">
+  <haloMassFunction value="shethTormen">
     <a             value="+0.791"/>
     <p             value="+0.218"/>
     <normalization value="+0.302"/>
-  </haloMassFunctionMethod>
+  </haloMassFunction>
   <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
   <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
 

--- a/testSuite/parameters/concentrationDistributionLudlow2016Environmental.xml
+++ b/testSuite/parameters/concentrationDistributionLudlow2016Environmental.xml
@@ -19,12 +19,20 @@
     <HubbleConstant  value="70.400000"/>
     <OmegaMatter     value=" 0.272000"/>
     <OmegaDarkEnergy value=" 0.728000"/>
-    <OmegaBaryon     value=" 0.044550"/>
+    <OmegaBaryon     value=" 0.000000"/>
     <temperatureCMB  value=" 2.725480"/>
   </cosmologyParameters>
 
   <!-- Power spectrum options -->
-  <transferFunction        value="CAMB"    />
+  <transferFunction        value="CAMB"     >
+    <cosmologyParameters value="simple">
+      <HubbleConstant  value="70.400000"/>
+      <OmegaMatter     value=" 0.272000"/>
+      <OmegaDarkEnergy value=" 0.728000"/>
+      <OmegaBaryon     value=" 0.044550"/>
+      <temperatureCMB  value=" 2.725480"/>
+    </cosmologyParameters>
+  </transferFunction>
   <powerSpectrumPrimordial value="powerLaw" >
     <index               value="0.967"/>
     <wavenumberReference value="1.000"/>

--- a/testSuite/parameters/concentrationDistributionLudlow2016Environmental.xml
+++ b/testSuite/parameters/concentrationDistributionLudlow2016Environmental.xml
@@ -24,24 +24,24 @@
   </cosmologyParameters>
 
   <!-- Power spectrum options -->
-  <transferFunctionMethod        value="CAMB"    />
-  <powerSpectrumPrimordialMethod value="powerLaw" >
+  <transferFunction        value="CAMB"    />
+  <powerSpectrumPrimordial value="powerLaw" >
     <index               value="0.967"/>
     <wavenumberReference value="1.000"/>
     <running             value="0.000"/>
-  </powerSpectrumPrimordialMethod>
-  <powerSpectrumPrimordialTransferredMethod value="simple"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
   <cosmologicalMassVariance value="filteredPower">
     <sigma_8 value="0.81"/>
   </cosmologicalMassVariance>
 
   <!-- Structure formation options -->
   <linearGrowth value="collisionlessMatter"/>
-  <haloMassFunctionMethod value="shethTormen">
+  <haloMassFunction value="shethTormen">
     <a             value="+0.791"/>
     <p             value="+0.218"/>
     <normalization value="+0.302"/>
-  </haloMassFunctionMethod>
+  </haloMassFunction>
   <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
   <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
   <haloEnvironment value="normal">


### PR DESCRIPTION
This should have happened along with the [commit](https://github.com/galacticusorg/galacticus/commit/f483d9caf532e5f33cdbe46aad53d076316ec394) that first removed these suffixes, but these two files were apparently missed.