### PR TITLE
Catch cases where the characteristic angular momentum decreases with time in the `nodeOperatorHaloAngularMomentumRandomWalk` class

### DIFF
--- a/source/nodes.operators.physics.halo_angular_momentum.Vitvitska2002.F90
+++ b/source/nodes.operators.physics.halo_angular_momentum.Vitvitska2002.F90
@@ -137,6 +137,8 @@ contains
     !!{
     Internal constructor for the {\normalfont \ttfamily haloAngularMomentumVitvitska2002} node operator class.
     !!}
+    use :: Error           , only : Component_List      , Error_Report
+    use :: Galacticus_Nodes, only : defaultSpinComponent
     implicit none
     type            (nodeOperatorHaloAngularMomentumVitvitska2002)                        :: self
     class           (haloSpinDistributionClass                   ), intent(in   ), target :: haloSpinDistribution_
@@ -150,6 +152,24 @@ contains
     <constructorAssign variables="exponentMass, angularMomentumVarianceSpecific, *darkMatterProfileScaleRadius_, *haloSpinDistribution_, *darkMatterProfileDMO_, *darkMatterHaloScale_, *virialOrbit_, *mergerTreeMassResolution_"/>
     !!]
 
+    ! Ensure that the spin component supports vector angular momentum.
+    if     (                                                                                                                               &
+         &  .not.                                                                                                                          &
+         &   (                                                                                                                             &
+         &     defaultSpinComponent%angularMomentumVectorIsGettable()                                                                      &
+         &    .and.                                                                                                                        &
+         &     defaultSpinComponent%angularMomentumVectorIsSettable()                                                                      &
+         &   )                                                                                                                             &
+         & )                                                                                                                               &
+         & call Error_Report                                                                                                               &
+         &      (                                                                                                                          &
+         &       'method requires a spin component that provides a gettable and settable "angularMomentumVector" property.'             // &
+         &       Component_List(                                                                                                           &
+         &                      'spin'                                                                                                  ,  &
+         &                       defaultSpinComponent%angularMomentumVectorAttributeMatch(requireGettable=.true.,requireSettable=.true.)   &
+         &                     )                                                                                                        // &
+         &       {introspection:location}                                                                                                  &
+         &      )
     return
   end function haloAngularMomentumVitvitska2002ConstructorInternal
 

--- a/source/nodes.operators.physics.halo_angular_momentum_random_walk.F90
+++ b/source/nodes.operators.physics.halo_angular_momentum_random_walk.F90
@@ -137,6 +137,7 @@ contains
     !!}
     use :: Galacticus_Nodes      , only : nodeComponentBasic                     , nodeComponentSpin
     use :: Dark_Matter_Halo_Spins, only : Dark_Matter_Halo_Angular_Momentum_Scale
+    use :: Vectors               , only : Vector_Magnitude
     implicit none
     class           (nodeOperatorHaloAngularMomentumRandomWalk), intent(inout), target       :: self
     type            (treeNode                                 ), intent(inout), target       :: node
@@ -188,17 +189,20 @@ contains
              angularMomentumVector(i)=+angularMomentumVector(i)                                              &
                   &                   +sqrt(                                                                 &
                   &                         +self%angularMomentumVarianceSpecific                            &
-                  &                         *(                                                               &
-                  &                           +angularMomentumCurrent **2                                    &
-                  &                           -angularMomentumPrevious**2                                    &
-                  &                          )                                                               &
+                  &                         *max(                                                            &
+                  &                              +angularMomentumCurrent **2                                 &
+                  &                              -angularMomentumPrevious**2,                                &
+                  &                              +0.0d0                                                      &
+                  &                             )                                                            &
                   &                        )                                                                 &
                   &                   *nodeProgenitor%hostTree%randomNumberGenerator_%standardNormalSample()
           end do
           ! Store the scalar angular momentum.
-          call spinProgenitor%angularMomentumSet(sqrt(sum(angularMomentumVector**2)))
+          call        spinProgenitor%angularMomentumSet      (Vector_Magnitude(angularMomentumVector))
+          if (spinProgenitor%angularMomentumVectorIsSettable())                                        &
+               & call spinProgenitor%angularMomentumVectorSet(                 angularMomentumVector )
           ! Store the current characteristic angular momentum.
-          angularMomentumPrevious=angularMomentumCurrent
+          angularMomentumPrevious=max(angularMomentumPrevious,angularMomentumCurrent)
           ! Move to the next descendant halo.
           if (nodeProgenitor%isPrimaryProgenitor()) then
              nodeProgenitor  => nodeProgenitor%parent


### PR DESCRIPTION
This can happen in N-body merger trees where a halo can decrease in mass for example. In such cases we assume that the Wiener process describing the angular momentum of the halo is frozen until the characteristic angular momentum begins to grow again.
