### PR TITLE
Implement correct treatment of angles in `keplerOrbit` objects

### DIFF
--- a/source/merger_trees.construct.read.F90
+++ b/source/merger_trees.construct.read.F90
@@ -3480,19 +3480,38 @@ contains
     use :: Vectors      , only : Vector_Magnitude, Vector_Product
     implicit none
     type            (keplerOrbit)                              :: orbit
-    double precision                           , intent(in   ) :: mass1   , mass2
-    double precision             , dimension(3), intent(in   ) :: position, velocity
+    double precision                           , intent(in   ) :: mass1             , mass2
+    double precision             , dimension(3), intent(in   ) :: position          , velocity
+    double precision             , dimension(3)                :: velocityTangential, velocityRadial  , &
+         &                                                        vectorEpsilon1    , vectorEpsilon2  , &
+         &                                                        vectorRadial 
+    double precision                                           :: positionMagnitude , velocityEpsilon1, &
+         &                                                        velocityEpsilon2
 
+    positionMagnitude =Vector_Magnitude(position)
+    vectorRadial      =+position          &
+         &             /positionMagnitude
+    velocityRadial    =+Dot_Product(velocity,position) &
+         &             *vectorRadial
+    velocityTangential=+velocity       &
+         &             -velocityRadial
+    vectorEpsilon1    =Vector_Product(vectorRadial  ,[0.0d0,0.0d0,1.0d0])
+    vectorEpsilon2    =Vector_Product(vectorEpsilon1,vectorRadial       )
+    vectorEpsilon1    =vectorEpsilon1/Vector_Magnitude(vectorEpsilon1)
+    vectorEpsilon2    =vectorEpsilon2/Vector_Magnitude(vectorEpsilon2)
+    velocityEpsilon1  =Dot_Product(velocityTangential,vectorEpsilon1)
+    velocityEpsilon2  =Dot_Product(velocityTangential,vectorEpsilon2)
     call orbit%reset()
     call orbit%massesSet            (       &
          &                           mass1, &
          &                           mass2  &
          &                          )
-    call orbit%radiusSet            (                                                   Vector_Magnitude(position))
-    call orbit%velocityRadialSet    (                    Dot_Product(velocity,position)/Vector_Magnitude(position))
-    call orbit%velocityTangentialSet(Vector_Magnitude(Vector_Product(velocity,position)/Vector_Magnitude(position)))
-    call orbit%thetaSet             (acos (position(3)/sqrt(sum(position**2))            ))
-    call orbit%phiSet               (atan2(position(2)                       ,position(1)))
+    call orbit%radiusSet            (                                     positionMagnitude)
+    call orbit%velocityRadialSet    (Dot_Product     (velocity,position )/positionMagnitude)
+    call orbit%velocityTangentialSet(Vector_Magnitude(velocityTangential)                  )
+    call orbit%thetaSet             (acos (position        (3)/positionMagnitude                    ))
+    call orbit%phiSet               (atan2(position        (2)                  ,position        (1)))
+    call orbit%epsilonSet           (atan2(velocityEpsilon2                     ,velocityEpsilon1   ))
     return
   end function readOrbitConstruct
 

