### PR TITLE
Provide a more helpful error message when single epoch output is not allowed

### DIFF
--- a/source/geometry.surveys.Baldry-2012-GAMA.F90
+++ b/source/geometry.surveys.Baldry-2012-GAMA.F90
@@ -169,30 +169,37 @@ contains
          &                                                                     luminosity     , starFormationRate
     integer                                       , intent(in   ), optional :: field
     double precision                                                        :: logarithmicMass
-    !$GLC attributes unused :: magnitudeAbsolute, luminosity, starFormationRate
 
     ! Validate field.
     if (.not.present(field)) call Error_Report('field must be specified'//{introspection:location})
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Compute the limiting distance.
-    logarithmicMass=log10(mass)
-    select case (field)
-    case (1,3) ! Fields G09 and G15.
-       baldry2012GAMADistanceMaximum                          &
-            & =10.0d0**(                                      &
-            &           -0.521147071716417d0                  &
-            &           +0.318557607893107d0*logarithmicMass  &
-            &          )
-    case (2)
-       baldry2012GAMADistanceMaximum                          &
-            & =10.0d0**(                                      &
-            &           -0.361147071716369d0                  &
-            &           +0.318557607893101d0*logarithmicMass  &
-            &          )
-    case default
-       baldry2012GAMADistanceMaximum=0.0d0
-       call Error_Report('1 ≤ field ≤ 3 required'//{introspection:location})
-    end select
-    baldry2012GAMADistanceMaximum=min(baldry2012GAMADistanceMaximum,self%distanceMaximumSurvey)
+    if (present(mass)) then
+       logarithmicMass=log10(mass)
+       select case (field)
+       case (1,3) ! Fields G09 and G15.
+          baldry2012GAMADistanceMaximum                          &
+               & =10.0d0**(                                      &
+               &           -0.521147071716417d0                  &
+               &           +0.318557607893107d0*logarithmicMass  &
+               &          )
+       case (2)
+          baldry2012GAMADistanceMaximum                          &
+               & =10.0d0**(                                      &
+               &           -0.361147071716369d0                  &
+               &           +0.318557607893101d0*logarithmicMass  &
+               &          )
+       case default
+          baldry2012GAMADistanceMaximum=0.0d0
+          call Error_Report('1 ≤ field ≤ 3 required'//{introspection:location})
+       end select
+       baldry2012GAMADistanceMaximum=min(baldry2012GAMADistanceMaximum,self%distanceMaximumSurvey)
+    else
+       baldry2012GAMADistanceMaximum=self%distanceMaximumSurvey
+    end if
     return
   end function baldry2012GAMADistanceMaximum
 

--- a/source/geometry.surveys.Bernardi-2013-SDSS.F90
+++ b/source/geometry.surveys.Bernardi-2013-SDSS.F90
@@ -132,11 +132,19 @@ contains
          &                                                                       luminosity     , starFormationRate
     integer                                         , intent(in   ), optional :: field
     double precision                                                          :: logarithmicMass,
-    !$GLC attributes unused :: self, field, magnitudeAbsolute, luminosity, starFormationRate
+    !$GLC attributes unused :: self, field
 
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Find the limiting distance for this mass completeness limits. (See
     ! constraints/dataAnalysis/stellarMassFunction_SDSS_z0.07_Bernardi/massDistanceRelation.pl for details.)
-    logarithmicMass=min(log10(mass),12.5d0)
+    if (present(mass)) then
+       logarithmicMass=min(log10(mass),12.5d0)
+    else
+       logarithmicMass=                12.5d0
+    end if
     bernardi2013SDSSDistanceMaximum                                                         &
          &                         =10.0d0**(                                               &
          &                                                         +1282.1065495948200000d0 &

--- a/source/geometry.surveys.Caputi-2011-UKIDSS-UDS.F90
+++ b/source/geometry.surveys.Caputi-2011-UKIDSS-UDS.F90
@@ -202,23 +202,30 @@ contains
          &                                                                          luminosity, starFormationRate
     integer                                            , intent(in   ), optional :: field
     double precision                                                             :: redshift  , logarithmicMass
-    !$GLC attributes unused :: magnitudeAbsolute, luminosity, starFormationRate
 
     ! Validate field.
     if (present(field).and.field /= 1) call Error_Report('field = 1 required'//{introspection:location})
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Find the limiting redshift for this mass using a fit derived from Millennium Simulation SAMs. (See
     ! constraints/dataAnalysis/stellarMassFunctions_UKIDSS_UDS_z3_5/massLuminosityRelation.pl for details.)
-    logarithmicMass=log10(mass)
-    redshift=-56.247426278132d0+logarithmicMass*(5.88091022342758d0)
-    ! Convert from redshift to comoving distance.
-    caputi2011UKIDSSUDSDistanceMaximum                                                                                             &
-         &=self%cosmologyFunctions_%distanceComovingConvert(                                                                       &
-         &                                                  output  =distanceTypeComoving                                        , &
-         &                                                  redshift=min(max(redshift,self%redshiftMinimum),self%redshiftMaximum)  &
-         &                                                 )
-    ! Limit the maximum distance.
-    caputi2011UKIDSSUDSDistanceMaximum=min(caputi2011UKIDSSUDSDistanceMaximum,self%binDistanceMaximum)
-    return
+    if (present(mass)) then
+       logarithmicMass=log10(mass)
+       redshift=-56.247426278132d0+logarithmicMass*(5.88091022342758d0)
+       ! Convert from redshift to comoving distance.
+       caputi2011UKIDSSUDSDistanceMaximum                                                                                             &
+            &=self%cosmologyFunctions_%distanceComovingConvert(                                                                       &
+            &                                                  output  =distanceTypeComoving                                        , &
+            &                                                  redshift=min(max(redshift,self%redshiftMinimum),self%redshiftMaximum)  &
+            &                                                 )
+       ! Limit the maximum distance.
+       caputi2011UKIDSSUDSDistanceMaximum=min(caputi2011UKIDSSUDSDistanceMaximum,self%binDistanceMaximum)
+    else
+       caputi2011UKIDSSUDSDistanceMaximum=                                       self%binDistanceMaximum
+    end if
+       return
   end function caputi2011UKIDSSUDSDistanceMaximum
 
   double precision function caputi2011UKIDSSUDSVolumeMaximum(self,mass,field)

--- a/source/geometry.surveys.Davidzon-2013-VIPERS.F90
+++ b/source/geometry.surveys.Davidzon-2013-VIPERS.F90
@@ -217,24 +217,32 @@ contains
          &                                                                         luminosity     , starFormationRate
     integer                                           , intent(in   ), optional :: field
     double precision                                                            :: logarithmicMass
-    !$GLC attributes unused :: field, magnitudeAbsolute, luminosity, starFormationRate
+    !$GLC attributes unused :: field
 
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Find the limiting distance for this mass. (See
     ! constraints/dataAnalysis/stellarMassFunctions_VIPERS_z0_1/massDistanceRelation.pl for details.)
-    logarithmicMass=log10(mass)
-    select case (self%redshiftBin)
-    case (0)
-       davidzon2013VIPERSDistanceMaximum=3.20663737335189d0+logarithmicMass*(0.0124101908903665d0)
-    case (1)
-       davidzon2013VIPERSDistanceMaximum=3.14840402683405d0+logarithmicMass*(0.0268494389098537d0)
-    case (2)
-       davidzon2013VIPERSDistanceMaximum=3.20688538211015d0+logarithmicMass*(0.0273132827274515d0)
-    case default
-       davidzon2013VIPERSDistanceMaximum=0.0d0
-       call Error_Report('invalid redshift bin'//{introspection:location})
-    end select
-    ! Limit the maximum distance.
-    davidzon2013VIPERSDistanceMaximum=min(10.0d0**davidzon2013VIPERSDistanceMaximum,self%binDistanceMaximum)
+    if (present(mass)) then
+       logarithmicMass=log10(mass)
+       select case (self%redshiftBin)
+       case (0)
+          davidzon2013VIPERSDistanceMaximum=3.20663737335189d0+logarithmicMass*(0.0124101908903665d0)
+       case (1)
+          davidzon2013VIPERSDistanceMaximum=3.14840402683405d0+logarithmicMass*(0.0268494389098537d0)
+       case (2)
+          davidzon2013VIPERSDistanceMaximum=3.20688538211015d0+logarithmicMass*(0.0273132827274515d0)
+       case default
+          davidzon2013VIPERSDistanceMaximum=0.0d0
+          call Error_Report('invalid redshift bin'//{introspection:location})
+       end select
+       ! Limit the maximum distance.
+       davidzon2013VIPERSDistanceMaximum=min(10.0d0**davidzon2013VIPERSDistanceMaximum,self%binDistanceMaximum)
+    else
+        davidzon2013VIPERSDistanceMaximum=                                             self%binDistanceMaximum
+    end if
     return
   end function davidzon2013VIPERSDistanceMaximum
 

--- a/source/geometry.surveys.Gunawardhana-2013-SDSS.F90
+++ b/source/geometry.surveys.Gunawardhana-2013-SDSS.F90
@@ -136,34 +136,40 @@ contains
     double precision                                    , parameter               :: fluxLimiting           =1.0d-18 ! W m⁻².
     double precision                                                              :: distanceMaximumRedshift        , distanceMaximumLuminosity, &
          &                                                                           distanceLuminosity
-    !$GLC attributes unused :: field, mass, magnitudeAbsolute, starFormationRate
+    !$GLC attributes unused :: field
 
-    ! Validate input.
-    if (.not.present(luminosity)) call Error_Report('luminosity must be supplied '//{introspection:location})
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(mass             )) call Error_Report(             '`mass` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Compute limiting distances. We find the luminosity distance from the supplied luminosity and the limiting flux of the survey.
-    distanceLuminosity      =sqrt(                 &
-         &                        +luminosity      &
-         &                        *ergs            &
-         &                        /4.0d0           &
-         &                        /Pi              &
-         &                        /fluxLimiting    &
-         &                        /megaParsec  **2 &
-         &                       )
-    distanceMaximumRedshift =self   %cosmologyFunctions_%distanceComoving           (                                         &
-         &                    self  %cosmologyFunctions_%cosmicTime                  (                                        &
-         &                     self %cosmologyFunctions_%expansionFactorFromRedshift  (                                       &
-         &                                                                                              1.0d-1                &
-         &                                                                            )                                       &
-         &                                                                           )                                        &
+    distanceMaximumRedshift =self   %cosmologyFunctions_%distanceComoving           (          &
+         &                    self  %cosmologyFunctions_%cosmicTime                  (         &
+         &                     self %cosmologyFunctions_%expansionFactorFromRedshift  (        &
+         &                                                                              1.0d-1 &
+         &                                                                            )        &
+         &                                                                           )         &
          &                                                                          )
-    distanceMaximumLuminosity=self   %cosmologyFunctions_%distanceComovingConvert    (                                        &
-         &                                                                           output            =distanceTypeComoving, &
-         &                                                                           distanceLuminosity=distanceLuminosity    &
-         &                                                                          )
-    ! Take the smaller of the two distances.
-    gunawardhana2013SDSSDistanceMaximum=min(                           &
-         &                                  distanceMaximumRedshift  , &
-         &                                  distanceMaximumLuminosity  &
-         &                                 )
+    if (present(luminosity)) then
+       distanceLuminosity      =sqrt(                 &
+            &                        +luminosity      &
+            &                        *ergs            &
+            &                        /4.0d0           &
+            &                        /Pi              &
+            &                        /fluxLimiting    &
+            &                        /megaParsec  **2 &
+            &                       )
+       distanceMaximumLuminosity=self   %cosmologyFunctions_%distanceComovingConvert(                                         &
+            &                                                                        output            =distanceTypeComoving, &
+            &                                                                        distanceLuminosity=distanceLuminosity    &
+            &                                                                       )
+       ! Take the smaller of the two distances.
+       gunawardhana2013SDSSDistanceMaximum=min(                           &
+            &                                  distanceMaximumRedshift  , &
+            &                                  distanceMaximumLuminosity  &
+            &                                 )
+    else
+       gunawardhana2013SDSSDistanceMaximum=    distanceMaximumRedshift
+    end if
     return
   end function gunawardhana2013SDSSDistanceMaximum

--- a/source/geometry.surveys.Hearin-2014-SDSS.F90
+++ b/source/geometry.surveys.Hearin-2014-SDSS.F90
@@ -143,13 +143,20 @@ contains
     double precision                              , intent(in   ), optional :: mass      , magnitudeAbsolute, &
          &                                                                     luminosity, starFormationRate
     integer                                       , intent(in   ), optional :: field
-    !$GLC attributes unused :: field, magnitudeAbsolute, luminosity, starFormationRate
-
-    if (mass /= self%massPrevious)                                                                                 &
-         & self%distanceMaximumPrevious=min(                                                                       &
-         &                                  self%surveyGeometryBernardi2013SDSS%distanceMaximum(mass,field=field), &
-         &                                  self%distanceMaximumLimit                                              &
-         &                                 )
-    hearin2014SDSSDistanceMaximum=self%distanceMaximumPrevious
+    !$GLC attributes unused :: field
+        ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
+    if (present(mass)) then
+       if (mass /= self%massPrevious)                                                                                 &
+            & self%distanceMaximumPrevious=min(                                                                       &
+            &                                  self%surveyGeometryBernardi2013SDSS%distanceMaximum(mass,field=field), &
+            &                                  self%distanceMaximumLimit                                              &
+            &                                 )
+       hearin2014SDSSDistanceMaximum=self%distanceMaximumPrevious
+    else
+       hearin2014SDSSDistanceMaximum=self%distanceMaximumLimit
+    end if
     return
   end function hearin2014SDSSDistanceMaximum

--- a/source/geometry.surveys.Kelvin-2014-GAMAnear.F90
+++ b/source/geometry.surveys.Kelvin-2014-GAMAnear.F90
@@ -114,17 +114,24 @@ contains
          &                                                                         luminosity     , starFormationRate
     integer                                           , intent(in   ), optional :: field
     double precision                                                            :: logarithmicMass
-    !$GLC attributes unused :: magnitudeAbsolute, luminosity, starFormationRate
 
     ! Validate field.
     if (present(field).and.(field < 1 .or. field > 3)) call Error_Report('1 ≤ field ≤ 3 required'//{introspection:location})
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Compute the limiting distance. For the GAMAnear sample, all fields are limited to r=19.4
-    logarithmicMass=log10(mass)
-    kelvin2014GAMAnearDistanceMaximum                      &
-         & =10.0d0**(                                      &
-         &           -0.521147071716417d0                  &
-         &           +0.318557607893107d0*logarithmicMass  &
-         &          )
-    kelvin2014GAMAnearDistanceMaximum=min(kelvin2014GAMAnearDistanceMaximum,self%distanceMaximumSurvey)
+    if (present(mass)) then
+       logarithmicMass=log10(mass)
+       kelvin2014GAMAnearDistanceMaximum                      &
+            & =10.0d0**(                                      &
+            &           -0.521147071716417d0                  &
+            &           +0.318557607893107d0*logarithmicMass  &
+            &          )
+       kelvin2014GAMAnearDistanceMaximum=min(kelvin2014GAMAnearDistanceMaximum,self%distanceMaximumSurvey)
+    else
+       kelvin2014GAMAnearDistanceMaximum=                                      self%distanceMaximumSurvey
+    end if
     return
   end function kelvin2014GAMAnearDistanceMaximum

--- a/source/geometry.surveys.Li-White-2009-SDSS.F90
+++ b/source/geometry.surveys.Li-White-2009-SDSS.F90
@@ -205,42 +205,49 @@ contains
          &                                                                      luminosity, starFormationRate
     integer                                        , intent(in   ), optional :: field
     double precision                                                         :: redshift, logarithmicMass
-    !$GLC attributes unused :: self, magnitudeAbsolute, luminosity, starFormationRate
 
     ! Validate field.
     if (present(field).and.field /= 1) call Error_Report('field = 1 required'//{introspection:location})
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Find the limiting redshift for this mass using a fit derived from Millennium Simulation SAMs. (See
     ! constraints/dataAnalysis/stellarMassFunction_SDSS_z0.07/massLuminosityRelation.pl for details.)
-    logarithmicMass=log10(mass)
-    redshift=                                   &
-         & max(                                 &
-         &     -5.9502006195004d0               &
-         &     +logarithmicMass                 &
-         &     *(                               &
-         &       +2.63793788603951d0            &
-         &       +logarithmicMass               &
-         &       *(                             &
-         &         -0.421075858899237d0         &
-         &         +logarithmicMass             &
-         &         *(                           &
-         &           +0.0285198776926787d0      &
-         &           +logarithmicMass           &
-         &           *(                         &
-         &             -0.000678327494720407d0  &
-         &            )                         &
-         &          )                           &
-         &        )                             &
-         &      )                             , &
-         &     +0.0d0                           &
-         &    )
-    ! Convert from redshift to comoving distance.
-    liWhite2009SDSSDistanceMaximum=min(                                                                                &
-         &                             self%limitDistanceMaximum                                                     , &
-         &                             self%cosmologyFunctions_%distanceComovingConvert(                               &
-         &                                                                              output  =distanceTypeComoving, &
-         &                                                                              redshift=redshift              &
-         &                                                                             )                               &
-         &                            )
+    if (present(mass)) then
+       logarithmicMass=log10(mass)
+       redshift=                                   &
+            & max(                                 &
+            &     -5.9502006195004d0               &
+            &     +logarithmicMass                 &
+            &     *(                               &
+            &       +2.63793788603951d0            &
+            &       +logarithmicMass               &
+            &       *(                             &
+            &         -0.421075858899237d0         &
+            &         +logarithmicMass             &
+            &         *(                           &
+            &           +0.0285198776926787d0      &
+            &           +logarithmicMass           &
+            &           *(                         &
+            &             -0.000678327494720407d0  &
+            &            )                         &
+            &          )                           &
+            &        )                             &
+            &      )                             , &
+            &     +0.0d0                           &
+            &    )
+       ! Convert from redshift to comoving distance.
+       liWhite2009SDSSDistanceMaximum=min(                                                                                &
+            &                             self%limitDistanceMaximum                                                     , &
+            &                             self%cosmologyFunctions_%distanceComovingConvert(                               &
+            &                                                                              output  =distanceTypeComoving, &
+            &                                                                              redshift=redshift              &
+            &                                                                             )                               &
+            &                            )
+    else
+       liWhite2009SDSSDistanceMaximum=    self%limitDistanceMaximum
+    end if
     return
   end function liWhite2009SDSSDistanceMaximum
 

--- a/source/geometry.surveys.Local_Group_DES.F90
+++ b/source/geometry.surveys.Local_Group_DES.F90
@@ -112,15 +112,23 @@ contains
     double precision                             , intent(in   ), optional :: mass      , magnitudeAbsolute, &
          &                                                                    luminosity, starFormationRate
     integer                                      , intent(in   ), optional :: field
-    !$GLC attributes unused :: self, field, magnitudeAbsolute, luminosity, starFormationRate
+    !$GLC attributes unused :: field
 
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Find the limiting distance for this mass completeness limits. The following functional form should be considered to be
     ! approximate at best. It was derived by fitting a polynomial in stellar mass (assuming a mass-to-light ratio of 1 in Solar
     ! units in the V band) to the detection efficiencies reported by Drlica-Wagner et al. (2015, ApJ, 813, 109;
     ! https://ui.adsabs.harvard.edu/abs/2015ApJ...813..109D) - with galaxies where the efficiency was 1 excluded (since by
     ! necessity the efficiency is truncated at 1), and then solving for distance as a function of mass for the point at which the
     ! detection efficiency is 90%.
-    localGroupDESDistanceMaximum=min(11.3d-3*(mass/100.0d0)**0.48d0,self%distanceMaximumSurvey)
+    if (present(mass)) then
+       localGroupDESDistanceMaximum=min(11.3d-3*(mass/100.0d0)**0.48d0,self%distanceMaximumSurvey)
+    else
+       localGroupDESDistanceMaximum=                                   self%distanceMaximumSurvey
+    end if
     return
   end function localGroupDESDistanceMaximum
 

--- a/source/geometry.surveys.Local_Group_SDSS.F90
+++ b/source/geometry.surveys.Local_Group_SDSS.F90
@@ -92,12 +92,20 @@ contains
     double precision                              , intent(in   ), optional :: mass      , magnitudeAbsolute, &
          &                                                                     luminosity, starFormationRate
     integer                                       , intent(in   ), optional :: field
-    !$GLC attributes unused :: self, field, magnitudeAbsolute, luminosity, starFormationRate
+    !$GLC attributes unused :: field
 
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Find the limiting distance for this mass completeness limits. We adopt the model of Kim, Peter & Hargis (2018,
     ! Phys. Rev. Lett. 121, 211302; https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.121.211302), assuming a
     ! luminosity-to-mass ratio of 1 in Solar units. (Their model is in turn based on the results of Walsh, Willman & Jerjen, 2008,
     ! AJ, 137, 1; https://iopscience.iop.org/article/10.1088/0004-6256/137/1/450/meta.)
-    localGroupSDSSDistanceMaximum=min(15.7d-3*(mass/100.0d0)**0.51d0,self%distanceMaximumSurvey)
+    if (present(mass)) then
+       localGroupSDSSDistanceMaximum=min(15.7d-3*(mass/100.0d0)**0.51d0,self%distanceMaximumSurvey)
+    else
+       localGroupSDSSDistanceMaximum=                                   self%distanceMaximumSurvey
+    end if
     return
   end function localGroupSDSSDistanceMaximum

--- a/source/geometry.surveys.Local_Group_classical.F90
+++ b/source/geometry.surveys.Local_Group_classical.F90
@@ -121,14 +121,22 @@ contains
     double precision                                   , intent(in   ), optional :: mass      , magnitudeAbsolute, &
          &                                                                          luminosity, starFormationRate
     integer                                            , intent(in   ), optional :: field
-    !$GLC attributes unused :: field, magnitudeAbsolute, luminosity, starFormationRate
+    !$GLC attributes unused :: field
 
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! For galaxies above the mass threshold, assume they can be detected out to the maximum specified distance. Galaxies below the
     ! threshold are never detected.
-    if (mass > self%massThreshold) then
-       localGroupClassicalDistanceMaximum=self%distanceMaximumSurvey
+    if (present(mass)) then
+       if (mass > self%massThreshold) then
+          localGroupClassicalDistanceMaximum=self%distanceMaximumSurvey
+       else
+          localGroupClassicalDistanceMaximum=0.0d0
+       end if
     else
-       localGroupClassicalDistanceMaximum=0.0d0
+       localGroupClassicalDistanceMaximum   =self%distanceMaximumSurvey
     end if
     return
   end function localGroupClassicalDistanceMaximum

--- a/source/geometry.surveys.Martin-2010-ALFALFA.F90
+++ b/source/geometry.surveys.Martin-2010-ALFALFA.F90
@@ -163,24 +163,32 @@ contains
     double precision                                 , parameter               :: massNormalization               =2.356d5
     double precision                                                           :: logarithmicMass                                       , lineWidth                                , &
          &                                                                        integratedFluxLimit
-    !$GLC attributes unused :: self, magnitudeAbsolute, luminosity, starFormationRate
 
     ! Validate field.
     if (present(field).and.field /= 1) call Error_Report('field = 1 required'//{introspection:location})
-    ! Get the logarithm of the mass.
-    logarithmicMass=log10(mass)
-    ! Find the median line width for this mass. (See
-    ! constraints/dataAnalysis/hiMassFunction_ALFALFA_z0.00/lineWidthMassRelation.pl for details.)
-    lineWidth=10.0d0**(lineWidthCoefficient0+lineWidthCoefficient1*logarithmicMass)
-    ! Compute the limiting integrated flux using equation (A1) of Martin et al. (2010).
-    if (lineWidth < lineWidthCharacteristic) then
-       integratedFluxLimit=integratedFluxLimitNormalization*signalToNoise*sqrt(lineWidth/lineWidthCharacteristic)
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
+    ! Find the maximum distance.
+    if (present(mass)) then
+       ! Get the logarithm of the mass.
+       logarithmicMass=log10(mass)
+       ! Find the median line width for this mass. (See
+       ! constraints/dataAnalysis/hiMassFunction_ALFALFA_z0.00/lineWidthMassRelation.pl for details.)
+       lineWidth=10.0d0**(lineWidthCoefficient0+lineWidthCoefficient1*logarithmicMass)
+       ! Compute the limiting integrated flux using equation (A1) of Martin et al. (2010).
+       if (lineWidth < lineWidthCharacteristic) then
+          integratedFluxLimit=integratedFluxLimitNormalization*signalToNoise*sqrt(lineWidth/lineWidthCharacteristic)
+       else
+          integratedFluxLimit=integratedFluxLimitNormalization*signalToNoise*    (lineWidth/lineWidthCharacteristic)
+       end if
+       ! Convert from mass and limiting integrated flux to maximum distance using relation given in text of section 2.2 of Martin et
+       ! al. (2010). Limit by the maximum velocity allowed for galaxies to make it into the sample.
+       martin2010ALFALFADistanceMaximum=min(sqrt(mass/massNormalization/integratedFluxLimit),sampleVelocityMaximum/self%cosmologyParameters_%hubbleConstant())
     else
-       integratedFluxLimit=integratedFluxLimitNormalization*signalToNoise*    (lineWidth/lineWidthCharacteristic)
+       martin2010ALFALFADistanceMaximum=                                                     sampleVelocityMaximum/self%cosmologyParameters_%hubbleConstant()
     end if
-    ! Convert from mass and limiting integrated flux to maximum distance using relation given in text of section 2.2 of Martin et
-    ! al. (2010). Limit by the maximum velocity allowed for galaxies to make it into the sample.
-    martin2010ALFALFADistanceMaximum=min(sqrt(mass/massNormalization/integratedFluxLimit),sampleVelocityMaximum/self%cosmologyParameters_%hubbleConstant())
     return
   end function martin2010ALFALFADistanceMaximum
 

--- a/source/geometry.surveys.Moustakas-2013-PRIMUS.F90
+++ b/source/geometry.surveys.Moustakas-2013-PRIMUS.F90
@@ -229,51 +229,58 @@ contains
          &                                                                          luminosity, starFormationRate
     integer                                            , intent(in   ), optional :: field
     double precision                                                             :: redshift  , logarithmicMass
-    !$GLC attributes unused :: magnitudeAbsolute, luminosity, starFormationRate
 
     ! Validate field.
     if (.not.present(field)) call Error_Report('field must be specified'//{introspection:location})
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Find the limiting redshift for this mass completeness limits from Moustakas et al. (2013; Table 2). (See
     ! constraints/dataAnalysis/stellarMassFunctions_PRIMUS_z0_1/massRedshiftRelation.pl for details.)
-    logarithmicMass=log10(mass)
-    select case (field)
-    case (1) ! COSMOS
-       redshift=                  +3.51240871481968000d0  &
-            &   +logarithmicMass*(-0.94131511297034200d0  &
-            &   +logarithmicMass*(+0.06507208866075860d0) &
-            &                                           )
-    case (2) ! XMM-SXDS
-       redshift=                  +2.46068289817352000d0  &
-            &   +logarithmicMass*(-0.72960045705258400d0  &
-            &   +logarithmicMass*(+0.05422457500058130d0) &
-            &                                           )
-    case (3) ! XMM-CFHTLS
-       redshift=                  -3.60001396783385000d0  &
-            &   +logarithmicMass*(+0.50007933123305700d0  &
-            &   +logarithmicMass*(-0.00781044013508246d0) &
-            &                                           )
-    case (4) ! CDFS
-       redshift=                  +5.86929723910240000d0  &
-            &   +logarithmicMass*(-1.52816338306828000d0  &
-            &   +logarithmicMass*(+0.09815249638377170d0) &
-            &                                           )
-    case (5) ! ELAIS-S1
-       redshift=                  +6.87489619768651000d0  &
-            &   +logarithmicMass*(-1.65556365363183000d0  &
-            &   +logarithmicMass*(+0.10030052053225000d0) &
-            &                                           )
-    case default
-       redshift=0.0d0
-       call Error_Report('1 ≤ field ≤ 5 required'//{introspection:location})
-    end select
-    ! Convert from redshift to comoving distance.
-    moustakas2013PRIMUSDistanceMaximum                                                                                             &
-         &=self%cosmologyFunctions_%distanceComovingConvert(                                                                       &
-         &                                                  output  =distanceTypeComoving                                        , &
-         &                                                  redshift=max(min(redshift,self%redshiftMaximum),self%redshiftMinimum)  &
-         &                                                 )
-    ! Limit the maximum distance.
-    moustakas2013PRIMUSDistanceMaximum=min(moustakas2013PRIMUSDistanceMaximum,self%binDistanceMaximum)
+    if (present(mass)) then
+       logarithmicMass=log10(mass)
+       select case (field)
+       case (1) ! COSMOS
+          redshift=                  +3.51240871481968000d0  &
+               &   +logarithmicMass*(-0.94131511297034200d0  &
+               &   +logarithmicMass*(+0.06507208866075860d0) &
+               &                                           )
+       case (2) ! XMM-SXDS
+          redshift=                  +2.46068289817352000d0  &
+               &   +logarithmicMass*(-0.72960045705258400d0  &
+               &   +logarithmicMass*(+0.05422457500058130d0) &
+               &                                           )
+       case (3) ! XMM-CFHTLS
+          redshift=                  -3.60001396783385000d0  &
+               &   +logarithmicMass*(+0.50007933123305700d0  &
+               &   +logarithmicMass*(-0.00781044013508246d0) &
+               &                                           )
+       case (4) ! CDFS
+          redshift=                  +5.86929723910240000d0  &
+               &   +logarithmicMass*(-1.52816338306828000d0  &
+               &   +logarithmicMass*(+0.09815249638377170d0) &
+               &                                           )
+       case (5) ! ELAIS-S1
+          redshift=                  +6.87489619768651000d0  &
+               &   +logarithmicMass*(-1.65556365363183000d0  &
+               &   +logarithmicMass*(+0.10030052053225000d0) &
+               &                                           )
+       case default
+          redshift=0.0d0
+          call Error_Report('1 ≤ field ≤ 5 required'//{introspection:location})
+       end select
+       ! Convert from redshift to comoving distance.
+       moustakas2013PRIMUSDistanceMaximum                                                                                             &
+            &=self%cosmologyFunctions_%distanceComovingConvert(                                                                       &
+            &                                                  output  =distanceTypeComoving                                        , &
+            &                                                  redshift=max(min(redshift,self%redshiftMaximum),self%redshiftMinimum)  &
+            &                                                 )
+       ! Limit the maximum distance.
+       moustakas2013PRIMUSDistanceMaximum=min(moustakas2013PRIMUSDistanceMaximum,self%binDistanceMaximum)
+    else
+       moustakas2013PRIMUSDistanceMaximum=                                       self%binDistanceMaximum
+    end if
     return
   end function moustakas2013PRIMUSDistanceMaximum
 

--- a/source/geometry.surveys.Tomczak-2014-ZFOURGE.F90
+++ b/source/geometry.surveys.Tomczak-2014-ZFOURGE.F90
@@ -228,30 +228,37 @@ contains
          &                                                                         luminosity, starFormationRate
     integer                                           , intent(in   ), optional :: field
     double precision                                                            :: redshift  , logarithmicMass
-    !$GLC attributes unused :: magnitudeAbsolute, luminosity, starFormationRate
 
     ! Validate field.
     if (.not.present(field)) call Error_Report('field must be specified'//{introspection:location})
+    ! Validate arguments.
+    if (present(magnitudeAbsolute)) call Error_Report('`magnitudeAbsolute` is not supported'//{introspection:location})
+    if (present(luminosity       )) call Error_Report(       '`luminosity` is not supported'//{introspection:location})
+    if (present(starFormationRate)) call Error_Report('`starFormationRate` is not supported'//{introspection:location})
     ! Find the limiting redshift for this mass. (See
     ! constraints/dataAnalysis/stellarMassFunctions_ZFOURGE_z0.2_2.5/massRedshiftRelation.pl for details.)
-    logarithmicMass=log10(mass)
-    select case (field)
-    case (1)
-       redshift=-114.659703302477d0+logarithmicMass*(45.9008293873578d0+logarithmicMass*(-6.16172903321726d0+logarithmicMass*(0.278223082977791d0)))
-    case (2)
-       redshift=-58.4827675323933d0+logarithmicMass*(20.2501133330335d0+logarithmicMass*(-2.35628286307041d0+logarithmicMass*(0.0927047000361006d0)))
-    case default
-       redshift=0.0d0
-       call Error_Report('1 ≤ field ≤ 2 required'//{introspection:location})
-    end select
-    ! Convert from redshift to comoving distance.
-    tomczak2014ZFOURGEDistanceMaximum                                                                                              &
-         &=self%cosmologyFunctions_%distanceComovingConvert(                                                                       &
-         &                                                  output  =distanceTypeComoving                                        , &
-         &                                                  redshift=min(max(redshift,self%redshiftMinimum),self%redshiftMaximum)  &
-         &                                                 )
-    ! Limit the maximum distance.
-    tomczak2014ZFOURGEDistanceMaximum=min(tomczak2014ZFOURGEDistanceMaximum,self%binDistanceMaximum)
+    if (present(mass)) then
+       logarithmicMass=log10(mass)
+       select case (field)
+       case (1)
+          redshift=-114.659703302477d0+logarithmicMass*(45.9008293873578d0+logarithmicMass*(-6.16172903321726d0+logarithmicMass*(0.278223082977791d0)))
+       case (2)
+          redshift=-58.4827675323933d0+logarithmicMass*(20.2501133330335d0+logarithmicMass*(-2.35628286307041d0+logarithmicMass*(0.0927047000361006d0)))
+       case default
+          redshift=0.0d0
+          call Error_Report('1 ≤ field ≤ 2 required'//{introspection:location})
+       end select
+       ! Convert from redshift to comoving distance.
+       tomczak2014ZFOURGEDistanceMaximum                                                                                              &
+            &=self%cosmologyFunctions_%distanceComovingConvert(                                                                       &
+            &                                                  output  =distanceTypeComoving                                        , &
+            &                                                  redshift=min(max(redshift,self%redshiftMinimum),self%redshiftMaximum)  &
+            &                                                 )
+       ! Limit the maximum distance.
+       tomczak2014ZFOURGEDistanceMaximum=min(tomczak2014ZFOURGEDistanceMaximum,self%binDistanceMaximum)
+    else
+       tomczak2014ZFOURGEDistanceMaximum=self%binDistanceMaximum
+    end if
     return
   end function tomczak2014ZFOURGEDistanceMaximum
 


### PR DESCRIPTION
In `outputAnalysis` classes which do not allow single epoch output, explain the problem and suggest a fix, providing the relevant range of redshifts in the error message.