### PR TITLE
Add option to leave stubs of subsampled branches in place

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1051,6 +1051,7 @@ jobs:
                 test-branchSubsampling.pl,
                 test-CGM-mass-cooled.pl,
                 test-concentration-Ludlow2016.pl,
+                test-concentration-Johnson2021.pl,
                 test-tidallyTruncatedNFWFit.pl,
                 test-constraint-deterministic-spins.pl,
                 test-constraint-mass-function.pl,

--- a/perl/Galacticus/Build/Components/TreeNodes.pm
+++ b/perl/Galacticus/Build/Components/TreeNodes.pm
@@ -123,7 +123,7 @@ sub Build_Tree_Node_Class {
 	 {
 	     type        => "procedure"                                                                                                       ,
 	     name        => "isPrimaryProgenitor"                                                                                             ,
-	     function    => "Tree_Node_Is_Primary_Progenitor"                                                                                 ,
+	     function    => "treeNodeIsPrimaryProgenitor"                                                                                 ,
 	     description => "Return true if this node is the primary progenitor of its descendant, false otherwise."                          ,
 	     returnType  => "\\logicalzero"                                                                                                   ,
 	     arguments   => ""

--- a/source/dark_matter_profiles.structure.scale.concentration.F90
+++ b/source/dark_matter_profiles.structure.scale.concentration.F90
@@ -343,12 +343,12 @@ contains
     call state_(stateCount)%darkMatterProfile%scaleSet(radiusCore)
     call Calculations_Reset(state_(stateCount)%nodeWork)
     ! Find the non-alt density.
-    densityOuter=+state_(stateCount)%self%cosmologyFunctions_   %matterDensityEpochal(                                                          state_(stateCount)%basic%time()) &
-         &       *state_(stateCount)%self%virialDensityContrast_%densityContrast     (state_(stateCount)%basic%mass(),state_(stateCount)%basic%time())
+    densityOuter=+state_(stateCount)%self%cosmologyFunctions_           %matterDensityEpochal  (                                state_(stateCount)%basic%time()) &
+         &       *state_(stateCount)%self%virialDensityContrast_        %densityContrast       (state_(stateCount)%basic%mass(),state_(stateCount)%basic%time())
     ! Solve for radius which encloses required non-alt density.
-    radiusOuter=state_(stateCount)%self%darkMatterProfileDMODefinition%radiusEnclosingDensity(state_(stateCount)%nodeWork,densityOuter)
+    radiusOuter =+state_(stateCount)%self%darkMatterProfileDMODefinition%radiusEnclosingDensity(state_(stateCount)%nodeWork    ,densityOuter)
     ! Get the mass within this radius.
-    massOuter  =state_(stateCount)%self%darkMatterProfileDMODefinition%enclosedMass          (state_(stateCount)%nodeWork, radiusOuter)
+    massOuter   =+state_(stateCount)%self%darkMatterProfileDMODefinition%enclosedMass          (state_(stateCount)%nodeWork    , radiusOuter)
     ! Return root function.
     concentrationMassRoot=massOuter-state_(stateCount)%mass
     return

--- a/source/nodes.operators.clean_subsample_stubs.F90
+++ b/source/nodes.operators.clean_subsample_stubs.F90
@@ -1,0 +1,169 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a node operator class that cleans any remaining stubs of the merger tree left in place by subsampling.  
+  !!}
+  
+  !![
+  <nodeOperator name="nodeOperatorCleanSubsampleStubs">
+   <description>
+    A node operator class that cleans any remaining stubs of the merger tree left in place by subsampling.
+   </description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorCleanSubsampleStubs
+     !!{
+     A node operator class that cleans any remaining stubs of the merger tree left in place by subsampling.
+     !!}
+     private
+     double precision :: factorMassGrowthConsolidate
+   contains
+     procedure :: nodeTreeInitialize => cleanSubsampleStubsNodeTreeInitialize
+  end type nodeOperatorCleanSubsampleStubs
+  
+  interface nodeOperatorCleanSubsampleStubs
+     !!{
+     Constructors for the {\normalfont \ttfamily cleanSubsampleStubs} node operator class.
+     !!}
+     module procedure cleanSubsampleStubsConstructorParameters
+     module procedure cleanSubsampleStubsConstructorInternal
+  end interface nodeOperatorCleanSubsampleStubs
+  
+contains
+  
+  function cleanSubsampleStubsConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily cleanSubsampleStubs} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (nodeOperatorCleanSubsampleStubs)                :: self
+    type            (inputParameters                ), intent(inout) :: parameters
+    double precision                                                 :: factorMassGrowthConsolidate
+
+    !![
+    <inputParameter>
+      <name>factorMassGrowthConsolidate</name>
+      <source>parameters</source>
+      <description>The maximum factor by which the mass is allowed to grow between child and parent when consolidating nodes. A non-positive value prevents consolidation.</description>
+      <defaultValue>0.0d0</defaultValue>
+    </inputParameter>
+    !!]
+    self=nodeOperatorCleanSubsampleStubs(factorMassGrowthConsolidate)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function cleanSubsampleStubsConstructorParameters
+
+  function cleanSubsampleStubsConstructorInternal(factorMassGrowthConsolidate) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily cleanSubsampleStubs} node operator class.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (nodeOperatorCleanSubsampleStubs)                :: self
+    double precision                                 , intent(in   ) :: factorMassGrowthConsolidate
+    !![
+    <constructorAssign variables="factorMassGrowthConsolidate"/>
+    !!]
+
+    return
+  end function cleanSubsampleStubsConstructorInternal
+
+  subroutine cleanSubsampleStubsNodeTreeInitialize(self,node)
+    !!{
+    Clean the tree of any stub branches left over from subsampling the merger tree.
+    !!}
+    use :: Merger_Tree_Walkers, only : mergerTreeWalkerIsolatedNodes
+    use :: Galacticus_Nodes   , only : nodeComponentBasic
+    implicit none
+    class  (nodeOperatorCleanSubsampleStubs), intent(inout), target  :: self
+    type   (treeNode                       ), intent(inout), target  :: node
+    type   (treeNode                       )               , pointer :: nodeWork      , nodeChild  , &
+         &                                                              nodeGrandchild, nodeParent , &
+         &                                                              nodeNext
+    class  (nodeComponentBasic             )               , pointer :: basic         , basicParent
+    type   (mergerTreeWalkerIsolatedNodes  )                         :: treeWalker
+    integer(c_size_t                       )                         :: countNodes
+    logical                                                          :: finished
+
+    ! Only operator once the root node is reached so that we can be sure that none of the stubs are needed.
+    if (associated(node%parent)) return
+    treeWalker=mergerTreeWalkerIsolatedNodes(node%hostTree,spanForest=.false.)
+    finished  =treeWalker%next(nodeWork)
+    do while (.not.finished)
+       finished=treeWalker%next(nodeNext)
+       if (nodeWork%subsamplingWeight() < 0.0d0) then
+          ! Decouple the node from the tree.
+          nodeParent => nodeWork  %parent
+          nodeChild  => nodeParent%firstChild
+          do while (.not.associated(nodeChild%sibling,nodeWork))
+             nodeChild => nodeChild%sibling
+          end do
+          nodeChild%sibling => nodeWork%sibling
+          ! Destroy and deallocate the node.
+          call nodeWork%destroy()
+          deallocate(nodeWork)
+          ! Determine if we can consolidate any nodes down the parent branch.
+          if (self%factorMassGrowthConsolidate > 0.0d0) then
+             ! Seek down through the branch until which find a node which either has a sibling (so can't be consolidated), or
+             ! which has a mass sufficiently different from that of the starting node. Count how many such nodes we find.
+             nodeChild   => nodeParent
+             basic       => nodeChild %basic()
+             basicParent => nodeParent%basic()
+             countNodes  =  0_c_size_t          
+             do while (                                                              &
+                  &         associated(nodeChild%firstChild)                         &
+                  &    .and.                                                         &
+                  &    .not.associated(nodeChild%sibling   )                         &
+                  &    .and.                                                         &
+                  &      basic      %mass()*(1.0d0+self%factorMassGrowthConsolidate) &
+                  &     >                                                            &
+                  &      basicParent%mass()                                          &
+                  &   )
+                nodeChild  => nodeChild%firstChild
+                basic      => nodeChild%basic     ()
+                countNodes =  countNodes+1_c_size_t
+             end do
+             ! If we have found nodes that can be consolidated, remove the intervening nodes.
+             if (countNodes > 1_c_size_t) then
+                nodeChild => nodeParent%firstChild
+                do while (countNodes > 1_c_size_t)
+                   nodeGrandchild => nodeChild%firstChild
+                   call nodeChild%destroy()
+                   deallocate(nodeChild)
+                   countNodes =  countNodes-1_c_size_t
+                   nodeChild  => nodeGrandchild
+                end do
+                nodeParent%firstChild => nodeChild
+                nodeChild %parent     => nodeParent
+                do while (associated(nodeChild%sibling))
+                   nodeChild        => nodeChild %sibling
+                   nodeChild%parent => nodeParent
+                end do
+             end if
+          end if
+       end if
+       nodeWork => nodeNext
+    end do
+    return
+  end subroutine cleanSubsampleStubsNodeTreeInitialize
+    

--- a/source/nodes.operators.clean_subsample_stubs.F90
+++ b/source/nodes.operators.clean_subsample_stubs.F90
@@ -103,14 +103,14 @@ contains
     class  (nodeComponentBasic             )               , pointer :: basic         , basicParent
     type   (mergerTreeWalkerIsolatedNodes  )                         :: treeWalker
     integer(c_size_t                       )                         :: countNodes
-    logical                                                          :: finished
+    logical                                                          :: nodesRemain
 
     ! Only operator once the root node is reached so that we can be sure that none of the stubs are needed.
     if (associated(node%parent)) return
     treeWalker=mergerTreeWalkerIsolatedNodes(node%hostTree,spanForest=.false.)
-    finished  =treeWalker%next(nodeWork)
-    do while (.not.finished)
-       finished=treeWalker%next(nodeNext)
+    nodesRemain  =treeWalker%next(nodeWork)
+    do while (nodesRemain)
+       nodesRemain=treeWalker%next(nodeNext)
        if (nodeWork%subsamplingWeight() < 0.0d0) then
           ! Decouple the node from the tree.
           nodeParent => nodeWork  %parent

--- a/source/nodes.operators.filtered.main_branch.F90
+++ b/source/nodes.operators.filtered.main_branch.F90
@@ -1,0 +1,149 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a node operator class that applies only to main branch nodes during tree initialization only.
+  !!}
+
+  !![
+  <nodeOperator name="nodeOperatorFilteredMainBranch">
+    <description>
+      A node operator class that applies only to main branch nodes during tree initialization only. This uses a fast algorithm to
+      determine main branch status, so is more efficient that using the \refClass{nodeOperatorFiltered} class along with a
+      \refClass{galacticFilterMainBranch} filter.
+    </description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorMulti) :: nodeOperatorFilteredMainBranch
+     !!{
+     A node operator class that applies only to main branch nodes during tree initialization only.
+     !!}
+     private
+     logical            :: isTreeInitialization=.false., invertFilter
+     integer(kind_int8) :: uniqueIDMainBranch          , uniqueIDMainBranchRoot
+   contains
+     procedure :: nodeTreeInitialize => filteredMainBranchNodeTreeInitialize
+     procedure :: isActive           => filteredMainBranchIsActive
+  end type nodeOperatorFilteredMainBranch
+
+  interface nodeOperatorFilteredMainBranch
+     !!{
+     Constructors for the {\normalfont \ttfamily filteredMainBranch} node operator class.
+     !!}
+     module procedure filteredMainBranchConstructorParameters
+     module procedure filteredMainBranchConstructorInternal
+  end interface nodeOperatorFilteredMainBranch
+
+contains
+
+  function filteredMainBranchConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily filteredMainBranch} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type   (nodeOperatorFilteredMainBranch)                :: self
+    type   (inputParameters               ), intent(inout) :: parameters
+
+    self%nodeOperatorMulti=nodeOperatorMulti(parameters)
+    !![
+    <inputParameter>
+      <name>invertFilter</name>
+      <variable>self%invertFilter</variable>
+      <defaultValue>.false.</defaultValue>
+      <description>If true, the filter is inverted to pass only nodes \emph{not} on the main branch.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParametersValidate source="parameters" multiParameters="nodeOperator"/>
+    !!]
+    self%uniqueIDMainBranchRoot=-huge(1_kind_int8)
+    self%uniqueIDMainBranch    =-huge(1_kind_int8)
+    return
+  end function filteredMainBranchConstructorParameters
+
+  function filteredMainBranchConstructorInternal(processes,invertFilter) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily filteredMainBranch} node operator class.
+    !!}
+    implicit none
+    type   (nodeOperatorFilteredMainBranch)                        :: self
+    type   (multiProcessList              ), intent(in   ), target :: processes
+    logical                                , intent(in   )         :: invertFilter
+
+    self%nodeOperatorMulti     =nodeOperatorMulti(processes)
+    self%invertFilter          =invertFilter
+    self%uniqueIDMainBranchRoot=-huge(1_kind_int8)
+    self%uniqueIDMainBranch    =-huge(1_kind_int8)
+    return
+  end function filteredMainBranchConstructorInternal
+
+  subroutine filteredMainBranchNodeTreeInitialize(self,node)
+    !!{
+    Perform node tree initialization.
+    !!}
+    implicit none
+    class(nodeOperatorFilteredMainBranch), intent(inout), target  :: self
+    type (treeNode                      ), intent(inout), target  :: node
+    type (multiProcessList              )               , pointer :: process_
+
+    self%isTreeInitialization=.true.
+    if (self%isActive(node)) then
+       process_ => self%processes
+       do while (associated(process_))
+          call process_%process_%nodeTreeInitialize(node)
+          process_ => process_%next
+       end do
+    end if
+    self%isTreeInitialization=.false.
+    return
+  end subroutine filteredMainBranchNodeTreeInitialize
+
+  logical function filteredMainBranchIsActive(self,node) result(isActive)
+    !!{
+    Return true if the given {\normalfont \ttfamily node} is on the main branch of the tree. Here we assume that a depth-first
+    walk of the tree is being performed. As such, we keep a record of the (unique ID of the) last main branch node seen (starting
+    from the tip of the main branch). A subsequent node is then only on the main branch if its first child is that same last seen
+    main branch node.
+    !!}
+    implicit none
+    class(nodeOperatorFilteredMainBranch), intent(inout) :: self
+    type (treeNode                      ), intent(inout) :: node
+    type (treeNode                      ), pointer       :: nodeMainBranch
+
+    isActive=.false.
+    if (.not.self%isTreeInitialization) return
+    if (node%hostTree%nodeBase%uniqueID() /= self%uniqueIDMainBranchRoot) then
+       nodeMainBranch => node%hostTree%nodeBase
+       do while (associated(nodeMainBranch%firstChild))
+          nodeMainBranch => nodeMainBranch%firstChild
+       end do
+       self%uniqueIDMainBranchRoot=node          %hostTree%nodeBase%uniqueID()
+       self%uniqueIDMainBranch    =nodeMainBranch                  %uniqueID()
+    end if
+
+    if (associated(node%firstChild)) then
+       isActive=node%firstChild%uniqueID() == self%uniqueIDMainBranch
+       if (isActive) self%uniqueIDMainBranch=node%uniqueID()
+    else
+       isActive=node           %uniqueID() == self%uniqueIDMainBranch
+    end if
+    if (self%invertFilter) isActive=.not.isActive
+    if (.not.associated(node%parent)) self%uniqueIDMainBranchRoot=-huge(0_kind_int8)
+    return
+  end function filteredMainBranchIsActive

