### PR TITLE
Fix lightcone redshift observed

### DIFF
--- a/source/nodes.property_extractor.lightcone.F90
+++ b/source/nodes.property_extractor.lightcone.F90
@@ -274,7 +274,7 @@ contains
          &                                                                          )
     lightconeExtract   (8  )=self%geometryLightcone_%solidAngle()/degreesToRadians**2
     if (self%includeObservedRedshift) then
-       ! Compute the relativistic velocity β=v/c.
+       ! Compute the line-of-sight peculiar velocity divided by the speed of light: β_los=v_los/c.
        velocityBeta                                     =+Dot_Product     (lightconeExtract(4:6),lightconeExtract(1:3)) &
             &                                            /Vector_Magnitude(                      lightconeExtract(1:3)) &
             &                                            *kilo                                                          &
@@ -282,16 +282,12 @@ contains
        ! Compute the observed redshift. This is given by:
        !  1 + zₒ = (1 + zₕ) (1 + zₚ),
        ! where zₒ is observed redshift, zₕ is cosmological redshift (due to Hubble expansion), and zₚ is the peculiar redshift,
-       ! given by
-       !  1 + zₚ = √[(1+βₚ)/(1-βₚ)]
-       ! where βₚ=vₚ/c is the dimensionless peculiar velocity (e.g. Davis et al.; 2011; ApJ; 741; 67; eqn. 4;
+       ! given by (in the non-relativistic limit) zₚ = β_los
+       ! (e.g. Davis et al.; 2011; ApJ; 741; 67; below eqn. 4;
        ! https://ui.adsabs.harvard.edu/abs/2011ApJ...741...67D).
        lightconeExtract(self%redshiftObservedOffset  +1)=                                       -1.0d0  &
             &                                            +    (+1.0d0                           +lightconeExtract(7  )) &
-            &                                            *sqrt(                                                         &
-            &                                                  +(+1.0d0+velocityBeta)                                   &
-            &                                                  /(+1.0d0-velocityBeta)                                   &
-            &                                                 )
+            &                                            *    (+1.0d0 + velocityBeta )
     end if
     if (self%includeAngularCoordinates) then
        lightconeExtract(self%angularCoordinatesOffset+1)=atan2(                              &

--- a/source/nodes.property_extractor.lightcone.F90
+++ b/source/nodes.property_extractor.lightcone.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Robertson, Andrew Benson
+  
   use            :: Cosmology_Functions, only : cosmologyFunctions, cosmologyFunctionsClass
   use            :: Geometry_Lightcones, only : geometryLightcone , geometryLightconeClass
   use, intrinsic :: ISO_C_Binding      , only : c_size_t
@@ -281,13 +283,14 @@ contains
             &                                            /speedLight
        ! Compute the observed redshift. This is given by:
        !  1 + zₒ = (1 + zₕ) (1 + zₚ),
-       ! where zₒ is observed redshift, zₕ is cosmological redshift (due to Hubble expansion), and zₚ is the peculiar redshift,
-       ! given by (in the non-relativistic limit) zₚ = β_los
-       ! (e.g. Davis et al.; 2011; ApJ; 741; 67; below eqn. 4;
+       ! where zₒ is observed redshift, zₕ is cosmological redshift (due
+       ! to Hubble expansion), and zₚ is the peculiar redshift, given by
+       ! (in the non-relativistic limit) zₚ = β_los (e.g. Davis et al.;
+       ! 2011; ApJ; 741; 67; below eqn. 4;
        ! https://ui.adsabs.harvard.edu/abs/2011ApJ...741...67D).
-       lightconeExtract(self%redshiftObservedOffset  +1)=                                       -1.0d0  &
-            &                                            +    (+1.0d0                           +lightconeExtract(7  )) &
-            &                                            *    (+1.0d0 + velocityBeta )
+       lightconeExtract(self%redshiftObservedOffset+1)=  -1.0d0                      &
+            &                                          +(+1.0d0+lightconeExtract(7)) &
+            &                                          *(+1.0d0+velocityBeta       )
     end if
     if (self%includeAngularCoordinates) then
        lightconeExtract(self%angularCoordinatesOffset+1)=atan2(                              &

--- a/source/nodes.property_extractor.lightcone.F90
+++ b/source/nodes.property_extractor.lightcone.F90
@@ -286,7 +286,7 @@ contains
        !  1 + zₚ = √[(1+βₚ)/(1-βₚ)]
        ! where βₚ=vₚ/c is the dimensionless peculiar velocity (e.g. Davis et al.; 2011; ApJ; 741; 67; eqn. 4;
        ! https://ui.adsabs.harvard.edu/abs/2011ApJ...741...67D).
-       lightconeExtract(self%redshiftObservedOffset  +1)=+                                       lightconeExtract(7  )  &
+       lightconeExtract(self%redshiftObservedOffset  +1)=                                       -1.0d0  &
             &                                            +    (+1.0d0                           +lightconeExtract(7  )) &
             &                                            *sqrt(                                                         &
             &                                                  +(+1.0d0+velocityBeta)                                   &


### PR DESCRIPTION
Peculiar and cosmological redshifts should add according to $1 + z_\mathrm{obs} = (1 + z_\mathrm{cos}) (1 + z_\mathrm{pec})$. The old code contained a bug where $z_\mathrm{obs} = z_\mathrm{cos} + (1 + z_\mathrm{cos}) (1 + z_\mathrm{pec})$. This has been fixed. 

In addition, the code previously used a special relativistic formula for $z_\mathrm{pec}$, valid when the peculiar velocity is purely along the line-of-sight. A full special-relativistic treatment would include time dilation effects (leading to a non-zero $z_\mathrm{pec}$ even for motion in the plane of the sky), but also shifts in the positions (on the sky) where galaxies are observed, due to relativistic aberration. Given these other relativistic effects are being ignored, the code now uses the non-relativistic limit in which $z_\mathrm{pec} = v_\mathrm{los} / c$, with $v_\mathrm{los}$ the line-of-sight component of the peculiar velocity.     