### PR TITLE
Add new optimization functionality

### DIFF
--- a/source/models.likelihoods.galaxy_population.F90
+++ b/source/models.likelihoods.galaxy_population.F90
@@ -35,7 +35,8 @@
      !!}
      private
      type   (varying_string               )          :: failedParametersFileName
-     logical                                         :: randomize                         , collaborativeMPI
+     logical                                         :: randomize                         , collaborativeMPI, &
+          &                                             outputAnalyses
      type   (enumerationVerbosityLevelType)          :: evolveForestsVerbosity
      class  (*                            ), pointer :: task_                    => null()
      class  (outputAnalysisClass          ), pointer :: outputAnalysis_          => null()
@@ -67,7 +68,8 @@ contains
     type   (posteriorSampleLikelihoodGalaxyPopulation)                :: self
     type   (inputParameters                          ), intent(inout) :: parameters
     type   (varying_string)                                           :: baseParametersFileName, failedParametersFileName
-    logical                                                           :: randomize             , collaborativeMPI
+    logical                                                           :: randomize             , collaborativeMPI        , &
+         &                                                               outputAnalyses
     type   (varying_string)                                           :: evolveForestsVerbosity
     type   (inputParameters                          ), pointer       :: parametersModel
 
@@ -75,6 +77,12 @@ contains
     <inputParameter>
       <name>baseParametersFileName</name>
       <description>The base set of parameters to use.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>outputAnalyses</name>
+      <description>If true, results of the analyses on each step will be stored to the output file.</description>
+      <defaultValue>.false.</defaultValue>
       <source>parameters</source>
     </inputParameter>
     <inputParameter>
@@ -104,7 +112,7 @@ contains
     !!]
     allocate(parametersModel)
     parametersModel=inputParameters                          (baseParametersFileName,noOutput=.true.)
-    self           =posteriorSampleLikelihoodGalaxyPopulation(parametersModel,randomize,collaborativeMPI,enumerationVerbosityLevelEncode(evolveForestsVerbosity,includesPrefix=.false.),failedParametersFileName)
+    self           =posteriorSampleLikelihoodGalaxyPopulation(parametersModel,randomize,outputAnalyses,collaborativeMPI,enumerationVerbosityLevelEncode(evolveForestsVerbosity,includesPrefix=.false.),failedParametersFileName)
     !![
     <inputParametersValidate source="parameters"/>
     !!]
@@ -112,18 +120,19 @@ contains
     return
   end function galaxyPopulationConstructorParameters
 
-  function galaxyPopulationConstructorInternal(parametersModel,randomize,collaborativeMPI,evolveForestsVerbosity,failedParametersFileName) result(self)
+  function galaxyPopulationConstructorInternal(parametersModel,randomize,outputAnalyses,collaborativeMPI,evolveForestsVerbosity,failedParametersFileName) result(self)
     !!{
     Constructor for ``galaxyPopulation'' posterior sampling likelihood class.
     !!}
     implicit none
     type   (posteriorSampleLikelihoodGalaxyPopulation)                        :: self
     type   (inputParameters                          ), intent(inout), target :: parametersModel
-    logical                                           , intent(in   )         :: randomize               , collaborativeMPI
+    logical                                           , intent(in   )         :: randomize               , collaborativeMPI, &
+         &                                                                       outputAnalyses
     type   (enumerationVerbosityLevelType            ), intent(in   )         :: evolveForestsVerbosity
     type   (varying_string                           ), intent(in   )         :: failedParametersFileName
     !![
-    <constructorAssign variables="*parametersModel, randomize, collaborativeMPI, evolveForestsVerbosity, failedParametersFileName"/>
+    <constructorAssign variables="*parametersModel, randomize, outputAnalyses, collaborativeMPI, evolveForestsVerbosity, failedParametersFileName"/>
     !!]
 
     return
@@ -177,7 +186,7 @@ contains
     real                                                                                       :: timeBegin             , timeEnd
     double precision                                                                           :: logLikelihoodProposed
     character       (len=24                                   )                                :: valueText
-    type            (varying_string                           )                                :: message
+    type            (varying_string                           )                                :: message               , groupName
     logical                                                                                    :: isActive
     !$GLC attributes unused :: logPriorCurrent, logLikelihoodCurrent, forceAcceptance, temperature, simulationConvergence
 
@@ -249,7 +258,15 @@ contains
           ! Extract the log-likelihood. This is evaluated by all chains (as they likely need to perform reduction across MPI
           ! processes), but only stored for the chain of this rank.
           logLikelihoodProposed=self%outputAnalysis_%logLikelihood()
-          if (isActive) galaxyPopulationEvaluate=logLikelihoodProposed
+          ! For active analysis, return this likelihood.
+          if (isActive) then
+             galaxyPopulationEvaluate=logLikelihoodProposed
+             ! Optionally output results.
+             if (self%outputAnalyses) then
+                groupName=var_str("step")//simulationState%count()//":chain"//simulationState%chainIndex()
+                call self%outputAnalysis_%finalize(groupName)
+             end if
+          end if
        end if
        if (isActive) then
           ! Record timing information.

--- a/source/output.analyses.F90
+++ b/source/output.analyses.F90
@@ -56,6 +56,7 @@ module Output_Analyses
     <description>Finalize the analysis.</description>
     <type>void</type>
     <pass>yes</pass>
+    <argument>type(varying_string), intent(in   ), optional :: groupName</argument>
    </method>
    <method name="reduce" >
     <description>Reduce the object onto another object of the class.</description>

--- a/source/output.analyses.Local_Group.mass_metallicity_relation.F90
+++ b/source/output.analyses.Local_Group.mass_metallicity_relation.F90
@@ -544,14 +544,15 @@ contains
     return
   end subroutine localGroupMassMetallicityRelationReduce
 
-  subroutine localGroupMassMetallicityRelationFinalize(self)
+  subroutine localGroupMassMetallicityRelationFinalize(self,groupName)
     !!{
     Implement a {\normalfont \ttfamily localGroupMassMetallicityRelation} output analysis finalization.
     !!}
     implicit none
