### PR TITLE
Change the definition of dynamical timescale to follow that in Binney & Tremaine, "Galactic Dynamics".

### DIFF
--- a/source/satellites.tidal_stripping.rate.Zentner2005.F90
+++ b/source/satellites.tidal_stripping.rate.Zentner2005.F90
@@ -50,7 +50,7 @@
     If {\normalfont \ttfamily [useDynamicalTimeScale]} is set to true, $T_\mathrm{loss}$ is taken to be the dynamical time scale
     computed at the tidal radius
     \begin{equation}
-    T_\mathrm{dyn} = \sqrt{\frac{3\pi r_\mathrm{tidal}^3}{16 G M_\mathrm{sat}(r_\mathrm{tidal})}}.
+    T_\mathrm{dyn} = \sqrt{\frac{3 \pi}{16 G \overline{\rho}_\mathrm{sat}(r_\mathrm{tidal})}} = 2 \pi \sqrt{\frac{r_\mathrm{tidal}^3}{16 G M_\mathrm{sat}(r_\mathrm{tidal})}}.
     \end{equation}
    </description>
   </satelliteTidalStripping>
@@ -197,11 +197,11 @@ contains
     massEnclosedTidalRadius=max(0.0d0,self%galacticStructure_            %massEnclosed(node,radiusTidal))
     ! Check whether to use the dynamical time scale or the orbital time scale for mass loss rate.
     if (self%useDynamicalTimeScale .and. massEnclosedTidalRadius > 0.0d0) then
