### PR TITLE
Remove an unused condition

### DIFF
--- a/source/satellites.tidal_heating.rate.Gnedin1999.F90
+++ b/source/satellites.tidal_heating.rate.Gnedin1999.F90
@@ -200,7 +200,6 @@ contains
     if (useFrequencyOrbital) then
        radiusHalfMassSatellite  =     massDistribution_%radiusEnclosingMass (mass  =                                massHalfSatellite      )
        velocityCircularSatellite=     massDistribution_%rotationCurve       (radius=                          radiusHalfMassSatellite      )
-       useFrequencyOrbital      =radiusHalfMassSatellite > radiusHalfMassSatelliteTiny
        ! Compute the orbital frequency.
        orbitalFrequencySatellite =  +velocityCircularSatellite &
             &                       /radiusHalfMassSatellite   &


### PR DESCRIPTION
A condition was evaluated but never used - remove it.