### PR TITLE
Do not record that warnings have been found if the verbosity level is sufficient that they will be reported immediately

### DIFF
--- a/source/error.F90
+++ b/source/error.F90
@@ -195,10 +195,10 @@ contains
           allocate(newWarning%next)
           newWarning => newWarning%next
        end if
-       newWarning%next    => null   ()
-       newWarning%message =  message
+       newWarning   %next    => null   ()
+       newWarning   %message =  message
+       warningsFound         =  .true.
     end if
-    warningsFound=.true.
     !$omp end critical (Warn)
     return
   end subroutine Warn_Char


### PR DESCRIPTION
Doing so caused segfaults because the linked list of warning messages would then be assumed to be initialized, even though it wasn't.