### PR TITLE
Avoid deadlocks when reporting the location of the `datasets` repo

### DIFF
--- a/source/atomic.data.F90
+++ b/source/atomic.data.F90
@@ -197,26 +197,28 @@ contains
     use :: Input_Paths       , only : inputPath            , pathTypeDataStatic
     use :: IO_XML            , only : XML_Array_Read_Static, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, XML_Parse         , &
          &                            xmlNodeList
-    use :: ISO_Varying_String, only : char
+    use :: ISO_Varying_String, only : char                 , varying_string                   , assignment(=)
     use :: String_Handling   , only : String_Lower_Case    , char
     implicit none
-    type            (Node       )              , pointer     :: abundanceTypeElement, doc              , &
-         &                                                      atom                , element
-    type            (xmlNodeList), dimension(:), allocatable :: elementList
-    integer                      , dimension(1)              :: elementValueInteger
-    double precision             , dimension(1)              :: elementValueDouble
-    integer                                                  :: atomicNumber        , iAbundancePattern, &
-         &                                                      iAtom               , ioErr
-    double precision                                         :: abundance           , totalMass
-    character       (len=100    )                            :: abundanceType
+    type            (Node          )              , pointer     :: abundanceTypeElement, doc              , &
+         &                                                         atom                , element
+    type            (xmlNodeList   ), dimension(:), allocatable :: elementList
+    integer                         , dimension(1)              :: elementValueInteger
+    double precision                , dimension(1)              :: elementValueDouble
+    integer                                                     :: atomicNumber        , iAbundancePattern, &
+         &                                                         iAtom               , ioErr
+    double precision                                            :: abundance           , totalMass
+    character       (len=100       )                            :: abundanceType
+    type            (varying_string)                            :: fileName
 
     ! Check if module is initialized.
     !$omp critical(atomicDataInitialize)
     if (.not.atomicDataInitialized) then
 
        ! Read in the atomic data.
+       fileName=char(inputPath(pathTypeDataStatic))//"abundances/Atomic_Data.xml"
        !$omp critical (FoX_DOM_Access)
