### PR TITLE
Move setting of black hole seeds to a `nodeOperator`

### DIFF
--- a/parameters.xml
+++ b/parameters.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -253,6 +252,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters.xml
+++ b/parameters.xml
@@ -254,8 +254,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+	<massSeed value="100"/>
+	<spinSeed value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters.xml
+++ b/parameters.xml
@@ -253,10 +253,10 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-	<massSeed value="100"/>
-	<spinSeed value="0"/>
+	<mass value="100"/>
+	<spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>

--- a/parameters.xml
+++ b/parameters.xml
@@ -253,7 +253,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
 	<mass value="100"/>
 	<spin value="0"/>

--- a/parameters/baryonicPhysicsConstrained.xml
+++ b/parameters/baryonicPhysicsConstrained.xml
@@ -270,8 +270,10 @@
     <!-- Positions for subhalos -->
     <nodeOperator value="positionTraceDarkMatter"/>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/parameters/baryonicPhysicsConstrained.xml
+++ b/parameters/baryonicPhysicsConstrained.xml
@@ -269,7 +269,7 @@
     <nodeOperator value="satelliteMassLoss"/>
     <!-- Positions for subhalos -->
     <nodeOperator value="positionTraceDarkMatter"/>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/parameters/baryonicPhysicsConstrained.xml
+++ b/parameters/baryonicPhysicsConstrained.xml
@@ -269,11 +269,11 @@
     <nodeOperator value="satelliteMassLoss"/>
     <!-- Positions for subhalos -->
     <nodeOperator value="positionTraceDarkMatter"/>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/parameters/baryonicPhysicsConstrained.xml
+++ b/parameters/baryonicPhysicsConstrained.xml
@@ -18,7 +18,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="simple">
-    <massSeed value="100.0"/>
     <growthRatioToStellarSpheroid value="1.36151389582815"/>
     <heatsHotHalo value="true"/>
     <efficiency value="0.00361121531459326"/>
@@ -270,6 +269,10 @@
     <nodeOperator value="satelliteMassLoss"/>
     <!-- Positions for subhalos -->
     <nodeOperator value="positionTraceDarkMatter"/>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
   
   <!-- Numerical tolerances -->

--- a/parameters/parametersProfile.xml
+++ b/parameters/parametersProfile.xml
@@ -254,7 +254,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/parameters/parametersProfile.xml
+++ b/parameters/parametersProfile.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -254,6 +253,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/parametersProfile.xml
+++ b/parameters/parametersProfile.xml
@@ -255,8 +255,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/parametersProfile.xml
+++ b/parameters/parametersProfile.xml
@@ -254,11 +254,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/parametersProfileLarge.xml
+++ b/parameters/parametersProfileLarge.xml
@@ -254,7 +254,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/parameters/parametersProfileLarge.xml
+++ b/parameters/parametersProfileLarge.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -254,6 +253,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/parametersProfileLarge.xml
+++ b/parameters/parametersProfileLarge.xml
@@ -255,8 +255,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/parametersProfileLarge.xml
+++ b/parameters/parametersProfileLarge.xml
@@ -254,11 +254,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/quickTest.haloMassFunction.xml
+++ b/parameters/quickTest.haloMassFunction.xml
@@ -255,7 +255,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/parameters/quickTest.haloMassFunction.xml
+++ b/parameters/quickTest.haloMassFunction.xml
@@ -14,7 +14,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -255,6 +254,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/quickTest.haloMassFunction.xml
+++ b/parameters/quickTest.haloMassFunction.xml
@@ -256,8 +256,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/quickTest.haloMassFunction.xml
+++ b/parameters/quickTest.haloMassFunction.xml
@@ -255,11 +255,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/quickTest.xml
+++ b/parameters/quickTest.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -249,6 +248,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/quickTest.xml
+++ b/parameters/quickTest.xml
@@ -249,11 +249,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/quickTest.xml
+++ b/parameters/quickTest.xml
@@ -249,7 +249,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/parameters/quickTest.xml
+++ b/parameters/quickTest.xml
@@ -250,8 +250,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -242,8 +242,10 @@
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -241,7 +241,7 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -7,7 +7,6 @@
   <!-- Component selection -->
   <componentBasic             value="standard"/>
   <componentBlackHole         value="standard" >
-    <massSeed                                    value="100.0000"/>
     <heatsHotHalo                                value="true"    />
     <efficiencyWind                              value="  0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"    />
@@ -241,6 +240,10 @@
     </nodeOperator>
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -241,11 +241,11 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/reference/evolutionGalaxyFormationNBody.xml
+++ b/parameters/reference/evolutionGalaxyFormationNBody.xml
@@ -7,7 +7,6 @@
   <!-- Component selection -->
   <componentBasic             value="standard"/>
   <componentBlackHole         value="standard" >
-    <massSeed                                    value="100.0000"/>
     <heatsHotHalo                                value="true"    />
     <efficiencyWind                              value="  0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"    />
@@ -219,6 +218,10 @@
 	<correlationNormalization value="1.000e0"/>
 	<correlationRedshiftExponent value="0.000e0"/>
       </nbodyHaloMassError>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/reference/evolutionGalaxyFormationNBody.xml
+++ b/parameters/reference/evolutionGalaxyFormationNBody.xml
@@ -219,11 +219,11 @@
 	<correlationRedshiftExponent value="0.000e0"/>
       </nbodyHaloMassError>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/reference/evolutionGalaxyFormationNBody.xml
+++ b/parameters/reference/evolutionGalaxyFormationNBody.xml
@@ -219,7 +219,7 @@
 	<correlationRedshiftExponent value="0.000e0"/>
       </nbodyHaloMassError>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/parameters/reference/evolutionGalaxyFormationNBody.xml
+++ b/parameters/reference/evolutionGalaxyFormationNBody.xml
@@ -220,8 +220,10 @@
       </nbodyHaloMassError>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/tutorials/galaxyMergerTree.xml
+++ b/parameters/tutorials/galaxyMergerTree.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -265,6 +264,10 @@
       <nodePropertyExtractor value="starFormationRate">
 	<component value="total"/>
       </nodePropertyExtractor>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/tutorials/galaxyMergerTree.xml
+++ b/parameters/tutorials/galaxyMergerTree.xml
@@ -265,11 +265,11 @@
 	<component value="total"/>
       </nodePropertyExtractor>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/tutorials/galaxyMergerTree.xml
+++ b/parameters/tutorials/galaxyMergerTree.xml
@@ -265,7 +265,7 @@
 	<component value="total"/>
       </nodePropertyExtractor>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/parameters/tutorials/galaxyMergerTree.xml
+++ b/parameters/tutorials/galaxyMergerTree.xml
@@ -266,8 +266,10 @@
       </nodePropertyExtractor>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/tutorials/lightconeOutput.xml
+++ b/parameters/tutorials/lightconeOutput.xml
@@ -272,8 +272,10 @@
       <lengthBox value="684.9315068493151"/>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/tutorials/lightconeOutput.xml
+++ b/parameters/tutorials/lightconeOutput.xml
@@ -271,7 +271,7 @@
     <nodeOperator value="positionInterpolated">
       <lengthBox value="684.9315068493151"/>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/parameters/tutorials/lightconeOutput.xml
+++ b/parameters/tutorials/lightconeOutput.xml
@@ -271,11 +271,11 @@
     <nodeOperator value="positionInterpolated">
       <lengthBox value="684.9315068493151"/>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/parameters/tutorials/lightconeOutput.xml
+++ b/parameters/tutorials/lightconeOutput.xml
@@ -11,7 +11,6 @@
   <!-- Component selection -->
   <componentBasic             value="standard" />
   <componentBlackHole         value="standard"  >
-    <massSeed                                    value="100.0" />
     <growthRatioToStellarSpheroid                value="1.0d-3"/>
     <heatsHotHalo                                value="true"  />
     <efficiencyWind                              value="0.001" />
@@ -271,6 +270,10 @@
     <!-- Position interpolation -->
     <nodeOperator value="positionInterpolated">
       <lengthBox value="684.9315068493151"/>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/scripts/aux/launch.pl
+++ b/scripts/aux/launch.pl
@@ -144,8 +144,11 @@ sub Construct_Models {
 		        = &{$Galacticus::Launch::Hooks::moduleHooks{$launchScript->{'launchMethod'}}->{'outputFileName'}}
 		           ($galacticusOutputFile,$launchScript);
 		    # Set the random seed.
-		    $parameters->{'randomSeed'}->{'value'} = $randomSeed 
-			unless ( exists($parameters->{'randomSeed'}) );
+		    $parameters->{'randomNumberGenerator'} = {
+			value => "GSL",
+			seed  => {value => $randomSeed}
+		    }
+			unless ( exists($parameters->{'randomNumberGenerator'}) );
 		    # Set a state restore file.
 		    if ( $launchScript->{'useStateFile'} eq "yes" ) {
 			(my $stateFile = $parameters->{'outputFileName'}->{'value'}) =~ s/\.hdf5//;

--- a/scripts/aux/migrations.xml
+++ b/scripts/aux/migrations.xml
@@ -225,6 +225,9 @@
       <remove/>
     </translation>
   </migration>
+  <migration commit="085033d9d7d8f1956eb0b5b7918ce731229d57e2">
+    <translation function="blackHoleSeedMass"/>
+  </migration>
 
   <!-- Known default values for parameters -->
   <default parameter="componentBlackHole"             value="standard"        />

--- a/scripts/aux/migrations.xml
+++ b/scripts/aux/migrations.xml
@@ -43,7 +43,7 @@
       <name new="componentBlackHole--bondiHoyleAccretionTemperatureSpheroid"/>
     </translation>
     <translation xpath="/parameters/blackHoleSeedMass[@value]">
-      <name new="componentBlackHole--massSeed"/>
+      <name new="componentBlackHole--mass"/>
     </translation>
     <translation xpath="/parameters/tripleBlackHoleInteraction[@value]">
       <name new="componentBlackHole--tripleInteraction"/>

--- a/scripts/aux/parametersMigrate.pl
+++ b/scripts/aux/parametersMigrate.pl
@@ -77,22 +77,22 @@ if ( exists($options{'lastModifiedRevision'}) ) {
     }
 } else {
     # Look for a last modification hash.
-    my $elementLastModified = $root->findnodes('lastModified')->[0];
+    my $elementLastModified = $root->findnodes('//lastModified')->[0];
     if ( defined($elementLastModified) ) {
 	# A last modified element exists, extract the hash, and update.
 	$hashLastModified = $elementLastModified->getAttribute('revision');
-   } else {
-	# No last modified element exists. Set the last modified hash that immediately prior to the earliest one that this script
-	# is aware of, and add a last modified element.
-	$hashLastModified           = "6eab8997cd73cb0a474228ade542d133890ad138^";
-	my $elementLastModifiedNode = $input->createElement("lastModified");
-	my $newBreak                = $input->createTextNode("\n  "   );
-	$root->insertBefore($elementLastModifiedNode,$root->firstChild());
-	$root->insertBefore($newBreak               ,$root->firstChild());
-    }
+   }
 }
 ## Update the last modified metadata.
 my $elementLastModified = $root->findnodes('lastModified')->[0];
+unless ( defined($elementLastModified) ) {
+    $hashLastModified           = "6eab8997cd73cb0a474228ade542d133890ad138^";
+    my $elementLastModifiedNode = $input->createElement("lastModified");
+    my $newBreak                = $input->createTextNode("\n  "   );
+    $root->insertBefore($elementLastModifiedNode,$root->firstChild());
+    $root->insertBefore($newBreak               ,$root->firstChild());    
+    $elementLastModified = $root->findnodes('lastModified')->[0];
+}
 $elementLastModified->setAttribute('revision',$hashHead);
 $elementLastModified->setAttribute('time'    ,DateTime->now());
 
