### PR TITLE
Enforce minimum time in lightcone output

### DIFF
--- a/source/geometry.lightcones.F90
+++ b/source/geometry.lightcones.F90
@@ -77,8 +77,8 @@ module Geometry_Lightcones
     <description>Returns the next time in the interval from the current node time to {\normalfont \ttfamily timeEnd} at which any replicant of this node will cross the lightcone. If no crossing occurs during this interval a very large value is returned instead.</description>
     <type>double precision</type>
     <pass>yes</pass>
-    <argument>type            (treeNode), intent(inout) :: node   </argument>
-    <argument>double precision          , intent(in   ) :: timeEnd</argument>
+    <argument>type            (treeNode), intent(inout) :: node              </argument>
+    <argument>double precision          , intent(in   ) :: timeStart, timeEnd</argument>
    </method>
    <method name="positionLightconeCrossing" >
     <description>Returns the position of the node at the time of lightcone crossing---which must have been previously identified via the {\normalfont \ttfamily timeLightconeCrossing} method.</description>

--- a/source/geometry.lightcones.cylindrical.F90
+++ b/source/geometry.lightcones.cylindrical.F90
@@ -614,7 +614,7 @@ contains
     return
   end function cylindricalVelocity
 
-  double precision function cylindricalTimeLightconeCrossing(self,node,timeEnd)
+  double precision function cylindricalTimeLightconeCrossing(self,node,timeStart,timeEnd)
     !!{
     Return the time of the next lightcone crossing for this node.
     !!}
@@ -622,8 +622,8 @@ contains
     implicit none
     class           (geometryLightconeCylindrical), intent(inout) :: self
     type            (treeNode                    ), intent(inout) :: node
-    double precision                              , intent(in   ) :: timeEnd
-    !$GLC attributes unused :: self, node, timeEnd
+    double precision                              , intent(in   ) :: timeStart, timeEnd
+    !$GLC attributes unused :: self, node, timeStart, timeEnd
 
     cylindricalTimeLightconeCrossing=0.0d0
     call Error_Report('not implemented'//{introspection:location})

--- a/source/geometry.lightcones.null.F90
+++ b/source/geometry.lightcones.null.F90
@@ -155,15 +155,15 @@ contains
     return
   end function nullVelocity
 
-  double precision function nullTimeLightconeCrossing(self,node,timeEnd)
+  double precision function nullTimeLightconeCrossing(self,node,timeStart,timeEnd)
     !!{
     Return the time of the next lightcone crossing for this node.
     !!}
     implicit none
     class           (geometryLightconeNull), intent(inout)  :: self
     type            (treeNode             ), intent(inout)  :: node
-    double precision                       , intent(in   )  :: timeEnd
-    !$GLC attributes unused :: self, node, timeEnd
+    double precision                       , intent(in   )  :: timeStart, timeEnd
+    !$GLC attributes unused :: self, node, timeStart, timeEnd
 
     nullTimeLightconeCrossing=huge(0.0d0)
     return

--- a/source/geometry.lightcones.square.F90
+++ b/source/geometry.lightcones.square.F90
@@ -831,7 +831,7 @@ contains
     return
   end function squarePositionAtOutput
 
-  double precision function squareTimeLightconeCrossing(self,node,timeEnd)
+  double precision function squareTimeLightconeCrossing(self,node,timeStart,timeEnd)
     !!{
     Return the time of the next lightcone crossing for this node.
     !!}
@@ -843,7 +843,7 @@ contains
     implicit none
     class           (geometryLightconeSquare), intent(inout)  :: self
     type            (treeNode               ), intent(inout)  :: node
-    double precision                         , intent(in   )  :: timeEnd
+    double precision                         , intent(in   )  :: timeStart                   , timeEnd
     integer                                  , dimension(3,2) :: periodicRange
     class           (nodeComponentBasic     ), pointer        :: basic
     class           (nodeComponentPosition  ), pointer        :: position
@@ -860,11 +860,11 @@ contains
          &                                                       k
     type            (rootFinder             )                 :: finder
  
-    basic                       => node    %basic                               (               )
-    position                    => node    %position                            (               )
-    positionReference           =  position%position                            (               )
-    distanceMinimum             =  self    %cosmologyFunctions_%distanceComoving(      timeEnd  )
-    distanceMaximum             =  self    %cosmologyFunctions_%distanceComoving(basic%time   ())
+    basic                       => node    %basic                               (                           )
+    position                    => node    %position                            (                           )
+    positionReference           =  position%position                            (                           )
+    distanceMinimum             =  self    %cosmologyFunctions_%distanceComoving(    timeEnd                )
+    distanceMaximum             =  self    %cosmologyFunctions_%distanceComoving(max(timeStart,basic%time()))
     radiusBuffer                =  +(                       &
          &                           +      timeEnd         &
          &                           -basic%time   ()       &

--- a/source/merger_trees.evolve.timesteps.lightcone_crossing.F90
+++ b/source/merger_trees.evolve.timesteps.lightcone_crossing.F90
@@ -153,7 +153,7 @@ contains
        ! If the maximum time is after the current time, find the time (if any) of lightcone crossing.
        basic => node%basic()
        if (timeMaximum > basic%time()) then       
-          timeCrossing=self%geometryLightcone_%timeLightconeCrossing(node,timeMaximum)
+          timeCrossing=self%geometryLightcone_%timeLightconeCrossing(node,self%timeMinimum,timeMaximum)
           if (timeCrossing <= timeEnd) lightconeCrossingTimeEvolveTo=timeCrossing
        end if
     end if


### PR DESCRIPTION
An initial check was made that the maximum time in the step, `timeEnd`, exceeds the minimum allowed time in the lightcone, but, if this check passed and a lightcone crossing time was found no check was made that _that_ time exceeded the minimum allowed time.