### PR TITLE
Make the `galacticFilterStellarMass` retrieve the stellar mass from a node's `massDistribution`

### DIFF
--- a/source/galactic.filters.stellar_mass.F90
+++ b/source/galactic.filters.stellar_mass.F90
@@ -87,24 +87,23 @@ contains
     return
   end function stellarMassConstructorInternal
 
-  logical function stellarMassPasses(self,node)
+  logical function stellarMassPasses(self,node) result(passes)
     !!{
-    Implement a  stellar mass high-pass galactic filter.
+    Implement a stellar mass high-pass galactic filter.
     !!}
-    use :: Galacticus_Nodes, only : nodeComponentDisk, nodeComponentSpheroid, treeNode
+    use :: Mass_Distributions        , only : massDistributionClass, massDistributionComposite
+    use :: Galactic_Structure_Options, only : massTypeStellar
     implicit none
-    class           (galacticFilterStellarMass), intent(inout)         :: self
-    type            (treeNode                 ), intent(inout), target :: node
-    class           (nodeComponentDisk        ), pointer               :: disk
-    class           (nodeComponentSpheroid    ), pointer               :: spheroid
-    double precision                                                   :: stellarMass
+    class(galacticFilterStellarMass), intent(inout)          :: self
+    type (treeNode                 ), intent(inout), target  :: node
+    class(massDistributionClass    )               , pointer :: massDistribution_
 
-    disk              => node    %disk       ()
-    spheroid          => node    %spheroid   ()
-    stellarMass       = +disk    %massStellar() &
-         &              +spheroid%massStellar()
-    stellarMassPasses =  stellarMass            &
-         &              >=                      &
-         &               self%massThreshold
+    massDistribution_ =>  node             %massDistribution(massType=massTypeStellar)
+    passes            =   massDistribution_%massTotal       (                        ) &
+         &               >=                                                            &
+         &                self             %massThreshold
+    !![
+    <objectDestructor name="massDistribution_"/>
+    !!]
     return
   end function stellarMassPasses

--- a/source/geometry.surveys.Bernardi-2013-SDSS.F90
+++ b/source/geometry.surveys.Bernardi-2013-SDSS.F90
@@ -131,7 +131,7 @@ contains
     double precision                                , intent(in   ), optional :: mass           , magnitudeAbsolute, &
          &                                                                       luminosity     , starFormationRate
     integer                                         , intent(in   ), optional :: field
-    double precision                                                          :: logarithmicMass,
+    double precision                                                          :: logarithmicMass
     !$GLC attributes unused :: self, field
 
     ! Validate arguments.
@@ -141,9 +141,11 @@ contains
     ! Find the limiting distance for this mass completeness limits. (See
     ! constraints/dataAnalysis/stellarMassFunction_SDSS_z0.07_Bernardi/massDistanceRelation.pl for details.)
     if (present(mass)) then
-       logarithmicMass=min(log10(mass),12.5d0)
+       ! Limit the mass to the range for which our empirical mass-distance relation is calibrated.
+       logarithmicMass=max(8.0d0,min(12.5d0,log10(mass)))
     else
-       logarithmicMass=                12.5d0
+       ! If no mass is given, use the largest calibrated mass (which will give the largest distance).
+       logarithmicMass=              12.5d0
     end if
     bernardi2013SDSSDistanceMaximum                                                         &
          &                         =10.0d0**(                                               &


### PR DESCRIPTION
This ensures consistency with the stellar mass retrieved by the `nodePropertyExtractorMassStellar` class which is important for `outputAnalysis` classes to ensure that any masses used are consist in the analysis and any filter applied prior to analyzing.
