### PR TITLE
Allow specifying output times via the lookback time

### DIFF
--- a/source/output.times.list.F90
+++ b/source/output.times.list.F90
@@ -21,7 +21,20 @@
 
   !![
   <outputTimes name="outputTimesList">
-   <description>An output times class which simply reads a list of output times from a parameter.</description>
+    <description>      
+      An output times class which simply reads a list of output times specified via parameters. Times can be given as a
+      (space-separated) list of actual cosmic times (in Gyr) via the {\normalfont \ttfamily [times]} parameter, or as a
+      (space-separated) list of redshifts via the {\normalfont \ttfamily [redshifts]} parameter, or by a combination of the
+      two. The {\normalfont \ttfamily [times]} parameter allows negative values which are interpretted as lookback times. For
+      example, in a cosmological model where the universe is currently 13.8~Gyr old the following:
+      \begin{verbatim}
+      &lt;outputTimes value="list"&gt;
+	&lt;redshifts value=" 0.0"/&gt;
+	&lt;times     value="-1.0"/&gt;
+      &lt;/outtputTimes&gt;
+      \end{verbatim}
+      will result in output at 12.8 and 13.8~Gyr.
+    </description>
   </outputTimes>
   !!]
   type, extends(outputTimesClass) :: outputTimesList
@@ -55,53 +68,65 @@ contains
     !!{
     Constructor for the {\normalfont \ttfamily list} output times class which takes a parameter set as input.
     !!}
-    use :: Array_Utilities  , only : Array_Reverse
     use :: Input_Parameters , only : inputParameter, inputParameters
     use :: Sorting          , only : sort
+    use :: Error            , only : Error_Report
     implicit none
     type            (outputTimesList        )                            :: self
     type            (inputParameters        ), intent(inout)             :: parameters
     class           (cosmologyFunctionsClass), pointer                   :: cosmologyFunctions_
-    double precision                         , allocatable, dimension(:) :: times
-    integer         (c_size_t               )                            :: outputCount        , i
+    double precision                         , allocatable, dimension(:) :: times              , redshifts    , &
+         &                                                                  timesFromRedshifts , timesCombined
+    integer         (c_size_t               )                            :: i
+    logical :: haveTimes, haveRedshifts
 
     !![
     <objectBuilder class="cosmologyFunctions" name="cosmologyFunctions_" source="parameters"/>
     !!]
-    if      (parameters%isPresent('times'    )) then
-       outputCount=parameters%count('times'    )
-    else if (parameters%isPresent('redshifts')) then
-       outputCount=parameters%count('redshifts')
-    else
-       outputCount=1_c_size_t
-    end if
-    allocate(times(outputCount))
-    if (parameters%isPresent('times')) then
-       !![
-       <inputParameter>
-         <name>times</name>
-         <description>A list of (space-separated) times at which \glc\ results should be output. Times need not be in any particular order.</description>
-         <source>parameters</source>
-       </inputParameter>
-       !!]
-       call sort(times)
-    else
+    haveTimes    =parameters%isPresent('times'    )
+    haveRedshifts=parameters%isPresent('redshifts')
+    if (haveRedshifts.or..not.(haveRedshifts.or.haveTimes)) then
+       allocate(redshifts         (max(1,parameters%count('redshifts',zeroIfNotPresent=.true.))))
+       allocate(timesFromRedshifts(size(redshifts)                                             ))
        !![
        <inputParameter>
          <name>redshifts</name>
          <defaultValue>[0.0d0]</defaultValue>
-         <variable>times</variable>
          <description>A list of (space-separated) redshifts at which \glc\ results should be output. Redshifts need not be in any particular order.</description>
          <source>parameters</source>
        </inputParameter>
        !!]
-       call sort(times)
-       times=Array_Reverse(times)
-       do i=1,outputCount
-          times(i)=cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(times(i)))
+       ! Convert redshifts to times.
+       do i=1,size(redshifts)
+          timesFromRedshifts(i)=cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(redshifts(i)))
        end do
