### PR TITLE
Provide a `nodeOperatorFiltered` class

### DIFF
--- a/source/nodes.operators.filtered.F90
+++ b/source/nodes.operators.filtered.F90
@@ -1,0 +1,111 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Contains a module which implements a filtered node operator class.
+  !!}
+
+  use :: Galactic_Filters, only : galacticFilterClass
+  
+  !![
+  <nodeOperator name="nodeOperatorFiltered">
+   <description>A filtered node operator class.</description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorMulti) :: nodeOperatorFiltered
+     !!{
+     A filtered node operator class, which applies multiple node operators but only if the node passes the provided filter.
+     !!}
+     private
+     class(galacticFilterClass), pointer :: galacticFilter_ => null()
+   contains
+     final     ::             filteredDestructor
+     procedure :: isActive => filteredIsActive
+  end type nodeOperatorFiltered
+
+  interface nodeOperatorFiltered
+     !!{
+     Constructors for the {\normalfont \ttfamily filtered} node operator class.
+     !!}
+     module procedure filteredConstructorParameters
+     module procedure filteredConstructorInternal
+  end interface nodeOperatorFiltered
+
+contains
+
+  function filteredConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily filtered} node operator property process class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    use :: Error           , only : Error_Report
+    implicit none
+    type(nodeOperatorFiltered)                :: self
+    type(inputParameters     ), intent(inout) :: parameters
+
+
+    if (.not.parameters%isPresent('galacticFilter')) call Error_Report('A [galacticFilter] must be given explicitly for this class'//{introspection:location})
+    self%nodeOperatorMulti=nodeOperatorMulti(parameters)
+    !![
+    <objectBuilder class="galacticFilter" name="self%galacticFilter_" source="parameters"/>
+    <inputParametersValidate source="parameters" multiParameters="nodeOperator"/>
+    !!]
+    return
+  end function filteredConstructorParameters
+
+  function filteredConstructorInternal(processes,galacticFilter_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily filtered} output process property process class.
+    !!}
+    implicit none
+    type (nodeOperatorFiltered)                        :: self
+    type (multiProcessList    ), intent(in   ), target :: processes
+    class(galacticFilterClass ), intent(inout), target :: galacticFilter_
+    !![
+    <constructorAssign variables="*galacticFilter_"/>
+    !!]
+    
+    self%nodeOperatorMulti=nodeOperatorMulti(processes)
+    return
+  end function filteredConstructorInternal
+
+  subroutine filteredDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily filtered} output process property process class.
+    !!}
+    implicit none
+    type(nodeOperatorFiltered), intent(inout) :: self
+    
+    !![
+    <objectDestructor name="self%galacticFilter_"/>
+    !!]
+    return
+  end subroutine filteredDestructor
+
+  logical function filteredIsActive(self,node) result(isActive)
+    !!{
+    Return true if the operators are active for the given {\normalfont \ttfamily node}.
+    !!}
+    implicit none
+    class(nodeOperatorFiltered), intent(inout) :: self
+    type (treeNode            ), intent(inout) :: node
+    
+    isActive=self%galacticFilter_%passes(node)
+    return
+  end function filteredIsActive

--- a/source/nodes.operators.multi.F90
+++ b/source/nodes.operators.multi.F90
@@ -39,6 +39,11 @@
      private
      type(multiProcessList), pointer :: processes => null()
    contains
+     !![
+     <methods>
+	<method method="isActive" description="Return true if the operators are active for the given {\normalfont \ttfamily node}."/>
+     </methods>
+     !!]
      final     ::                                        multiDestructor
      procedure :: nodeTreeInitialize                  => multiNodeTreeInitialize
      procedure :: nodeInitialize                      => multiNodeInitialize
@@ -54,6 +59,7 @@
      procedure :: differentialEvolutionStepFinalState => multiDifferentialEvolutionStepFinalState
      procedure :: differentialEvolutionPost           => multiDifferentialEvolutionPost
      procedure :: differentialEvolutionPostStep       => multiDifferentialEvolutionPostStep
+     procedure :: isActive                            => multiIsActive
   end type nodeOperatorMulti
 
   interface nodeOperatorMulti
@@ -148,6 +154,7 @@ contains
     type (treeNode         ), intent(inout), target  :: node
     type (multiProcessList )               , pointer :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%nodeTreeInitialize(node)
@@ -165,6 +172,7 @@ contains
     type (treeNode         ), intent(inout), target  :: node
     type (multiProcessList )               , pointer :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%nodeInitialize(node)
@@ -182,6 +190,7 @@ contains
     type (treeNode         ), intent(inout) :: node
     type (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%nodesMerge(node)
@@ -199,6 +208,7 @@ contains
     type (treeNode         ), intent(inout) :: node
     type (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%nodePromote(node)
@@ -216,6 +226,7 @@ contains
     type (treeNode         ), intent(inout) :: node
     type (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%galaxiesMerge(node)
@@ -233,6 +244,7 @@ contains
     type (treeNode         ), intent(inout) :: node
     type (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%differentialEvolutionPre(node)
@@ -250,6 +262,7 @@ contains
     type (treeNode         ), intent(inout) :: node
     type (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%differentialEvolutionScales(node)
@@ -267,6 +280,7 @@ contains
     type (treeNode         ), intent(inout) :: node
     type (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%differentialEvolutionAnalytics(node)
@@ -284,6 +298,7 @@ contains
     type (treeNode         ), intent(inout) :: node
     type (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%differentialEvolutionInactives(node)
@@ -304,6 +319,7 @@ contains
     integer                     , intent(in   )          :: propertyType
     type     (multiProcessList )               , pointer :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%differentialEvolution(node,interrupt,functionInterrupt,propertyType)
@@ -322,6 +338,7 @@ contains
     double precision                   , intent(in   ) :: time
     type            (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%differentialEvolutionSolveAnalytics(node,time)
@@ -339,6 +356,7 @@ contains
     type (treeNode         ), intent(inout) :: node
     type (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%differentialEvolutionStepFinalState(node)
@@ -356,6 +374,7 @@ contains
     type (treeNode         ), intent(inout) :: node
     type (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%differentialEvolutionPost(node)
@@ -374,6 +393,7 @@ contains
     integer                   , intent(inout) :: status
     type   (multiProcessList ), pointer       :: process_
 
+    if (.not.self%isActive(node)) return
     process_ => self%processes
     do while (associated(process_))
        call process_%process_%differentialEvolutionPostStep(node,status)
@@ -381,3 +401,16 @@ contains
     end do
     return
   end subroutine multiDifferentialEvolutionPostStep
+
+  logical function multiIsActive(self,node) result(isActive)
+    !!{
+    Return true if the operators are active for the given {\normalfont \ttfamily node}.
+    !!}
+    implicit none
+    class(nodeOperatorMulti), intent(inout) :: self
+    type (treeNode         ), intent(inout) :: node
+    !$GLC attributes unused :: self, node
+    
+    isActive=.true.
+    return
+  end function multiIsActive


### PR DESCRIPTION
This class applies a set of other `nodeOperator`s, but only if the `treeNode` being operated on passes the supplied `galacticFilter`.