-    class(outputAnalysisLocalGroupMassMetallicityRelation), intent(inout) :: self
+    class(outputAnalysisLocalGroupMassMetallicityRelation), intent(inout)           :: self
+    type (varying_string                                 ), intent(in   ), optional :: groupName
 
-    call self%outputAnalysis_%finalize()
+    call self%outputAnalysis_%finalize(groupName)
     return
   end subroutine localGroupMassMetallicityRelationFinalize
 

--- a/source/output.analyses.Local_Group.mass_size_relation.F90
+++ b/source/output.analyses.Local_Group.mass_size_relation.F90
@@ -559,14 +559,15 @@ contains
     return
   end subroutine localGroupMassSizeRelationReduce
 
-  subroutine localGroupMassSizeRelationFinalize(self)
+  subroutine localGroupMassSizeRelationFinalize(self,groupName)
     !!{
     Implement a {\normalfont \ttfamily localGroupMassSizeRelation} output analysis finalization.
     !!}
     implicit none
-    class(outputAnalysisLocalGroupMassSizeRelation), intent(inout) :: self
+    class(outputAnalysisLocalGroupMassSizeRelation), intent(inout)           :: self
+    type (varying_string                          ), intent(in   ), optional :: groupName
 
-    call self%outputAnalysis_%finalize()
+    call self%outputAnalysis_%finalize(groupName)
     return
   end subroutine localGroupMassSizeRelationFinalize
 

--- a/source/output.analyses.Local_Group.mass_velocity_dispersion_relation.F90
+++ b/source/output.analyses.Local_Group.mass_velocity_dispersion_relation.F90
@@ -575,14 +575,15 @@ contains
     return
   end subroutine localGroupMassVelocityDispersionRelationReduce
 
-  subroutine localGroupMassVelocityDispersionRelationFinalize(self)
+  subroutine localGroupMassVelocityDispersionRelationFinalize(self,groupName)
     !!{
     Implement a {\normalfont \ttfamily localGroupMassVelocityDispersionRelation} output analysis finalization.
     !!}
     implicit none
-    class(outputAnalysisLocalGroupMassVelocityDispersionRelation), intent(inout) :: self
+    class(outputAnalysisLocalGroupMassVelocityDispersionRelation), intent(inout)           :: self
+    type (varying_string                                        ), intent(in   ), optional :: groupName
 
-    call self%outputAnalysis_%finalize()
+    call self%outputAnalysis_%finalize(groupName)
     return
   end subroutine localGroupMassVelocityDispersionRelationFinalize
 

--- a/source/output.analyses.Local_Group.stellar_mass_halo_mass_relation.F90
+++ b/source/output.analyses.Local_Group.stellar_mass_halo_mass_relation.F90
@@ -456,8 +456,8 @@ contains
     !!}
     implicit none
     class  (outputAnalysisLocalGroupStellarMassHaloMassRelation), intent(inout) :: self
-    type   (treeNode                                       ), intent(inout) :: node
-    integer(c_size_t                                       ), intent(in   ) :: iOutput
+    type   (treeNode                                           ), intent(inout) :: node
+    integer(c_size_t                                           ), intent(in   ) :: iOutput
 
     call self%outputAnalysis_%analyze(node,iOutput)
     return
@@ -470,7 +470,7 @@ contains
     use :: Error, only : Error_Report
     implicit none
     class(outputAnalysisLocalGroupStellarMassHaloMassRelation), intent(inout) :: self
-    class(outputAnalysisClass                            ), intent(inout) :: reduced
+    class(outputAnalysisClass                                ), intent(inout) :: reduced
 
     select type (reduced)
     class is (outputAnalysisLocalGroupStellarMassHaloMassRelation)
@@ -481,14 +481,15 @@ contains
     return
   end subroutine localGroupStellarMassHaloMassRelationReduce
 
-  subroutine localGroupStellarMassHaloMassRelationFinalize(self)
+  subroutine localGroupStellarMassHaloMassRelationFinalize(self,groupName)
     !!{
     Implement a {\normalfont \ttfamily localGroupStellarMassHaloMassRelation} output analysis finalization.
     !!}
     implicit none
-    class(outputAnalysisLocalGroupStellarMassHaloMassRelation), intent(inout) :: self
+    class(outputAnalysisLocalGroupStellarMassHaloMassRelation), intent(inout)           :: self
+    type (varying_string                                     ), intent(in   ), optional :: groupName
 
-    call self%outputAnalysis_%finalize()
+    call self%outputAnalysis_%finalize(groupName)
     return
   end subroutine localGroupStellarMassHaloMassRelationFinalize
 

--- a/source/output.analyses.cross_correlator_1d.F90
+++ b/source/output.analyses.cross_correlator_1d.F90
@@ -464,12 +464,13 @@ contains
     return
   end subroutine crossCorrelator1DReduce
 
-  subroutine crossCorrelator1DFinalize(self)
+  subroutine crossCorrelator1DFinalize(self,groupName)
     !!{
     Implement a crossCorrelator1D output analysis finalization.
     !!}
     implicit none
-    class(outputAnalysisCrossCorrelator1D), intent(inout) :: self
+    class(outputAnalysisCrossCorrelator1D), intent(inout)           :: self
+    type (varying_string                 ), intent(in   ), optional :: groupName
 
     ! Finalize analysis.
     call self%finalizeAnalysis()

--- a/source/output.analyses.heated_likelihood.F90
+++ b/source/output.analyses.heated_likelihood.F90
@@ -132,14 +132,15 @@ contains
     return
   end subroutine heatedLikelihoodAnalyze
 
-  subroutine heatedLikelihoodFinalize(self)
+  subroutine heatedLikelihoodFinalize(self,groupName)
     !!{
     Finalize all analyses.
     !!}
     implicit none
-    class(outputAnalysisHeatedLikelihood), intent(inout) :: self
+    class(outputAnalysisHeatedLikelihood), intent(inout)           :: self
+    type (varying_string                ), intent(in   ), optional :: groupName
 
