### PR TITLE
Avoid memory leak in events filtering

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Process/EventHooks.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/EventHooks.pm
@@ -395,6 +395,7 @@ CODE
    {$name}EventBackups => {$name}EventBackups%next
    select type (eventHook_ => eventHookBackup%eventHook_)
    type is (eventHook{$interfaceType})
+      if (allocated({$name}Event%hooks_)) deallocate({$name}Event%hooks_)
       {$name}Event        =  eventHook_
    class default
       call Error_Report('eventHook has incorrect class'//{$location})


### PR DESCRIPTION
Deallocate a derived-type component before reassignment to that derived-type.