@@ -345,4 +345,37 @@ sub radiationFieldIntergalacticBackgroundCMB {
 	$node         ->parentNode->insertAfter($summationNode,$node);
 	$node         ->parentNode->removeChild(               $node);
     }
+}
+
+sub blackHoleSeedMass {
+    # Special handling to add black hole seed mass models.
+    my $input      = shift();
+    my $parameters = shift();
+    # Look for "componentBlackHole" parameters.
+    my $massSeed = 100.0; # This was the default value, to be used if no value was explicitly set.
+    foreach my $node ( $parameters->findnodes("//componentBlackHole[\@value='simple' or \@value='standard' or \@value='nonCentral']/massSeed[\@value]")->get_nodelist() ) {
+	print "   translate special '//componentBlackHole[\@value]/massSeed[\@value]'\n";
+	# Extract the seed mass.
+	$massSeed = $node->getAttribute('value');
+	# Delete this node.
+	$node->parentNode->removeChild($node);
+    }
+    # Find nodeOperators.
+    my @nodeOperators = $parameters->findnodes("//nodeOperator[\@value='multi']")->get_nodelist();
+    die("can not find any `nodeOperator[\@value='multi']` into which to insert a black hole seed operator")
+	if ( scalar(@nodeOperators) == 0 );
+    die("found multiple `nodeOperator[\@value='multi']` nodes - unknown into which to insert a black hole seed operator")
+	if ( scalar(@nodeOperators) >  1 );
+    # Create a new node operator and insert into the list.
+    my $operatorNode = $input->createElement("nodeOperator");
+    my $massNode     = $input->createElement("massSeed"    );
+    my $spinNode     = $input->createElement("spinSeed"    );
+    $operatorNode->setAttribute('value','blackHolesSeed');
+    $massNode    ->setAttribute('value',$massSeed       );
+    $spinNode    ->setAttribute('value',0.0             );
+    # Assemble our new nodes.
+    $operatorNode->addChild($massNode);
+    $operatorNode->addChild($spinNode);
+    # Insert the new parameters.
+    $nodeOperators[0]->insertAfter($operatorNode,$nodeOperators[0]->lastChild);
 }

--- a/scripts/aux/parametersMigrate.pl
+++ b/scripts/aux/parametersMigrate.pl
@@ -367,15 +367,18 @@ sub blackHoleSeedMass {
     die("found multiple `nodeOperator[\@value='multi']` nodes - unknown into which to insert a black hole seed operator")
 	if ( scalar(@nodeOperators) >  1 );
     # Create a new node operator and insert into the list.
-    my $operatorNode = $input->createElement("nodeOperator");
-    my $massNode     = $input->createElement("massSeed"    );
-    my $spinNode     = $input->createElement("spinSeed"    );
+    my $operatorNode = $input->createElement("nodeOperator"  );
+    my $seedNode     = $input->createElement("blackHoleSeeds");
+    my $massNode     = $input->createElement("massSeed"      );
+    my $spinNode     = $input->createElement("spinSeed"      );
     $operatorNode->setAttribute('value','blackHolesSeed');
+    $seedNode    ->setAttribute('value','fixed'         );
     $massNode    ->setAttribute('value',$massSeed       );
     $spinNode    ->setAttribute('value',0.0             );
     # Assemble our new nodes.
-    $operatorNode->addChild($massNode);
-    $operatorNode->addChild($spinNode);
+    $operatorNode->addChild($seedNode);
+    $seedNode    ->addChild($massNode);
+    $seedNode    ->addChild($spinNode);
     # Insert the new parameters.
     $nodeOperators[0]->insertAfter($operatorNode,$nodeOperators[0]->lastChild);
 }

--- a/scripts/aux/parametersMigrate.pl
+++ b/scripts/aux/parametersMigrate.pl
@@ -369,8 +369,8 @@ sub blackHoleSeedMass {
     # Create a new node operator and insert into the list.
     my $operatorNode = $input->createElement("nodeOperator"  );
     my $seedNode     = $input->createElement("blackHoleSeeds");
-    my $massNode     = $input->createElement("massSeed"      );
-    my $spinNode     = $input->createElement("spinSeed"      );
+    my $massNode     = $input->createElement("mass"          );
+    my $spinNode     = $input->createElement("spin"          );
     $operatorNode->setAttribute('value','blackHolesSeed');
     $seedNode    ->setAttribute('value','fixed'         );
     $massNode    ->setAttribute('value',$massSeed       );

--- a/source/black_holes.seeds.F90
+++ b/source/black_holes.seeds.F90
@@ -1,0 +1,55 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which implements a class for black hole seeds.
+!!}
+
+module Black_Hole_Seeds
+  !!{
+  Implements a class for black hole seeds.
+  !!}
+  use :: Galacticus_Nodes, only : treeNode
+  implicit none
+  private
+
+  !![
+  <functionClass>
+   <name>blackHoleSeeds</name>
+   <descriptiveName>Black Hole Seeds</descriptiveName>
+   <description>
+    Class providing models of black hole seeds.
+   </description>
+   <default>fixed</default>
+   <method name="mass" >
+    <description>Computes the mass of the black hole seed in the given {\normalfont \ttfamily node}.</description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>type(treeNode), intent(inout) :: node</argument>
+   </method>
+   <method name="spin" >
+    <description>Computes the spin of the black hole seed in the given {\normalfont \ttfamily node}.</description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>type(treeNode), intent(inout) :: node</argument>
+   </method>
+  </functionClass>
+  !!]
+
+end module Black_Hole_Seeds

--- a/source/black_holes.seeds.fixed.F90
+++ b/source/black_holes.seeds.fixed.F90
@@ -1,0 +1,121 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements the fixed mass and spin black hole seeds.
+  !!}
+
+  !![
+  <blackHoleSeeds name="blackHoleSeedsFixed">
+   <description>
+    A model of black hole seeds in which seeds have fixed mass and spin, indepedent of the halo in which they form.
+   </description>
+  </blackHoleSeeds>
+  !!]
+  type, extends(blackHoleSeedsClass) :: blackHoleSeedsFixed
+     !!{
+     A model of black hole seeds in which seeds have fixed mass and spin, indepedent of the halo in which they form.
+     !!}
+     private
+     double precision :: mass_, spin_   
+   contains
+     procedure :: mass => fixedMass
+     procedure :: spin => fixedSpin
+  end type blackHoleSeedsFixed
+  
+  interface blackHoleSeedsFixed
+     !!{
+     Constructors for the {\normalfont \ttfamily standard} black hole accretion rate class.
+     !!}
+     module procedure standardConstructorParameters
+     module procedure standardConstructorInternal
+  end interface blackHoleSeedsFixed
+
+contains
+
+  function standardConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily fixed} black hole seeds class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (blackHoleSeedsFixed)                :: self
+    type            (inputParameters    ), intent(inout) :: parameters
+    double precision                                     :: mass      , spin
+    
+    !![
+    <inputParameter>
+      <name>mass</name>
+      <defaultValue>100.0d0</defaultValue>
+      <description>The mass of seed black holes.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>spin</name>
+      <defaultValue>0.0d0</defaultValue>
+      <description>The spin of seed black holes.</description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=blackHoleSeedsFixed(mass,spin)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function standardConstructorParameters
+
+  function standardConstructorInternal(mass_,spin_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily fixed} black hole seed class.
+    !!}
+    implicit none
+    type            (blackHoleSeedsFixed)                :: self
+    double precision                     , intent(in   ) :: mass_, spin_
+    !![
+    <constructorAssign variables="mass_, spin_"/>
+    !!]
+
+    return
+  end function standardConstructorInternal
+
+  double precision function fixedMass(self,node) result(mass)
+    !!{
+    Compute the mass of the seed black hole.
+    !!}
+    implicit none
+    class(blackHoleSeedsFixed), intent(inout) :: self
+    type (treeNode           ), intent(inout) :: node
+    !$GLC attributes unused :: node
+    
+    mass=self%mass_
+    return
+  end function fixedMass
+
+  double precision function fixedSpin(self,node) result(spin)
+    !!{
+    Compute the spin of the seed black hole.
+    !!}
+    implicit none
+    class(blackHoleSeedsFixed), intent(inout) :: self
+    type (treeNode           ), intent(inout) :: node
+    !$GLC attributes unused :: node
+    
+    spin=self%spin_
+    return
+  end function fixedSpin

--- a/source/black_holes.seeds.fixed.F90
+++ b/source/black_holes.seeds.fixed.F90
@@ -24,13 +24,13 @@
   !![
   <blackHoleSeeds name="blackHoleSeedsFixed">
    <description>
-    A model of black hole seeds in which seeds have fixed mass and spin, indepedent of the halo in which they form.
+    A model of black hole seeds in which seeds have fixed mass and spin, independent of the halo in which they form.
    </description>
   </blackHoleSeeds>
   !!]
   type, extends(blackHoleSeedsClass) :: blackHoleSeedsFixed
      !!{
-     A model of black hole seeds in which seeds have fixed mass and spin, indepedent of the halo in which they form.
+     A model of black hole seeds in which seeds have fixed mass and spin, independent of the halo in which they form.
      !!}
      private
      double precision :: mass_, spin_   
@@ -41,7 +41,7 @@
   
   interface blackHoleSeedsFixed
      !!{
-     Constructors for the {\normalfont \ttfamily standard} black hole accretion rate class.
+     Constructors for the {\normalfont \ttfamily fixed} black hole seeds class.
      !!}
      module procedure standardConstructorParameters
      module procedure standardConstructorInternal

