### PR TITLE
Allow different fractions of angular momentum to be retained in disk and spheroid during disk instabilities

### DIFF
--- a/parameters/baryonicPhysicsConfig.xml
+++ b/parameters/baryonicPhysicsConfig.xml
@@ -132,7 +132,7 @@
        </distributionFunction1DPerturber>
      </modelParameter>
      <modelParameter value="active">
-       <name value="nodeOperator::nodeOperator[4]::galacticDynamicsBarInstability::fractionAngularMomentumRetained"/>
+       <name value="nodeOperator::nodeOperator[4]::galacticDynamicsBarInstability::fractionAngularMomentumRetainedDisk"/>
        <distributionFunction1DPrior value="uniform">
 	 <limitLower value="0.0"/>
 	 <limitUpper value="1.0"/>

--- a/parameters/baryonicPhysicsConstrained.xml
+++ b/parameters/baryonicPhysicsConstrained.xml
@@ -250,7 +250,7 @@
       <galacticDynamicsBarInstability value="efstathiou1982">
 	<stabilityThresholdGaseous value="0.751314746070123"/>
 	<stabilityThresholdStellar value="0.757125972218825"/>
-	<fractionAngularMomentumRetained value="0.951702062215515"/>
+	<fractionAngularMomentumRetainedDisk value="0.951702062215515"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <!-- Halo concentrations -->

--- a/scripts/aux/migrations.xml
+++ b/scripts/aux/migrations.xml
@@ -199,6 +199,11 @@
   <migration commit="7030a7dab187c4e0aa5112681b3273647595bbde">
     <translation function="radiationFieldIntergalacticBackgroundCMB"/>
   </migration>
+  <migration commit="bdcfda39270bcb782937b8106034dd32144f44cd">
+    <translation xpath="//galacticDynamicsBarInstability[@value='efstathiou1982' or @value='efstathiou1982Tidal' or @value='fixedTimescale']/fractionAngularMomentumRetained[@value]">
+      <name new="fractionAngularMomentumRetainedDisk"/>
+    </translation>
+  </migration>
 
   <!-- Known default values for parameters -->
   <default parameter="componentBlackHole"             value="standard"        />

--- a/source/galactic_dynamics.bar_instability.Efstathiou1982Tidal.F90
+++ b/source/galactic_dynamics.bar_instability.Efstathiou1982Tidal.F90
@@ -105,21 +105,21 @@ contains
     return
   end function efstathiou1982TidalConstructorParameters
 
-  function efstathiou1982TidalConstructorInternal(stabilityThresholdStellar,stabilityThresholdGaseous,timescaleMinimum,fractionAngularMomentumRetained_,massThresholdHarrassment,satelliteTidalField_) result(self)
+  function efstathiou1982TidalConstructorInternal(stabilityThresholdStellar,stabilityThresholdGaseous,timescaleMinimum,fractionAngularMomentumRetainedDisk_,fractionAngularMomentumRetainedSpheroid_,massThresholdHarrassment,satelliteTidalField_) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily efstathiou1982Tidal} model for galactic disk bar instability class.
     !!}
     implicit none
     type            (galacticDynamicsBarInstabilityEfstathiou1982Tidal)                        :: self
-    double precision                                                   , intent(in   )         :: stabilityThresholdStellar, stabilityThresholdGaseous       , &
-         &                                                                                        timescaleMinimum         , fractionAngularMomentumRetained_, &
-         &                                                                                        massThresholdHarrassment
+    double precision                                                   , intent(in   )         :: stabilityThresholdStellar, stabilityThresholdGaseous               , &
+         &                                                                                        timescaleMinimum         , fractionAngularMomentumRetainedDisk_    , &
+         &                                                                                        massThresholdHarrassment , fractionAngularMomentumRetainedSpheroid_
     class           (satelliteTidalFieldClass                         ), intent(in   ), target :: satelliteTidalField_
     !![
     <constructorAssign variables="massThresholdHarrassment, *satelliteTidalField_"/>
     !!]
 
-    self%galacticDynamicsBarInstabilityEfstathiou1982=galacticDynamicsBarInstabilityEfstathiou1982(stabilityThresholdStellar,stabilityThresholdGaseous,timescaleMinimum,fractionAngularMomentumRetained_)
+    self%galacticDynamicsBarInstabilityEfstathiou1982=galacticDynamicsBarInstabilityEfstathiou1982(stabilityThresholdStellar,stabilityThresholdGaseous,timescaleMinimum,fractionAngularMomentumRetainedDisk_,fractionAngularMomentumRetainedSpheroid_)
     return
   end function efstathiou1982TidalConstructorInternal
 
