### PR TITLE
Fix a sign error in the `mergerTreeOperatorPruneHierarchy` class

### DIFF
--- a/source/merger_trees.operators.prune_hierarchy.F90
+++ b/source/merger_trees.operators.prune_hierarchy.F90
@@ -148,7 +148,7 @@ contains
              ! Find which node we should prune.
              nodeListCurrent => nodeListHead
              if (hierarchyDepth > self%hierarchyDepth) then
-                do i=1,self%hierarchyDepth-hierarchyDepth
+                do i=1,hierarchyDepth-self%hierarchyDepth
                    nodeListCurrent => nodeListCurrent%next
                 end do
              end if


### PR DESCRIPTION
This did not affect results as code affected is not reached for extended Press-Schechter merger trees.