### PR TITLE
Various fixes related to reading tree masses from file

### DIFF
--- a/source/merger_trees.construct.build.masses.read.XML.F90
+++ b/source/merger_trees.construct.build.masses.read.XML.F90
@@ -120,8 +120,8 @@ contains
     use :: File_Utilities, only : File_Name_Expand
     implicit none
     class           (mergerTreeBuildMassesReadXML), intent(inout)                            :: self
-    double precision                              , intent(  out), allocatable, dimension(:) :: mass, weight
-    type            (node                        ), pointer                                  :: doc , rootNode
+    double precision                              , intent(  out), allocatable, dimension(:) :: mass , weight
+    type            (node                        ), pointer                                  :: doc  , rootNode
     integer                                                                                  :: ioErr
 
     !$omp critical (FoX_DOM_Access)
@@ -131,7 +131,10 @@ contains
     ! Read all tree masses.
     call XML_Array_Read(doc,"treeRootMass",mass)
     ! Extract tree weights if available.
-    if (XML_Path_Exists(rootNode,"treeWeight")) call XML_Array_Read_Static(doc,"treeWeight",weight)
+    if (XML_Path_Exists(rootNode,"treeWeight")) then
+       call XML_Array_Read(doc,"treeWeight",weight)
+       if (size(weight) /= size(mass)) call Error_Report('`mass` and `weight` arrays must have the same size'//{introspection:location})
+    end if
     ! Finished - destroy the XML document.
     call destroy(doc)
     !$omp end critical (FoX_DOM_Access)


### PR DESCRIPTION
* Make tree weights optional when replicating tree masses;
* Set minimum and maximum mass interval for trees when multiple trees have the same mass;
* Check `treeRootMass` and `treeWeight` arrays have the same size.