--- a/source/nodes.operators.physics.black_holes.seed.F90
+++ b/source/nodes.operators.physics.black_holes.seed.F90
@@ -1,0 +1,120 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a node operator class that creates black hole seeds in nodes.
+  !!}
+
+  use :: Black_Hole_Seeds, only : blackHoleSeedsClass
+
+  !![
+  <nodeOperator name="nodeOperatorBlackHolesSeed">
+   <description>A node operator class that create black hole seeds in nodes.</description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorBlackHolesSeed
+     !!{
+     A node operator class that creates black hole seeds in nodes. 
+     !!}
+     private
+     class(blackHoleSeedsClass), pointer :: blackHoleSeeds_ => null()
+   contains
+     final     ::                   blackHolesSeedDestructor
+     procedure :: nodeInitialize => blackHolesSeedNodeInitialize
+  end type nodeOperatorBlackHolesSeed
+  
+  interface nodeOperatorBlackHolesSeed
+     !!{
+     Constructors for the {\normalfont \ttfamily blackHolesSeed} node operator class.
+     !!}
+     module procedure blackHolesSeedConstructorParameters
+     module procedure blackHolesSeedConstructorInternal
+  end interface nodeOperatorBlackHolesSeed
+  
+contains
+
+  function blackHolesSeedConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily starFormation} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type (nodeOperatorBlackHolesSeed)                :: self
+    type (inputParameters           ), intent(inout) :: parameters
+    class(blackHoleSeedsClass       ), pointer       :: blackHoleSeeds_
+    
+    !![
+    <objectBuilder class="blackHoleSeeds" name="blackHoleSeeds_" source="parameters"/>
+    !!]
+    self=nodeOperatorBlackHolesSeed(blackHoleSeeds_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="blackHoleSeeds_"/>
+    !!]
+    return
+  end function blackHolesSeedConstructorParameters
+
+  function blackHolesSeedConstructorInternal(blackHoleSeeds_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily blackHolesSeed} node operator class.
+    !!}
+    implicit none
+    type (nodeOperatorBlackHolesSeed)                        :: self
+    class(blackHoleSeedsClass       ), intent(in   ), target :: blackHoleSeeds_
+    !![
+    <constructorAssign variables="*blackHoleSeeds_"/>
+    !!]
+    
+    return
+  end function blackHolesSeedConstructorInternal
+
+  subroutine blackHolesSeedDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily blackHolesSeed} node operator class.
+    !!}
+    implicit none
+    type(nodeOperatorBlackHolesSeed), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%blackHoleSeeds_"/>
+    !!]
+    return
+  end subroutine blackHolesSeedDestructor
+  
+  subroutine blackHolesSeedNodeInitialize(self,node)
+    !!{
+    Create any initial black hole seeds.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentBlackHole
+    implicit none
+    class           (nodeOperatorBlackHolesSeed), intent(inout), target  :: self
+    type            (treeNode                  ), intent(inout), target  :: node
+    class           (nodeComponentBlackHole    )               , pointer :: blackHole
+    double precision                                                     :: massSeed
+
+    massSeed=self%blackHoleSeeds_%mass(node)
+    ! Create a black hole component only if the seed mass is non-zero.
+    if (massSeed > 0.0d0) then
+       blackHole => node%blackHole(autoCreate=.true.)
+       call        blackHole%massSet(                     massSeed      )
+       if (blackHole%spinIsSettable()) &
+            & call blackHole%spinSet(self%blackHoleSeeds_%spin    (node))
+    end if
+    return
+  end subroutine blackHolesSeedNodeInitialize

--- a/source/nodes.operators.physics.star_formation.disks.F90
+++ b/source/nodes.operators.physics.star_formation.disks.F90
@@ -32,7 +32,7 @@
   !!]
   type, extends(nodeOperatorClass) :: nodeOperatorStarFormationDisks
      !!{
-     A node operator class that shifts node indices at node promotion.
+     A node operator class that performs star formation.
      !!}
      private
      class           (starFormationRateDisksClass     ), pointer :: starFormationRateDisks_      => null()

--- a/source/objects.nodes.components.black_hole.non_central.F90
+++ b/source/objects.nodes.components.black_hole.non_central.F90
@@ -28,6 +28,7 @@ module Node_Component_Black_Hole_Noncentral
   use :: Black_Hole_Binary_Mergers          , only : blackHoleBinaryMergerClass
   use :: Black_Hole_Binary_Recoil_Velocities, only : blackHoleBinaryRecoilClass
   use :: Black_Hole_Binary_Separations      , only : blackHoleBinarySeparationGrowthRateClass
+  use :: Black_Hole_Seeds                   , only : blackHoleSeedsClass
   use :: Dark_Matter_Halo_Scales            , only : darkMatterHaloScaleClass
   implicit none
   private
@@ -62,7 +63,8 @@ module Node_Component_Black_Hole_Noncentral
   class(blackHoleBinaryRecoilClass              ), pointer :: blackHoleBinaryRecoil_
   class(blackHoleBinaryMergerClass              ), pointer :: blackHoleBinaryMerger_
   class(blackHoleBinarySeparationGrowthRateClass), pointer :: blackHoleBinarySeparationGrowthRate_
-  !$omp threadprivate(darkMatterHaloScale_,blackHoleBinaryRecoil_,blackHoleBinaryMerger_,blackHoleBinarySeparationGrowthRate_)
+  class(blackHoleSeedsClass                     ), pointer :: blackHoleSeeds_
+  !$omp threadprivate(darkMatterHaloScale_,blackHoleBinaryRecoil_,blackHoleBinaryMerger_,blackHoleBinarySeparationGrowthRate_,blackHoleSeeds_)
 
   ! Option specifying whether the triple black hole interaction should be used.
   logical :: tripleInteraction
@@ -127,6 +129,7 @@ contains
        <objectBuilder class="blackHoleBinaryRecoil"               name="blackHoleBinaryRecoil_"               source="subParameters"/>
        <objectBuilder class="blackHoleBinaryMerger"               name="blackHoleBinaryMerger_"               source="subParameters"/>
        <objectBuilder class="blackHoleBinarySeparationGrowthRate" name="blackHoleBinarySeparationGrowthRate_" source="subParameters"/>
+       <objectBuilder class="blackHoleSeeds"                      name="blackHoleSeeds_"                      source="subParameters"/>
        !!]
     end if
     return
@@ -150,6 +153,7 @@ contains
        <objectDestructor name="blackHoleBinaryRecoil_"              />
        <objectDestructor name="blackHoleBinaryMerger_"              />
        <objectDestructor name="blackHoleBinarySeparationGrowthRate_"/>
+       <objectDestructor name="blackHoleSeeds_"                     />
        !!]
     end if
     return
@@ -368,8 +372,8 @@ contains
     velocityRecoil=blackHoleBinaryRecoil_%velocity(blackHolePrimary,blackHoleSecondary)
     ! Compare the recoil velocity to the potential and determine whether the binary is ejected or stays in the galaxy.
     if (Node_Component_Black_Hole_Noncentral_Recoil_Escapes(node,velocityRecoil,radius=0.0d0,ignoreCentralBlackHole=.true.)) then
-       massBlackHoleNew=blackHole1%massSeed()
-       spinBlackHoleNew=blackHole1%spinSeed()
+       massBlackHoleNew=blackHoleSeeds_%mass(node)
+       spinBlackHoleNew=blackHoleSeeds_%spin(node)
     end if
     ! Set the mass and spin of the central black hole.
     call blackHole1%massSet(massBlackHoleNew)
@@ -383,7 +387,7 @@ contains
     !!{
     Handles triple black holes interactions, using conditions similar to those of \cite{volonteri_assembly_2003}.
     !!}
-    use :: Galacticus_Nodes            , only : nodeComponentBasic             , nodeComponentBlackHole, treeNode
+    use :: Galacticus_Nodes                , only : nodeComponentBasic             , nodeComponentBlackHole, treeNode
     use :: Numerical_Constants_Astronomical, only : gravitationalConstantGalacticus
     implicit none
     type            (treeNode              ), intent(inout), target   :: node
@@ -548,7 +552,7 @@ contains
 
     call displayMessage('Storing state for: componentBlackHole -> nonCentral',verbosity=verbosityLevelInfo)
     !![
-    <stateStore variables="darkMatterHaloScale_ blackHoleBinaryRecoil_ blackHoleBinaryMerger_ blackHoleBinarySeparationGrowthRate_"/>
+    <stateStore variables="darkMatterHaloScale_ blackHoleBinaryRecoil_ blackHoleBinaryMerger_ blackHoleBinarySeparationGrowthRate_ blackHoleSeeds_"/>
     !!]
     return
   end subroutine Node_Component_Black_Hole_NonCentral_State_Store
@@ -571,7 +575,7 @@ contains
 
     call displayMessage('Retrieving state for: componentBlackHole -> nonCentral',verbosity=verbosityLevelInfo)
     !![
-    <stateRestore variables="darkMatterHaloScale_ blackHoleBinaryRecoil_ blackHoleBinaryMerger_ blackHoleBinarySeparationGrowthRate_"/>
+    <stateRestore variables="darkMatterHaloScale_ blackHoleBinaryRecoil_ blackHoleBinaryMerger_ blackHoleBinarySeparationGrowthRate_ blackHoleSeeds_"/>
     !!]
     return
   end subroutine Node_Component_Black_Hole_NonCentral_State_Restore

--- a/source/objects.nodes.components.black_hole.simple.F90
+++ b/source/objects.nodes.components.black_hole.simple.F90
@@ -47,14 +47,7 @@ module Node_Component_Black_Hole_Simple
       <type>double</type>
       <rank>0</rank>
       <attributes isSettable="true" isGettable="true" isEvolvable="true" />
-      <classDefault>defaultBlackHoleComponent%massSeed()</classDefault>
       <output unitsInSI="massSolar" comment="Mass of the black hole."/>
-    </property>
-    <property>
-      <name>massSeed</name>
-      <type>double</type>
-      <rank>0</rank>
-      <attributes isSettable="false" isGettable="true" isEvolvable="false" isVirtual="true" isDeferred="get" />
     </property>
    </properties>
    <bindings>
@@ -71,9 +64,6 @@ module Node_Component_Black_Hole_Simple
   class(blackHoleBinaryMergerClass     ), pointer :: blackHoleBinaryMerger_
   class(blackHoleAccretionRateClass    ), pointer :: blackHoleAccretionRate_
   !$omp threadprivate(darkMatterHaloScale_,blackHoleAccretionRate_,coolingRadius_,blackHoleBinaryMerger_)
-
-  ! Seed mass for black holes.
-  double precision :: massSeed
 
   ! Feedback parameters.
   double precision :: efficiencyHeating, efficiencyWind
@@ -94,26 +84,13 @@ contains
     !!{
     Initializes the simple black hole node component module.
     !!}
-    use :: Galacticus_Nodes, only : nodeComponentBlackHoleSimple
-    use :: Input_Parameters, only : inputParameter              , inputParameters
+    use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(inputParameters             ), intent(inout) :: parameters
-    type(nodeComponentBlackHoleSimple)                :: blackHoleSimple
-    type(inputParameters             )                :: subParameters
+    type(inputParameters), intent(inout) :: parameters
+    type(inputParameters)                :: subParameters
 
-    ! Bind deferred functions.
-    call blackHoleSimple%massSeedFunction(Node_Component_Black_Hole_Simple_Seed_Mass)
     ! Find our parameters.
     subParameters=parameters%subParameters('componentBlackHole')
