### PR TITLE
Provide a guess for a parameter name when no matching parameter is found in auto-descriptor

### DIFF
--- a/.github/actions/buildMacOS/action.yml
+++ b/.github/actions/buildMacOS/action.yml
@@ -210,6 +210,7 @@ runs:
         sudo perl -MCPAN -e 'force("install","XML::SAX::ParserFactory")'
         sudo perl -MCPAN -e 'force("install","XML::Validator::Schema")'
         sudo perl -MCPAN -e 'force("install","Text::Template")'
+        sudo perl -MCPAN -e 'force("install","Text::Levenshtein)'
         sudo perl -MCPAN -e 'force("install","List::Uniq")'
         sudo perl -MCPAN -e 'force("install","IO::Util")'
         sudo perl -MCPAN -e 'force("install","Class::Util")'

--- a/.github/actions/buildMacOS/action.yml
+++ b/.github/actions/buildMacOS/action.yml
@@ -210,7 +210,7 @@ runs:
         sudo perl -MCPAN -e 'force("install","XML::SAX::ParserFactory")'
         sudo perl -MCPAN -e 'force("install","XML::Validator::Schema")'
         sudo perl -MCPAN -e 'force("install","Text::Template")'
-        sudo perl -MCPAN -e 'force("install","Text::Levenshtein)'
+        sudo perl -MCPAN -e 'force("install","Text::Levenshtein")'
         sudo perl -MCPAN -e 'force("install","List::Uniq")'
         sudo perl -MCPAN -e 'force("install","IO::Util")'
         sudo perl -MCPAN -e 'force("install","Class::Util")'

--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -417,13 +417,15 @@ sub Process_FunctionClass {
 					    }
 					} else {
 					    $supported = -1;
-					    my @potentialNames = map {@{$_->{'variableNames'}}} @{$potentialNames->{'parameters'}};
-					    my @distances      = &Text::Levenshtein::distance(lc($name),map {lc($_)} @potentialNames);
-					    my $indexMinimum   = first_index {$_ == &List::Util::min(@distances)} @distances;
 					    my $message = "could not find a matching internal variable for parameter [".$name."]";
-					    unless ( $indexMinimum == -1 ) {
-						(my $nameGuess = $potentialNames[$indexMinimum]) =~ s/_//;
-						$message .= " - did you mean [".$nameGuess."]";
+					    my @potentialNames = map {@{$_->{'variableNames'}}} @{$potentialNames->{'parameters'}};
+					    if ( scalar(@potentialNames) > 0 ) {
+						my @distances      = &Text::Levenshtein::distance(lc($name),map {lc($_)} @potentialNames);
+						my $indexMinimum   = first_index {$_ == &List::Util::min(@distances)} @distances;
+						unless ( $indexMinimum == -1 ) {
+						    (my $nameGuess = $potentialNames[$indexMinimum]) =~ s/_//;
+						    $message .= " - did you mean [".$nameGuess."]";
+						}
 					    }
 					    push(@failureMessage,$message);
 					}


### PR DESCRIPTION
If no matching parameter can be found in a class when attempting to build an auto-descriptor, we now provide a guess of which parameter was intended by comparing the given name to the available names using the Levenshtein distance.