### PR TITLE
Fix issues in the normalization of log-likelihoods in `outputAnalysis` classes

### DIFF
--- a/source/output.analyses.correlation_function.F90
+++ b/source/output.analyses.correlation_function.F90
@@ -1371,8 +1371,8 @@ contains
        residual                  =vector(functionValueDifference   )
        covariance                =matrix(functionCovarianceCombined)
        ! Compute the log-likelihood.
-       correlationFunctionLogLikelihood=-0.5d0*covariance%covarianceProduct(residual,status) &
-            &                           -0.5d0*covariance%determinant()                      &
+       correlationFunctionLogLikelihood=-0.5d0*covariance%covarianceProduct     (residual,status) &
+            &                           -0.5d0*covariance%logarithmicDeterminant(               ) &
             &                           -0.5d0*dble(self%binCount)*log(2.0d0*Pi)
        if (status /= GSL_Success) correlationFunctionLogLikelihood=logImprobable
     else

--- a/source/output.analyses.mean_function_1d.F90
+++ b/source/output.analyses.mean_function_1d.F90
@@ -841,7 +841,7 @@ contains
        if (status == GSL_Success) then
           if (self%likelihoodNormalize)                                                      &
                & meanFunction1DLogLikelihood=+meanFunction1DLogLikelihood                    &
-               &                             -0.5d0*covariance%determinant()                 &
+               &                             -0.5d0*covariance%logarithmicDeterminant()      &
                &                             -0.5d0*dble(size(self%binCenter))*log(2.0d0*Pi)
        else
           meanFunction1DLogLikelihood       =+logImprobable

--- a/source/output.analyses.scatter_function_1d.F90
+++ b/source/output.analyses.scatter_function_1d.F90
@@ -66,11 +66,19 @@
      logical                                                                                     :: finalized                                      , likelihoodNormalize                             , &
           &                                                                                         xAxisIsLog                                     , yAxisIsLog
    contains
-     final     ::                  scatterFunction1DDestructor
-     procedure :: analyze       => scatterFunction1DAnalyze
-     procedure :: finalize      => scatterFunction1DFinalize
-     procedure :: reduce        => scatterFunction1DReduce
-     procedure :: logLikelihood => scatterFunction1DLogLikelihood
+     !![
+     <methods>
+       <method description="Return the results of the scatter function operator." method="results"         />
+       <method description="Finalize analysis of the scatter function operator."  method="finalizeAnalysis"/>
+     </methods>
+     !!]
+     final     ::                     scatterFunction1DDestructor
+     procedure :: analyze          => scatterFunction1DAnalyze
+     procedure :: finalize         => scatterFunction1DFinalize
+     procedure :: finalizeAnalysis => scatterFunction1DFinalizeAnalysis
+     procedure :: reduce           => scatterFunction1DReduce
+     procedure :: results          => scatterFunction1DResults
+     procedure :: logLikelihood    => scatterFunction1DLogLikelihood
   end type outputAnalysisScatterFunction1D
 
   interface outputAnalysisScatterFunction1D
@@ -609,7 +617,7 @@ contains
     type (hdf5Object                     )                          :: analysisGroup, dataset
 
     ! Finalize the analysis.
-    call scatterFunction1DFinalizeAnalysis(self)
+    call self%finalizeAnalysis()
     ! Output the resulting scatter function.
     !$ call hdf5Access%set()
     analysesGroup =  outputFile   %openGroup('analyses'     )
@@ -665,6 +673,36 @@ contains
     return
   end subroutine scatterFunction1DFinalize
 
