### PR TITLE
Add an abstract class which automates tabulation of parametric, spherically-symmetric, collisionless mass distributions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -839,6 +839,7 @@ jobs:
                       tests.interpolation.2D.exe,
                       tests.make_ranges.exe,
                       tests.mass_distributions.exe,
+                      tests.mass_distributions.tabulated.exe,
                       tests.math_special_functions.exe,
                       tests.math_distributions.exe,
                       tests.math.fast.exe,

--- a/scripts/build/sourceDigests.pl
+++ b/scripts/build/sourceDigests.pl
@@ -223,7 +223,8 @@ store($digestsPerFile,$ENV{'BUILDPATH'}."/".$blobFileName);
 (my $outputFileName = $targetName) =~ s/\.(exe|o)$/.md5s.c/;
 open(my $outputFile,">".$ENV{'BUILDPATH'}."/".$outputFileName);
 foreach my $hashName ( sort(keys(%{$digestsPerFile->{'types'}})) ) {
-    print $outputFile "char ".$hashName."MD5[]=\"".$digestsPerFile->{'types'}->{$hashName}->{'compositeMD5'}."\";\n"
+    (my $digest = $digestsPerFile->{'types'}->{$hashName}->{'compositeMD5'}) =~ s/\//\@/g;
+    print $outputFile "char ".$hashName."MD5[]=\"".$digest."\";\n"
 }
 close($outputFile);
 

--- a/source/kinematic_distributions.collisionless.tabulated.F90
+++ b/source/kinematic_distributions.collisionless.tabulated.F90
@@ -1,0 +1,139 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implementation of a kinematic distribution class for collisionless mass distributions using tabulated solutions.
+  !!}
+
+  !![
+  <kinematicsDistribution name="kinematicsDistributionCollisionlessTabulated">
+   <description>A kinematic distribution class for collisionless mass distributions using tabulated solutions.</description>
+  </kinematicsDistribution>
+  !!]
+  type, public, extends(kinematicsDistributionClass) :: kinematicsDistributionCollisionlessTabulated
+     !!{
+     A kinematics distribution for collisionless distributions using tabulated solutions.
+     !!}
+   contains
+     procedure :: isCollisional        => collisionlessTabulatedIsCollisional
+     procedure :: velocityDispersion1D => collisionlessTabulatedVelocityDispersion1D
+  end type kinematicsDistributionCollisionlessTabulated
+
+  interface kinematicsDistributionCollisionlessTabulated
+     !!{
+     Constructors for the {\normalfont \ttfamily collisionless} kinematic distribution class.
+     !!}
+     module procedure collisionlessTabulatedConstructorParameters
+     module procedure collisionlessTabulatedConstructorInternal
+     module procedure collisionlessTabulatedConstructorDecorated
+  end interface kinematicsDistributionCollisionlessTabulated
+
+contains
+
+  function collisionlessTabulatedConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily collisionlessTabulated} kinematic distribution class which builds the object from a parameter
+    set.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (kinematicsDistributionCollisionlessTabulated)                :: self
+    type            (inputParameters                             ), intent(inout) :: parameters
+    double precision                                                              :: toleranceRelativeVelocityDispersion, toleranceRelativeVelocityDispersionMaximum
+
+    !![
+    <inputParameter>
+      <name>toleranceRelativeVelocityDispersion</name>
+      <defaultValue>1.0d-6</defaultValue>
+      <source>parameters</source>
+      <description>The relative tolerance to use in numerical solutions for the velocity dispersion in dark-matter-only density profiles.</description>
+    </inputParameter>
+    <inputParameter>
+      <name>toleranceRelativeVelocityDispersionMaximum</name>
+      <defaultValue>1.0d-3</defaultValue>
+      <source>parameters</source>
+      <description>The maximum relative tolerance to use in numerical solutions for the velocity dispersion in dark-matter-only density profiles.</description>
+    </inputParameter>
+    !!]
+    self=kinematicsDistributionCollisionlessTabulated(toleranceRelativeVelocityDispersion,toleranceRelativeVelocityDispersionMaximum)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function collisionlessTabulatedConstructorParameters
+
+  function collisionlessTabulatedConstructorInternal(toleranceRelativeVelocityDispersion,toleranceRelativeVelocityDispersionMaximum) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily collisionlessTabulated} kinematic distribution class.
+    !!}
+    implicit none
+    type            (kinematicsDistributionCollisionlessTabulated)                          :: self
+    double precision                                              , intent(in   ), optional :: toleranceRelativeVelocityDispersion, toleranceRelativeVelocityDispersionMaximum
+    !![
+    <constructorAssign variables="toleranceRelativeVelocityDispersion, toleranceRelativeVelocityDispersionMaximum"/>
+    !!]
+
+    return
+  end function collisionlessTabulatedConstructorInternal
+  
+  function collisionlessTabulatedConstructorDecorated(kinematicsDistribution_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily collisionlessTabulated} kinematic distribution class.
+    !!}
+    implicit none
+    type (kinematicsDistributionCollisionlessTabulated)                :: self
+    class(kinematicsDistributionClass                 ), intent(in   ) :: kinematicsDistribution_
+
+    self%toleranceRelativeVelocityDispersion       =kinematicsDistribution_%toleranceRelativeVelocityDispersion
+    self%toleranceRelativeVelocityDispersionMaximum=kinematicsDistribution_%toleranceRelativeVelocityDispersionMaximum
+    return
+  end function collisionlessTabulatedConstructorDecorated
+  
+  logical function collisionlessTabulatedIsCollisional(self)
+    !!{
+    Return false indicating that the tabulated collisionless kinematic distribution represents collisionless particles.
+    !!}
+    implicit none
+    class(kinematicsDistributionCollisionlessTabulated), intent(inout) :: self
+    
+    collisionlessTabulatedIsCollisional=.false.
+    return
+  end function collisionlessTabulatedIsCollisional
+
+  double precision function collisionlessTabulatedVelocityDispersion1D(self,coordinates,massDistributionEmbedding) result(velocityDispersion)
+    !!{
+    Return the 1D velocity dispersion at the specified {\normalfont \ttfamily coordinates} in a tabulated collisionless kinematic distribution.
+    !!}
+    implicit none
+    class(kinematicsDistributionCollisionlessTabulated), intent(inout), target :: self
+    class(coordinate                                  ), intent(in   )         :: coordinates
+    class(massDistributionClass                       ), intent(inout)         :: massDistributionEmbedding
+
+    select type (massDistributionEmbedding)
+    class is (massDistributionSphericalTabulated)
+       if (.not.massDistributionEmbedding%isTabulating()) then
+          velocityDispersion=massDistributionEmbedding%velocityDispersion1D         (coordinates                          )
+       else
+          velocityDispersion=self                     %velocityDispersion1DNumerical(coordinates,massDistributionEmbedding)
+       end if
+    class default
+       velocityDispersion   =self                     %velocityDispersion1DNumerical(coordinates,massDistributionEmbedding)
+    end select
+    return
+  end function collisionlessTabulatedVelocityDispersion1D

--- a/source/mass_distributions.F90
+++ b/source/mass_distributions.F90
@@ -643,8 +643,7 @@ module Mass_Distributions
     <argument>class(coordinate           ), intent(in   ) :: coordinates              </argument>
     <argument>class(massDistributionClass), intent(inout) :: massDistributionEmbedding</argument>
     <code>
-      !$GLC attributes unused :: self, coordinates, massDistributionEmbedding
-      kinematicsDistributionVelocityDispersion1D=0.0d0
+      kinematicsDistributionVelocityDispersion1D=self%velocityDispersion1DNumerical(coordinates,massDistributionEmbedding)
     </code>
    </method>
    <method name="velocityDispersion1DNumerical" >

--- a/source/mass_distributions.spherical.F90
+++ b/source/mass_distributions.spherical.F90
@@ -522,8 +522,6 @@ contains
     double precision                                   , dimension(:) , allocatable :: potentials                  , radii               , &
          &                                                                             potentials_                 , radii_
     double precision                                   , parameter                  :: countPointsPerOctave=4.0d+0
-    double precision                                   , parameter                  :: radiusMaximumFactor =1.0d+1
-    double precision                                   , parameter                  :: toleranceRelative   =1.0d-6
     type            (integrator                       )                             :: integrator_
     integer         (c_size_t                )                                      :: countRadii                  , iMinimum            , &
          &                                                                             iMaximum                    , iPrevious           , &
@@ -707,10 +705,9 @@ contains
     use :: Numerical_Comparison            , only : Values_Agree
     implicit none
     class           (massDistributionSpherical        ), intent(inout), target   :: self
-    class           (coordinate                       ), intent(in   )           :: coordinates1              , coordinates2
+    class           (coordinate                       ), intent(in   )           :: coordinates1            , coordinates2
     type            (enumerationStructureErrorCodeType), intent(  out), optional :: status
-    double precision                                   , parameter               :: toleranceRelative  =1.0d-3
-    double precision                                   , parameter               :: radiusMaximumFactor=1.0d+1
+    double precision                                   , parameter               :: toleranceRelative=1.0d-3
     type            (integrator                       )                          :: integrator_
 
     if (present(status)) status=structureErrorCodeSuccess