-    call self%outputAnalysis_%finalize()
+    call self%outputAnalysis_%finalize(groupName)
     return
   end subroutine heatedLikelihoodFinalize
 

--- a/source/output.analyses.morphological_fraction.GAMA_Moffett2016.F90
+++ b/source/output.analyses.morphological_fraction.GAMA_Moffett2016.F90
@@ -477,7 +477,7 @@ contains
     return
   end function morphologicalFractionGAMAMoffett2016LogLikelihood
 
-  subroutine morphologicalFractionGAMAMoffett2016Finalize(self)
+  subroutine morphologicalFractionGAMAMoffett2016Finalize(self,groupName)
     !!{
     Implement a {\normalfont \ttfamily morphologicalFractionGAMAMoffett2016} output analysis finalization.
     !!}
@@ -485,9 +485,10 @@ contains
     use :: HDF5_Access, only : hdf5Access
     use :: IO_HDF5    , only : hdf5Object
     implicit none
-    class(outputAnalysisMorphologicalFractionGAMAMoffett2016), intent(inout) :: self
-    type (hdf5Object                                        )                :: analysesGroup, analysisGroup, &
-         &                                                                      dataset
+    class(outputAnalysisMorphologicalFractionGAMAMoffett2016), intent(inout)           :: self
+    type (varying_string                                    ), intent(in   ), optional :: groupName
+    type (hdf5Object                                        )                          :: analysesGroup, analysisGroup, &
+         &                                                                                dataset
 
     ! Finalize the analysis.
     call self%finalizeAnalysis()

--- a/source/output.analyses.multi.F90
+++ b/source/output.analyses.multi.F90
@@ -166,17 +166,18 @@ contains
     return
   end subroutine multiAnalyze
 
-  subroutine multiFinalize(self)
+  subroutine multiFinalize(self,groupName)
     !!{
     Finalize all analyses.
     !!}
     implicit none
-    class(outputAnalysisMulti), intent(inout) :: self
-    type (multiAnalysisList  ), pointer       :: analysis_
+    class(outputAnalysisMulti), intent(inout)           :: self
+    type (varying_string     ), intent(in   ), optional :: groupName
+    type (multiAnalysisList  ), pointer                 :: analysis_
 
     analysis_ => self%analyses
     do while (associated(analysis_))
-       call analysis_%analysis_%finalize()
+       call analysis_%analysis_%finalize(groupName)
        analysis_ => analysis_%next
     end do
     return

--- a/source/output.analyses.null.F90
+++ b/source/output.analyses.null.F90
@@ -76,13 +76,14 @@ contains
     return
   end subroutine nullAnalyze
 
-  subroutine nullFinalize(self)
+  subroutine nullFinalize(self,groupName)
     !!{
     Implement a null output analysis finalization.
     !!}
     implicit none
-    class(outputAnalysisNull), intent(inout) :: self
-    !$GLC attributes unused :: self
+    class(outputAnalysisNull), intent(inout)           :: self
+    type (varying_string    ), intent(in   ), optional :: groupName
+    !$GLC attributes unused :: self, groupName
 
     return
   end subroutine nullFinalize

--- a/source/output.analyses.satellite_velocity_maximum.F90
+++ b/source/output.analyses.satellite_velocity_maximum.F90
@@ -235,7 +235,7 @@ contains
     return
   end subroutine satelliteVelocityMaximumReduce
 
-  subroutine satelliteVelocityMaximumFinalize(self)
+  subroutine satelliteVelocityMaximumFinalize(self,groupName)
     !!{
     Output results of the maximum velocity tidal track output analysis.
     !!}
@@ -247,9 +247,11 @@ contains
     use :: IO_HDF5                         , only : hdf5Object
     use :: Numerical_Constants_Astronomical, only : gigaYear
     implicit none
-    class(outputAnalysisSatelliteVelocityMaximum), intent(inout) :: self
-    type (hdf5Object                            )                :: analysesGroup, analysisGroup, &
-         &                                                          dataset
+    class(outputAnalysisSatelliteVelocityMaximum), intent(inout)           :: self
+    type (varying_string                        ), intent(in   ), optional :: groupName
+    type (hdf5Object                            )               , target   :: analysesGroup, subGroup
+    type (hdf5Object                            )               , pointer  :: inGroup
+    type (hdf5Object                            )                          :: analysisGroup, dataset
 
 #ifdef USEMPI
     ! If running under MPI, accumulate tracks across all processes.
@@ -257,8 +259,13 @@ contains
     self%logLikelihood_         =mpiSelf%sum(self%logLikelihood_         )
 #endif
     !$ call hdf5Access%set()
-    analysesGroup=outputFile   %openGroup('analyses'                                                                                )
-    analysisGroup=analysesGroup%openGroup('satelliteVelocityMaximum','Analysis of the satellite maximum circular velocity vs. time.')
+    analysesGroup =  outputFile   %openGroup('analyses'                         )
+    inGroup       => analysesGroup
+    if (present(groupName)) then
+       subGroup   =  analysesGroup%openGroup(char(groupName)                    )
+       inGroup    => subGroup
+    end if
+    analysisGroup=inGroup%openGroup('satelliteVelocityMaximum','Analysis of the satellite maximum circular velocity vs. time.')
     ! Write metadata describing this analysis.
     call analysisGroup%writeAttribute('Satellite maximum circular velocity fraction vs. time.','description'                        )
     call analysisGroup%writeAttribute("function1D"                                            ,'type'                               )
@@ -284,6 +291,8 @@ contains
     call dataset      %writeAttribute(1.0d0                             ,'unitsInSI'                                                                                             )
     call dataset      %close         (                                                                                                                                           )
     call analysisGroup%close         (                                                                                                                                           )
+    if (present(groupName)) &
+         & call subGroup%close       (                                                                                                                                           )
     call analysesGroup%close         (                                                                                                                                           )
     !$ call hdf5Access%unset()
     return

--- a/source/output.analyses.volume_function_1d.F90
+++ b/source/output.analyses.volume_function_1d.F90
@@ -682,7 +682,7 @@ contains
     return
   end subroutine volumeFunction1DReduce
 
