### PR TITLE
Add functionality to track and output gas-mass-based major merger times

### DIFF
--- a/source/nodes.operators.analyses.galaxy_gas_major_merger_time.F90
+++ b/source/nodes.operators.analyses.galaxy_gas_major_merger_time.F90
@@ -1,0 +1,178 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a node operator class that records the times of gas-mass-based major mergers between galaxies.
+  !!}
+
+  use, intrinsic :: ISO_C_Binding, only : c_size_t
+
+  !![
+  <nodeOperator name="nodeOperatorGalaxyGasMajorMergerTime">
+   <description>A node operator class that records the times of gas-mass-based major mergers between galaxies.</description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorGalaxyGasMajorMergerTime
+     !!{
+     A node operator class that records the times of gas-mass-based major mergers between galaxies.
+     !!}
+     private
+     integer                    :: galaxyGasMajorMergerTimeID
+     integer         (c_size_t) :: countTimesMaximum
+     double precision           :: ratioGasMajorMerger
+  contains
+     final     ::             galaxyGasMajorMergerTimeDestructor
+     procedure :: autoHook => galaxyGasMajorMergerTimeAutoHook
+  end type nodeOperatorGalaxyGasMajorMergerTime
+  
+  interface nodeOperatorGalaxyGasMajorMergerTime
+     !!{
+     Constructors for the {\normalfont \ttfamily galaxyGasMajorMergerTime} node operator class.
+     !!}
+     module procedure galaxyGasMajorMergerTimeConstructorParameters
+     module procedure galaxyGasMajorMergerTimeConstructorInternal
+  end interface nodeOperatorGalaxyGasMajorMergerTime
+  
+contains
+
+  function galaxyGasMajorMergerTimeConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily galaxyGasMajorMergerTime} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (nodeOperatorGalaxyGasMajorMergerTime)                :: self
+    type            (inputParameters                     ), intent(inout) :: parameters
+    integer         (c_size_t                            )                :: countTimesMaximum
+    double precision                                                      :: ratioGasMajorMerger
+    
+    !![
+    <inputParameter>
+      <name>countTimesMaximum</name>
+      <defaultValue>huge(0_c_size_t)</defaultValue>
+      <description>The maximum number of major merger times to accumulate for each node. Defaults to the maximum possible.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>ratioGasMajorMerger</name>
+      <defaultValue>0.25d0</defaultValue>
+      <description>The gas mass ratio threshold defining a major merger.</description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=nodeOperatorGalaxyGasMajorMergerTime(countTimesMaximum,ratioGasMajorMerger)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function galaxyGasMajorMergerTimeConstructorParameters
+
+  function galaxyGasMajorMergerTimeConstructorInternal(countTimesMaximum,ratioGasMajorMerger) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily galaxyGasMajorMergerTime} node operator class.
+    !!}
+    use :: Galacticus_Nodes, only : defaultBasicComponent
+    implicit none
+    type            (nodeOperatorGalaxyGasMajorMergerTime)                        :: self
+    integer         (c_size_t                            ), intent(in   )         :: countTimesMaximum
+    double precision                                      , intent(in   )         :: ratioGasMajorMerger
+    !![
+    <constructorAssign variables="countTimesMaximum, ratioGasMajorMerger"/>
+    !!]
+    
+    !![
+    <addMetaProperty component="basic" name="galaxyGasMajorMergerTime" id="self%galaxyGasMajorMergerTimeID" rank="1" isCreator="yes"/>
+    !!]
+    return
+  end function galaxyGasMajorMergerTimeConstructorInternal
+
+  subroutine galaxyGasMajorMergerTimeAutoHook(self)
+    !!{
+    Attach to various event hooks.
+    !!}
+    use :: Events_Hooks, only : satelliteMergerEvent, openMPThreadBindingAtLevel, dependencyDirectionAfter, dependencyRegEx
+    implicit none
+    class(nodeOperatorGalaxyGasMajorMergerTime), intent(inout) :: self
+    type (dependencyRegEx                     ), dimension(1)  :: dependenciesSatelliteMerger 
+
+    dependenciesSatelliteMerger(1)=dependencyRegEx(dependencyDirectionAfter,'^remnantStructure:')
+    call satelliteMergerEvent%attach(self,satelliteMerger,openMPThreadBindingAtLevel,label='preAnalysis:galaxyGasMajorMergerTime',dependencies=dependenciesSatelliteMerger)
+    return
+  end subroutine galaxyGasMajorMergerTimeAutoHook
+  
+  subroutine galaxyGasMajorMergerTimeDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily galaxyGasMajorMergerTime} node operator class.
+    !!}
+    use :: Events_Hooks, only : satelliteMergerEvent
+    implicit none
+    type(nodeOperatorGalaxyGasMajorMergerTime), intent(inout) :: self
+
+    if (satelliteMergerEvent%isAttached(self,satelliteMerger)) call satelliteMergerEvent%detach(self,satelliteMerger)
+    return
+  end subroutine galaxyGasMajorMergerTimeDestructor
+
+  subroutine satelliteMerger(self,node)
+    !!{
+    Record times of galaxy-galaxy major mergers.
+    !!}
+    use :: Error                           , only : Error_Report
+    use :: Galacticus_Nodes                , only : nodeComponentBasic              , nodeComponentDisk, nodeComponentSpheroid
+    use :: Satellite_Merging_Mass_Movements, only : enumerationDestinationMergerType
+    implicit none
+    class           (*                    ), intent(inout)              :: self
+    type            (treeNode             ), intent(inout), target      :: node
+    type            (treeNode             )               , pointer     :: nodeHost
+    class           (nodeComponentBasic   )               , pointer     :: basicHost
+    class           (nodeComponentDisk    )               , pointer     :: disk                   , diskHost
+    class           (nodeComponentSpheroid)               , pointer     :: spheroid               , spheroidHost
+    double precision                       , dimension(:) , allocatable :: majorMergerTimesCurrent, majorMergerTimesNew
+    logical                                                             :: mergerIsMajor
+    double precision                                                    :: massGas                , massGasHost
+    
+    select type (self)
+    class is (nodeOperatorGalaxyGasMajorMergerTime)
+       nodeHost      =>  node    %mergesWith()
+       disk          =>  node    %disk      ()
+       spheroid      =>  node    %spheroid  ()
+       diskHost      =>  nodeHost%disk      ()
+       spheroidHost  =>  nodeHost%spheroid  ()
+       massGas       =  +disk    %massGas()+spheroid    %massGas()
+       massGasHost   =  +diskHost%massGas()+spheroidHost%massGas()
+       mergerIsMajor =   massGas > self%ratioGasMajorMerger*massGasHost
+       if (mergerIsMajor) then
+       ! Find the node to merge with.
+       basicHost => nodeHost%basic()
+       ! Append the merger time.
+       majorMergerTimesCurrent=basicHost%floatRank1MetaPropertyGet(self%galaxyGasMajorMergerTimeID)
+       if (size(majorMergerTimesCurrent) < self%countTimesMaximum) then
+          allocate(majorMergerTimesNew(size(majorMergerTimesCurrent)+1_c_size_t))
+          majorMergerTimesNew(1_c_size_t:size(majorMergerTimesCurrent)           )=majorMergerTimesCurrent(          :                             )
+       else
+          allocate(majorMergerTimesNew(size(majorMergerTimesCurrent)           ))
+          majorMergerTimesNew(1_c_size_t:size(majorMergerTimesCurrent)-1_c_size_t)=majorMergerTimesCurrent(2_c_size_t:size(majorMergerTimesCurrent))
+       end if
+       majorMergerTimesNew(size(majorMergerTimesNew))=basicHost%time()
+       call basicHost%floatRank1MetaPropertySet(self%galaxyGasMajorMergerTimeID,majorMergerTimesNew)
+    end if
+    class default
+       call Error_Report('incorrect class'//{introspection:location})
+    end select
+    return
+  end subroutine satelliteMerger

--- a/source/nodes.operators.analyses.galaxy_major_merger_time.F90
+++ b/source/nodes.operators.analyses.galaxy_major_merger_time.F90
@@ -109,7 +109,7 @@ contains
     type (dependencyRegEx                  ), dimension(1)  :: dependenciesSatelliteMerger 
 
     dependenciesSatelliteMerger(1)=dependencyRegEx(dependencyDirectionAfter,'^remnantStructure:')
-    call satelliteMergerEvent%attach(self,satelliteMerger ,openMPThreadBindingAtLevel,label='galaxyMajorMergerTime',dependencies=dependenciesSatelliteMerger)
+    call satelliteMergerEvent%attach(self,satelliteMerger,openMPThreadBindingAtLevel,label='galaxyMajorMergerTime',dependencies=dependenciesSatelliteMerger)
     return
   end subroutine galaxyMajorMergerTimeAutoHook
   
@@ -121,7 +121,7 @@ contains
     implicit none
     type(nodeOperatorGalaxyMajorMergerTime), intent(inout) :: self
 
-    if (satelliteMergerEvent%isAttached(self,satelliteMerger )) call satelliteMergerEvent%detach(self,satelliteMerger )
+    if (satelliteMergerEvent%isAttached(self,satelliteMerger)) call satelliteMergerEvent%detach(self,satelliteMerger)
     !![
     <objectDestructor name="self%mergerMassMovements_"/>
     !!]

--- a/source/nodes.property_extractor.galaxy_gas_major_merger_time.F90
+++ b/source/nodes.property_extractor.galaxy_gas_major_merger_time.F90
@@ -1,0 +1,154 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !![
+  <nodePropertyExtractor name="nodePropertyExtractorGalaxyGasMajorMergerTime">
+   <description>
+     A node property extractor which extracts the times of gas-mass-based major mergers for each galaxy.
+   </description>
+  </nodePropertyExtractor>
+  !!]
+  type, extends(nodePropertyExtractorList) :: nodePropertyExtractorGalaxyGasMajorMergerTime
+     !!{
+     A property extractor which extracts the times of gas-mass-based major merger for each galaxy.
+     !!}
+     private
+     integer :: galaxyGasMajorMergerTimeID
+   contains
+     procedure :: elementCount => galaxyGasMajorMergerTimeElementCount
+     procedure :: extract      => galaxyGasMajorMergerTimeExtract
+     procedure :: names        => galaxyGasMajorMergerTimeNames
+     procedure :: descriptions => galaxyGasMajorMergerTimeDescriptions
+     procedure :: unitsInSI    => galaxyGasMajorMergerTimeUnitsInSI
+  end type nodePropertyExtractorGalaxyGasMajorMergerTime
+
+  interface nodePropertyExtractorGalaxyGasMajorMergerTime
+     !!{
+     Constructors for the ``galaxyGasMajorMergerTime'' output extractor class.
+     !!}
+     module procedure galaxyGasMajorMergerTimeConstructorParameters
+     module procedure galaxyGasMajorMergerTimeConstructorInternal
+  end interface nodePropertyExtractorGalaxyGasMajorMergerTime
+
+contains
+
+  function galaxyGasMajorMergerTimeConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the ``galaxyGasMajorMergerTime'' property extractor class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type(nodePropertyExtractorGalaxyGasMajorMergerTime)                :: self
+    type(inputParameters                              ), intent(inout) :: parameters
+
+    self=nodePropertyExtractorGalaxyGasMajorMergerTime()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function galaxyGasMajorMergerTimeConstructorParameters
+
+  function galaxyGasMajorMergerTimeConstructorInternal() result(self)
+    !!{
+    Internal constructor for the ``galaxyGasMajorMergerTime'' output extractor property extractor class.
+    !!}
+    implicit none
+    type(nodePropertyExtractorGalaxyGasMajorMergerTime) :: self
+    
+    !![
+    <addMetaProperty component="basic" name="galaxyGasMajorMergerTime" id="self%galaxyGasMajorMergerTimeID" rank="1" isCreator="no"/>
+    !!]
+    return
+  end function galaxyGasMajorMergerTimeConstructorInternal
+
+  integer function galaxyGasMajorMergerTimeElementCount(self)
+    !!{
+    Return a count of the number of properties extracted.
+    !!}
+    implicit none
+    class(nodePropertyExtractorGalaxyGasMajorMergerTime), intent(inout) :: self
+
+    galaxyGasMajorMergerTimeElementCount=1
+    return
+  end function galaxyGasMajorMergerTimeElementCount
+
+  function galaxyGasMajorMergerTimeExtract(self,node,instance) result(timeMajorMergers)
+    !!{
+    Implement a galaxyGasMajorMergerTime output extractor.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentBasic
+    implicit none
+    double precision                                               , dimension(:,:), allocatable :: timeMajorMergers
+    class           (nodePropertyExtractorGalaxyGasMajorMergerTime), intent(inout)               :: self
+    type            (treeNode                                     ), intent(inout)               :: node
+    type            (multiCounter                                 ), intent(inout) , optional    :: instance
+    class           (nodeComponentBasic                           )                , pointer     :: basic
+    double precision                                               , dimension(:  ), allocatable :: times
+    !$GLC attributes unused :: instance
+    !$GLC attributes initialized :: times
+
+    basic => node %basic                    (                            )
+    times =  basic%floatRank1MetaPropertyGet(self%galaxyGasMajorMergerTimeID)
+    allocate(timeMajorMergers(size(times),1))
+    timeMajorMergers(:,1)=times
+    return
+  end function galaxyGasMajorMergerTimeExtract
+  
+  subroutine galaxyGasMajorMergerTimeNames(self,names)
+    !!{
+    Return the names of the {\normalfont \ttfamily galaxyGasMajorMergerTime} properties.
+    !!}
+    implicit none
+    class(nodePropertyExtractorGalaxyGasMajorMergerTime), intent(inout)                             :: self
+    type (varying_string                               ), intent(inout), dimension(:) , allocatable :: names
+    !$GLC attributes unused :: self
+
+    allocate(names(1))
+    names(1)=var_str('galaxyGasMajorMergerTime')
+    return
+  end subroutine galaxyGasMajorMergerTimeNames
+
+  subroutine galaxyGasMajorMergerTimeDescriptions(self,descriptions)
+    !!{
+    Return the descriptions of the {\normalfont \ttfamily galaxyGasMajorMergerTime} properties.
+    !!}
+    implicit none
+    class(nodePropertyExtractorGalaxyGasMajorMergerTime), intent(inout)                             :: self
+    type (varying_string                               ), intent(inout), dimension(:) , allocatable :: descriptions
+    !$GLC attributes unused :: self
+
+    allocate(descriptions(1))
+    descriptions(1)=var_str('Times of gas-mass-based galaxy major mergers.')
+    return
+  end subroutine galaxyGasMajorMergerTimeDescriptions
+
+  function galaxyGasMajorMergerTimeUnitsInSI(self) result(unitsInSI)
+    !!{
+    Return the units of the {\normalfont \ttfamily galaxyGasMajorMergerTime} properties in the SI system.
+    !!}
+    use :: Numerical_Constants_Astronomical, only : gigaYear
+    implicit none
+    double precision                                               , dimension(:) , allocatable :: unitsInSI
+    class           (nodePropertyExtractorGalaxyGasMajorMergerTime), intent(inout)              :: self
+    !$GLC attributes unused :: self
+
+    allocate(unitsInSI(1))
+    unitsInSI(1)=gigaYear
+    return
+  end function galaxyGasMajorMergerTimeUnitsInSI

--- a/source/objects.nodes.components.disk.standard.F90
+++ b/source/objects.nodes.components.disk.standard.F90
@@ -295,7 +295,7 @@ contains
     use :: Node_Component_Disk_Standard_Data, only : massDistributionDisk       , massDistributionDisk_        
     implicit none
     type            (inputParameters), intent(inout) :: parameters
-    type            (dependencyRegEx), dimension(1)  :: dependencies
+    type            (dependencyRegEx), dimension(2)  :: dependencies
     double precision                                 :: massDistributionDiskDensityMoment1, massDistributionDiskDensityMoment2
     logical                                          :: surfaceDensityMoment1IsInfinite   , surfaceDensityMoment2IsInfinite
     type            (inputParameters)                :: subParameters
@@ -303,6 +303,7 @@ contains
     ! Check if this implementation is selected. If so, initialize the mass distribution.
     if (defaultDiskComponent%standardIsActive()) then
        dependencies(1)=dependencyRegEx(dependencyDirectionAfter,'^remnantStructure:')
+       dependencies(2)=dependencyRegEx(dependencyDirectionAfter,'^preAnalysis:'     )
        call satelliteMergerEvent      %attach(thread,satelliteMerger      ,openMPThreadBindingAtLevel,label='nodeComponentDiskStandard',dependencies=dependencies)
        call postEvolveEvent           %attach(thread,postEvolve           ,openMPThreadBindingAtLevel,label='nodeComponentDiskStandard'                          )
        call mergerTreeExtraOutputEvent%attach(thread,mergerTreeExtraOutput,openMPThreadBindingAtLevel,label='nodeComponentDiskStandard'                          )

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -279,14 +279,15 @@ contains
     logical                                          :: densityMoment2IsInfinite                   , densityMoment3IsInfinite
     double precision                                 :: massDistributionSpheroidDensityMomentum2   , massDistributionSpheroidDensityMomentum3, &
          &                                              ratioAngularMomentumScaleRadiusDefault
-    type            (dependencyRegEx), dimension(2)  :: dependencies
+    type            (dependencyRegEx), dimension(3)  :: dependencies
     type            (inputParameters)                :: subParameters
 
     ! Check if this implementation is selected. If so, initialize the mass distribution.
     if (defaultSpheroidComponent%standardIsActive()) then
-       call postEvolveEvent           %attach(thread,postEvolve           ,openMPThreadBindingAtLevel,label='nodeComponentSpheroidStandard'                          )
+       call postEvolveEvent           %attach(thread,postEvolve           ,openMPThreadBindingAtLevel,label='nodeComponentSpheroidStandard'                          ) 
        dependencies(1)=dependencyRegEx(dependencyDirectionAfter,'^remnantStructure:')
-       dependencies(2)=dependencyRegEx(dependencyDirectionAfter,'^nodeComponentDisk')
+       dependencies(2)=dependencyRegEx(dependencyDirectionAfter,'^preAnalysis:'     )
+       dependencies(3)=dependencyRegEx(dependencyDirectionAfter,'^nodeComponentDisk')
        call satelliteMergerEvent      %attach(thread,satelliteMerger      ,openMPThreadBindingAtLevel,label='nodeComponentSpheroidStandard',dependencies=dependencies)
        call mergerTreeExtraOutputEvent%attach(thread,mergerTreeExtraOutput,openMPThreadBindingAtLevel,label='nodeComponentSpheroidStandard'                          )
        ! Find our parameters.


### PR DESCRIPTION
A gas-mass major merger is defined as

$$M_\mathrm{gas, sat} > f M_\mathrm{gas, host}$$

where $M_\mathrm{gas, sat}$, and $M_\mathrm{gas, host}$ are the (disk + spheroid) gas masses of satellite and central respectively, and $f$ is a parameter `ratioGasMajorMerger`.