### PR TITLE
Add a warning message for dangerous power spectrum extrapolation

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -69,7 +69,7 @@ jobs:
                 apt list | grep -P linux\-tools\-[0-9\.\-]+\-azure >> $GITHUB_STEP_SUMMARY
                 # Create a dummy file here so that we have something to upload.
                 mkdir -p ./testSuite/outputs
-                echo "perf tests disabled due to missing linux-tools" ./testSuite/outputs/${{ inputs.name }}.${{ format('{0}',inputs.profiler) == 'perf' && 'perf.bz2' || 'gprof.bz2' }}
+                echo "perf tests disabled due to missing linux-tools" > ./testSuite/outputs/${{ inputs.name }}.${{ format('{0}',inputs.profiler) == 'perf' && 'perf.bz2' || 'gprof.bz2' }}
              fi
           else
              echo linux-tools was found

--- a/source/numerical.interpolation.F90
+++ b/source/numerical.interpolation.F90
@@ -455,15 +455,63 @@ contains
     !!{
     Return interpolating factors for linear interpolation in the array {\normalfont \ttfamily xArray()} given {\normalfont \ttfamily x}.
     !!}
+    use :: Error       , only : Error_Report
+    use :: Table_Labels, only : extrapolationTypeAbort, extrapolationTypeExtrapolate, extrapolationTypeFix, extrapolationTypeZero
     implicit none
     class           (interpolator)                , intent(inout) :: self
     double precision                              , intent(in   ) :: x
     integer         (c_size_t    )                , intent(  out) :: i
     double precision              , dimension(0:1), intent(  out) :: h
+    double precision                                              :: x_
 
     call self%assertInterpolatable()
