### PR TITLE
Fix the name of a dataset used in an importer function

### DIFF
--- a/source/merger_trees.construct.read.F90
+++ b/source/merger_trees.construct.read.F90
@@ -841,14 +841,14 @@ contains
          &                   {introspection:location}                                             &
          &                  )
     ! Check that half-mass radius information is present if required.
-    if     (                                                                                                                                              &
-         &   self%presetScaleRadii                                                                                                                        &
-         &  .and.                                                                                                                                         &
-         &   .not.self%mergerTreeImporter_%scaleRadiiAvailable()                                                                                          &
-         & )  call Error_Report(                                                                                                                          &
-         &                      "presetting scale radii requires that at least one of readRadiusHalfMass or scaleRadius datasets be present in merger"//  &
-         &                      "tree file; try setting"//char(10)//"  [presetScaleRadii]=false"                                                      //  &
-         &                      {introspection:location}                                                                                                  &
+    if     (                                                                                                                                               &
+         &   self%presetScaleRadii                                                                                                                         &
+         &  .and.                                                                                                                                          &
+         &   .not.self%mergerTreeImporter_%scaleRadiiAvailable()                                                                                           &
+         & )  call Error_Report(                                                                                                                           &
+         &                      "presetting scale radii requires that at least one of readRadiusHalfMass or scaleRadius datasets be present in merger "//  &
+         &                      "tree file; try setting"//char(10)//"  [presetScaleRadii]=false"                                                       //  &
+         &                      {introspection:location}                                                                                                   &
          &                     )
     ! Check that angular momentum information is present if required.
     if     (                                                                                                  &

--- a/source/merger_trees.construct.read.importer.galacticus.F90
+++ b/source/merger_trees.construct.read.importer.galacticus.F90
@@ -914,7 +914,7 @@ contains
     galacticusScaleRadiiAvailable=                        &
          &  self%forestHalos%hasDataset("halfMassRadius") &
          & .or.                                           &
-         &  self%forestHalos%hasDataset("position"      )
+         &  self%forestHalos%hasDataset("scaleRadius"   )
     !$ call hdf5Access%unset()
     return
   end function galacticusScaleRadiiAvailable


### PR DESCRIPTION
Previously incorrectly checked for `position` instead of  `scaleRadius`.