-  subroutine volumeFunction1DFinalize(self)
+  subroutine volumeFunction1DFinalize(self,groupName)
     !!{
     Implement a volumeFunction1D output analysis finalization.
     !!}
@@ -690,16 +690,23 @@ contains
     use :: HDF5_Access, only : hdf5Access
     use :: IO_HDF5    , only : hdf5Object
     implicit none
-    class(outputAnalysisVolumeFunction1D), intent(inout) :: self
-    type (hdf5Object                    )                :: analysesGroup, analysisGroup, &
-         &                                                  dataset
+    class(outputAnalysisVolumeFunction1D), intent(inout)           :: self
+    type (varying_string                ), intent(in   ), optional :: groupName
+    type (hdf5Object                    )               , target   :: analysesGroup, subGroup
+    type (hdf5Object                    )               , pointer  :: inGroup
+    type (hdf5Object                    )                          :: analysisGroup, dataset
 
     ! Finalize analysis.
     call self%finalizeAnalysis()
     ! Output.
     !$ call hdf5Access%set()
-    analysesGroup=outputFile   %openGroup('analyses'                         )
-    analysisGroup=analysesGroup%openGroup(char(self%label),char(self%comment))
+    analysesGroup =  outputFile   %openGroup('analyses'                         )
+    inGroup       => analysesGroup
+    if (present(groupName)) then
+       subGroup   =  analysesGroup%openGroup(char(groupName)                    )
+       inGroup    => subGroup
+    end if
+    analysisGroup =  inGroup      %openGroup(char(self%label),char(self%comment))
     ! Write metadata describing this analysis.
     call    analysisGroup%writeAttribute(     char(self%       comment   )                       ,'description'                                                                                                          )
     call    analysisGroup%writeAttribute("function1D"                                            ,'type'                                                                                                                 )
@@ -741,6 +748,8 @@ contains
        call dataset      %close         (                                                                                                                                                                                )
     end if
     call    analysisGroup%close         (                                                                                                                                                                                )
+    if (present(groupName)) &
+         & call subGroup %close         (                                                                                                                                                                                )
     call    analysesGroup%close         (                                                                                                                                                                                )
     !$ call hdf5Access%unset()
     return

--- a/source/posterior_sampling.simulation.grid.F90
+++ b/source/posterior_sampling.simulation.grid.F90
@@ -21,9 +21,9 @@
   Implementation of a posterior sampling simulation class which implements a simple grid search.
   !!}
 
