### PR TITLE
Catch cases where the time of collapse for a halo is undefined

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1203,7 +1203,8 @@ jobs:
                 testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml,
                 testSuite/regressions/treeWithNoPrimaryProgenitor.xml,
                 testSuite/regressions/outputRank2ExtendSegFault.xml,
-                testSuite/regressions/barInstabilityFPE.xml ]
+                testSuite/regressions/barInstabilityFPE.xml,
+		testSuite/regressions/haloMassFunctionWDMIndeterminateCollapseTime.xml ]
     uses: ./.github/workflows/testModel.yml
     with:
       file: ${{ matrix.file }}

--- a/testSuite/regressions/haloMassFunctionWDMIndeterminateCollapseTime.xml
+++ b/testSuite/regressions/haloMassFunctionWDMIndeterminateCollapseTime.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Model with a low mass WDM particle that previously failed as the collapse time for (strongly-suppressed) low mass halos becomes indeterminate. -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="165490f4968c699f7e5bb73ef60bcb7e626f51e6"/>
+
+  <!-- Specify tasks to perform -->
+  <task value="haloMassFunction">
+    <haloMassMinimum value="1.0e7"/>    
+  </task>
+
+  <!-- Component selection -->
+  <componentBasic             value="standard"/>
+  <componentDarkMatterProfile value="scale"   />
+
+  <!-- Use a thermal WDM particle - mass is in keV -->
+  <darkMatterParticle value="WDMThermal">
+    <degreesOfFreedomEffective value="1.5" />
+    <mass value="0.25" />
+  </darkMatterParticle>
+
+  <!-- Cosmological parameters -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.20000"/>
+    <OmegaMatter value=" 0.27250"/>
+    <OmegaDarkEnergy value=" 0.72750"/>
+    <OmegaBaryon value=" 0.04550"/>
+    <temperatureCMB value=" 2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <!-- Use the Bode et al. (2001) transfer function for thermal WDM -->
+  <transferFunction value="bode2001">
+    <epsilon value="0.359" />
+    <eta value="3.810" />
+    <nu value="1.100" />
+    <!-- Bode2001 transfer function works by modifying a CDM transfer function - so feed it a CDM transfer function here -->
+    <transferFunction value="eisensteinHu1999">
+      <!-- Feed this transfer function a CDM particle - otherwise it will see the WDM particle defined above and complain that it
+           can not compute WDM transfer functions -->
+      <darkMatterParticle value="CDM" />
+      <neutrinoNumberEffective value="3.046"/>
+      <neutrinoMassSummed value="0.000"/>
+    </transferFunction>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <!-- When computing sigma(M) for power spectra with a cut off it's better to use a filter that is sharp in k-space, instead of
+       the usual real-space top-hat (which introduces artificial halos below the cut-off scale -->
+  <cosmologicalMassVariance value="filteredPower">
+    <monotonicInterpolation value="true" />
+    <nonMonotonicIsFatal value="false" />
+    <powerSpectrumWindowFunction value="sharpKSpace">
+      <normalization value="2.5" />
+    </powerSpectrumWindowFunction>
+    <sigma_8 value="0.807" />
+    <tolerance value="3.0e-4" />
+    <toleranceTopHat value="3.0e-4" />
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <!-- Use the Barkana et al. (2001) method for the critical overdensity for collapse for WDM -->
+  <criticalOverdensity value="barkana2001WDM">
+    <!-- Barkana2001 critical overdensity works by modifying a CDM critical overdensity - so feed it a CDM critical overdensity
+         here -->
+    <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt">
+      <!-- Feed this critical overdensity a CDM particle - otherwise it will see the WDM particle defined above and complain that
+           it can not compute WDM critical overdensities-->
+      <darkMatterParticle value="CDM" />
+    </criticalOverdensity>
+  </criticalOverdensity>
+  
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileConcentration value="schneider2015">
+    <!-- Define a reference CDM universe - the Schneider algorithm works by finding halos with the same formation epoch in this
+         reference universe -->
+    <reference>
+      <darkMatterParticle value="CDM" />
+      <darkMatterProfileConcentration value="gao2008"/>
+      <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+      <cosmologicalMassVariance value="filteredPower">
+	<sigma_8 value="0.807"/>
+	<monotonicInterpolation value="true" />
+	<nonMonotonicIsFatal value="false" />
+	<powerSpectrumPrimordial value="powerLaw">
+	  <index value="0.961"/>
+	  <wavenumberReference value="1.000"/>
+	  <running value="0.000"/>
+	</powerSpectrumPrimordial>
+	<powerSpectrumPrimordialTransferred value="simple"/>
+	<powerSpectrumWindowFunction value="sharpKSpace">
+	  <normalization value="2.5" />
+	</powerSpectrumWindowFunction>
+	<transferFunction value="eisensteinHu1999">
+	  <darkMatterParticle value="CDM" />
+	  <neutrinoNumberEffective value="3.046"/>
+	  <neutrinoMassSummed value="0.000"/>
+	</transferFunction>
+      </cosmologicalMassVariance>
+    </reference>
+  </darkMatterProfileConcentration>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  1.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/regressions/haloMassFunctionWDMIndeterminateCollapseTime.hdf5"/>
+  <outputTimes value="list">
+    <redshifts value="0.0 1.0"/>
+  </outputTimes>
+
+</parameters>


### PR DESCRIPTION
This can happen if the collapse threshold is never reached due to the upper bound on linear growth (in a universe with a cosmological constant for example). Optionally returns an error status in such cases.

This is now tested for in the `darkMatterHaloMassAccretionHistoryWechsler2002` class and an unphysical value returned in such cases.