@@ -136,7 +136,7 @@ contains
     return
   end subroutine efstathiou1982Destructor
 
-  subroutine efstathiou1982TidalTimescale(self,node,timescale,externalDrivingSpecificTorque,fractionAngularMomentumRetained)
+  subroutine efstathiou1982TidalTimescale(self,node,timescale,externalDrivingSpecificTorque,fractionAngularMomentumRetainedDisk,fractionAngularMomentumRetainedSpheroid)
     !!{
     Computes a timescale for depletion of a disk to a pseudo-bulge via bar instability based on the criterion of
     \cite{efstathiou_stability_1982}.
@@ -145,11 +145,11 @@ contains
     implicit none
     class           (galacticDynamicsBarInstabilityEfstathiou1982Tidal), intent(inout) :: self
     type            (treeNode                                         ), intent(inout) :: node
-    double precision                                                   , intent(  out) :: externalDrivingSpecificTorque  , timescale, &
-         &                                                                                fractionAngularMomentumRetained
+    double precision                                                   , intent(  out) :: externalDrivingSpecificTorque      , timescale                              , &
+         &                                                                                fractionAngularMomentumRetainedDisk, fractionAngularMomentumRetainedSpheroid
     class           (nodeComponentSpheroid                            ), pointer       :: spheroid
 
-    call self%galacticDynamicsBarInstabilityEfstathiou1982%timescale(node,timescale,externalDrivingSpecificTorque,fractionAngularMomentumRetained)
+    call self%galacticDynamicsBarInstabilityEfstathiou1982%timescale(node,timescale,externalDrivingSpecificTorque,fractionAngularMomentumRetainedDisk,fractionAngularMomentumRetainedSpheroid)
     ! Compute the external torque.
     if (timescale > 0.0d0) then
        spheroid                      =>  node    %spheroid         (    )

--- a/source/galactic_dynamics.bar_instability.F90
+++ b/source/galactic_dynamics.bar_instability.F90
@@ -40,12 +40,12 @@ module Galactic_Dynamics_Bar_Instabilities
     <description>
      Returns a timescale on which the bar instability depletes material from a disk into a pseudo-bulge. A negative value
      indicates no instability. Also returns the net torque due to any external force causing this instability, and the fraction of
-     the angular momentum of the material depleted into the pseudo-bulge which is retained by the disk.
+     the angular momentum of the material depleted into the pseudo-bulge which is retained by the disk and the spheroid.
      </description>
     <type>void</type>
     <pass>yes</pass>
     <argument>type            (treeNode), intent(inout) :: node</argument>
-    <argument>double precision          , intent(  out) :: timescale, externalDrivingSpecificTorque, fractionAngularMomentumRetained</argument>
+    <argument>double precision          , intent(  out) :: timescale, externalDrivingSpecificTorque, fractionAngularMomentumRetainedDisk, fractionAngularMomentumRetainedSpheroid</argument>
    </method>
   </functionClass>
   !!]

--- a/source/galactic_dynamics.bar_instability.fixed_timescale.F90
+++ b/source/galactic_dynamics.bar_instability.fixed_timescale.F90
@@ -31,7 +31,8 @@
      Implementation of a simple model for galactic disk bar instability in which the timescale is fixed.
      !!}
      private
-     double precision :: timescale_, fractionAngularMomentumRetained
+     double precision :: fractionAngularMomentumRetainedDisk, fractionAngularMomentumRetainedSpheroid, &
+          &              timescale_
    contains
      procedure :: timescale => fixedTimescaleTimescale
   end type galacticDynamicsBarInstabilityFixedTimescale
@@ -55,7 +56,8 @@ contains
     implicit none
     type            (galacticDynamicsBarInstabilityFixedTimescale)                :: self
     type            (inputParameters                             ), intent(inout) :: parameters
-    double precision                                                              :: timescale , fractionAngularMomentumRetained
+    double precision                                                              :: fractionAngularMomentumRetainedDisk, fractionAngularMomentumRetainedSpheroid, &
+         &                                                                           timescale
 
     !![
     <inputParameter>
@@ -65,46 +67,54 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter>
-      <name>fractionAngularMomentumRetained</name>
+      <name>fractionAngularMomentumRetainedDisk</name>
       <defaultValue>1.0d0</defaultValue>
       <description>The fraction of angular momentum of material depleted from the disk by bar instability which is retained in the disk.</description>
       <source>parameters</source>
     </inputParameter>
+    <inputParameter>
+      <name>fractionAngularMomentumRetainedSpheroid</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>The fraction of angular momentum of material depleted from the disk by bar instability which is retained in the spheroid.</description>
+      <source>parameters</source>
+    </inputParameter>
     !!]
