### PR TITLE
Optimize evolution of high resolution merger trees

### DIFF
--- a/source/merger_trees.operators.consolidate_branches.F90
+++ b/source/merger_trees.operators.consolidate_branches.F90
@@ -1,0 +1,201 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a merger tree operator that consolidates branches spanning a given amount of time or mass growth.
+  !!}
+
+  !![
+  <mergerTreeOperator name="mergerTreeOperatorConsolidateBranches">
+   <description>
+    A merger tree operator class that consolidates branches spanning a given amount of time or mass growth. Starting from the tip
+    of each branch, the branch is broken into segments for which the mass growth is less than $1+${\normalfont \ttfamily
+    [fractionGrowthMass]} and the time growth is less than $1+${\normalfont \ttfamily [fractionGrowthTime]}. Any intermediate
+    nodes in each segment are removed, with their siblings (if any) being made siblings of the node at the end of the
+    segment. This reduces the time resolution along branches which can make evolution more efficient (at the cost of some loss of
+    precision.
+   </description>
+  </mergerTreeOperator>
+  !!]
+  type, extends(mergerTreeOperatorClass) :: mergerTreeOperatorConsolidateBranches
+     !!{
+     A merger tree operator class that consolidates branches spanning a given amount of time or mass growth.
+     !!}
+     private
+     double precision :: fractionGrowthMass, fractionGrowthTime
+   contains
+     procedure :: operatePreEvolution => consolidateBranchesOperatePreEvolution
+  end type mergerTreeOperatorConsolidateBranches
+
+  interface mergerTreeOperatorConsolidateBranches
+     !!{
+     Constructors for the {\normalfont \ttfamily consolidateBranches} merger tree operator class.
+     !!}
+     module procedure consolidateBranchesConstructorParameters
+     module procedure consolidateBranchesConstructorInternal
+  end interface mergerTreeOperatorConsolidateBranches
+
+contains
+
+  function consolidateBranchesConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily consolidateBranches} merger tree operator class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (mergerTreeOperatorConsolidateBranches)                :: self
+    type            (inputParameters                      ), intent(inout) :: parameters
+    double precision                                                       :: fractionGrowthMass, fractionGrowthTime
+
+    !![
+    <inputParameter>
+      <name>fractionGrowthMass</name>
+      <description>The fraction of growth in mass over which branches may be consolidated.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>fractionGrowthTime</name>
+      <description>The fraction of growth in time over which branches may be consolidated.</description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=mergerTreeOperatorConsolidateBranches(fractionGrowthMass,fractionGrowthTime)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function consolidateBranchesConstructorParameters
+
+  function consolidateBranchesConstructorInternal(fractionGrowthMass,fractionGrowthTime) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily consolidateBranches} merger tree operator class.
+    !!}
+    implicit none
+    type            (mergerTreeOperatorConsolidateBranches)                :: self
+    double precision                                       , intent(in   ) :: fractionGrowthMass, fractionGrowthTime
+    !![
+    <constructorAssign variables="fractionGrowthMass, fractionGrowthTime"/>
+    !!]
+
+    return
+  end function consolidateBranchesConstructorInternal
+
+  subroutine consolidateBranchesOperatePreEvolution(self,tree)
+    !!{
+    Perform a mass growth monotonizing operation on a merger tree.
+    !!}
+    use :: Galacticus_Nodes   , only : mergerTree                   , nodeComponentBasic, treeNode
+    use :: Merger_Tree_Walkers, only : mergerTreeWalkerIsolatedNodes
+    implicit none
+    class           (mergerTreeOperatorConsolidateBranches), intent(inout), target :: self
+    type            (mergerTree                           ), intent(inout), target :: tree
+    type            (treeNode                             ), pointer               :: nodeDescendant  , nodeBase   , &
+         &                                                                            node            , nodeNext   , &
+         &                                                                            nodePriorSibling, nodeSibling, &
+         &                                                                            nodeBranch
+    class           (nodeComponentBasic                   ), pointer               :: basicDescendant , basic
+    type            (mergerTree                           ), pointer               :: treeCurrent
+    type            (mergerTreeWalkerIsolatedNodes        )                        :: treeWalker
+    integer                                                                        :: countNodes
+
+    ! Iterate over trees.
+    treeCurrent => tree
+    do while (associated(treeCurrent))       
+       ! Walk the tree.
+       treeWalker=mergerTreeWalkerIsolatedNodes(treeCurrent)
+       do while (treeWalker%next(node))
+          ! Ignore nodes that have children.
+          if (associated(node%firstChild)) cycle
+          ! Walk up the branch until sufficient growth in mass or time has occured.
+          nodeBase       => node
+          nodeDescendant => node
+          basic          => nodeBase%basic()
+          countNodes     =  0
+          do while (associated(nodeDescendant))
+             basicDescendant => nodeDescendant%basic()
+             countNodes      =  countNodes+1
+             if     (                                                                       &
+                  &   basicDescendant%mass() > (1.0d0+self%fractionGrowthMass)*basic%mass() &
+                  &  .or.                                                                   &
+                  &   basicDescendant%time() > (1.0d0+self%fractionGrowthTime)*basic%time() &
+                  & ) then
+                ! Back up to the previous node as we don't want to exceed the specified growth fractions.
+                nodeDescendant => nodeDescendant%firstChild
+                countNodes     =  countNodes-1
+                ! If there are more than two nodes in the segment, there must be intermediate nodes that we can remove.
+                if (countNodes > 2) then
+                   basicDescendant => nodeDescendant%basic()
+                   ! Find the final sibling of the final node in the segment.
+                   nodePriorSibling => nodeDescendant
+                   do while (associated(nodePriorSibling%sibling))
+                      nodePriorSibling => nodePriorSibling%sibling
+                   end do
+                   ! Update parent pointers for any siblings of the first node in the segment.
+                   nodeSibling => nodeBase%sibling
+                   do while (associated(nodeSibling))
+                      nodeSibling%parent => nodeDescendant
+                      nodeSibling        => nodeSibling   %sibling
+                   end do
+                   ! Walk up the branch moving any siblings to the descendant node, and destroy the intermediate nodes.
+                   nodeBranch => nodeBase%parent
+                   do while (.not.associated(nodeBranch,nodeDescendant))
+                      ! Find the next node in the branch for future reference.
+                      nodeNext    => nodeBranch%parent
+                      ! Update parent pointers for any siblings.
+                      nodeSibling => nodeBranch%sibling
+                      do while (associated(nodeSibling))
+                         nodeSibling%parent => nodeDescendant%parent
+                         nodeSibling        => nodeSibling   %sibling
+                      end do
+                      ! Move siblings to the node at the end of the segment.
+                      nodePriorSibling%sibling => nodeBranch%sibling
+                      do while (associated(nodePriorSibling%sibling))
+                         nodePriorSibling => nodePriorSibling%sibling
+                      end do
+                      ! Destroy the intermediate node.
+                      call nodeBranch%destroy()
+                      deallocate(nodeBranch)
+                      ! Move to the next node.
+                      nodeBranch => nodeNext
+                   end do
+                   ! Link the nodes at the start and end of the segment.
+                   nodeDescendant%firstChild => nodeBase
+                   nodeBase      %parent     => nodeDescendant
+                end if
+                ! Go back to the parent node and reset the base point for further segments.
+                nodeDescendant => nodeDescendant%parent
+                nodeBase       => nodeDescendant
+                basic          => nodeBase      %basic ()
+                countNodes     =  0
+             end if
+             ! Move up the branch, stopping when we are no longer the primary progenitor.
+             if (nodeDescendant%isPrimaryProgenitor()) then
+                nodeDescendant => nodeDescendant%parent
+             else
+                nodeDescendant => null()
+             end if
+          end do
+       end do
+       ! Move to the next tree.
+       treeCurrent => treeCurrent%nextTree
+    end do
+    return
+  end subroutine consolidateBranchesOperatePreEvolution
+