--- a/source/nodes.operators.physics.dark_matter_profile_scale.set.F90
+++ b/source/nodes.operators.physics.dark_matter_profile_scale.set.F90
@@ -21,15 +21,17 @@
   Implements a node operator class that sets dark matter profile scale radius.
   !!}
 
+  use :: Galacticus_Nodes          , only : treeNodeLinkedList
   use :: Dark_Matter_Profile_Scales, only : darkMatterProfileScaleRadiusClass
   
   type :: branchStack
      !!{
      Type used to create a stack of branches being processed.
      !!}
-     double precision                       :: mass              , radiusScale
-     type            (branchStack), pointer :: next     => null()
-     integer         (kind_int8  )          :: indexTip
+     double precision                              :: mass              , radiusScale
+     type            (branchStack       ), pointer :: next     => null()
+     type            (treeNodeLinkedList), pointer :: node     => null()
+     integer         (kind_int8         )          :: indexTip
   end type branchStack
   
   !![
@@ -47,6 +49,7 @@
      class           (darkMatterProfileScaleRadiusClass), pointer :: darkMatterProfileScaleRadius_ => null()
      type            (branchStack                      ), pointer :: branch                        => null()
      double precision                                             :: factorReset
+     logical                                                      :: forward
    contains
      final     ::                       darkMatterProfileScaleSetConstructorDestructor
      procedure :: nodeTreeInitialize => darkMatterProfileScaleSetNodeTreeInitialize
@@ -73,6 +76,7 @@ contains
     type            (inputParameters                      ), intent(inout) :: parameters
     class           (darkMatterProfileScaleRadiusClass    ), pointer       :: darkMatterProfileScaleRadius_
     double precision                                                       :: factorReset
+    logical                                                                :: forward
 
     !![
     <inputParameter>
@@ -81,9 +85,15 @@ contains
       <description>The factor by which a node must increase in mass before its scale radius is reset.</description>
       <source>parameters</source>
     </inputParameter>
+    <inputParameter>
+      <name>forward</name>
+      <defaultValue>.true.</defaultValue>
+      <description>If true, updates to the scale radius are determined by walking forward along the branch until the mass exceeds by {\normalfont \ttfamily [factor]} that for which the scale radius was last computed. If false, updates are computed by walking backward along the branch until the mass is less than $1/${\normalfont \ttfamily [factor]} of that for which the scale radius was last computed.</description>
+      <source>parameters</source>
+    </inputParameter>
     <objectBuilder class="darkMatterProfileScaleRadius" name="darkMatterProfileScaleRadius_" source="parameters"/>
     !!]
-    self=nodeOperatorDarkMatterProfileScaleSet(factorReset,darkMatterProfileScaleRadius_)
+    self=nodeOperatorDarkMatterProfileScaleSet(factorReset,forward,darkMatterProfileScaleRadius_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="darkMatterProfileScaleRadius_"/>
@@ -91,7 +101,7 @@ contains
     return
   end function darkMatterProfileScaleSetConstructorParameters
 
-  function darkMatterProfileScaleSetConstructorInternal(factorReset,darkMatterProfileScaleRadius_) result(self)
+  function darkMatterProfileScaleSetConstructorInternal(factorReset,forward,darkMatterProfileScaleRadius_) result(self)
     !!{
     Constructor for the {\normalfont \ttfamily darkMatterProfileScaleSet} node operator class which takes a parameter set as input.
     !!}
@@ -100,8 +110,9 @@ contains
     type            (nodeOperatorDarkMatterProfileScaleSet)                        :: self
     class           (darkMatterProfileScaleRadiusClass    ), intent(in   ), target :: darkMatterProfileScaleRadius_
     double precision                                       , intent(in   )         :: factorReset
+    logical                                                , intent(in   )         :: forward
     !![
-    <constructorAssign variables="factorReset, *darkMatterProfileScaleRadius_"/>
+    <constructorAssign variables="factorReset, forward, *darkMatterProfileScaleRadius_"/>
     !!]
 
     return
@@ -128,29 +139,70 @@ contains
     implicit none
     class           (nodeOperatorDarkMatterProfileScaleSet), intent(inout), target  :: self
     type            (treeNode                             ), intent(inout), target  :: node
-    class           (nodeComponentBasic                   )               , pointer :: basic
+    class           (nodeComponentBasic                   )               , pointer :: basic              , basicDescendant
     class           (nodeComponentDarkMatterProfile       )               , pointer :: darkMatterProfile
     type            (branchStack                          )               , pointer :: branchPrevious
-    double precision                                                                :: radiusScalePrevious
+    type            (treeNodeLinkedList                   )               , pointer :: nodeNext
+    type            (treeNode                             )               , pointer :: nodeDescendant
+    double precision                                                                :: radiusScalePrevious, radiusScaleUpdated
     logical                                                                         :: radiusScaleNew
 
     if (self%factorReset > 0.0d0) then
        basic => node%basic()
        if (.not.associated(node%firstChild)) then
-          ! This is the tip of a branch. Push the branch onto the stack, and record the initial mass.
+          ! This is the tip of a branch. Push the branch onto the stack, and build a stack of nodes at which new scale radii must
+          ! be computed.
           branchPrevious => self%branch
           nullify (self%branch)
           allocate(self%branch)
           self%branch%next     => branchPrevious
-          self%branch%mass     =  basic         %mass    ()
           self%branch%indexTip =  node          %uniqueID()
+          if (self%forward) then
+             self%branch%mass=basic%mass()
+          else
+             nodeDescendant => node
+             do while (nodeDescendant%isPrimaryProgenitor())
+                nodeDescendant => nodeDescendant%parent
+             end do
+             allocate(self%branch%node)
+             basicDescendant                  => nodeDescendant %basic()
+             self           %branch%node%node => nodeDescendant
+             self           %branch%node%next => null()
+             self           %branch%mass      =  basicDescendant%mass ()
+             do while (associated(nodeDescendant))
+                basicDescendant => nodeDescendant%basic()
+                if (basicDescendant%mass() < self%branch%mass/self%factorReset) then
+                   nodeNext => self%branch%node
+                   nullify (self%branch%node)
+                   allocate(self%branch%node)
+                   self%branch%mass      =  basicDescendant%mass()
+                   self%branch%node%node => nodeDescendant
+                   self%branch%node%next => nodeNext
+                end if
+                nodeDescendant => nodeDescendant%firstChild
+             end do
+          end if
           ! In this case we must always compute a new scale radius.
           radiusScaleNew=.true.
        else
-          ! This is not a branch tip - a new scale radius is computed only if the prior mass is exceeded by the required factor.
-          radiusScaleNew=basic%mass() > self%factorReset*self%branch%mass
-          ! If a new scale radius is to be computed, record the mass at which this occurred.
-          if (radiusScaleNew) self%branch%mass=basic%mass()
+          ! This is not a branch tip.
+          if (self%forward) then
+             ! A new scale radius is computed only if the prior mass is exceeded by the required factor.
+             radiusScaleNew=basic%mass() > self%factorReset*self%branch%mass
+             ! If a new scale radius is to be computed, record the mass at which this occurred.
+             if (radiusScaleNew) self%branch%mass=basic%mass()
+          else
+             ! A new scale radius is computed only if we have reached the prior node for which it was computed.
+             radiusScaleNew=associated(self%branch%node%node,node)
+             if (radiusScaleNew) then
+                nodeNext => self%branch%node%next
+                deallocate(self%branch%node)
+                self%branch%node => nodeNext
+             end if
+             ! If there are no more nodes along this branch at which to compute the scale radius, mark that scale radius is not to
+             ! be computed.
+             if (.not.associated(self%branch%node)) radiusScaleNew=.false.
+          end if
        end if
     else
        ! The reset factor is zero - we assign a new scale radius for every node.
@@ -159,8 +211,27 @@ contains
     darkMatterProfile => node%darkMatterProfile(autoCreate=.true.)
     if (radiusScaleNew) then
        ! Compute a new scale radius, and save it on our current branch.
-       radiusScalePrevious=self%darkMatterProfileScaleRadius_%radius(node)
-       if (associated(self%branch)) self%branch%radiusScale=radiusScalePrevious
+       if (self%forward .or. self%factorReset <= 0.0d0) then
+          nodeDescendant =>             node
+       else
+          nodeDescendant => self%branch%node%node
+       end if
+       radiusScaleUpdated=self%darkMatterProfileScaleRadius_%radius(nodeDescendant)
+       ! If the current node was one for which we needed to compute a new scale radius, pop the node stack here. This can happen
+       ! if the branch tip node is a node for which we must compute the scale radius.
+       if (self%factorReset > 0.0d0 .and. .not.self%forward  .and. associated(self%branch%node%node,node)) then
+          nodeNext => self%branch%node%next
+          deallocate(self%branch%node)
+          self%branch%node => nodeNext
+       end if
+       ! If using the "forward" approach, or this is the branch tip, we update the actual scale radius now, as we want to apply it
+       ! to this node. Otherwise, use the previous value.
+       if (self%factorReset <= 0.0d0 .or. self%forward .or. .not.associated(node%firstChild)) then
+          radiusScalePrevious=            radiusScaleUpdated
+       else
+          radiusScalePrevious=self%branch%radiusScale
+       end if
+       if (associated(self%branch)) self%branch%radiusScale=radiusScaleUpdated
     else
        ! Use the previously computed scale radius for this branch.
        radiusScalePrevious=self%branch%radiusScale

--- a/source/nodes.operators.physics.dark_matter_profile_scale.set.F90
+++ b/source/nodes.operators.physics.dark_matter_profile_scale.set.F90
@@ -155,8 +155,8 @@ contains
        ! The reset factor is zero - we assign a new scale radius for every node.
        radiusScaleNew=.true.
     end if
-    if (radiusScaleNew) radiusScalePrevious=self%darkMatterProfileScaleRadius_%radius(node)
     darkMatterProfile => node%darkMatterProfile(autoCreate=.true.)
+    if (radiusScaleNew) radiusScalePrevious=self%darkMatterProfileScaleRadius_%radius(node)
     call darkMatterProfile%scaleSet(radiusScalePrevious)
     return
   end subroutine darkMatterProfileScaleSetNodeTreeInitialize

--- a/source/nodes.operators.physics.dark_matter_profile_scale.set.F90
+++ b/source/nodes.operators.physics.dark_matter_profile_scale.set.F90
@@ -27,9 +27,9 @@
      !!{
      Type used to create a stack of branches being processed.
      !!}
-     double precision                       :: mass, radiusScale
-     type            (branchStack), pointer :: next
-     integer(kind_int8) :: indexTip
+     double precision                       :: mass              , radiusScale
+     type            (branchStack), pointer :: next     => null()
+     integer         (kind_int8  )          :: indexTip
   end type branchStack
   
   !![

--- a/source/objects.nodes.F90
+++ b/source/objects.nodes.F90
@@ -476,27 +476,20 @@ module Galacticus_Nodes
     return
   end subroutine Tree_Node_Remove_Paired_Event
 
-  logical function Tree_Node_Is_Primary_Progenitor(self)
+  logical function treeNodeIsPrimaryProgenitor(self) result(isPrimaryProgenitor)
     !!{
     Returns true if {\normalfont \ttfamily self} is the primary progenitor of its parent node.
     !!}
-    use :: Error, only : Error_Report
     implicit none
-    class(treeNode), intent(inout) :: self
+    class(treeNode), intent(inout), target:: self
 
-    select type (self)
-    type is (treeNode)
-       if (associated(self%parent)) then
-          Tree_Node_Is_Primary_Progenitor=associated(self%parent%firstChild,self)
-       else
-          Tree_Node_Is_Primary_Progenitor=.false.
-       end if
-    class default
-       Tree_Node_Is_Primary_Progenitor=.false.
-       call Error_Report('treeNode is of unknown class'//{introspection:location})
-    end select
+    if (associated(self%parent)) then
+       isPrimaryProgenitor=associated(self%parent%firstChild,self)
+    else
+       isPrimaryProgenitor=.false.
+    end if
     return
-  end function Tree_Node_Is_Primary_Progenitor
+  end function treeNodeIsPrimaryProgenitor
 
   logical function Tree_Node_Is_Primary_Progenitor_Of_Index(self,targetNodeIndex)
     !!{

--- a/testSuite/parameters/concentrationDistributionJohnson2021.xml
+++ b/testSuite/parameters/concentrationDistributionJohnson2021.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="3f3d9a2af2b05c0a279e4aa3602f89fd682665cc"/>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="null"/>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="null"/>
+  <componentSpin value="null"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant  value="70.400000"/>
+    <OmegaMatter     value=" 0.272000"/>
+    <OmegaDarkEnergy value=" 0.728000"/>
+    <OmegaBaryon     value=" 0.0000000"/>
+    <temperatureCMB  value=" 2.725480"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction        value="CAMB"     >
+    <cosmologyParameters value="simple">
+      <HubbleConstant  value="70.400000"/>
+      <OmegaMatter     value=" 0.272000"/>
+      <OmegaDarkEnergy value=" 0.728000"/>
+      <OmegaBaryon     value=" 0.044550"/>
+      <temperatureCMB  value=" 2.725480"/>
+    </cosmologyParameters>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw" >
+    <index               value="0.967"/>
+    <wavenumberReference value="1.000"/>
+    <running             value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.81"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="shethTormen">
+    <a             value="+0.791"/>
+    <p             value="+0.218"/>
+    <normalization value="+0.302"/>
+  </haloMassFunction>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.01"/>
+    <mergeProbability value="0.1"/>
+    <branchIntervalStep value="true"/>
+    <redshiftMaximum    value="12.0"/>
+    <toleranceTimeEarliest value="1.0e-5"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="PCHPlus">
+    <!-- Merger tree branching rates are computed using the PCH+ algorithm, with parameters constrained to match progenitor -->
+    <!-- mass functions in the MDPL simulation suite.                                                                       -->
+    <!-- See: https://github.com/galacticusorg/galacticus/wiki/Constraints:-Dark-matter-progenitor-halo-mass-functions      -->
+    <!-- CDM assumptions are used here to speed up tree construction.                                                       -->
+    <G0                 value="+1.1425468378985500"/>
+    <gamma1             value="-0.3273597030267590"/>
+    <gamma2             value="+0.0587448775510245"/>
+    <gamma3             value="+0.6456170934757410"/>
+    <accuracyFirstOrder value="+0.1000000000000000"/>
+    <cdmAssumptions     value="true"               />
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMinimum value="1.0e9"/>
+    <massTreeMaximum value="18.0e9"/>
+    <treesPerDecade value="3000"/>
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e6"/>
+  </mergerTreeMassResolution>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileConcentration value="diemerJoyce2019">
+    <scatter value="0.16"/>
+  </darkMatterProfileConcentration>
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="filtered">
+      <galacticFilter value="mainBranch"/>
+      <nodeOperator value="darkMatterProfileScaleSet">
+	<factorReset value="1.0"/>
+	<darkMatterProfileScaleRadius value="concentrationLimiter">
+	  <concentrationMinimum value="  2.0"/>
+	  <concentrationMaximum value="100.0"/>
+	  <darkMatterProfileScaleRadius value="johnson2021">
+	    <!-- Scale radii are computed using the energy random walk model of Johnson, Benson, & Grin (2021; ApJ; 908; 33;
+		 http://adsabs.harvard.edu/abs/2021ApJ...908...33J). Best-fit values of the parameters are taken from that
+		 paper. -->
+	    <energyBoost      value="0.673"/>
+	    <massExponent     value="1.518"/>
+	    <unresolvedEnergy value="0.550"/>
+	    <darkMatterProfileScaleRadius value="concentration"/>
+	  </darkMatterProfileScaleRadius>
+	</darkMatterProfileScaleRadius>
+      </nodeOperator>
+    </nodeOperator>
+    <nodeOperator value="filtered">
+      <galacticFilter value="not">
+	<galacticFilter value="mainBranch"/>
+      </galacticFilter>
+      <nodeOperator value="darkMatterProfileScaleSet">
+	<factorReset value="2.0"/>
+	<darkMatterProfileScaleRadius value="concentrationLimiter">
+	  <concentrationMinimum value="  2.0"/>
+	  <concentrationMaximum value="100.0"/>
+	  <darkMatterProfileScaleRadius value="concentration"/>
+	</darkMatterProfileScaleRadius>
+      </nodeOperator>
+    </nodeOperator>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"   />
+  </nodeOperator>
+  
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Evolvers -->
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/concentrationDistributionJohnson2021.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <redshifts value="0.0"/>
+  </outputTimes>
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="nodeIndices"/>
+    <nodePropertyExtractor value="massHalo">
+      <virialDensityContrastDefinition value="fixed">
+	<densityContrastValue value="200"/>
+	<densityType value="critical"/>
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="concentration">
+      <virialDensityContrastDefinition value="fixed">
+	<densityContrastValue value="200"/>
+	<densityType value="critical"/>
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+  </nodePropertyExtractor>
+ 
+</parameters>

--- a/testSuite/parameters/concentrationDistributionJohnson2021Subsample1e7.xml
+++ b/testSuite/parameters/concentrationDistributionJohnson2021Subsample1e7.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="3f3d9a2af2b05c0a279e4aa3602f89fd682665cc"/>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="null"/>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="null"/>
+  <componentSpin value="null"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant  value="70.400000"/>
+    <OmegaMatter     value=" 0.272000"/>
+    <OmegaDarkEnergy value=" 0.728000"/>
+    <OmegaBaryon     value=" 0.0000000"/>
+    <temperatureCMB  value=" 2.725480"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction        value="CAMB"     >
+    <cosmologyParameters value="simple">
+      <HubbleConstant  value="70.400000"/>
+      <OmegaMatter     value=" 0.272000"/>
+      <OmegaDarkEnergy value=" 0.728000"/>
+      <OmegaBaryon     value=" 0.044550"/>
+      <temperatureCMB  value=" 2.725480"/>
+    </cosmologyParameters>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw" >
+    <index               value="0.967"/>
+    <wavenumberReference value="1.000"/>
+    <running             value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.81"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="shethTormen">
+    <a             value="+0.791"/>
+    <p             value="+0.218"/>
+    <normalization value="+0.302"/>
+  </haloMassFunction>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.01"/>
+    <mergeProbability value="0.1"/>
+    <branchIntervalStep value="true"/>
+    <redshiftMaximum    value="12.0"/>
+    <toleranceTimeEarliest value="1.0e-5"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="PCHPlus">
+    <!-- Merger tree branching rates are computed using the PCH+ algorithm, with parameters constrained to match progenitor -->
+    <!-- mass functions in the MDPL simulation suite.                                                                       -->
+    <!-- See: https://github.com/galacticusorg/galacticus/wiki/Constraints:-Dark-matter-progenitor-halo-mass-functions      -->
+    <!-- CDM assumptions are used here to speed up tree construction.                                                       -->
+    <G0                 value="+1.1425468378985500"/>
+    <gamma1             value="-0.3273597030267590"/>
+    <gamma2             value="+0.0587448775510245"/>
+    <gamma3             value="+0.6456170934757410"/>
+    <accuracyFirstOrder value="+0.1000000000000000"/>
+    <cdmAssumptions     value="true"               />
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMinimum value="1.0e9"/>
+    <massTreeMaximum value="18.0e9"/>
+    <treesPerDecade value="3000"/>
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e6"/>
+  </mergerTreeMassResolution>
+  <mergerTreeBuildController value="subsample">
+    <massThreshold               value="1.0e7"/>
+    <subsamplingRateAtThreshold  value="1.0"  />
+    <exponent                    value="1.0"  />
+    <destroyStubs                value="sideBranchesOnly"/>
+    <factorMassGrowthConsolidate value="0.01" />
+  </mergerTreeBuildController>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileConcentration value="diemerJoyce2019">
+    <scatter value="0.16"/>
+  </darkMatterProfileConcentration>
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="filtered">
+      <galacticFilter value="mainBranch"/>
+      <nodeOperator value="darkMatterProfileScaleSet">
+	<factorReset value="1.0"/>
+	<darkMatterProfileScaleRadius value="concentrationLimiter">
+	  <concentrationMinimum value="  2.0"/>
+	  <concentrationMaximum value="100.0"/>
+	  <darkMatterProfileScaleRadius value="johnson2021">
+	    <!-- Scale radii are computed using the energy random walk model of Johnson, Benson, & Grin (2021; ApJ; 908; 33;
+		 http://adsabs.harvard.edu/abs/2021ApJ...908...33J). Best-fit values of the parameters are taken from that
+		 paper. -->
+	    <energyBoost      value="0.673"/>
+	    <massExponent     value="1.518"/>
+	    <unresolvedEnergy value="0.550"/>
+	    <darkMatterProfileScaleRadius value="concentration"/>
+	  </darkMatterProfileScaleRadius>
+	</darkMatterProfileScaleRadius>
+      </nodeOperator>
+    </nodeOperator>
+    <nodeOperator value="filtered">
+      <galacticFilter value="not">
+	<galacticFilter value="mainBranch"/>
+      </galacticFilter>
+      <nodeOperator value="darkMatterProfileScaleSet">
+	<factorReset value="2.0"/>
+	<darkMatterProfileScaleRadius value="concentrationLimiter">
+	  <concentrationMinimum value="  2.0"/>
+	  <concentrationMaximum value="100.0"/>
+	  <darkMatterProfileScaleRadius value="concentration"/>
+	</darkMatterProfileScaleRadius>
+      </nodeOperator>
+    </nodeOperator>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"   />
+    <!-- Clean up subsampled branch stubs -->
+    <nodeOperator value="cleanSubsampleStubs">
+      <factorMassGrowthConsolidate value="0.01"/>
+    </nodeOperator>
+  </nodeOperator>
+  
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Evolvers -->
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/concentrationDistributionJohnson2021Subsample1e7.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <redshifts value="0.0"/>
+  </outputTimes>
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="nodeIndices"/>
+    <nodePropertyExtractor value="massHalo">
+      <virialDensityContrastDefinition value="fixed">
+	<densityContrastValue value="200"/>
+	<densityType value="critical"/>
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="concentration">
+      <virialDensityContrastDefinition value="fixed">
+	<densityContrastValue value="200"/>
+	<densityType value="critical"/>
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+  </nodePropertyExtractor>
+ 
+</parameters>

--- a/testSuite/parameters/concentrationDistributionJohnson2021Subsample1e8.xml
+++ b/testSuite/parameters/concentrationDistributionJohnson2021Subsample1e8.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="3f3d9a2af2b05c0a279e4aa3602f89fd682665cc"/>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="null"/>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="null"/>
+  <componentSpin value="null"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant  value="70.400000"/>
+    <OmegaMatter     value=" 0.272000"/>
+    <OmegaDarkEnergy value=" 0.728000"/>
+    <OmegaBaryon     value=" 0.0000000"/>
+    <temperatureCMB  value=" 2.725480"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction        value="CAMB"     >
+    <cosmologyParameters value="simple">
+      <HubbleConstant  value="70.400000"/>
+      <OmegaMatter     value=" 0.272000"/>
+      <OmegaDarkEnergy value=" 0.728000"/>
+      <OmegaBaryon     value=" 0.044550"/>
+      <temperatureCMB  value=" 2.725480"/>
+    </cosmologyParameters>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw" >
+    <index               value="0.967"/>
+    <wavenumberReference value="1.000"/>
+    <running             value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.81"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="shethTormen">
+    <a             value="+0.791"/>
+    <p             value="+0.218"/>
+    <normalization value="+0.302"/>
+  </haloMassFunction>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.01"/>
+    <mergeProbability value="0.1"/>
+    <branchIntervalStep value="true"/>
+    <redshiftMaximum    value="12.0"/>
+    <toleranceTimeEarliest value="1.0e-5"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="PCHPlus">
+    <!-- Merger tree branching rates are computed using the PCH+ algorithm, with parameters constrained to match progenitor -->
+    <!-- mass functions in the MDPL simulation suite.                                                                       -->
+    <!-- See: https://github.com/galacticusorg/galacticus/wiki/Constraints:-Dark-matter-progenitor-halo-mass-functions      -->
+    <!-- CDM assumptions are used here to speed up tree construction.                                                       -->
+    <G0                 value="+1.1425468378985500"/>
+    <gamma1             value="-0.3273597030267590"/>
+    <gamma2             value="+0.0587448775510245"/>
+    <gamma3             value="+0.6456170934757410"/>
+    <accuracyFirstOrder value="+0.1000000000000000"/>
+    <cdmAssumptions     value="true"               />
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMinimum value="1.0e9"/>
+    <massTreeMaximum value="18.0e9"/>
+    <treesPerDecade value="3000"/>
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e6"/>
+  </mergerTreeMassResolution>
+  <mergerTreeBuildController value="subsample">
+    <massThreshold               value="1.0e8"/>
+    <subsamplingRateAtThreshold  value="1.0"  />
+    <exponent                    value="1.0"  />
+    <destroyStubs                value="sideBranchesOnly"/>
+    <factorMassGrowthConsolidate value="0.01" />
+  </mergerTreeBuildController>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileConcentration value="diemerJoyce2019">
+    <scatter value="0.16"/>
+  </darkMatterProfileConcentration>
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="filtered">
+      <galacticFilter value="mainBranch"/>
+      <nodeOperator value="darkMatterProfileScaleSet">
+	<factorReset value="1.0"/>
+	<darkMatterProfileScaleRadius value="concentrationLimiter">
+	  <concentrationMinimum value="  2.0"/>
+	  <concentrationMaximum value="100.0"/>
+	  <darkMatterProfileScaleRadius value="johnson2021">
+	    <!-- Scale radii are computed using the energy random walk model of Johnson, Benson, & Grin (2021; ApJ; 908; 33;
+		 http://adsabs.harvard.edu/abs/2021ApJ...908...33J). Best-fit values of the parameters are taken from that
+		 paper. -->
+	    <energyBoost      value="0.673"/>
+	    <massExponent     value="1.518"/>
+	    <unresolvedEnergy value="0.550"/>
+	    <darkMatterProfileScaleRadius value="concentration"/>
+	  </darkMatterProfileScaleRadius>
+	</darkMatterProfileScaleRadius>
+      </nodeOperator>
+    </nodeOperator>
+    <nodeOperator value="filtered">
+      <galacticFilter value="not">
+	<galacticFilter value="mainBranch"/>
+      </galacticFilter>
+      <nodeOperator value="darkMatterProfileScaleSet">
+	<factorReset value="2.0"/>
+	<darkMatterProfileScaleRadius value="concentrationLimiter">
+	  <concentrationMinimum value="  2.0"/>
+	  <concentrationMaximum value="100.0"/>
+	  <darkMatterProfileScaleRadius value="concentration"/>
+	</darkMatterProfileScaleRadius>
+      </nodeOperator>
+    </nodeOperator>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"   />
+    <!-- Clean up subsampled branch stubs -->
+    <nodeOperator value="cleanSubsampleStubs">
+      <factorMassGrowthConsolidate value="0.01"/>
+    </nodeOperator>
+  </nodeOperator>
+  
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Evolvers -->
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/concentrationDistributionJohnson2021Subsample1e8.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <redshifts value="0.0"/>
+  </outputTimes>
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="nodeIndices"/>
+    <nodePropertyExtractor value="massHalo">
+      <virialDensityContrastDefinition value="fixed">
+	<densityContrastValue value="200"/>
+	<densityType value="critical"/>
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="concentration">
+      <virialDensityContrastDefinition value="fixed">
+	<densityContrastValue value="200"/>
+	<densityType value="critical"/>
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+  </nodePropertyExtractor>
+ 
+</parameters>

--- a/testSuite/test-concentration-Johnson2021.pl
+++ b/testSuite/test-concentration-Johnson2021.pl
@@ -1,0 +1,96 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib $ENV{'GALACTICUS_EXEC_PATH'}."/perl";
+use PDL;
+use PDL::NiceSlice;
+use PDL::IO::HDF5;
+use PDL::Stats::Basic;
+use System::Redirect;
+use File::Slurp qw(slurp);
+
+# Run models that check that the results of Johnson, Benson & Grin (2021; https://ui.adsabs.harvard.edu/abs/2021ApJ...908...33J)
+# applying their concentration model to merger trees can be reproduced.
+# Andrew Benson (23-September-2024)
+
+# Make output directory.
+system("mkdir -p outputs/");
+
+# Specify the tests to run. Mean and tolerance targets are taken from Table 2 of Benson, Ludlow, & Cole (2019).
+my @tests =
+    (
+     {
+	 # Model with no subsampling.
+	 suffix           => "",
+	 mean             => 1.104,
+	 meanTolerance    => 0.040,
+	 scatter          => 0.103,
+	 scatterTolerance => 0.040
+     },
+     {
+	 # Model with subsampling below 10⁸M☉.
+	 suffix           => "Subsample1e8",
+	 mean             => 1.104,
+	 meanTolerance    => 0.040,
+	 scatter          => 0.103,
+	 scatterTolerance => 0.040
+     },
+     {
+	 # Model with subsampling below 10⁷M☉.
+	 suffix           => "Subsample1e7",
+	 mean             => 1.104,
+	 meanTolerance    => 0.040,
+	 scatter          => 0.103,
+	 scatterTolerance => 0.040
+     }
+    );
+
+# Iterate over tests.
+foreach my $test ( @tests ) {
+
+    # Run the model.
+    system("cd ..; ./Galacticus.exe testSuite/parameters/concentrationDistributionJohnson2021".ucfirst($test->{'suffix'}).".xml");
+    unless ( $? == 0 ) {
+	print "FAILED: Johnson2021 ".$test->{'suffix'}." concentration model failed to run\n";
+	exit;
+    }
+    
+    # Select halos in the mass range used for the results in Table 2 of Benson, Ludlow, & Cole (2019), and compute the mean and
+    # scatter in concentration.
+    my $model          = new PDL::IO::HDF5("outputs/concentrationDistributionJohnson2021".ucfirst($test->{'suffix'}).".hdf5");
+    my $outputs        = $model   ->group  ('Outputs'                )       ;
+    my $output         = $outputs ->group  ('Output1'                )       ;
+    my $nodeData       = $output  ->group  ('nodeData'               )       ;
+    my $nodeIsIsolated = $nodeData->dataset('nodeIsIsolated'         )->get();
+    my $massHalo       = $nodeData->dataset('massHaloEnclosedCurrent')->get();
+    my $concentration  = $nodeData->dataset('concentration'          )->get();
+    # Compute N-body measurement uncertainties to both halo masses and concentrations.
+    my $massParticle             = pdl 1.6e5; # COCO simulation particle mass.
+    my $countParticles           = $massHalo/$massParticle;
+    my $alpha                    = -0.20+1.46*log10($concentration)-0.25*log10($concentration)**2;
+    my $b                        = -0.54;
+    my $concentrationUncertainty = 10.0**($alpha+$b*log10($countParticles)); # Concentration uncertainty model from equation 5 of Benson, Ludlow, & Cole (2019).
+    my $massUncertainty          = 0.135*(1000.0/$countParticles)**(1.0/3.0); # Mass uncertainty model from Trenti et al. (2010; http://adsabs.harvard.edu/abs/2012ApJ...747..100S).
+    # Construct perturbed halo masses.
+    my $massMeasured = $massHalo*exp($massUncertainty*grandom(nelem($massHalo)));
+    # Select halos for inclusion.
+    my $selection = which(($nodeIsIsolated == 1) & ($massMeasured->log10() >= 9.402) & ($massMeasured->log10() < 9.902));
+    # Construct perturbed concentrations.
+    my $concentrationsMeasured = $concentration->log10()->($selection)+$concentrationUncertainty->($selection)*grandom(nelem($selection));
+    # Evaluate the mean and scatter and check these match the target values.
+    my $mean    = $concentrationsMeasured->average();
+    my $scatter = $concentrationsMeasured->stdv();
+    print "Mean   : ".sprintf("%5.3f",$mean   )." (target = ".$test->{'mean'   }." ± ".$test->{'meanTolerance'   }.")\n";
+    print "Scatter: ".sprintf("%5.3f",$scatter)." (target = ".$test->{'scatter'}." ± ".$test->{'scatterTolerance'}.")\n";
+    my $status  =
+	(
+	 abs($mean   -$test->{'mean'   }) < $test->{'meanTolerance'   }
+	 &&
+	 abs($scatter-$test->{'scatter'}) < $test->{'scatterTolerance'}
+	)
+	? "SUCCESS"
+	: "FAILED";
+    print $status.": Johnson2021 ".$test->{'suffix'}." concentration\n";
+}
+
+exit;


### PR DESCRIPTION
- Fix a bug in consolidating branches where the set of nodes consolidated was erroneously shifted by one node.

- Allow the `nodeOperatorDarkMatterProfileScaleSet` class to only update scale radii after some amount of mass growth.

- Add a test of the `darkMatterProfileScaleRadiusJohnson2021` class when subsampling is used.