-    ! Get the seed mass
-    !![
-    <inputParameter>
-      <name>massSeed</name>
-      <source>subParameters</source>
-      <defaultValue>100.0d0</defaultValue>
-      <description>The mass of the seed black hole placed at the center of each newly formed galaxy.</description>
-    </inputParameter>
-    !!]
     ! Options controlling AGN feedback.
     !![
     <inputParameter>
@@ -231,17 +208,14 @@ contains
        ! Get the spheroid component.
        spheroid => node%spheroid()
        ! Set scale for mass.
-       call blackHole%massScale(                                                             &
-            &                   max(                                                         &
-            &                                                 blackHole%massSeed         (), &
-            &                       max(                                                     &
-            &                               massScaleRelative*spheroid %massStellar      (), &
-            &                           max(                                                 &
-            &                                                           massScaleAbsolute  , &
-            &                                                 blackHole%mass             ()  &
-            &                              )                                                 &
-            &                          )                                                     &
-            &                      )                                                         &
+       call blackHole%massScale(                                                         &
+             &                  max(                                                     &
+            &                           massScaleRelative*spheroid %massStellar      (), &
+            &                       max(                                                 &
+            &                                                       massScaleAbsolute  , &
+            &                                             blackHole%mass             ()  &
+            &                          )                                                 &
+            &                      )                                                     &
             &                  )
     end select
     return
@@ -256,6 +230,7 @@ contains
     !!{
     Compute the black hole mass rate of change.
     !!}
+    use :: Error                       , only : Error_Report
     use :: Galacticus_Nodes            , only : defaultBlackHoleComponent, interruptTask        , nodeComponentBlackHole, nodeComponentBlackHoleSimple, &
           &                                     nodeComponentHotHalo     , nodeComponentSpheroid, propertyInactive      , treeNode
     use :: Numerical_Constants_Physical, only : speedLight
@@ -298,11 +273,7 @@ contains
        select type (blackHole)
        type is (nodeComponentBlackHole)
           ! Generic type - interrupt and create a simple black hole if accretion rate is non-zero.
-          if (massAccretionRate /= 0.0d0) then
-             interrupt=.true.
-             interruptProcedure => Node_Component_Black_Hole_Simple_Create
-          end if
-          return
+          if (massAccretionRate /= 0.0d0) call Error_Report('accretion onto non-existant black hole'//{introspection:location})
        class is (nodeComponentBlackHoleSimple)
           ! Get the spheroid component.
           spheroid => node%spheroid()
@@ -372,37 +343,6 @@ contains
     call blackHole    %massSet(           0.0d0)
     return
   end subroutine satelliteMerger
-
-  subroutine Node_Component_Black_Hole_Simple_Create(node,timeEnd)
-    !!{
-    Creates a simple black hole component for {\normalfont \ttfamily node}.
-    !!}
-    use :: Galacticus_Nodes, only : nodeComponentBlackHole, treeNode
-    implicit none
-    type            (treeNode              ), intent(inout), target   :: node
-    double precision                        , intent(in   ), optional :: timeEnd
-    class           (nodeComponentBlackHole)               , pointer  :: blackHole
-    !$GLC attributes unused :: timeEnd
-    
-    ! Create the component.
-    blackHole => node%blackHole(autoCreate=.true.)
-    ! Set the seed mass.
-    call blackHole%massSet(massSeed)
-    return
-  end subroutine Node_Component_Black_Hole_Simple_Create
-
-  double precision function Node_Component_Black_Hole_Simple_Seed_Mass(self)
-    !!{
-    Return the seed mass for simple black holes.
-    !!}
-    use :: Galacticus_Nodes, only : nodeComponentBlackHoleSimple
-    implicit none
-    class(nodeComponentBlackHoleSimple), intent(inout) :: self
-    !$GLC attributes unused :: self
-    
-    Node_Component_Black_Hole_Simple_Seed_Mass=massSeed
-    return
-  end function Node_Component_Black_Hole_Simple_Seed_Mass
 
   !![
   <stateStoreTask>

--- a/source/objects.nodes.components.black_hole.standard.F90
+++ b/source/objects.nodes.components.black_hole.standard.F90
@@ -29,8 +29,8 @@ module Node_Component_Black_Hole_Standard
   use :: Black_Hole_Binary_Initial_Separation, only : blackHoleBinaryInitialSeparationClass
   use :: Black_Hole_Binary_Mergers           , only : blackHoleBinaryMergerClass
   use :: Black_Hole_Binary_Recoil_Velocities , only : blackHoleBinaryRecoilClass
-  use :: Black_Hole_Binary_Separations       , only : blackHoleBinarySeparationGrowthRateClass
   use :: Black_Hole_Accretion_Rates          , only : blackHoleAccretionRateClass
+  use :: Black_Hole_Seeds                    , only : blackHoleSeedsClass
   use :: Cosmology_Parameters                , only : cosmologyParametersClass
   use :: Dark_Matter_Halo_Scales             , only : darkMatterHaloScaleClass
   implicit none
@@ -52,7 +52,6 @@ module Node_Component_Black_Hole_Standard
       <type>double</type>
       <rank>0</rank>
       <attributes isSettable="true" isGettable="true" isEvolvable="true" />
-      <classDefault>defaultBlackHoleComponent%massSeed()</classDefault>
       <output unitsInSI="massSolar" comment="Mass of the black hole."/>
     </property>
     <property>
@@ -61,7 +60,6 @@ module Node_Component_Black_Hole_Standard
       <rank>0</rank>
       <attributes isSettable="true" isGettable="true" isEvolvable="true" />
       <getFunction>Node_Component_Black_Hole_Standard_Spin</getFunction>
-      <classDefault>self%spinSeed()</classDefault>
       <output unitsInSI="0.0d0" comment="Spin of the black hole."/>
     </property>
     <property>
@@ -75,19 +73,6 @@ module Node_Component_Black_Hole_Standard
       <type>double</type>
       <rank>0</rank>
       <attributes isSettable="true" isGettable="true" isEvolvable="false" />
-    </property>
-    <property>
-      <name>massSeed</name>
-      <type>double</type>
-      <rank>0</rank>
-      <attributes isSettable="false" isGettable="true" isEvolvable="false" isVirtual="true" isDeferred="get"  />
-    </property>
-    <property>
-      <name>spinSeed</name>
-      <type>double</type>
-      <rank>0</rank>
-      <attributes isSettable="false" isGettable="true" isEvolvable="false" isVirtual="true" />
-      <getFunction>Node_Component_Black_Hole_Standard_Seed_Spin</getFunction>
     </property>
     <property>
       <name>accretionRate</name>
@@ -111,14 +96,14 @@ module Node_Component_Black_Hole_Standard
   !!]
 
   ! Objects used by this component.
-  class(accretionDisksClass                     ), pointer :: accretionDisks_
-  class(blackHoleBinaryRecoilClass              ), pointer :: blackHoleBinaryRecoil_
-  class(blackHoleAccretionRateClass             ), pointer :: blackHoleAccretionRate_
-  class(blackHoleBinaryInitialSeparationClass   ), pointer :: blackHoleBinaryInitialSeparation_
-  class(blackHoleBinaryMergerClass              ), pointer :: blackHoleBinaryMerger_
-  class(blackHoleBinarySeparationGrowthRateClass), pointer :: blackHoleBinarySeparationGrowthRate_
-  class(darkMatterHaloScaleClass                ), pointer :: darkMatterHaloScale_
-  !$omp threadprivate(accretionDisks_,blackHoleAccretionRate_,blackHoleBinaryRecoil_,blackHoleBinaryInitialSeparation_,blackHoleBinaryMerger_,blackHoleBinarySeparationGrowthRate_,darkMatterHaloScale_)
+  class(accretionDisksClass                  ), pointer :: accretionDisks_
+  class(blackHoleBinaryRecoilClass           ), pointer :: blackHoleBinaryRecoil_
+  class(blackHoleAccretionRateClass          ), pointer :: blackHoleAccretionRate_
+  class(blackHoleBinaryInitialSeparationClass), pointer :: blackHoleBinaryInitialSeparation_
+  class(blackHoleBinaryMergerClass           ), pointer :: blackHoleBinaryMerger_
+  class(blackHoleSeedsClass                  ), pointer :: blackHoleSeeds_
+  class(darkMatterHaloScaleClass             ), pointer :: darkMatterHaloScale_
+  !$omp threadprivate(accretionDisks_,blackHoleAccretionRate_,blackHoleBinaryRecoil_,blackHoleBinaryInitialSeparation_,blackHoleBinaryMerger_,blackHoleSeeds_,darkMatterHaloScale_)
 
   ! Accretion model parameters.
   ! Enhancement factors for the accretion rate.
@@ -127,9 +112,6 @@ module Node_Component_Black_Hole_Standard
   double precision :: bondiHoyleAccretionTemperatureSpheroid
   ! Control for hot mode only accretion.
   logical          :: bondiHoyleAccretionHotModeOnly
-
-  ! Seed mass for black holes.
-  double precision :: massSeed
 
   ! Feedback parameters.
   double precision :: efficiencyWind                        , efficiencyRadioMode
@@ -163,19 +145,8 @@ contains
     type(nodeComponentBlackHoleStandard)                :: blackHoleStandardComponent
     type(inputParameters               )                :: subParameters
 
-    ! Bind deferred functions.
-    call blackHoleStandardComponent%massSeedFunction(Node_Component_Black_Hole_Standard_Seed_Mass)
     ! Find our parameters.
     subParameters=parameters%subParameters('componentBlackHole')
-    ! Get the seed mass
-    !![
-    <inputParameter>
-      <name>massSeed</name>
-      <source>subParameters</source>
-      <defaultValue>100.0d0</defaultValue>
-      <description>The mass of the seed black hole placed at the center of each newly formed galaxy.</description>
-    </inputParameter>
-    !!]
     ! Get accretion rate enhancement factors.
     !![
     <inputParameter>
@@ -281,13 +252,13 @@ contains
        ! Find our parameters.
        subParameters=parameters%subParameters('componentBlackHole')
        !![
-       <objectBuilder class="accretionDisks"                      name="accretionDisks_"                      source="subParameters"/>
-       <objectBuilder class="blackHoleAccretionRate"              name="blackHoleAccretionRate_"              source="subParameters"/>
-       <objectBuilder class="blackHoleBinaryRecoil"               name="blackHoleBinaryRecoil_"               source="subParameters"/>
-       <objectBuilder class="blackHoleBinaryInitialSeparation"    name="blackHoleBinaryInitialSeparation_"    source="subParameters"/>
-       <objectBuilder class="blackHoleBinaryMerger"               name="blackHoleBinaryMerger_"               source="subParameters"/>
-       <objectBuilder class="blackHoleBinarySeparationGrowthRate" name="blackHoleBinarySeparationGrowthRate_" source="subParameters"/>
-       <objectBuilder class="darkMatterHaloScale"                 name="darkMatterHaloScale_"                 source="subParameters"/>
+       <objectBuilder class="accretionDisks"                   name="accretionDisks_"                   source="subParameters"/>
+       <objectBuilder class="blackHoleAccretionRate"           name="blackHoleAccretionRate_"           source="subParameters"/>
+       <objectBuilder class="blackHoleSeeds"                   name="blackHoleSeeds_"                   source="subParameters"/>
+       <objectBuilder class="blackHoleBinaryRecoil"            name="blackHoleBinaryRecoil_"            source="subParameters"/>
+       <objectBuilder class="blackHoleBinaryInitialSeparation" name="blackHoleBinaryInitialSeparation_" source="subParameters"/>
+       <objectBuilder class="blackHoleBinaryMerger"            name="blackHoleBinaryMerger_"            source="subParameters"/>
+       <objectBuilder class="darkMatterHaloScale"              name="darkMatterHaloScale_"              source="subParameters"/>
        !!]     
     end if
     return
@@ -309,13 +280,13 @@ contains
     if (defaultBlackHoleComponent%standardIsActive()) then
        if (satelliteMergerEvent%isAttached(thread,satelliteMerger)) call satelliteMergerEvent%detach(thread,satelliteMerger)
        !![
-       <objectDestructor name="accretionDisks_"                     />
-       <objectDestructor name="blackHoleAccretionRate_"             />
-       <objectDestructor name="blackHoleBinaryRecoil_"              />
-       <objectDestructor name="blackHoleBinaryInitialSeparation_"   />
-       <objectDestructor name="blackHoleBinaryMerger_"              />
-       <objectDestructor name="blackHoleBinarySeparationGrowthRate_"/>
-       <objectDestructor name="darkMatterHaloScale_"                />
+       <objectDestructor name="accretionDisks_"                  />
+       <objectDestructor name="blackHoleAccretionRate_"          />
+       <objectDestructor name="blackHoleSeeds_"                  />
+       <objectDestructor name="blackHoleBinaryRecoil_"           />
+       <objectDestructor name="blackHoleBinaryInitialSeparation_"/>
+       <objectDestructor name="blackHoleBinaryMerger_"           />
+       <objectDestructor name="darkMatterHaloScale_"             />
        !!]
     end if
     return
@@ -330,6 +301,7 @@ contains
     !!{
     Compute the black hole node mass rate of change.
     !!}
+    use :: Error                           , only : Error_Report
     use :: Galacticus_Nodes                , only : defaultBlackHoleComponent, interruptTask        , nodeComponentBasic, nodeComponentBlackHole, &
           &                                         nodeComponentHotHalo     , nodeComponentSpheroid, propertyInactive  , treeNode
     use :: Numerical_Constants_Astronomical, only : gigaYear                 , megaParsec
@@ -390,12 +362,9 @@ contains
           end if
           ! Find the rate of increase in mass of the black hole.
           massAccretionRate=restMassAccretionRate*(1.0d0-radiativeEfficiency-jetEfficiency)
-          ! If no black hole component currently exists and we have some accretion then interrupt and create a black hole.
-          if (instanceCount == 0 .and. massAccretionRate /= 0.0d0) then
-             interrupt=.true.
-             interruptProcedure => Node_Component_Black_Hole_Standard_Create
-             return
-          end if
+          ! If no black hole component currently exists and we have some accretion then this is an error - we can not have
+          ! accretion onto a non-existant black hole.
+          if (instanceCount == 0 .and. massAccretionRate /= 0.0d0) call Error_Report('accretion onto non-existant black hole'//{introspection:location})
           ! Skip to the next black hole if this one has non-positive mass and a negative accretion rate.
           if (blackHole%mass() <= 0.0d0 .and. massAccretionRate < 0.0d0) cycle
           ! Add the accretion to the black hole.
@@ -477,17 +446,14 @@ contains
           ! Get the black hole.
           blackHole => node%blackHole(instance=instance)
           ! Set scale for mass.
-          call blackHole%massScale(                                                       &
-               &                   max(                                                   &
-               &                                                 blackHole%massSeed   (), &
-               &                       max(                                               &
-               &                               scaleMassRelative*spheroid %massStellar(), &
-               &                           max(                                           &
-               &                               scaleMassAbsolute                        , &
-               &                                                 blackHole%mass       ()  &
-               &                              )                                           &
-               &                          )                                               &
-               &                      )                                                   &
+          call blackHole%massScale(                                                   &
+               &                   max(                                               &
+               &                           scaleMassRelative*spheroid %massStellar(), &
+               &                       max(                                           &
+               &                           scaleMassAbsolute                        , &
+               &                                             blackHole%mass       ()  &
+               &                          )                                           &
+               &                      )                                               &
                &                  )
 
           ! Set scale for spin.
@@ -568,11 +534,8 @@ contains
           end if
           ! Move the black hole to the host.
           call Node_Component_Black_Hole_Standard_Output_Merger(node,massBlackHole1,massBlackHole2)
-          call blackHoleHostCentral%massSet(massBlackHoleNew           )
-          call blackHoleHostCentral%spinSet(spinBlackHoleNew           )
-          ! Reset the satellite black hole to zero mass.
-          call blackHole           %massSet(blackHole       %massSeed())
-          call blackHole           %spinSet(blackHole       %spinSeed())
+          call blackHoleHostCentral%massSet(blackHoleSeeds_%mass(node))
+          call blackHoleHostCentral%spinSet(blackHoleSeeds_%spin(node))
        end do
     else
        ! Adjust the radii of the black holes in the satellite galaxy.
@@ -638,26 +601,6 @@ contains
          &  +      potentialSelf
     return
   end function Node_Component_Black_Hole_Standard_Recoil_Escapes
-
-  subroutine Node_Component_Black_Hole_Standard_Create(node,timeEnd)
-    !!{
-    Creates a black hole component for {\normalfont \ttfamily node}.
-    !!}
-    use :: Galacticus_Nodes, only : nodeComponentBlackHole, treeNode
-    implicit none
-    type            (treeNode              ), intent(inout), target   :: node
-    double precision                        , intent(in   ), optional :: timeEnd
-    class           (nodeComponentBlackHole)               , pointer  :: blackHole
-    !$GLC attributes unused :: timeEnd
-    
-    ! Create the black hole.
-    blackHole => node%blackHole(autoCreate=.true.)
-    ! Set to the seed mass.
-    call blackHole%          massSet(blackHole%massSeed())
-    call blackHole%          spinSet(blackHole%spinSeed())
-    call blackHole%radialPositionSet(               0.0d0)
-    return
-  end subroutine Node_Component_Black_Hole_Standard_Create
 
   subroutine Node_Component_Black_Hole_Standard_Output_Merger(node,massBlackHole1,massBlackHole2)
     !!{
@@ -759,8 +702,8 @@ contains
              end if
              if (blackHole%mass() < 0.0d0) then
                 ! Note that "status" is not set to failure as this change in state of the black hole should not change any
-                ! calculation of differential evolution rates as the mass was in an unphysical regime anyway
-                call blackHole%massSet(blackHole%massSeed())
+                ! calculation of differential evolution rates as the mass was in an unphysical regime anyway.
+                call blackHole%massSet(blackHoleSeeds_%mass(node))
                 ! Indicate that ODE evolution should continue after this state change.
                 if (status == GSL_Success) status=GSL_Continue
              end if
@@ -769,19 +712,6 @@ contains
     end if
     return
   end subroutine Node_Component_Black_Hole_Standard_Post_Evolve
-
-  double precision function Node_Component_Black_Hole_Standard_Seed_Mass(self)
-    !!{
-    Return the seed mass for standard black holes.
-    !!}
-    use :: Galacticus_Nodes, only : nodeComponentBlackHoleStandard
-    implicit none
-    class(nodeComponentBlackHoleStandard), intent(inout) :: self
-    !$GLC attributes unused :: self
-    
-    Node_Component_Black_Hole_Standard_Seed_Mass=massSeed
-    return
-  end function Node_Component_Black_Hole_Standard_Seed_Mass
 
   !![
   <stateStoreTask>
@@ -801,7 +731,7 @@ contains
 
     call displayMessage('Storing state for: componentBlackHole -> standard',verbosity=verbosityLevelInfo)
     !![
-    <stateStore variables="accretionDisks_ blackHoleBinaryRecoil_ blackHoleBinaryInitialSeparation_ blackHoleBinaryMerger_ blackHoleBinarySeparationGrowthRate_ blackHoleAccretionRate_ darkMatterHaloScale_"/>
+    <stateStore variables="accretionDisks_ blackHoleBinaryRecoil_ blackHoleBinaryInitialSeparation_ blackHoleBinaryMerger_ blackHoleSeeds_ blackHoleAccretionRate_ darkMatterHaloScale_"/>
     !!]
     return
   end subroutine Node_Component_Black_Hole_Standard_State_Store
@@ -824,7 +754,7 @@ contains
 
     call displayMessage('Retrieving state for: componentBlackHole -> standard',verbosity=verbosityLevelInfo)
     !![
-    <stateRestore variables="accretionDisks_ blackHoleBinaryRecoil_ blackHoleBinaryInitialSeparation_ blackHoleBinaryMerger_ blackHoleBinarySeparationGrowthRate_ blackHoleAccretionRate_ darkMatterHaloScale_"/>
+    <stateRestore variables="accretionDisks_ blackHoleBinaryRecoil_ blackHoleBinaryInitialSeparation_ blackHoleBinaryMerger_ blackHoleSeeds_ blackHoleAccretionRate_ darkMatterHaloScale_"/>
     !!]
     return
   end subroutine Node_Component_Black_Hole_Standard_State_Restore

--- a/source/objects.nodes.components.black_hole.standard.F90
+++ b/source/objects.nodes.components.black_hole.standard.F90
@@ -363,8 +363,8 @@ contains
           ! Find the rate of increase in mass of the black hole.
           massAccretionRate=restMassAccretionRate*(1.0d0-radiativeEfficiency-jetEfficiency)
           ! If no black hole component currently exists and we have some accretion then this is an error - we can not have
-          ! accretion onto a non-existant black hole.
-          if (instanceCount == 0 .and. massAccretionRate /= 0.0d0) call Error_Report('accretion onto non-existant black hole'//{introspection:location})
+          ! accretion onto a non-existent black hole.
+          if (instanceCount == 0 .and. massAccretionRate /= 0.0d0) call Error_Report('accretion onto non-existent black hole'//{introspection:location})
           ! Skip to the next black hole if this one has non-positive mass and a negative accretion rate.
           if (blackHole%mass() <= 0.0d0 .and. massAccretionRate < 0.0d0) cycle
           ! Add the accretion to the black hole.

--- a/testSuite/parameters/activeLuminosities.xml
+++ b/testSuite/parameters/activeLuminosities.xml
@@ -262,7 +262,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/activeLuminosities.xml
+++ b/testSuite/parameters/activeLuminosities.xml
@@ -263,8 +263,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/activeLuminosities.xml
+++ b/testSuite/parameters/activeLuminosities.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -262,6 +261,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/activeLuminosities.xml
+++ b/testSuite/parameters/activeLuminosities.xml
@@ -262,11 +262,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/benchmark-quickTest.xml
+++ b/testSuite/parameters/benchmark-quickTest.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -250,6 +249,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/benchmark-quickTest.xml
+++ b/testSuite/parameters/benchmark-quickTest.xml
@@ -250,11 +250,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/benchmark-quickTest.xml
+++ b/testSuite/parameters/benchmark-quickTest.xml
@@ -250,7 +250,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/benchmark-quickTest.xml
+++ b/testSuite/parameters/benchmark-quickTest.xml
@@ -251,8 +251,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/bolshoiTestTreesGLC.xml
+++ b/testSuite/parameters/bolshoiTestTreesGLC.xml
@@ -271,7 +271,7 @@
     </nodeOperator>
     <!-- Shift preset named N-body properties -->
     <nodeOperator value="presetNamedShift"/>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/bolshoiTestTreesGLC.xml
+++ b/testSuite/parameters/bolshoiTestTreesGLC.xml
@@ -9,7 +9,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <growthRatioToStellarSpheroid value="1.0d-3"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.001"/>
@@ -272,6 +271,10 @@
     </nodeOperator>
     <!-- Shift preset named N-body properties -->
     <nodeOperator value="presetNamedShift"/>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/bolshoiTestTreesGLC.xml
+++ b/testSuite/parameters/bolshoiTestTreesGLC.xml
@@ -272,8 +272,10 @@
     <!-- Shift preset named N-body properties -->
     <nodeOperator value="presetNamedShift"/>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/bolshoiTestTreesGLC.xml
+++ b/testSuite/parameters/bolshoiTestTreesGLC.xml
@@ -271,11 +271,11 @@
     </nodeOperator>
     <!-- Shift preset named N-body properties -->
     <nodeOperator value="presetNamedShift"/>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/bug745815.xml
+++ b/testSuite/parameters/bug745815.xml
@@ -16,7 +16,6 @@
 
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <efficiencyWind value="0.001"/>
     <bondiHoyleAccretionEnhancementHotHalo value="1"/>
     <bondiHoyleAccretionEnhancementSpheroid value="1"/>

--- a/testSuite/parameters/checkpointingCheckpoints.xml
+++ b/testSuite/parameters/checkpointingCheckpoints.xml
@@ -446,8 +446,10 @@
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/checkpointingCheckpoints.xml
+++ b/testSuite/parameters/checkpointingCheckpoints.xml
@@ -445,6 +445,10 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
   <!-- Merger tree evolution -->

--- a/testSuite/parameters/checkpointingCheckpoints.xml
+++ b/testSuite/parameters/checkpointingCheckpoints.xml
@@ -445,7 +445,7 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/checkpointingCheckpoints.xml
+++ b/testSuite/parameters/checkpointingCheckpoints.xml
@@ -445,11 +445,11 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/checkpointingNoCheckpoints.xml
+++ b/testSuite/parameters/checkpointingNoCheckpoints.xml
@@ -444,7 +444,7 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/checkpointingNoCheckpoints.xml
+++ b/testSuite/parameters/checkpointingNoCheckpoints.xml
@@ -445,8 +445,10 @@
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/checkpointingNoCheckpoints.xml
+++ b/testSuite/parameters/checkpointingNoCheckpoints.xml
@@ -444,6 +444,10 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
   <!-- Merger tree evolution -->

--- a/testSuite/parameters/checkpointingNoCheckpoints.xml
+++ b/testSuite/parameters/checkpointingNoCheckpoints.xml
@@ -444,11 +444,11 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/checkpointingResume.xml
+++ b/testSuite/parameters/checkpointingResume.xml
@@ -444,7 +444,7 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/checkpointingResume.xml
+++ b/testSuite/parameters/checkpointingResume.xml
@@ -445,8 +445,10 @@
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/checkpointingResume.xml
+++ b/testSuite/parameters/checkpointingResume.xml
@@ -444,6 +444,10 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
   <!-- Merger tree evolution -->

--- a/testSuite/parameters/checkpointingResume.xml
+++ b/testSuite/parameters/checkpointingResume.xml
@@ -444,11 +444,11 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/duplicatedOutputPropertyName.xml
+++ b/testSuite/parameters/duplicatedOutputPropertyName.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -249,6 +248,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/duplicatedOutputPropertyName.xml
+++ b/testSuite/parameters/duplicatedOutputPropertyName.xml
@@ -249,11 +249,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/duplicatedOutputPropertyName.xml
+++ b/testSuite/parameters/duplicatedOutputPropertyName.xml
@@ -249,7 +249,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/duplicatedOutputPropertyName.xml
+++ b/testSuite/parameters/duplicatedOutputPropertyName.xml
@@ -250,8 +250,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/galacticStructureStateDeallocateBug.xml
+++ b/testSuite/parameters/galacticStructureStateDeallocateBug.xml
@@ -9,7 +9,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <growthRatioToStellarSpheroid value="2.32959186797031"/>
     <heatsHotHalo value="true"/>
     <efficiencyHeating value="0.00140338137883176"/>
@@ -413,6 +412,10 @@
      <tidalStripping value="simple">
      <beta value="0.01"/>
      </tidalStripping>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/galacticStructureStateDeallocateBug.xml
+++ b/testSuite/parameters/galacticStructureStateDeallocateBug.xml
@@ -413,11 +413,11 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/galacticStructureStateDeallocateBug.xml
+++ b/testSuite/parameters/galacticStructureStateDeallocateBug.xml
@@ -414,8 +414,10 @@
      </tidalStripping>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/galacticStructureStateDeallocateBug.xml
+++ b/testSuite/parameters/galacticStructureStateDeallocateBug.xml
@@ -413,7 +413,7 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/impulsiveHeating.xml
+++ b/testSuite/parameters/impulsiveHeating.xml
@@ -420,8 +420,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/impulsiveHeating.xml
+++ b/testSuite/parameters/impulsiveHeating.xml
@@ -419,11 +419,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/impulsiveHeating.xml
+++ b/testSuite/parameters/impulsiveHeating.xml
@@ -17,7 +17,6 @@
   <!-- Baryonic components are set to null since we are not modeling them here. -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -419,6 +418,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/impulsiveHeating.xml
+++ b/testSuite/parameters/impulsiveHeating.xml
@@ -419,7 +419,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/inactiveLuminosities.xml
+++ b/testSuite/parameters/inactiveLuminosities.xml
@@ -264,11 +264,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/inactiveLuminosities.xml
+++ b/testSuite/parameters/inactiveLuminosities.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -264,6 +263,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/inactiveLuminosities.xml
+++ b/testSuite/parameters/inactiveLuminosities.xml
@@ -264,7 +264,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/inactiveLuminosities.xml
+++ b/testSuite/parameters/inactiveLuminosities.xml
@@ -265,8 +265,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/inactiveNumerics.xml
+++ b/testSuite/parameters/inactiveNumerics.xml
@@ -419,7 +419,7 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/inactiveNumerics.xml
+++ b/testSuite/parameters/inactiveNumerics.xml
@@ -420,8 +420,10 @@
      </tidalStripping>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/inactiveNumerics.xml
+++ b/testSuite/parameters/inactiveNumerics.xml
@@ -419,11 +419,11 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/inactiveNumerics.xml
+++ b/testSuite/parameters/inactiveNumerics.xml
@@ -419,6 +419,10 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/parameters/interoutputStarFormationRate.xml
+++ b/testSuite/parameters/interoutputStarFormationRate.xml
@@ -222,11 +222,11 @@
         </stellarFeedbackOutflows>
       </stellarFeedbackOutflows>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/interoutputStarFormationRate.xml
+++ b/testSuite/parameters/interoutputStarFormationRate.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -222,6 +221,10 @@
           <exponent value="3.5"/>
         </stellarFeedbackOutflows>
       </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/interoutputStarFormationRate.xml
+++ b/testSuite/parameters/interoutputStarFormationRate.xml
@@ -223,8 +223,10 @@
       </stellarFeedbackOutflows>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/interoutputStarFormationRate.xml
+++ b/testSuite/parameters/interoutputStarFormationRate.xml
@@ -222,7 +222,7 @@
         </stellarFeedbackOutflows>
       </stellarFeedbackOutflows>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/memoryLeakFormationHalos.xml
+++ b/testSuite/parameters/memoryLeakFormationHalos.xml
@@ -256,8 +256,10 @@
       <massFactorReformation value="2.0"/>      
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/memoryLeakFormationHalos.xml
+++ b/testSuite/parameters/memoryLeakFormationHalos.xml
@@ -255,7 +255,7 @@
     <nodeOperator value="nodeFormationTimeCole2000">
       <massFactorReformation value="2.0"/>      
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/memoryLeakFormationHalos.xml
+++ b/testSuite/parameters/memoryLeakFormationHalos.xml
@@ -10,7 +10,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -255,6 +254,10 @@
     <!-- Formation times -->
     <nodeOperator value="nodeFormationTimeCole2000">
       <massFactorReformation value="2.0"/>      
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/memoryLeakFormationHalos.xml
+++ b/testSuite/parameters/memoryLeakFormationHalos.xml
@@ -255,11 +255,11 @@
     <nodeOperator value="nodeFormationTimeCole2000">
       <massFactorReformation value="2.0"/>      
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/mergerTreeEvolverThreaded.xml
+++ b/testSuite/parameters/mergerTreeEvolverThreaded.xml
@@ -267,11 +267,11 @@
     	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/mergerTreeEvolverThreaded.xml
+++ b/testSuite/parameters/mergerTreeEvolverThreaded.xml
@@ -16,7 +16,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -267,6 +266,10 @@
     	<stabilityThresholdGaseous value="0.7"/>
     	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/mergerTreeEvolverThreaded.xml
+++ b/testSuite/parameters/mergerTreeEvolverThreaded.xml
@@ -267,7 +267,7 @@
     	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/mergerTreeEvolverThreaded.xml
+++ b/testSuite/parameters/mergerTreeEvolverThreaded.xml
@@ -268,8 +268,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
+++ b/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
@@ -69,8 +69,10 @@
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
+++ b/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
@@ -68,11 +68,11 @@
     <nodeOperator value="DMOInterpolate"/>    
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
+++ b/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
@@ -68,6 +68,10 @@
     <nodeOperator value="DMOInterpolate"/>    
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
   
   <outputFileName value="testSuite/outputs/mostMassiveProgenitorIsSubhalo.hdf5"/>

--- a/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
+++ b/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
@@ -68,7 +68,7 @@
     <nodeOperator value="DMOInterpolate"/>    
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/noninstantaneous_recycling.xml
+++ b/testSuite/parameters/noninstantaneous_recycling.xml
@@ -416,11 +416,11 @@
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
 
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/noninstantaneous_recycling.xml
+++ b/testSuite/parameters/noninstantaneous_recycling.xml
@@ -416,6 +416,10 @@
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
 
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/parameters/noninstantaneous_recycling.xml
+++ b/testSuite/parameters/noninstantaneous_recycling.xml
@@ -416,7 +416,7 @@
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
 
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/noninstantaneous_recycling.xml
+++ b/testSuite/parameters/noninstantaneous_recycling.xml
@@ -417,8 +417,10 @@
     <nodeOperator value="timeFirstInfall"/>
 
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/outputDatasetSuffixes.xml
+++ b/testSuite/parameters/outputDatasetSuffixes.xml
@@ -250,11 +250,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/outputDatasetSuffixes.xml
+++ b/testSuite/parameters/outputDatasetSuffixes.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -250,6 +249,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/outputDatasetSuffixes.xml
+++ b/testSuite/parameters/outputDatasetSuffixes.xml
@@ -250,7 +250,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/outputDatasetSuffixes.xml
+++ b/testSuite/parameters/outputDatasetSuffixes.xml
@@ -251,8 +251,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/outputSelector.xml
+++ b/testSuite/parameters/outputSelector.xml
@@ -9,7 +9,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -275,6 +274,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/outputSelector.xml
+++ b/testSuite/parameters/outputSelector.xml
@@ -275,7 +275,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/outputSelector.xml
+++ b/testSuite/parameters/outputSelector.xml
@@ -275,11 +275,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/outputSelector.xml
+++ b/testSuite/parameters/outputSelector.xml
@@ -276,8 +276,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/outputTreeContiguosity.xml
+++ b/testSuite/parameters/outputTreeContiguosity.xml
@@ -9,7 +9,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -275,6 +274,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/outputTreeContiguosity.xml
+++ b/testSuite/parameters/outputTreeContiguosity.xml
@@ -275,7 +275,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/outputTreeContiguosity.xml
+++ b/testSuite/parameters/outputTreeContiguosity.xml
@@ -275,11 +275,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/outputTreeContiguosity.xml
+++ b/testSuite/parameters/outputTreeContiguosity.xml
@@ -276,8 +276,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/parametersDiff1.xml
+++ b/testSuite/parameters/parametersDiff1.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -253,6 +252,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/parametersDiff1.xml
+++ b/testSuite/parameters/parametersDiff1.xml
@@ -253,11 +253,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/parametersDiff1.xml
+++ b/testSuite/parameters/parametersDiff1.xml
@@ -253,7 +253,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/parametersDiff1.xml
+++ b/testSuite/parameters/parametersDiff1.xml
@@ -254,8 +254,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/parametersDiff2.xml
+++ b/testSuite/parameters/parametersDiff2.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0023"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -253,6 +252,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/parametersDiff2.xml
+++ b/testSuite/parameters/parametersDiff2.xml
@@ -253,11 +253,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/parametersDiff2.xml
+++ b/testSuite/parameters/parametersDiff2.xml
@@ -253,7 +253,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/parametersDiff2.xml
+++ b/testSuite/parameters/parametersDiff2.xml
@@ -254,8 +254,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/parametersExtract.xml
+++ b/testSuite/parameters/parametersExtract.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100.0"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -249,6 +248,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/parametersExtract.xml
+++ b/testSuite/parameters/parametersExtract.xml
@@ -249,11 +249,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/parametersExtract.xml
+++ b/testSuite/parameters/parametersExtract.xml
@@ -249,7 +249,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/parametersExtract.xml
+++ b/testSuite/parameters/parametersExtract.xml
@@ -250,8 +250,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/setProperties.xml
+++ b/testSuite/parameters/setProperties.xml
@@ -253,8 +253,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/setProperties.xml
+++ b/testSuite/parameters/setProperties.xml
@@ -252,7 +252,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/setProperties.xml
+++ b/testSuite/parameters/setProperties.xml
@@ -252,11 +252,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/setProperties.xml
+++ b/testSuite/parameters/setProperties.xml
@@ -15,7 +15,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -252,6 +251,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-mass-conservation-coldMode.xml
+++ b/testSuite/parameters/test-mass-conservation-coldMode.xml
@@ -308,10 +308,10 @@
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
       </nodeOperator>
-      <nodeOperator value="blackHolesSeed">
+      <nodeOperator value="blackHoleSeeds">
 	<blackHoleSeeds value="fixed">
-	  <massSeed value="0"/>
-	  <spinSeed value="0"/>
+	  <mass value="0"/>
+	  <spin value="0"/>
 	</blackHoleSeeds>
       </nodeOperator>
     </nodeOperator>

--- a/testSuite/parameters/test-mass-conservation-coldMode.xml
+++ b/testSuite/parameters/test-mass-conservation-coldMode.xml
@@ -308,7 +308,7 @@
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
       </nodeOperator>
-      <nodeOperator value="blackHolesSeed">
+      <nodeOperator value="blackHolesSeed" iterable="no">
 	<blackHoleSeeds value="fixed">
 	  <mass value="0"/>
 	  <spin value="0"/>

--- a/testSuite/parameters/test-mass-conservation-coldMode.xml
+++ b/testSuite/parameters/test-mass-conservation-coldMode.xml
@@ -308,7 +308,7 @@
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
       </nodeOperator>
-      <nodeOperator value="blackHoleSeeds">
+      <nodeOperator value="blackHolesSeed">
 	<blackHoleSeeds value="fixed">
 	  <mass value="0"/>
 	  <spin value="0"/>

--- a/testSuite/parameters/test-mass-conservation-coldMode.xml
+++ b/testSuite/parameters/test-mass-conservation-coldMode.xml
@@ -20,7 +20,6 @@
     <!-- Component selection -->
     <componentBasic value="standard"/>
     <componentBlackHole value="standard">
-      <massSeed value="0.0"/>
       <heatsHotHalo value="false"/>
       <efficiencyWind value="0.0024"/>
       <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -308,6 +307,10 @@
 	  <stabilityThresholdGaseous value="0.7"/>
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
+      </nodeOperator>
+      <nodeOperator value="blackHolesSeed">
+	<massSeed value="0"/>
+	<spinSeed value="0"/>
       </nodeOperator>
     </nodeOperator>
 

--- a/testSuite/parameters/test-mass-conservation-coldMode.xml
+++ b/testSuite/parameters/test-mass-conservation-coldMode.xml
@@ -309,8 +309,10 @@
 	</galacticDynamicsBarInstability>
       </nodeOperator>
       <nodeOperator value="blackHolesSeed">
-	<massSeed value="0"/>
-	<spinSeed value="0"/>
+	<blackHoleSeeds value="fixed">
+	  <massSeed value="0"/>
+	  <spinSeed value="0"/>
+	</blackHoleSeeds>
       </nodeOperator>
     </nodeOperator>
 

--- a/testSuite/parameters/test-mass-conservation-simple.xml
+++ b/testSuite/parameters/test-mass-conservation-simple.xml
@@ -246,6 +246,10 @@
 	  </stellarFeedbackOutflows>
 	</stellarFeedbackOutflows>
       </nodeOperator>
+      <nodeOperator value="blackHolesSeed">
+	<massSeed value="100"/>
+	<spinSeed value="0"/>
+      </nodeOperator>
     </nodeOperator>
 
     <nodePropertyExtractor value="multi">

--- a/testSuite/parameters/test-mass-conservation-simple.xml
+++ b/testSuite/parameters/test-mass-conservation-simple.xml
@@ -247,8 +247,10 @@
 	</stellarFeedbackOutflows>
       </nodeOperator>
       <nodeOperator value="blackHolesSeed">
-	<massSeed value="100"/>
-	<spinSeed value="0"/>
+	<blackHoleSeeds value="fixed">
+	  <massSeed value="0"/>
+	  <spinSeed value="0"/>
+	</blackHoleSeeds>
       </nodeOperator>
     </nodeOperator>
 

--- a/testSuite/parameters/test-mass-conservation-simple.xml
+++ b/testSuite/parameters/test-mass-conservation-simple.xml
@@ -246,7 +246,7 @@
 	  </stellarFeedbackOutflows>
 	</stellarFeedbackOutflows>
       </nodeOperator>
-      <nodeOperator value="blackHolesSeed">
+      <nodeOperator value="blackHolesSeed" iterable="no">
 	<blackHoleSeeds value="fixed">
 	  <mass value="0"/>
 	  <spin value="0"/>

--- a/testSuite/parameters/test-mass-conservation-simple.xml
+++ b/testSuite/parameters/test-mass-conservation-simple.xml
@@ -246,10 +246,10 @@
 	  </stellarFeedbackOutflows>
 	</stellarFeedbackOutflows>
       </nodeOperator>
-      <nodeOperator value="blackHolesSeed">
+      <nodeOperator value="blackHoleSeeds">
 	<blackHoleSeeds value="fixed">
-	  <massSeed value="0"/>
-	  <spinSeed value="0"/>
+	  <mass value="0"/>
+	  <spin value="0"/>
 	</blackHoleSeeds>
       </nodeOperator>
     </nodeOperator>

--- a/testSuite/parameters/test-mass-conservation-simple.xml
+++ b/testSuite/parameters/test-mass-conservation-simple.xml
@@ -246,7 +246,7 @@
 	  </stellarFeedbackOutflows>
 	</stellarFeedbackOutflows>
       </nodeOperator>
-      <nodeOperator value="blackHoleSeeds">
+      <nodeOperator value="blackHolesSeed">
 	<blackHoleSeeds value="fixed">
 	  <mass value="0"/>
 	  <spin value="0"/>

--- a/testSuite/parameters/test-mass-conservation-standard.xml
+++ b/testSuite/parameters/test-mass-conservation-standard.xml
@@ -20,7 +20,6 @@
     <!-- Component selection -->
     <componentBasic value="standard"/>
     <componentBlackHole value="standard">
-      <massSeed value="0"/>
       <heatsHotHalo value="false"/>
       <efficiencyWind value="0.0024"/>
       <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -310,6 +309,10 @@
 	  <stabilityThresholdGaseous value="0.7"/>
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
+      </nodeOperator>
+      <nodeOperator value="blackHolesSeed">
+	<massSeed value="0"/>
+	<spinSeed value="0"/>
       </nodeOperator>
     </nodeOperator>
 

--- a/testSuite/parameters/test-mass-conservation-standard.xml
+++ b/testSuite/parameters/test-mass-conservation-standard.xml
@@ -311,8 +311,10 @@
 	</galacticDynamicsBarInstability>
       </nodeOperator>
       <nodeOperator value="blackHolesSeed">
-	<massSeed value="0"/>
-	<spinSeed value="0"/>
+	<blackHoleSeeds value="fixed">
+	  <massSeed value="0"/>
+	  <spinSeed value="0"/>
+	</blackHoleSeeds>
       </nodeOperator>
     </nodeOperator>
 

--- a/testSuite/parameters/test-mass-conservation-standard.xml
+++ b/testSuite/parameters/test-mass-conservation-standard.xml
@@ -310,7 +310,7 @@
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
       </nodeOperator>
-      <nodeOperator value="blackHoleSeeds">
+      <nodeOperator value="blackHolesSeed">
 	<blackHoleSeeds value="fixed">
 	  <mass value="0"/>
 	  <spin value="0"/>

--- a/testSuite/parameters/test-mass-conservation-standard.xml
+++ b/testSuite/parameters/test-mass-conservation-standard.xml
@@ -310,7 +310,7 @@
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
       </nodeOperator>
-      <nodeOperator value="blackHolesSeed">
+      <nodeOperator value="blackHolesSeed" iterable="no">
 	<blackHoleSeeds value="fixed">
 	  <mass value="0"/>
 	  <spin value="0"/>

--- a/testSuite/parameters/test-mass-conservation-standard.xml
+++ b/testSuite/parameters/test-mass-conservation-standard.xml
@@ -310,10 +310,10 @@
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
       </nodeOperator>
-      <nodeOperator value="blackHolesSeed">
+      <nodeOperator value="blackHoleSeeds">
 	<blackHoleSeeds value="fixed">
-	  <massSeed value="0"/>
-	  <spinSeed value="0"/>
+	  <mass value="0"/>
+	  <spin value="0"/>
 	</blackHoleSeeds>
       </nodeOperator>
     </nodeOperator>

--- a/testSuite/parameters/test-output-times.xml
+++ b/testSuite/parameters/test-output-times.xml
@@ -253,11 +253,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-output-times.xml
+++ b/testSuite/parameters/test-output-times.xml
@@ -253,7 +253,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/test-output-times.xml
+++ b/testSuite/parameters/test-output-times.xml
@@ -254,8 +254,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-output-times.xml
+++ b/testSuite/parameters/test-output-times.xml
@@ -15,7 +15,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -253,6 +252,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-output.xml
+++ b/testSuite/parameters/test-output.xml
@@ -253,11 +253,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-output.xml
+++ b/testSuite/parameters/test-output.xml
@@ -253,7 +253,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/test-output.xml
+++ b/testSuite/parameters/test-output.xml
@@ -254,8 +254,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-output.xml
+++ b/testSuite/parameters/test-output.xml
@@ -15,7 +15,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -253,6 +252,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-splitForests-split.xml
+++ b/testSuite/parameters/test-splitForests-split.xml
@@ -16,7 +16,7 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="null">
-    <massSeed value="100"/>
+    <mass value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>

--- a/testSuite/parameters/test-splitForests-unsplit.xml
+++ b/testSuite/parameters/test-splitForests-unsplit.xml
@@ -16,7 +16,7 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="null">
-    <massSeed value="100"/>
+    <mass value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>

--- a/testSuite/parameters/test-star-formation-histories-adaptive.xml
+++ b/testSuite/parameters/test-star-formation-histories-adaptive.xml
@@ -253,8 +253,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-star-formation-histories-adaptive.xml
+++ b/testSuite/parameters/test-star-formation-histories-adaptive.xml
@@ -11,7 +11,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -252,6 +251,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-star-formation-histories-adaptive.xml
+++ b/testSuite/parameters/test-star-formation-histories-adaptive.xml
@@ -252,7 +252,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/test-star-formation-histories-adaptive.xml
+++ b/testSuite/parameters/test-star-formation-histories-adaptive.xml
@@ -252,11 +252,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-star-formation-histories-inSitu.xml
+++ b/testSuite/parameters/test-star-formation-histories-inSitu.xml
@@ -253,8 +253,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-star-formation-histories-inSitu.xml
+++ b/testSuite/parameters/test-star-formation-histories-inSitu.xml
@@ -11,7 +11,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -252,6 +251,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/test-star-formation-histories-inSitu.xml
+++ b/testSuite/parameters/test-star-formation-histories-inSitu.xml
@@ -252,7 +252,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/test-star-formation-histories-inSitu.xml
+++ b/testSuite/parameters/test-star-formation-histories-inSitu.xml
@@ -252,11 +252,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/default-valid.xml
+++ b/testSuite/parameters/validation/default-valid.xml
@@ -244,8 +244,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/default-valid.xml
+++ b/testSuite/parameters/validation/default-valid.xml
@@ -243,11 +243,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/default-valid.xml
+++ b/testSuite/parameters/validation/default-valid.xml
@@ -243,7 +243,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/validation/default-valid.xml
+++ b/testSuite/parameters/validation/default-valid.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -243,6 +242,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/duplicate-parameter-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-parameter-invalid.xml
@@ -238,11 +238,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/validation/duplicate-parameter-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-parameter-invalid.xml
@@ -238,7 +238,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/validation/duplicate-parameter-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-parameter-invalid.xml
@@ -239,8 +239,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/validation/duplicate-parameter-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-parameter-invalid.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -238,6 +237,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/parameters/validation/duplicate-subparameter-valid.xml
+++ b/testSuite/parameters/validation/duplicate-subparameter-valid.xml
@@ -245,11 +245,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/duplicate-subparameter-valid.xml
+++ b/testSuite/parameters/validation/duplicate-subparameter-valid.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -245,6 +244,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/duplicate-subparameter-valid.xml
+++ b/testSuite/parameters/validation/duplicate-subparameter-valid.xml
@@ -246,8 +246,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/duplicate-subparameter-valid.xml
+++ b/testSuite/parameters/validation/duplicate-subparameter-valid.xml
@@ -245,7 +245,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/validation/duplicate-value-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-value-invalid.xml
@@ -246,11 +246,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/duplicate-value-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-value-invalid.xml
@@ -247,8 +247,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/duplicate-value-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-value-invalid.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -246,6 +245,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/duplicate-value-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-value-invalid.xml
@@ -246,7 +246,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/parameters/validation/missing-value-invalid.xml
+++ b/testSuite/parameters/validation/missing-value-invalid.xml
@@ -241,8 +241,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/missing-value-invalid.xml
+++ b/testSuite/parameters/validation/missing-value-invalid.xml
@@ -240,11 +240,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/missing-value-invalid.xml
+++ b/testSuite/parameters/validation/missing-value-invalid.xml
@@ -8,7 +8,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -240,6 +239,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/parameters/validation/missing-value-invalid.xml
+++ b/testSuite/parameters/validation/missing-value-invalid.xml
@@ -240,7 +240,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/adaptiveSFHLengths.xml
+++ b/testSuite/regressions/adaptiveSFHLengths.xml
@@ -443,8 +443,10 @@
     <nodeOperator value="timeFirstInfall"/>
 
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/adaptiveSFHLengths.xml
+++ b/testSuite/regressions/adaptiveSFHLengths.xml
@@ -442,6 +442,10 @@
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
 
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/regressions/adaptiveSFHLengths.xml
+++ b/testSuite/regressions/adaptiveSFHLengths.xml
@@ -442,11 +442,11 @@
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
 
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/adaptiveSFHLengths.xml
+++ b/testSuite/regressions/adaptiveSFHLengths.xml
@@ -442,7 +442,7 @@
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
 
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/barInstabilityFPE.xml
+++ b/testSuite/regressions/barInstabilityFPE.xml
@@ -412,11 +412,11 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/barInstabilityFPE.xml
+++ b/testSuite/regressions/barInstabilityFPE.xml
@@ -412,7 +412,7 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/barInstabilityFPE.xml
+++ b/testSuite/regressions/barInstabilityFPE.xml
@@ -12,7 +12,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <growthRatioToStellarSpheroid value="2.32959186797031"/>
     <heatsHotHalo value="true"/>
     <efficiencyHeating value="0.00140338137883176"/>
@@ -412,6 +411,10 @@
      <tidalStripping value="simple">
      <beta value="0.01"/>
      </tidalStripping>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/barInstabilityFPE.xml
+++ b/testSuite/regressions/barInstabilityFPE.xml
@@ -413,8 +413,10 @@
      </tidalStripping>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/bug711424.xml
+++ b/testSuite/regressions/bug711424.xml
@@ -78,6 +78,10 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
   <cosmologicalMassVariance value="filteredPower">
@@ -103,7 +107,6 @@
   <cosmologyFunctions value="matterLambda"/>
   <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <efficiencyWind value="0.001"/>
     <bondiHoyleAccretionTemperatureSpheroid value="100"/>
     <bondiHoyleAccretionEnhancementHotHalo value="1"/>

--- a/testSuite/regressions/bug711424.xml
+++ b/testSuite/regressions/bug711424.xml
@@ -78,7 +78,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/bug711424.xml
+++ b/testSuite/regressions/bug711424.xml
@@ -79,8 +79,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/bug711424.xml
+++ b/testSuite/regressions/bug711424.xml
@@ -78,11 +78,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/bug725315.xml
+++ b/testSuite/regressions/bug725315.xml
@@ -78,8 +78,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/bug725315.xml
+++ b/testSuite/regressions/bug725315.xml
@@ -77,7 +77,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/bug725315.xml
+++ b/testSuite/regressions/bug725315.xml
@@ -77,6 +77,10 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
   <cosmologicalMassVariance value="filteredPower">
@@ -108,7 +112,6 @@
   <cosmologyFunctions value="matterLambda"/>
   <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <efficiencyWind value="0.001"/>
     <bondiHoyleAccretionTemperatureSpheroid value="100"/>
     <bondiHoyleAccretionEnhancementHotHalo value="1"/>

--- a/testSuite/regressions/bug725315.xml
+++ b/testSuite/regressions/bug725315.xml
@@ -77,11 +77,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/coincidentMergerAndBranchJump.xml
+++ b/testSuite/regressions/coincidentMergerAndBranchJump.xml
@@ -11,7 +11,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <bondiHoyleAccretionEnhancementHotHalo value="1.5"/>
@@ -250,6 +249,10 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
   <!-- Galaxy merger options -->

--- a/testSuite/regressions/coincidentMergerAndBranchJump.xml
+++ b/testSuite/regressions/coincidentMergerAndBranchJump.xml
@@ -250,8 +250,10 @@
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/coincidentMergerAndBranchJump.xml
+++ b/testSuite/regressions/coincidentMergerAndBranchJump.xml
@@ -249,11 +249,11 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/coincidentMergerAndBranchJump.xml
+++ b/testSuite/regressions/coincidentMergerAndBranchJump.xml
@@ -249,7 +249,7 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
@@ -116,7 +116,7 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
@@ -116,11 +116,11 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
@@ -116,6 +116,10 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
 </parameters>

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
@@ -117,8 +117,10 @@
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
@@ -117,11 +117,11 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
@@ -117,6 +117,10 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
 </parameters>

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
@@ -117,7 +117,7 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
@@ -118,8 +118,10 @@
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/issue142.xml
+++ b/testSuite/regressions/issue142.xml
@@ -350,8 +350,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/issue142.xml
+++ b/testSuite/regressions/issue142.xml
@@ -349,7 +349,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/issue142.xml
+++ b/testSuite/regressions/issue142.xml
@@ -349,11 +349,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/issue142.xml
+++ b/testSuite/regressions/issue142.xml
@@ -32,7 +32,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -349,6 +348,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/linearGrowthForFutureModel.xml
+++ b/testSuite/regressions/linearGrowthForFutureModel.xml
@@ -250,11 +250,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/linearGrowthForFutureModel.xml
+++ b/testSuite/regressions/linearGrowthForFutureModel.xml
@@ -250,7 +250,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/linearGrowthForFutureModel.xml
+++ b/testSuite/regressions/linearGrowthForFutureModel.xml
@@ -251,8 +251,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/linearGrowthForFutureModel.xml
+++ b/testSuite/regressions/linearGrowthForFutureModel.xml
@@ -17,7 +17,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -250,6 +249,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/ludlowScaleSetBeforeTreeInitialization.xml
+++ b/testSuite/regressions/ludlowScaleSetBeforeTreeInitialization.xml
@@ -8,7 +8,7 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="null">
-    <massSeed value="100"/>
+    <mass value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>

--- a/testSuite/regressions/outputRank2ExtendSegFault.xml
+++ b/testSuite/regressions/outputRank2ExtendSegFault.xml
@@ -406,6 +406,10 @@
     <nodeOperator value="indexShift"/>
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/regressions/outputRank2ExtendSegFault.xml
+++ b/testSuite/regressions/outputRank2ExtendSegFault.xml
@@ -407,8 +407,10 @@
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/outputRank2ExtendSegFault.xml
+++ b/testSuite/regressions/outputRank2ExtendSegFault.xml
@@ -406,7 +406,7 @@
     <nodeOperator value="indexShift"/>
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/outputRank2ExtendSegFault.xml
+++ b/testSuite/regressions/outputRank2ExtendSegFault.xml
@@ -406,11 +406,11 @@
     <nodeOperator value="indexShift"/>
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
+++ b/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
@@ -448,11 +448,11 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
+++ b/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
@@ -18,7 +18,6 @@
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
   <heatsHotHalo value="true"/>
-    <massSeed value="100"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
     <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
@@ -448,6 +447,10 @@
     </nodeOperator>
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
+++ b/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
@@ -449,8 +449,10 @@
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
   

--- a/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
+++ b/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
@@ -448,7 +448,7 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
+++ b/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
@@ -261,11 +261,11 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
+++ b/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
@@ -11,7 +11,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <bondiHoyleAccretionEnhancementHotHalo value="1.5"/>
@@ -262,6 +261,10 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
+    </nodeOperator>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
+++ b/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
@@ -261,7 +261,7 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
+++ b/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
@@ -262,8 +262,10 @@
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/test-model-integration-default.xml
+++ b/testSuite/test-model-integration-default.xml
@@ -13,7 +13,6 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="standard">
-    <massSeed value="100"/>
     <heatsHotHalo value="true"/>
     <efficiencyWind value="0.0024"/>
     <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
@@ -257,6 +256,10 @@
 	<stabilityThresholdGaseous value="0.7"/>
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <massSeed value="100"/>
+      <spinSeed value="0"/>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/test-model-integration-default.xml
+++ b/testSuite/test-model-integration-default.xml
@@ -257,11 +257,11 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHolesSeed">
+    <nodeOperator value="blackHoleSeeds">
       <blackHoleSeeds value="fixed">
-        <massSeed value="100"/>
-        <spinSeed value="0"/>
-      </blackHolesSeed>
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/test-model-integration-default.xml
+++ b/testSuite/test-model-integration-default.xml
@@ -257,7 +257,7 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
-    <nodeOperator value="blackHoleSeeds">
+    <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>

--- a/testSuite/test-model-integration-default.xml
+++ b/testSuite/test-model-integration-default.xml
@@ -258,8 +258,10 @@
       </galacticDynamicsBarInstability>
     </nodeOperator>
     <nodeOperator value="blackHolesSeed">
-      <massSeed value="100"/>
-      <spinSeed value="0"/>
+      <blackHoleSeeds value="fixed">
+        <massSeed value="100"/>
+        <spinSeed value="0"/>
+      </blackHolesSeed>
     </nodeOperator>
   </nodeOperator>
 

--- a/testSuite/test-parameter-migration.pl
+++ b/testSuite/test-parameter-migration.pl
@@ -1,8 +1,10 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use lib $ENV{'GALACTICUS_EXEC_PATH'}."/perl";
 use XML::Simple;
 use Data::Dumper;
+use List::ExtraUtils;
 
 # Test migration of parameter files.
 # Andrew Benson (27-January-2023)
@@ -20,8 +22,9 @@ my $xml        = new XML::Simple();
 my $parameters = $xml->XMLin("outputs/parameterMigrated.xml");
 
 # Check expected state.
+my @nodeOperators = &List::ExtraUtils::as_array($parameters->{'nodeOperator'}->{'nodeOperator'});
 print "FAILED: missing parameter 'massDestructionAbsolute'\n"
-    unless ( exists($parameters->{'nodeOperator'}->{'nodeOperator'}->{'massDestructionAbsolute'}) );
+    unless ( exists($nodeOperators[0]->{'massDestructionAbsolute'}) );
 print "FAILED: unremoved parameter 'spheroidVerySimpleTrackLuminosities'\n"
     if ( exists($parameters->{'spheroidVerySimpleTrackLuminosities'}) );
 


### PR DESCRIPTION
This:
1. Moves physics out of the `nodeComponentBlackHole` class; and,
2. Allows for more flexibility in how black holes are seeded.
