### PR TITLE
Do not evaluate parameters when counting them

### DIFF
--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -1620,7 +1620,7 @@ contains
     !!]
 
     if (self%isPresent(parameterName)) then
-       call self%value(parameterName,parameterText,writeOutput=.false.)
+       call self%value(parameterName,parameterText,writeOutput=.false.,evaluate=.false.)
        inputParametersCount=String_Count_Words(char(parameterText))
     else
        if (zeroIfNotPresent_) then


### PR DESCRIPTION
For counting parameters parameters are read as text (even if they are numerical). If evaluated this would cause text parameter requirements to be asserted which would fail.