-    self=galacticDynamicsBarInstabilityFixedTimescale(timescale,fractionAngularMomentumRetained)
+    self=galacticDynamicsBarInstabilityFixedTimescale(timescale,fractionAngularMomentumRetainedDisk,fractionAngularMomentumRetainedSpheroid)
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function fixedTimescaleConstructorParameters
 
-  function fixedTimescaleConstructorInternal(timescale_,fractionAngularMomentumRetained) result(self)
+  function fixedTimescaleConstructorInternal(timescale_,fractionAngularMomentumRetainedDisk,fractionAngularMomentumRetainedSpheroid) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily fixedTimescale} model for galactic disk bar instability class.
     !!}
     implicit none
     type            (galacticDynamicsBarInstabilityFixedTimescale)                :: self
-    double precision                                              , intent(in   ) :: timescale_, fractionAngularMomentumRetained
+    double precision                                              , intent(in   ) :: fractionAngularMomentumRetainedDisk, fractionAngularMomentumRetainedSpheroid, &
+         &                                                                           timescale_
     !![
-    <constructorAssign variables="timescale_, fractionAngularMomentumRetained"/>
+    <constructorAssign variables="timescale_, fractionAngularMomentumRetainedDisk, fractionAngularMomentumRetainedSpheroid"/>
     !!]
 
     return
   end function fixedTimescaleConstructorInternal
 
-  subroutine fixedTimescaleTimescale(self,node,timescale,externalDrivingSpecificTorque,fractionAngularMomentumRetained)
+  subroutine fixedTimescaleTimescale(self,node,timescale,externalDrivingSpecificTorque,fractionAngularMomentumRetainedDisk,fractionAngularMomentumRetainedSpheroid)
     !!{
     Assume a constant timescale for depletion of a disk to a pseudo-bulge via bar instability.
     !!}
     implicit none
     class           (galacticDynamicsBarInstabilityFixedTimescale), intent(inout) :: self
     type            (treeNode                                    ), intent(inout) :: node
-    double precision                                              , intent(  out) :: externalDrivingSpecificTorque  , timescale, &
-         &                                                                           fractionAngularMomentumRetained
+    double precision                                              , intent(  out) :: externalDrivingSpecificTorque      , timescale                              , &
+         &                                                                           fractionAngularMomentumRetainedDisk, fractionAngularMomentumRetainedSpheroid
     !$GLC attributes unused :: node
 
-    timescale                      =self%timescale_
-    fractionAngularMomentumRetained=self%fractionAngularMomentumRetained
-    externalDrivingSpecificTorque  =0.0d0
+    timescale                              =self%timescale_
+    fractionAngularMomentumRetainedDisk    =self%fractionAngularMomentumRetainedDisk
+    fractionAngularMomentumRetainedSpheroid=self%fractionAngularMomentumRetainedSpheroid
+    externalDrivingSpecificTorque          =0.0d0
     return
   end subroutine fixedTimescaleTimescale

--- a/source/galactic_dynamics.bar_instability.stable.F90
+++ b/source/galactic_dynamics.bar_instability.stable.F90
@@ -64,7 +64,7 @@ contains
     return
   end function stableConstructorParameters
 