-    i=self%locate(x)
-    call self%linearWeights(x,i,h)
+    ! Handle extrapolation types.
+    if (x > self%x(self%countArray)) then
+       ! Extrapolate to high values.
+       select case (self%extrapolationType(2)%ID)
+       case (extrapolationTypeExtrapolate%ID)
+          x_=x
+       case (extrapolationTypeFix        %ID)
+          x_=self%x(self%countArray)
+       case (extrapolationTypeZero       %ID)
+          i =self%countArray-1
+          h =0.0d0
+          return
+       case (extrapolationTypeAbort      %ID)
+          i =0
+          h =0.0d0
+          call Error_Report('extrapolation is not allowed'//{introspection:location})
+       case default
+          i =0
+          h =0.0d0
+          call Error_Report('unknown extrapolation type'  //{introspection:location})
+       end select
+    else if (x < self%x(1)) then
+       ! Extrapolate to low values.
+       select case (self%extrapolationType(1)%ID)
+       case (extrapolationTypeExtrapolate%ID)
+          x_=x
+       case (extrapolationTypeFix        %ID)
+          x_=self%x(self%countArray)
+       case (extrapolationTypeZero       %ID)
+          i =1
+          h =0.0d0
+          return
+       case (extrapolationTypeAbort      %ID)
+          i =0
+          h =0.0d0
+          call Error_Report('extrapolation is not allowed'//{introspection:location})
+       case default
+          i =0
+          h =0.0d0
+          call Error_Report('unknown extrapolation type'  //{introspection:location})
+       end select
+    else
+       ! No extrapolation needed.
+       x_=x
+    end if
+    i=self%locate(x_)
+    call self%linearWeights(x_,i,h)
     return
   end subroutine interpolatorLinearFactors
 

--- a/source/numerical.interpolation.F90
+++ b/source/numerical.interpolation.F90
@@ -462,6 +462,7 @@ contains
     double precision                              , intent(in   ) :: x
     integer         (c_size_t    )                , intent(  out) :: i
     double precision              , dimension(0:1), intent(  out) :: h
+    double precision              , parameter                     :: rangeTolerance=1.0d-6
     double precision                                              :: x_
 
     call self%assertInterpolatable()
@@ -470,7 +471,7 @@ contains
        ! Extrapolate to high values.
        select case (self%extrapolationType(2)%ID)
        case (extrapolationTypeExtrapolate%ID)
-          x_=x
+          x_=     x
        case (extrapolationTypeFix        %ID)
           x_=self%x(self%countArray)
        case (extrapolationTypeZero       %ID)
@@ -478,29 +479,37 @@ contains
           h =0.0d0
           return
        case (extrapolationTypeAbort      %ID)
-          i =0
-          h =0.0d0
-          call Error_Report('extrapolation is not allowed'//{introspection:location})
+          if (x > self%x(self%countArray)*(1.0d0+rangeTolerance)) then
+             i =0
+             h =0.0d0
+             call Error_Report('extrapolation is not allowed'//{introspection:location})
+          else
+             x_=self%x(self%countArray)
+          end if
        case default
           i =0
           h =0.0d0
           call Error_Report('unknown extrapolation type'  //{introspection:location})
        end select
-    else if (x < self%x(1)) then
+    else if (x < self%x(              1)) then
        ! Extrapolate to low values.
        select case (self%extrapolationType(1)%ID)
        case (extrapolationTypeExtrapolate%ID)
-          x_=x
+          x_=     x
        case (extrapolationTypeFix        %ID)
-          x_=self%x(self%countArray)
+          x_=self%x(              1)
        case (extrapolationTypeZero       %ID)
           i =1
           h =0.0d0
           return
        case (extrapolationTypeAbort      %ID)
-          i =0
-          h =0.0d0
-          call Error_Report('extrapolation is not allowed'//{introspection:location})
+          if (x < self%x(              1)*(1.0d0-rangeTolerance)) then
+             i =0
+             h =0.0d0
+             call Error_Report('extrapolation is not allowed'//{introspection:location})
+          else
+             x_=self%x(              1)
+          end if
        case default
           i =0
           h =0.0d0

--- a/source/radiation.intergalactic_background.file.F90
+++ b/source/radiation.intergalactic_background.file.F90
@@ -137,13 +137,14 @@ contains
     !!{
     Internal constructor for the {\normalfont \ttfamily intergalacticBackgroundFile} radiation field class.
     !!}
-    use :: Array_Utilities  , only : Array_Is_Monotonic               , Array_Reverse        , directionIncreasing
-    use :: FoX_DOM          , only : destroy                          , extractDataContent   , node
-    use :: Error            , only : Error_Report
-    use :: HDF5_Access      , only : hdf5Access
-    use :: IO_HDF5          , only : hdf5Object
-    use :: IO_XML           , only : XML_Array_Read                   , XML_Array_Read_Static, XML_Count_Elements_By_Tag_Name, XML_Get_Elements_By_Tag_Name, &
-          &                          XML_Get_First_Element_By_Tag_Name, XML_Parse            , xmlNodeList
+    use :: Array_Utilities, only : Array_Is_Monotonic               , Array_Reverse        , directionIncreasing
+    use :: FoX_DOM        , only : destroy                          , extractDataContent   , node
+    use :: Error          , only : Error_Report
+    use :: HDF5_Access    , only : hdf5Access
+    use :: IO_HDF5        , only : hdf5Object
+    use :: IO_XML         , only : XML_Array_Read                   , XML_Array_Read_Static, XML_Count_Elements_By_Tag_Name, XML_Get_Elements_By_Tag_Name, &
+         &                         XML_Get_First_Element_By_Tag_Name, XML_Parse            , xmlNodeList
+    use :: Table_Labels   , only : extrapolationTypeZero
     implicit none
     type            (radiationFieldIntergalacticBackgroundFile)                                :: self
     type            (varying_string                           ), intent(in   )                 :: fileName
@@ -247,8 +248,8 @@ contains
     else
        call Error_Report('unrecognized file format'//{introspection:location})
     end if
-    self%interpolatorWavelengths=interpolator(self%spectraWavelengths)
-    self%interpolatorTimes      =interpolator(self%spectraTimes      )
+    self%interpolatorWavelengths=interpolator(self%spectraWavelengths,extrapolationType=extrapolationTypeZero)
+    self%interpolatorTimes      =interpolator(self%spectraTimes      ,extrapolationType=extrapolationTypeZero)
     return
   end function intergalacticBackgroundFileConstructorInternal
 

--- a/source/radiation.intergalactic_background.internal.F90
+++ b/source/radiation.intergalactic_background.internal.F90
@@ -192,7 +192,8 @@ contains
     !!{
     Internal constructor for the {\normalfont \ttfamily intergalacticBackgroundInternal} radiation field class.
     !!}
-    use :: Numerical_Ranges , only : Make_Range   , rangeTypeLogarithmic
+    use :: Numerical_Ranges, only : Make_Range          , rangeTypeLogarithmic
+    use :: Table_Labels    , only : extrapolationTypeFix, extrapolationTypeZero
     implicit none
     type            (radiationFieldIntergalacticBackgroundInternal)                        :: self
     integer                                                        , intent(in   )         :: wavelengthCountPerDecade          , timeCountPerDecade
@@ -280,8 +281,8 @@ contains
        self%crossSectionSinglyIonizedHelium(iWavelength)=self%atomicCrossSectionIonizationPhoto_%crossSection(2,2,1,self%wavelength(iWavelength))
     end do
     ! Build interpolators.
-    self%interpolatorWavelength=interpolator(self%wavelength)
-    self%interpolatorTime      =interpolator(self%time_     )
+    self%interpolatorWavelength=interpolator(self%wavelength,extrapolationType=extrapolationTypeZero)
+    self%interpolatorTime      =interpolator(self%time_     ,extrapolationType=extrapolationTypeFix )
     ! Initialize state.
     self%statePrevious            => null()
     self%timePrevious             =  -1.0d0

--- a/source/stellar_populations.broad_band_luminosities.standard.F90
+++ b/source/stellar_populations.broad_band_luminosities.standard.F90
@@ -304,20 +304,21 @@ contains
     !!{
     Tabulate stellar population luminosity in the given filters.
     !!}
-    use            :: Abundances_Structure            , only : logMetallicityZero , metallicityTypeLogarithmicByMassSolar
-    use            :: Display                         , only : displayCounter     , displayCounterClear                  , displayGreen            , displayIndent        , &
-          &                                                    displayMagenta     , displayReset                         , displayUnindent         , verbosityLevelWorking
-    use            :: File_Utilities                  , only : File_Exists        , File_Lock                            , File_Unlock             , lockDescriptor
-    use            :: Error                           , only : Error_Report       , Warn                                 , errorStatusFail         , errorStatusSuccess
+    use            :: Abundances_Structure            , only : logMetallicityZero          , metallicityTypeLogarithmicByMassSolar
+    use            :: Display                         , only : displayCounter              , displayCounterClear                  , displayGreen            , displayIndent        , &
+          &                                                    displayMagenta              , displayReset                         , displayUnindent         , verbosityLevelWorking
+    use            :: File_Utilities                  , only : File_Exists                 , File_Lock                            , File_Unlock             , lockDescriptor
+    use            :: Error                           , only : Error_Report                , Warn                                 , errorStatusFail         , errorStatusSuccess
     use            :: HDF5_Access                     , only : hdf5Access
     use            :: IO_HDF5                         , only : hdf5Object
     use, intrinsic :: ISO_C_Binding                   , only : c_size_t
-    use            :: ISO_Varying_String              , only : assignment(=)      , char                                 , operator(//)            , var_str
+    use            :: ISO_Varying_String              , only : assignment(=)               , char                                 , operator(//)            , var_str
     use            :: Input_Parameters                , only : inputParameters
-    use            :: Instruments_Filters             , only : Filter_Extent      , Filter_Name                          , Filter_Response_Function
+    use            :: Instruments_Filters             , only : Filter_Extent               , Filter_Name                          , Filter_Response_Function
     use            :: Numerical_Constants_Astronomical, only : metallicitySolar
-    use            :: Numerical_Integration           , only : GSL_Integ_Gauss15  , integrator
+    use            :: Numerical_Integration           , only : GSL_Integ_Gauss15           , integrator
     use            :: String_Handling                 , only : operator(//)
+    use            :: Table_Labels                    , only : extrapolationTypeExtrapolate
     implicit none
     class           (stellarPopulationBroadBandLuminositiesStandard), intent(inout)                   :: self
     integer                                                         , intent(in   ), dimension(:    ) :: filterIndex                                   , luminosityIndex
@@ -417,8 +418,8 @@ contains
                    self%luminosityTables(populationID)%metallicity=logMetallicityZero
                 end where
                 allocate(self%luminosityTables(populationID)%luminosity(luminosityIndexMaximum,self%luminosityTables(populationID)%agesCount,self%luminosityTables(populationID)%metallicitiesCount))
-                self%luminosityTables(populationID)%interpolatorAge        =interpolator(self%luminosityTables(populationID)%age        )
-                self%luminosityTables(populationID)%interpolatorMetallicity=interpolator(self%luminosityTables(populationID)%metallicity)
+                self%luminosityTables(populationID)%interpolatorAge        =interpolator(self%luminosityTables(populationID)%age        ,extrapolationType=extrapolationTypeExtrapolate)
+                self%luminosityTables(populationID)%interpolatorMetallicity=interpolator(self%luminosityTables(populationID)%metallicity,extrapolationType=extrapolationTypeExtrapolate)
                 computeTable=.true.
              end if
              !$omp end single

--- a/source/stellar_populations.spectra.file.F90
+++ b/source/stellar_populations.spectra.file.F90
@@ -273,6 +273,7 @@ contains
     use :: Error         , only : Error_Report
     use :: HDF5_Access   , only : hdf5Access
     use :: IO_HDF5       , only : hdf5Object
+    use :: Table_Labels  , only : extrapolationTypeExtrapolate, extrapolationTypeZero, extrapolationTypeFix
     implicit none
     class  (stellarPopulationSpectraFile), intent(inout) :: self
     integer                                              :: fileFormatVersion
@@ -302,9 +303,9 @@ contains
        !$ call hdf5Access%unset()
        self%fileRead=.true.
        ! Build interpolators.
-       self%spectra%interpolatorAge        =interpolator(self%spectra%ages         )
-       self%spectra%interpolatorWavelength =interpolator(self%spectra%wavelengths  )
-       self%spectra%interpolatorMetallicity=interpolator(self%spectra%metallicities)
+       self%spectra%interpolatorAge        =interpolator(self%spectra%ages         ,extrapolationType=extrapolationTypeExtrapolate)
+       self%spectra%interpolatorWavelength =interpolator(self%spectra%wavelengths  ,extrapolationType=extrapolationTypeZero       )
+       self%spectra%interpolatorMetallicity=interpolator(self%spectra%metallicities,extrapolationType=extrapolationTypeFix        )
     end if
     return
   end subroutine fileReadFile

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
@@ -407,13 +407,14 @@ contains
     !!{
     Return the excursion set barrier at the given variance and time.
     !!}
-    use :: Display          , only : displayCounter              , displayCounterClear  , displayIndent       , displayMessage, &
-          &                          displayUnindent             , verbosityLevelWorking
-    use :: Error_Functions  , only : Error_Function_Complementary
-    use :: File_Utilities   , only : File_Lock                   , File_Unlock          , lockDescriptor
-    use :: Kind_Numbers     , only : kind_dble                   , kind_quad
-    use :: MPI_Utilities    , only : mpiBarrier                  , mpiSelf
-    use :: Numerical_Ranges , only : Make_Range                  , rangeTypeLinear      , rangeTypeLogarithmic
+    use :: Display         , only : displayCounter              , displayCounterClear  , displayIndent       , displayMessage, &
+          &                         displayUnindent             , verbosityLevelWorking
+    use :: Error_Functions , only : Error_Function_Complementary
+    use :: File_Utilities  , only : File_Lock                   , File_Unlock          , lockDescriptor
+    use :: Kind_Numbers    , only : kind_dble                   , kind_quad
+    use :: MPI_Utilities   , only : mpiBarrier                  , mpiSelf
+    use :: Numerical_Ranges, only : Make_Range                  , rangeTypeLinear      , rangeTypeLogarithmic
+    use :: Table_Labels    , only : extrapolationTypeFix
     implicit none
     class           (excursionSetFirstCrossingFarahi), intent(inout)                 :: self
     double precision                                 , intent(in   )                 :: variance                        , time
@@ -643,8 +644,8 @@ contains
           if (allocated(self%interpolatorTime    )) deallocate(self%interpolatorTime    )
           allocate(self%interpolatorVariance)
           allocate(self%interpolatorTime    )
-          self%interpolatorVariance=interpolator(self%variance)
-          self%interpolatorTime    =interpolator(self%time    )
+          self%interpolatorVariance=interpolator(self%variance,extrapolationType=extrapolationTypeFix)
+          self%interpolatorTime    =interpolator(self%time    ,extrapolationType=extrapolationTypeFix)
           ! Record that the table is now built.
           self%tableInitialized=.true.
           ! Write the table to file if possible.
@@ -851,13 +852,14 @@ contains
     !!{
     Tabulate the excursion set crossing rate.
     !!}
-    use :: Display          , only : displayCounter              , displayCounterClear  , displayIndent       , displayMessage, &
-          &                          displayUnindent             , verbosityLevelWorking
-    use :: Error_Functions  , only : Error_Function_Complementary
-    use :: File_Utilities   , only : File_Lock                   , File_Unlock          , lockDescriptor
-    use :: Kind_Numbers     , only : kind_dble                   , kind_quad
-    use :: MPI_Utilities    , only : mpiBarrier                  , mpiSelf
-    use :: Numerical_Ranges , only : Make_Range                  , rangeTypeLinear      , rangeTypeLogarithmic
+    use :: Display         , only : displayCounter              , displayCounterClear  , displayIndent       , displayMessage, &
+          &                         displayUnindent             , verbosityLevelWorking
+    use :: Error_Functions , only : Error_Function_Complementary
+    use :: File_Utilities  , only : File_Lock                   , File_Unlock          , lockDescriptor
+    use :: Kind_Numbers    , only : kind_dble                   , kind_quad
+    use :: MPI_Utilities   , only : mpiBarrier                  , mpiSelf
+    use :: Numerical_Ranges, only : Make_Range                  , rangeTypeLinear      , rangeTypeLogarithmic
+    use :: Table_Labels    , only : extrapolationTypeFix
     implicit none
     class           (excursionSetFirstCrossingFarahi), intent(inout)               :: self
     double precision                                 , intent(in   )               :: time                             , varianceProgenitor
@@ -1256,10 +1258,10 @@ contains
           allocate(self%interpolatorVarianceCurrentRate           )
           allocate(self%interpolatorVarianceCurrentRateNonCrossing)
           allocate(self%interpolatorTimeRate                      )
-          self%interpolatorVarianceRate                  =interpolator(self%varianceProgenitorRate        )
-          self%interpolatorVarianceCurrentRate           =interpolator(self%varianceCurrentRate           )
-          self%interpolatorVarianceCurrentRateNonCrossing=interpolator(self%varianceCurrentRateNonCrossing)
-          self%interpolatorTimeRate                      =interpolator(self%timeRate                      )
+          self%interpolatorVarianceRate                  =interpolator(self%varianceProgenitorRate        ,extrapolationType=extrapolationTypeFix)
+          self%interpolatorVarianceCurrentRate           =interpolator(self%varianceCurrentRate           ,extrapolationType=extrapolationTypeFix)
+          self%interpolatorVarianceCurrentRateNonCrossing=interpolator(self%varianceCurrentRateNonCrossing,extrapolationType=extrapolationTypeFix)
+          self%interpolatorTimeRate                      =interpolator(self%timeRate                      ,extrapolationType=extrapolationTypeFix)
           ! Set previous variance and time to unphysical values to force recompute of interpolation factors on next call.
           self%variancePreviousRate=-1.0d0
           self%timePreviousRate    =-1.0d0
@@ -1288,12 +1290,13 @@ contains
     !!{
     Read tabulated data on excursion set first crossing probabilities from file.
     !!}
-    use :: Display           , only : displayIndent, displayMessage  , displayUnindent, verbosityLevelWorking
-    use :: File_Utilities    , only : File_Exists  , File_Name_Expand
+    use :: Display           , only : displayIndent       , displayMessage  , displayUnindent, verbosityLevelWorking
+    use :: File_Utilities    , only : File_Exists         , File_Name_Expand
     use :: HDF5_Access       , only : hdf5Access
     use :: IO_HDF5           , only : hdf5Object
-    use :: ISO_Varying_String, only : operator(//) , var_str         , varying_string
+    use :: ISO_Varying_String, only : operator(//)        , var_str         , varying_string
     use :: String_Handling   , only : operator(//)
+    use :: Table_Labels      , only : extrapolationTypeFix
     implicit none
     class           (excursionSetFirstCrossingFarahi), intent(inout)                   :: self
     type            (hdf5Object                     )                                  :: dataFile                     , dataGroup
@@ -1346,8 +1349,8 @@ contains
        if (allocated(self%interpolatorTime    )) deallocate(self%interpolatorTime    )
        allocate(self%interpolatorVariance)
        allocate(self%interpolatorTime    )
-       self%interpolatorVariance=interpolator(self%variance)
-       self%interpolatorTime    =interpolator(self%time    )
+       self%interpolatorVariance=interpolator(self%variance,extrapolationType=extrapolationTypeFix)
+       self%interpolatorTime    =interpolator(self%time    ,extrapolationType=extrapolationTypeFix)
        ! Report.
        message=var_str('read excursion set first crossing probability from: ')//char(self%fileName)
        call displayIndent  (message,verbosityLevelWorking)
@@ -1422,10 +1425,10 @@ contains
        allocate(self%interpolatorVarianceCurrentRate           )
        allocate(self%interpolatorVarianceCurrentRateNonCrossing)
        allocate(self%interpolatorTimeRate                      )
-       self%interpolatorVarianceRate                  =interpolator(self%varianceProgenitorRate        )
-       self%interpolatorVarianceCurrentRate           =interpolator(self%varianceCurrentRate           )
-       self%interpolatorVarianceCurrentRateNonCrossing=interpolator(self%varianceCurrentRateNonCrossing)
-       self%interpolatorTimeRate                      =interpolator(self%timeRate                      )
+       self%interpolatorVarianceRate                  =interpolator(self%varianceProgenitorRate        ,extrapolationType=extrapolationTypeFix)
+       self%interpolatorVarianceCurrentRate           =interpolator(self%varianceCurrentRate           ,extrapolationType=extrapolationTypeFix)
+       self%interpolatorVarianceCurrentRateNonCrossing=interpolator(self%varianceCurrentRateNonCrossing,extrapolationType=extrapolationTypeFix)
+       self%interpolatorTimeRate                      =interpolator(self%timeRate                      ,extrapolationType=extrapolationTypeFix)
        ! Report.
        message=var_str('read excursion set first crossing rates from: ')//char(self%fileName)
        call displayIndent  (message,verbosityLevelWorking)

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.midpoint.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.midpoint.F90
@@ -115,13 +115,14 @@ contains
     !!{
     Return the excursion set barrier at the given variance and time.
     !!}
-    use :: Display          , only : displayCounter              , displayCounterClear  , displayIndent       , displayMessage, &
-          &                          displayUnindent             , verbosityLevelWorking
-    use :: Error_Functions  , only : Error_Function_Complementary
-    use :: File_Utilities   , only : File_Lock                   , File_Unlock          , lockDescriptor
-    use :: Kind_Numbers     , only : kind_dble                   , kind_quad
-    use :: MPI_Utilities    , only : mpiBarrier                  , mpiSelf
-    use :: Numerical_Ranges , only : Make_Range                  , rangeTypeLinear      , rangeTypeLogarithmic
+    use :: Display         , only : displayCounter              , displayCounterClear  , displayIndent       , displayMessage, &
+          &                         displayUnindent             , verbosityLevelWorking
+    use :: Error_Functions , only : Error_Function_Complementary
+    use :: File_Utilities  , only : File_Lock                   , File_Unlock          , lockDescriptor
+    use :: Kind_Numbers    , only : kind_dble                   , kind_quad
+    use :: MPI_Utilities   , only : mpiBarrier                  , mpiSelf
+    use :: Numerical_Ranges, only : Make_Range                  , rangeTypeLinear      , rangeTypeLogarithmic
+    use :: Table_Labels    , only : extrapolationTypeFix
     implicit none
     class           (excursionSetFirstCrossingFarahiMidpoint), intent(inout)                 :: self
     double precision                                         , intent(in   )                 :: variance                       , time
@@ -387,8 +388,8 @@ contains
           if (allocated(self%interpolatorTime    )) deallocate(self%interpolatorTime    )
           allocate(self%interpolatorVariance)
           allocate(self%interpolatorTime    )
-          self%interpolatorVariance=interpolator(self%variance)
-          self%interpolatorTime    =interpolator(self%time    )
+          self%interpolatorVariance=interpolator(self%variance,extrapolationType=extrapolationTypeFix)
+          self%interpolatorTime    =interpolator(self%time    ,extrapolationType=extrapolationTypeFix)
           ! Record that the table is now built.
           self%tableInitialized=.true.
           ! Write the table to file if possible.
@@ -426,14 +427,15 @@ contains
     !!{
     Tabulate the excursion set crossing rate.
     !!}
-    use :: Display          , only : displayCounter              , displayCounterClear  , displayIndent       , displayMagenta  , &
-          &                          displayMessage              , displayReset         , displayUnindent     , displayVerbosity, &
-          &                          verbosityLevelWarn          , verbosityLevelWorking
-    use :: Error_Functions  , only : Error_Function_Complementary
-    use :: File_Utilities   , only : File_Lock                   , File_Unlock          , lockDescriptor
-    use :: Kind_Numbers     , only : kind_dble                   , kind_quad
-    use :: MPI_Utilities    , only : mpiBarrier                  , mpiSelf
-    use :: Numerical_Ranges , only : Make_Range                  , rangeTypeLinear      , rangeTypeLogarithmic
+    use :: Display         , only : displayCounter              , displayCounterClear  , displayIndent       , displayMagenta  , &
+          &                         displayMessage              , displayReset         , displayUnindent     , displayVerbosity, &
+          &                         verbosityLevelWarn          , verbosityLevelWorking
+    use :: Error_Functions , only : Error_Function_Complementary
+    use :: File_Utilities  , only : File_Lock                   , File_Unlock          , lockDescriptor
+    use :: Kind_Numbers    , only : kind_dble                   , kind_quad
+    use :: MPI_Utilities   , only : mpiBarrier                  , mpiSelf
+    use :: Numerical_Ranges, only : Make_Range                  , rangeTypeLinear      , rangeTypeLogarithmic
+    use :: Table_Labels    , only : extrapolationTypeFix
     implicit none
     class           (excursionSetFirstCrossingFarahiMidpoint), intent(inout)                   :: self
     double precision                                         , intent(in   )                   :: time                                         , varianceProgenitor
@@ -981,10 +983,10 @@ contains
           allocate(self%interpolatorVarianceCurrentRate           )
           allocate(self%interpolatorVarianceCurrentRateNonCrossing)
           allocate(self%interpolatorTimeRate                      )
-          self%interpolatorVarianceRate                  =interpolator(self%varianceProgenitorRate        )
-          self%interpolatorVarianceCurrentRate           =interpolator(self%varianceCurrentRate           )
-          self%interpolatorVarianceCurrentRateNonCrossing=interpolator(self%varianceCurrentRateNonCrossing)
-          self%interpolatorTimeRate                      =interpolator(self%timeRate                      )
+          self%interpolatorVarianceRate                  =interpolator(self%varianceProgenitorRate        ,extrapolationType=extrapolationTypeFix)
+          self%interpolatorVarianceCurrentRate           =interpolator(self%varianceCurrentRate           ,extrapolationType=extrapolationTypeFix)
+          self%interpolatorVarianceCurrentRateNonCrossing=interpolator(self%varianceCurrentRateNonCrossing,extrapolationType=extrapolationTypeFix)
+          self%interpolatorTimeRate                      =interpolator(self%timeRate                      ,extrapolationType=extrapolationTypeFix)
           ! Set previous variance and time to unphysical values to force recompute of interpolation factors on next call.
           self%variancePreviousRate=-1.0d0
           self%timePreviousRate    =-1.0d0


### PR DESCRIPTION
If a tabulated power spectrum is increasing in wavenumber at the highest wavenumbers tabulated, and extrapolation in wavenumber in wavenumber is requested, report a warning message that this can be dangerous as it leads to extremely large power on small scales.