### PR TITLE
Refactor the `starFormationHistoryInSitu` class

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1070,6 +1070,7 @@ jobs:
                 test-reproducibility.pl,
                 test-splitForests.pl,
                 test-star-formation-histories-adaptive.py,
+                test-star-formation-histories-inSitu.py,
                 test-mostMassiveProgenitorIsSubhalo.py,
                 test-stateRestore.pl,
                 test-checkpointing.pl,

--- a/source/star_formation.histories.in_situ.F90
+++ b/source/star_formation.histories.in_situ.F90
@@ -37,11 +37,6 @@ Implements a star formation histories class which records \emph{in situ} star fo
      private
      class(starFormationHistoryClass), pointer :: starFormationHistory_ => null()
    contains
-     !![
-     <methods>
-       <method description="Make the star formation history." method="make" />
-     </methods>
-     !!]
      final     ::                          inSituDestructor
      procedure :: create                => inSituCreate
      procedure :: rate                  => inSituRate

--- a/source/star_formation.histories.in_situ.F90
+++ b/source/star_formation.histories.in_situ.F90
@@ -26,7 +26,7 @@ Implements a star formation histories class which records \emph{in situ} star fo
    <description>
      A star formation histories class which records \emph{in situ} star formation. Another {\normalfont \ttfamily
      starFormationHistory} object is used to provide the base star formation history. This class tracks a second copy which is
-     indentical but excludes any star formation from merging galaxies.
+     identical but excludes any star formation from merging galaxies.
    </description>
   </starFormationHistory>
   !!]

--- a/source/star_formation.histories.in_situ.F90
+++ b/source/star_formation.histories.in_situ.F90
@@ -18,17 +18,15 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a star formation histories class which records \emph{in situ} star formation.
+Implements a star formation histories class which records \emph{in situ} star formation alongside the star formation history computed by some other class.
 !!}
-
-  use :: Output_Times, only : outputTimes, outputTimesClass
 
   !![
   <starFormationHistory name="starFormationHistoryInSitu">
    <description>
-    A star formation histories class which records \emph{in situ} star formation. The star formation history is tabulated on a
-    grid of time and is split between in-situ and accreted star formation. The time grid is the same as (and controlled by the
-    same parameters) are for the {\normalfont \ttfamily metallicitySplit} method.
+     A star formation histories class which records \emph{in situ} star formation. Another {\normalfont \ttfamily
+     starFormationHistory} object is used to provide the base star formation history. This class tracks a second copy which is
+     indentical but excludes any star formation from merging galaxies.
    </description>
   </starFormationHistory>
   !!]
@@ -37,9 +35,7 @@ Contains a module which implements a star formation histories class which record
      A star formation histories class which records \emph{in situ} star formation.
      !!}
      private