--- a/source/mass_distributions.spherical.cored_NFW.F90
+++ b/source/mass_distributions.spherical.cored_NFW.F90
@@ -1,0 +1,394 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implementation of a cored NFW \citep{navarro_structure_1996} mass distribution class.
+  !!}
+
+  !![
+  <massDistribution name="massDistributionCoredNFW">
+    <description>
+      A cored NFW \citep{navarro_structure_1996} mass distribution class. The density profile is given by:
+      \begin{equation}
+       \rho_\mathrm{dark matter}(r) \propto \left({r_\mathrm{c}\over r_\mathrm{s}}+{r\over r_\mathrm{s}}\right)^{-1} \left[1 + \left({r\over r_\mathrm{s}}\right)
+      \right]^{-2}.
+      \end{equation}
+    </description>
+  </massDistribution>
+  !!]
+  type, public, extends(massDistributionSphericalTabulated) :: massDistributionCoredNFW
+     !!{
+     The cored NFW \citep{navarro_structure_1996} mass distribution.
+     !!}
+     private
+     double precision :: densityNormalization, radiusScale        , &
+          &              radiusCore          , radiusCoreScaleFree
+   contains
+     procedure :: density               => coredNFWDensity
+     procedure :: densityGradientRadial => coredNFWDensityGradientRadial
+     procedure :: parameters            => coredNFWParameters
+     procedure :: factoryTabulation     => coredNFWFactoryTabulation
+     procedure :: descriptor            => coredNFWDescriptor
+     procedure :: suffix                => coredNFWSuffix
+  end type massDistributionCoredNFW
+  
+  interface massDistributionCoredNFW
+     !!{
+     Constructors for the {\normalfont \ttfamily coredNFW} mass distribution class.
+     !!}
+     module procedure coredNFWConstructorParameters
+     module procedure coredNFWConstructorInternal
+  end interface massDistributionCoredNFW
+
+  ! Tabulated solutions.
+  logical                                     :: containerCoredNFWInitialized=.false.
+  type   (massDistributionContainer), pointer :: containerCoredNFW
+  !$omp threadprivate(containerCoredNFW,containerCoredNFWInitialized)
+  
+  ! Generate a source digest.
+  !![
+  <sourceDigest name="massDistributionCoredNFWSourceDigest"/>
+  !!]
+
+contains
+
+  function coredNFWConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily coredNFW} mass distribution class which builds the object from a parameter
+    set.
+    !!}
+    use :: Input_Parameters          , only : inputParameter                , inputParameters
+    use :: Galactic_Structure_Options, only : enumerationComponentTypeEncode, enumerationMassTypeEncode
+    use :: Numerical_Constants_Math  , only : Pi
+    implicit none
+    type            (massDistributionCoredNFW)                :: self
+    type            (inputParameters         ), intent(inout) :: parameters
+    double precision                                          :: mass                      , radiusScale  , &
+         &                                                       densityNormalization      , concentration, &
+         &                                                       radiusVirial              , radiusCore   , &
+         &                                                       toleranceRelativePotential
+    logical                                                   :: dimensionless
+    type            (varying_string          )                :: componentType
+    type            (varying_string          )                :: massType
+
+    !![
+    <inputParameter>
+      <name>densityNormalization</name>
+      <defaultValue>1.0d0/2.0d0/Pi/(log(4.0d0)-1.0d0)</defaultValue>
+      <description>The density normalization of the cored NFW profile.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>radiusScale</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>The scale radius of the cored NFW profile.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>radiusCore</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>The core radius of the cored NFW profile.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>mass</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>The mass of the cored profile.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>concentration</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>The concentration of the cored NFW profile.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>radiusVirial</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>The virial radius of the cored NFW profile.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>dimensionless</name>
+      <defaultValue>.true.</defaultValue>
+      <description>If true the cored NFW profile is considered to be dimensionless.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>componentType</name>
+      <defaultValue>var_str('unknown')</defaultValue>
+      <description>The component type that this mass distribution represents.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>massType</name>
+      <defaultValue>var_str('unknown')</defaultValue>
+      <description>The mass type that this mass distribution represents.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>toleranceRelativePotential</name>
+      <defaultValue>1.0d-3</defaultValue>
+      <source>parameters</source>
+      <description>The relative tolerance to use in numerical solutions for the gravitational potential.</description>
+    </inputParameter>
+    <conditionalCall>
+     <call>self=massDistributionCoredNFW(radiusCore=radiusCore,toleranceRelativePotential=toleranceRelativePotential,componentType=enumerationComponentTypeEncode(componentType,includesPrefix=.false.),massType=enumerationMassTypeEncode(massType,includesPrefix=.false.){conditions})</call>
+     <argument name="densityNormalization" value="densityNormalization" parameterPresent="parameters"/>
+     <argument name="mass"                 value="mass"                 parameterPresent="parameters"/>
+     <argument name="radiusScale"          value="radiusScale"          parameterPresent="parameters"/>
+     <argument name="radiusVirial"         value="radiusVirial"         parameterPresent="parameters"/>
+     <argument name="concentration"        value="concentration"        parameterPresent="parameters"/>
+     <argument name="dimensionless"        value="dimensionless"        parameterPresent="parameters"/>
+    </conditionalCall>
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function coredNFWConstructorParameters
+
+  function coredNFWConstructorInternal(radiusScale,radiusCore,concentration,densityNormalization,mass,radiusVirial,dimensionless,componentType,massType,toleranceRelativePotential) result(self)
+    !!{
+    Internal constructor for ``coreNFW'' mass distribution class.
+    !!}
+    use :: Error                   , only : Error_Report
+    use :: Numerical_Constants_Math, only : Pi
+    implicit none
+    type            (massDistributionCoredNFW    )                          :: self
+    double precision                              , intent(in   ), optional :: radiusScale               , concentration      , &
+         &                                                                     densityNormalization      , mass               , &
+         &                                                                     radiusVirial              , radiusCore         , &
+         &                                                                     toleranceRelativePotential
+    logical                                       , intent(in   ), optional :: dimensionless
+    type            (enumerationComponentTypeType), intent(in   ), optional :: componentType
+    type            (enumerationMassTypeType     ), intent(in   ), optional :: massType
+    double precision                                                        :: radiusScaleFree           , radiusCoreScaleFree
+    !![
+    <constructorAssign variables="componentType, massType, toleranceRelativePotential"/>
+    !!]
+
+    ! Determine core radius.
+    if      (                            &
+         &   present(radiusCore   )      &
+         &  ) then
+       self%radiusCore          =radiusCore
+    else
+       call Error_Report('no means to determine core radius' //{introspection:location})
+    end if
+    ! Determine scale radius.
+    if      (                            &
+         &   present(radiusScale  )      &
+         &  ) then
+       self%radiusScale         =radiusScale
+    else if (                            &
+         &   present(concentration).and. &
+         &   present(radiusVirial )      &
+         &  ) then
+       self%radiusScale=radiusVirial/concentration
+    else
+       call Error_Report('no means to determine scale radius'//{introspection:location})
+    end if
+    ! Determine density normalization.
+    if      (                                   &
+         &   present(densityNormalization)      &
+         &  ) then
+       self%densityNormalization=densityNormalization
+    else if (                                   &
+         &   present(mass                ).and. &
+         &   present(radiusVirial        )      &
+         &  ) then
+       radiusScaleFree          =+     radiusVirial/self%radiusScale
+       radiusCoreScaleFree      =+self%radiusCore  /self%radiusScale
+       self%densityNormalization=+mass                                                                                                    &
+            &                    /self%radiusScale**3                                                                                     &
+            &                    /4.0d0                                                                                                   &
+            &                    /Pi                                                                                                      &
+            &                    *(1.0d0-radiusCoreScaleFree)**2                                                                          &
+            &                    /(                                                                                                       &
+            &                      +(1.0d0-2.0d0*radiusCoreScaleFree   )*log(  +1.0d0              +radiusScaleFree                     ) &
+            &                      +             radiusCoreScaleFree**2 *log(+(+radiusCoreScaleFree+radiusScaleFree)/radiusCoreScaleFree) &
+            &                      -(1.0d0-      radiusCoreScaleFree   )*radiusScaleFree/(1.0d0+radiusScaleFree)                          &
+            &                     )
+    else
+       call Error_Report('either "densityNormalization", or "mass" and "radiusVirial" must be specified'//{introspection:location})
+    end if
+    ! Determine if profile is dimensionless.
+    if      (present(dimensionless     )) then
+       self%dimensionless=dimensionless
+    else
+       self%dimensionless=.false.
+    end if
+    ! Compute scale-free core radius.
+    self%radiusCoreScaleFree=+self%radiusCore  &
+         &                   /self%radiusScale
+    return
+  end function coredNFWConstructorInternal
+
+  function coredNFWFactoryTabulation(self,parameters) result(instance)
+    !!{
+    Construct an instance of this class using tabulation parameters.
+    !!}
+    implicit none
+    class           (massDistributionSphericalTabulated)               , pointer      :: instance
+    class           (massDistributionCoredNFW          ), intent(inout)               :: self
+    double precision                                    , intent(in   ), dimension(:) :: parameters
+    !$GLC attributes unused :: self
+    
+    allocate(massDistributionCoredNFW :: instance)
+    select type(instance)
+    type is (massDistributionCoredNFW)
+       instance=massDistributionCoredNFW(radiusScale=1.0d0,densityNormalization=1.0d0,radiusCore=parameters(1),toleranceRelativePotential=self%toleranceRelativePotential)
+    end select
+    return
+  end function coredNFWFactoryTabulation
+  
+  double precision function coredNFWDensity(self,coordinates) result(density)
+    !!{
+    Return the density at the specified {\normalfont \ttfamily coordinates} in a cored NFW mass distribution.
+    !!}
+    implicit none
+    class           (massDistributionCoredNFW), intent(inout) :: self
+    class           (coordinate              ), intent(in   ) :: coordinates
+    double precision                                          :: radiusScaleFree
+
+    ! Compute the density at this position.
+    radiusScaleFree=+coordinates%rSpherical () &
+         &          /self       %radiusScale
+    density        =+self       %densityNormalization              &
+         &          /(self%radiusCoreScaleFree+radiusScaleFree)    &
+         &          /(1.0d0                   +radiusScaleFree)**2
+    return
+  end function coredNFWDensity
+  
+  double precision function coredNFWDensityGradientRadial(self,coordinates,logarithmic) result(densityGradient)
+    !!{
+    Return the radial density gradient at the specified {\normalfont \ttfamily coordinates} in a cored NFW mass distribution.
+    !!}
+    implicit none
+    class           (massDistributionCoredNFW), intent(inout), target   :: self
+    class           (coordinate              ), intent(in   )           :: coordinates
+    logical                                   , intent(in   ), optional :: logarithmic
+    double precision                                                    :: radiusScaleFree
+    !![
+    <optionalArgument name="logarithmic" defaultsTo=".false."/>
+    !!]
+
+    radiusScaleFree=+coordinates%rSpherical () &
+         &          /self       %radiusScale
+    if (logarithmic_) then
+       densityGradient=-     3.0d0                                                          &
+            &          +     2.0d0              /(     1.0d0              +radiusScaleFree) &
+            &          +self%radiusCoreScaleFree/(self%radiusCoreScaleFree+radiusScaleFree)
+    else
+       densityGradient=-self%densityNormalization                                        &
+            &          /self%radiusScale                                                 &
+            &          *(+1.0d0+2.0d0*self%radiusCoreScaleFree+3.0d0*radiusScaleFree)    &
+            &          /(      +      self%radiusCoreScaleFree+      radiusScaleFree)**2 &
+            &          /(+1.0d0                               +      radiusScaleFree)**3
+    end if
+    return
+  end function coredNFWDensityGradientRadial
+
+  subroutine coredNFWParameters(self,densityNormalization,radiusNormalization,parameters,container)
+    !!{
+    Establish parameters for tabulation.
+    !!}
+    implicit none
+    class           (massDistributionCoredNFW ), intent(inout)                              :: self
+    double precision                           , intent(  out)                              :: densityNormalization, radiusNormalization
+    double precision                           , intent(inout), allocatable, dimension(:  ) :: parameters
+    type            (massDistributionContainer), intent(  out), pointer                     :: container
+
+    if (.not.containerCoredNFWInitialized) then
+       ! Allocate the table and initialize.
+       allocate(containerCoredNFW)
+       call containerCoredNFW%initialize(1)
+       ! Specify the number of tabulation points per interval in radius and each parameter.
+       containerCoredNFW%mass                      %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%mass                      %parametersCountPer   =+20_c_size_t
+       containerCoredNFW%potential                 %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%potential                 %parametersCountPer   =+20_c_size_t
+       containerCoredNFW%velocityDispersion1D      %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%velocityDispersion1D      %parametersCountPer   =+20_c_size_t
+       containerCoredNFW%energy                    %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%energy                    %parametersCountPer   =+20_c_size_t
+       containerCoredNFW%radiusFreefall            %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%radiusFreefall            %parametersCountPer   =+20_c_size_t
+       containerCoredNFW%radiusFreefallIncreaseRate%radiusCountPer       =+20_c_size_t
+       containerCoredNFW%radiusFreefallIncreaseRate%parametersCountPer   =+20_c_size_t
+       containerCoredNFW%densityRadialMoment0      %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%densityRadialMoment0      %parametersCountPer   =+20_c_size_t
+       containerCoredNFW%densityRadialMoment1      %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%densityRadialMoment1      %parametersCountPer   =+20_c_size_t
+       containerCoredNFW%densityRadialMoment2      %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%densityRadialMoment2      %parametersCountPer   =+20_c_size_t
+       containerCoredNFW%densityRadialMoment3      %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%densityRadialMoment3      %parametersCountPer   =+20_c_size_t
+       containerCoredNFW%fourierTransform          %radiusCountPer       =+20_c_size_t
+       containerCoredNFW%fourierTransform          %parametersCountPer   =+20_c_size_t
+       ! Specify names and descriptions of the parameters.
+       containerCoredNFW%nameParameters                               (1)='radiusCoreOverRadiusScale'
+       containerCoredNFW%descriptionParameters                        (1)='The ratio of core to scale radii.'
+       ! Record that the table is now initialized.
+       containerCoredNFWInitialized                                =.true.
+    end if
+    allocate(parameters(1))
+    densityNormalization    =  +self%densityNormalization
+    radiusNormalization     =  +self%radiusScale
+    parameters          (1) =  +self%radiusCoreScaleFree
+    container               =>       containerCoredNFW
+    return
+  end subroutine coredNFWParameters
+
+  subroutine coredNFWDescriptor(self,descriptor,includeClass,includeFileModificationTimes)
+    !!{
+    Return an input parameter list descriptor which could be used to recreate this object.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    class    (massDistributionCoredNFW), intent(inout)           :: self
+    type     (inputParameters         ), intent(inout)           :: descriptor
+    logical                            , intent(in   ), optional :: includeClass  , includeFileModificationTimes
+    character(len=18                  )                          :: parameterLabel
+    type     (inputParameters         )                          :: parameters
+    !$GLC attributes unused :: includeFileModificationTimes
+    
+    if (.not.present(includeClass).or.includeClass) call descriptor%addParameter('massDistribution','coredNFW')
+    parameters=descriptor%subparameters('massDistribution')
+    write (parameterLabel,'(e17.10)') self%densityNormalization
+    call parameters%addParameter('densityNormalization',trim(adjustl(parameterLabel)))
+    write (parameterLabel,'(e17.10)') self%radiusScale
+    call parameters%addParameter('radiusScale'         ,trim(adjustl(parameterLabel)))
+    write (parameterLabel,'(e17.10)') self%radiusCore
+    call parameters%addParameter('radiusCore'          ,trim(adjustl(parameterLabel)))
+    return
+  end subroutine coredNFWDescriptor
+
+  function coredNFWSuffix(self) result(suffix)
+    !!{
+    Return a suffix for tabulated file names.
+    !!}
+    use :: String_Handling, only : String_C_To_Fortran
+    implicit none
+    type (varying_string          )                :: suffix
+    class(massDistributionCoredNFW), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    suffix=String_C_To_Fortran(massDistributionCoredNFWSourceDigest)
+    return
+  end function coredNFWSuffix

--- a/source/mass_distributions.spherical.tabulated.F90
+++ b/source/mass_distributions.spherical.tabulated.F90
@@ -661,7 +661,7 @@ contains
 
   double precision function sphericalTabulatedInterpolate(self,radiusScaled,parameters,tabulation) result(interpolated)
     !!{
-    Interpolate in the tabulatd mass distribution.
+    Interpolate in the tabulated mass distribution.
     !!}
     use :: Multi_Counters, only : multiCounter
     implicit none

--- a/source/mass_distributions.spherical.tabulated.F90
+++ b/source/mass_distributions.spherical.tabulated.F90
@@ -1,0 +1,983 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implementation of an abstract mass distribution class for tabulated spherically symmetric distributions.
+  !!}
+
+  use, intrinsic :: ISO_C_Binding, only : c_size_t
+
+  !![
+  <massDistribution name="massDistributionSphericalTabulated" abstract="yes">
+   <description>An abstract mass distribution class for tabulated spherically symmetric distributions.</description>
+  </massDistribution>
+  !!]
+  type, extends(massDistributionSpherical), abstract :: massDistributionSphericalTabulated
+     !!{
+     Implementation of an abstract mass distribution class for tabulated spherically symmetric distributions.
+     !!}
+     private
+   contains
+     !![
+     <methods>
+       <method method="parameters"           description="Return parameters of the current mass distribution."                  />
+       <method method="factoryTabulation"    description="Return an instance of the class with the given tabulation parameters."/>
+       <method method="fileRead"             description="Read tabulation data from file."                                      />
+       <method method="fileWrite"            description="Write tabulation data to file."                                       />
+       <method method="tabulate"             description="(Re)tabulate the mass distribution."                                  />
+       <method method="interpolate"          description="Interpolate in the mass distribution."                                />
+       <method method="isTabulating"         description="Return true if the thread associated with the object is tabulating."  />
+       <method method="velocityDispersion1D" description="Compute the 1D velocity dispersion at the given coordinates."         />
+     </methods>
+     !!]
+     procedure(sphericalTabulatedParameters       ), deferred :: parameters
+     procedure(sphericalTabulatedFactoryTabulation), deferred :: factoryTabulation
+     procedure(sphericalTabulatedSuffix           ), deferred :: suffix
+     procedure                                                :: fileRead                   => sphericalTabulatedFileRead
+     procedure                                                :: fileWrite                  => sphericalTabulatedFileWrite
+     procedure                                                :: tabulate                   => sphericalTabulatedTabulate
+     procedure                                                :: interpolate                => sphericalTabulatedInterpolate
+     procedure                                                :: isTabulating               => sphericalTabulatedIsTabulating
+     procedure                                                :: massEnclosedBySphere       => sphericalTabulatedMassEnclosedBySphere
+     procedure                                                :: potential                  => sphericalTabulatedPotential
+     procedure                                                :: fourierTransform           => sphericalTabulatedFourierTransform
+     procedure                                                :: energy                     => sphericalTabulatedEnergy
+     procedure                                                :: densityRadialMoment        => sphericalTabulatedDensityRadialMoment
+     procedure                                                :: radiusFreefall             => sphericalTabulatedRadiusFreefall
+     procedure                                                :: radiusFreefallIncreaseRate => sphericalTabulatedRadiusFreefallIncreaseRate
+     procedure                                                :: velocityDispersion1D       => sphericalTabulatedVelocityDispersion1D
+  end type massDistributionSphericalTabulated
+
+  !![
+  <enumeration>
+   <name>quantity</name>
+   <description>Quantities for tabulation mass distributions.</description>
+   <decodeFunction>yes</decodeFunction>
+   <entry label="mass"                      />
+   <entry label="potential"                 />
+   <entry label="energy"                    />
+   <entry label="fourierTransform"          />
+   <entry label="radiusFreefall"            />
+   <entry label="radiusFreefallIncreaseRate"/>
+   <entry label="densityRadialMoment0"      />
+   <entry label="densityRadialMoment1"      />
+   <entry label="densityRadialMoment2"      />
+   <entry label="densityRadialMoment3"      />
+   <entry label="velocityDispersion1D"      />
+  </enumeration>
+  !!]
+  
+  type :: massDistributionTabulation
+     !!{
+     Object used to store individual mass distribution tabulations.
+     !!}
+     type            (enumerationQuantityType)                                 :: quantity
+     logical                                                                   :: logTransform         , isNegative
+     double precision                                                          :: radiusMinimum        , radiusMaximum    , &
+          &                                                                       radiusInverseStep
+     double precision                          , allocatable, dimension(:    ) :: parametersMinimum    , parametersMaximum, &
+          &                                                                       parametersInverseStep
+     integer         (c_size_t                )                                :: radiusCountPer
+     integer         (c_size_t                ), allocatable, dimension(:    ) :: parametersCountPer
+     double precision                          , allocatable, dimension(:,:,:) :: table
+  end type massDistributionTabulation
+
+  type :: massDistributionContainer
+     !!{
+     Object to store collections of mass distribution tabulations.
+     !!}
+     type(varying_string            ), allocatable, dimension(:  ) :: nameParameters, descriptionParameters
+     ! Tabulations for individual quantities.
+     type(massDistributionTabulation)                              :: mass                      =massDistributionTabulation(quantityMass                      ,.true. ,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: potential                 =massDistributionTabulation(quantityPotential                 ,.false.,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: energy                    =massDistributionTabulation(quantityEnergy                    ,.false.,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: fourierTransform          =massDistributionTabulation(quantityFourierTransform          ,.false.,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: radiusFreefall            =massDistributionTabulation(quantityRadiusFreefall            ,.false.,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: radiusFreefallIncreaseRate=massDistributionTabulation(quantityRadiusFreefallIncreaseRate,.false.,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: densityRadialMoment0      =massDistributionTabulation(quantityDensityRadialMoment0      ,.true. ,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: densityRadialMoment1      =massDistributionTabulation(quantityDensityRadialMoment1      ,.true. ,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: densityRadialMoment2      =massDistributionTabulation(quantityDensityRadialMoment2      ,.true. ,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: densityRadialMoment3      =massDistributionTabulation(quantityDensityRadialMoment3      ,.true. ,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+     type(massDistributionTabulation)                              :: velocityDispersion1D      =massDistributionTabulation(quantityVelocityDispersion1D      ,.true. ,.false.,0.0d0,0.0d0,0.0d0,null(),null(),null(),0_c_size_t,null(),null())
+   contains
+     !![
+     <methods>
+       <method method="initialize"      description="Initialize the container (specifically the number of parameters)."/>
+       <method method="nameParameter"   description="Return the name of the index parameter for a given tabulation."   />
+       <method method="countParameters" description="Return the number of parameters for a given tabulation."          />
+     </methods>
+     !!]
+     procedure :: initialize      => massDistributionContainerInitialize
+     procedure :: nameParameter   => massDistributionContainerNameParameter
+     procedure :: countParameters => massDistributionContainerCountParameters
+  end type massDistributionContainer
+  
+  abstract interface
+     !!{
+     Interfaces to deferred functions.
+     !!}
+     subroutine sphericalTabulatedParameters(self,densityNormalization,radiusNormalization,parameters,container)
+       import massDistributionSphericalTabulated, massDistributionContainer
+       class           (massDistributionSphericalTabulated), intent(inout)                              :: self
+       double precision                                    , intent(  out)                              :: densityNormalization, radiusNormalization
+       double precision                                    , intent(inout), allocatable, dimension(:  ) :: parameters
+       type            (massDistributionContainer         ), intent(  out), pointer                     :: container
+     end subroutine sphericalTabulatedParameters
+
+     function sphericalTabulatedFactoryTabulation(self,parameters) result(instance)
+       import massDistributionSphericalTabulated
+       class           (massDistributionSphericalTabulated)               , pointer        :: instance
+       class           (massDistributionSphericalTabulated), intent(inout)                 :: self
+       double precision                                    , intent(in   ), dimension(:  ) :: parameters
+     end function sphericalTabulatedFactoryTabulation
+ 
+     function sphericalTabulatedSuffix(self) result(suffix)
+       import massDistributionSphericalTabulated, varying_string
+       type (varying_string                    )                :: suffix
+       class(massDistributionSphericalTabulated), intent(inout) :: self
+     end function sphericalTabulatedSuffix
+  end interface
+
+  ! Indicator used to record if tabulation is underway. When tabulating a property, *do not* use tabulated versions of other
+  ! properties - we want a precise calculation when building the tables.
+  logical :: tabulating=.false.
+  !$omp threadprivate(tabulating)
+  
+contains
+
+  double precision function sphericalTabulatedMassEnclosedBySphere(self,radius) result(mass)
+    !!{
+    Computes the mass enclosed within a sphere of given {\normalfont \ttfamily radius} for spherically-symmetric mass
+    distributions using a tabulation.
+    !!}
+    implicit none
+    class           (massDistributionSphericalTabulated), intent(inout) , target      :: self
+    double precision                                    , intent(in   )               :: radius
+    double precision                                    , dimension(:  ), allocatable :: parameters
+    type            (massDistributionContainer         )                , pointer     :: container
+    double precision                                                                  :: densityNormalization, radiusNormalization, &
+         &                                                                               radiusScaled
+
+    if (tabulating) then
+       mass=self%massEnclosedBySphereNumerical(radius)
+    else
+       ! Get the tabulation properties.
+       call self%parameters(densityNormalization,radiusNormalization,parameters,container)
+       radiusScaled=+radius              &
+            &       /radiusNormalization
+       call self%tabulate(radiusScaled,parameters,container,container%mass)
+       ! Perform the interpolation.
+       mass   =+self%interpolate         (radiusScaled,parameters,container%mass) &
+            &  *     densityNormalization                                         &
+            &  *     radiusNormalization **3
+    end if
+    return
+  end function sphericalTabulatedMassEnclosedBySphere
+
+  double precision function sphericalTabulatedPotential(self,coordinates,status) result(potential)
+    !!{
+    Compute the potential at the given {\normalfont \ttfamily coordinates} in a spherical mass distribution using a tabulation.
+    !!}
+    use :: Galactic_Structure_Options, only : structureErrorCodeSuccess
+    implicit none
+    class           (massDistributionSphericalTabulated), intent(inout) , target      :: self
+    class           (coordinate                        ), intent(in   )               :: coordinates
+    type            (enumerationStructureErrorCodeType ), intent(  out) , optional    :: status
+    double precision                                    , dimension(:  ), allocatable :: parameters
+    type            (massDistributionContainer         )                , pointer     :: container
+    double precision                                                                  :: densityNormalization, radiusNormalization, &
+         &                                                                               radiusScaled
+
+    if (.not.tabulating) then
+       ! Get the tabulation properties.
+       call self%parameters(densityNormalization,radiusNormalization,parameters,container)
+       radiusScaled=+coordinates%rSpherical         () &
+            &       /            radiusNormalization
+       call self%tabulate(radiusScaled,parameters,container,container%potential)
+       ! Perform the interpolation.
+       potential=+self%interpolate         (radiusScaled,parameters,container%potential) &
+            &    *     densityNormalization                                              &
+            &    *     radiusNormalization **2
+       ! Set return status.
+       if (present(status)) status=structureErrorCodeSuccess
+    else
+       ! If tabulating then fall back to a numerical evaluation.
+       potential=self%potentialNumerical(coordinates,status)
+    end if
+    return
+  end function sphericalTabulatedPotential
+
+  double precision function sphericalTabulatedVelocityDispersion1D(self,coordinates) result(velocityDispersion)
+    !!{
+    Compute the 1D velocity dispersion at the given {\normalfont \ttfamily coordinates} in a spherical mass distribution using a tabulation.
+    !!}
+    use :: Galactic_Structure_Options, only : structureErrorCodeSuccess
+    implicit none
+    class           (massDistributionSphericalTabulated), intent(inout) , target      :: self
+    class           (coordinate                        ), intent(in   )               :: coordinates
+    double precision                                    , dimension(:  ), allocatable :: parameters
+    type            (massDistributionContainer         )                , pointer     :: container
+    double precision                                                                  :: densityNormalization, radiusNormalization, &
+         &                                                                               radiusScaled
+
+    if (.not.tabulating) then
+       ! Get the tabulation properties.
+       call self%parameters(densityNormalization,radiusNormalization,parameters,container)
+       radiusScaled=+coordinates%rSpherical         () &
+            &       /            radiusNormalization
+       call self%tabulate(radiusScaled,parameters,container,container%velocityDispersion1D)
+       ! Perform the interpolation.
+       velocityDispersion=+self%interpolate         (radiusScaled,parameters,container%velocityDispersion1D) &
+            &             *     densityNormalization**0.5d0                                                  &
+            &             *     radiusNormalization
+    else
+       ! If tabulating then fall back to a numerical evaluation.
+       velocityDispersion=+self%kinematicsDistribution_%velocityDispersion1D(coordinates,self)
+    end if
+    return
+  end function sphericalTabulatedVelocityDispersion1D
+
+  double precision function sphericalTabulatedEnergy(self,radiusOuter,massDistributionEmbedding) result(energy)
+    !!{
+    Compute the energy within a given {\normalfont \ttfamily radius} in a spherical mass distribution using a tabulation.
+    !!}
+    implicit none
+    class           (massDistributionSphericalTabulated), intent(inout) , target      :: self
+    double precision                                    , intent(in   )               :: radiusOuter
+    class           (massDistributionClass             ), intent(inout) , target      :: massDistributionEmbedding
+    double precision                                    , dimension(:  ), allocatable :: parameters
+    class           (massDistributionClass             )                , pointer     :: self_
+    type            (massDistributionContainer         )                , pointer     :: container
+    double precision                                                                  :: densityNormalization     , radiusNormalization, &
+         &                                                                               radiusOuterScaled
+
+    self_ => self
+    if (.not.tabulating.and.associated(self_,massDistributionEmbedding)) then
+       ! Get the tabulation properties.
+       call self%parameters(densityNormalization,radiusNormalization,parameters,container)
+       radiusOuterScaled=+radiusOuter         &
+            &            /radiusNormalization
+       call self%tabulate(radiusOuterScaled,parameters,container,container%energy)
+       ! Perform the interpolation.
+       energy =+self%interpolate         (radiusOuterScaled,parameters,container%energy) &
+            &  *     densityNormalization**2                                             &
+            &  *     radiusNormalization **5
+    else
+       ! If embedded in some other mass distribution, we must fall back to a fully numerical calculation.
+       energy=self%energyNumerical(radiusOuter,massDistributionEmbedding)
+    end if
+    return
+  end function sphericalTabulatedEnergy
+
+  double precision function sphericalTabulatedFourierTransform(self,radiusOuter,wavenumber) result(fourierTransform)
+    !!{    
+    Compute the Fourier transform of the density profile at the given {\normalfont \ttfamily wavenumber} in a spherical mass
+    distribution using a tabulation.
+    !!}
+    implicit none
+    class           (massDistributionSphericalTabulated), intent(inout)               :: self
+    double precision                                    , intent(in   )               :: radiusOuter         , wavenumber
+    double precision                                    , dimension(:  ), allocatable :: parameters          , parametersExtended
+    type            (massDistributionContainer         )                , pointer     :: container
+    double precision                                                                  :: densityNormalization, radiusNormalization, &
+         &                                                                               radiusOuterScaled   , wavenumberScaled
+
+    if (.not.tabulating) then
+       ! Get the tabulation properties.
+       call self%parameters(densityNormalization,radiusNormalization,parameters,container)
+       wavenumberScaled =+wavenumber          &
+            &            *radiusNormalization
+       radiusOuterScaled=+radiusOuter         &
+            &            /radiusNormalization
+       ! Make the scaled outer radius an extra parameter.
+       allocate(parametersExtended(size(parameters)+1))
+       parametersExtended(1:size(parameters)  )=parameters
+       parametersExtended(  size(parameters)+1)=radiusOuterScaled
+       call self%tabulate(wavenumberScaled,parametersExtended,container,container%fourierTransform)
+       ! Perform the interpolation.
+       fourierTransform=+self%interpolate(wavenumberScaled,parametersExtended,container%fourierTransform)
+    else
+       ! If already tabulating fall back to a numerical calculation.
+       fourierTransform=self%fourierTransformNumerical(radiusOuter,wavenumber)
+    end if
+    return
+  end function sphericalTabulatedFourierTransform
+
+  double precision function sphericalTabulatedRadiusFreefall(self,time) result(radius)
+    !!{
+    Compute the freefall radius at a given {\normalfont \ttfamily time} in a spherical mass distribution using a tabulation.
+    !!}
+    implicit none
+    class           (massDistributionSphericalTabulated), intent(inout)               :: self
+    double precision                                    , intent(in   )               :: time
+    double precision                                    , dimension(:  ), allocatable :: parameters
+    type            (massDistributionContainer         )                , pointer     :: container
+    double precision                                                                  :: densityNormalization, radiusNormalization, &
+         &                                                                               timeScaled          , timeNormalization
+
+    if (tabulating) then
+       radius=self%radiusFreefallNumerical(time)
+    else
+       ! Get the tabulation properties.
+       call self%parameters(densityNormalization,radiusNormalization,parameters,container)
+       timeNormalization=+1.0d0                      &
+            &            /sqrt(densityNormalization)
+       timeScaled      =+time              &
+            &           /timeNormalization
+       call self%tabulate(timeScaled,parameters,container,container%radiusFreefall)
+       ! Perform the interpolation.
+       radius =+self%interpolate        (timeScaled,parameters,container%radiusFreefall) &
+            &  *     radiusNormalization
+    end if
+    return
+  end function sphericalTabulatedRadiusFreefall
+
+  double precision function sphericalTabulatedRadiusFreefallIncreaseRate(self,time) result(radiusIncreaseRate)
+    !!{
+    Compute the rate of increase of freefall radius at a given {\normalfont \ttfamily time} in a spherical mass distribution using a tabulation.
+    !!}
+    implicit none
+    class           (massDistributionSphericalTabulated), intent(inout)               :: self
+    double precision                                    , intent(in   )               :: time
+    double precision                                    , dimension(:  ), allocatable :: parameters
+    type            (massDistributionContainer         )                , pointer     :: container
+    double precision                                                                  :: densityNormalization, radiusNormalization, &
+         &                                                                               timeScaled          , timeNormalization
+
+    if (tabulating) then
+       radiusIncreaseRate=self%radiusFreefallIncreaseRateNumerical(time)
+    else
+       ! Get the tabulation properties.
+       call self%parameters(densityNormalization,radiusNormalization,parameters,container)
+       timeNormalization=+1.0d0                      &
+            &            /sqrt(densityNormalization)
+       timeScaled      =+time              &
+            &           /timeNormalization
+       call self%tabulate(timeScaled,parameters,container,container%radiusFreefallIncreaseRate)
+       ! Perform the interpolation.
+       radiusIncreaseRate=+self%interpolate        (timeScaled,parameters,container%radiusFreefallIncreaseRate) &
+            &             *     radiusNormalization                                                             &
+            &             /     timeNormalization
+    end if
+    return
+  end function sphericalTabulatedRadiusFreefallIncreaseRate
+
+  double precision function sphericalTabulatedDensityRadialMoment(self,moment,radiusMinimum,radiusMaximum,isInfinite) result(densityRadialMoment)
+    !!{
+    Computes radial density moments for spherically-symmetric mass distributions using a tabulation.
+    !!}
+    use :: Numerical_Comparison, only : Values_Agree
+    implicit none
+    class           (massDistributionSphericalTabulated), intent(inout)               :: self
+    double precision                                    , intent(in   )               :: moment
+    double precision                                    , intent(in   ) , optional    :: radiusMinimum       , radiusMaximum
+    logical                                             , intent(  out) , optional    :: isInfinite
+    double precision                                    , dimension(:  ), allocatable :: parameters
+    type            (massDistributionContainer         )                , pointer     :: container
+    double precision                                                                  :: densityNormalization, radiusNormalization, &
+         &                                                                               radiusMinimumScaled , radiusMaximumScaled
+    logical                                                                           :: useTabulation
+    integer                                                                           :: moment_
+
+    useTabulation=.not.tabulating.and.present(radiusMaximum) ! Do not tabulate for infinite outer radius or if already tabulating some other property.
+    ! Detect cases for which we can use a tabulation - we tabulate only for the most commonly-used moments.
+    if (useTabulation) then
+       if      (Values_Agree(moment,0.0d0,absTol=1.0d-6)) then
+          moment_      =0
+       else if (Values_Agree(moment,1.0d0,absTol=1.0d-6)) then
+          moment_      =1
+       else if (Values_Agree(moment,2.0d0,absTol=1.0d-6)) then
+          moment_      =2
+       else if (Values_Agree(moment,3.0d0,absTol=1.0d-6)) then
+          moment_      =3
+       else
+          moment_      =-huge(0)
+          useTabulation=.false.
+       end if
+    end if
+    if (useTabulation) then
+       ! Get the tabulation properties.
+       call self%parameters(densityNormalization,radiusNormalization,parameters,container)
+       if (present(radiusMinimum) .and. radiusMinimum > 0.0d0) then
+          radiusMinimumScaled=+radiusMinimum       &
+               &              /radiusNormalization
+       end if
+       radiusMaximumScaled=+radiusMaximum       &
+            &              /radiusNormalization
+       select case (moment_)
+       case (0)
+          call    self%tabulate(radiusMaximumScaled,parameters,container,container%densityRadialMoment0)
+          densityRadialMoment   =                    +self%interpolate(radiusMaximumScaled,parameters,container%densityRadialMoment0)
+          if (present(radiusMinimum) .and. radiusMinimum > 0.0d0) then
+             call self%tabulate(radiusMinimumScaled,parameters,container,container%densityRadialMoment0)
+             densityRadialMoment=+densityRadialMoment-self%interpolate(radiusMinimumScaled,parameters,container%densityRadialMoment0)
+          end if
+       case (1)
+          call    self%tabulate(radiusMaximumScaled,parameters,container,container%densityRadialMoment1)
+          densityRadialMoment   =                    +self%interpolate(radiusMaximumScaled,parameters,container%densityRadialMoment1)
+          if (present(radiusMinimum) .and. radiusMinimum > 0.0d0) then
+             call self%tabulate(radiusMinimumScaled,parameters,container,container%densityRadialMoment1)
+             densityRadialMoment=+densityRadialMoment-self%interpolate(radiusMinimumScaled,parameters,container%densityRadialMoment1)
+          end if
+       case (2)
+          call    self%tabulate(radiusMaximumScaled,parameters,container,container%densityRadialMoment2)
+          densityRadialMoment   =                    +self%interpolate(radiusMaximumScaled,parameters,container%densityRadialMoment2)
+          if (present(radiusMinimum) .and. radiusMinimum > 0.0d0) then
+             call self%tabulate(radiusMinimumScaled,parameters,container,container%densityRadialMoment2)
+             densityRadialMoment=+densityRadialMoment-self%interpolate(radiusMinimumScaled,parameters,container%densityRadialMoment2)
+          end if
+       case (3)
+          call    self%tabulate(radiusMaximumScaled,parameters,container,container%densityRadialMoment3)
+          densityRadialMoment   =                    +self%interpolate(radiusMaximumScaled,parameters,container%densityRadialMoment3)
+          if (present(radiusMinimum) .and. radiusMinimum > 0.0d0) then
+             call self%tabulate(radiusMinimumScaled,parameters,container,container%densityRadialMoment3)
+             densityRadialMoment=+densityRadialMoment-self%interpolate(radiusMinimumScaled,parameters,container%densityRadialMoment3)
+          end if
+       end select
+       ! Perform the interpolation.
+       densityRadialMoment=+densityRadialMoment                  &
+            &              *densityNormalization                 &
+            &              *radiusNormalization **(moment+1.0d0)
+    else
+       ! Fall back to a numerical calculation.
+       densityRadialMoment=self%densityRadialMomentNumerical(moment,radiusMinimum,radiusMaximum,isInfinite)
+    end if
+    return
+  end function sphericalTabulatedDensityRadialMoment
+
+  subroutine sphericalTabulatedTabulate(self,radiusScaled,parameters,container,tabulation)
+    !!{
+    Tabulate the mass distribution.
+    !!}
+    use :: Coordinates                 , only : coordinateSpherical, assignment(=)
+    use :: Multi_Counters              , only : multiCounter
+    use :: Display                     , only : displayIndent      , displayUnindent    , displayMessage, verbosityLevelWorking, &
+         &                                      displayCounter     , displayCounterClear
+    use :: Numerical_Constants_Prefixes, only : siFormat
+    implicit none
+    class           (massDistributionSphericalTabulated )                , intent(inout) :: self
+    double precision                                                     , intent(in   ) :: radiusScaled
+    double precision                                     , dimension(:  ), intent(in   ) :: parameters
+    type            (massDistributionContainer          )                , intent(inout) :: container
+    type            (massDistributionTabulation         )                , intent(inout) :: tabulation
+    class           (massDistributionSphericalTabulated )                , pointer       :: instance
+    type            (kinematicsDistributionCollisionless)                , pointer       :: instanceKinematicsDistribution
+    double precision                                     , dimension(:  ), allocatable   :: parameters_                   , parametersReduced_
+    integer         (c_size_t                           ), dimension(:  ), allocatable   :: countParameters               , iParameters
+    integer         (c_size_t                           )                                :: countRadii                    , iRadius             , &
+         &                                                                                  i                             , lengthMaximum       , &
+         &                                                                                  iterationCount                , iterationCountTotal
+    double precision                                                                     :: radius_                       , quantity_           , &
+         &                                                                                  time_                         , wavenumber_         , &
+         &                                                                                  radiusOuter_
+    logical                                                                              :: workRemains
+    type            (multiCounter                       )                                :: counter
+    character       (len= 8                             )                                :: labelLower                    , labelUpper
+    character       (len=64                             )                                :: labelSize
+    type            (varying_string                     )                                :: message
+    type            (coordinateSpherical                )                                :: coordinates                   , coordinatesZeroPoint
+ 
+    ! Test if within current tabulation range.
+    if (retabulate()) then
+       tabulating=.true.
+       ! Restore tabulation from file if necessary.
+       call self%fileRead(container,tabulation)
+       ! Test if within current tabulation range.
+       if (retabulate()) then
+          call displayIndent("tabulating "//enumerationQuantityDecode(tabulation%quantity)//" profile for '"//char(self%objectType())//"'",verbosityLevelWorking)
+          ! Construct radius and parameter ranges.
+          tabulation%radiusMinimum        =min(tabulation%radiusMinimum    ,0.5d0*radiusScaled)
+          tabulation%radiusMaximum        =max(tabulation%radiusMaximum    ,2.0d0*radiusScaled)
+          tabulation%parametersMinimum    =min(tabulation%parametersMinimum,0.5d0*parameters  )
+          tabulation%parametersMaximum    =max(tabulation%parametersMaximum,2.0d0*parameters  )
+          countRadii                      =int(log10(    tabulation%radiusMaximum/tabulation%    radiusMinimum)*dble(    tabulation%radiusCountPer),kind=c_size_t)+1_c_size_t
+          countParameters                 =int(log10(tabulation%parametersMaximum/tabulation%parametersMinimum)*dble(tabulation%parametersCountPer),kind=c_size_t)+1_c_size_t
+          tabulation%radiusInverseStep    =dble(countRadii     -1_c_size_t)/log(tabulation%    radiusMaximum/tabulation%    radiusMinimum)
+          tabulation%parametersInverseStep=dble(countParameters-1_c_size_t)/log(tabulation%parametersMaximum/tabulation%parametersMinimum)
+          if (allocated(tabulation%table)) deallocate(tabulation%table)
+          select case(size(countParameters))
+          case (1)
+             allocate(tabulation%table(countRadii,countParameters(1),1                 ))
+          case (2)
+             allocate(tabulation%table(countRadii,countParameters(1),countParameters(2)))
+          case default
+             call Error_Report('rank not supported'//{introspection:location})
+          end select
+          ! Report on tabulation.
+          lengthMaximum=max(12,maxval(len(container%nameParameters)))
+          write (labelLower,'(e8.2)') tabulation%radiusMinimum
+          write (labelUpper,'(e8.2)') tabulation%radiusMaximum
+          message=labelLower//" ≤ radiusScaled"//repeat(" ",lengthMaximum-12)//" ≤ "//labelUpper
+          call displayMessage(message,verbosityLevelWorking)
+          do i=1,size(countParameters)
+             write (labelLower,'(e8.2)') tabulation%parametersMinimum(i)
+             write (labelUpper,'(e8.2)') tabulation%parametersMaximum(i)
+             message=labelLower//" ≤ "//container%nameParameter(i,tabulation)//repeat(" ",lengthMaximum-len(container%nameParameter(i,tabulation)))//" ≤ "//labelUpper
+             call displayMessage(message,verbosityLevelWorking)
+          end do
+          labelSize=siFormat(dble(sizeof(tabulation%table)),'f8.2,1x')
+          message="tabulation size = "//trim(adjustl(labelSize))//"B"
+          call displayMessage(message,verbosityLevelWorking)
+          ! Iterate over parameters.
+          iterationCount     =0_c_size_t
+          iterationCountTotal=product(countParameters)
+          ! Tabulate in parallel.
+          !$omp parallel private(iRadius,radius_,time_,radiusOuter_,wavenumber_,coordinates,coordinatesZeroPoint,quantity_,instance,instanceKinematicsDistribution,iParameters,parameters_,parametersReduced_,workRemains,counter)
+          ! This is a new thread, so mark it as tabulating.
+          tabulating         =.true.
+          ! Initialize the counter and iterate over parameter states.
+          counter            =multiCounter(countParameters)
+          do while (.true.)
+             !$omp barrier
+             workRemains=counter%increment()
+             if (.not.workRemains) exit
+             !$omp master
+             call displayCounter(int(100.0d0*dble(iterationCount)/dble(iterationCountTotal)),iterationCount==0,verbosityLevelWorking)
+             iterationCount=iterationCount+1_c_size_t
+             !$omp end master
+             iParameters   =counter%states()
+             parameters_   =exp(log(tabulation%parametersMinimum)+dble(iParameters-1_c_size_t)/tabulation%parametersInverseStep)
+             ! Call the factory function in the child class to get an instance built with the current parameters.
+             select case (tabulation%quantity%ID)
+             case (quantityFourierTransform%ID)
+                if (.not.allocated(parametersReduced_)) allocate(parametersReduced_(size(parameters_-1)))
+                parametersReduced_ =  parameters_(1:size(parameters_)-1)
+                radiusOuter_       =  parameters_(  size(parameters_)  )
+                instance           => self%factoryTabulation(parametersReduced_)
+             case default
+                instance           => self%factoryTabulation(parameters_       )
+             end select
+             allocate(instanceKinematicsDistribution)
+             instanceKinematicsDistribution=kinematicsDistributionCollisionless(                                                                                                                    &
+                  &                                                             toleranceRelativeVelocityDispersion       =self%kinematicsDistribution_%toleranceRelativeVelocityDispersion       , &
+                  &                                                             toleranceRelativeVelocityDispersionMaximum=self%kinematicsDistribution_%toleranceRelativeVelocityDispersionMaximum  &
+                  &                                                            )
+             call instance%setKinematicsDistribution(instanceKinematicsDistribution)
+             ! Iterate over scaled radii.
+             !$omp do
+             do iRadius=1,countRadii
+                radius_             =exp(log(tabulation%radiusMinimum)+dble(iRadius-1_c_size_t)/tabulation%radiusInverseStep)
+                time_               = radius_
+                wavenumber_         = radius_
+                coordinates         =[radius_,0.0d0,0.0d0]
+                coordinatesZeroPoint=[1.0d0  ,0.0d0,0.0d0]
+                ! Compute the quantity numerically.
+                select case (tabulation%quantity%ID)
+                case (quantityMass                      %ID)
+                   quantity_=+instance%massEnclosedBySphereNumerical      (             radius_                      )
+                case (quantityEnergy                    %ID)
+                   quantity_=+instance%energyNumerical                    (             radius_             ,instance)
+                case (quantityPotential                 %ID)
+                   ! Potential is always referenced to a zero-point at the normalization radius.
+                   quantity_=+instance%potentialNumerical                 (             coordinates                  ) &
+                        &    -instance%potentialNumerical                 (             coordinatesZeroPoint         )
+                case (quantityVelocityDispersion1D      %ID)
+                   quantity_=+instance%velocityDispersion1D               (             coordinates                  )
+                case (quantityFourierTransform          %ID)
+                   quantity_=+instance%fourierTransformNumerical          (radiusOuter_,wavenumber_                  )
+                case (quantityRadiusFreefall            %ID)
+                   quantity_=+instance%radiusFreefallNumerical            (             time_                        )
+                case (quantityRadiusFreefallIncreaseRate%ID)
+                   quantity_=+instance%radiusFreefallIncreaseRateNumerical(             time_                        )
+                case (quantityDensityRadialMoment0      %ID)
+                   quantity_=+instance% densityRadialMomentNumerical      (0.0d0,0.0d0 ,radius_                      )
+                case (quantityDensityRadialMoment1      %ID)
+                   quantity_=+instance% densityRadialMomentNumerical      (1.0d0,0.0d0 ,radius_                      )
+                case (quantityDensityRadialMoment2      %ID)
+                   quantity_=+instance% densityRadialMomentNumerical      (2.0d0,0.0d0 ,radius_                      )
+                case (quantityDensityRadialMoment3      %ID)
+                   quantity_=+instance% densityRadialMomentNumerical      (3.0d0,0.0d0 ,radius_                      )
+                case default
+                   quantity_=+0.0d0
+                   call Error_Report('unknown quantity'//{introspection:location})
+                end select
+                ! For quantities that are negative, invert the sign prior to any logarithmic transform.
+                if (tabulation%isNegative  ) quantity_=-    quantity_
+                ! If logarithmic interpolation is requested, log-transform now.
+                if (tabulation%logTransform) quantity_=+log(quantity_)
+                ! Store the quantity.
+                select case(size(countParameters))
+                case (1)
+                   tabulation%table(iRadius,iParameters(1),1             )=quantity_
+                case (2)
+                   tabulation%table(iRadius,iParameters(1),iParameters(2))=quantity_
+                case default
+                   call Error_Report('rank not supported'//{introspection:location})
+                end select
+             end do
+             !$omp end do
+             deallocate(instance)
+          end do
+          !$omp master
+          call displayCounterClear(verbosityLevelWorking)
+          !$omp end master
+          tabulating=.false.
+          !$omp end parallel
+          ! Store tabulation to file.
+          call self%fileWrite(container,tabulation)
+          call displayUnindent('done',verbosityLevelWorking)
+       end if
+       tabulating=.false.
+    end if
+    return
+
+  contains
+
+    logical function retabulate()
+      !!{
+      Test if the mass profile must be retabulated.
+      !!}
+      implicit none
+      
+      retabulate=.not.allocated(tabulation%table)
+      if (.not.retabulate)                                                 &
+           &  retabulate=     radiusScaled < tabulation%radiusMinimum      &
+           &             .or.                                              &
+           &                  radiusScaled > tabulation%radiusMaximum      &
+           &             .or.                                              &
+           &              any(parameters   < tabulation%parametersMinimum) &
+           &             .or.                                              &
+           &              any(parameters   > tabulation%parametersMaximum)
+      return
+    end function retabulate
+
+  end subroutine sphericalTabulatedTabulate
+
+  double precision function sphericalTabulatedInterpolate(self,radiusScaled,parameters,tabulation) result(interpolated)
+    !!{
+    Interpolate in the tabulatd mass distribution.
+    !!}
+    use :: Multi_Counters, only : multiCounter
+    implicit none
+    class           (massDistributionSphericalTabulated), intent(inout)                 :: self
+    double precision                                    , intent(in   )                 :: radiusScaled
+    double precision                                    , intent(in   ), dimension(:  ) :: parameters
+    type            (massDistributionTabulation        ), intent(in   )                 :: tabulation
+    double precision                                                   , dimension(2  ) :: hRadius
+    integer         (c_size_t                          ), allocatable  , dimension(:  ) :: iParameters , jParameters
+    double precision                                    , allocatable  , dimension(:,:) :: hParameters
+    integer         (c_size_t                          )                                :: iRadius     , jRadius
+    type            (multiCounter                      )                                :: counter
+
+    ! Compute interpolating factors.
+    allocate(hParameters(2,size(parameters)))
+    hRadius    (2  )=log(radiusScaled/tabulation%radiusMinimum    )*tabulation%radiusInverseStep    +1_c_size_t
+    hParameters(2,:)=log(parameters  /tabulation%parametersMinimum)*tabulation%parametersInverseStep+1_c_size_t
+    iRadius         =int(hRadius    (2  ),kind=c_size_t)
+    iParameters     =int(hParameters(2,:),kind=c_size_t)
+    hRadius    (2  )=hRadius    (2  )-dble(iRadius    )
+    hParameters(2,:)=hParameters(2,:)-dble(iParameters)
+    hRadius    (1  )=1.0d0-hRadius    (2  )
+    hParameters(1,:)=1.0d0-hParameters(2,:)    
+    ! Perform the interpolation.
+    interpolated=0.0d0
+    counter     =multiCounter(spread(2_c_size_t,1,size(parameters)))
+    select case(size(parameters))
+    case (1)
+       do while (counter%increment())
+          jParameters=counter%states()
+          do jRadius=1,2
+             interpolated=+interpolated                                                 &
+                  &       +tabulation %table(                                           &
+                  &                          iRadius       +jRadius       -1_c_size_t,  &
+                  &                          iParameters(1)+jParameters(1)-1_c_size_t,  &
+                  &                                                        1_c_size_t   &
+                  &                         )                                           &
+                  &       *hRadius          (                                           &
+                  &                                         jRadius                     &
+                  &                         )                                           &
+                  &       *hParameters      (                                           &
+                  &                                         jParameters(1)           ,1 &
+                  &                         )
+          end do
+       end do
+    case (2)
+       do while (counter%increment())
+          jParameters=counter%states()
+          do jRadius=1,2
+             interpolated=+interpolated                                                 &
+                  &       +tabulation %table(                                           &
+                  &                          iRadius       +jRadius       -1_c_size_t,  &
+                  &                          iParameters(1)+jParameters(1)-1_c_size_t,  &
+                  &                          iParameters(2)+jParameters(2)-1_c_size_t   &
+                  &                         )                                           &
+                  &       *hRadius          (                                           &
+                  &                                         jRadius                     &
+                  &                         )                                           &
+                  &       *hParameters      (                                           &
+                  &                                         jParameters(1)           ,1 &
+                  &                         )                                           &
+                  &       *hParameters      (                                           &
+                  &                                         jParameters(2)           ,2 &
+                  &                         )
+          end do
+       end do
+    case default
+       call Error_Report('rank not supported'//{introspection:location})
+    end select
+    ! If logarithmic interpolation was used, inverse transform now.
+    if (tabulation%logTransform) interpolated=+exp(interpolated)
+    ! For quantities that are negative, invert the sign.
+    if (tabulation%isNegative  ) interpolated=-    interpolated
+    return
+  end function sphericalTabulatedInterpolate
+  
+  logical function sphericalTabulatedIsTabulating(self) result(isTabulating)
+    !!{
+    Return true if this thread is currently tabulating.
+    !!}
+    implicit none
+    class(massDistributionSphericalTabulated), intent(inout) :: self
+    !$GLC attributes unused :: self
+    
+    isTabulating=tabulating
+    return
+  end function sphericalTabulatedIsTabulating
+  
+  subroutine sphericalTabulatedFileRead(self,container,tabulation)
+    !!{
+    Read tabulated data from file.
+    !!}
+    use :: Input_Paths    , only : inputPath              , pathTypeDataDynamic
+    use :: HDF5_Access    , only : hdf5Access
+    use :: IO_HDF5        , only : hdf5Object
+    use :: File_Utilities , only : File_Lock              , File_Path            , File_Unlock, lockDescriptor, &
+         &                         File_Exists
+    use :: String_Handling, only : String_Upper_Case_First
+    use :: Display        , only : displayMessage         , verbosityLevelWorking
+    implicit none
+    class  (massDistributionSphericalTabulated), intent(inout) :: self
+    type   (massDistributionContainer         ), intent(inout) :: container
+    type   (massDistributionTabulation        ), intent(inout) :: tabulation
+    type   (varying_string                    )                :: fileName  , quantityName
+    type   (hdf5Object                        )                :: file
+    type   (lockDescriptor                    )                :: fileLock
+    integer(c_size_t                          )                :: i
+
+    if (allocated(tabulation%table)) deallocate(tabulation%table)
+    quantityName=enumerationQuantityDecode(tabulation%quantity)
+    fileName    =inputPath(pathTypeDataDynamic)//'massDistributions/'//self%objectType()//'_'//quantityName//'_'//self%suffix()//'.hdf5'
+    if (File_Exists(fileName)) then
+       call displayMessage("reading tabulated "//enumerationQuantityDecode(tabulation%quantity)//" profile from '"//char(fileName)//"'",verbosityLevelWorking)
+       ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
+       if (.not.allocated(tabulation%parametersMinimum    )) allocate(tabulation%parametersMinimum    (container%countParameters(tabulation)))
+       if (.not.allocated(tabulation%parametersMaximum    )) allocate(tabulation%parametersMaximum    (container%countParameters(tabulation)))
+       if (.not.allocated(tabulation%parametersInverseStep)) allocate(tabulation%parametersInverseStep(container%countParameters(tabulation)))
+       call File_Lock(char(fileName),fileLock,lockIsShared=.true.)
+       !$ call hdf5Access%set()
+       call    file%openFile     (char(fileName)                                                                                         ,readOnly=.true.                    )
+       call    file%readAttribute(char(quantityName)//'RadiusMinimum'                                                                    ,tabulation%radiusMinimum           )
+       call    file%readAttribute(char(quantityName)//'RadiusMaximum'                                                                    ,tabulation%radiusMaximum           )
+       call    file%readAttribute(char(quantityName)//'RadiusInverseStep'                                                                ,tabulation%radiusInverseStep       )
+       do i=1,container%countParameters(tabulation)
+          call file%readAttribute(char(quantityName)//String_Upper_Case_First(char(container%nameParameter(i,tabulation)))//'Minimum'    ,tabulation%parametersMinimum    (i))
+          call file%readAttribute(char(quantityName)//String_Upper_Case_First(char(container%nameParameter(i,tabulation)))//'Maximum'    ,tabulation%parametersMaximum    (i))
+          call file%readAttribute(char(quantityName)//String_Upper_Case_First(char(container%nameParameter(i,tabulation)))//'InverseStep',tabulation%parametersInverseStep(i))
+       end do
+       call    file%readDataset  (char(quantityName)                                                                                     ,tabulation%table                   )
+       call    file%close        (                                                                                                                                           )
+       !$ call hdf5Access%unset()
+       call File_Unlock(fileLock)
+    end if
+    return
+  end subroutine sphericalTabulatedFileRead
+
+  subroutine sphericalTabulatedFileWrite(self,container,tabulation)
+    !!{
+    Read tabulated data from file.
+    !!}
+    use :: Input_Paths    , only : inputPath              , pathTypeDataDynamic
+    use :: HDF5_Access    , only : hdf5Access
+    use :: IO_HDF5        , only : hdf5Object
+    use :: File_Utilities , only : File_Lock              , File_Path            , File_Unlock, lockDescriptor, &
+         &                         Directory_Make
+    use :: String_Handling, only : String_Upper_Case_First
+    use :: Display        , only : displayMessage         , verbosityLevelWorking
+    implicit none
+    class  (massDistributionSphericalTabulated), intent(inout) :: self
+    type   (massDistributionContainer         ), intent(inout) :: container
+    type   (massDistributionTabulation        ), intent(in   ) :: tabulation
+    type   (varying_string                    )                :: fileName  , quantityName
+    type   (hdf5Object                        )                :: file
+    type   (lockDescriptor                    )                :: fileLock
+    integer(c_size_t                          )                :: i
+
+    quantityName=enumerationQuantityDecode(tabulation%quantity)
+    fileName    =inputPath(pathTypeDataDynamic)//'massDistributions/'//self%objectType()//'_'//quantityName//'_'//self%suffix()//'.hdf5'
+    call Directory_Make(char(File_Path(char(fileName))))
+    call displayMessage("writing tabulated "//char(quantityName)//" profile to '"//char(fileName)//"'",verbosityLevelWorking)
+    ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
+    call File_Lock(char(fileName),fileLock,lockIsShared=.false.)
+    !$ call hdf5Access%set()
+    call    file%openFile      (char(fileName)                     ,overWrite=.true.                                                                                                                                     )
+    call    file%writeAttribute(tabulation%radiusMinimum           ,char(quantityName)//'RadiusMinimum'                                                                                                                  )
+    call    file%writeAttribute(tabulation%radiusMaximum           ,char(quantityName)//'RadiusMaximum'                                                                                                                  )
+    call    file%writeAttribute(tabulation%radiusInverseStep       ,char(quantityName)//'RadiusInverseStep'                                                                                                              )
+    do i=1,container%countParameters(tabulation)
+       call file%writeAttribute(tabulation%parametersMinimum    (i),char(quantityName)//String_Upper_Case_First(char(container%nameParameter(i,tabulation)))//'Minimum'                                                  )
+       call file%writeAttribute(tabulation%parametersMaximum    (i),char(quantityName)//String_Upper_Case_First(char(container%nameParameter(i,tabulation)))//'Maximum'                                                  )
+       call file%writeAttribute(tabulation%parametersInverseStep(i),char(quantityName)//String_Upper_Case_First(char(container%nameParameter(i,tabulation)))//'InverseStep'                                              )
+    end do
+    call    file%writeDataset  (tabulation%table                   ,char(quantityName)                                                                                     ,'Tabulated '//char(quantityName)//' profile.')
+    call    file%close         (                                                                                                                                                                                         )
+    !$ call hdf5Access%unset()
+    call File_Unlock(fileLock)
+    return
+  end subroutine sphericalTabulatedFileWrite
+
+  subroutine massDistributionContainerInitialize(self,countParameters)
+    !!{
+    Initialize the container to the specified number of parameters.
+    !!}
+    implicit none
+    class  (massDistributionContainer), intent(inout) :: self
+    integer                           , intent(in   ) :: countParameters
+
+    ! Allocate the internal arrays.
+    allocate(self                           %descriptionParameters(countParameters  ))
+    allocate(self                           %nameParameters       (countParameters  ))
+    allocate(self%mass                      %parametersMinimum    (countParameters  ))
+    allocate(self%mass                      %parametersMaximum    (countParameters  ))
+    allocate(self%mass                      %parametersCountPer   (countParameters  ))
+    allocate(self%energy                    %parametersMinimum    (countParameters  ))
+    allocate(self%energy                    %parametersMaximum    (countParameters  ))
+    allocate(self%energy                    %parametersCountPer   (countParameters  ))
+    allocate(self%potential                 %parametersMinimum    (countParameters  ))
+    allocate(self%potential                 %parametersMaximum    (countParameters  ))
+    allocate(self%potential                 %parametersCountPer   (countParameters  ))
+    allocate(self%velocityDispersion1D      %parametersMinimum    (countParameters  ))
+    allocate(self%velocityDispersion1D      %parametersMaximum    (countParameters  ))
+    allocate(self%velocityDispersion1D      %parametersCountPer   (countParameters  ))
+    allocate(self%radiusFreefall            %parametersMinimum    (countParameters  ))
+    allocate(self%radiusFreefall            %parametersMaximum    (countParameters  ))
+    allocate(self%radiusFreefall            %parametersCountPer   (countParameters  ))
+    allocate(self%radiusFreefallIncreaseRate%parametersMinimum    (countParameters  ))
+    allocate(self%radiusFreefallIncreaseRate%parametersMaximum    (countParameters  ))
+    allocate(self%radiusFreefallIncreaseRate%parametersCountPer   (countParameters  ))
+    allocate(self%densityRadialMoment0      %parametersMinimum    (countParameters  ))
+    allocate(self%densityRadialMoment0      %parametersMaximum    (countParameters  ))
+    allocate(self%densityRadialMoment0      %parametersCountPer   (countParameters  ))
+    allocate(self%densityRadialMoment1      %parametersMinimum    (countParameters  ))
+    allocate(self%densityRadialMoment1      %parametersMaximum    (countParameters  ))
+    allocate(self%densityRadialMoment1      %parametersCountPer   (countParameters  ))
+    allocate(self%densityRadialMoment2      %parametersMinimum    (countParameters  ))
+    allocate(self%densityRadialMoment2      %parametersMaximum    (countParameters  ))
+    allocate(self%densityRadialMoment2      %parametersCountPer   (countParameters  ))
+    allocate(self%densityRadialMoment3      %parametersMinimum    (countParameters  ))
+    allocate(self%densityRadialMoment3      %parametersMaximum    (countParameters  ))
+    allocate(self%densityRadialMoment3      %parametersCountPer   (countParameters  ))
+    allocate(self%fourierTransform          %parametersMinimum    (countParameters+1))
+    allocate(self%fourierTransform          %parametersMaximum    (countParameters+1))
+    allocate(self%fourierTransform          %parametersCountPer   (countParameters+1))
+    ! Initialize minima/maxima of tabulation ranges. These are chosen to ensure that the first tabulation will force these to
+    ! be reset.
+    self%mass                      %radiusMinimum    =+huge(0.0d0)
+    self%mass                      %radiusMaximum    =-huge(0.0d0)
+    self%energy                    %radiusMinimum    =+huge(0.0d0)
+    self%energy                    %radiusMaximum    =-huge(0.0d0)
+    self%potential                 %radiusMinimum    =+huge(0.0d0)
+    self%potential                 %radiusMaximum    =-huge(0.0d0)
+    self%velocityDispersion1D      %radiusMinimum    =+huge(0.0d0)
+    self%velocityDispersion1D      %radiusMaximum    =-huge(0.0d0)
+    self%radiusFreefall            %radiusMinimum    =+huge(0.0d0)
+    self%radiusFreefall            %radiusMaximum    =-huge(0.0d0)
+    self%radiusFreefallIncreaseRate%radiusMinimum    =+huge(0.0d0)
+    self%radiusFreefallIncreaseRate%radiusMaximum    =-huge(0.0d0)
+    self%densityRadialMoment0      %radiusMinimum    =+huge(0.0d0)
+    self%densityRadialMoment0      %radiusMaximum    =-huge(0.0d0)
+    self%densityRadialMoment1      %radiusMinimum    =+huge(0.0d0)
+    self%densityRadialMoment1      %radiusMaximum    =-huge(0.0d0)
+    self%densityRadialMoment2      %radiusMinimum    =+huge(0.0d0)
+    self%densityRadialMoment2      %radiusMaximum    =-huge(0.0d0)
+    self%densityRadialMoment3      %radiusMinimum    =+huge(0.0d0)
+    self%densityRadialMoment3      %radiusMaximum    =-huge(0.0d0)
+    self%fourierTransform          %radiusMinimum    =+huge(0.0d0)
+    self%fourierTransform          %radiusMaximum    =-huge(0.0d0)
+    self%mass                      %parametersMinimum=+huge(0.0d0)
+    self%mass                      %parametersMaximum=-huge(0.0d0)
+    self%energy                    %parametersMinimum=+huge(0.0d0)
+    self%energy                    %parametersMaximum=-huge(0.0d0)
+    self%potential                 %parametersMinimum=+huge(0.0d0)
+    self%potential                 %parametersMaximum=-huge(0.0d0)
+    self%velocityDispersion1D      %parametersMinimum=+huge(0.0d0)
+    self%velocityDispersion1D      %parametersMaximum=-huge(0.0d0)
+    self%radiusFreefall            %parametersMinimum=+huge(0.0d0)
+    self%radiusFreefall            %parametersMaximum=-huge(0.0d0)
+    self%radiusFreefallIncreaseRate%parametersMinimum=+huge(0.0d0)
+    self%radiusFreefallIncreaseRate%parametersMaximum=-huge(0.0d0)
+    self%densityRadialMoment0      %parametersMinimum=+huge(0.0d0)
+    self%densityRadialMoment0      %parametersMaximum=-huge(0.0d0)
+    self%densityRadialMoment1      %parametersMinimum=+huge(0.0d0)
+    self%densityRadialMoment1      %parametersMaximum=-huge(0.0d0)
+    self%densityRadialMoment2      %parametersMinimum=+huge(0.0d0)
+    self%densityRadialMoment2      %parametersMaximum=-huge(0.0d0)
+    self%densityRadialMoment3      %parametersMinimum=+huge(0.0d0)
+    self%densityRadialMoment3      %parametersMaximum=-huge(0.0d0)
+    self%fourierTransform          %parametersMinimum=+huge(0.0d0)
+    self%fourierTransform          %parametersMaximum=-huge(0.0d0)
+    return
+  end subroutine massDistributionContainerInitialize
+
+  function massDistributionContainerNameParameter(self,indexParameter,tabulation) result(nameParameter)
+    !!{
+    Return the name of the indexed parameter.
+    !!}
+    implicit none
+    type   (varying_string            )                :: nameParameter
+    class  (massDistributionContainer ), intent(inout) :: self
+    integer(c_size_t                  ), intent(in   ) :: indexParameter
+    type   (massDistributionTabulation), intent(in   ) :: tabulation
+    integer(c_size_t                  )                :: countParameters
+
+    countParameters=self%countParameters(tabulation)
+    if     (                                  &
+         &   indexParameter < 1               &
+         &  .or.                              &
+         &   indexParameter > countParameters &
+         & ) call Error_Report('`indexParameter` is out of range'//{introspection:location})
+    select case (tabulation%quantity%ID)
+    case (quantityFourierTransform%ID)
+       if (indexParameter == countParameters) then
+          nameParameter='radiusOuter'
+       else
+          nameParameter=self%nameParameters(indexParameter)
+       end if
+    case default
+       nameParameter   =self%nameParameters(indexParameter)
+    end select
+    return
+  end function massDistributionContainerNameParameter
+  
+  function massDistributionContainerCountParameters(self,tabulation) result(countParameters)
+    !!{
+    Return the name of the indexed parameter.
+    !!}
+    implicit none
+    integer(c_size_t                  )                :: countParameters
+    class  (massDistributionContainer ), intent(inout) :: self
+    type   (massDistributionTabulation), intent(in   ) :: tabulation
+
+    select case (tabulation%quantity%ID)
+    case (quantityFourierTransform%ID)
+       countParameters=size(self%nameParameters)+1_c_size_t
+    case default
+       countParameters=size(self%nameParameters)
+    end select
+    return
+  end function massDistributionContainerCountParameters

--- a/source/tests.mass_distributions.tabulated.F90
+++ b/source/tests.mass_distributions.tabulated.F90
@@ -1,0 +1,163 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a program to test tabulated mass distributions.
+!!}
+
+program Test_Mass_Distributions_Tabulated
+  !!{
+  Tests mass distributions.
+  !!}
+  use :: Coordinates                     , only : coordinateSpherical    , assignment(=)
+  use :: Display                         , only : displayVerbositySet    , verbosityLevelWorking
+  use :: Events_Hooks                    , only : eventsHooksInitialize
+  use :: Mass_Distributions              , only : massDistributionClass  , massDistributionSpherical      , massDistributionCoredNFW, kinematicsDistributionCollisionlessTabulated
+  use :: Numerical_Constants_Astronomical, only : Mpc_per_km_per_s_To_Gyr, gravitationalConstantGalacticus
+  use :: Numerical_Constants_Math        , only : Pi
+  use :: Unit_Tests                      , only : Assert                 , Unit_Tests_Begin_Group         , Unit_Tests_End_Group    , Unit_Tests_Finish
+  implicit none
+  class           (massDistributionClass                       ), allocatable             :: massDistribution_
+  type            (kinematicsDistributionCollisionlessTabulated), pointer                 :: kinematicsDistribution_
+  double precision                                              , parameter               :: radiusVirial     =0.25d0, radiusScale               =0.025d0, &
+       &                                                                                     massVirial       =1.0d12, radiusCore                =0.010d0
+  double precision                                                         , dimension(7) :: mass                    , densityMoment0                    , &
+       &                                                                                     densityMoment1          , densityMoment2                    , &
+       &                                                                                     densityMoment3          , energy                            , &
+       &                                                                                     radiusFreefall          , radiusFreefallIncreaseRate        , &
+       &                                                                                     potential               , fourierTransform                  , &
+       &                                                                                     velocityDispersion
+  type            (coordinateSpherical                         )                          :: coordinates
+  double precision                                                                        :: timeScale
+  integer                                                                                 :: i
+  double precision                                              , parameter, dimension(7) :: radiiScaleFree      =[                                           &
+       &                                                                                                           0.010000000000000d00,0.030000000000000d00, &
+       &                                                                                                           0.100000000000000d00,0.300000000000000d00, &
+       &                                                                                                           1.000000000000000d00,3.000000000000000d00, &
+       &                                                                                                           1.000000000000000d01                       &
+       &                                                                                                          ]
+  double precision                                              , parameter, dimension(7) :: massTarget          =[                                           &
+       &                                                                                                           6.370508886341162d05,1.611292088903051d07, &
+       &                                                                                                           4.820816988421535d08,7.794652959722677d09, &
+       &                                                                                                           8.579226849001460d10,3.725560473368585d11, &
+       &                                                                                                           1.000000000000000d12                       &
+       &                                                                                                          ]
+  double precision                                              , parameter, dimension(7) :: densityMoment0Target=[                                           &
+       &                                                                                                           2.460730293686941d12,7.069365704837000d12, &
+       &                                                                                                           2.048945657552057d13,4.439368231418265d13, &
+       &                                                                                                           7.258203857541593d13,8.492694861727370d13, &
+       &                                                                                                           8.799525923615780d13                       &
+       &                                                                                                          ]
+  double precision                                              , parameter, dimension(7) :: densityMoment1Target=[                                           &
+       &                                                                                                           3.053052459464275d08,2.592947607342040d09, &
+       &                                                                                                           2.384847303281488d10,1.367185830935901d11, &
+       &                                                                                                           5.322663280946257d11,1.037860585072224d12, &
+       &                                                                                                           1.407477797390162d12                       &
+       &                                                                                                          ]
+  double precision                                              , parameter, dimension(7) :: densityMoment2Target=[                                           &
+       &                                                                                                           5.069489879599125d04,1.282225499839590d06, &
+       &                                                                                                           3.836284256845901d07,6.202787726771978d08, &
+       &                                                                                                           6.827131793393528d09,2.964706822499870d10, &
+       &                                                                                                           7.957747149596004d10                       &
+       &                                                                                                          ]
+  double precision                                              , parameter, dimension(7) :: densityMoment3Target=[                                           &
+       &                                                                                                           9.484085428575420d00,7.165022587728307d02, &
+       &                                                                                                           7.043283943903859d04,3.296870652850856d06, &
+       &                                                                                                           1.105431237182676d08,1.240614494009899d09, &
+       &                                                                                                           8.818052733199510d09                       &
+       &                                                                                                          ]
+  double precision                                                         , dimension(7) :: energyTarget
+  double precision                                                         , dimension(7) :: radiusFreefallTarget
+  double precision                                                         , dimension(7) :: radiusFreefallIncreaseRateTarget
+  double precision                                                         , dimension(7) :: potentialTarget
+  double precision                                                         , dimension(7) :: fourierTransformTarget
+  double precision                                                         , dimension(7) :: velocityDispersionTarget
+  
+  ! Set verbosity level.
+  call displayVerbositySet(verbosityLevelWorking)
+  ! Initialize event hooks.
+  call eventsHooksInitialize()
+  ! Begin unit tests.
+  call Unit_Tests_Begin_Group("Tabulated mass distributions")
+
+  ! Cored NFW profile.
+  call Unit_Tests_Begin_Group("Cored NFW profile")
+  allocate(massDistributionCoredNFW :: massDistribution_      )
+  allocate(                            kinematicsDistribution_)
+  kinematicsDistribution_=kinematicsDistributionCollisionlessTabulated(toleranceRelativeVelocityDispersion=1.0d-3,toleranceRelativeVelocityDispersionMaximum=1.0d-3)
+  select type (massDistribution_)
+  type is (massDistributionCoredNFW)
+     massDistribution_   =massDistributionCoredNFW(mass=massVirial,radiusVirial=radiusVirial,radiusScale=radiusScale,radiusCore=radiusCore,dimensionless=.false.,toleranceRelativePotential=1.0d-3)
+     call massDistribution_%setKinematicsDistribution(kinematicsDistribution_)
+  end select
+  timeScale=+1.0d0                                 &
+       &    /sqrt(                                 &
+       &          +gravitationalConstantGalacticus &
+       &          *3.0d0                           &
+       &          /4.0d0                           &
+       &          /Pi                              &
+       &          *massVirial                      &
+       &          /radiusVirial**3                 &
+       &         )                                 &
+       &    *Mpc_per_km_per_s_To_Gyr
+  select type (massDistribution_)
+  class is (massDistributionSpherical)
+     do i=1,7
+        coordinates                        =[radiusScale*radiiScaleFree(i),0.0d0,0.0d0]
+        mass                            (i)=massDistribution_      %massEnclosedBySphere               (                         radiiScaleFree(i)*radiusScale                  )
+        potential                       (i)=massDistribution_      %potential                          (                                           coordinates                  )
+        potentialTarget                 (i)=massDistribution_      %potentialNumerical                 (                                           coordinates                  )
+        energy                          (i)=massDistribution_      %energy                             (                         radiiScaleFree(i)*radiusScale,massDistribution_)
+        energyTarget                    (i)=massDistribution_      %energyNumerical                    (                         radiiScaleFree(i)*radiusScale,massDistribution_)
+        velocityDispersion              (i)=kinematicsDistribution_%velocityDispersion1D               (                                           coordinates,massDistribution_)
+        velocityDispersionTarget        (i)=kinematicsDistribution_%velocityDispersion1DNumerical      (                                           coordinates,massDistribution_)
+        densityMoment0                  (i)=massDistribution_      %densityRadialMoment                (0.0d0,0.0d0,             radiiScaleFree(i)*radiusScale                  )
+        densityMoment1                  (i)=massDistribution_      %densityRadialMoment                (1.0d0,0.0d0,             radiiScaleFree(i)*radiusScale                  )
+        densityMoment2                  (i)=massDistribution_      %densityRadialMoment                (2.0d0,0.0d0,             radiiScaleFree(i)*radiusScale                  )
+        densityMoment3                  (i)=massDistribution_      %densityRadialMoment                (3.0d0,0.0d0,             radiiScaleFree(i)*radiusScale                  )
+        radiusFreefall                  (i)=massDistribution_      %radiusFreefall                     (                         radiiScaleFree(i)*  timeScale                  )
+        radiusFreefallTarget            (i)=massDistribution_      %radiusFreefallNumerical            (                         radiiScaleFree(i)*  timeScale                  )
+        radiusFreefallIncreaseRate      (i)=massDistribution_      %radiusFreefallIncreaseRate         (                         radiiScaleFree(i)*  timeScale                  )
+        radiusFreefallIncreaseRateTarget(i)=massDistribution_      %radiusFreefallIncreaseRateNumerical(                         radiiScaleFree(i)*  timeScale                  )
+        fourierTransform                (i)=massDistribution_      %fourierTransform                   (            radiusVirial,radiiScaleFree(i)/radiusScale                  )
+        fourierTransformTarget          (i)=massDistribution_      %fourierTransformNumerical          (            radiusVirial,radiiScaleFree(i)/radiusScale                  )
+     end do
+     ! Only potential differences are relevant.
+     potential      =potential      -potential      (1)
+     potentialTarget=potentialTarget-potentialTarget(1)
+     ! Test assertions.
+     call Assert("Mass within radius"           ,mass                      ,massTarget                      ,relTol=3.0d-3                                     )
+     call Assert("Energy within radius"         ,energy                    ,energyTarget                    ,relTol=2.0d-2                                     )
+     call Assert("Potential"                    ,potential                 ,potentialTarget                 ,relTol=8.0d-3                                     )
+     call Assert("Velocity dispersion"          ,velocityDispersion        ,velocityDispersionTarget        ,relTol=8.0d-3                                     )
+     call Assert("Radial density moment (m=0)"  ,densityMoment0            ,densityMoment0Target            ,relTol=1.0d-3                                     )
+     call Assert("Radial density moment (m=1)"  ,densityMoment1            ,densityMoment1Target            ,relTol=1.0d-3                                     )
+     call Assert("Radial density moment (m=2)"  ,densityMoment2            ,densityMoment2Target            ,relTol=1.0d-3                                     )
+     call Assert("Radial density moment (m=3)"  ,densityMoment3            ,densityMoment3Target            ,relTol=1.0d-3                                     )
+     call Assert("Fourier transform"            ,fourierTransform          ,fourierTransformTarget          ,relTol=1.2d-2                                     )
+     call Assert("Freefall radius"              ,radiusFreefall            ,radiusFreefallTarget            ,relTol=2.0d-3,absTol=1.0d-1*radiusCore            )
+     call Assert("Freefall radius increase rate",radiusFreefallIncreaseRate,radiusFreefallIncreaseRateTarget,relTol=1.0d-2,absTol=2.0d+0*radiusVirial/timeScale)
+  end select
+  deallocate(massDistribution_)
+  call Unit_Tests_End_Group()
+
+  ! End unit tests.
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Finish   ()
+end program Test_Mass_Distributions_Tabulated

--- a/source/utility.multi_counter.F90
+++ b/source/utility.multi_counter.F90
@@ -41,12 +41,13 @@ module Multi_Counters
    contains
      !![
      <methods>
-       <method description="Reset the multi-counter back to its initial count state, such that the next increment will return the first count." method="reset" />
-       <method description="Return the number of counters configured in this multi-counter." method="count" />
-       <method description="Append a new counter to the multi-counter, with the specified {\normalfont \ttfamily range}." method="append" />
-       <method description="Increment the state of the multi-counter. Return {\normalfont \ttfamily .false.} if incrementing was not possible (i.e. counter was in the final state), {\normalfont \ttfamily .true.} otherwise." method="increment" />
-       <method description="Return {\normalfont \ttfamily .true.} if the counter is in its final state, {\normalfont \ttfamily .false.} otherwise." method="isFinal" />
-       <method description="Return the state of the {\normalfont \ttfamily i}$^\mathrm{th}$ counter." method="state" />
+       <method method="reset"     description="Reset the multi-counter back to its initial count state, such that the next increment will return the first count."                                                                                />
+       <method method="count"     description="Return the number of counters configured in this multi-counter."                                                                                                                                   />
+       <method method="append"    description="Append a new counter to the multi-counter, with the specified {\normalfont \ttfamily range}."                                                                                                      />
+       <method method="increment" description="Increment the state of the multi-counter. Return {\normalfont \ttfamily .false.} if incrementing was not possible (i.e. counter was in the final state), {\normalfont \ttfamily .true.} otherwise."/>
+       <method method="isFinal"   description="Return {\normalfont \ttfamily .true.} if the counter is in its final state, {\normalfont \ttfamily .false.} otherwise."                                                                            />
+       <method method="state"     description="Return the state of the {\normalfont \ttfamily i}$^\mathrm{th}$ counter."                                                                                                                          />
+       <method method="states"    description="Return the states of all counters."                                                                                                                                                                />
      </methods>
      !!]
      final     ::              multiCounterDestructor
@@ -54,6 +55,7 @@ module Multi_Counters
      procedure :: reset     => multiCounterReset
      procedure :: count     => multiCounterCount
      procedure :: state     => multiCounterState
+     procedure :: states    => multiCounterStates
      procedure :: increment => multiCounterIncrement
      procedure :: isFinal   => multiCounterIsFinal
   end type multiCounter
@@ -154,6 +156,18 @@ contains
     multiCounterState=self%values(i)
     return
   end function multiCounterState
+
+  function multiCounterStates(self) result(states)
+    !!{
+    Return the states of the multi-counter.
+    !!}
+    implicit none
+    class  (multiCounter), intent(inout)                :: self
+    integer(c_size_t    ), dimension(size(self%values)) :: states
+
+    states=self%values
+    return
+  end function multiCounterStates
 
   subroutine multiCounterAppend(self,range)
     !!{


### PR DESCRIPTION
- Works for any parametric, spherically-symmetric, collisionless mass distribution
- Class must specify methods:
   - `density()` - gives $\rho(r)$ (optionally also `densityGradientRadial()` - easy to derive);
   - `parameters()` - returns $\hat{\rho}$, $\hat{r}$, $\mathbf{p}$ (density normalization, radius normalization, other parameters);
   - `factoryTabulation()` - returns an instance of the class with $\hat{\rho}=1$, $\hat{r}=1$, and whatever $\mathbf{p}$ is provided to it - used to perform numerical integrations to build the tables;
   - `suffix()` - a suffix for use in tabulation file names (typically an MD5 hash generated automatically from the source code)
- Handles $M(r)$, $\phi(r)$, ℘₁,₂,₃ $(r)$, $\sigma(r)$,  $F(k)$, $E(r)$, $r_\mathrm{ff}(t)$, $\mathrm{d}r_\mathrm{ff}/\mathrm{d}t(t)$;
- Can override any of these with analytic solutions if available;
- Results automatically tabulated (in parallel) over required range, stored/restored to/from file.