-       doc => XML_Parse(char(inputPath(pathTypeDataStatic))//"abundances/Atomic_Data.xml",iostat=ioErr)
+       doc => XML_Parse(char(fileName),iostat=ioErr)
        if (ioErr /= 0) call Error_Report('Unable to parse data file'//{introspection:location})
 
        ! Get list of all element elements.

--- a/source/instruments.filters.F90
+++ b/source/instruments.filters.F90
@@ -477,22 +477,24 @@ contains
     use            :: Error                  , only : Error_Report
     use            :: Input_Paths            , only : inputPath            , pathTypeDataStatic
     use            :: IO_XML                 , only : XML_Array_Read       , XML_Parse
-    use            :: ISO_Varying_String     , only : var_str              , char              , operator(//)
+    use            :: ISO_Varying_String     , only : var_str              , char              , operator(//), assignment(=), &
+         &                                            varying_string
     use            :: Numerical_Integration  , only : GSL_Integ_Gauss15    , integrator
     use            :: Numerical_Interpolation, only : interpolator
     use            :: Table_Labels           , only : extrapolationTypeZero
     implicit none
-    integer                       , intent(in   )              :: indexFilter
-    type            (integrator  )               , allocatable :: integratorVegaBuserV_        , integratorABBuserV_  , &
-         &                                                        integratorVegaFilter_        , integratorABFilter_
-    type            (interpolator), pointer                    :: interpolatorBuserV_          , interpolatorFilter_
-    type            (interpolator), save                       :: interpolatorVega_
-    type            (node        ), pointer                    :: doc
-    logical                       , save                       :: vegaLoaded           =.false.
-    double precision              , dimension(2)               :: wavelengthRangeBuserV        , wavelengthRangeFilter
-    double precision              , dimension(:) , allocatable :: wavelengthVega               , spectrumVega
-    integer                                                    :: indexBuserV                  , ioErr
-    logical                                                    :: isLocked
+    integer                         , intent(in   )              :: indexFilter
+    type            (integrator    )               , allocatable :: integratorVegaBuserV_        , integratorABBuserV_  , &
+         &                                                          integratorVegaFilter_        , integratorABFilter_
+    type            (interpolator  ), pointer                    :: interpolatorBuserV_          , interpolatorFilter_
+    type            (interpolator  ), save                       :: interpolatorVega_
+    type            (node          ), pointer                    :: doc
+    logical                         , save                       :: vegaLoaded           =.false.
+    double precision                , dimension(2)               :: wavelengthRangeBuserV        , wavelengthRangeFilter
+    double precision                , dimension(:) , allocatable :: wavelengthVega               , spectrumVega
+    integer                                                      :: indexBuserV                  , ioErr
+    logical                                                      :: isLocked
+    type            (varying_string)                             :: fileName
 
     isLocked=lock%owned()
     if (.not.isLocked) call lock%setRead()
@@ -507,8 +509,9 @@ contains
        if (.not.vegaLoaded) then
           !$omp critical (loadVegaSpectrum)
           if (.not.vegaLoaded) then
+             fileName=inputPath(pathTypeDataStatic)//'stellarAstrophysics/vega/A0V_Castelli.xml'
              !$omp critical (FoX_DOM_Access)
-             doc => XML_Parse(char(inputPath(pathTypeDataStatic)//'stellarAstrophysics/vega/A0V_Castelli.xml'),iostat=ioErr)
+             doc => XML_Parse(char(fileName),iostat=ioErr)
              if (ioErr /= 0) call Error_Report('failed to read Vega spectrum'//{introspection:location})
              call XML_Array_Read(doc,"datum",wavelengthVega,spectrumVega)
              call destroy(doc)

--- a/source/interface.Local_Group_database.F90
+++ b/source/interface.Local_Group_database.F90
@@ -131,12 +131,16 @@ contains
     !!}
     use :: Input_Paths       , only : inputPath                   , pathTypeDataStatic
     use :: IO_XML            , only : XML_Get_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name, XML_Parse
-    use :: ISO_Varying_String, only : char
+    use :: ISO_Varying_String, only : char                        , varying_string                   , operator(//)
     implicit none
-    type(localGroupDB) :: self
-
-    self%database => XML_Parse(char(inputPath(pathTypeDataStatic))//"observations/localGroup/localGroupSatellites.xml")
+    type(localGroupDB  ) :: self
+    type(varying_string) :: fileName
+    
+    fileName=inputPath(pathTypeDataStatic)//"observations/localGroup/localGroupSatellites.xml"
+    !$omp critical (FoX_DOM_Access)
+    self%database => XML_Parse(char(fileName))
     call XML_Get_Elements_By_Tag_Name(XML_Get_First_Element_By_Tag_Name(self%database,'galaxies'),'galaxy',self%galaxies)
+    !$omp end critical (FoX_DOM_Access)
     allocate(self%selected(0:size(self%galaxies)-1))
     self%selected=.false.
     return

--- a/source/objects.chemical_structure.F90
+++ b/source/objects.chemical_structure.F90
@@ -97,17 +97,19 @@ contains
     use :: Error             , only : Error_Report
     use :: Input_Paths       , only : inputPath                   , pathTypeDataStatic
     use :: IO_XML            , only : XML_Get_Elements_By_Tag_Name, xmlNodeList       , XML_Parse
-    use :: ISO_Varying_String, only : char                        , assignment(=)
+    use :: ISO_Varying_String, only : char                        , assignment(=)     , varying_string
     implicit none
-    type     (Node       ), pointer                   :: doc     , atom    , bond        , chemical, element
-    type     (xmlNodeList), allocatable, dimension(:) :: atomList, bondList, chemicalList, list
-    integer                                           :: iAtom   , iBond   , iChemical   , ioErr   , jAtom
-    character(len=128    )                            :: name
+    type     (Node          ), pointer                   :: doc     , atom    , bond        , chemical, element
+    type     (xmlNodeList   ), allocatable, dimension(:) :: atomList, bondList, chemicalList, list
+    integer                                              :: iAtom   , iBond   , iChemical   , ioErr   , jAtom
+    character(len=128       )                            :: name
+    type     (varying_string)                           :: fileName
 
     ! Check if the chemical database is initialized.
     if (.not.chemicalDatabaseInitialized) then
+       fileName=char(inputPath(pathTypeDataStatic))//'abundances/Chemical_Database.cml'
        !$omp critical (FoX_DOM_Access)
-       doc => XML_Parse(char(inputPath(pathTypeDataStatic))//'abundances/Chemical_Database.cml',iostat=ioErr)
+       doc => XML_Parse(char(fileName),iostat=ioErr)
        if (ioErr /= 0) call Error_Report('Unable to find chemical database file'//{introspection:location})
        ! Get a list of all chemicals.
        call XML_Get_Elements_By_Tag_Name(doc,"chemical",chemicalList)

--- a/source/stellar_astrophysics.supernovae_type_Ia.fixed_yield.F90
+++ b/source/stellar_astrophysics.supernovae_type_Ia.fixed_yield.F90
@@ -52,12 +52,13 @@ contains
     !!{
     Read data for the {\normalfont \ttfamily fixedYield} supernovae type Ia class.
     !!}
-    use :: Atomic_Data, only : Atom_Lookup                   , Atomic_Data_Atoms_Count
-    use :: FoX_dom    , only : destroy                       , node                             , extractDataContent
-    use :: Error      , only : Error_Report
-    use :: Input_Paths, only : inputPath                     , pathTypeDataStatic
-    use :: IO_XML     , only : XML_Count_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList, &
-         &                     XML_Parse
+    use :: Atomic_Data       , only : Atom_Lookup                   , Atomic_Data_Atoms_Count
+    use :: FoX_dom           , only : destroy                       , node                             , extractDataContent
+    use :: Error             , only : Error_Report
+    use :: Input_Paths       , only : inputPath                     , pathTypeDataStatic
+    use :: IO_XML            , only : XML_Count_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList, &
+         &                            XML_Parse
+    use :: ISO_Varying_String, only : varying_string
     implicit none
     class           (supernovaeTypeIaFixedYield), intent(inout)               :: self
     type            (node                      ), pointer                     :: doc         , atom        , &
@@ -66,6 +67,7 @@ contains
     integer                                                                   :: atomicIndex , atomicNumber, &
          &                                                                       iIsotope    , ioErr
     double precision                                                          :: isotopeYield
+    type            (varying_string            )                              :: fileName
     
     if (self%initialized) return
     ! Allocate an array to store individual element yields.
@@ -73,9 +75,9 @@ contains
     self%elementYield=0.0d0
     self%totalYield  =0.0d0
     ! Read in Type Ia yields.
+    fileName=char(inputPath(pathTypeDataStatic))//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml'
     !$omp critical (FoX_DOM_Access)
-    ! Open the XML file containing yields.
-    doc => XML_Parse(char(inputPath(pathTypeDataStatic))//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml',iostat=ioErr)
+    doc => XML_Parse(char(fileName),iostat=ioErr)
     if (ioErr /= 0) call Error_Report('Unable to parse yields file'//{introspection:location})
     ! Get a list of all isotopes.
     call XML_Get_Elements_By_Tag_Name(doc,"isotope",isotopesList)


### PR DESCRIPTION
Previously, the `inputPath()` function was called within a `FoX_Access` OpenMP `critical` section. If compiled with `-DTHREADSAFEIO` such `critical` sections are changed into `gfortranInternalIO` `critical` sections. This then caused a deadlock with the same `critical` section within the `displayMessage()` function when diplaying the location of the `datasets` repo. To fix this, the `inputPath()` function is now called prior to entering the `FoX_Access` OpenMP `critical` section.