### PR TITLE
Remove memoized structure variables

### DIFF
--- a/source/objects.nodes.components.disk.standard.F90
+++ b/source/objects.nodes.components.disk.standard.F90
@@ -34,9 +34,9 @@ module Node_Component_Disk_Standard
   public :: Node_Component_Disk_Standard_Scale_Set                 , Node_Component_Disk_Standard_Pre_Evolve                  , &
        &    Node_Component_Disk_Standard_Radius_Solver_Plausibility, Node_Component_Disk_Standard_Radius_Solver               , &
        &    Node_Component_Disk_Standard_Post_Step                 , Node_Component_Disk_Standard_Thread_Uninitialize         , &
-       &    Node_Component_Disk_Standard_Initialize                , Node_Component_Disk_Standard_Calculation_Reset           , &
+       &    Node_Component_Disk_Standard_Initialize                , Node_Component_Disk_Standard_Thread_Initialize           , &
        &    Node_Component_Disk_Standard_State_Store               , Node_Component_Disk_Standard_State_Retrieve              , &
-       &    Node_Component_Disk_Standard_Thread_Initialize         , Node_Component_Disk_Standard_Inactive
+       &    Node_Component_Disk_Standard_Inactive
 
   !![
   <component>
@@ -385,27 +385,6 @@ contains
     end if
     return
   end subroutine Node_Component_Disk_Standard_Thread_Uninitialize
-
-  !![
-  <calculationResetTask>
-    <unitName>Node_Component_Disk_Standard_Calculation_Reset</unitName>
-  </calculationResetTask>
-  !!]
-  subroutine Node_Component_Disk_Standard_Calculation_Reset(node,uniqueID)
-    !!{
-    Reset standard disk structure calculations.
-    !!}
-    use :: Galacticus_Nodes                 , only : treeNode
-    use :: Kind_Numbers                     , only : kind_int8
-    use :: Node_Component_Disk_Standard_Data, only : Node_Component_Disk_Standard_Reset
-    implicit none
-    type   (treeNode ), intent(inout) :: node
-    integer(kind_int8), intent(in   ) :: uniqueID
-    !$GLC attributes unused :: node
-    
-    call Node_Component_Disk_Standard_Reset(uniqueID)
-    return
-  end subroutine Node_Component_Disk_Standard_Calculation_Reset
 
   !![
   <preEvolveTask>

--- a/source/objects.nodes.components.disk.standard.data.F90
+++ b/source/objects.nodes.components.disk.standard.data.F90
@@ -25,46 +25,13 @@ module Node_Component_Disk_Standard_Data
   !!{
   Stores data for the standard disk node component.
   !!}
-  use :: Kind_Numbers      , only : kind_int8
   use :: Mass_Distributions, only : massDistributionClass, kinematicsDistributionLocal
   implicit none
   public
 
-  ! Record of unique ID of node which we last computed results for.
-  integer         (kind=kind_int8             )          :: lastUniqueID                    =-1
-  !$omp threadprivate(lastUniqueID)
-  ! Records of previously computed and stored quantities.
-  logical                                                :: surfaceDensityCentralGasComputed   , surfaceDensityCentralStellarComputed, &
-       &                                                    surfaceDensityCentralTotalComputed
-  !$omp threadprivate(surfaceDensityCentralGasComputed,surfaceDensityCentralStellarComputed,surfaceDensityCentralTotalComputed)
-  double precision                                       :: surfaceDensityCentralGas           , surfaceDensityCentralStellar        , &
-       &                                                    surfaceDensityCentralTotal
-  !$omp threadprivate(surfaceDensityCentralGas,surfaceDensityCentralStellar,surfaceDensityCentralTotal)
-  logical                                                :: radiusScaleDiskComputed
-  !$omp threadprivate(radiusScaleDiskComputed)
-  double precision                                       :: radiusScaleDisk
-  !$omp threadprivate(radiusScaleDisk)
-
   ! The mass distribution objects.
-  class           (massDistributionClass      ), pointer :: massDistributionStellar_           , massDistributionGas_
-  type            (kinematicsDistributionLocal), pointer :: kinematicDistribution_
+  class(massDistributionClass      ), pointer :: massDistributionStellar_, massDistributionGas_
+  type (kinematicsDistributionLocal), pointer :: kinematicDistribution_
   !$omp threadprivate(massDistributionStellar_,massDistributionGas_,kinematicDistribution_)
-
-contains
-
-  subroutine Node_Component_Disk_Standard_Reset(uniqueID)
-    !!{
-    Reset calculations for the standard disk component.
-    !!}
-    implicit none
-    integer(kind=kind_int8), intent(in   ) :: uniqueID
-
-    radiusScaleDiskComputed             =.false.
-    surfaceDensityCentralGasComputed    =.false.
-    surfaceDensityCentralStellarComputed=.false.
-    surfaceDensityCentralTotalComputed  =.false.
-    lastUniqueID                        =uniqueID
-    return
-  end subroutine Node_Component_Disk_Standard_Reset
 
 end module Node_Component_Disk_Standard_Data

--- a/source/objects.nodes.components.disk.very_simple.size.F90
+++ b/source/objects.nodes.components.disk.very_simple.size.F90
@@ -30,7 +30,7 @@ module Node_Component_Disk_Very_Simple_Size
   public :: Node_Component_Disk_Very_Simple_Size_Radius_Solver_Plausibility, Node_Component_Disk_Very_Simple_Size_Radius_Solver    , &
        &    Node_Component_Disk_Very_Simple_Size_Initialize                , Node_Component_Disk_Very_Simple_Size_Thread_Initialize, &
        &    Node_Component_Disk_Very_Simple_Size_State_Store               , Node_Component_Disk_Very_Simple_Size_State_Retrieve   , &
-       &    Node_Component_Disk_Very_Simple_Size_Thread_Uninitialize       , Node_Component_Disk_Very_Simple_Size_Calculation_Reset
+       &    Node_Component_Disk_Very_Simple_Size_Thread_Uninitialize
 
   !![
   <component>
@@ -182,27 +182,6 @@ contains
     end if
     return
   end subroutine Node_Component_Disk_Very_Simple_Size_Thread_Uninitialize
-
-  !![
-  <calculationResetTask>
-    <unitName>Node_Component_Disk_Very_Simple_Size_Calculation_Reset</unitName>
-  </calculationResetTask>
-  !!]
-  subroutine Node_Component_Disk_Very_Simple_Size_Calculation_Reset(node,uniqueID)
-    !!{
-    Reset very simple size disk structure calculations.
-    !!}
-    use :: Galacticus_Nodes                         , only : treeNode
-    use :: Kind_Numbers                             , only : kind_int8
-    use :: Node_Component_Disk_Very_Simple_Size_Data, only : Node_Component_Disk_Very_Simple_Size_Reset
-    implicit none
-    type   (treeNode ), intent(inout) :: node
-    integer(kind_int8), intent(in   ) :: uniqueID
-    !$GLC attributes unused :: node
-
-    call Node_Component_Disk_Very_Simple_Size_Reset(uniqueID)
-    return
-  end subroutine Node_Component_Disk_Very_Simple_Size_Calculation_Reset
 
   !![
   <radiusSolverPlausibility>

--- a/source/objects.nodes.components.disk.very_simple.size.data.F90
+++ b/source/objects.nodes.components.disk.very_simple.size.data.F90
@@ -25,45 +25,12 @@ module Node_Component_Disk_Very_Simple_Size_Data
   !!{
   Stores data for the very simple size disk node component.
   !!}
-  use :: Kind_Numbers      , only : kind_int8
   use :: Mass_Distributions, only : massDistributionClass
   implicit none
   public
 
-  ! Record of unique ID of node which we last computed results for.
-  integer         (kind=kind_int8       )          :: lastUniqueID                      =-1
-  !$omp threadprivate(lastUniqueID)
-  ! Records of previously computed and stored quantities.
-  logical                                          :: surfaceDensityCentralGasComputed  =.false., surfaceDensityCentralStellarComputed=.false., &
-       &                                              surfaceDensityCentralTotalComputed=.false.
-  !$omp threadprivate(surfaceDensityCentralGasComputed,surfaceDensityCentralStellarComputed,surfaceDensityCentralTotalComputed)
-  double precision                                 :: surfaceDensityCentralGas                  , surfaceDensityCentralStellar                 , &
-       &                                              surfaceDensityCentralTotal
-  !$omp threadprivate(surfaceDensityCentralGas,surfaceDensityCentralStellar,surfaceDensityCentralTotal)
-  logical                                          :: radiusScaleDiskComputed
-  !$omp threadprivate(radiusScaleDiskComputed)
-  double precision                                 :: radiusScaleDisk
-  !$omp threadprivate(radiusScaleDisk)
-
   ! The mass distribution objects.
-  class           (massDistributionClass), pointer :: massDistributionStellar_                  , massDistributionGas_
+  class(massDistributionClass), pointer :: massDistributionStellar_, massDistributionGas_
   !$omp threadprivate(massDistributionStellar_,massDistributionGas_)
-
-contains
-
-  subroutine Node_Component_Disk_Very_Simple_Size_Reset(uniqueID)
-    !!{
-    Reset calculations for the very simple size disk component.
-    !!}
-    implicit none
-    integer(kind=kind_int8), intent(in   ) :: uniqueID
-
-    radiusScaleDiskComputed             =.false.
-    surfaceDensityCentralGasComputed    =.false.
-    surfaceDensityCentralStellarComputed=.false.
-    surfaceDensityCentralTotalComputed  =.false.
-    lastUniqueID                        =uniqueID
-    return
-  end subroutine Node_Component_Disk_Very_Simple_Size_Reset
 
 end module Node_Component_Disk_Very_Simple_Size_Data


### PR DESCRIPTION
These are no longer needed after the [recent refactoring](https://github.com/galacticusorg/galacticus/commit/9caa7c7d42304bbc9a5631e33267f10de814a7c1) of the `massDistribution` class.

The associated `calculationReset` tasks are also removed.