-  use :: Model_Parameters        , only : modelParameterList
-  use :: Models_Likelihoods      , only : posteriorSampleLikelihoodClass
-  use :: Posterior_Sampling_State, only : posteriorSampleStateClass
+  use :: Model_Parameters                , only : modelParameterList
+  use :: Models_Likelihoods              , only : posteriorSampleLikelihoodClass
+  use :: Posterior_Sampling_State_Samples, only : posteriorSamplesClass
 
   !![
   <posteriorSampleSimulation name="posteriorSampleSimulationGrid">
@@ -38,10 +38,9 @@
      private
      type   (modelParameterList            ), pointer, dimension(:) :: modelParametersActive_     => null(), modelParametersInactive_ => null()
      class  (posteriorSampleLikelihoodClass), pointer               :: posteriorSampleLikelihood_ => null()
-     class  (posteriorSampleStateClass     ), pointer               :: posteriorSampleState_      => null()
+     class  (posteriorSamplesClass         ), pointer               :: posteriorSamples_          => null()
      integer                                                        :: parameterCount                      , logFlushCount
-     integer(c_size_t                      )                        :: countGrid
-     logical                                                        :: appendLogs
+     logical                                                        :: appendLogs                          , outputLikelihoods
      type   (varying_string                )                        :: logFileRoot
    contains
      !![
@@ -83,20 +82,14 @@ contains
     type   (modelParameterList            ), pointer      , dimension(:) :: modelParametersActive_    , modelParametersInactive_
     class  (modelParameterClass           ), pointer                     :: modelParameter_
     class  (posteriorSampleLikelihoodClass), pointer                     :: posteriorSampleLikelihood_
-    class  (posteriorSampleStateClass     ), pointer                     :: posteriorSampleState_
-    type   (varying_string                )                              :: logFileRoot, message
+    class  (posteriorSamplesClass         ), pointer                     :: posteriorSamples_
+    type   (varying_string                )                              :: logFileRoot               , message
     integer                                                              :: inactiveParameterCount    , activeParameterCount  , &
          &                                                                  iInactive                 , iActive, &
          &                                                                  logFlushCount             , i
-    integer(c_size_t                      )                              :: countGrid
-    logical                                                              :: appendLogs
+    logical                                                              :: appendLogs                , outputLikelihoods
 
     !![
-    <inputParameter>
-      <name>countGrid</name>
-      <description>The number of grid steps in each parameter.</description>
-      <source>parameters</source>
-    </inputParameter>
     <inputParameter>
       <name>logFlushCount</name>
       <defaultValue>10</defaultValue>
@@ -114,8 +107,14 @@ contains
       <source>parameters</source>
       <defaultValue>.false.</defaultValue>
     </inputParameter>
+    <inputParameter>
+      <name>outputLikelihoods</name>
+      <description>If true, write likelihoods (and corresponding state vectors) to the output file.</description>
+      <source>parameters</source>
+      <defaultValue>.false.</defaultValue>
+    </inputParameter>
     <objectBuilder class="posteriorSampleLikelihood" name="posteriorSampleLikelihood_" source="parameters"/>
-    <objectBuilder class="posteriorSampleState"      name="posteriorSampleState_"      source="parameters"/>
+    <objectBuilder class="posteriorSamples"          name="posteriorSamples_"          source="parameters"/>
     !!]
     ! Determine the number of parameters.
     activeParameterCount  =0
@@ -167,11 +166,11 @@ contains
        <objectDestructor name="modelParameter_"/>
        !!]
     end do
-    self=posteriorSampleSimulationGrid(modelParametersActive_,modelParametersInactive_,posteriorSampleLikelihood_,posteriorSampleState_,countGrid,logFlushCount,char(logFileRoot),appendLogs)
+    self=posteriorSampleSimulationGrid(modelParametersActive_,modelParametersInactive_,posteriorSampleLikelihood_,posteriorSamples_,logFlushCount,char(logFileRoot),appendLogs,outputLikelihoods)
     !![
     <inputParametersValidate source="parameters" multiParameters="modelParameter"/>
-    <objectDestructor name="posteriorSampleLikelihood_"       />
-    <objectDestructor name="posteriorSampleState_"            />
+    <objectDestructor name="posteriorSampleLikelihood_"/>
+    <objectDestructor name="posteriorSamples_"         />
     !!]
     do i=1,  activeParameterCount
        !![
@@ -188,7 +187,7 @@ contains
     return
   end function gridConstructorParameters
 
-  function gridConstructorInternal(modelParametersActive_,modelParametersInactive_,posteriorSampleLikelihood_,posteriorSampleState_,countGrid,logFlushCount,logFileRoot,appendLogs) result(self)
+  function gridConstructorInternal(modelParametersActive_,modelParametersInactive_,posteriorSampleLikelihood_,posteriorSamples_,logFlushCount,logFileRoot,appendLogs,outputLikelihoods) result(self)
     !!{
     Internal constructor for the ``grid'' simulation class.
     !!}
@@ -196,14 +195,13 @@ contains
     type     (posteriorSampleSimulationGrid )                                      :: self
     type     (modelParameterList            ), intent(in   ), target, dimension(:) :: modelParametersActive_    , modelParametersInactive_
     class    (posteriorSampleLikelihoodClass), intent(in   ), target               :: posteriorSampleLikelihood_
-    class    (posteriorSampleStateClass     ), intent(in   ), target               :: posteriorSampleState_
+    class    (posteriorSamplesClass         ), intent(in   ), target               :: posteriorSamples_
     character(len=*                         ), intent(in   )                       :: logFileRoot
     integer                                  , intent(in   )                       :: logFlushCount
-    integer  (c_size_t                      ), intent(in   )                       :: countGrid
-    logical                                  , intent(in   )                       :: appendLogs
+    logical                                  , intent(in   )                       :: appendLogs                , outputLikelihoods
     integer                                                                        :: i
     !![
-    <constructorAssign variables="*posteriorSampleLikelihood_, *posteriorSampleState_, countGrid, logFlushCount, logFileRoot, appendLogs"/>
+    <constructorAssign variables="*posteriorSampleLikelihood_, *posteriorSamples_, logFlushCount, logFileRoot, appendLogs, outputLikelihoods"/>
     !!]
 
     allocate(self%modelParametersActive_  (size(modelParametersActive_  )))
@@ -221,7 +219,6 @@ contains
        !!]
     end do
     self%parameterCount=size(modelParametersActive_)
-    call self%posteriorSampleState_%parameterCountSet(self%parameterCount)
     return
   end function gridConstructorInternal
 
@@ -235,7 +232,7 @@ contains
 
     !![
     <objectDestructor name="self%posteriorSampleLikelihood_"/>
-    <objectDestructor name="self%posteriorSampleState_"     />
+    <objectDestructor name="self%posteriorSamples_"         />
     !!]
     if (associated(self%modelParametersActive_  )) then
        do i=1,size(self%modelParametersActive_  )
@@ -258,23 +255,23 @@ contains
     !!{
     Perform a grid simulation.
     !!}
-    use :: Display        , only : displayIndent  , displayMagenta, displayMessage, displayReset, &
-          &                        displayUnindent
-    use :: Error          , only : Error_Report
-    use :: Multi_Counters , only : multiCounter
-    use :: MPI_Utilities  , only : mpiBarrier     , mpiSelf
-    use :: String_Handling, only : operator(//)
+    use :: Display                 , only : displayIndent             , displayMagenta, displayMessage, displayReset, &
+          &                                 displayUnindent
+    use :: Error                   , only : Error_Report
+    use :: MPI_Utilities           , only : mpiBarrier                , mpiSelf
+    use :: Posterior_Sampling_State, only : posteriorSampleStateSimple
+    use :: String_Handling         , only : operator(//)
     implicit none
-    class           (posteriorSampleSimulationGrid), intent(inout)                  :: self
-    double precision                               , dimension(self%parameterCount) :: stateVector
-    type            (multiCounter                 )                                 :: counter
-    real                                                                            :: timeEvaluate
-    double precision                                                                :: logPosterior, logLikelihood
-    type            (varying_string               )                                 :: logFileName , message 
-    integer                                                                         :: logFileUnit
-    integer         (c_size_t                     )                                 :: i           , j
+    class           (posteriorSampleSimulationGrid), intent(inout)                               :: self
+    double precision                               , dimension(self%parameterCount)              :: stateVector
+    type            (posteriorSampleStateSimple   ), dimension(                  :), allocatable :: stateSamples
+    real                                                                                         :: timeEvaluate
+    double precision                                                                             :: logPosterior, logLikelihood
+    type            (varying_string               )                                              :: logFileName , message 
+    integer                                                                                      :: logFileUnit
+    integer         (c_size_t                     )                                              :: i           , j
 
-   ! Write start-up message.
+    ! Write start-up message.
     message="Process "//mpiSelf%rankLabel()//" [PID: "
     message=message//getPID()//"] is running on host '"//mpiSelf%hostAffinity()//"'"
     call displayMessage(message)
@@ -285,38 +282,26 @@ contains
     else
        open(newunit=logFileUnit,file=char(logFileName),status='unknown',form='formatted'                  )
     end if
-    ! Iterate over the grid.
-    if (mod(self%countGrid**self%parameterCount,mpiSelf%count()) /= 0) call Error_Report('MPI count must be a divisor of number of grid points'//{introspection:location})
-    counter=multiCounter(spread(self%countGrid,1,self%parameterCount))
-    j      =-1    
-    do while (counter%increment())
-       j=j+1
+    ! Get list of states to sample.
+    call self%posteriorSamples_%samples(stateSamples,self%modelParametersActive_)
+    ! Iterate over the states.
+    do j=1,size(stateSamples)
        if (mod(j,mpiSelf%count()) /= mpiSelf%rank()) cycle
-       ! Construct the state.
-       do i=1,self%parameterCount
-          stateVector(i)=self%modelParametersActive_(i)%modelParameter_%map        (                                     &
-               &         self%modelParametersActive_(i)%modelParameter_%priorInvert (                                    &
-               &                                                                     +(dble(counter%state    (i))-0.5d0) &
-               &                                                                     / dble(self   %countGrid   )        &
-               &                                                                    )                                    &
-               &                                                                   )
-       end do
-       ! Store the state vector.
-       call self%posteriorSampleState_%update(stateVector,.true.,.true.)
        ! Evaluate the posterior in the initial state.
-       call self%posterior(self%posteriorSampleState_,logPosterior,logLikelihood,timeEvaluate)
+       call self%posterior(stateSamples(j),logPosterior,logLikelihood,timeEvaluate)
        ! Unmap parameters and write to log file.
+       stateVector=stateSamples(j)%get()
        do i=1,size(stateVector)
           stateVector(i)=self%modelParametersActive_(i)%modelParameter_%unmap(stateVector(i))
        end do
-       write (logFileUnit,*) self   %posteriorSampleState_%count(), &
-            &                mpiSelf%rank                       (), &
-            &                timeEvaluate                         , &
-            &                .true.                               , &
-            &                logPosterior                         , &
-            &                logLikelihood                        , &
+       write (logFileUnit,*) j              , &
+            &                mpiSelf%rank (), &
+            &                timeEvaluate   , &
+            &                .true.         , &
+            &                logPosterior   , &
+            &                logLikelihood  , &
             &                stateVector
-       if (mod(self%posteriorSampleState_%count(),self%logFlushCount) == 0) call flush(logFileUnit)
+       if (mod(j,self%logFlushCount) == 0) call flush(logFileUnit)
        call mpiBarrier()
     end do
     close(logFileUnit)
@@ -327,17 +312,25 @@ contains
     !!{
     Return the log of the posterior for the current state.
     !!}
+    use :: Output_HDF5                   , only : outputFile
+    use :: HDF5_Access                   , only : hdf5Access
+    use :: IO_HDF5                       , only : hdf5Object
     use :: Model_Parameters              , only : modelParameterListLogPrior
     use :: Models_Likelihoods_Constants  , only : logImpossible
     use :: Posterior_Sampling_Convergence, only : posteriorSampleConvergenceAlways
+    use :: String_Handling               , only : operator(//)
     implicit none
-    class           (posteriorSampleSimulationGrid   ), intent(inout) :: self
-    class           (posteriorSampleStateClass       ), intent(inout) :: posteriorSampleState_
-    double precision                                  , intent(  out) :: logPosterior                     , logLikelihood
-    real                                              , intent(inout) :: timeEvaluate
-    double precision                                  , parameter     :: temperature                =1.0d0
-    double precision                                                  :: logPrior
-    type            (posteriorSampleConvergenceAlways)                :: posteriorSampleConvergence_
+    class           (posteriorSampleSimulationGrid   ), intent(inout)               :: self
+    class           (posteriorSampleStateClass       ), intent(inout)               :: posteriorSampleState_
+    double precision                                  , intent(  out)               :: logPosterior                     , logLikelihood
+    real                                              , intent(inout)               :: timeEvaluate
+    double precision                                  , parameter                   :: temperature                =1.0d0
+    double precision                                  , allocatable  , dimension(:) :: stateVector
+    double precision                                                                :: logPrior
+    type            (posteriorSampleConvergenceAlways)                              :: posteriorSampleConvergence_
+    type            (hdf5Object                      )                              :: analysesGroup                    , subGroup
+    type            (varying_string                  )                              :: groupName
+    integer                                                                         :: i
     
     ! Evaluate the proposed prior.
     logPrior                   =modelParameterListLogPrior      (self%modelParametersActive_,posteriorSampleState_)
@@ -357,6 +350,25 @@ contains
          &                                                              )
     logPosterior               =+logPrior      &
          &                      +logLikelihood
+    ! Store results to file also.
+    if (self%outputLikelihoods) then
+       stateVector=posteriorSampleState_%get()
+       do i=1,size(stateVector)
+          stateVector(i)=self%modelParametersActive_(i)%modelParameter_%unmap(stateVector(i))
+       end do
+       !$ call hdf5Access%set()
+       groupName    =var_str("step")//posteriorSampleState_%count()//":chain"//posteriorSampleState_%chainIndex()
+       analysesGroup=outputFile   %openGroup(    'analyses' )
+       subGroup     =analysesGroup%openGroup(char(groupName))
+       ! Write metadata describing this analysis.
+       call      subGroup%writeAttribute(logPrior     ,'logPrior'                                               )
+       call      subGroup%writeAttribute(logLikelihood,'logLikelihood'                                          )
+       call      subGroup%writeAttribute(logPosterior ,'logPosterior'                                           )
+       call      subGroup%writeDataset  (stateVector  ,"simulationState","The state vector for this likelihood.")
+       call      subGroup%close         (                                                                       )
+       call analysesGroup%close         (                                                                       )
+       !$ call hdf5Access%unset()
+    end if
     return
   end subroutine gridPosterior
 

--- a/source/posterior_sampling.state.samples.F90
+++ b/source/posterior_sampling.state.samples.F90
@@ -1,0 +1,48 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module that implements a class that returns lists of states at which to sample the posterior.
+!!}
+
+module Posterior_Sampling_State_Samples
+  !!{
+  Implements a class that returns lists of states at which to sample the posterior.
+  !!}
+  use :: Model_Parameters        , only : modelParameterList
+  use :: Posterior_Sampling_State, only : posteriorSampleStateSimple
+  private
+
+  !![
+  <functionClass>
+   <name>posteriorSamples</name>
+   <descriptiveName>Posterior Samples</descriptiveName>
+   <description>Class providing lists of states at which to sample the posterior.</description>
+   <default>priorGrid</default>
+   <method name="samples" >
+    <description>Return a list of states at which to sample the posterior.</description>
+    <type>void</type>
+    <pass>yes</pass>
+    <argument>type(posteriorSampleStateSimple), intent(inout), dimension(:), allocatable :: simulationStates</argument>
+    <argument>type(modelParameterList        ), intent(inout), dimension(:)              :: modelParameters_</argument>
+   </method>
+  </functionClass>
+  !!]
+
+end module Posterior_Sampling_State_Samples

--- a/source/posterior_sampling.state.samples.Latin_hypercube.F90
+++ b/source/posterior_sampling.state.samples.Latin_hypercube.F90
@@ -1,0 +1,186 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implementation of a posterior state samples class which draws samples from a Latin hypercube in the cumulative distribution of the priors.
+  !!}
+  
+  use :: Numerical_Random_Numbers, only : randomNumberGeneratorClass
+
+  !![
+  <posteriorSamples name="posteriorSamplesLatinHypercube">
+   <description>
+    A posterior state samples class which draws samples from a Latin hypercube in the cumulative distribution of the priors.
+   </description>
+  </posteriorSamples>
+  !!]
+  type, extends(posteriorSamplesClass) :: posteriorSamplesLatinHypercube
+     !!{
+     Implementation of a posterior state samples class which draws samples from a Latin hypercube in the cumulative distribution of the priors.
+     !!}
+     private
+     integer                                      :: countSamples                    , maximinTrialCount
+     class  (randomNumberGeneratorClass), pointer :: randomNumberGenerator_ => null()
+   contains
+     final     ::             latinHypercubeDestructor
+     procedure :: samples  => latinHypercubeSamples
+  end type posteriorSamplesLatinHypercube
+
+  interface posteriorSamplesLatinHypercube
+     !!{
+     Constructors for the {\normalfont \ttfamily latinHypercube} posterior sampling state initialization class.
+     !!}
+     module procedure latinHypercubeConstructorParameters
+     module procedure latinHypercubeConstructorInternal
+  end interface posteriorSamplesLatinHypercube
+
+contains
+
+  function latinHypercubeConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily latinHypercube} posterior sampling state initialization class.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type   (posteriorSamplesLatinHypercube)                :: self
+    type   (inputParameters               ), intent(inout) :: parameters
+    class  (randomNumberGeneratorClass    ), pointer       :: randomNumberGenerator_
+    integer                                                :: countSamples          , maximinTrialCount
+    
+    !![
+    <inputParameter>
+      <name>countSamples</name>
+      <description>The number of samples to draw.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>maximinTrialCount</name>
+      <defaultValue>1000</defaultValue>
+      <description>The number of trial Latin Hypercubes to construct when seeking the maximum minimum separation sample.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="randomNumberGenerator" name="randomNumberGenerator_" source="parameters"/>
+    !!]
+    self=posteriorSamplesLatinHypercube(countSamples,maximinTrialCount,randomNumberGenerator_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="randomNumberGenerator_"/>
+    !!]
+    return
+  end function latinHypercubeConstructorParameters
+
+  function latinHypercubeConstructorInternal(countSamples,maximinTrialCount,randomNumberGenerator_) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily latinHypercube} posterior sampling state initialization class.
+    !!}
+    implicit none
+    type   (posteriorSamplesLatinHypercube)                        :: self
+    integer                                , intent(in   )         :: countSamples          , maximinTrialCount
+    class  (randomNumberGeneratorClass    ), intent(in   ), target :: randomNumberGenerator_
+
+    !![
+    <constructorAssign variables="countSamples, maximinTrialCount, *randomNumberGenerator_"/>
+    !!]
+    return
+  end function latinHypercubeConstructorInternal
+
+  subroutine latinHypercubeDestructor(self)
+    !!{
+    Destructor for the  {\normalfont \ttfamily latinHypercube} posterior sampling state initialization class.
+    !!}
+    implicit none
+    type(posteriorSamplesLatinHypercube), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%randomNumberGenerator_"/>
+    !!]
+    return
+  end subroutine latinHypercubeDestructor
+
+  subroutine latinHypercubeSamples(self,simulationStates,modelParameters_)
+    !!{
+    Generate simulation states by sampling a Latin hypercube in the cumulative distribution of priors.
+    !!}
+    use, intrinsic :: ISO_C_Binding, only : c_size_t
+    use            :: MPI_Utilities, only : mpiBarrier, mpiSelf
+    use            :: Sorting      , only : sortIndex
+    implicit none
+    class           (posteriorSamplesLatinHypercube), intent(inout)                              :: self
+    type            (posteriorSampleStateSimple    ), intent(inout), dimension(:  ), allocatable :: simulationStates
+    type            (modelParameterList            ), intent(inout), dimension(:  )              :: modelParameters_
+    integer         (kind=c_size_t                 )               , dimension(:  ), allocatable :: order
+    double precision                                               , dimension(:  ), allocatable :: x                , y
+    double precision                                               , dimension(:,:), allocatable :: stateGrid        , stateGridBest
+    integer                                                                                      :: i                , j                       , &
+         &                                                                                          i1               , i2                      , &
+         &                                                                                          k
+    double precision                                                                             :: separationMinimum, separationMinimumMaximum
+
+    ! Generate random sequence.
+    allocate(        x       (0:self%countSamples-1                       ))
+    allocate(        y       (0:self%countSamples-1                       ))
+    allocate(    order       (0:self%countSamples-1                       ))
+    allocate(stateGrid       (0:self%countSamples-1,size(modelParameters_)))
+    allocate(stateGridBest   (0:self%countSamples-1,size(modelParameters_)))
+    allocate(simulationStates(1:self%countSamples                         ))
+    separationMinimumMaximum=0.0d0
+    do k=1,self%maximinTrialCount
+       do j=1,size(modelParameters_)
+          x                =0.0d0
+          do i=0,self%countSamples-1
+             if (mod(i,mpiSelf%count()) /= mpiSelf%rank()) cycle
+             x(mpiSelf%rank())=self%randomNumberGenerator_%uniformSample()
+          end do
+          y    =mpiSelf%sum(x)
+          call mpiBarrier()
+          order=sortIndex(y)-1
+          do i=0,self%countSamples-1
+             stateGrid(i,j)=(dble(order(i))+0.5d0)/self%countSamples
+          end do
+       end do
+       ! Find minimum separation.
+       separationMinimum=huge(1.0d0)
+       do i1=0,self%countSamples-1
+          do i2=i1+1,self%countSamples-1
+             separationMinimum=min(separationMinimum,sum((stateGrid(i1,:)-stateGrid(i2,:))**2))
+          end do
+       end do
+       ! Check if this is the maximum minimum separation yet found.
+       if (separationMinimum > separationMinimumMaximum) then
+          separationMinimumMaximum=separationMinimum
+          stateGridBest           =stateGrid
+       end if
+    end do
+    ! Convert the cumulative density to a value of the prior.
+    do i=0,self%countSamples-1
+       do j=1,size(modelParameters_)
+          stateGridBest(i,j)=modelParameters_(j)%modelParameter_%map        (      &
+               &             modelParameters_(j)%modelParameter_%priorInvert (     &
+               &             stateGridBest                                    (    &
+               &                                                               i,j &
+               &                                                              )    &
+               &                                                             )     &
+               &                                                            )
+       end do
+       simulationStates(i+1)=posteriorSampleStateSimple(acceptedStateCount=1)
+       call simulationStates(i+1)%parameterCountSet(size(modelParameters_))       
+       call simulationStates(i+1)%update(stateGridBest(i,:),.false.,.false.)
+    end do
+    return
+  end subroutine latinHypercubeSamples

