### PR TITLE
Store the run time (and time at which the run ends) to the output file

### DIFF
--- a/doc/Advanced.tex
+++ b/doc/Advanced.tex
@@ -176,7 +176,9 @@ galacticus.hdf5
  +-> Version                                  Group
       |
       +-> buildTime                           Attribute {1}
-      +-> runTime                             Attribute {1}
+      +-> runStartTime                        Attribute {1}
+      +-> runEndTime                          Attribute {1}
+      +-> runDuration                         Attribute {1}
       +-> gitBranch                           Attribute {1}
       +-> gitHash                             Attribute {1}
       +-> gitHashDatasets                     Attribute {1}
@@ -229,7 +231,7 @@ The {\normalfont \ttfamily Parameters} group contains a record of all parameter 
 
 \subsection{Version}
 
-The {\normalfont \ttfamily Version} group contains a record of the \glc\ version used for this model, storing the {\normalfont \scshape Git} commit branch and hash (if the code is being maintained using {\normalfont \scshape Git}, otherwise a value of ``{\normalfont \ttfamily unknown}'' is entered) in the attributes {\normalfont \ttfamily gitBranch} and {\normalfont \ttfamily gitHash} respectively, along with the time at which the executable was built as {\normalfont \ttfamily buildTime}. If the {\normalfont \ttfamily datasets} path is a {\normalfont \scshape Git} repo then the hash of the checked-out commit is stored as {\normalfont \ttfamily gitHashDatasets} (if {\normalfont \ttfamily datasets} is not a {\normalfont \scshape Git} repo then a value of ``{\normalfont \ttfamily unknown}'' is entered instead). Additionally, the time at which the model was run is stored as {\normalfont \ttfamily runTime} and, if the {\normalfont \ttfamily galacticusConfig.xml} file (see \S\ref{sec:ConfigFile}) is present and contains contact details, the name and e-mail address of the person who ran the model are stored as {\normalfont \ttfamily runByName} and {\normalfont \ttfamily runByEmail} respectively.
+The {\normalfont \ttfamily Version} group contains a record of the \glc\ version used for this model, storing the {\normalfont \scshape Git} commit branch and hash (if the code is being maintained using {\normalfont \scshape Git}, otherwise a value of ``{\normalfont \ttfamily unknown}'' is entered) in the attributes {\normalfont \ttfamily gitBranch} and {\normalfont \ttfamily gitHash} respectively, along with the time at which the executable was built as {\normalfont \ttfamily buildTime}. If the {\normalfont \ttfamily datasets} path is a {\normalfont \scshape Git} repo then the hash of the checked-out commit is stored as {\normalfont \ttfamily gitHashDatasets} (if {\normalfont \ttfamily datasets} is not a {\normalfont \scshape Git} repo then a value of ``{\normalfont \ttfamily unknown}'' is entered instead). Additionally, the times at which the model run started and eneded are stored as {\normalfont \ttfamily runStartTime} and {\normalfont \ttfamily runEndTime}, with the duration of the run (in seconds) stored as {\normalfont \ttfamily runDuration}. If the {\normalfont \ttfamily galacticusConfig.xml} file (see \S\ref{sec:ConfigFile}) is present and contains contact details, the name and e-mail address of the person who ran the model are stored as {\normalfont \ttfamily runByName} and {\normalfont \ttfamily runByEmail} respectively.
 
 \subsection{Outputs}
 


### PR DESCRIPTION
The time and date at which the run ends is stored to the attribute `Version/runEndTime` (note that the time and date at which the run starts is now stored to the attribute `Version/runStartTime` instead of `Version/runTime`). Additionally, the duration of the run (in seconds) is stored to the attribute `Version/runDuration`).