-       timeScaleMassLoss=+sqrt(                                 &
-            &                  + 3.0d0                          &
+       timeScaleMassLoss=+2.0d0                                 &
+            &            *Pi                                    &
+            &            *sqrt(                                 &
+            &                  +radiusTidal**3                  &
             &                  /16.0d0                          &
-            &                  *Pi                              &
-            &                  *radiusTidal**3                  &
             &                  /gravitationalConstantGalacticus &
             &                  /massEnclosedTidalRadius         &
             &                 )                                 &

--- a/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.005_alpha_1.0_beta_3.0_gamma_1.5.xml
+++ b/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.005_alpha_1.0_beta_3.0_gamma_1.5.xml
@@ -117,7 +117,7 @@
   </satelliteTidalHeatingRate>
   <satelliteTidalStripping    value="zentner2005"      >
     <useDynamicalTimeScale value="true" />
-    <efficiency            value="10.0" />
+    <efficiency            value="20.0" />
   </satelliteTidalStripping>
   <satelliteTidalStrippingRadius value="king1962">
     <efficiencyCentrifugal value="0.0"  />

--- a/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.01_alpha_1.0_beta_3.0_gamma_1.5.xml
+++ b/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.01_alpha_1.0_beta_3.0_gamma_1.5.xml
@@ -117,7 +117,7 @@
   </satelliteTidalHeatingRate>
   <satelliteTidalStripping    value="zentner2005"      >
     <useDynamicalTimeScale value="true" />
-    <efficiency            value="10.0" />
+    <efficiency            value="20.0" />
   </satelliteTidalStripping>
   <satelliteTidalStrippingRadius value="king1962">
     <efficiencyCentrifugal value="0.0"  />

--- a/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.05_alpha_1.0_beta_3.0_gamma_0.5.xml
+++ b/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.05_alpha_1.0_beta_3.0_gamma_0.5.xml
@@ -118,8 +118,8 @@
     <gamma            value="0.0"     />
   </satelliteTidalHeatingRate>
   <satelliteTidalStripping    value="zentner2005"      >
-    <useDynamicalTimeScale value="true"     />
-    <efficiency            value="0.4957011"/>
+    <useDynamicalTimeScale value="true"    />
+    <efficiency            value="1.01453" />
   </satelliteTidalStripping>
   <satelliteTidalStrippingRadius value="king1962">
     <efficiencyCentrifugal value="0.0"     />

--- a/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.05_alpha_1.0_beta_3.0_gamma_1.0.xml
+++ b/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.05_alpha_1.0_beta_3.0_gamma_1.0.xml
@@ -113,7 +113,7 @@
   </satelliteTidalHeatingRate>
   <satelliteTidalStripping    value="zentner2005"      >
     <useDynamicalTimeScale value="true"    />
-    <efficiency            value="1.86658" />
+    <efficiency            value="3.82024" />
   </satelliteTidalStripping>
   <satelliteTidalStrippingRadius value="king1962">
     <efficiencyCentrifugal value="0.0"     />

--- a/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.2_alpha_1.0_beta_3.0_gamma_0.0.xml
+++ b/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.2_alpha_1.0_beta_3.0_gamma_0.0.xml
@@ -119,7 +119,7 @@
   </satelliteTidalHeatingRate>
   <satelliteTidalStripping    value="zentner2005"      >
     <useDynamicalTimeScale value="true"    />
-    <efficiency            value="1.16711" />
+    <efficiency            value="2.38868" />
   </satelliteTidalStripping>
   <satelliteTidalStrippingRadius value="king1962">
     <efficiencyCentrifugal value="0.0"     />

--- a/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.2_alpha_1.0_beta_3.0_gamma_0.5.xml
+++ b/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.2_alpha_1.0_beta_3.0_gamma_0.5.xml
@@ -118,8 +118,8 @@
     <gamma            value="0.0"     />
   </satelliteTidalHeatingRate>
   <satelliteTidalStripping    value="zentner2005"      >
-    <useDynamicalTimeScale value="true"      />
-    <efficiency            value="0.4957011" />
+    <useDynamicalTimeScale value="true"    />
+    <efficiency            value="1.01453" />
   </satelliteTidalStripping>
   <satelliteTidalStrippingRadius value="king1962">
     <efficiencyCentrifugal value="0.0"     />

--- a/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.2_alpha_1.0_beta_3.0_gamma_1.0.xml
+++ b/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.2_alpha_1.0_beta_3.0_gamma_1.0.xml
@@ -113,7 +113,7 @@
   </satelliteTidalHeatingRate>
   <satelliteTidalStripping    value="zentner2005"      >
     <useDynamicalTimeScale value="true"    />
-    <efficiency            value="1.86658" />
+    <efficiency            value="3.82024" />
   </satelliteTidalStripping>
   <satelliteTidalStrippingRadius value="king1962">
     <efficiencyCentrifugal value="0.0"     />

--- a/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.4_alpha_1.0_beta_3.0_gamma_0.0.xml
+++ b/testSuite/parameters/idealizedSubhaloSimulations/tidalTrackBestFit_xc_0.7_ratio_0.4_alpha_1.0_beta_3.0_gamma_0.0.xml
@@ -119,7 +119,7 @@
   </satelliteTidalHeatingRate>
   <satelliteTidalStripping    value="zentner2005"      >
     <useDynamicalTimeScale value="true"    />
-    <efficiency            value="1.16711" />
+    <efficiency            value="2.38868" />
   </satelliteTidalStripping>
   <satelliteTidalStrippingRadius value="king1962">
     <efficiencyCentrifugal value="0.0"     />


### PR DESCRIPTION
A constant of order unity was ignored in the definition of dynamical timescale, $T_{\rm dyn}$, when computing the tidal mass loss. To be consistent with the definition in the book "Galactic Dynamics" by Binney & Tremaine, $T_{\rm dyn}$ is changed from
$$T_{\rm dyn} = \sqrt{\frac{3 \pi r_{\rm t}^3}{16  G  M_{\rm sub}(r_{\rm t})}}$$
to
$$T_{\rm dyn} = \sqrt{\frac{3 \pi}{16 G  \overline{\rho}(r_{\rm t})}} = 2 \pi \sqrt{\frac{r_{\rm t}^3}{16  G  M_{\rm sub}(r_{\rm t})}}.$$
The updated definition gives a value $\sqrt{4 \pi /3}$ times larger than that from the old definition. Accordingly, the best-fit value of the tidal stripping coefficient $\alpha_{s}$ must also be $\sqrt{4 \pi /3}$ times larger in order to keep the tidal mass loss unchanged, i.e.
$$\frac{d M_{\rm sat}}{dt} = -\alpha_s \frac{M_{\rm sat} - M(r_{\rm t})}{T_{\rm dyn}}.$$

This issue is related to #613. @cgannonucm 