### PR TITLE
Fix sample grid state size for the `posteriorSamplesPriorGrid` class

### DIFF
--- a/source/posterior_sampling.state.samples.prior_grid.F90
+++ b/source/posterior_sampling.state.samples.prior_grid.F90
@@ -99,8 +99,8 @@ contains
     double precision                                           , dimension(size(modelParameters_))              :: stateVector
     type            (multiCounter              )                                                                :: counter
     integer         (c_size_t                  )                                                                :: i               , j
-        
-    allocate(simulationStates(self%countGrid*size(modelParameters_)))
+
+    allocate(simulationStates(self%countGrid**size(modelParameters_)))
     counter=multiCounter(spread(self%countGrid,1,size(modelParameters_)))
     i      =0
     do while (counter%increment())

--- a/source/utility.multi_counter.F90
+++ b/source/utility.multi_counter.F90
@@ -63,6 +63,7 @@ module Multi_Counters
      Constructors for multi-counters.
      !!}
      module procedure multiCounterConstructor
+     module procedure multiCounterConstructorShortInt
   end interface multiCounter
 
 contains
@@ -71,7 +72,7 @@ contains
     !!{
     Constructor for multi-counters where the ranges are provided.
     !!}
-    use :: Error            , only : Error_Report
+    use :: Error, only : Error_Report
     implicit none
     type   (multiCounter)                              :: self
     integer(c_size_t    ), intent(in   ), dimension(:) :: ranges
@@ -86,6 +87,18 @@ contains
     return
   end function multiCounterConstructor
 
+  function multiCounterConstructorShortInt(ranges) result (self)
+    !!{
+    Constructor for multi-counters where the ranges are provided as short integers.
+    !!}
+    implicit none
+    type   (multiCounter)                              :: self
+    integer              , intent(in   ), dimension(:) :: ranges
+
+    self=multiCounter(int(ranges,kind=c_size_t))
+    return
+  end function multiCounterConstructorShortInt
+  
   subroutine multiCounterDestructor(self)
     !!{
     Destroy a multi-counter object.


### PR DESCRIPTION
Was previously multiplying the grid size by the number of parameters, instead of raising to that power.
