### PR TITLE
Store (and use) indexing information in Cloudy emission line tables

### DIFF
--- a/scripts/ssps/createEmissionLinesTable.pl
+++ b/scripts/ssps/createEmissionLinesTable.pl
@@ -479,7 +479,8 @@ sub establishGridSSP {
     $grid->{'logHydrogenDensities'   } = pdl [ 1.0,  1.5,  2.0,  2.5,  3.0, 3.5, 4.0 ];
 
     # Specify the iterables in the grid.
-    @{$grid->{'iterables'}} = ( "ages", "logMetallicities", "logHydrogenLuminosities", "logHydrogenDensities" );
+    @{$grid->{'iterables'}} = ( "ages", "logMetallicities", "logHydrogenLuminosities"   , "logHydrogenDensities" );
+    @{$grid->{'names'    }} = ( "age" , "metallicity"     , "ionizingLuminosityHydrogen", "densityHydrogen"      );
 }
 
 sub establishGridAGN {
@@ -501,6 +502,7 @@ sub establishGridAGN {
 
     # Specify the iterables in the grid.
     @{$grid->{'iterables'}} = ( "spectralIndices", "logMetallicities", "logIonizationParameters", "logHydrogenDensities" );
+    @{$grid->{'names'    }} = ( "spectralIndex"  , "metallicity"     , "ionizationParameter"    , "densityHydrogen"      );
 
     # Construct spectra, and their bolometric luminosity normalization factors.
     ## Our spectrum is (Feltre, Charlot & Gutkin; 2016; MNRAS; 456; 3354; https://ui.adsabs.harvard.edu/abs/2016MNRAS.456.3354F):
@@ -1096,7 +1098,12 @@ sub outputSSP {
     $tableFile->dataset('densityHydrogen'                     )->attrSet(description => "Hydrogen density."                                             );
     $tableFile->dataset('densityHydrogen'                     )->attrSet(units       => "cm¯³"                                                          );
     $tableFile->dataset('densityHydrogen'                     )->attrSet(unitsInSI   => $mega                                                           );
-    
+    # Write index in the tables for each iterable.
+    my $i = 0;
+    foreach my $iterable ( @{$grid->{'names'}} ) {
+	$tableFile->dataset($iterable)->attrSet(index => pdl long $i);
+	++$i;
+    }
     # Write table of ionizing rates per unit mass of stars formed.
     $tableFile->dataset('ionizingLuminosityHydrogenNormalized')->    set(               $grid->{'ionizingLuminosityPerMass'}                            );
     $tableFile->dataset('ionizingLuminosityHydrogenNormalized')->attrSet(description => "Hydrogen ionizing photon emission rate per unit mass of stars.");
@@ -1136,6 +1143,12 @@ sub outputAGN {
     $tableFile->dataset('densityHydrogen'    )->attrSet(description => "Hydrogen density."                                  );
     $tableFile->dataset('densityHydrogen'    )->attrSet(units       => "cm¯³"                                               );
     $tableFile->dataset('densityHydrogen'    )->attrSet(unitsInSI   => $mega                                                );
+    # Write index in the tables for each iterable.
+    my $i = 0;
+    foreach my $iterable ( @{$grid->{'names'}} ) {
+	$tableFile->dataset($iterable)->attrSet(index => pdl long $i);
+	++$i;
+    }
 
     # Write line data.
     my $lineGroup = $tableFile->group('lines');

--- a/source/nodes.property_extractor.luminosity_emission_line.F90
+++ b/source/nodes.property_extractor.luminosity_emission_line.F90
@@ -22,12 +22,13 @@
   !!{
   Contains a module which implements a property extractor class for the emission line luminosity of a component.
   !!}
-  use :: Galactic_Structure_Options     , only : enumerationComponentTypeType
-  use :: Output_Times                   , only : outputTimesClass
-  use :: Star_Formation_Histories       , only : starFormationHistoryClass
-  use :: HII_Region_Luminosity_Functions, only : hiiRegionLuminosityFunctionClass
-  use :: Star_Formation_Histories       , only : starFormationHistoryClass
-  use :: hii_Region_Density_Distributions,only : hiiRegionDensityDistributionClass  
+  use, intrinsic :: ISO_C_Binding                  , only : c_size_t
+  use            :: Galactic_Structure_Options     , only : enumerationComponentTypeType
+  use            :: Output_Times                   , only : outputTimesClass
+  use            :: Star_Formation_Histories       , only : starFormationHistoryClass
+  use            :: HII_Region_Luminosity_Functions, only : hiiRegionLuminosityFunctionClass
+  use            :: Star_Formation_Histories       , only : starFormationHistoryClass
+  use            :: hii_Region_Density_Distributions,only : hiiRegionDensityDistributionClass  
   type:: emissionLineLuminosityTemplate
      !!{
      Type used to store luminosity templates for emission lines.
@@ -57,6 +58,8 @@
      class           (hiiRegionDensityDistributionClass), pointer                       :: hiiRegionDensityDistribution_        => null()
      type            (enumerationComponentTypeType     )                                :: component
      integer                                                                            :: countWavelengths                             , countLines
+     integer         (c_size_t                         )                                :: indexAge                                     , indexMetallicity            , &
+          &                                                                                indexIonizingLuminosityHydrogen              , indexDensityHydrogen
      type            (varying_string                   ), allocatable, dimension(:    ) :: lineNames                                    , names_                      , &
           &                                                                                descriptions_
      double precision                                   , allocatable, dimension(:    ) :: metallicityBoundaries                        , metallicities               , &
@@ -161,6 +164,7 @@ contains
     !!{
     Internal constructor for the {\normalfont \ttfamily sed} property extractor class.
     !!}
+    use :: Array_Utilities                 , only : slice
     use :: Galactic_Structure_Options      , only : componentTypeDisk, componentTypeSpheroid
     use :: Galacticus_Nodes                , only : nodeComponentDisk, nodeComponentSpheroid
     use :: Error                           , only : Error_Report
@@ -184,9 +188,12 @@ contains
          &                                                                                                rateHydrogenIonizingPhotonsMaximum, densityHydrogenMinimum            , &
          &                                                                                                densityHydrogenMaximum            , deltaDensityHydrogen 
     double precision                                             , allocatable  , dimension(:        ) :: ionizingLuminosityHydrogen        , densityHydrogen
+    integer                                                                     , dimension(5        ) :: shapeLines
     double precision                                             , allocatable  , dimension(:,:,:,:,:) :: luminosities
-    type            (hdf5Object                                 )                                      :: emissionLinesFile                 , lines
-    integer                                                                                            :: i                                 , k
+    integer         (c_size_t                                   )               , dimension(3        ) :: permutation
+    type            (hdf5Object                                 )                                      :: emissionLinesFile                 , lines                             , &
+         &                                                                                                dataset
+    integer         (c_size_t                                   )                                      :: i                                 , k
     !![
     <constructorAssign variables="cloudyTableFileName, lineNames, component, toleranceRelative, *starFormationHistory_, *outputTimes_, *hiiRegionLuminosityFunction_, *hiiRegionDensityDistribution_"/>
     !!]
@@ -208,19 +215,36 @@ contains
     call emissionLinesFile%readDataset('ionizingLuminosityHydrogen'          ,     ionizingLuminosityHydrogen          )
     call emissionLinesFile%readDataset('ionizingLuminosityHydrogenNormalized',self%ionizingLuminosityHydrogenNormalized)
     call emissionLinesFile%readDataset('densityHydrogen'                     ,     densityHydrogen                     )
+    ! Extract indexing into the lines arrays.
+    dataset=emissionLinesFile%openDataset('metallicity'               )
+    call dataset%readAttribute('index',self%indexMetallicity               )
+    call dataset%close        (                     )
+    dataset=emissionLinesFile%openDataset('age'                       )
+    call dataset%readAttribute('index',self%indexAge                       )
+    call dataset%close        (                     )
+    dataset=emissionLinesFile%openDataset('ionizingLuminosityHydrogen')
+    call dataset%readAttribute('index',self%indexIonizingLuminosityHydrogen)
+    call dataset%close        (                     )
+    dataset=emissionLinesFile%openDataset('densityHydrogen'           )
+    call dataset%readAttribute('index',self%indexDensityHydrogen           )
+    call dataset%close        (                     )
+    ! Offset indexing to Fortran standard (i.e. starting from 1 instead of 0).
+    self%indexMetallicity               =self%indexMetallicity               +1
+    self%indexAge                       =self%indexAge                       +1
+    self%indexIonizingLuminosityHydrogen=self%indexIonizingLuminosityHydrogen+1
+    self%indexDensityHydrogen           =self%indexDensityHydrogen           +1
+    ! Establish arrays.
     self%metallicityPopulationMinimum=minval(self%metallicities)
     self%metallicityPopulationMaximum=maxval(self%metallicities)
     self%agePopulationMaximum        =maxval(self%ages         )
-    allocate(                                        &
-         &        luminosities                       &
-         &   (                                       &
-         &    size(self%ages                      ), &
-         &    size(self%metallicities             ), &
-         &    size(     ionizingLuminosityHydrogen), &
-         &    size(     densityHydrogen           ), &
-         &    size(     lineNames                 )  &
-         &   )                                       &
-         &  )
+    shapeLines(self%indexMetallicity               )=size(self%metallicities             )
+    shapeLines(self%indexAge                       )=size(self%ages                      )
+    shapeLines(self%indexIonizingLuminosityHydrogen)=size(     ionizingLuminosityHydrogen)
+    shapeLines(self%indexDensityHydrogen           )=size(     densityHydrogen           )
+    shapeLines(     5                              )=size(     lineNames                 )
+    !![
+    <allocate variable="luminosities" shape="shapeLines"/>
+    !!]
     allocate(                                        &
          &   self%luminositiesReduced                &
          &   (                                       &
@@ -235,13 +259,21 @@ contains
     end do
     call lines            %close()
     call emissionLinesFile%close()
-    !$ call hdf5Access%unset()
+    !$ call hdf5Access%unset()    
     ! Calculate emission line luminosities as a function of age and metallicity by averaging over the distribution of HII region
-    ! luminosities.
+    ! luminosities. Account for any needed permutation in the indexing needed to get our final array to be (age,metallicity,line)
+    ! ordered.
     deltaIonizingLuminosityHydrogen=+ionizingLuminosityHydrogen(2) &
          &                          /ionizingLuminosityHydrogen(1)
     deltaDensityHydrogen           =+densityHydrogen           (2) &
          &                          /densityHydrogen           (1)
+    permutation(1)=self%indexAge
+    permutation(2)=self%indexMetallicity
+    permutation(3)=     3
+    if (self%indexIonizingLuminosityHydrogen < self%indexAge        ) permutation(1)=permutation(1)-1_c_size_t
+    if (self%indexIonizingLuminosityHydrogen < self%indexMetallicity) permutation(2)=permutation(2)-1_c_size_t
+    if (self%indexDensityHydrogen            < self%indexAge        ) permutation(1)=permutation(1)-1_c_size_t
+    if (self%indexDensityHydrogen            < self%indexMetallicity) permutation(2)=permutation(2)-1_c_size_t
     do i=1,size(ionizingLuminosityHydrogen)
        rateHydrogenIonizingPhotonsMinimum=ionizingLuminosityHydrogen(i)/sqrt(deltaIonizingLuminosityHydrogen)
        rateHydrogenIonizingPhotonsMaximum=ionizingLuminosityHydrogen(i)*sqrt(deltaIonizingLuminosityHydrogen)
@@ -252,7 +284,15 @@ contains
           self%luminositiesReduced=+self%luminositiesReduced                                                                                                                 &
                &                   +self%hiiRegionLuminosityFunction_ %cumulativeDistributionFunction(rateHydrogenIonizingPhotonsMinimum,rateHydrogenIonizingPhotonsMaximum) &
                &                   *self%hiiRegionDensityDistribution_%cumulativeDensityDistribution (            densityHydrogenMinimum,            densityHydrogenMaximum) &
-               &                   *luminosities(:,:,i,k,:)
+               &                   *reshape(                                                                                                                                 &
+               &                                   slice(                                                                                                                    &
+               &                                         luminosities                                                                                                ,       &
+               &                                         [self%indexIonizingLuminosityHydrogen,self%indexDensityHydrogen                                            ],       &
+               &                                         [     i                              ,     k                                                               ]        &
+               &                                        )                                                                                                            ,       &
+               &                                         [size(luminosities,dim=self%indexAge),size(luminosities,dim=self%indexMetallicity),size(luminosities,dim=5)],       &
+               &                             order=permutation                                                                                                               &
+               &                            )
        end do
     end do
     ! Normalize reduced luminosities to the total fraction of HII regions in the luminosity interval spanned by the table. Also,

--- a/source/nodes.property_extractor.luminosity_emission_line.Panuzzo2003.F90
+++ b/source/nodes.property_extractor.luminosity_emission_line.Panuzzo2003.F90
@@ -117,10 +117,10 @@ Implements an emission line luminosity node property extractor class.
    <description>Specifies the different interpolants for emission line calculations.</description>
    <indexing>1</indexing>
    <entry label="metallicity"/>
-   <entry label="density"  />
-   <entry label="hydrogen"  />
-   <entry label="helium"  />
-   <entry label="oxygen"  />
+   <entry label="density"    />
+   <entry label="hydrogen"   />
+   <entry label="helium"     />
+   <entry label="oxygen"     />
   </enumeration>
   !!]
 

--- a/source/tests.arrays.F90
+++ b/source/tests.arrays.F90
@@ -25,45 +25,52 @@ program Test_Array_Monotonicity
   !!{
   Tests that array functions.
   !!}
-  use :: Array_Utilities   , only : Array_Cumulate     , Array_Is_Monotonic      , Array_Reverse       , directionDecreasing, &
-          &                         directionIncreasing, operator(.intersection.)
-  use :: Display           , only : displayVerbositySet, verbosityLevelStandard
-  use :: ISO_Varying_String, only : assignment(=)      , char                    , varying_string
-  use :: Kind_Numbers      , only : kind_int8
-  use :: Unit_Tests        , only : Assert             , Unit_Tests_Begin_Group  , Unit_Tests_End_Group, Unit_Tests_Finish
+  use, intrinsic :: ISO_C_Binding     , only : c_size_t
+  use            :: Array_Utilities   , only : Array_Cumulate     , Array_Is_Monotonic      , Array_Reverse       , directionDecreasing, &
+          &                                    directionIncreasing, operator(.intersection.), slice
+  use            :: Display           , only : displayVerbositySet, verbosityLevelStandard
+  use            :: ISO_Varying_String, only : assignment(=)      , char                    , varying_string
+  use            :: Kind_Numbers      , only : kind_int8
+  use            :: Unit_Tests        , only : Assert             , Unit_Tests_Begin_Group  , Unit_Tests_End_Group, Unit_Tests_Finish
   implicit none
-  double precision                , dimension( 1,2), target     :: singleElementArrays       =reshape([1.23d0,-2.31d0],shape(singleElementArrays))
-  integer         (kind=kind_int8), dimension( 1,2), target     :: singleElementArraysInteger=reshape([123,-231],shape(singleElementArraysInteger))
-  logical                         , dimension( 9,2), target     :: singleElementExpectations =reshape([.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.],shape(singleElementExpectations))
-  character(len=128),      target , dimension(   2)             :: singleElementNames=    [                                                                              &
-       &                                                                                    'Single element array (positive value)'                                      &
-       &                                                                                   ,'Single element array (negative value)'                                      &
-       &                                                                                  ]
-  double precision                , dimension(10,6), target     :: tenElementArrays       =reshape([1.0d0,2.0d0,3.0d0,4.0d0,5.0d0,6.0d0,7.0d0,8.0d0,9.0d0,10.0d0,3.0d0,2.0d0,1.0d0,0.0d0,-1.0d0,-2.0d0,-3.0d0,-4.0d0,-5.0d0,-6.0d0,1.0d0,0.0d0,3.0d0,4.0d0,-3.0d0,5.0d0,1.0d0,8.0d0,2.0d0,3.0d0,1.0d0,1.0d0,1.0d0,4.0d0,5.0d0,6.0d0,7.0d0,8.0d0,9.0d0,10.0d0,3.0d0,2.0d0,1.0d0,1.0d0,-1.0d0,-2.0d0,-3.0d0,-4.0d0,-5.0d0,-6.0d0,1.0d0,0.0d0,3.0d0,3.0d0,-3.0d0,5.0d0,1.0d0,8.0d0,2.0d0,3.0d0],shape(tenElementArrays))
-  integer         (kind=kind_int8), dimension(10,6), target     :: tenElementArraysInteger=reshape([10,20,30,40,50,60,70,80,90,100,30,20,10,00,-10,-20,-30,-40,-50,-60,10,00,30,40,-30,50,10,80,20,30,10,10,10,40,50,60,70,80,90,100,30,20,10,10,-10,-20,-30,-40,-50,-60,10,00,30,30,-30,50,10,80,20,30],shape(tenElementArrays))
-  logical                         , dimension( 9,6), target     :: tenElementExpectations =reshape([.true.,.true.,.false.,.true.,.true.,.false.,.true.,.true.,.false.,.true.,.false.,.true.,.true.,.false.,.true.,.true.,.false.,.true.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.true.,.true.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.true.,.false.,.true.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.],shape(tenElementExpectations))
-  character(len=128),      target , dimension(   6)             :: tenElementNames=       [                                                                              &
-       &                                                                                    'Increasing array (no equalities)     '                                      &
-       &                                                                                   ,'Decreasing array (no equalities)     '                                      &
-       &                                                                                   ,'Non-monotinic array (no equalities)  '                                      &
-       &                                                                                   ,'Increasing array (with equalities)   '                                      &
-       &                                                                                   ,'Decreasing array (with equalities)   '                                      &
-       &                                                                                   ,'Non-monotinic array (with equalities)'                                      &
-       &                                                                                  ]
-  double precision                , dimension(  10)              :: doubleArray         =[0.0d0,1.0d0,2.0d0,3.0d0,4.0d0,5.0d0,6.0d0,7.0d0,8.0d0,9.0d0]
-  double precision                , dimension(  10)              :: doubleArrayReversed =[9.0d0,8.0d0,7.0d0,6.0d0,5.0d0,4.0d0,3.0d0,2.0d0,1.0d0,0.0d0]
-  double precision                , dimension(  10)              :: doubleArrayCumulated=[0.0d0,1.0d0,3.0d0,6.0d0,10.0d0,15.0d0,21.0d0,28.0d0,36.0d0,45.0d0]
-  real                            , dimension(  10)              :: realArray           =[0.0e0,1.0e0,2.0e0,3.0e0,4.0e0,5.0e0,6.0e0,7.0e0,8.0e0,9.0e0]
-  real                            , dimension(  10)              :: realArrayReversed   =[9.0e0,8.0e0,7.0e0,6.0e0,5.0e0,4.0e0,3.0e0,2.0e0,1.0e0,0.0e0]
-  double precision                , dimension( :,:), pointer     :: arraySet
-  integer         (kind=kind_int8), dimension( :,:), pointer     :: arraySetInteger
-  logical                         , dimension( :,:), pointer     :: expectations
-  character       (len=128       ), dimension(   :), pointer     :: names
-  type            (varying_string), dimension(   :), allocatable :: set1                                                                                    , set2     , &
-       &                                                            set3
-  logical                                                        :: isMonotonic
-  integer                                                        :: iArray                                                                                  , iArraySet
-  type            (varying_string)                               :: test
+  double precision                , dimension( 1,2      ), target     :: singleElementArrays       =reshape([1.23d0,-2.31d0],shape(singleElementArrays))
+  integer         (kind=kind_int8), dimension( 1,2      ), target     :: singleElementArraysInteger=reshape([123,-231],shape(singleElementArraysInteger))
+  logical                         , dimension( 9,2      ), target     :: singleElementExpectations =reshape([.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.,.true.],shape(singleElementExpectations))
+  character(len=128),      target , dimension(   2      )             :: singleElementNames=    [                                                                              &
+       &                                                                                          'Single element array (positive value)'                                      &
+       &                                                                                         ,'Single element array (negative value)'                                      &
+       &                                                                                        ]
+  double precision                , dimension(10,6      ), target     :: tenElementArrays       =reshape([1.0d0,2.0d0,3.0d0,4.0d0,5.0d0,6.0d0,7.0d0,8.0d0,9.0d0,10.0d0,3.0d0,2.0d0,1.0d0,0.0d0,-1.0d0,-2.0d0,-3.0d0,-4.0d0,-5.0d0,-6.0d0,1.0d0,0.0d0,3.0d0,4.0d0,-3.0d0,5.0d0,1.0d0,8.0d0,2.0d0,3.0d0,1.0d0,1.0d0,1.0d0,4.0d0,5.0d0,6.0d0,7.0d0,8.0d0,9.0d0,10.0d0,3.0d0,2.0d0,1.0d0,1.0d0,-1.0d0,-2.0d0,-3.0d0,-4.0d0,-5.0d0,-6.0d0,1.0d0,0.0d0,3.0d0,3.0d0,-3.0d0,5.0d0,1.0d0,8.0d0,2.0d0,3.0d0],shape(tenElementArrays))
+  integer         (kind=kind_int8), dimension(10,6      ), target     :: tenElementArraysInteger=reshape([10,20,30,40,50,60,70,80,90,100,30,20,10,00,-10,-20,-30,-40,-50,-60,10,00,30,40,-30,50,10,80,20,30,10,10,10,40,50,60,70,80,90,100,30,20,10,10,-10,-20,-30,-40,-50,-60,10,00,30,30,-30,50,10,80,20,30],shape(tenElementArrays))
+  logical                         , dimension( 9,6      ), target     :: tenElementExpectations =reshape([.true.,.true.,.false.,.true.,.true.,.false.,.true.,.true.,.false.,.true.,.false.,.true.,.true.,.false.,.true.,.true.,.false.,.true.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.true.,.true.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.true.,.false.,.true.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.],shape(tenElementExpectations))
+  character(len=128),      target , dimension(   6      )             :: tenElementNames=       [                                                                              &
+       &                                                                                          'Increasing array (no equalities)     '                                      &
+       &                                                                                         ,'Decreasing array (no equalities)     '                                      &
+       &                                                                                         ,'Non-monotinic array (no equalities)  '                                      &
+       &                                                                                         ,'Increasing array (with equalities)   '                                      &
+       &                                                                                         ,'Decreasing array (with equalities)   '                                      &
+       &                                                                                         ,'Non-monotinic array (with equalities)'                                      &
+       &                                                                                        ]
+  double precision                , dimension(10        )              :: doubleArray         =[0.0d0,1.0d0,2.0d0,3.0d0,4.0d0,5.0d0,6.0d0,7.0d0,8.0d0,9.0d0]
+  double precision                , dimension(10        )              :: doubleArrayReversed =[9.0d0,8.0d0,7.0d0,6.0d0,5.0d0,4.0d0,3.0d0,2.0d0,1.0d0,0.0d0]
+  double precision                , dimension(10        )              :: doubleArrayCumulated=[0.0d0,1.0d0,3.0d0,6.0d0,10.0d0,15.0d0,21.0d0,28.0d0,36.0d0,45.0d0]
+  real                            , dimension(10        )              :: realArray           =[0.0e0,1.0e0,2.0e0,3.0e0,4.0e0,5.0e0,6.0e0,7.0e0,8.0e0,9.0e0]
+  real                            , dimension(10        )              :: realArrayReversed   =[9.0e0,8.0e0,7.0e0,6.0e0,5.0e0,4.0e0,3.0e0,2.0e0,1.0e0,0.0e0]
+  double precision                , dimension( :,:,:    ), allocatable :: array3D                                                                                 , array3DTarget
+  double precision                , dimension( :,:,:,:,:), allocatable :: array5D
+  integer         (c_size_t      ), dimension( 2        )              :: sliceDimension                                                                          , sliceIndex
+  double precision                , dimension( :,:      ), pointer     :: arraySet
+  integer         (kind=kind_int8), dimension( :,:      ), pointer     :: arraySetInteger
+  logical                         , dimension( :,:      ), pointer     :: expectations
+  character       (len=128       ), dimension(   :      ), pointer     :: names
+  type            (varying_string), dimension(   :      ), allocatable :: set1                                                                                    , set2     , &
+       &                                                                  set3
+  logical                                                              :: isMonotonic
+  integer                                                              :: iArray                                                                                  , iArraySet, &
+       &                                                                  index1                                                                                  , index2   , &
+       &                                                                  index3                                                                                  , index4   , &
+       &                                                                  index5
+  type            (varying_string)                                     :: test
 
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
@@ -206,6 +213,27 @@ program Test_Array_Monotonicity
   call Assert('Array intersection',set1.intersection.set2,set3)
   deallocate(set1,set2)
 
+  ! Test array slicing.
+  allocate(array5D      (3,3,3,3,3))
+  allocate(array3DTarget(3,  3,  3))
+  do index1=1,3
+     do index2=1,3
+        do index3=1,3
+           do index4=1,3
+              do index5=1,3
+                 array5D(index1,index2,index3,index4,index5)=dble(index1)+dble(index2)+dble(index3)+dble(index4)+dble(index5)
+                 if (index4 == 2 .and. index2 == 1) &
+                      & array3DTarget(index1,index3,index5)=array5D(index1,index2,index3,index4,index5)
+              end do
+           end do
+        end do
+     end do
+  end do
+  sliceDimension=[4,2]
+  sliceIndex    =[2,1]
+  array3D       =slice(array5D,sliceDimension,sliceIndex)
+  call Assert("Array slicing",array3D,array3DTarget,absTol=1.0d-30)
+  
   ! End unit tests.
   call Unit_Tests_End_Group()
   call Unit_Tests_Finish()

--- a/source/utility.arrays.F90
+++ b/source/utility.arrays.F90
@@ -27,7 +27,7 @@ module Array_Utilities
   !!}
   implicit none
   private
-  public :: Array_Reverse, Array_Cumulate, Array_Is_Monotonic, Array_Is_Uniform, Array_Which, Array_Index, operator(.intersection.)
+  public :: Array_Reverse, Array_Cumulate, Array_Is_Monotonic, Array_Is_Uniform, Array_Which, Array_Index, operator(.intersection.), slice
 
   interface operator(.intersection.)
      module procedure Array_Intersection_Varying_String
@@ -67,9 +67,16 @@ module Array_Utilities
      module procedure Array_Index_Double_2D
   end interface Array_Index
 
+  interface slice
+     !!{
+     Interface to generic functions that return a slice of an array along a given dimension.
+     !!}
+     module procedure slice5Dto3D
+  end interface slice
+     
   ! Types of direction for monotonic arrays.
   integer, parameter, public :: directionDecreasing=-1
-  integer, parameter, public :: directionIncreasing=1
+  integer, parameter, public :: directionIncreasing=+1
 
 contains
 
@@ -474,4 +481,45 @@ contains
     return
   end function Array_Is_Uniform
 
+  function slice5Dto3D(array,dimension_,index_) result(slice)
+    !!{
+    Return a 3D slice of a 5D array.
+    !!}
+    use, intrinsic :: ISO_C_Binding, only : c_size_t
+    use            :: Error        , only : Error_Report
+    implicit none
+    double precision          , allocatable  , dimension(:,:,:    ) :: slice
+    double precision          , intent(in   ), dimension(:,:,:,:,:) :: array
+    integer         (c_size_t), intent(in   ), dimension(2        ) :: dimension_  , index_
+    integer         (c_size_t)               , dimension(5        ) :: permutation , shape_
+    double precision          , allocatable  , dimension(:,:,:,:,:) :: arrayOrdered
+    integer                                                         :: i           , j
+
+    ! Validate inputs.
+    if (any(dimension_ < 1 .or. dimension_ > 5)) call Error_Report('dimension is out of range'//{introspection:location})
+    do i=1,1
+       if (any(dimension_(i) == dimension_(i+1:2))) call Error_Report('duplicated dimension'//{introspection:location})
+    end do
+    ! Permute the array so the dimensions to remove are the final two.
+    j=0
+    do i=1,5
+       if (.not.any(dimension_ == i)) then
+          j             =j+1
+          permutation(j)=               i
+          shape_     (j)=size(array,dim=i)
+       end if
+    end do
+    permutation(4)=               dimension_(1)
+    permutation(5)=               dimension_(2)
+    shape_     (4)=size(array,dim=dimension_(1))
+    shape_     (5)=size(array,dim=dimension_(2))
+    arrayOrdered=reshape(array,shape_,order=permutation)
+    ! Slice the final two dimensions of the re-ordered array to get out request slice.
+    !![
+    <allocate variable="slice" shape="shape_"/>
+    !!]
+    slice=arrayOrdered(:,:,:,index_(1),index_(2))
+    return
+  end function slice5Dto3D
+  
 end module Array_Utilities


### PR DESCRIPTION
Each dataset (e.g. age, metallicity) now stores an index which indicates which dimension of the line table corresponds to that property. This allows Galacticus to programmatically determine the indexing at run time, and manipulate the tables into the required internal order.