--- a/source/nodes.operators.physics.halo_angular_momentum.Vitvitska2002.F90
+++ b/source/nodes.operators.physics.halo_angular_momentum.Vitvitska2002.F90
@@ -314,8 +314,11 @@ contains
        angularMomentumRootVariance=+sqrt(                                      &
             &                            +self%angularMomentumVarianceSpecific &
             &                            *(                                    &
-            &                              +angularMomentumScale       **2     &
-            &                              -angularMomentumScaleChild  **2     &
+            &                              +max(                               &
+            &                                   +angularMomentumScale     **2  &
+            &                                   -angularMomentumScaleChild**2, &
+            &                                   +0.0d0                         &
+            &                                  )                               &
             &                              *(                                  &
             &                                +basic   %mass          ()        &
             &                                -         massUnresolved          &

--- a/source/objects.kepler_orbits.F90
+++ b/source/objects.kepler_orbits.F90
@@ -71,7 +71,7 @@ module Kepler_Orbits
      velocities and the radius. If it can obtain these, any other parameter can be computed. Getting these three parameters
      relies on having known conversions from other possible combinations of parameters. The position of the object is described
      by $(r,\theta,\phi)$ in standard spherical coordinates. The direction of the tangential component is velocity is taken to
-     be the direction of the vector $\mathbf{r} \times \mathbf{e}_\mathrm{\hat{z}}$, rotated by an angle $\epsilon$ around the
+     be the direction of the vector $\mathbf{r} \times \mathbf{\hat{e}}_\mathrm{z}$, rotated by an angle $\epsilon$ around the
      vector $\mathbf{r}$.
      !!}
      private
@@ -951,20 +951,31 @@ contains
     !!}
     use :: Error                           , only : Error_Report
     use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
+    use :: Vectors                         , only : Vector_Magnitude               , Vector_Product
     implicit none
     class           (keplerOrbit), intent(inout)           :: orbit
     double precision             , intent(in   )           :: newRadius
     logical                      , intent(in   ), optional :: infalling
-    double precision                                       :: angularMomentum      , energy, newVelocityRadial, &
-         &                                                    newVelocityTangential
+    double precision             , dimension(3)            :: position             , positionNew          , &
+         &                                                    velocity             , velocityNew          , &
+         &                                                    vectorEpsilon1       , vectorEpsilon2       , &
+         &                                                    vectorNormal         , vectorPlane          , &
+         &                                                    vectorRadial         , vectorRadialNew      , &
+         &                                                    vectorTangential1    , vectorTangential2    , &
+         &                                                    velocityTangentialNew
+    double precision                                       :: angularMomentum      , energy               , &
+         &                                                    newVelocityRadial    , newVelocityTangential, &
+         &                                                    eccentricity         , semiMajorAxis        , &
+         &                                                    thetaInitial         , thetaFinal           , &
+         &                                                    velocityEpsilon1     , velocityEpsilon2
 
     ! Assert that the orbit is defined.
     call orbit%assertIsDefined()
     ! Check that the radius is within the allowed range.
-    if     (                                                                                                               &
-         &    newRadius < orbit%radiusPericenter()                                                                         &
-         &  .or.                                                                                                           &
-         &   (newRadius > orbit%radiusApocenter () .and. orbit%radiusApocenter() > 0.0d0)                                  &
+    if     (                                                                                                    &
+         &    newRadius < orbit%radiusPericenter()                                                              &
+         &  .or.                                                                                                &
+         &   (newRadius > orbit%radiusApocenter () .and. orbit%radiusApocenter() > 0.0d0)                       &
          & ) call Error_Report('radius lies outside of allowed range for this orbit'//{introspection:location})
     ! Get the energy and angular momentum
     energy         =orbit%energy         ()
@@ -976,14 +987,72 @@ contains
     if (present(infalling)) then
        if (infalling) newVelocityRadial=-newVelocityRadial
     end if
+    ! If position information is set, propagate that also.
+    if     (                    &
+         &   orbit%  thetaIsSet &
+         &  .and.               &
+         &   orbit%    phiIsSet &
+         &  .and.               &
+         &   orbit%epsilonIsSet &
+         & ) then
+       ! Get orbital eccentricity and semi-major axis.
+       eccentricity =orbit%eccentricity ()
+       semiMajorAxis=orbit%semiMajorAxis()
+       ! Get initial position and velocity.
+       vectorRadial     = [sin(orbit%theta())*cos(orbit%phi()),sin(orbit%theta())*sin(orbit%phi()),cos(orbit%theta())]
+       vectorTangential1= Vector_Product(vectorRadial     ,[0.0d0,0.0d0,1.0d0])
+       vectorTangential2= Vector_Product(vectorTangential1,vectorRadial       )
+       vectorTangential1= vectorTangential1/Vector_Magnitude(vectorTangential1)
+       vectorTangential2= vectorTangential2/Vector_Magnitude(vectorTangential2)
+       position         =+  orbit%radius            ()             &
+            &            *  vectorRadial
+       velocity         =+  orbit%velocityRadial    ()             &
+            &            *  vectorRadial                           &
+            &            +  orbit%velocityTangential()             &
+            &            *(                                        &
+            &              +vectorTangential1*cos(orbit%epsilon()) &
+            &              +vectorTangential2*sin(orbit%epsilon()) &
+            &             )
+       ! Find the vector defining the orbital plane.
+       vectorNormal=+Vector_Product  (position,velocity)
+       vectorNormal=+vectorNormal                        &
+            &       /Vector_Magnitude(vectorNormal)
+       ! Find the orbital angle corresponding to the initial position.
+       thetaInitial=acos(max(-1.0d0,min(1.0d0,((1.0d0-eccentricity**2)*semiMajorAxis/orbit%radius    ()-1.0d0)/eccentricity)))
+       if (orbit%velocityRadial() < 0.0d0) thetaInitial=-thetaInitial
+       ! Find the orbital angle corresponding to the new position.
+       thetaFinal  =acos(max(-1.0d0,min(1.0d0,((1.0d0-eccentricity**2)*semiMajorAxis/       newRadius  -1.0d0)/eccentricity)))
+       if (newVelocityRadial      < 0.0d0) thetaFinal  =-thetaFinal
+       ! Rotate the radial vector around the normal vector by the difference in angle.
+       vectorPlane    = Vector_Product(vectorRadial,vectorNormal)
+       vectorRadialNew=+vectorRadial*cos(thetaFinal-thetaInitial) &
+            &          +vectorPlane* sin(thetaFinal-thetaInitial)
+       ! Find the new position.
+       positionNew=vectorRadialNew*newRadius
+       ! Construct the new velocity.
+       velocityTangentialNew=newVelocityTangential*vectorPlane
+       velocityNew          =vectorRadialNew*newVelocityRadial+velocityTangentialNew
+       ! Construct epsilon vectors.
+       vectorEpsilon1  =Vector_Product(vectorRadialNew,[0.0d0,0.0d0,1.0d0])
+       vectorEpsilon2  =Vector_Product(vectorEpsilon1 ,vectorRadialNew    )
+       vectorEpsilon1  =vectorEpsilon1/Vector_Magnitude(vectorEpsilon1)
+       vectorEpsilon2  =vectorEpsilon2/Vector_Magnitude(vectorEpsilon2)
+       velocityEpsilon1=Dot_Product(velocityTangentialNew,vectorEpsilon1)
+       velocityEpsilon2=Dot_Product(velocityTangentialNew,vectorEpsilon2)
+       ! Set new angles.
+       call orbit%thetaSet  (acos (positionNew        (3)/newRadius                    ))
+       call orbit%phiSet    (atan2(positionNew        (2)          ,positionNew     (1)))
+       call orbit%epsilonSet(atan2(velocityEpsilon2                ,velocityEpsilon1   ))
+    else
+       ! Incomplete position information present - mark position as unset.
+       orbit%  thetaIsSet=.false.
+       orbit%    phiIsSet=.false.
+       orbit%epsilonIsSet=.false.
+    end if
     ! Set new values for the state vector.
     call orbit%radiusSet            (newRadius            )
     call orbit%velocityTangentialSet(newVelocityTangential)
     call orbit%velocityRadialSet    (newVelocityRadial    )
-    ! Propagation of positional information is not yet supported.
-    orbit%  thetaIsSet=.false.
-    orbit%    phiIsSet=.false.
-    orbit%epsilonIsSet=.false.
     return
   end subroutine Kepler_Orbits_Propagate
 

--- a/source/tests.kepler_orbits.F90
+++ b/source/tests.kepler_orbits.F90
@@ -26,6 +26,7 @@ program Tests_Kepler_Orbits
   use :: Input_Parameters                , only : inputParameters
   use :: Kepler_Orbits                   , only : keplerOrbit
   use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
+  use :: Numerical_Constants_Math        , only : Pi
   use :: Unit_Tests                      , only : Assert                         , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish, &
           &                                       compareEquals
   implicit none
@@ -133,8 +134,26 @@ program Tests_Kepler_Orbits
   valueExpected=1.0d0
   call Assert('Semi-major axis of circular orbit'    ,valueActual,valueExpected,compare=compareEquals,relTol=1.0d-6)
 
+  ! Create an elliptical orbit, starting from pericenter, propagate to apocenter. The orbit is placed in the x-y plane, with the
+  ! pericenter located on the +x axis.
+  call orbit%reset                (                            )
+  call orbit%massesSet            (0.0d0                 ,1.0d0)
+  call orbit%velocityRadialSet    (0.0d0                       )
+  call orbit%velocityTangentialSet(2.29541910309191000d-4      )
+  call orbit%radiusSet            (0.14285714285714285d+0      )
+  call orbit%thetaSet             (0.5d0*Pi                    )
+  call orbit%phiSet               (0.0d0                       )
+  call orbit%epsilonSet           (0.0d0                       )
+  ! Propagate to orbit to apocenter (or very close to it, to avoid rounding errors).
+  call orbit%propagate            (1.0d0-1.0d-6)
+  ! Check that we are at the expected position.
+  call Assert('Propagation: θ',orbit%theta             (),0.5d0               *Pi,absTol=1.0d-2              )
+  call Assert('Propagation: φ',orbit%phi               (),1.0d0               *Pi,absTol=1.0d-2              )
+  call Assert('Propagation: ε',orbit%epsilon           (),0.0d0                  ,absTol=1.0d-2              )
+  call Assert('Propagation: vᵣ',orbit%velocityRadial    (),0.0d0                  ,absTol=1.0d-2*velocityScale)
+  call Assert('Propagation: vᵩ',orbit%velocityTangential(),3.279170147274157d-5   ,absTol=1.0d-2*velocityScale)
   ! End unit tests.
   call Unit_Tests_End_Group()
-  call Unit_Tests_Finish()
+  call Unit_Tests_Finish   ()
 
 end program Tests_Kepler_Orbits


### PR DESCRIPTION
* Update orbital angles when propagating an orbit to a new radius;
* Set the ε angle for orbits when reading merger trees from file.