+  subroutine scatterFunction1DResults(self,binCenter,scatterValue,scatterCovariance)
+    !!{
+    Implement a scatterFunction1D output analysis finalization.
+    !!}
+    implicit none
+    class           (outputAnalysisScatterFunction1D)                             , intent(inout)           :: self
+    double precision                                 , allocatable, dimension(:  ), intent(inout), optional :: binCenter     , scatterValue
+    double precision                                 , allocatable, dimension(:,:), intent(inout), optional :: scatterCovariance
+
+    ! Finalize analysis.
+    call self%finalizeAnalysis()
+    ! Return results.
+    if (present(binCenter        )) then
+       if (allocated(binCenter        )) deallocate(binCenter        )
+       allocate(binCenter(size(self%binCenter)))
+       binCenter         =self%binCenter
+    end if
+    if (present(scatterValue     )) then
+       if (allocated(scatterValue     )) deallocate(scatterValue     )
+       allocate(scatterValue(size(self%scatterValue)))
+       scatterValue     =self%scatterValue
+    end if
+    if (present(scatterCovariance)) then
+       if (allocated(scatterCovariance)) deallocate(scatterCovariance)
+       allocate(scatterCovariance(size(self%scatterCovariance,dim=1),size(self%scatterCovariance,dim=2)))
+       scatterCovariance=self%scatterCovariance
+    end if
+    return
+  end subroutine scatterFunction1DResults
+
   double precision function scatterFunction1DLogLikelihood(self)
     !!{
     Return the log-likelihood of a scatterFunction1D output analysis.
@@ -685,7 +723,7 @@ contains
     ! Check for existence of a target distribution.
     if (allocated(self%scatterValueTarget)) then
        ! Finalize analysis.
-       call scatterFunction1DFinalizeAnalysis(self)
+       call self%finalizeAnalysis()
        ! Allocate workspaces.
        allocate(scatterCovarianceCombined(size(self%binCenter),size(self%binCenter)))
        allocate(scatterValueDifference   (size(self%binCenter)                     ))

--- a/source/output.analyses.scatter_function_1d.F90
+++ b/source/output.analyses.scatter_function_1d.F90
@@ -739,7 +739,7 @@ contains
        if (status == GSL_Success) then
           if (self%likelihoodNormalize)                                                         &
                & scatterFunction1DLogLikelihood=+scatterFunction1DLogLikelihood                 &
-               &                                -0.5d0*covariance%determinant()                 &
+               &                                -0.5d0*covariance%logarithmicDeterminant()      &
                &                                -0.5d0*dble(size(self%binCenter))*log(2.0d0*Pi)
        else
           scatterFunction1DLogLikelihood       =+logImprobable

--- a/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
+++ b/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
@@ -707,63 +707,74 @@ contains
     class           (outputAnalysisStellarVsHaloMassRelationLeauthaud2012), intent(inout)                 :: self
     double precision                                                      , parameter                     :: massStellarLogarithmicTiny              =1.0d-3
     double precision                                                      , allocatable  , dimension(:,:) :: massStellarLogarithmicCovarianceCombined       , massStellarLogarithmicCovarianceCombinedSelected, &
-         &                                                                                                   massStellarLogarithmicCovariance
+         &                                                                                                   massStellarLogarithmicCovariance               , massStellarLogarithmicCovarianceTarget
     double precision                                                      , allocatable  , dimension(:  ) :: massStellarLogarithmicDifference               , massStellarLogarithmicDifferenceSelected        , &
-         &                                                                                                   massStellarLogarithmic
+         &                                                                                                   massStellarLogarithmic                         , massStellarLogarithmicTarget
     type            (vector                                              )                                :: residual
     type            (matrix                                              )                                :: covariance
     integer                                                                                               :: i                                              , j                                               , &
          &                                                                                                   status
 
     select type (outputAnalysis_ => self%outputAnalysis_)
-    class is (outputAnalysisMeanFunction1D)
+    class is (outputAnalysisMeanFunction1D   )
        ! Retrieve the results of the analysis.
-       call outputAnalysis_%results(meanValue=massStellarLogarithmic,meanCovariance=massStellarLogarithmicCovariance)
-       if     (                                                                                                                       &
-            &   (size(self%likelihoodBins) == 0 .and. any(massStellarLogarithmic                      <= massStellarLogarithmicTiny)) &
-            &  .or.                                                                                                                   &
-            &                                         any(massStellarLogarithmic(self%likelihoodBins) <= massStellarLogarithmicTiny)  &
-            & ) then
-          ! If any active bins contain zero galaxies, judge this model to be improbable.
-          logLikelihood=                     logImprobable
-       else
-          ! Finalize analysis.
-          call outputAnalysis_%finalizeAnalysis()
-          ! Compute difference with the target dataset.
-          allocate(massStellarLogarithmicDifference        ,mold=massStellarLogarithmic          )
-          allocate(massStellarLogarithmicCovarianceCombined,mold=massStellarLogarithmicCovariance)
-          massStellarLogarithmicDifference        =+massStellarLogarithmic          -self%massStellarLogarithmicTarget
-          massStellarLogarithmicCovarianceCombined=+massStellarLogarithmicCovariance+self%massStellarLogarithmicCovarianceTarget
-          ! Construct a reduced set of bins.
-          if (size(self%likelihoodBins) > 0) then
-             allocate(massStellarLogarithmicDifferenceSelected        (size(self%likelihoodBins)                          ))
-             allocate(massStellarLogarithmicCovarianceCombinedSelected(size(self%likelihoodBins),size(self%likelihoodBins)))
-             do i=1,size(self%likelihoodBins)
-                massStellarLogarithmicDifferenceSelected           (i  )=massStellarLogarithmicDifference        (self%likelihoodBins(i)                       )
-                do j=1,size(self%likelihoodBins)
-                   massStellarLogarithmicCovarianceCombinedSelected(i,j)=massStellarLogarithmicCovarianceCombined(self%likelihoodBins(i),self%likelihoodBins(j))
-                end do
-             end do
-          else
-             allocate(massStellarLogarithmicDifferenceSelected        ,source=massStellarLogarithmicDifference        )
-             allocate(massStellarLogarithmicCovarianceCombinedSelected,source=massStellarLogarithmicCovarianceCombined)
-          end if
-          ! Construct residual vector and covariance matrix.
-          residual  =vector(massStellarLogarithmicDifferenceSelected   )
-          covariance=matrix(massStellarLogarithmicCovarianceCombinedSelected)
-          ! Compute the log-likelihood.
-          logLikelihood=-0.5d0*covariance%covarianceProduct(residual,status)
-          if (status == GSL_Success) then
-             if (self%likelihoodNormalize)                                                                  &
-                  & logLikelihood=+logLikelihood                                                            &
-                  &               -0.5d0*covariance%determinant()                                           &
-                  &               -0.5d0*dble(size(massStellarLogarithmicDifferenceSelected))*log(2.0d0*Pi)
-          else
-             logLikelihood       =+logImprobable
-          end if
-       end if
+       call outputAnalysis_%results(   meanValue=massStellarLogarithmic,   meanCovariance=massStellarLogarithmicCovariance)
+       allocate(massStellarLogarithmicTarget          ,source=self%massStellarLogarithmicTarget          )
+       allocate(massStellarLogarithmicCovarianceTarget,source=self%massStellarLogarithmicCovarianceTarget)
+    class is (outputAnalysisScatterFunction1D)
+       ! Retrieve the results of the analysis.
+       call outputAnalysis_%results(scatterValue=massStellarLogarithmic,scatterCovariance=massStellarLogarithmicCovariance)
+       allocate(massStellarLogarithmicTarget          ,mold  =self%massStellarLogarithmicTarget          )
+       allocate(massStellarLogarithmicCovarianceTarget,mold  =self%massStellarLogarithmicCovarianceTarget)
+       massStellarLogarithmicCovarianceTarget=0.0d0
+       do i=1,size(massStellarLogarithmicTarget)
+          massStellarLogarithmicTarget          (i  )=0.16d0
+          massStellarLogarithmicCovarianceTarget(i,i)=0.04d0**2
+       end do
     class default
-       logLikelihood             =+outputAnalysis_%logLikelihood()
+       logLikelihood=+outputAnalysis_%logLikelihood()
+       return
     end select
+    if     (                                                                                                                       &
+         &   (size(self%likelihoodBins) == 0 .and. any(massStellarLogarithmic                      <= massStellarLogarithmicTiny)) &
+         &  .or.                                                                                                                   &
+         &                                         any(massStellarLogarithmic(self%likelihoodBins) <= massStellarLogarithmicTiny)  &
+         & ) then
+       ! If any active bins contain zero galaxies, judge this model to be improbable.
+       logLikelihood=                     logImprobable
+    else
+       ! Compute difference with the target dataset.
+       allocate(massStellarLogarithmicDifference        ,mold=massStellarLogarithmic          )
+       allocate(massStellarLogarithmicCovarianceCombined,mold=massStellarLogarithmicCovariance)
+       massStellarLogarithmicDifference        =+massStellarLogarithmic          -massStellarLogarithmicTarget
+       massStellarLogarithmicCovarianceCombined=+massStellarLogarithmicCovariance+massStellarLogarithmicCovarianceTarget
+       ! Construct a reduced set of bins.
+       if (size(self%likelihoodBins) > 0) then
+          allocate(massStellarLogarithmicDifferenceSelected        (size(self%likelihoodBins)                          ))
+          allocate(massStellarLogarithmicCovarianceCombinedSelected(size(self%likelihoodBins),size(self%likelihoodBins)))
+          do i=1,size(self%likelihoodBins)
+             massStellarLogarithmicDifferenceSelected           (i  )=massStellarLogarithmicDifference        (self%likelihoodBins(i)                       )
+             do j=1,size(self%likelihoodBins)
+                massStellarLogarithmicCovarianceCombinedSelected(i,j)=massStellarLogarithmicCovarianceCombined(self%likelihoodBins(i),self%likelihoodBins(j))
+             end do
+          end do
+       else
+          allocate(massStellarLogarithmicDifferenceSelected        ,source=massStellarLogarithmicDifference        )
+          allocate(massStellarLogarithmicCovarianceCombinedSelected,source=massStellarLogarithmicCovarianceCombined)
+       end if
+       ! Construct residual vector and covariance matrix.
+       residual  =vector(massStellarLogarithmicDifferenceSelected        )
+       covariance=matrix(massStellarLogarithmicCovarianceCombinedSelected)
+       ! Compute the log-likelihood.
+       logLikelihood=-0.5d0*covariance%covarianceProduct(residual,status)
+       if (status == GSL_Success) then
+          if (self%likelihoodNormalize)                                                                  &
+               & logLikelihood=+logLikelihood                                                            &
+               &               -0.5d0*covariance%determinant()                                           &
+               &               -0.5d0*dble(size(massStellarLogarithmicDifferenceSelected))*log(2.0d0*Pi)
+       else
+          logLikelihood       =+logImprobable
+       end if
+    end if
     return
   end function stellarVsHaloMassRelationLeauthaud2012LogLikelihood

--- a/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
+++ b/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
@@ -770,7 +770,7 @@ contains
        if (status == GSL_Success) then
           if (self%likelihoodNormalize)                                                                  &
                & logLikelihood=+logLikelihood                                                            &
-               &               -0.5d0*covariance%determinant()                                           &
+               &               -0.5d0*covariance%logarithmicDeterminant()                                &
                &               -0.5d0*dble(size(massStellarLogarithmicDifferenceSelected))*log(2.0d0*Pi)
        else
           logLikelihood       =+logImprobable

--- a/source/output.analyses.volume_function_1d.F90
+++ b/source/output.analyses.volume_function_1d.F90
@@ -883,10 +883,10 @@ contains
           ! Compute the log-likelihood.
           volumeFunction1DLogLikelihood          =-0.5d0*covariance%covarianceProduct(residual,status)
           if (status == GSL_Success) then
-             if (self%likelihoodNormalize)                                                      &
-                  & volumeFunction1DLogLikelihood=+volumeFunction1DLogLikelihood                &
-                  &                               -0.5d0*covariance%determinant      (        ) &
-                  &                               -0.5d0*dble(self%binCount)                    &
+             if (self%likelihoodNormalize)                                                   &
+                  & volumeFunction1DLogLikelihood=+volumeFunction1DLogLikelihood             &
+                  &                               -0.5d0*covariance%logarithmicDeterminant() &
+                  &                               -0.5d0*dble(self%binCount)                 &
                   &                               *log(2.0d0*Pi)
           else
              volumeFunction1DLogLikelihood       =+logImprobable


### PR DESCRIPTION
Compute likelihood for the scatter in the stellar mass-halo mass relation using only active bins. Specifically, removes inactive bins from the data vector and covariance matrix before evaluating the likelihood.

In the normalization of a multivariate Gaussian, there is a term $\mathrm{det}(\mathbf{\Sigma})^{-1/2}$. Previously, when evaluating log-likelihoods, this was included as $-(1/2) \mathrm{det}(\mathbf{\Sigma})$ instead of $-(1/2) \log \mathrm{det}(\mathbf{\Sigma})$. This is now corrected.

