### PR TITLE
Add a trailing newline to the last line of source files if not present when preprocessing

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Process/SourceIntrospection.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/SourceIntrospection.pm
@@ -16,6 +16,10 @@ sub ReadFile {
     my $fileName  = shift();
     my (%options) = @_;
     my $code      = slurp($fileName);
+    # Ensure that there is a newline character on the last line of the file. (Some editors do not add this automatically.)
+    $code .= "\n"
+	if (substr($code,-1) ne "\n");
+    my $str = substr($code,-1);
     $code         = &Instrument($code)
 	unless ( exists($options{'instrument'}) && ! $options{'instrument'} );
     return $code;


### PR DESCRIPTION
Some editors do not add a newline to the last line of the file by default. The lack of a newline can cause problems with parsing the file as this last line may be concatenated with further code - with no newline the concatenated code will be erroneously appended to the last line.