### PR DESCRIPTION
Run times can become extremely long for high resolution trees. At lower resolutions the scaling of run time, $\tau$, with resolution, $M_\mathrm{res}$ is approximately $\tau \propto M_\mathrm{res}^{-1}$ - which is expected since as $M_\mathrm{res}$ decreases there are proportionally more halos in the tree, each of which must be evolved.

When resolution becomes high, not only does the number of halos in the tree increase proportionally, but the frequency of halo mergers increases as a direct result. Each merger requires that differential evolution of the branch be stopped, the merger processed, and then differetial evolution resumed. For each such resumption, we have to process the host halo on the branch, which means determining how far it can be evolved, which means checking each of its satellites. This results in a $\mathcal{O}(N^2)$ scaling in the number of halos, so eventually we get behavior closer to $\tau \propto M\_\mathrm{res}^{-2}$ resulting in very long run times.

A simple way to mitigate this is to realize that, in most circumstances, we don't need such high time resolution in the merger trees - if mergers onto the main branch of the tree are happening, on average, every 1,000 years for example, it's unlikely such precise timing is crucial to any result. Therefore, we can consolidate growth along a branch - accumulating mergers and merging them all after some amount of time.

This PR brings in a new `mergerTreeOperatorConsolidateBranches` which implements this. Each branch is broken into segments which grow by at most a factor of $1+f_m$ in mass or $1+f_t$ in time (whichever occurs first). Any mergers within each such segment are held until the end of the segment, and any intervening nodes in the branch between the start and end node of the segment are then removed. This makes the number of segments in a tree largely independent of resolution for high resolutions.

The table below shows benchmarks for a $M=10^{13}\mathrm{M}\_\odot$ merger tree run at various resolutions with and without ($f_m=f_t=0.0$) branch consolidation active. With no branch consolidation, trom resolution $\log\_{10}(M\_\mathrm{res}/\mathrm{M}\_\odot)=8$ to $7$ we see the expected factor of around 10 increase in run time, but going to $\log\_{10}(M_\mathrm{res}/\mathrm{M}\_\odot)=6$ in an increase by a factor of 38. Switching on consolidation with $f_m=f_t=0.01$ makes only a modest change in the run times for the lower resolution cases, but a factor 2.4 for the highest resolution case - with halo merging times and mass growth still accurate to better than 1%. Going to $f_m=f_t=0.10$ does not substantially improve run times, so is probably not warranted.

| $log_{10}(M_\mathrm{res}/\mathrm{M}_\odot)$ | $f_m=f_t$ | $\tau$ [s] | Peak memory [GB] |
| ------------------------------------------- | --------- | ---------- | ---------------- |
|                     8                       |   0.00    |     64.7   |      0.9         |
|                     8                       |   0.01    |     63.4   |      0.9         |
|                     8                       |   0.10    |     61.9   |      0.9         |
|                     7                       |   0.00    |    661.7   |      7.7         |
|                     7                       |   0.01    |    571.8   |      7.7         |
|                     7                       |   0.10    |    561.4   |      7.7         |
|                     6                       |   0.00    |  25306.1   |     69.6         |
|                     6                       |   0.01    |  10576.7   |     69.6         |
|                     6                       |   0.10    |   9542.5   |     69.6         |

Note that memory use is unaffected - this likely peaks when the tree is built, before any consolidation.
