### PR TITLE
Avoid segfault when evaluating delay time integrals

### DIFF
--- a/source/stellar_astrophysics.supernovae_type_Ia.mass_independent_delay_time_distribution.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.mass_independent_delay_time_distribution.F90
@@ -50,8 +50,8 @@
        Interface for cumulative number of Type Ia SNe.
        !!}
        import supernovaeTypeIaMassIndependentDTD
-       class           (supernovaeTypeIaMassIndependentDTD), intent(inout) :: self
-       double precision                                    , intent(in   ) :: age , metallicity
+       class           (supernovaeTypeIaMassIndependentDTD), intent(inout), target :: self
+       double precision                                    , intent(in   )         :: age , metallicity
      end function numberCumulativeTemplate
   end interface
 

--- a/source/stellar_astrophysics.supernovae_type_Ia.power_law_delay_time_distribution.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.power_law_delay_time_distribution.F90
@@ -111,8 +111,8 @@ contains
     Compute the cumulative number of Type Ia SNe assuming a power-law delay time distribution.
     !!}
     implicit none
-    class           (supernovaeTypeIaPowerLawDTD), intent(inout) :: self
-    double precision                             , intent(in   ) :: age , metallicity
+    class           (supernovaeTypeIaPowerLawDTD), intent(inout), target :: self
+    double precision                             , intent(in   )         :: age , metallicity
     !$GLC attributes unused :: metallicity
     
     if (age > self%timeMinimum) then


### PR DESCRIPTION
The integrand function was previously `contain`ed in the function performing the integral, which can lead to segfaults. The integrand function is now moved outside of the integrating function to avoid this.