+    else
+       allocate(timesFromRedshifts(0))
     end if
-    self=outputTimesList(times,cosmologyFunctions_)
+    if (haveTimes) then
+       allocate(times(parameters%count('times')))
+       !![
+       <inputParameter>
+         <name>times</name>
+         <description>A list of (space-separated) times at which \glc\ results should be output. Times need not be in any particular order. Negative times are interpretted as look-back times.</description>
+         <source>parameters</source>
+       </inputParameter>
+       !!]
+       ! Convert any look-back times to actual times.
+       do i=1,size(times)
+          if (times(i) < 0.0d0) then
+             times(i)=cosmologyFunctions_%cosmicTime(1.0d0)+times(i)
+             if (times(i) < 0.0d0) call Error_Report('look-back time exceeds the age of the universe'//{introspection:location})
+          end if
+       end do
+    else
+       allocate(times(0))
+    end if
+    allocate(timesCombined(size(times)+size(timesFromRedshifts)))
+    if (size(times             ) > 0) timesCombined(1            :size(times)                         )=times
+    if (size(timesFromRedshifts) > 0) timesCombined(1+size(times):size(times)+size(timesFromRedshifts))=timesFromRedshifts
+    call sort(timesCombined)
+    self=outputTimesList(timesCombined,cosmologyFunctions_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"/>

--- a/testSuite/parameters/test-output-times.xml
+++ b/testSuite/parameters/test-output-times.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Parameters used for testing that outputs are created -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <version>0.9.4</version>
+
+  <!-- Set output file name -->
+  <outputFileName value="testSuite/outputs/test-output-times.hdf5"/>
+
+  <!-- Limit halo mass -->
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMaximum value="1.0e12"/>
+  </mergerTreeBuildMasses>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard">
+    <massSeed value="100"/>
+    <heatsHotHalo value="true"/>
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+  </componentBlackHole>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard">
+    <fractionLossAngularMomentum value="0.3"/>
+    <starveSatellites value="false"/>
+    <efficiencyStrippingOutflow value="0.1"/>
+    <trackStrippedGas value="true"/>
+  </componentHotHalo>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <ratioAngularMomentumScaleRadius value="0.5"/>
+    <efficiencyEnergeticOutflow value="1.0e-2"/>
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.0"/>
+    <OmegaMatter value="1.0"/>
+    <OmegaDarkEnergy value="0.0"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.04"/>
+    <neutrinoMassSummed value="0.0"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileConcentration value="gao2008"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="simple">
+    <redshiftReionization value="10.5"/>
+    <velocitySuppressionReionization value="35.0"/>
+  </accretionHalo>
+
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="5.0"/>
+  </hotHaloOutflowReincorporation>
+
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0"/>
+  </coolingTimeAvailable>
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <!-- Galactic structure solver options -->
+  <galacticStructureSolver value="equilibrium"/>
+  <darkMatterProfile value="adiabaticGnedin2004">
+    <A value="0.73"/>
+    <omega value="0.7"/>
+  </darkMatterProfile>
+
+  <!-- Star formation rate options -->
+  <starFormationRateDisks value="intgrtdSurfaceDensity"/>
+  <starFormationRateSurfaceDensityDisks value="krumholz2009">
+    <frequencyStarFormation value="0.385"/>
+    <clumpingFactorMolecularComplex value="5.000"/>
+    <molecularFractionFast value="true"/>
+  </starFormationRateSurfaceDensityDisks>
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.04"/>
+      <exponentVelocity value="2.0"/>
+      <timescaleMinimum value="0.001"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="instantaneous"/>
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+
+  <initialMassFunction value="chabrier2001"/>
+  <stellarPopulation value="standard">
+    <recycledFraction value="0.46"/>
+    <metalYield value="0.035"/>
+  </stellarPopulation>
+
+  <!-- AGN feedback options -->
+  <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <!-- Accretion disk properties -->
+  <accretionDisks value="switched">
+    <accretionRateThinDiskMaximum value="0.30"/>
+    <accretionRateThinDiskMinimum value="0.01"/>
+    <scaleADAFRadiativeEfficiency value="true"/>
+    <accretionDisksShakuraSunyaev value="shakuraSunyaev"/>
+    <accretionDisksADAF value="ADAF">
+      <efficiencyRadiationType value="thinDisk"/>
+      <adiabaticIndex value="1.444"/>
+      <energyOption value="pureADAF"/>
+      <efficiencyRadiation value="0.01"/>
+      <viscosityOption value="fit"/>
+      <efficiencyJetMaximum value="2.0"/>
+    </accretionDisksADAF>
+  </accretionDisks>
+
+  <!-- Black hole options -->
+  <blackHoleBinaryMergers value="rezzolla2008"/>
+  <!-- Galaxy merger options -->
+  <virialOrbit value="benson2005"/>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"/>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+    <nodeOperator value="starFormationSpheroids"/>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="250.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <exponent value="3.5"/>
+          <velocityCharacteristic value="100.0"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <!-- Bar instability in galactic disks -->
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="0.7"/>
+	<stabilityThresholdStellar value="1.1"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <redshifts value="0.0 1.0 2.0"/>
+    <times value="8.0 9.0 -2.4"/>
+  </outputTimes>
+
+</parameters>

--- a/testSuite/test-output-times.pl
+++ b/testSuite/test-output-times.pl
@@ -1,0 +1,49 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use PDL;
+use PDL::IO::HDF5;
+
+# Run a single Galacticus model and ensure that outputs are created.
+# Andrew Benson (04-April-2014)
+
+# Simply run the models.
+system("cd ..; mkdir -p testSuite/outputs; ./Galacticus.exe testSuite/parameters/test-output-times.xml");
+
+# Check for outputs.
+die("test-output-times.pl: FAILED to run Galacticus model")
+    unless ( -e "outputs/test-output-times.hdf5" );
+# Find all output times.
+my $file    = new PDL::IO::HDF5("outputs/test-output-times.hdf5");
+my $outputs = $file->group('Outputs');
+my $times = pdl [];
+foreach my $outputName ( $outputs->groups() ) {
+    my $output = $outputs->group($outputName);
+    (my $outputTime) = $output->attrGet('outputTime');
+    $times = $times->append($outputTime);
+}
+# Construct the expected times.
+my $HubbleConstant = pdl 70.0;
+my $megaParsec     = pdl 3.08528229e22;
+my $kilo           = pdl 1.0e3;
+my $gigaYear       = pdl 3.15576e16;
+my $ageUniverse    = (2.0/3.0)*$megaParsec/$kilo/$gigaYear/$HubbleConstant;
+# Fixed times.
+my $timesExpected  = pdl [ 8.0, 9.0 ];
+# Lookback times.
+$timesExpected     = $timesExpected->append($ageUniverse-2.4);
+# Redshifts.
+my $redshifts      = pdl [ 0.0, 1.0, 2.0 ];
+$timesExpected     = $timesExpected->append($ageUniverse/(1.0+$redshifts)**1.5);
+# Sort the times.
+$timesExpected     = $timesExpected->qsort();
+# Compare the times.
+if ( nelem($times) != nelem($timesExpected) ) {
+    print "test-output-times.pl: FAILED - number of times does not match\n";
+} elsif ( any(abs($times-$timesExpected)/$timesExpected > 1.0e-3) ) {
+    print "test-output-times.pl: FAILED - times do not match\n";
+} else {
+    print "test-output-times.pl: SUCCESS\n";
+}
+
+exit;


### PR DESCRIPTION
The `outputTimesList` class now accept negative times and inteprets them as lookback times. Additionally, it also allows a mixture of `times` and `redshifts` to be specified.