-     class           (outputTimesClass), pointer :: outputTimes_ => null()
-     double precision                            :: timeStep              , timeStepFine, &
-          &                                         timeFine
+     class(starFormationHistoryClass), pointer :: starFormationHistory_ => null()
    contains
      !![
      <methods>
@@ -51,7 +47,6 @@ Contains a module which implements a star formation histories class which record
      procedure :: rate                  => inSituRate
      procedure :: update                => inSituUpdate
      procedure :: scales                => inSituScales
-     procedure :: make                  => inSituMake
      procedure :: autoHook              => inSituAutoHook
      procedure :: metallicityBoundaries => inSituMetallicityBoundaries
   end type starFormationHistoryInSitu
@@ -64,14 +59,6 @@ Contains a module which implements a star formation histories class which record
      module procedure inSituConstructorInternal
   end interface starFormationHistoryInSitu
 
-  ! Type used to store timestep range information.
-  type inSituTimeStepRange
-     private
-     integer                                        :: count
-     double precision                               :: timeBegin          , timeEnd
-     type            (inSituTimeStepRange), pointer :: next      => null()
-  end type inSituTimeStepRange
-
 contains
 
   function inSituConstructorParameters(parameters) result(self)
@@ -80,52 +67,30 @@ contains
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type            (starFormationHistoryInSitu)                :: self
-    type            (inputParameters           ), intent(inout) :: parameters
-    class           (outputTimesClass          ), pointer       :: outputTimes_
-    double precision                                            :: timeStep    , timeStepFine, &
-         &                                                         timeFine
+    type (starFormationHistoryInSitu)                :: self
+    type (inputParameters           ), intent(inout) :: parameters
+    class(starFormationHistoryClass ), pointer       :: starFormationHistory_
 
     !![
-    <inputParameter>
-      <name>timeStep</name>
-      <defaultValue>0.1d0</defaultValue>
-      <description>The time step to use in tabulations of star formation histories [Gyr].</description>
-      <source>parameters</source>
-    </inputParameter>
-    <inputParameter>
-      <name>timeStepFine</name>
-      <defaultValue>0.01d0</defaultValue>
-      <description>The fine time step to use in tabulations of star formation histories [Gyr].</description>
-      <source>parameters</source>
-    </inputParameter>
-    <inputParameter>
-      <name>timeFine</name>
-      <defaultValue>0.1d0</defaultValue>
-      <description>The period prior to each output for which the fine time step is used in tabulations of star formation histories [Gyr].</description>
-      <source>parameters</source>
-    </inputParameter>
-    <objectBuilder class="outputTimes" name="outputTimes_" source="parameters"/>
+    <objectBuilder class="starFormationHistory" name="starFormationHistory_" source="parameters"/>
     !!]
-    self=starFormationHistoryInSitu(timeStep,timeStepFine,timeFine,outputTimes_)
+    self=starFormationHistoryInSitu(starFormationHistory_)
     !![
     <inputParametersValidate source="parameters"/>
-    <objectDestructor name="outputTimes_"/>
+    <objectDestructor name="starFormationHistory_"/>
     !!]
     return
   end function inSituConstructorParameters
 
-  function inSituConstructorInternal(timeStep,timeStepFine,timeFine,outputTimes_) result(self)
+  function inSituConstructorInternal(starFormationHistory_) result(self)
     !!{
     Internal constructor for the ``inSitu'' star formation history class.
     !!}
     implicit none
-    type            (starFormationHistoryInSitu)                        :: self
-    double precision                            , intent(in   )         :: timeStep    , timeStepFine, &
-         &                                                                 timeFine
-    class           (outputTimesClass          ), intent(in   ), target :: outputTimes_
+    type (starFormationHistoryInSitu)                        :: self
+    class(starFormationHistoryClass ), intent(in   ), target :: starFormationHistory_
     !![
-    <constructorAssign variables="timeStep, timeStepFine, timeFine, *outputTimes_"/>
+    <constructorAssign variables="*starFormationHistory_"/>
     !!]
 
     return
@@ -151,7 +116,7 @@ contains
     type(starFormationHistoryInSitu), intent(inout) :: self
 
     !![
-    <objectDestructor name="self%outputTimes_"/>
+    <objectDestructor name="self%starFormationHistory_"/>
     !!]
     return
   end subroutine inSituDestructor
@@ -160,22 +125,20 @@ contains
     !!{
     Create the history required for storing star formation history.
     !!}
-    use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
     implicit none
     class           (starFormationHistoryInSitu), intent(inout)           :: self
     type            (treeNode                  ), intent(inout)           :: node
     type            (history                   ), intent(inout)           :: historyStarFormation
     double precision                            , intent(in   )           :: timeBegin
     double precision                            , intent(in   ), optional :: timeEnd
-    class           (nodeComponentBasic        ), pointer                 :: basic
-    double precision                                                      :: timeBeginActual     , timeEnd_
-    !$GLC attributes unused :: timeEnd
+    type            (history                   )                          :: history_
     
-    ! Find the start and end times for this history.
-    basic           =>               node %basic()
-    timeBeginActual =  min(timeBegin,basic%time ())
-    timeEnd_        =  self%outputTimes_%timeNext(timeBegin)
-    call self%make(historyStarFormation,timeBeginActual,timeEnd_)
+    call self%starFormationHistory_%create(node,history_,timeBegin,timeEnd)
+    historyStarFormation%rangeType=history_%rangeType
+    historyStarFormation%time     =history_%time
+    allocate(historyStarFormation%data(size(history_%data,dim=1),2*size(history_%data,dim=2)))
+    historyStarFormation%data(:,1                          :  size(history_%data,dim=2))=history_%data
+    historyStarFormation%data(:,1+size(history_%data,dim=2):2*size(history_%data,dim=2))=history_%data
     return
   end subroutine inSituCreate
 
@@ -183,32 +146,22 @@ contains
     !!{
     Set the rate the star formation history for {\normalfont \ttfamily node}.
     !!}
-    use :: Arrays_Search   , only : searchArray
-    use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
-    use :: Error           , only : Error_Report
     implicit none
     class           (starFormationHistoryInSitu), intent(inout) :: self
     type            (treeNode                  ), intent(inout) :: node
     type            (history                   ), intent(inout) :: historyStarFormation
     type            (abundances                ), intent(in   ) :: abundancesFuel
     double precision                            , intent(in   ) :: rateStarFormation
-    class           (nodeComponentBasic        ), pointer       :: basic
-    integer                                                     :: historyCount
-    integer         (c_size_t                  )                :: iHistory
-    double precision                                            :: timeNode
-    !$GLC attributes unused :: self, abundancesFuel
+    type            (history                   )                :: history_
 
-    ! Check if history exists.
-    if (historyStarFormation%exists()) then
-       basic                                 =>             node                %basic()
-       timeNode                              =              basic               %time ()
-       historyCount                          =         size(historyStarFormation%time            )
-       iHistory                              =  searchArray(historyStarFormation%time   ,timeNode)+1
-       historyStarFormation%data(iHistory,:) =  rateStarFormation
-    else
-       ! No history exists - this is acceptable only if the star formation rate is zero.
-       if (rateStarFormation > 0.0d0) call Error_Report('non-zero star formation rate, but star formation history is uninitialized'//{introspection:location})
-    end if
+    allocate(history_%time(size(historyStarFormation%data,dim=1)                                        ))
+    allocate(history_%data(size(historyStarFormation%data,dim=1),size(historyStarFormation%data,dim=2)/2))
+    history_%rangeType=historyStarFormation%rangeType
+    history_%time     =historyStarFormation%time
+    history_%data=historyStarFormation%data(:,1:size(historyStarFormation%data,dim=2)/2)
+    call self%starFormationHistory_%rate(node,history_,abundancesFuel,rateStarFormation)
+    historyStarFormation%data(:,1                                        :size(historyStarFormation%data,dim=2)/2)=history_%data
+    historyStarFormation%data(:,1+size(historyStarFormation%data,dim=2)/2:size(historyStarFormation%data,dim=2)  )=history_%data
     return
   end subroutine inSituRate
 
@@ -218,32 +171,32 @@ contains
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic
     implicit none
-    class           (starFormationHistoryInSitu  ), intent(inout)         :: self
-    type            (treeNode                    ), intent(inout), target :: node
-    type            (history                     ), intent(inout)         :: historyStarFormation
-    integer         (c_size_t                    ), intent(in   )         :: indexOutput
-    class           (nodeComponentBasic          ), pointer               :: basicParent
-    type            (treeNode                    ), pointer               :: nodeParent
-    double precision                                                      :: timeBegin           , timeEnd
-    type            (history                     )                        :: newHistory
+    class  (starFormationHistoryInSitu), intent(inout)         :: self
+    type   (treeNode                  ), intent(inout), target :: node
+    type   (history                   ), intent(inout)         :: historyStarFormation
+    integer(c_size_t                  ), intent(in   )         :: indexOutput
+    type   (history                   )                        :: history1            , history2
 
     if (.not.historyStarFormation%exists()) return
-    timeBegin=historyStarFormation%time(1)
-    if (indexOutput < self%outputTimes_%count()) then
-       timeEnd=self%outputTimes_%time(indexOutput+1)
-    else
-       nodeParent => node
-       do while (associated(nodeParent%parent))
-          nodeParent => nodeParent%parent
-       end do
-       basicParent => nodeParent %basic()
-       timeEnd     =  basicParent%time ()
-    end if
-    call self%make(newHistory,timeBegin,timeEnd,historyStarFormation%time)
-    newHistory%data(1:size(historyStarFormation%time),:)=historyStarFormation%data(:,:)
+    allocate(history1%time(size(historyStarFormation%data,dim=1)                                        ))
+    allocate(history2%time(size(historyStarFormation%data,dim=1)                                        ))
+    allocate(history1%data(size(historyStarFormation%data,dim=1),size(historyStarFormation%data,dim=2)/2))
+    allocate(history2%data(size(historyStarFormation%data,dim=1),size(historyStarFormation%data,dim=2)/2))
+    history1%rangeType=historyStarFormation%rangeType
+    history2%rangeType=historyStarFormation%rangeType
+    history1%time     =historyStarFormation%time
+    history2%time     =historyStarFormation%time
+    history1%data=historyStarFormation%data(:,1                                        :size(historyStarFormation%data,dim=2)/2)
+    history2%data=historyStarFormation%data(:,1+size(historyStarFormation%data,dim=2)/2:size(historyStarFormation%data,dim=2)  )
+    call self%starFormationHistory_%update(node,indexOutput,history1)
+    call self%starFormationHistory_%update(node,indexOutput,history2)
     call historyStarFormation%destroy()
-    historyStarFormation=newHistory
-    call newHistory%destroy()
+    allocate(historyStarFormation%time(size(history1%data,dim=1)                            ))
+    allocate(historyStarFormation%data(size(history1%data,dim=1),size(history1%data,dim=2)*2))
+    historyStarFormation%rangeType=history1%rangeType
+    historyStarFormation%time     =history1%time
+    historyStarFormation%data(:,1                          :  size(history1%data,dim=2))=history1%data
+    historyStarFormation%data(:,1+size(history1%data,dim=2):2*size(history1%data,dim=2))=history2%data
     return
   end subroutine inSituUpdate
 
@@ -252,168 +205,26 @@ contains
     Set the scalings for error control on the absolute values of star formation histories.
     !!}
     implicit none
-    class           (starFormationHistoryInSitu), intent(inout)               :: self
-    double precision                            , intent(in   )               :: massStellar
-    type            (abundances                ), intent(in   )               :: abundancesStellar
-    type            (history                   ), intent(inout)               :: historyStarFormation
-    double precision                            , allocatable  , dimension(:) :: timeSteps
-    double precision                            , parameter                   :: massStellarMinimum  =1.0d0
-    integer                                                                   :: i
-    !$GLC attributes unused :: self, abundancesStellar
+    class           (starFormationHistoryInSitu), intent(inout) :: self
+    double precision                            , intent(in   ) :: massStellar
+    type            (abundances                ), intent(in   ) :: abundancesStellar
+    type            (history                   ), intent(inout) :: historyStarFormation
+    type            (history                   )                :: history_
 
-    if (.not.historyStarFormation%exists()) return
-    call historyStarFormation%timeSteps(timeSteps)
-    forall(i=1:2)
-       historyStarFormation%data(:,i)=max(massStellar,massStellarMinimum)/timeSteps
-    end forall
-    deallocate(timeSteps)
+    allocate(history_%time(size(historyStarFormation%data,dim=1)                                        ))
+    allocate(history_%data(size(historyStarFormation%data,dim=1),size(historyStarFormation%data,dim=2)/2))
+    history_%rangeType=historyStarFormation%rangeType
+    history_%time     =historyStarFormation%time
+    history_%data=historyStarFormation%data(:,1:size(historyStarFormation%data,dim=2)/2)
+    call self%starFormationHistory_%scales(history_,massStellar,abundancesStellar)
+    historyStarFormation%data(:,1                                        :size(historyStarFormation%data,dim=2)/2)=history_%data
+    historyStarFormation%data(:,1+size(historyStarFormation%data,dim=2)/2:size(historyStarFormation%data,dim=2)  )=history_%data
     return
   end subroutine inSituScales
 
-  subroutine inSituMake(self,historyStarFormation,timeBegin,timeEnd,timesCurrent)
-    !!{
-    Create the history required for storing star formation history.
-    !!}
-    use :: Error           , only : Error_Report
-    use :: Numerical_Ranges, only : Make_Range  , rangeTypeLinear
-    implicit none
-    class           (starFormationHistoryInSitu), intent(inout)                         :: self
-    type            (history                   ), intent(inout)                         :: historyStarFormation
-    double precision                            , intent(in   )                         :: timeBegin           , timeEnd
-    double precision                            , intent(in   ), dimension(:), optional :: timesCurrent
-    type            (inSituTimeStepRange       ), pointer                               :: timeStepFirst       , timeStepNext , &
-         &                                                                                 timeStepCurrent
-    integer                                                                             :: countTimeCoarse     , countTimeFine, &
-         &                                                                                 countTime
-    logical                                                                             :: timeStepFirstFound
-    double precision                                                                    :: timeCoarseBegin     , timeCoarseEnd, &
-         &                                                                                 timeFineBegin       , timeNext     , &
-         &                                                                                 timeNow
-
-    ! Exit with a null history if it would contain no time.
-    if (timeEnd <= timeBegin) then
-       call historyStarFormation%destroy()
-       return
-    end if
-    ! If we have a set of times tabulated already, do some sanity checks.
-    if (present(timesCurrent)) then
-       ! Complain if the beginning time is before the given list of times.
-       if (timeBegin < timesCurrent(1                 )) call Error_Report('requested begin time is before currently tabulated times'//{introspection:location})
-       ! Complain if the end time is less than the maximum tabulated time.
-       if (timeEnd   < timesCurrent(size(timesCurrent))) call Error_Report('requested end time is within currently tabulated times'  //{introspection:location})
-    end if
-
-    ! Step through time, creating a set of timesteps as needed.
-    if (present(timesCurrent)) then
-       timeNow         =  timesCurrent(size(timesCurrent))
-    else
-       timeNow         =  timeBegin
-    end if
-    countTime          =  0
-    timeStepFirstFound =  .false.
-    timeStepCurrent    => null()
-    do while (timeNow < timeEnd)
-       ! Get the time of the next output
-       timeNext=self%outputTimes_%timeNext(timeNow)
-       ! Unphysical (negative) value indicates no next output.
-       if (timeNext < 0.0d0 .or. timeNext > timeEnd) timeNext=timeEnd
-       ! Construct coarse and fine timesteps for this output, recording the parameters of each range.
-       ! Determine the number of fine timestep bins required and the time at which we begin using fine timesteps.
-       if (self%timeFine > 0.0d0) then
-          countTimeFine  =int(min(timeNext-timeNow,self%timeFine)/self%timeStepFine)+1
-          timeFineBegin  =timeNext-self%timeStepFine*dble(countTimeFine-1)
-          timeCoarseBegin=timeNow      +self%timeStep
-          timeCoarseEnd  =timeFineBegin-self%timeStepFine
-       else
-          countTimeFine  =0
-          timeFineBegin  =timeNext
-          timeCoarseBegin=timeNow      +self%timeStep
-          timeCoarseEnd  =timeNext
-       end if
-       ! Determine the number of coarse time bins required for this history.
-       if (timeCoarseEnd > timeCoarseBegin) then
-          countTimeCoarse=max(int((timeCoarseEnd-timeCoarseBegin)/self%timeStep)+1,2)
-       else if (countTimeFine == 0) then
-          countTimeCoarse=2
-          timeCoarseBegin=(timeCoarseEnd-timeNow)/3.0d0+timeNow
-       else
-          countTimeCoarse=0
-       end if
-       ! Create the time steps.
-       if (timeStepFirstFound) then
-          allocate(timeStepCurrent%next)
-          timeStepCurrent => timeStepCurrent%next
-       else
-          allocate(timeStepFirst)
-          timeStepCurrent => timeStepFirst
-          if (countTimeCoarse > 0) then
-             countTimeCoarse=countTimeCoarse+1
-             timeCoarseBegin=max(timeCoarseBegin-self%timeStep    ,0.0d0)
-          else
-             countTimeFine  =countTimeFine  +1
-             timeFineBegin  =max(timeFineBegin  -self%timeStepFine,0.0d0)
-          end if
-          timeStepFirstFound=.true.
-       end if
-       if (countTimeCoarse > 0) then
-          timeStepCurrent%count    =  countTimeCoarse
-          timeStepCurrent%timeBegin=  timeCoarseBegin
-          timeStepCurrent%timeEnd  =  timeCoarseEnd
-          allocate(timeStepCurrent%next)
-          timeStepCurrent          => timeStepCurrent%next
-       end if
-       if (countTimeFine > 0) then
-          timeStepCurrent%count    =  countTimeFine
-          timeStepCurrent%timeBegin=  timeFineBegin
-          timeStepCurrent%timeEnd  =  timeNext
-       end if
-       timeStepCurrent%next => null()
-       ! Increment the total number of steps required.
-       countTime=countTime+countTimeFine+countTimeCoarse
-       ! Increment the time.
-       timeNow=timeNext
-    end do
-    ! Shift the end point for the final step to the overall end time.
-    if (timeStepFirstFound) timeStepCurrent%timeEnd=timeNext
-    ! Copy in existing times if necessary.
-    if (present(timesCurrent)) then
-       countTime=countTime+size(timesCurrent)
-       if (timeStepFirstFound) countTime=countTime-1
-    end if
-    call historyStarFormation%create(2,countTime)
-    countTime=0
-    if (present(timesCurrent)) then
-       if (timeStepFirstFound) then
-          historyStarFormation%time(countTime+1:countTime+size(timesCurrent)-1)=timesCurrent(1:size(timesCurrent)-1)
-          countTime=size(timesCurrent)-1
-       else
-          historyStarFormation%time(countTime+1:countTime+size(timesCurrent)  )=timesCurrent(1:size(timesCurrent)  )
-          countTime=size(timesCurrent)
-       end if
-    end if
-    ! Create new times if necessary.
-    if (timeStepFirstFound) then
-       timeStepCurrent => timeStepFirst
-       do while (associated(timeStepCurrent))
-          ! Populate the time array.
-          if      (timeStepCurrent%count == 1) then
-             historyStarFormation%time(countTime+1                                )=                                     timeStepCurrent%timeEnd
-          else if (timeStepCurrent%count >  1) then
-             historyStarFormation%time(countTime+1:countTime+timeStepCurrent%count)=Make_Range(timeStepCurrent%timeBegin,timeStepCurrent%timeEnd,timeStepCurrent%count,rangeTypeLinear)
-          end if
-          countTime=countTime+timeStepCurrent%count
-          ! Jump to the next time step.
-          timeStepNext => timeStepCurrent%next
-          deallocate(timeStepCurrent)
-          timeStepCurrent => timeStepNext
-       end do
-    end if
-    return
-  end subroutine inSituMake
-
   subroutine inSituSatelliteMerger(self,node)
     !!{
-    Zero any in-situ star formation history for galaxy about to merge.
+    Zero any in-situ star formation history for the galaxy about to merge.
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentDisk, nodeComponentSpheroid, treeNode
@@ -431,11 +242,11 @@ contains
        historyStarFormationDisk               =  disk    %starFormationHistory()
        historyStarFormationSpheroid           =  spheroid%starFormationHistory()
        if (historyStarFormationDisk    %exists()) then
-          historyStarFormationDisk    %data(:,1)=0.0d0
+          historyStarFormationDisk    %data(:,1+size(historyStarFormationDisk    %data,dim=2)/2:size(historyStarFormationDisk    %data,dim=2))=0.0d0
           call disk    %starFormationHistorySet(    historyStarFormationDisk)
        end if
        if (historyStarFormationSpheroid%exists()) then
-          historyStarFormationSpheroid%data(:,1)=0.0d0
+          historyStarFormationSpheroid%data(:,1+size(historyStarFormationSpheroid%data,dim=2)/2:size(historyStarFormationSpheroid%data,dim=2))=0.0d0
           call spheroid%starFormationHistorySet(historyStarFormationSpheroid)
        end if
     class default
@@ -452,7 +263,6 @@ contains
     double precision                            , allocatable  , dimension(:) :: inSituMetallicityBoundaries
     class           (starFormationHistoryInSitu), intent(inout)               :: self
 
-    allocate(inSituMetallicityBoundaries(0:1))
-    inSituMetallicityBoundaries(0:1)=[0.0d0,huge(0.0d0)]
+    inSituMetallicityBoundaries=self%starFormationHistory_%metallicityBoundaries()
     return
   end function inSituMetallicityBoundaries

--- a/testSuite/parameters/test-star-formation-histories-adaptive.xml
+++ b/testSuite/parameters/test-star-formation-histories-adaptive.xml
@@ -6,7 +6,7 @@
   <version>0.9.4</version>
 
   <!-- Output file -->
-  <outputFileName value="testSuite/outputs/test-star-formation-histories-adapative/galacticus.hdf5"/>
+  <outputFileName value="testSuite/outputs/test-star-formation-histories-adaptive/galacticus.hdf5"/>
 
   <!-- Component selection -->
   <componentBasic value="standard"/>

--- a/testSuite/parameters/test-star-formation-histories-inSitu.xml
+++ b/testSuite/parameters/test-star-formation-histories-inSitu.xml
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Parameters for a model used to test output of adaptively-binned star formation histories -->
+<!-- 25-March-2021                                                                            -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <version>0.9.4</version>
+
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/test-star-formation-histories-inSitu/galacticus.hdf5"/>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard">
+    <massSeed value="100"/>
+    <heatsHotHalo value="true"/>
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+  </componentBlackHole>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard">
+    <fractionLossAngularMomentum value="0.3"/>
+    <starveSatellites value="false"/>
+    <efficiencyStrippingOutflow value="0.1"/>
+    <trackStrippedGas value="true"/>
+  </componentHotHalo>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <ratioAngularMomentumScaleRadius value="0.5"/>
+    <efficiencyEnergeticOutflow value="1.0e-2"/>
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+  
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMinimum value="1.0e10"/>
+    <massTreeMaximum value="1.0e13"/>
+    <treesPerDecade value="20"/>
+  </mergerTreeBuildMasses>
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileConcentration value="gao2008"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="simple">
+    <redshiftReionization value="10.5"/>
+    <velocitySuppressionReionization value="35.0"/>
+  </accretionHalo>
+
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="5.0"/>
+  </hotHaloOutflowReincorporation>
+
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0"/>
+  </coolingTimeAvailable>
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <!-- Galactic structure solver options -->
+  <galacticStructureSolver value="equilibrium"/>
+  <darkMatterProfile value="adiabaticGnedin2004">
+    <A value="0.73"/>
+    <omega value="0.7"/>
+  </darkMatterProfile>
+  <!-- Star formation rate options -->
+  <starFormationRateDisks value="intgrtdSurfaceDensity"/>
+  <starFormationRateSurfaceDensityDisks value="krumholz2009">
+    <frequencyStarFormation value="0.385"/>
+    <clumpingFactorMolecularComplex value="5.000"/>
+    <molecularFractionFast value="true"/>
+  </starFormationRateSurfaceDensityDisks>
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.04"/>
+      <exponentVelocity value="2.0"/>
+      <timescaleMinimum value="0.001"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="instantaneous"/>
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+
+  <initialMassFunction value="chabrier2001"/>
+  <stellarPopulation value="standard">
+    <recycledFraction value="0.46"/>
+    <metalYield value="0.035"/>
+  </stellarPopulation>
+
+  <!-- AGN feedback options -->
+  <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <!-- Accretion disk properties -->
+  <accretionDisks value="switched">
+    <accretionRateThinDiskMaximum value="0.30"/>
+    <accretionRateThinDiskMinimum value="0.01"/>
+    <scaleADAFRadiativeEfficiency value="true"/>
+    <accretionDisksShakuraSunyaev value="shakuraSunyaev"/>
+    <accretionDisksADAF value="ADAF">
+      <efficiencyRadiationType value="thinDisk"/>
+      <adiabaticIndex value="1.444"/>
+      <energyOption value="pureADAF"/>
+      <efficiencyRadiation value="0.01"/>
+      <viscosityOption value="fit"/>
+    </accretionDisksADAF>
+  </accretionDisks>
+
+  <!-- Black hole options -->
+  <blackHoleBinaryMergers value="rezzolla2008"/>
+  <!-- Galaxy merger options -->
+  <virialOrbit value="benson2005"/>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"/>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+    <nodeOperator value="starFormationSpheroids"/>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="250.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="100.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <!-- Bar instability in galactic disks -->
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="0.7"/>
+	<stabilityThresholdStellar value="1.1"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <redshifts value="0.0 1.0"/>
+  </outputTimes>
+  <nodePropertyExtractor value="multi">    
+    <nodePropertyExtractor value="nodeIndices"/>
+    <nodePropertyExtractor value="indicesTree"/>
+    <nodePropertyExtractor value="starFormationHistory">
+      <component value="disk"/>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="starFormationHistory">
+      <component value="spheroid"/>
+    </nodePropertyExtractor>
+  </nodePropertyExtractor>
+
+  <!-- Star formation history -->
+  <starFormationHistory value="inSitu">
+    <starFormationHistory value="adaptive">
+      <countTimeStepsMaximum value="30"/>
+      <countOutputBuffer value=" 3"/>
+    </starFormationHistory>
+  </starFormationHistory>
+
+</parameters>

--- a/testSuite/test-star-formation-histories-adaptive.py
+++ b/testSuite/test-star-formation-histories-adaptive.py
@@ -9,26 +9,26 @@ import numpy as np
 
 # Run the model and check for completion                                                                                                                                                                                 
 print("Running model...")
-status = subprocess.run("mkdir -p outputs/test-star-formation-histories-adapative",shell=True)
-log = open("outputs/test-star-formation-histories-adapative/galacticus.log","w")
+status = subprocess.run("mkdir -p outputs/test-star-formation-histories-adaptive",shell=True)
+log = open("outputs/test-star-formation-histories-adaptive/galacticus.log","w")
 status = subprocess.run("cd ..; ./Galacticus.exe testSuite/parameters/test-star-formation-histories-adaptive.xml",stdout=log,stderr=log,shell=True)
 log.close()
 print("...done ("+str(status)+")")
 if status.returncode != 0:
     print("FAILED: model run:")
-    subprocess.run("cat outputs/test-star-formation-histories-adapative/galacticus.log",shell=True)
+    subprocess.run("cat outputs/test-star-formation-histories-adaptive/galacticus.log",shell=True)
     sys.exit()
 print("Checking for errors...")
-status = subprocess.run("grep -q -i -e fatal -e aborted -e \"Galacticus experienced an error in the GSL library\" outputs/test-star-formation-histories-adapative/galacticus.log",shell=True)
+status = subprocess.run("grep -q -i -e fatal -e aborted -e \"Galacticus experienced an error in the GSL library\" outputs/test-star-formation-histories-adaptive/galacticus.log",shell=True)
 print("...done ("+str(status)+")")
 if status.returncode == 0:
     print("FAILED: model run (errors):")
-    subprocess.run("cat outputs/test-star-formation-histories-adapative/galacticus.log",shell=True)
+    subprocess.run("cat outputs/test-star-formation-histories-adaptive/galacticus.log",shell=True)
     sys.exit()
 print("SUCCESS: model run")
 
 # Open the model and extract the recycled fraction.
-model             = h5py.File('outputs/test-star-formation-histories-adapative/galacticus.hdf5','r')
+model             = h5py.File('outputs/test-star-formation-histories-adaptive/galacticus.hdf5','r')
 outputs           = model['Outputs'                     ]
 stellarPopulation = model['Parameters/stellarPopulation']
 recycledFraction  = stellarPopulation.attrs['recycledFraction']

--- a/testSuite/test-star-formation-histories-inSitu.py
+++ b/testSuite/test-star-formation-histories-inSitu.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import h5py
+import numpy as np
+
+# Check internal self-consistency of in situ star formation histories.
+# Andrew Benson (17-July-2024)
+
+# Run the model and check for completion                                                                                                                                                                                 
+print("Running model...")
+status = subprocess.run("mkdir -p outputs/test-star-formation-histories-inSitu",shell=True)
+log = open("outputs/test-star-formation-histories-inSitu/galacticus.log","w")
+status = subprocess.run("cd ..; ./Galacticus.exe testSuite/parameters/test-star-formation-histories-inSitu.xml",stdout=log,stderr=log,shell=True)
+log.close()
+print("...done ("+str(status)+")")
+if status.returncode != 0:
+    print("FAILED: model run:")
+    subprocess.run("cat outputs/test-star-formation-histories-inSitu/galacticus.log",shell=True)
+    sys.exit()
+print("Checking for errors...")
+status = subprocess.run("grep -q -i -e fatal -e aborted -e \"Galacticus experienced an error in the GSL library\" outputs/test-star-formation-histories-inSitu/galacticus.log",shell=True)
+print("...done ("+str(status)+")")
+if status.returncode == 0:
+    print("FAILED: model run (errors):")
+    subprocess.run("cat outputs/test-star-formation-histories-inSitu/galacticus.log",shell=True)
+    sys.exit()
+print("SUCCESS: model run")
+
+# Open the model and extract the recycled fraction.
+model             = h5py.File('outputs/test-star-formation-histories-inSitu/galacticus.hdf5','r')
+outputs           = model['Outputs'                     ]
+stellarPopulation = model['Parameters/stellarPopulation']
+recycledFraction  = stellarPopulation.attrs['recycledFraction']
+
+# Iterate over outputs to check that the star formation histories integrates to the expected total stellar mass.
+for output in outputs.keys():
+    print(output+":")
+    # Get the nodeData group.
+    nodes                            = outputs[output+"/nodeData"]
+    # Read stellar masses and star formation histories.
+    nodesMassStellarDisk             = nodes['diskMassStellar'                 ][:]
+    nodesMassStellarSpheroid         = nodes['spheroidMassStellar'             ][:]
+    sfhDiskStarFormationHistory      = nodes['diskStarFormationHistoryMass'    ][:]
+    sfhSpheroidStarFormationHistory  = nodes['spheroidStarFormationHistoryMass'][:]
+    # Sum star formation history masses over times and metallicities. For in-situ star formation histories the first half of the
+    # columns correspond to the total star formation history.
+    nodesSFHIntegratedDisk           = np.array(list(map(lambda x: np.sum(x)*(1.0-recycledFraction),list(map(lambda x: sum(x[:int(len(x)/2) ]),sfhDiskStarFormationHistory    )))))
+    nodesSFHIntegratedSpheroid       = np.array(list(map(lambda x: np.sum(x)*(1.0-recycledFraction),list(map(lambda x: sum(x[:int(len(x)/2) ]),sfhSpheroidStarFormationHistory)))))
+    # The second half correspond to the in-situ component.
+    nodesSFHIntegratedDiskInSitu     = np.array(list(map(lambda x: np.sum(x)*(1.0-recycledFraction),list(map(lambda x: sum(x[-int(len(x)/2):]),sfhDiskStarFormationHistory    )))))
+    nodesSFHIntegratedSpheroidInSitu = np.array(list(map(lambda x: np.sum(x)*(1.0-recycledFraction),list(map(lambda x: sum(x[-int(len(x)/2):]),sfhSpheroidStarFormationHistory)))))
+    # Test accuracy of total star formation histories.
+    tolerance      = 1.0e-3
+    statusDisk     = "FAILED" if any(abs(nodesSFHIntegratedDisk    -nodesMassStellarDisk    ) > tolerance*nodesMassStellarDisk    ) else "SUCCESS"
+    statusSpheroid = "FAILED" if any(abs(nodesSFHIntegratedSpheroid-nodesMassStellarSpheroid) > tolerance*nodesMassStellarSpheroid) else "SUCCESS"
+    print(" -> "+statusDisk    +": total disk stellar mass"    )
+    print(" -> "+statusSpheroid+": total spheroid stellar mass")
+    # Test in-situ star formation histories.
+    tolerance      = 1.0e-3
+    statusDisk     = "FAILED" if any(nodesSFHIntegratedDiskInSitu     > nodesSFHIntegratedDisk    ) else "SUCCESS"
+    statusSpheroid = "FAILED" if any(nodesSFHIntegratedSpheroidInSitu > nodesSFHIntegratedSpheroid) else "SUCCESS"
+    print(" -> "+statusDisk    +": in-situ disk stellar mass"    )
+    print(" -> "+statusSpheroid+": in-situ spheroid stellar mass")
+    print(nodesSFHIntegratedSpheroidInSitu)
+    print(nodesSFHIntegratedSpheroid)


### PR DESCRIPTION
This now works by wrapping another `starFormationHistory` object, making a duplicate copy of its star formation history, and zeroing out any entries in that duplicate in merging galaxies. This allows the duplicate copy to track in-situ star formation, using whatever binning the wrapped object does. Includes a new test case.
