### PR TITLE
Ignore empty lines when parsing directives

### DIFF
--- a/perl/Galacticus/Build/Directives.pm
+++ b/perl/Galacticus/Build/Directives.pm
@@ -34,7 +34,7 @@ sub Extract_Directive {
 	    $xmlText .= $line;
 	    $depth += () = ( $line =~ /<([a-zA-Z0-9]+)[^\/>]*>/g ); # Increment depth by count of any opening elements.
 	    $depth -= () = ( $line =~ /<\/([a-zA-Z0-9]+)>/g      ); # Decrement depth by count of any closing elements.
-	    if ( defined($xmlText) && $depth == 0 ) {
+	    if ( defined($xmlText) && $xmlText !~ m/^\s*$/ && $depth == 0 ) {
 		# Parse the XML.
 		my $xml    = new XML::Simple(KeepRoot => 1);
 		$directive = eval{$xml->XMLin($xmlText)};


### PR DESCRIPTION
Previously empty lines such as in this directive section:
```
     !![
     <inputParameter>
       <name>efficiency</name>
       <defaultValue>0.01d0</defaultValue>
       <description>The efficiency of star formation.</description>
       <source>parameters</source>
     </inputParameter>

     !!]                                                                                                                                                                                                                  
```
would cause XML parsing errors. Now they are ignored.