--- a/source/posterior_sampling.state.samples.prior_grid.F90
+++ b/source/posterior_sampling.state.samples.prior_grid.F90
@@ -1,0 +1,123 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implementation of a posterior state samples class which draws samples from a grid in the cumulative distribution of the priors.
+  !!}
+
+  !![
+  <posteriorSamples name="posteriorSamplesPriorGrid">
+   <description>
+    A posterior state samples class which draws samples from a grid in the cumulative distribution of the priors.
+   </description>
+  </posteriorSamples>
+  !!]
+  type, extends(posteriorSamplesClass) :: posteriorSamplesPriorGrid
+     !!{
+     Implementation of a posterior state samples class which draws samples from a grid in the cumulative distribution of the priors.
+     !!}
+     private
+     integer :: countGrid
+   contains
+     procedure :: samples  => priorGridSamples
+  end type posteriorSamplesPriorGrid
+
+  interface posteriorSamplesPriorGrid
+     !!{
+     Constructors for the {\normalfont \ttfamily priorGrid} posterior sampling state initialization class.
+     !!}
+     module procedure priorGridConstructorParameters
+     module procedure priorGridConstructorInternal
+  end interface posteriorSamplesPriorGrid
+
+contains
+
+  function priorGridConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily priorGrid} posterior sampling state initialization class.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type   (posteriorSamplesPriorGrid)                :: self
+    type   (inputParameters          ), intent(inout) :: parameters
+    integer                                           :: countGrid
+    
+    !![
+    <inputParameter>
+      <name>countGrid</name>
+      <description>The number of grid steps in each parameter.</description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=posteriorSamplesPriorGrid(countGrid)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function priorGridConstructorParameters
+
+  function priorGridConstructorInternal(countGrid) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily priorGrid} posterior sampling state initialization class.
+    !!}
+    implicit none
+    type   (posteriorSamplesPriorGrid)                :: self
+    integer                           , intent(in   ) :: countGrid
+    !![
+    <constructorAssign variables="countGrid"/>
+    !!]
+    
+    return
+  end function priorGridConstructorInternal
+
+  subroutine priorGridSamples(self,simulationStates,modelParameters_)
+    !!{
+    Generate simulation states by sampling on a grid in the cumulative distribution of priors.
+    !!}
+    use, intrinsic :: ISO_C_Binding , only : c_size_t
+    use            :: Multi_Counters, only : multiCounter
+    implicit none
+    class           (posteriorSamplesPriorGrid ), intent(inout)                                                 :: self
+    type            (posteriorSampleStateSimple), intent(inout), dimension(                    : ), allocatable :: simulationStates
+    type            (modelParameterList        ), intent(inout), dimension(                    : )              :: modelParameters_
+    double precision                                           , dimension(size(modelParameters_))              :: stateVector
+    type            (multiCounter              )                                                                :: counter
+    integer         (c_size_t                  )                                                                :: i               , j
+        
+    allocate(simulationStates(self%countGrid*size(modelParameters_)))
+    counter=multiCounter(spread(self%countGrid,1,size(modelParameters_)))
+    i      =0
+    do while (counter%increment())
+       i=i+1
+       ! Construct the state.
+       do j=1,size(modelParameters_)
+          stateVector(j)=modelParameters_(j)%modelParameter_%map        (                                     &
+               &         modelParameters_(j)%modelParameter_%priorInvert (                                    &
+               &                                                          +(dble(counter%state    (j))-0.5d0) &
+               &                                                          / dble(self   %countGrid   )        &
+               &                                                         )                                    &
+               &                                                        )
+       end do
+       ! Store the state vector.
+       simulationStates(i)=posteriorSampleStateSimple(acceptedStateCount=1)
+       call simulationStates(i)%parameterCountSet(size(modelParameters_))
+       call simulationStates(i)%update(stateVector,.false.,.false.)
+    end do
+    return
+  end subroutine priorGridSamples


### PR DESCRIPTION
- Add functionality to output results of analyses to file when doing posterior sampling;
- Provide a more flexible way of sampling posteriors on pre-defined "grids";
   - The "grid" can be any set of pre-defined points.
   - Current implementations are:
      - A uniform grid in the cumulative distribution of each prior;
      - A Latin hypercube in the cumulative distribution of each prior.