-  subroutine stableTimescale(self,node,timescale,externalDrivingSpecificTorque,fractionAngularMomentumRetained)
+  subroutine stableTimescale(self,node,timescale,externalDrivingSpecificTorque,fractionAngularMomentumRetainedDisk,fractionAngularMomentumRetainedSpheroid)
     !!{
     Computes a timescale for depletion of a disk to a pseudo-bulge via bar instability based on the criterion of
     \cite{efstathiou_stability_1982}.
@@ -72,15 +72,16 @@ contains
     implicit none
     class           (galacticDynamicsBarInstabilityStable), intent(inout) :: self
     type            (treeNode                            ), intent(inout) :: node
-    double precision                                      , intent(  out) :: externalDrivingSpecificTorque  , timescale, &
-         &                                                                   fractionAngularMomentumRetained
+    double precision                                      , intent(  out) :: externalDrivingSpecificTorque      , timescale                              , &
+         &                                                                   fractionAngularMomentumRetainedDisk, fractionAngularMomentumRetainedSpheroid
     !$GLC attributes unused :: self, node
 
     ! Assume infinite timescale (i.e. no instability).
     timescale                      =-1.0d0
     ! Also assume no torque.
     externalDrivingSpecificTorque  =+0.0d0
-    ! Fraction of angular momentum retained is arbitrary.
-    fractionAngularMomentumRetained=+1.0d0
+    ! Fractions of angular momentum retained are arbitrary.
+    fractionAngularMomentumRetainedDisk    =+1.0d0
+    fractionAngularMomentumRetainedSpheroid=+1.0d0
     return
   end subroutine stableTimescale

--- a/source/merger_trees.operators.scale_weight.F90
+++ b/source/merger_trees.operators.scale_weight.F90
@@ -1,0 +1,98 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Implements a merger tree operator that scales the weight of each tree by a fixed factor.
+!!}
+
+  !![
+  <mergerTreeOperator name="mergerTreeOperatorScaleWeight">
+   <description>A merger tree operator that scales the weight of each tree by a fixed factor.</description>
+  </mergerTreeOperator>
+  !!]
+  type, extends(mergerTreeOperatorClass) :: mergerTreeOperatorScaleWeight
+     !!{
+     A merger tree operator that scales the weight of each tree by a fixed factor.
+     !!}
+     private
+     double precision :: scaleFactor
+   contains
+     procedure :: operatePreInitialization => scaleFactorOperatePreInitialization
+  end type mergerTreeOperatorScaleWeight
+
+  interface mergerTreeOperatorScaleWeight
+     !!{
+     Constructors for the scaleWeight merger tree operator class.
+     !!}
+     module procedure scaleWeightConstructorParameters
+     module procedure scaleWeightConstructorInternal
+  end interface mergerTreeOperatorScaleWeight
+
+contains
+
+  function scaleWeightConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the scaleWeight merger tree operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (mergerTreeOperatorScaleWeight)                :: self
+    type            (inputParameters              ), intent(inout) :: parameters
+    double precision                                               :: scaleFactor
+    
+    !![
+    <inputParameter>
+      <name>scaleFactor</name>
+      <description>The factor by which to scale merger tree weights.</description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=mergerTreeOperatorScaleWeight(scaleFactor)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function scaleWeightConstructorParameters
+
+  function scaleWeightConstructorInternal(scaleFactor) result(self)
+    !!{
+    Internal constructor for the scaleWeight merger tree operator class.
+    !!}
+    implicit none
+    type            (mergerTreeOperatorScaleWeight)                :: self
+    double precision                               , intent(inout) :: scaleFactor
+    !![
+    <constructorAssign variables="scaleFactor"/>
+    !!]
+    
+    return
+  end function scaleWeightConstructorInternal
+
+  subroutine scaleFactorOperatePreInitialization(self,tree)
+    !!{
+    Scale the weight of a merger tree by a fixed factor.
+    !!}
+    implicit none
+    class(mergerTreeOperatorScaleWeight), intent(inout), target :: self
+    type (mergerTree                   ), intent(inout), target :: tree
+
+    tree%volumeWeight=+tree%volumeWeight &
+         &            *self%scaleFactor
+    return
+  end subroutine scaleFactorOperatePreInitialization

--- a/source/nodes.property_extractor.bar_instability_timescale.F90
+++ b/source/nodes.property_extractor.bar_instability_timescale.F90
@@ -108,10 +108,11 @@ contains
     class           (nodePropertyExtractorTimescaleBarInstability), intent(inout), target   :: self
     type            (treeNode                                    ), intent(inout), target   :: node
     type            (multiCounter                                ), intent(inout), optional :: instance
-    double precision                                                                        :: torqueSpecificExternal, fractionAngularMomentumRetained
+    double precision                                                                        :: fractionAngularMomentumRetainedDisk, fractionAngularMomentumRetainedSpheroid, &
+         &                                                                                     torqueSpecificExternal
     !$GLC attributes unused :: instance
 
-    call self%galacticDynamicsBarInstability_%timescale(node,timescaleBarInstabilityExtract,torqueSpecificExternal,fractionAngularMomentumRetained)
+    call self%galacticDynamicsBarInstability_%timescale(node,timescaleBarInstabilityExtract,torqueSpecificExternal,fractionAngularMomentumRetainedDisk,fractionAngularMomentumRetainedSpheroid)
     return
   end function timescaleBarInstabilityExtract
 


### PR DESCRIPTION
Also adds a merger tree operator that scales the weight of each tree by a fixed factor.
