### PR TITLE
Correct variable used in function call in the `virialOrbitWetzel2010` class

### DIFF
--- a/source/satellites.merging.virial_orbits.Wetzel2010.F90
+++ b/source/satellites.merging.virial_orbits.Wetzel2010.F90
@@ -264,7 +264,7 @@ contains
     massHost     =Dark_Matter_Profile_Mass_Definition(                                                                                                                             &
          &                                                                   host                                                                                                , &
          &                                                                   self%virialDensityContrastDefinition_%densityContrast(basicHost%mass(),basicHost%timeLastIsolated()), &
-         &                                                                   radiusHost                                                                                          , &
+         &                                                                   radiusHostSelf                                                                                      , &
          &                                                                   velocityHost                                                                                        , &
          &                                            cosmologyParameters_  =self%cosmologyParameters_                                                                           , &
          &                                            cosmologyFunctions_   =self%cosmologyFunctions_                                                                            , &


### PR DESCRIPTION
The wrong variable (`radiusHost`) was used in a function call resulting in use of an uninitialized value (`radiusHostSelf`) later in the calculation.