### PR TITLE
Add a constrained merger tree builder

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1157,7 +1157,8 @@ jobs:
       # Ensure all jobs are run, even if some fail.
       fail-fast: false
       matrix:
-        file: [ testSuite/parameters/mergerTreeEvolverThreaded.xml ]
+        file: [ testSuite/parameters/mergerTreeEvolverThreaded.xml,
+                testSuite/parameters/constrainedMilkyWay.xml ]
     uses: ./.github/workflows/testModel.yml
     with:
       file: ${{ matrix.file }}

--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -441,7 +441,7 @@ sub Process_FunctionClass {
 				    $name =~ s/\s//g;
 				    if ( grep {$_ eq lc($name)} @{$potentialNames->{'objects'}} ) {
 					push(@{$descriptorParameters->{'objects'}},{name => $name, source => $constructorNode->{'directive'}->{'source'}});
-				    } elsif ( exists($nonAbstractClass->{'linkedList'}) && $nonAbstractClass->{'linkedList'}->{'object'} eq $name ) {
+				    } elsif ( exists($nonAbstractClass->{'linkedList'}) && grep {$_ eq $name} split(" ",$nonAbstractClass->{'linkedList'}->{'object'}) ) {
 					push(@{$descriptorParameters->{'linkedLists'}},$nonAbstractClass->{'linkedList'});
 				    } else {
 					$supported = -5;
@@ -2843,6 +2843,9 @@ sub deepCopyLinkedList {
     return ("","","",undef())
 	unless ( exists($class->{'linkedList'}) );
     my $linkedList = $class->{'linkedList'};
+    # Get object names and types.
+    my @objects     = split(" ",$linkedList->{'object'    });
+    my @objectTypes = split(" ",$linkedList->{'objectType'});
     # Add variables needed for linked list processing.
     push(
 	@{$linkedListVariables},
@@ -2850,7 +2853,7 @@ sub deepCopyLinkedList {
 	    intrinsic  => 'type',
 	    type       => $linkedList->{'type'},
 	    attributes => [ 'pointer' ],
-	    variables  => [ $linkedList->{'object'}.'item', $linkedList->{'object'}.'destination', $linkedList->{'object'}.'itemNew' ]
+	    variables  => [ $linkedList->{'type'}.'item', $linkedList->{'type'}.'destination', $linkedList->{'type'}.'itemNew' ]
 	}
 	)
 	unless ( grep {$_->{'type'} eq $linkedList->{'type'}} @{$linkedListVariables} );
@@ -2860,7 +2863,7 @@ sub deepCopyLinkedList {
 	    intrinsic  => 'type',
 	    type       => $linkedList->{'type'},
 	    attributes => [ 'pointer' ],
-	    variables  => [ $linkedList->{'object'}.'item' ]
+	    variables  => [ $linkedList->{'type'}.'item' ]
 	}
 	)
 	unless ( grep {$_->{'type'} eq $linkedList->{'type'}} @{$linkedListResetVariables} );
@@ -2870,66 +2873,91 @@ sub deepCopyLinkedList {
 	    intrinsic  => 'type',
 	    type       => $linkedList->{'type'},
 	    attributes => [ 'pointer' ],
-	    variables  => [ $linkedList->{'object'}.'item' ]
+	    variables  => [ $linkedList->{'type'}.'item' ]
 	}
 	)
 	unless ( grep {$_->{'type'} eq $linkedList->{'type'}} @{$linkedListFinalizeVariables} );
     # Generate code for the walk through the linked list.
-    $code::variable        =                                            $linkedList->{'variable'       }          ;
-    $code::object          =                                            $linkedList->{'object'         }          ;
-    $code::objectType      =                                            $linkedList->{'objectType'     }          ;
-    $code::objectIntrinsic = exists($linkedList->{'objectIntrinsic'}) ? $linkedList->{'objectIntrinsic'} : "class";
-    $code::next            =                                            $linkedList->{'next'           }          ;
-    $code::location        = &Galacticus::Build::SourceTree::Process::SourceIntrospection::Location($class->{'node'},$class->{'node'}->{'line'});
-    $code::debugCode       = $debugging ? "if (debugReporting.and.mpiSelf\%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): [".$code::objectType."] : ".$code::object." : ')//loc(".$code::object."itemNew)//' : '//loc(".$code::object."itemNew%".$code::object.")//' : '//".&Galacticus::Build::SourceTree::Process::SourceIntrospection::Location($class->{'node'},$class->{'node'}->{'line'},compact => 1).",verbosityLevelSilent)\n" : "";
-    my $deepCopyCode = fill_in_string(<<'CODE', PACKAGE => 'code');
+    my $deepCopyCode;
+    my $deepCopyResetCode;
+    my $deepCopyFinalizeCode;
+    for(my $i=0;$i<scalar(@objects);++$i) {
+	$code::type            =                                            $linkedList->{'type'    };
+	$code::variable        =                                            $linkedList->{'variable'};
+	$code::next            =                                            $linkedList->{'next'    };
+	$code::object          =                                            $objects    [$i]         ;
+	$code::objectType      =                                            $objectTypes[$i]         ;
+	$code::location        = &Galacticus::Build::SourceTree::Process::SourceIntrospection::Location($class->{'node'},$class->{'node'}->{'line'});
+	$code::debugCode       = $debugging ? "if (debugReporting.and.mpiSelf\%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): [".$code::objectType."] : ".$code::object." : ')//loc(".$code::object."itemNew)//' : '//loc(".$code::object."itemNew%".$code::object.")//' : '//".&Galacticus::Build::SourceTree::Process::SourceIntrospection::Location($class->{'node'},$class->{'node'}->{'line'},compact => 1).",verbosityLevelSilent)\n" : "";
+	if ( $i == 0 ) {
+	    $deepCopyCode .= fill_in_string(<<'CODE', PACKAGE => 'code');
 destination%{$variable} => null            ()
-{$object}destination    => null            ()
-{$object}item           => self%{$variable}
-do while (associated({$object}item))
-   allocate({$object}itemNew)
-   if (associated({$object}destination)) then
-      {$object}destination%{$next}     => {$object}itemNew
-      {$object}destination             => {$object}itemNew
+CODE
+	}
+	$deepCopyCode .= fill_in_string(<<'CODE', PACKAGE => 'code');
+{$type}destination      => null            ()
+{$type}item             => self%{$variable}
+do while (associated({$type}item))
+CODE
+	if ( $i == 0 ) {
+	    $deepCopyCode .= fill_in_string(<<'CODE', PACKAGE => 'code');
+   allocate({$type}itemNew)
+   if (associated({$type}destination)) then
+      {$type}destination%{$next}     => {$type}itemNew
+      {$type}destination             => {$type}itemNew
    else
-      destination         %{$variable} => {$object}itemNew
-      {$object}destination             => {$object}itemNew
+      destination       %{$variable} => {$type}itemNew
+      {$type}destination             => {$type}itemNew
    end if
-      nullify({$object}itemNew%{$object})
-      if (associated({$object}item%{$object})) then
-       if (associated({$object}item%{$object}%copiedSelf)) then
-        select type(s => {$object}item%{$object}%copiedSelf)
-        {$objectIntrinsic} is ({$objectType})
-         {$object}itemNew%{$object} => s
+CODE
+	} else {
+	    $deepCopyCode .= fill_in_string(<<'CODE', PACKAGE => 'code');
+   if (associated({$type}destination)) then
+      {$type}itemNew     => {$type}destination%{$next}
+      {$type}destination => {$type}destination%{$next}
+   else
+      {$type}itemNew     => destination       %{$variable}
+      {$type}destination => destination       %{$variable}
+   end if
+CODE
+	}
+	$deepCopyCode .= fill_in_string(<<'CODE', PACKAGE => 'code');
+      nullify({$type}itemNew%{$object})
+      if (associated({$type}item%{$object})) then
+       if (associated({$type}item%{$object}%copiedSelf)) then
+        select type(s => {$type}item%{$object}%copiedSelf)
+        class is ({$objectType})
+         {$type}itemNew%{$object} => s
         class default
          call Error_Report('copiedSelf has incorrect type'//{$location})
         end select
-        call {$object}item%{$object}%copiedSelf%referenceCountIncrement()
+        call {$type}item%{$object}%copiedSelf%referenceCountIncrement()
        else
-        allocate({$object}itemNew%{$object},mold={$object}item%{$object})
-        call {$object}item%{$object}%deepCopy({$object}itemNew%{$object})
-        {$object}item%{$object}%copiedSelf => {$object}itemNew%{$object}
-        call {$object}itemNew%{$object}%autoHook()
+        allocate({$type}itemNew%{$object},mold={$type}item%{$object})
+        call {$type}item%{$object}%deepCopy({$type}itemNew%{$object})
+        {$type}item%{$object}%copiedSelf => {$type}itemNew%{$object}
+        call {$type}itemNew%{$object}%autoHook()
        end if
        {$debugCode}
       end if
-   {$object}item => {$object}item%{$next}
+   {$type}item => {$type}item%{$next}
 end do
 CODE
-    my $deepCopyResetCode = fill_in_string(<<'CODE', PACKAGE => 'code');
-{$object}item => self%{$variable}
-do while (associated({$object}item))
-   call {$object}item%{$object}%deepCopyReset()
-   {$object}item => {$object}item%{$next}
+	$deepCopyResetCode .= fill_in_string(<<'CODE', PACKAGE => 'code');
+{$type}item => self%{$variable}
+do while (associated({$type}item))
+   call {$type}item%{$object}%deepCopyReset()
+   {$type}item => {$type}item%{$next}
 end do
 CODE
-    my $deepCopyFinalizeCode = fill_in_string(<<'CODE', PACKAGE => 'code');
-{$object}item => self%{$variable}
-do while (associated({$object}item))
-   call {$object}item%{$object}%deepCopyFinalize()
-   {$object}item => {$object}item%{$next}
+	$deepCopyFinalizeCode .= fill_in_string(<<'CODE', PACKAGE => 'code');
+{$type}item => self%{$variable}
+do while (associated({$type}item))
+   call {$type}item%{$object}%deepCopyFinalize()
+   {$type}item => {$type}item%{$next}
 end do
 CODE
+    }
     my $deepCopyModule = exists($linkedList->{'module'}) ? $linkedList->{'module'} : undef();
     return ($deepCopyCode,$deepCopyResetCode,$deepCopyFinalizeCode,$deepCopyModule);
 }
@@ -2942,6 +2970,8 @@ sub stateStoreLinkedList {
     return ("","","",undef())
 	unless ( exists($class->{'linkedList'}) );
     my $linkedList = $class->{'linkedList'};
+    # Get object names.
+    my @objects = split(" ",$linkedList->{'object'});
     # Add variables needed for linked list processing.
     push(
 	@{$linkedListVariables},
@@ -2949,28 +2979,33 @@ sub stateStoreLinkedList {
 	    intrinsic  => 'type',
 	    type       => $linkedList->{'type'},
 	    attributes => [ 'pointer' ],
-	    variables  => [ $linkedList->{'object'}.'item' ]
+	    variables  => [ $linkedList->{'type'}.'item' ]
 	}
 	)
 	unless ( grep {$_->{'type'} eq $linkedList->{'type'}} @{$linkedListVariables} );
     # Generate code for the walk through the linked list.
-    $code::variable = $linkedList->{'variable'};
-    $code::object   = $linkedList->{'object'  };
-    $code::next     = $linkedList->{'next'    };
-    my $inputCode   = fill_in_string(<<'CODE', PACKAGE => 'code');
-{$object}item => self%{$variable}
-do while (associated({$object}item))
-   call {$object}item%{$object}%stateRestore(stateFile,gslStateFile,stateOperationID)
-   {$object}item => {$object}item%{$next}
+    my $inputCode;
+    my $outputCode;
+    for(my $i=0;$i<scalar(@objects);++$i) {
+	$code::type     = $linkedList->{'type'    };
+	$code::variable = $linkedList->{'variable'};
+	$code::next     = $linkedList->{'next'    };
+	$code::object   = $objects[$i];
+	$inputCode .= fill_in_string(<<'CODE', PACKAGE => 'code');
+{$type}item => self%{$variable}
+do while (associated({$type}item))
+   call {$type}item%{$object}%stateRestore(stateFile,gslStateFile,stateOperationID)
+   {$type}item => {$type}item%{$next}
 end do
 CODE
-    my $outputCode = fill_in_string(<<'CODE', PACKAGE => 'code');
-{$object}item => self%{$variable}
-do while (associated({$object}item))
-   call {$object}item%{$object}%stateStore(stateFile,gslStateFile,stateOperationID)
-   {$object}item => {$object}item%{$next}
+	$outputCode .= fill_in_string(<<'CODE', PACKAGE => 'code');
+{$type}item => self%{$variable}
+do while (associated({$type}item))
+   call {$type}item%{$object}%stateStore(stateFile,gslStateFile,stateOperationID)
+   {$type}item => {$type}item%{$next}
 end do
 CODE
+    }
     my $deepCopyModule = exists($linkedList->{'module'}) ? $linkedList->{'module'} : undef();
     return ($inputCode,$outputCode,$deepCopyModule);
 }
@@ -2983,6 +3018,8 @@ sub allowedParametersLinkedList {
     return ("",undef())
 	unless ( exists($nonAbstractClass->{'linkedList'}) );
     my $linkedList = $nonAbstractClass->{'linkedList'};
+    # Get object names.
+    my @objects = split(" ",$linkedList->{'object'});
     # Add variables needed for linked list processing.
     push(
 	@{$linkedListVariables},
@@ -2990,22 +3027,26 @@ sub allowedParametersLinkedList {
 	    intrinsic  => 'type',
 	    type       => $linkedList->{'type'},
 	    attributes => [ 'pointer' ],
-	    variables  => [ $linkedList->{'object'}.'item' ]
+	    variables  => [ $linkedList->{'type'}.'item' ]
 	}
 	)
 	unless ( grep {$_->{'type'} eq $linkedList->{'type'}} @{$linkedListVariables} );
     # Generate code for the walk through the linked list.
-    $code::variable = $linkedList->{'variable'};
-    $code::object   = $linkedList->{'object'  };
-    $code::next     = $linkedList->{'next'    };
-    $code::source   = $source;
-    my $iterator   = fill_in_string(<<'CODE', PACKAGE => 'code');
-{$object}item => self%{$variable}
-do while (associated({$object}item))
-   call {$object}item%{$object}%allowedParameters(allowedParameters,'{$source}',.true.)
-   {$object}item => {$object}item%{$next}
+    my $iterator;
+    for(my $i=0;$i<scalar(@objects);++$i) {
+	$code::type     = $linkedList->{'type'    };
+	$code::variable = $linkedList->{'variable'};
+	$code::next     = $linkedList->{'next'    };
+	$code::object   = $objects[$i];
+	$code::source   = $source;
+	$iterator .= fill_in_string(<<'CODE', PACKAGE => 'code');
+{$type}item => self%{$variable}
+do while (associated({$type}item))
+   call {$type}item%{$object}%allowedParameters(allowedParameters,'{$source}',.true.)
+   {$type}item => {$type}item%{$next}
 end do
 CODE
+    }
     my $deepCopyModule = exists($linkedList->{'module'}) ? $linkedList->{'module'} : undef();
     return ($iterator,$deepCopyModule);
 }
@@ -3014,6 +3055,8 @@ sub autoDescriptorLinkedList {
     # Create auto-descriptor instructions for linked list objects.
     my $linkedList          = shift();
     my $linkedListVariables = shift();
+    # Get object names.
+    my @objects = split(" ",$linkedList->{'object'});
     # Add variables needed for linked list processing.
     push(
 	@{$linkedListVariables},
@@ -3021,21 +3064,25 @@ sub autoDescriptorLinkedList {
 	    intrinsic  => 'type',
 	    type       => $linkedList->{'type'},
 	    attributes => [ 'pointer' ],
-	    variables  => [ $linkedList->{'object'}.'item' ]
+	    variables  => [ $linkedList->{'type'}.'item' ]
 	}
 	)
 	unless ( grep {$_->{'type'} eq $linkedList->{'type'}} @{$linkedListVariables} );
     # Generate code for the walk through the linked list.
-    $code::variable = $linkedList->{'variable'};
-    $code::object   = $linkedList->{'object'  };
-    $code::next     = $linkedList->{'next'    };
-    my $iterator   = fill_in_string(<<'CODE', PACKAGE => 'code');
-{$object}item => self%{$variable}
-do while (associated({$object}item))
-   call {$object}item%{$object}%descriptor(parameters)
-   {$object}item => {$object}item%{$next}
+    my $iterator;
+    for(my $i=0;$i<scalar(@objects);++$i) {
+	$code::type     = $linkedList->{'type'    };
+	$code::variable = $linkedList->{'variable'};
+	$code::next     = $linkedList->{'next'    };
+	$code::object   = $objects[$i];
+	$iterator .= fill_in_string(<<'CODE', PACKAGE => 'code');
+{$type}item => self%{$variable}
+do while (associated({$type}item))
+   call {$type}item%{$object}%descriptor(parameters)
+   {$type}item => {$type}item%{$next}
 end do
 CODE
+    }
     my $deepCopyModule = exists($linkedList->{'module'}) ? $linkedList->{'module'} : undef();
     return ($iterator,$deepCopyModule);
 }

--- a/source/merger_trees.build.controller.mass_time_window.F90
+++ b/source/merger_trees.build.controller.mass_time_window.F90
@@ -1,0 +1,220 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Implements a merger tree build controller class which follows branches only if they lie within a window of time and mass.
+!!}
+
+  use :: Cosmology_Functions, only : cosmologyFunctionsClass
+    use :: Cosmological_Density_Field        , only : criticalOverdensityClass
+
+  !![
+  <mergerTreeBuildController name="mergerTreeBuildControllerMassTimeWindow">
+   <description>A merger tree build controller class which follows branches only if they lie within a window of time and mass.</description>
+  </mergerTreeBuildController>
+  !!]
+  type, extends(mergerTreeBuildControllerClass) :: mergerTreeBuildControllerMassTimeWindow
+     !!{     
+     A merger tree build controller class which follows branches only if they lie within a window of time and mass.
+     !!}
+     private
+     class(cosmologyFunctionsClass), pointer :: cosmologyFunctions_ => null()
+     class(criticalOverdensityClass), pointer :: criticalOverdensity_ => null()
+     class(mergerTreeBranchingProbabilityClass), pointer :: mergerTreeBranchingProbability_ => null()
+     double precision :: timeMinimum_, redshiftMaximum, &
+          & massMinimum
+   contains
+     !![
+     <methods>
+       <method method="passes" description="Returns true if the given node lies within the allowed window."/>
+     </methods>
+     !!]
+     final     ::                               massTimeWindowDestructor
+     procedure :: control                    => massTimeWindowControl
+     procedure :: branchingProbabilityObject => massTimeWindowBranchingProbabilityObject
+     procedure :: nodesInserted              => massTimeWindowNodesInserted
+     procedure :: passes                     => massTimeWindowPasses
+  end type mergerTreeBuildControllerMassTimeWindow
+
+  interface mergerTreeBuildControllerMassTimeWindow
+     !!{
+     Constructors for the ``massTimeWindow'' merger tree build controller class.
+     !!}
+     module procedure massTimeWindowConstructorParameters
+     module procedure massTimeWindowConstructorInternal
+  end interface mergerTreeBuildControllerMassTimeWindow
+
+contains
+
+  function massTimeWindowConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the ``massTimeWindow'' merger tree build controller class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Error, only : Error_Report
+    implicit none
+    type (mergerTreeBuildControllerMassTimeWindow  )                :: self
+    type (inputParameters                    ), intent(inout) :: parameters
+     class(cosmologyFunctionsClass), pointer :: cosmologyFunctions_
+     class(criticalOverdensityClass), pointer :: criticalOverdensity_
+    class(mergerTreeBranchingProbabilityClass), pointer       :: mergerTreeBranchingProbability_
+    double precision :: timeMinimum, redshiftMaximum, massMinimum
+    
+    !![
+    <inputParameter>
+      <name>massMinimum</name>
+      <source>parameters</source>
+      <description>The minimum mass to which branches should be followed.</description>
+    </inputParameter>
+    <objectBuilder class="cosmologyFunctions" name="cosmologyFunctions_" source="parameters"/>
+    <objectBuilder class="criticalOverdensity" name="criticalOverdensity_" source="parameters"/>
+    <objectBuilder class="mergerTreeBranchingProbability" name="mergerTreeBranchingProbability_" source="parameters"/>
+    !!]
+    if (parameters%isPresent('timeMinimum')) then
+       if (parameters%isPresent('redshiftMaximum')) call Error_Report('specify only one of [timeMinimum] and [redshiftMaximum]'//{introspection:location})
+       !![
+       <inputParameter>
+	 <name>timeMinimum</name>
+	 <source>parameters</source>
+	 <description>The minimum time to which branches should be followed.</description>
+       </inputParameter>
+       !!]
+    else if (parameters%isPresent('redshiftMaximum')) then
+       !![
+       <inputParameter>
+	 <name>redshiftMaximum</name>
+	 <source>parameters</source>
+	 <description>The maximum redshift to which branches should be followed.</description>
+       </inputParameter>
+       !!]
+       timeMinimum=cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(redshiftMaximum))
+     else
+       call Error_Report('specify one of [timeMinimum] and [redshiftMaximum]'//{introspection:location})
+    end if
+    self=mergerTreeBuildControllerMassTimeWindow(timeMinimum,massMinimum,cosmologyFunctions_,mergerTreeBranchingProbability_,criticalOverdensity_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="mergerTreeBranchingProbability_"/>
+    <objectDestructor name="cosmologyFunctions_"/>
+    <objectDestructor name="criticalOverdensity_"/>
+    !!]
+    return
+  end function massTimeWindowConstructorParameters
+
+  function massTimeWindowConstructorInternal(timeMinimum_,massMinimum,cosmologyFunctions_,mergerTreeBranchingProbability_,criticalOverdensity_) result(self)
+    !!{
+    Internal constructor for the ``massTimeWindow'' merger tree build controller class .
+    !!}
+    implicit none
+    type (mergerTreeBuildControllerMassTimeWindow  )                        :: self
+    class(mergerTreeBranchingProbabilityClass), intent(in   ), target :: mergerTreeBranchingProbability_
+    class(cosmologyFunctionsClass                ), intent(in   ), target :: cosmologyFunctions_
+    class(criticalOverdensityClass                ), intent(in   ), target :: criticalOverdensity_
+    double precision, intent(in   ) :: timeMinimum_, massMinimum
+    !![
+    <constructorAssign variables="timeMinimum_,massMinimum,*mergerTreeBranchingProbability_, *cosmologyFunctions_, *criticalOverdensity_"/>
+    !!]
+
+    self%redshiftMaximum=self%cosmologyFunctions_%redshiftFromExpansionFactor(self%cosmologyFunctions_%expansionFactor(timeMinimum_))
+    return
+  end function massTimeWindowConstructorInternal
+
+  subroutine massTimeWindowDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily massTimeWindow} merger tree build controller class.
+    !!}
+    implicit none
+    type(mergerTreeBuildControllerMassTimeWindow), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%mergerTreeBranchingProbability_"/>
+    <objectDestructor name="self%cosmologyFunctions_"                />
+    <objectDestructor name="self%criticalOverdensity_"                />
+    !!]
+    return
+  end subroutine massTimeWindowDestructor
+
+  logical function massTimeWindowControl(self,node,treeWalker_)
+    !!{
+    Skip side branches of a tree under construction.
+    !!}
+    implicit none
+    class(mergerTreeBuildControllerMassTimeWindow), intent(inout)           :: self    
+    type (treeNode                         ), intent(inout), pointer  :: node
+    class(mergerTreeWalkerClass            ), intent(inout), optional :: treeWalker_
+
+    massTimeWindowControl=.true.
+    ! Move to the next node in the tree while such exists, and the current node does not pass the filter.
+    do while (massTimeWindowControl.and..not.self%passes(node))
+       if (present(treeWalker_)) then
+          massTimeWindowControl=treeWalker_%next(node)
+       else
+          massTimeWindowControl=.false.
+       end if
+    end do
+    return
+  end function massTimeWindowControl
+
+  logical function massTimeWindowPasses(self,node) result(passes)
+    !!{
+    Return true if the given node lies within the allowed window.
+    !!}
+    use :: Galacticus_Nodes, only : treeNode, nodeComponentBasic
+    implicit none
+    class           (mergerTreeBuildControllerMassTimeWindow), intent(inout)          :: self    
+    type            (treeNode                               ), intent(inout), pointer :: node
+    class           (nodeComponentBasic                     )               , pointer :: basic
+    double precision                                                                  :: time
+
+    basic  => node                     %basic         (                                                            )
+    time   =  self%criticalOverdensity_%timeOfCollapse(criticalOverdensity=basic%time(),mass=basic%mass(),node=node)
+    passes =  time         >= self%timeMinimum_ &
+         &   .and.                              &
+         &    basic%mass() >= self%massMinimum
+    return
+  end function massTimeWindowPasses
+
+  function massTimeWindowBranchingProbabilityObject(self,node) result(mergerTreeBranchingProbability_)
+    !!{
+    Return a pointer the the merger tree branching probability object to use.
+    !!}
+    implicit none
+    class(mergerTreeBranchingProbabilityClass), pointer       :: mergerTreeBranchingProbability_
+    class(mergerTreeBuildControllerMassTimeWindow  ), intent(inout) :: self
+    type (treeNode                           ), intent(inout) :: node
+    !$GLC attributes unused :: node
+
+    mergerTreeBranchingProbability_ => self%mergerTreeBranchingProbability_
+    return
+  end function massTimeWindowBranchingProbabilityObject
+
+  subroutine massTimeWindowNodesInserted(self,nodeCurrent,nodeProgenitor1,nodeProgenitor2,didBranch)
+    !!{
+    Act on the insertion of nodes into the merger tree.
+    !!}
+    implicit none
+    class  (mergerTreeBuildControllerMassTimeWindow), intent(inout)           :: self
+    type   (treeNode                         ), intent(inout)           :: nodeCurrent    , nodeProgenitor1
+    type   (treeNode                         ), intent(inout), optional :: nodeProgenitor2
+    logical                                   , intent(in   ), optional :: didBranch
+    !$GLC attributes unused :: self, nodeCurrent, nodeProgenitor1, nodeProgenitor2, didBranch
+
+    ! Nothing to do.
+    return
+  end subroutine massTimeWindowNodesInserted

--- a/source/merger_trees.construct.builder.constrained.F90
+++ b/source/merger_trees.construct.builder.constrained.F90
@@ -1,0 +1,269 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  A merger tree builder class that enforces constraints on the merger tree built by some other builder.
+  !!}
+
+  use, intrinsic :: ISO_C_Binding      , only : c_size_t             , c_long
+  use            :: Merger_Tree_Filters, only : mergerTreeFilterClass
+  
+  type, public :: constrainedBuilderList
+     class(mergerTreeBuilderClass), pointer :: mergerTreeBuilder_ => null()
+     class(mergerTreeFilterClass ), pointer :: mergerTreeFilter_  => null()
+     type (constrainedBuilderList), pointer :: next               => null()
+  end type constrainedBuilderList
+
+  !![
+  <mergerTreeBuilder name="mergerTreeBuilderConstrained">
+   <description>
+    A merger tree builder class that enforces constraints on the merger tree built by some other builder.
+   </description>
+   <linkedList type="constrainedBuilderList" variable="mergerTreeBuilders" next="next" object="mergerTreeBuilder_ mergerTreeFilter_" objectType="mergerTreeBuilderClass mergerTreeFilterClass"/>
+  </mergerTreeBuilder>
+  !!]
+  type, extends(mergerTreeBuilderClass) :: mergerTreeBuilderConstrained
+     !!{
+     A merger tree builder class that enforces constraints on the merger tree built by some other builder.
+     !!}
+     private
+     type  (constrainedBuilderList), pointer :: mergerTreeBuilders => null()
+     integer(c_size_t             )          :: trialCountMaximum
+   contains
+     final     ::          constrainedDestructor
+     procedure :: build => constrainedBuild
+  end type mergerTreeBuilderConstrained
+
+  interface mergerTreeBuilderConstrained
+     !!{
+     Constructors for the {\normalfont \ttfamily constrained} merger tree builder class.
+     !!}
+     module procedure constrainedConstructorParameters
+     module procedure constrainedConstructorInternal
+  end interface mergerTreeBuilderConstrained
+
+  integer(c_long) :: constrainedSeed=0_c_long
+  
+contains
+
+  function constrainedConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the constrained merger tree building class which reads parameters from a provided parameter list.
+    !!}
+    implicit none
+    type   (mergerTreeBuilderConstrained)                :: self
+    type   (inputParameters             ), intent(inout) :: parameters
+    type   (constrainedBuilderList      ), pointer       :: mergerTreeBuilder_
+    integer                                              :: i
+
+    if (parameters%copiesCount('mergerTreeBuilder') == 0                                         ) &
+         & call Error_Report('at least one [mergerTreeBuilder] must be specified'                        //{introspection:location})
+    if (parameters%copiesCount('mergerTreeBuilder') /= parameters%copiesCount('mergerTreeFilter')) &
+         & call Error_Report('number of [mergerTreeBuilder] and [mergerTreeFilter] parameters must match'//{introspection:location})
+    mergerTreeBuilder_ => null()
+    do i=1,parameters%copiesCount('mergerTreeBuilder')
+       if (associated(mergerTreeBuilder_)) then
+          allocate(mergerTreeBuilder_%next)
+          mergerTreeBuilder_ => mergerTreeBuilder_%next
+       else
+          allocate(self%mergerTreeBuilders)
+          mergerTreeBuilder_ => self%mergerTreeBuilders
+       end if
+       !![
+       <objectBuilder class="mergerTreeBuilder" name="mergerTreeBuilder_%mergerTreeBuilder_" source="parameters" copy="i" />
+       !!]
+    end do
+    mergerTreeBuilder_ => self%mergerTreeBuilders
+    do i=1,parameters%copiesCount('mergerTreeFilter')
+       !![
+       <objectBuilder class="mergerTreeFilter" name="mergerTreeBuilder_%mergerTreeFilter_" source="parameters" copy="i" />
+       !!]
+       mergerTreeBuilder_ => mergerTreeBuilder_%next
+    end do
+    !![
+    <inputParameter>
+      <name>trialCountMaximum</name>
+      <variable>self%trialCountMaximum</variable>
+      <source>parameters</source>
+      <description>The maximum number of trials to attempt before failing.</description>
+      <defaultValue>huge(1_c_size_t)</defaultValue>
+    </inputParameter>
+    <inputParametersValidate source="parameters" multiParameters="mergerTreeBuilder, mergerTreeFilter"/>
+    !!]
+    return
+  end function constrainedConstructorParameters
+
+  function constrainedConstructorInternal(mergerTreeBuilders,trialCountMaximum) result(self)
+    !!{
+    Internal constructor for the constrained merger tree building class.
+    !!}
+    implicit none
+    type   (mergerTreeBuilderConstrained)                         :: self
+    type   (constrainedBuilderList      ), intent(in   ), target  :: mergerTreeBuilders
+    integer(c_size_t                    ), intent(in   )          :: trialCountMaximum
+    type   (constrainedBuilderList      )               , pointer :: mergerTreeBuilder_
+    !![
+    <constructorAssign variables="trialCountMaximum"/>
+    !!]
+    
+    self %mergerTreeBuilders => mergerTreeBuilders
+    mergerTreeBuilder_       => mergerTreeBuilders
+    do while (associated(mergerTreeBuilder_))
+       !![
+       <referenceCountIncrement owner="mergerTreeBuilder_" object="mergerTreeBuilder_"/>
+       <referenceCountIncrement owner="mergerTreeBuilder_" object="mergerTreeFilter_" />
+       !!]
+       mergerTreeBuilder_ => mergerTreeBuilder_%next
+    end do 
+    return
+  end function constrainedConstructorInternal
+
+  subroutine constrainedDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily constrained} merger tree builder class.
+    !!}
+    implicit none
+    type(mergerTreeBuilderConstrained), intent(inout) :: self
+    type(constrainedBuilderList      ), pointer       :: mergerTreeBuilder_, mergerTreeBuilderNext
+
+    if (associated(self%mergerTreeBuilders)) then
+       mergerTreeBuilder_ => self%mergerTreeBuilders
+       do while (associated(mergerTreeBuilder_))
+          mergerTreeBuilderNext => mergerTreeBuilder_%next
+          !![
+          <objectDestructor name="mergerTreeBuilder_%mergerTreeBuilder_"/>
+          <objectDestructor name="mergerTreeBuilder_%mergerTreeFilter_" />
+          !!]
+          deallocate(mergerTreeBuilder_)
+          mergerTreeBuilder_ => mergerTreeBuilderNext
+       end do
+    end if
+
+    return
+  end subroutine constrainedDestructor
+
+  subroutine constrainedBuild(self,tree)
+    !!{
+    Build a constrained merger tree.
+    !!}
+    use            :: Display            , only : displayMessage          , displayIndent, displayUnindent, verbosityLevelWorking
+    use            :: Kind_Numbers       , only : kind_int8
+    use            :: Galacticus_Nodes   , only : treeNodeLinkedList
+    use            :: Merger_Tree_Walkers, only : mergerTreeWalkerAllNodes
+    use            :: String_Handling    , only : operator(//)
+    use            :: ISO_Varying_String , only : operator(//)            , var_str
+    implicit none
+    class  (mergerTreeBuilderConstrained), intent(inout), target  :: self
+    type   (mergerTree                  ), intent(inout), target  :: tree
+    type   (treeNode                    )               , pointer :: nodeChild         , nodeNext
+    type   (treeNodeLinkedList          )               , pointer :: nodeLeavesHead    , nodeLeavesCurrent, &
+         &                                                           nodeLeavesNext
+    type   (constrainedBuilderList      )               , pointer :: mergerTreeBuilder_
+    logical                                                       :: passes
+    integer(c_size_t                    )                         :: trialCount        , trialCountTotal
+    integer                                                       :: stage
+    integer(kind_int8                   )                         :: treeIndex
+    type   (mergerTreeWalkerAllNodes    )                         :: treeWalker
+    
+    call displayIndent('Begin constrained tree build',verbosityLevelWorking)
+    ! Store the tree index so that we can restore this after building our tree.    
+    treeIndex=tree%index
+    ! Iterate over builders.
+    trialCountTotal    =  1_c_size_t
+    stage              =  0
+    mergerTreeBuilder_ => self%mergerTreeBuilders
+    do while (associated(mergerTreeBuilder_))
+       stage=stage+1
+       call displayIndent(var_str('Begin stage ')//stage,verbosityLevelWorking)
+       ! Initialize a counter for the number of trials used.
+       trialCount=0_c_size_t
+       ! Find leaf nodes of the current (partial) tree. This will allow us to restore state back to this current tree on a failed
+       ! build attempt.
+       nodeLeavesHead    => null()
+       nodeLeavesCurrent => null()
+       treeWalker        =  mergerTreeWalkerAllNodes(tree)
+       do while (treeWalker%next(nodeChild))
+          if (.not.associated(nodeChild%firstChild)) then
+             if (.not.associated(nodeLeavesHead)) then
+                allocate(nodeLeavesHead        )
+                nodeLeavesCurrent => nodeLeavesHead
+             else
+                allocate(nodeLeavesCurrent%next)
+                nodeLeavesCurrent => nodeLeavesCurrent%next
+             end if
+             nodeLeavesCurrent%node => nodeChild
+          end if
+       end do
+       ! Iterate until we find an acceptable tree.
+       passes=.false.
+       do while (.not.passes)
+          ! Increment counters.
+          trialCount=trialCount+1_c_size_t
+          if (mod(trialCount,100_c_size_t) == 0_c_size_t) &
+               & call displayMessage(var_str('trial number ')//trialCount,verbosityLevelWorking)
+          if (trialCount > self%trialCountMaximum) &
+               & call Error_Report('maximum number of trials exceeded'//{introspection:location})
+          ! Set tree seed and random number generator to ensure that a different random realization is made each time.
+          !$omp atomic
+          constrainedSeed      =constrainedSeed+1_c_long
+          tree           %index=constrainedSeed
+          call tree%randomNumberGenerator_%seedSet(constrainedSeed,offset=.true.)
+          ! Destroy any branches from the previous build attempt.
+          nodeLeavesCurrent => nodeLeavesHead
+          do while (associated(nodeLeavesCurrent))
+             nodeChild => nodeLeavesCurrent%node%firstChild
+             do while (associated(nodeChild))
+                nodeNext => nodeChild%sibling
+                call nodeChild%destroyBranch()
+                deallocate(nodeChild)
+                nodeChild => nodeNext
+             end do
+             nodeLeavesCurrent%node%firstChild => null()
+             nodeLeavesCurrent => nodeLeavesCurrent%next
+          end do
+          ! Build the tree.
+          call mergerTreeBuilder_%mergerTreeBuilder_%build(tree)
+          ! Determine if the tree is acceptable.
+          passes=mergerTreeBuilder_%mergerTreeFilter_%passes(tree)
+          if (passes) call displayMessage(var_str('success after ')//trialCount//' trials',verbosityLevelWorking)
+       end do
+       ! Destroy the list of leaf nodes.
+       nodeLeavesCurrent => nodeLeavesHead
+       do while (associated(nodeLeavesCurrent))
+          nodeLeavesNext => nodeLeavesCurrent%next
+          deallocate(nodeLeavesCurrent)
+          nodeLeavesCurrent => nodeLeavesNext
+       end do
+       ! Accumulate the number of trials.
+       trialCountTotal=+trialCountTotal &
+            &          *trialCount
+       ! Move to the next builder
+       mergerTreeBuilder_ => mergerTreeBuilder_%next
+       call displayUnindent('done',verbosityLevelWorking)
+    end do
+    ! Adjust the tree weight to account for the number of trials taken to construct this tree.
+    tree%volumeWeight=tree%volumeWeight/dble(trialCountTotal)
+    ! Restore the tree index.
+    tree%index=treeIndex
+    ! Report on the effective number of trials used.
+    call displayMessage (var_str('Effective number of trails = ')//trialCountTotal,verbosityLevelWorking)
+    call displayUnindent('done'                                                   ,verbosityLevelWorking)
+    return
+  end subroutine constrainedBuild
+

--- a/source/nodes.property_extractor.multi.F90
+++ b/source/nodes.property_extractor.multi.F90
@@ -238,35 +238,43 @@ contains
        class is (nodePropertyExtractorTuple        )
           elementCount=extractor_%elementCount(time)
           rank0=extractor_%extract(node,time,instance)
-          do i=1,elementCount
-             multiExtractDouble(offset+i)=polyRankDouble(rank0(i))
-             if (present(ranks)) ranks(offset+i)=0
-          end do
-          deallocate(rank0)
+          if (elementCount > 0) then
+             do i=1,elementCount
+                multiExtractDouble(offset+i)=polyRankDouble(rank0(i))
+                if (present(ranks)) ranks(offset+i)=0
+             end do
+             deallocate(rank0)
+          end if
        class is (nodePropertyExtractorArray        )
           elementCount=extractor_%elementCount(time)
-          rank1=extractor_%extract(node,time,instance)
-          do i=1,elementCount
-             multiExtractDouble(offset+i)=polyRankDouble(rank1(:,i))
-             if (present(ranks)) ranks(offset+i)=1
-          end do
-          deallocate(rank1)
+          if (elementCount > 0) then
+             rank1=extractor_%extract(node,time,instance)
+             do i=1,elementCount
+                multiExtractDouble(offset+i)=polyRankDouble(rank1(:,i))
+                if (present(ranks)) ranks(offset+i)=1
+             end do
+             deallocate(rank1)
+          end if
        class is (nodePropertyExtractorList         )
           elementCount=extractor_%elementCount()
-          rank1=extractor_%extract(node     ,instance)
-          do i=1,elementCount
-             multiExtractDouble(offset+i)=polyRankDouble(rank1(:,i))
-             if (present(ranks)) ranks(offset+i)=-1
-          end do
-          deallocate(rank1)
+          if (elementCount > 0) then
+             rank1=extractor_%extract(node     ,instance)
+             do i=1,elementCount
+                multiExtractDouble(offset+i)=polyRankDouble(rank1(:,i))
+                if (present(ranks)) ranks(offset+i)=-1
+             end do
+             deallocate(rank1)
+          end if
        class is (nodePropertyExtractorList2D       )
           elementCount=extractor_%elementCount()
-          rank2=extractor_%extract(node     ,instance)
-          do i=1,elementCount
-             multiExtractDouble(offset+i)=polyRankDouble(rank2(:,:,i))
-             if (present(ranks)) ranks(offset+i)=-2
-          end do
-          deallocate(rank2)
+          if (elementCount > 0) then
+             rank2=extractor_%extract(node     ,instance)
+             do i=1,elementCount
+                multiExtractDouble(offset+i)=polyRankDouble(rank2(:,:,i))
+                if (present(ranks)) ranks(offset+i)=-2
+             end do
+             deallocate(rank2)
+          end if
        class is (nodePropertyExtractorMulti        )
           elementCount=extractor_%elementCount(elementTypeDouble,time)
           if (elementCount > 0) then
@@ -341,20 +349,24 @@ contains
           if (present(ranks)) ranks(offset+1)=0
        class is (nodePropertyExtractorIntegerTuple )
           elementCount=extractor_%elementCount(time)
-          rank0=extractor_%extract(node,time,instance)
-          do i=1,elementCount
-             multiExtractInteger(offset+i)=polyRankInteger(rank0(i))
-             if (present(ranks)) ranks(offset+i)=0
-          end do
-          deallocate(rank0)
+          if (elementCount > 0) then
+             rank0=extractor_%extract(node,time,instance)
+             do i=1,elementCount
+                multiExtractInteger(offset+i)=polyRankInteger(rank0(i))
+                if (present(ranks)) ranks(offset+i)=0
+             end do
+             deallocate(rank0)
+          end if
        class is (nodePropertyExtractorIntegerList  )
           elementCount=extractor_%elementCount()
-          rank1=extractor_%extract(node     ,instance)
-          do i=1,elementCount
-             multiExtractInteger(offset+i)=polyRankInteger(rank1(:,i))
-             if (present(ranks)) ranks(offset+i)=-1
-          end do
-          deallocate(rank1)
+          if (elementCount > 0) then
+             rank1=extractor_%extract(node     ,instance)
+             do i=1,elementCount
+                multiExtractInteger(offset+i)=polyRankInteger(rank1(:,i))
+                if (present(ranks)) ranks(offset+i)=-1
+             end do
+             deallocate(rank1)
+          end if
        class is (nodePropertyExtractorMulti        )
           elementCount=extractor_%elementCount(elementTypeInteger,time)
           if (elementCount > 0) then

--- a/source/tasks.evolve_forests.F90
+++ b/source/tasks.evolve_forests.F90
@@ -630,7 +630,7 @@ contains
           if (outputTimeNext > 0.0d0) then
              treeIsFinished=.false.
           else
-             iOutput      =self%outputTimes_%count()+1
+             iOutput       =self%outputTimes_%count()+1
              treeIsFinished=.true.
           end if
           ! Iterate evolving the tree until no more outputs are required.

--- a/testSuite/parameters/constrainedMilkyWay.xml
+++ b/testSuite/parameters/constrainedMilkyWay.xml
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test of constrained merger tree building -->
+<!-- 18-December-2024                         -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="165490f4968c699f7e5bb73ef60bcb7e626f51e6"/>
+  <verbosityLevel value="working"/>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard">
+    <heatsHotHalo value="true"/>
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+  </componentBlackHole>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard">
+    <fractionLossAngularMomentum value="0.3"/>
+    <starveSatellites value="false"/>
+    <efficiencyStrippingOutflow value="0.1"/>
+    <trackStrippedGas value="true"/>
+  </componentHotHalo>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <ratioAngularMomentumScaleRadius value="0.5"/>
+    <efficiencyEnergeticOutflow value="1.0e-2"/>
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="constrained">
+    <!-- A three stage build, which builds: 1) LMC; 2) GSE; 3) everything else -->
+
+    <!-- Stage 1: LMC -->
+    <mergerTreeBuilder value="cole2000">
+      <accretionLimit   value="0.1"/>
+      <mergeProbability value="0.1"/>
+      <mergerTreeBuildController value="massTimeWindow">
+	<massMinimum value="1.2e11"/>
+	<timeMinimum value="11.6"  />
+      </mergerTreeBuildController>
+    </mergerTreeBuilder>
+    <mergerTreeFilter value="anyNode">
+      <!-- Label as LMC -->
+      <label            value="LMC"/>
+      <labelDescription value="Label indicating if this node is on the LMC branch."/>
+      <labelBranch      value="true"/>
+       <!-- Apply all LMC conditions -->
+      <galacticFilter value="all">
+	<!-- Consider the main branch (i.e. Milky Way halo) of the tree only -->
+	<galacticFilter value="mainBranch"/>
+	<!-- Consider only halos infalling at the right time. -->
+	<galacticFilter value="intervalPass">
+          <nodePropertyExtractor value="time"/>
+          <thresholdLow  value="11.6"/>
+          <thresholdHigh value="12.0"/>
+ 	</galacticFilter>
+	<!-- Consider only halos with a rank-2 child with a mass above 1.0e11 -->
+	<galacticFilter value="childNode">
+          <childRank value="2"/>
+          <galacticFilter value="intervalPass">
+            <nodePropertyExtractor value="massBasic"/>
+            <thresholdLow  value="1.2e11"/>
+            <thresholdHigh value="1.4e11"/>
+          </galacticFilter>
+	</galacticFilter>
+      </galacticFilter>
+    </mergerTreeFilter>
+
+    <!-- Stage 2: GSE -->
+    <mergerTreeBuilder value="cole2000">
+      <accretionLimit   value="0.1"/>
+      <mergeProbability value="0.1"/>
+      <mergerTreeBuildController value="massTimeWindow">
+	<massMinimum value="1.3e11"/>
+	<timeMinimum value="2.8"   />
+      </mergerTreeBuildController>
+    </mergerTreeBuilder>
+    <mergerTreeFilter value="anyNode">
+      <!-- Label as GSE -->
+      <label            value="GSE"/>
+      <labelDescription value="Label indicating if this node is on the GSE branch."/>
+      <labelBranch      value="true"/>
+      <!-- Apply all GSE conditions -->
+      <galacticFilter value="all">
+	<!-- Consider the main branch (i.e. Milky Way halo) of the tree only -->
+	<galacticFilter value="mainBranch"/>
+	<!-- Consider only halos infalling at the right time. -->
+	<galacticFilter value="intervalPass">
+          <nodePropertyExtractor value="time"/>
+          <thresholdLow  value="2.8"/>
+          <thresholdHigh value="5.8"/>
+ 	</galacticFilter>
+	<!-- Consider only halos with a rank-2 child with a mass above 1.0e11 -->
+	<galacticFilter value="childNode">
+          <childRank value="2"/>
+          <galacticFilter value="intervalPass">
+            <nodePropertyExtractor value="massBasic"/>
+            <thresholdLow  value="1.3e11"/>
+            <thresholdHigh value="2.5e11"/>
+          </galacticFilter>
+	</galacticFilter>
+      </galacticFilter>
+    </mergerTreeFilter>
+
+    <!-- Stage 3: Finalize -->
+    <mergerTreeBuilder value="cole2000">
+      <accretionLimit   value="0.1"/>
+      <mergeProbability value="0.1"/>
+      <mergerTreeBuildController value="uncontrolled"/>
+    </mergerTreeBuilder>
+    <mergerTreeFilter value="always"/>
+
+  </mergerTreeBuilder>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e6"/>
+  </mergerTreeMassResolution>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="fixedMass">
+    <massTree   value="1.0e12"/>
+    <treeCount value="1"/>
+  </mergerTreeBuildMasses>
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="gao2008"/>
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="simple">
+    <redshiftReionization value="10.5"/>
+    <velocitySuppressionReionization value="35.0"/>
+  </accretionHalo>
+
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="5.0"/>
+  </hotHaloOutflowReincorporation>
+
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0"/>
+  </coolingTimeAvailable>
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <!-- Galactic structure solver options -->
+  <galacticStructureSolver value="equilibrium"/>
+  <darkMatterProfile value="adiabaticGnedin2004">
+    <A value="0.73"/>
+    <omega value="0.7"/>
+  </darkMatterProfile>
+  <!-- Star formation rate options -->
+  <starFormationRateDisks value="intgrtdSurfaceDensity"/>
+  <starFormationRateSurfaceDensityDisks value="krumholz2009">
+    <frequencyStarFormation value="0.385"/>
+    <clumpingFactorMolecularComplex value="5.000"/>
+    <molecularFractionFast value="true"/>
+  </starFormationRateSurfaceDensityDisks>
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.04"/>
+      <exponentVelocity value="2.0"/>
+      <timescaleMinimum value="0.001"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="instantaneous"/>
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+
+  <initialMassFunction value="chabrier2001"/>
+  <stellarPopulation value="standard">
+    <recycledFraction value="0.46"/>
+    <metalYield value="0.035"/>
+  </stellarPopulation>
+
+  <!-- AGN feedback options -->
+  <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <!-- Accretion disk properties -->
+  <accretionDisks value="switched">
+    <accretionRateThinDiskMaximum value="0.30"/>
+    <accretionRateThinDiskMinimum value="0.01"/>
+    <scaleADAFRadiativeEfficiency value="true"/>
+    <accretionDisksShakuraSunyaev value="shakuraSunyaev"/>
+    <accretionDisksADAF value="ADAF">
+      <efficiencyRadiationType value="thinDisk"/>
+      <adiabaticIndex value="1.444"/>
+      <energyOption value="pureADAF"/>
+      <efficiencyRadiation value="0.01"/>
+      <viscosityOption value="fit"/>
+    </accretionDisksADAF>
+  </accretionDisks>
+
+  <!-- Black hole options -->
+  <blackHoleBinaryMerger value="rezzolla2008"/>
+  <!-- Galaxy merger options -->
+  <virialOrbit value="benson2005"/>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"/>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+    <nodeOperator value="starFormationSpheroids"/>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="250.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="100.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <!-- Bar instability in galactic disks -->
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="0.7"/>
+	<stabilityThresholdStellar value="1.1"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <nodeOperator value="blackHolesSeed">
+      <blackHoleSeeds value="fixed">
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
+    </nodeOperator>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="nonEvolving">
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="nodeIndices"/>
+    <nodePropertyExtractor value="labels"/>
+  </nodePropertyExtractor>
+
+</parameters>


### PR DESCRIPTION
Allows building of constrained merger trees in a sequential manner. Any number of (`mergerTreeBuilder`,`mergerTreeFilter`) pairs can be specified. Building is performed starting with the first `mergerTreeBuilder` (which may be given a `mergerTreeController` to limit the build to only that region of interest to the corresponding `mergerTreeFilter`). If the tree does not pass the corresponding `mergerTreeFilter` it is restored to the state at the start of this step in the sequence. Once the tree passes the corresponding `mergerTreeFilter` building continues with the next (`mergerTreeBuilder`,`mergerTreeFilter`) pair in the sequence. This allows constrain
ts to be applied sequentially.

Includes a test case which builds a Milky Way merger tree with both LMC and GSE mergers.