### PR TITLE
Refactor black hole physics to use `nodeOperators`

### DIFF
--- a/parameters.xml
+++ b/parameters.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -178,6 +170,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -194,7 +194,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -253,12 +260,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
-	<mass value="100"/>
-	<spin value="0"/>
+        <mass value="100"/>
+        <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/parameters/baryonicPhysicsConfig.xml
+++ b/parameters/baryonicPhysicsConfig.xml
@@ -294,7 +294,7 @@
      
      <!-- Black hole -->
      <modelParameter value="active">
-       <name value="componentBlackHole::growthRatioToStellarSpheroid"/>
+       <name value="blackHoleAccretionRate::growthRatioToStellarSpheroid"/>
        <distributionFunction1DPrior value="logUniform">
 	 <limitLower value="1.0e-1"/>
 	 <limitUpper value="1.0e+2"/>
@@ -330,11 +330,11 @@
        </distributionFunction1DPerturber>
      </modelParameter>
      <modelParameter value="derived">
-       <name value="componentBlackHole::efficiencyWind"/>
+       <name value="blackHoleWind::efficiencyWind"/>
        <definition value="%[componentBlackHole::efficiency]*(1.0-%[componentBlackHole::fractionJet])"/>
      </modelParameter>
      <modelParameter value="derived">
-       <name value="componentBlackHole::efficiencyHeating"/>
+       <name value="blackHoleCGMHeating::efficiencyHeating"/>
        <definition value="%[componentBlackHole::efficiency]*%[componentBlackHole::fractionJet]"/>
      </modelParameter>
      

--- a/parameters/baryonicPhysicsConstrained.xml
+++ b/parameters/baryonicPhysicsConstrained.xml
@@ -18,12 +18,8 @@
   <!-- Component selection -->
   <componentBasic value="standard"/>
   <componentBlackHole value="simple">
-    <growthRatioToStellarSpheroid value="1.36151389582815"/>
-    <heatsHotHalo value="true"/>
     <efficiency value="0.00361121531459326"/>
     <fractionJet value="0.0436415271218433"/>
-    <efficiencyHeating value="0.000157598951094638"/>
-    <efficiencyWind value="0.00345361636349862"/>
   </componentBlackHole>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
@@ -196,8 +192,18 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="simple">
+    <efficiencyWind value="0.00345361636349862"/>
+  </blackHoleWind>
+  <blackHoleCGMHeating value="quasistatic">
+    <efficiencyHeating value="0.000157598951094638"/>
+  </blackHoleCGMHeating>
+  
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="spheroidTracking">
+    <growthRatioToStellarSpheroid value="1.36151389582815"/>
+  </blackHoleAccretionRate>
 
   <!-- Galaxy merger options -->
   <virialOrbit value="li2020"/>

--- a/parameters/parametersProfile.xml
+++ b/parameters/parametersProfile.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -179,6 +171,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -195,7 +195,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -254,12 +261,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/parameters/parametersProfileLarge.xml
+++ b/parameters/parametersProfileLarge.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -179,6 +171,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -196,6 +196,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -254,12 +261,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion" />
+    <nodeOperator value="blackHolesWinds"     />
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/parameters/quickTest.haloMassFunction.xml
+++ b/parameters/quickTest.haloMassFunction.xml
@@ -13,15 +13,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -180,6 +172,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -196,7 +196,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -255,12 +262,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/parameters/quickTest.xml
+++ b/parameters/quickTest.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -173,6 +165,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -189,7 +189,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -249,12 +256,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/parameters/reference/evolutionGalaxyFormation.xml
+++ b/parameters/reference/evolutionGalaxyFormation.xml
@@ -6,15 +6,7 @@
   
   <!-- Component selection -->
   <componentBasic             value="standard"/>
-  <componentBlackHole         value="standard" >
-    <heatsHotHalo                                value="true"    />
-    <efficiencyWind                              value="  0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"    />
-    <bondiHoyleAccretionEnhancementHotHalo       value="  6.0000"/>
-    <bondiHoyleAccretionEnhancementSpheroid      value="  5.0000"/>
-    <bondiHoyleAccretionTemperatureSpheroid      value="100.0000"/>
-    <bondiHoyleAccretionHotModeOnly              value="true"    />
-  </componentBlackHole>
+  <componentBlackHole         value="standard"/>
   <componentDarkMatterProfile value="scale"   />
   <componentDisk              value="standard" >
     <massDistributionDisk value="exponentialDisk">
@@ -139,7 +131,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"          />
@@ -156,6 +155,12 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
 
   <!-- Galaxy merger options -->
@@ -241,12 +246,16 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Merger tree evolution -->

--- a/parameters/reference/evolutionGalaxyFormationNBody.xml
+++ b/parameters/reference/evolutionGalaxyFormationNBody.xml
@@ -6,15 +6,7 @@
   
   <!-- Component selection -->
   <componentBasic             value="standard"/>
-  <componentBlackHole         value="standard" >
-    <heatsHotHalo                                value="true"    />
-    <efficiencyWind                              value="  0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"    />
-    <bondiHoyleAccretionEnhancementHotHalo       value="  6.0000"/>
-    <bondiHoyleAccretionEnhancementSpheroid      value="  5.0000"/>
-    <bondiHoyleAccretionTemperatureSpheroid      value="100.0000"/>
-    <bondiHoyleAccretionHotModeOnly              value="true"    />
-  </componentBlackHole>
+  <componentBlackHole         value="standard"/>
   <componentDarkMatterProfile value="scale"   />
   <componentDisk              value="standard" >
     <massDistributionDisk value="exponentialDisk">
@@ -129,7 +121,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"          />
@@ -146,6 +145,12 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true" />
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
 
   <!-- Galaxy merger options -->
@@ -219,12 +224,16 @@
 	<correlationRedshiftExponent value="0.000e0"/>
       </nbodyHaloMassError>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Merger tree evolution -->

--- a/parameters/tutorials/galaxyMergerTree.xml
+++ b/parameters/tutorials/galaxyMergerTree.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -178,6 +170,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -194,7 +194,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -265,12 +272,16 @@
 	<component value="total"/>
       </nodePropertyExtractor>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/parameters/tutorials/lightconeOutput.xml
+++ b/parameters/tutorials/lightconeOutput.xml
@@ -10,16 +10,7 @@
 
   <!-- Component selection -->
   <componentBasic             value="standard" />
-  <componentBlackHole         value="standard"  >
-    <growthRatioToStellarSpheroid                value="1.0d-3"/>
-    <heatsHotHalo                                value="true"  />
-    <efficiencyWind                              value="0.001" />
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
-    <bondiHoyleAccretionEnhancementHotHalo       value="  1.0" />
-    <bondiHoyleAccretionEnhancementSpheroid      value="  1.0" />
-    <bondiHoyleAccretionTemperatureSpheroid      value="100.0" />
-    <bondiHoyleAccretionHotModeOnly              value="true"  />
-  </componentBlackHole>
+  <componentBlackHole         value="standard" />
   <componentDarkMatterProfile value="scale"    />
   <componentDisk              value="standard"  >
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -189,7 +180,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.001"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true" />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"          />
@@ -208,7 +206,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  
+    <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  1.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  1.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Satellite orbit options -->
 
   <!-- Galaxy merger options -->
@@ -271,12 +275,16 @@
     <nodeOperator value="positionInterpolated">
       <lengthBox value="684.9315068493151"/>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/scripts/aux/migrations.xml
+++ b/scripts/aux/migrations.xml
@@ -228,6 +228,9 @@
   <migration commit="085033d9d7d8f1956eb0b5b7918ce731229d57e2">
     <translation function="blackHoleSeedMass"/>
   </migration>
+  <migration commit="e87039e32d4d86a381ce015abf11e08a20c7e68e">
+    <translation function="blackHolePhysics"/>
+  </migration>
 
   <!-- Known default values for parameters -->
   <default parameter="componentBlackHole"             value="standard"        />

--- a/source/accretion_disks.spectra.utilities.F90
+++ b/source/accretion_disks.spectra.utilities.F90
@@ -1,0 +1,286 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module of globally-accessible functions supporting the \refClass{accretionDiskSpectraClass} class.
+!!}
+
+module Accretion_Disk_Spectra_Utilities
+  !!{
+  Provides globally-accessible functions supporting the \refClass{accretionDiskSpectraClass} class.
+  !!}
+  private
+  public :: accretionDiskSpectraConstruct       , accretionDiskSpectraDestruct    , accretionDiskSpectraDeepCopy  , accretionDiskSpectraDeepCopyReset, &
+       &    accretionDiskSpectraDeepCopyFinalize, accretionDiskSpectraStateRestore, accretionDiskSpectraStateStore, accretionDiskSpectraSpectrumNode
+
+  ! Module-scope pointer to our task object. This is used for reference counting so that debugging information is consistent
+  ! between the increments and decrements.
+  class(*), pointer :: accretionDiskSpectra__
+  !$omp threadprivate(accretionDiskSpectra__)
+
+contains
+
+  !![
+  <functionGlobal>
+   <unitName>accretionDiskSpectraConstruct</unitName>
+   <type>void</type>
+   <module>Input_Parameters, only : inputParameters</module>
+   <arguments>type (inputParameters), intent(inout), target  :: parameters           </arguments>
+   <arguments>class(*              ), intent(  out), pointer :: accretionDiskSpectra_</arguments>
+  </functionGlobal>
+  !!]
+  subroutine accretionDiskSpectraConstruct(parameters,accretionDiskSpectra_)
+    !!{
+    Build a {\normalfont \ttfamily accretionDiskSpectra} object from a given parameter set. This is a globally-callable function
+    to allow us to subvert the class/module hierarchy.
+    !!}
+    use :: Error                  , only : Error_Report
+    use :: Input_Parameters       , only : inputParameter           , inputParameters
+    use :: Accretion_Disk_Spectra , only : accretionDiskSpectraClass, accretionDiskSpectra
+    implicit none
+    type (inputParameters), intent(inout), target  :: parameters
+    class(*              ), intent(  out), pointer :: accretionDiskSpectra_
+    type (inputParameters)               , pointer :: parametersCurrent
+
+    parametersCurrent => parameters
+    do while (.not.parametersCurrent%isPresent('accretionDiskSpectra').and.associated(parametersCurrent%parent))
+       parametersCurrent => parametersCurrent%parent
+    end do
+    if (.not.parametersCurrent%isPresent('accretionDiskSpectra')) parametersCurrent => parameters
+    accretionDiskSpectra__ => accretionDiskSpectra(parametersCurrent)
+    select type (accretionDiskSpectra__)
+    class is (accretionDiskSpectraClass) 
+       !![
+       <referenceCountIncrement object="accretionDiskSpectra__"/>
+       !!]
+       call accretionDiskSpectra__%autoHook()
+    class default
+       call Error_Report('unexpected class'//{introspection:location})
+    end select
+    accretionDiskSpectra_ => accretionDiskSpectra__
+    return
+  end subroutine accretionDiskSpectraConstruct
+
+  !![
+  <functionGlobal>
+   <unitName>accretionDiskSpectraSpectrumNode</unitName>
+   <type>double precision</type>
+   <module>Galacticus_Nodes, only : treeNode</module>
+   <arguments>class           (*       ), intent(inout) :: accretionDiskSpectra_</arguments>
+   <arguments>type            (treeNode), intent(inout) :: node                 </arguments>
+   <arguments>double precision          , intent(in   ) :: wavelength           </arguments>
+  </functionGlobal>
+  !!]
+  double precision function accretionDiskSpectraSpectrumNode(accretionDiskSpectra_,node,wavelength) result(spectrum)
+    !!{
+    Evaluate AGN spectra using a {\normalfont \ttfamily accretionDiskSpectra} object passed to us as an unlimited polymorphic object.
+    !!}
+    use :: Error                 , only : Error_Report
+    use :: Accretion_Disk_Spectra, only : accretionDiskSpectraClass
+    use :: Galacticus_Nodes      , only : treeNode
+    implicit none
+    class           (*       ), intent(inout) :: accretionDiskSpectra_
+    type            (treeNode), intent(inout) :: node
+    double precision          , intent(in   ) :: wavelength
+    
+    select type (accretionDiskSpectra_)
+    class is (accretionDiskSpectraClass)
+       spectrum=accretionDiskSpectra_%spectrum(node,wavelength)
+    class default
+       spectrum=0.0d0
+       call Error_Report('unexpected class'//{introspection:location})
+    end select
+    return
+  end function accretionDiskSpectraSpectrumNode
+  
+  !![
+  <functionGlobal>
+   <unitName>accretionDiskSpectraDestruct</unitName>
+   <type>void</type>
+   <arguments>class(*), intent(inout), pointer :: accretionDiskSpectra_</arguments>
+  </functionGlobal>
+  !!]
+  subroutine accretionDiskSpectraDestruct(accretionDiskSpectra_)
+    !!{
+    Destruct a {\normalfont \ttfamily accretionDiskSpectra} object passed to us as an unlimited polymorphic object.
+    !!}
+    use :: Error                 , only : Error_Report
+    use :: Accretion_Disk_Spectra, only : accretionDiskSpectraClass
+    implicit none
+    class(*), intent(inout), pointer :: accretionDiskSpectra_
+
+    accretionDiskSpectra__ => accretionDiskSpectra_
+    select type (accretionDiskSpectra__)
+    class is (accretionDiskSpectraClass)
+       !![
+       <objectDestructor name="accretionDiskSpectra__"/>
+       !!]
+    class default
+       call Error_Report('unexpected class'//{introspection:location})
+    end select
+    return
+  end subroutine accretionDiskSpectraDestruct
+
+  !![
+  <functionGlobal>
+   <unitName>accretionDiskSpectraStateRestore</unitName>
+   <type>void</type>
+   <module>ISO_C_Binding, only : c_ptr, c_size_t</module>
+   <arguments>class  (*       ), intent(inout) :: self            </arguments>
+   <arguments>integer          , intent(in   ) :: stateFile       </arguments>
+   <arguments>type   (c_ptr   ), intent(in   ) :: gslStateFile    </arguments>
+   <arguments>integer(c_size_t), intent(in   ) :: stateOperationID</arguments>
+   </functionGlobal>
+  !!]
+  subroutine accretionDiskSpectraStateRestore(self,stateFile,gslStateFile,stateOperationID)
+    !!{
+    Perform a deep copy of galactic structure objects.
+    !!}
+    use, intrinsic :: ISO_C_Binding         , only : c_ptr                    , c_size_t
+    use            :: Error                 , only : Error_Report
+    use            :: Accretion_Disk_Spectra, only : accretionDiskSpectraClass
+    implicit none
+    class  (*       ), intent(inout) :: self
+    integer          , intent(in   ) :: stateFile
+    type   (c_ptr   ), intent(in   ) :: gslStateFile
+    integer(c_size_t), intent(in   ) :: stateOperationID
+
+    select type (self)
+    class is (accretionDiskSpectraClass)
+       call self%stateRestore(stateFile,gslStateFile,stateOperationID)
+    class default
+       call Error_Report("unexpected class"//{introspection:location})
+    end select
+    return
+  end subroutine accretionDiskSpectraStateRestore
+
+  !![
+  <functionGlobal>
+   <unitName>accretionDiskSpectraStateStore</unitName>
+   <type>void</type>
+   <module>ISO_C_Binding, only : c_ptr, c_size_t</module>
+   <arguments>class  (*       ), intent(inout) :: self            </arguments>
+   <arguments>integer          , intent(in   ) :: stateFile       </arguments>
+   <arguments>type   (c_ptr   ), intent(in   ) :: gslStateFile    </arguments>
+   <arguments>integer(c_size_t), intent(in   ) :: stateOperationID</arguments>
+  </functionGlobal>
+  !!]
+  subroutine accretionDiskSpectraStateStore(self,stateFile,gslStateFile,stateOperationID)
+    !!{
+    Perform a deep copy of galactic structure objects.
+    !!}
+    use, intrinsic :: ISO_C_Binding         , only : c_ptr                    , c_size_t
+    use            :: Error                 , only : Error_Report
+    use            :: Accretion_Disk_Spectra, only : accretionDiskSpectraClass
+    implicit none
+    class  (*       ), intent(inout) :: self
+    integer          , intent(in   ) :: stateFile
+    type   (c_ptr   ), intent(in   ) :: gslStateFile
+    integer(c_size_t), intent(in   ) :: stateOperationID
+
+    select type (self)
+    class is (accretionDiskSpectraClass)
+       call self%stateStore(stateFile,gslStateFile,stateOperationID)
+    class default
+       call Error_Report("unexpected class"//{introspection:location})
+    end select
+    return
+  end subroutine accretionDiskSpectraStateStore
+
+  !![
+  <functionGlobal>
+   <unitName>accretionDiskSpectraDeepCopyReset</unitName>
+   <type>void</type>
+   <arguments>class(*), intent(inout) :: self</arguments>
+  </functionGlobal>
+  !!]
+  subroutine accretionDiskSpectraDeepCopyReset(self)
+    !!{
+    Perform a deep copy of galactic structure objects.
+    !!}
+    use :: Error                 , only : Error_Report
+    use :: Accretion_Disk_Spectra, only : accretionDiskSpectraClass
+    implicit none
+    class(*), intent(inout) :: self
+    
+    select type (self)
+    class is (accretionDiskSpectraClass)
+       call self%deepCopyReset()
+    class default
+       call Error_Report("unexpected class"//{introspection:location})
+    end select
+    return
+  end subroutine accretionDiskSpectraDeepCopyReset
+  
+  !![
+  <functionGlobal>
+   <unitName>accretionDiskSpectraDeepCopyFinalize</unitName>
+   <type>void</type>
+   <arguments>class(*), intent(inout) :: self</arguments>
+  </functionGlobal>
+  !!]
+  subroutine accretionDiskSpectraDeepCopyFinalize(self)
+    !!{
+    Finalize a deep copy of galactic structure objects.
+    !!}
+    use :: Error                 , only : Error_Report
+    use :: Accretion_Disk_Spectra, only : accretionDiskSpectraClass
+    implicit none
+    class(*), intent(inout) :: self
+    
+    select type (self)
+    class is (accretionDiskSpectraClass)
+       call self%deepCopyFinalize()
+    class default
+       call Error_Report("unexpected class"//{introspection:location})
+    end select
+    return
+  end subroutine accretionDiskSpectraDeepCopyFinalize
+  
+  !![
+  <functionGlobal>
+   <unitName>accretionDiskSpectraDeepCopy</unitName>
+   <type>void</type>
+   <arguments>class(*), intent(inout) :: self, destination</arguments>
+  </functionGlobal>
+  !!]
+  subroutine accretionDiskSpectraDeepCopy(self,destination)
+    !!{
+    Perform a deep copy of galactic structure objects.
+    !!}
+    use :: Error                 , only : Error_Report
+    use :: Accretion_Disk_Spectra, only : accretionDiskSpectraClass
+    implicit none
+    class(*), intent(inout) :: self, destination
+
+    select type (self)
+    class is (accretionDiskSpectraClass)
+       select type (destination)
+       class is (accretionDiskSpectraClass)
+          call self%deepCopy(destination)
+       class default
+          call Error_Report("unexpected class"//{introspection:location})
+       end select
+    class default
+       call Error_Report("unexpected class"//{introspection:location})
+    end select
+    return
+  end subroutine accretionDiskSpectraDeepCopy
+
+end module Accretion_Disk_Spectra_Utilities

--- a/source/black_holes.CGM_heating.F90
+++ b/source/black_holes.CGM_heating.F90
@@ -1,0 +1,49 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which implements a class for black hole heating of the \gls{cgm}.
+!!}
+
+module Black_Hole_CGM_Heating
+  !!{
+  Implements a class for black hole heating of the \gls{cgm}.
+  !!}
+  use :: Galacticus_Nodes, only : nodeComponentBlackHole
+  implicit none
+  private
+
+  !![
+  <functionClass>
+   <name>blackHoleCGMHeating</name>
+   <descriptiveName>Black Hole CGM Heating</descriptiveName>
+   <description>
+    Class providing models of black hole heating of the \gls{cgm}.
+   </description>
+   <default>jetPower</default>
+   <method name="heatingRate" >
+    <description>Compute the heating rate of the CGM due to the given {\normalfont \ttfamily blackHole}.</description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>class(nodeComponentBlackHole), intent(inout) :: blackHole</argument>
+   </method>
+  </functionClass>
+  !!]
+
+end module Black_Hole_CGM_Heating

--- a/source/black_holes.CGM_heating.jet_power.F90
+++ b/source/black_holes.CGM_heating.jet_power.F90
@@ -1,0 +1,135 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a black hole CGM heating class using the accretion disk jet power.
+  !!}
+
+  use :: Black_Hole_Accretion_Rates, only : blackHoleAccretionRateClass
+  use :: Accretion_Disks           , only : accretionDisksClass
+
+  !![
+  <blackHoleCGMHeating name="blackHoleCGMHeatingJetPower">
+   <description>
+    A black hole CGM heating class using the accretion disk jet power.
+   </description>
+  </blackHoleCGMHeating>
+  !!]
+  type, extends(blackHoleCGMHeatingClass) :: blackHoleCGMHeatingJetPower
+     !!{
+     A black hole CGM heating class using the accretion disk jet power.
+     !!}
+     private
+     class           (blackHoleAccretionRateClass), pointer :: blackHoleAccretionRate_ => null()
+     class           (accretionDisksClass        ), pointer :: accretionDisks_         => null()
+     double precision                                       :: efficiencyRadioMode
+   contains
+     final     ::                jetPowerDestructor
+     procedure :: heatingRate => jetPowerHeatingRate
+  end type blackHoleCGMHeatingJetPower
+  
+  interface blackHoleCGMHeatingJetPower
+     !!{
+     Constructors for the {\normalfont \ttfamily jetPower} black hole winds class.
+     !!}
+     module procedure jetPowerConstructorParameters
+     module procedure jetPowerConstructorInternal
+  end interface blackHoleCGMHeatingJetPower
+
+contains
+
+  function jetPowerConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily jetPower} black hole winds class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (blackHoleCGMHeatingJetPower)                :: self
+    type            (inputParameters            ), intent(inout) :: parameters
+    class           (blackHoleAccretionRateClass), pointer       :: blackHoleAccretionRate_
+    class           (accretionDisksClass        ), pointer       :: accretionDisks_
+    double precision                                             :: efficiencyRadioMode
+    
+    !![
+    <inputParameter>
+      <name>efficiencyRadioMode</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>Efficiency with which radio-mode feedback is coupled to the \gls{cgm}.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="blackHoleAccretionRate" name="blackHoleAccretionRate_" source="parameters"/>
+    <objectBuilder class="accretionDisks"         name="accretionDisks_"         source="parameters"/>
+    !!]
+    self=blackHoleCGMHeatingJetPower(efficiencyRadioMode,blackHoleAccretionRate_,accretionDisks_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="blackHoleAccretionRate_"/>
+    <objectDestructor name="accretionDisks_"        />
+    !!]
+    return
+  end function jetPowerConstructorParameters
+
+  function jetPowerConstructorInternal(efficiencyRadioMode,blackHoleAccretionRate_,accretionDisks_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily jetPower} node operator class.
+    !!}
+    implicit none
+    type            (blackHoleCGMHeatingJetPower)                        :: self
+    class           (blackHoleAccretionRateClass), target, intent(in   ) :: blackHoleAccretionRate_
+    class           (accretionDisksClass        ), target, intent(in   ) :: accretionDisks_
+    double precision                                     , intent(in   ) :: efficiencyRadioMode
+    !![
+    <constructorAssign variables="efficiencyRadioMode, *blackHoleAccretionRate_, *accretionDisks_"/>
+    !!]
+
+    return
+  end function jetPowerConstructorInternal
+
+  subroutine jetPowerDestructor(self)
+    !!{
+    Destructor for the jetPower black hole CGM heating class.
+    !!}
+    implicit none
+    type(blackHoleCGMHeatingJetPower), intent(inout) :: self
+    
+    !![
+    <objectDestructor name="self%blackHoleAccretionRate_"/>
+    <objectDestructor name="self%accretionDisks_"        />
+    !!]
+    return
+  end subroutine jetPowerDestructor
+  
+  double precision function jetPowerHeatingRate(self,blackHole) result(rateHeating)
+    !!{
+    Compute the heating rate of the CGM based on the accretion disk jet power.
+    !!}
+    implicit none
+    class           (blackHoleCGMHeatingJetPower), intent(inout) :: self
+    class           (nodeComponentBlackHole     ), intent(inout) :: blackHole
+    double precision                                             :: rateAccretionSpheroid, rateAccretionHotHalo, &
+         &                                                          rateACcretion
+
+    ! Compute the jet power and CGM heating rate.
+    call self%blackHoleAccretionRate_%rateAccretion(blackHole,rateAccretionSpheroid,rateAccretionHotHalo)
+    rateAccretion=+rateAccretionSpheroid &
+         &        +rateAccretionHotHalo
+    rateHeating  =+self                %efficiencyRadioMode                          &
+         &        *self%accretionDisks_%powerJet           (blackHole,rateAccretion)
+    return
+  end function jetPowerHeatingRate

--- a/source/black_holes.CGM_heating.quasistatic.F90
+++ b/source/black_holes.CGM_heating.quasistatic.F90
@@ -1,0 +1,162 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a black hole CGM heating class where the coupling strength is determined by how quasistatic the \gls{cgm} is.
+  !!}
+
+  use :: Black_Hole_Accretion_Rates, only : blackHoleAccretionRateClass
+  use :: Cooling_Radii             , only : coolingRadiusClass
+  use :: Dark_Matter_Halo_Scales   , only : darkMatterHaloScaleClass
+
+  !![
+  <blackHoleCGMHeating name="blackHoleCGMHeatingQuasistatic">
+   <description>
+    A black hole CGM heating class where the coupling strength is determined by how quasistatic the \gls{cgm} is.
+   </description>
+  </blackHoleCGMHeating>
+  !!]
+  type, extends(blackHoleCGMHeatingClass) :: blackHoleCGMHeatingQuasistatic
+     !!{
+     A black hole CGM heating class where the coupling strength is determined by how quasistatic the \gls{cgm} is.
+     !!}
+     private
+     class           (blackHoleAccretionRateClass), pointer :: blackHoleAccretionRate_ => null()
+     class           (darkMatterHaloScaleClass   ), pointer :: darkMatterHaloScale_    => null()
+     class           (coolingRadiusClass         ), pointer :: coolingRadius_          => null()
+     double precision                                       :: efficiencyHeating
+   contains
+     final     ::                quasistaticDestructor
+     procedure :: heatingRate => quasistaticHeatingRate
+  end type blackHoleCGMHeatingQuasistatic
+  
+  interface blackHoleCGMHeatingQuasistatic
+     !!{
+     Constructors for the {\normalfont \ttfamily quasistatic} black hole winds class.
+     !!}
+     module procedure quasistaticConstructorParameters
+     module procedure quasistaticConstructorInternal
+  end interface blackHoleCGMHeatingQuasistatic
+
+contains
+
+  function quasistaticConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily quasistatic} black hole winds class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (blackHoleCGMHeatingQuasistatic)                :: self
+    type            (inputParameters               ), intent(inout) :: parameters
+    class           (blackHoleAccretionRateClass   ), pointer       :: blackHoleAccretionRate_
+    class           (darkMatterHaloScaleClass      ), pointer       :: darkMatterHaloScale_
+    class           (coolingRadiusClass            ), pointer       :: coolingRadius_
+    double precision                                                :: efficiencyHeating
+    
+    !![
+    <inputParameter>
+      <name>efficiencyHeating</name>
+      <defaultValue>1.0d-3</defaultValue>
+      <description>The efficiency with which accretion onto a black hole heats the \gls{cgm}.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="blackHoleAccretionRate" name="blackHoleAccretionRate_" source="parameters"/>
+    <objectBuilder class="darkMatterHaloScale"    name="darkMatterHaloScale_"    source="parameters"/>
+    <objectBuilder class="coolingRadius"          name="coolingRadius_"          source="parameters"/>
+    !!]
+    self=blackHoleCGMHeatingQuasistatic(efficiencyHeating,blackHoleAccretionRate_,darkMatterHaloScale_,coolingRadius_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="blackHoleAccretionRate_"/>
+    <objectDestructor name="darkMatterHaloScale_"   />
+    <objectDestructor name="coolingRadius_"         />
+    !!]
+    return
+  end function quasistaticConstructorParameters
+
+  function quasistaticConstructorInternal(efficiencyHeating,blackHoleAccretionRate_,darkMatterHaloScale_,coolingRadius_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily quasistatic} node operator class.
+    !!}
+    implicit none
+    type            (blackHoleCGMHeatingQuasistatic)                        :: self
+    class           (blackHoleAccretionRateClass   ), target, intent(in   ) :: blackHoleAccretionRate_
+    class           (darkMatterHaloScaleClass      ), target, intent(in   ) :: darkMatterHaloScale_
+    class           (coolingRadiusClass            ), target, intent(in   ) :: coolingRadius_
+    double precision                                        , intent(in   ) :: efficiencyHeating
+    !![
+    <constructorAssign variables="efficiencyHeating, *blackHoleAccretionRate_, *darkMatterHaloScale_, *coolingRadius_"/>
+    !!]
+
+    return
+  end function quasistaticConstructorInternal
+
+  subroutine quasistaticDestructor(self)
+    !!{
+    Destructor for the quasistatic black hole CGM heating class.
+    !!}
+    implicit none
+    type(blackHoleCGMHeatingQuasistatic), intent(inout) :: self
+    
+    !![
+    <objectDestructor name="self%blackHoleAccretionRate_"/>
+    <objectDestructor name="self%darkMatterHaloScale_"   />
+    <objectDestructor name="self%coolingRadius_"         />
+    !!]
+    return
+  end subroutine quasistaticDestructor
+  
+  double precision function quasistaticHeatingRate(self,blackHole) result(rateHeating)
+    !!{
+    Compute the heating rate of the CGM based on the accretion disk jet power.
+    !!}
+    use :: Numerical_Constants_Physical, only : speedLight
+    use :: Numerical_Constants_Prefixes, only : kilo
+    implicit none
+    class           (blackHoleCGMHeatingQuasistatic), intent(inout) :: self
+    class           (nodeComponentBlackHole        ), intent(inout) :: blackHole
+    double precision                                , parameter     :: radiusCoolingFractionalTransitionMinimum=0.9d0
+    double precision                                , parameter     :: radiusCoolingFractionalTransitionMaximum=1.0d0
+    double precision                                                :: rateAccretionSpheroid                         , rateAccretionHotHalo   , &
+         &                                                             rateAccretion                                 , radiusCoolingFractional, &
+         &                                                             efficiencyCoupling                            , x
+
+    ! Compute accretion rate onto the black hole.
+    call self%blackHoleAccretionRate_%rateAccretion(blackHole,rateAccretionSpheroid,rateAccretionHotHalo)
+    rateAccretion=+rateAccretionSpheroid &
+         &        +rateAccretionHotHalo
+    ! Compute coupling efficiency based on whether halo is cooling quasistatically.
+    radiusCoolingFractional=+self%coolingRadius_      %      radius(blackHole%hostNode) &
+         &                  /self%darkMatterHaloScale_%radiusVirial(blackHole%hostNode)
+    if      (radiusCoolingFractional < radiusCoolingFractionalTransitionMinimum) then
+       efficiencyCoupling=1.0d0
+    else if (radiusCoolingFractional > radiusCoolingFractionalTransitionMaximum) then
+       efficiencyCoupling=0.0d0
+    else
+       x                 =     +(radiusCoolingFractional                 -radiusCoolingFractionalTransitionMinimum) &
+            &                  /(radiusCoolingFractionalTransitionMaximum-radiusCoolingFractionalTransitionMinimum)
+       efficiencyCoupling=x**2*(2.0d0*x-3.0d0)+1.0d0
+    end if
+    ! Compute the heating rate.
+    rateHeating=+     efficiencyCoupling    &
+         &      *self%efficiencyHeating     &
+         &      *     rateAccretion         &
+         &      *     speedLight**2/kilo**2
+    return
+  end function quasistaticHeatingRate

--- a/source/black_holes.accretion_rates.standard.F90
+++ b/source/black_holes.accretion_rates.standard.F90
@@ -170,7 +170,7 @@ contains
     <objectDestructor name="self%hotHaloTemperatureProfile_"          />
     <objectDestructor name="self%coolingRadius_"                      />
     <objectDestructor name="self%darkMatterHaloScale_"                />
-    !!]                                                                                                                                                                                                               
+    !!]
     return
   end subroutine standardDestructor
   

--- a/source/black_holes.winds.Ciotti2009.F90
+++ b/source/black_holes.winds.Ciotti2009.F90
@@ -1,0 +1,248 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a black hole winds class based on the model of \cite{ciotti_feedbackcentral_2009}.
+  !!}
+
+  use :: Black_Hole_Accretion_Rates, only : blackHoleAccretionRateClass
+  use :: Accretion_Disks           , only : accretionDisksClass
+
+  !![
+  <blackHoleWind name="blackHoleWindCiotti2009">
+   <description>
+     A black hole winds class based (loosely) on the model of \cite{ciotti_feedbackcentral_2009}. The wind power is given by:
+     \begin{equation}
+     L_\mathrm{w} = \epsilon_\mathrm{w} \epsilon_\mathrm{r} f_\mathrm{w} \dot{M}_\bullet \mathrm{c}^2,
+     \end{equation}
+     where $\dot{M}_\bullet$ is the black hole accretion rate, $\epsilon_\mathrm{w}=${\normalfont \ttfamily [efficiencyWind]} is
+     an overall efficiency parameter, $\epsilon_\mathrm{r}$ is the radiative efficiency of the accretion flow \emph{if}
+     {\normalfont \ttfamily [efficiencyWindScalesWithEfficiencyRadiative]=true}, and $1$ otherwise, and $f_\mathrm{w}$ represents
+     the fraction of the wind power that is coupled to the surrounding galaxy.
+
+     The model for $f_\mathrm{w}$ is inspired by \cite{ciotti_feedbackcentral_2009} who state:
+     \begin{quotation}     
+     If the pressure corresponding to the momentum ﬂow within the jet or wind is much greater than the pressure in the ambient
+     gas, very little mass, momentum and kinetic energy is taken from it and deposited in that ambient gas. But when the [ratio of
+     ISM to wind pressure] approaches unity, the ``working surface'' has been reached and the jet or wind discharges its content.
+     \end{quotation}
+     
+     The energy density (pressure) in the wind at some radius $r$ in the galaxy is simply $\epsilon_\mathrm{w} \epsilon_\mathrm{r}
+     \dot{M} \mathrm{c}^2 / 4 \pi r^2 v_\mathrm{w}$ (i.e. the energy input into a shell over time $\delta t$, $\epsilon_\mathrm{w}
+     \epsilon_\mathrm{r} \dot{M} \mathrm{c}^2 \delta t$, divided by the volume of the shell occupied by the wind in time $\delta
+     t$, $4 \pi r^2 v_\mathrm{w} \delta t$) where $v_\mathrm{w}$ is the wind velocity (assumed fixed at $10^4$~km/s). The
+     corresponding ISM pressure is just $(3/2) \mathrm{k}T \rho(r)/m_\mathrm{H}$ where $T$ is the ISM temperature (assumed fixed
+     at $10^4$~K) and $\rho$ is the ISM density. We approximate that the spheroid ISM density as $3 M/4/\pi/r^3$, where $M$ is the
+     total gas mass in the spheroid, such that we find a ratio of ISM to wind pressures of:     
+     \begin{equation}
+      \frac{P_\mathrm{ISM}}{P_\mathrm{w}} = (3/2) \mathrm{k}T \rho(r)/m_\mathrm{H} \left/ \frac{\epsilon_\mathrm{w} \epsilon_\mathrm{r} \dot{M} \mathrm{c}^2}{4 \pi r^2 v_\mathrm{w}} \right. .
+     \end{equation}
+     We then smoothly interpolate $f_\mathrm{w}$ across the transition as:
+     \begin{equation}
+     f_\mathrm{w} = \left\{ \begin{array}{ll} 0 &amp; \hbox{if } x \le 0 \\ 3 x^2 - 2 x^3 &amp; \hbox{if } 0 &lt; x &lt; 1 \\ 1 &amp; \hbox{if } x \ge 1, \end{array} \right.
+     \end{equation}
+     where $x=P_\mathrm{ISM}/P_\mathrm{w}-1/2$.
+    </description>
+  </blackHoleWind>
+  !!]
+  type, extends(blackHoleWindClass) :: blackHoleWindCiotti2009
+     !!{
+     A black hole winds class based on the model of \cite{ciotti_feedbackcentral_2009}.
+     !!}
+     private
+     class           (blackHoleAccretionRateClass), pointer :: blackHoleAccretionRate_                     => null()
+     class           (accretionDisksClass        ), pointer :: accretionDisks_                             => null()
+     double precision                                       :: efficiencyWind
+     logical                                                :: efficiencyWindScalesWithEfficiencyRadiative
+   contains
+     final     ::          ciotti2009Destructor
+     procedure :: power => ciotti2009Power
+  end type blackHoleWindCiotti2009
+  
+  interface blackHoleWindCiotti2009
+     !!{
+     Constructors for the {\normalfont \ttfamily ciotti2009} black hole winds class.
+     !!}
+     module procedure ciotti2009ConstructorParameters
+     module procedure ciotti2009ConstructorInternal
+  end interface blackHoleWindCiotti2009
+
+contains
+
+  function ciotti2009ConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily ciotti2009} black hole winds class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (blackHoleWindCiotti2009    )                :: self
+    type            (inputParameters            ), intent(inout) :: parameters
+    class           (blackHoleAccretionRateClass), pointer       :: blackHoleAccretionRate_
+    class           (accretionDisksClass        ), pointer       :: accretionDisks_
+    double precision                                             :: efficiencyWind
+    logical                                                      :: efficiencyWindScalesWithEfficiencyRadiative
+
+    !![
+    <inputParameter>
+      <name>efficiencyWind</name>
+      <defaultValue>2.4d-3</defaultValue>
+      <description>The efficiency of the black hole accretion-driven wind: $L_\mathrm{wind} = \epsilon_\mathrm{wind} \dot{M}_\bullet \clight^2$.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>efficiencyWindScalesWithEfficiencyRadiative</name>
+      <defaultValue>.false.</defaultValue>
+      <description>Specifies whether the black hole wind efficiency should scale with the radiative efficiency of the accretion disk.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="blackHoleAccretionRate" name="blackHoleAccretionRate_" source="parameters"/>
+    <objectBuilder class="accretionDisks"         name="accretionDisks_"         source="parameters"/>
+    !!]
+    self=blackHoleWindCiotti2009(efficiencyWind,efficiencyWindScalesWithEfficiencyRadiative,blackHoleAccretionRate_,accretionDisks_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="blackHoleAccretionRate_"/>
+    <objectDestructor name="accretionDisks_"        />
+    !!]
+    return
+  end function ciotti2009ConstructorParameters
+
+  function ciotti2009ConstructorInternal(efficiencyWind,efficiencyWindScalesWithEfficiencyRadiative,blackHoleAccretionRate_,accretionDisks_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily ciotti2009} node operator class.
+    !!}
+    implicit none
+    type            (blackHoleWindCiotti2009    )                        :: self
+    class           (blackHoleAccretionRateClass), target, intent(in   ) :: blackHoleAccretionRate_
+    class           (accretionDisksClass        ), target, intent(in   ) :: accretionDisks_
+    double precision                                     , intent(in   ) :: efficiencyWind
+    logical                                              , intent(in   ) :: efficiencyWindScalesWithEfficiencyRadiative
+    !![
+    <constructorAssign variables="efficiencyWind, efficiencyWindScalesWithEfficiencyRadiative, *blackHoleAccretionRate_, *accretionDisks_"/>
+    !!]
+
+    return
+  end function ciotti2009ConstructorInternal
+
+  subroutine ciotti2009Destructor(self)
+    !!{
+    Destructor for the ciotti2009 black hole winds class.
+    !!}
+    implicit none
+    type(blackHoleWindCiotti2009), intent(inout) :: self
+    
+    !![
+    <objectDestructor name="self%blackHoleAccretionRate_"/>
+    <objectDestructor name="self%accretionDisks_"        />
+    !!]
+    return
+  end subroutine ciotti2009Destructor
+  
+  double precision function ciotti2009Power(self,blackHole) result(power)
+    !!{
+    Compute the power of a black hole-driven wind that couples to the surrounding galaxy.
+    !!}
+    use :: Galacticus_Nodes                , only : nodeComponentSpheroid
+    use :: Numerical_Constants_Astronomical, only : gigaYear             , megaParsec, massSolar
+    use :: Numerical_Constants_Atomic      , only : massHydrogenAtom
+    use :: Numerical_Constants_Math        , only : Pi
+    use :: Numerical_Constants_Physical    , only : boltzmannsConstant   , speedLight
+    use :: Numerical_Constants_Prefixes    , only : kilo
+    implicit none
+    class           (blackHoleWindCiotti2009), intent(inout) :: self
+    class           (nodeComponentBlackHole ), intent(inout) :: blackHole
+    double precision                         , parameter     :: velocityWind         =1.0d4
+    double precision                         , parameter     :: temperatureISM       =1.0d4
+    class           (nodeComponentSpheroid  ), pointer       :: spheroid
+    double precision                                         :: rateAccretionSpheroid      , rateAccretionHotHalo
+    double precision                                         :: efficiencyWind             , rateAccretion       , &
+         &                                                      pressureWind               , pressureISM         , &
+         &                                                      fractionWindCoupled        , massGasSpheroid     , &
+         &                                                      radiusSpheroid             , x
+    
+    ! Find the accretion rate and wind production efficiency.
+    call self%blackHoleAccretionRate_%rateAccretion(blackHole,rateAccretionSpheroid,rateAccretionHotHalo)
+    rateAccretion =+     rateAccretionSpheroid &
+         &         +     rateAccretionHotHalo
+    efficiencyWind=+self%efficiencyWind
+    ! Apply any scaling of the wind production efficiency with the radiative efficiency of the accretion disk.
+    if (self%efficiencyWindScalesWithEfficiencyRadiative)                                    &
+         & efficiencyWind=+                     efficiencyWind                               &
+         &                *self%accretionDisks_%efficiencyRadiative(blackHole,rateAccretion)
+    ! Return if there is no wind.
+    if     (                         &
+         &   rateAccretion  <= 0.0d0 &
+         &  .or.                     &
+         &   efficiencyWind <= 0.0d0 &
+         & ) then
+       power=0.0d0
+       return
+    end if
+    ! Compute the fraction of the wind that couples of the ISM of the spheroid component.
+    spheroid            => blackHole%hostNode%spheroid()
+    massGasSpheroid     =  spheroid          %massGas ()
+    fractionWindCoupled =  0.0d0
+    if (massGasSpheroid > 0.0d0) then
+       radiusSpheroid=spheroid%radius()
+       if (radiusSpheroid > 0.0d0) then
+          ! Evaluate wind and ISM pressures.
+          pressureWind=+efficiencyWind                       &
+               &       *rateAccretion    *massSolar/gigaYear &
+               &       *speedLight**2                        &
+               &       /4.0d0                                &
+               &       /Pi                                   &
+               &       /velocityWind     /kilo               &
+               &       /radiusSpheroid**2/megaParsec**2
+          pressureISM =+3.0d0                                &
+               &       /4.0d0                                &
+               &       /Pi                                   &
+               &       *massGasSpheroid  *massSolar          &
+               &       /radiusSpheroid**3/megaParsec**3      &
+               &       /massHydrogenAtom                     &
+               &       *3.0d0                                &
+               &       /2.0d0                                &
+               &       *boltzmannsConstant                   &
+               &       *temperatureISM
+          ! Construct an interpolating factor such that the energy input from the wind drops to zero below half of the ISM
+          ! pressure.
+          x      =+pressureISM  &
+               &  /pressureWind &
+               &  -0.50d0
+          if (x <= 0.0d0) then
+             ! No energy input below half of critical density.
+             fractionWindCoupled=+0.0d0
+          else if (x >= 1.0d0) then
+             ! Full energy input above 1.5 times critical density.
+             fractionWindCoupled=+1.0d0
+          else
+             ! Smooth polynomial interpolating function between these limits.
+             fractionWindCoupled=+3.0d0*x**2 &
+                  &              -2.0d0*x**3
+          end if
+       end if
+    end if
+    efficiencyWind=+efficiencyWind      &
+         &         *fractionWindCoupled
+    ! Evaluate the wind power.
+    power  =+efficiencyWind    &
+         &  *rateAccretion     &
+         &  *speedLight    **2 &
+         &  /kilo          **2
+    return
+  end function ciotti2009Power

--- a/source/black_holes.winds.F90
+++ b/source/black_holes.winds.F90
@@ -1,0 +1,49 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which implements a class for black hole winds.
+!!}
+
+module Black_Hole_Winds
+  !!{
+  Implements a class for black hole winds.
+  !!}
+  use :: Galacticus_Nodes, only : nodeComponentBlackHole
+  implicit none
+  private
+
+  !![
+  <functionClass>
+   <name>blackHoleWind</name>
+   <descriptiveName>Black Hole Winds</descriptiveName>
+   <description>
+    Class providing models of black hole winds.
+   </description>
+   <default>ciotti2009</default>
+   <method name="power" >
+    <description>Computes the power in the wind that couples to the surrounding galaxy.</description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>class(nodeComponentBlackHole), intent(inout) :: blackHole</argument>
+   </method>
+  </functionClass>
+  !!]
+
+end module Black_Hole_Winds

--- a/source/black_holes.winds.simple.F90
+++ b/source/black_holes.winds.simple.F90
@@ -1,0 +1,132 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a simple black hole winds class.
+  !!}
+
+  use :: Black_Hole_Accretion_Rates, only : blackHoleAccretionRateClass
+
+  !![
+  <blackHoleWind name="blackHoleWindSimple">
+   <description>
+    A simple black hole winds model.
+   </description>
+  </blackHoleWind>
+  !!]
+  type, extends(blackHoleWindClass) :: blackHoleWindSimple
+     !!{
+     A simple black hole winds model.
+     !!}
+     private
+     class           (blackHoleAccretionRateClass), pointer :: blackHoleAccretionRate_ => null()
+     double precision                                       :: efficiencyWind
+   contains
+     final     ::          simpleDestructor
+     procedure :: power => simplePower
+  end type blackHoleWindSimple
+  
+  interface blackHoleWindSimple
+     !!{
+     Constructors for the {\normalfont \ttfamily simple} black hole winds class.
+     !!}
+     module procedure simpleConstructorParameters
+     module procedure simpleConstructorInternal
+  end interface blackHoleWindSimple
+
+contains
+
+  function simpleConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily simple} black hole winds class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (blackHoleWindSimple        )                :: self
+    type            (inputParameters            ), intent(inout) :: parameters
+    class           (blackHoleAccretionRateClass), pointer       :: blackHoleAccretionRate_
+    double precision                                             :: efficiencyWind
+    
+    !![
+    <inputParameter>
+      <name>efficiencyWind</name>
+      <defaultValue>2.2157d-3</defaultValue>
+      <description>The efficiency of the black hole accretion-driven wind.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="blackHoleAccretionRate" name="blackHoleAccretionRate_" source="parameters"/>
+    !!]
+    self=blackHoleWindSimple(efficiencyWind,blackHoleAccretionRate_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="blackHoleAccretionRate_"/>
+    !!]
+    return
+  end function simpleConstructorParameters
+
+  function simpleConstructorInternal(efficiencyWind,blackHoleAccretionRate_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily simple} node operator class.
+    !!}
+    implicit none
+    type            (blackHoleWindSimple        )                        :: self
+    class           (blackHoleAccretionRateClass), target, intent(in   ) :: blackHoleAccretionRate_
+    double precision                                     , intent(in   ) :: efficiencyWind
+    !![
+    <constructorAssign variables="efficiencyWind, *blackHoleAccretionRate_"/>
+    !!]
+
+    return
+  end function simpleConstructorInternal
+
+  subroutine simpleDestructor(self)
+    !!{
+    Destructor for the simple black hole winds class.
+    !!}
+    implicit none
+    type(blackHoleWindSimple), intent(inout) :: self
+    
+    !![
+    <objectDestructor name="self%blackHoleAccretionRate_"/>
+    !!]
+    return
+  end subroutine simpleDestructor
+  
+  double precision function simplePower(self,blackHole) result(power)
+    !!{
+    Compute the power of a black hole-driven wind that couples to the surrounding galaxy.
+    !!}
+    use :: Numerical_Constants_Physical, only : speedLight
+    use :: Numerical_Constants_Prefixes, only : kilo
+    implicit none
+    class           (blackHoleWindSimple   ), intent(inout) :: self
+    class           (nodeComponentBlackHole), intent(inout) :: blackHole
+    double precision                                        :: rateAccretionSpheroid, rateAccretionHotHalo
+
+    ! Compute the wind power.
+    call self%blackHoleAccretionRate_%rateAccretion(blackHole,rateAccretionSpheroid,rateAccretionHotHalo)
+    power  =+self%efficiencyWind     &
+         &  *(                       &
+         &    +rateAccretionSpheroid &
+         &    +rateAccretionHotHalo  &
+         &   )                       &
+         &  *speedLight**2           &
+         &  /kilo      **2
+    return
+  end function simplePower

--- a/source/nodes.operators.physics.black_holes.CGM_heating.F90
+++ b/source/nodes.operators.physics.black_holes.CGM_heating.F90
@@ -1,0 +1,132 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a node operator class that implements heating of the \gls{cgm} driven by accretion onto black holes.
+  !!}
+
+  use :: Black_Hole_CGM_Heating, only : blackHoleCGMHeatingClass
+
+  !![
+  <nodeOperator name="nodeOperatorBlackHolesCGMHeating">
+   <description>A node operator class that implements heating of the \gls{cgm} driven by accretion onto black holes.</description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorBlackHolesCGMHeating
+     !!{
+     A node operator class that implements heating of the \gls{cgm} driven by accretion onto black holes.
+     !!}
+     private
+     class(blackHoleCGMHeatingClass), pointer :: blackHoleCGMHeating_ => null()
+   contains
+     final     ::                          blackHolesCGMHeatingDestructor
+     procedure :: differentialEvolution => blackHolesCGMHeatingDifferentialEvolution
+  end type nodeOperatorBlackHolesCGMHeating
+  
+  interface nodeOperatorBlackHolesCGMHeating
+     !!{
+     Constructors for the {\normalfont \ttfamily blackHolesCGMHeating} node operator class.
+     !!}
+     module procedure blackHolesCGMHeatingConstructorParameters
+     module procedure blackHolesCGMHeatingConstructorInternal
+  end interface nodeOperatorBlackHolesCGMHeating
+  
+contains
+
+  function blackHolesCGMHeatingConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily starFormation} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type (nodeOperatorBlackHolesCGMHeating)                :: self
+    type (inputParameters                 ), intent(inout) :: parameters
+    class(blackHoleCGMHeatingClass        ), pointer       :: blackHoleCGMHeating_
+    
+    !![
+    <objectBuilder class="blackHoleCGMHeating" name="blackHoleCGMHeating_" source="parameters"/>
+    !!]
+    self=nodeOperatorBlackHolesCGMHeating(blackHoleCGMHeating_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="blackHoleCGMHeating_"/>
+    !!]
+    return
+  end function blackHolesCGMHeatingConstructorParameters
+
+  function blackHolesCGMHeatingConstructorInternal(blackHoleCGMHeating_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily blackHolesCGMHeating} node operator class.
+    !!}
+    implicit none
+    type (nodeOperatorBlackHolesCGMHeating)                        :: self
+    class(blackHoleCGMHeatingClass        ), intent(in   ), target :: blackHoleCGMHeating_
+    !![
+    <constructorAssign variables="*blackHoleCGMHeating_"/>
+    !!]
+    
+    return
+  end function blackHolesCGMHeatingConstructorInternal
+
+  subroutine blackHolesCGMHeatingDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily blackHolesCGMHeating} node operator class.
+    !!}
+    implicit none
+    type(nodeOperatorBlackHolesCGMHeating), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%blackHoleCGMHeating_"/>
+    !!]
+    return
+  end subroutine blackHolesCGMHeatingDestructor
+
+  subroutine blackHolesCGMHeatingDifferentialEvolution(self,node,interrupt,functionInterrupt,propertyType)
+    !!{
+    Account for winds driven by accretion onto black holes.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentBlackHole, nodeComponentHotHalo
+    implicit none
+    class           (nodeOperatorBlackHolesCGMHeating), intent(inout), target  :: self
+    type            (treeNode                        ), intent(inout), target  :: node
+    logical                                           , intent(inout)          :: interrupt
+    procedure       (interruptTask                   ), intent(inout), pointer :: functionInterrupt
+    integer                                           , intent(in   )          :: propertyType
+    class           (nodeComponentBlackHole          )               , pointer :: blackHole
+    class           (nodeComponentHotHalo            )               , pointer :: hotHalo
+    integer                                                                    :: countBlackHole   , indexBlackHole
+    double precision                                                           :: rateHeating
+    !$GLC attributes unused :: interrupt, functionInterrupt, propertyType
+
+    ! If there are no black holes in this node, we have nothing to do - return immediately.
+    countBlackHole=node%blackHoleCount()
+    if (countBlackHole < 1) return
+    ! Get the hot halo component so that heating energy can be injected into it.
+    hotHalo => node%hotHalo()
+    ! Iterate over all black holes in the node.
+    do indexBlackHole=1,countBlackHole
+       ! Find the wind power from this black hole.
+       blackHole   => node%blackHole                       (instance=indexBlackHole)
+       rateHeating =  self%blackHoleCGMHeating_%heatingRate(              blackHole)
+       ! Inject this energy into the CGM.
+       call hotHalo%heatSourceRate(rateHeating,interrupt,functionInterrupt)
+    end do
+    return
+  end subroutine blackHolesCGMHeatingDifferentialEvolution
+  

--- a/source/nodes.operators.physics.black_holes.accretion.F90
+++ b/source/nodes.operators.physics.black_holes.accretion.F90
@@ -1,0 +1,163 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a node operator class that implements accretion onto black holes.
+  !!}
+
+  use :: Black_Hole_Accretion_Rates, only : blackHoleAccretionRateClass
+  use :: Accretion_Disks           , only : accretionDisksClass
+
+  !![
+  <nodeOperator name="nodeOperatorBlackHolesAccretion">
+   <description>A node operator class that implements accretion onto black holes.</description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorBlackHolesAccretion
+     !!{
+     A node operator class that implements accretion onto black holes.
+     !!}
+     private
+     class(blackHoleAccretionRateClass), pointer :: blackHoleAccretionRate_ => null()
+     class(accretionDisksClass        ), pointer :: accretionDisks_         => null()
+   contains
+     final     ::                          blackHolesAccretionDestructor
+     procedure :: differentialEvolution => blackHolesAccretionDifferentialEvolution
+  end type nodeOperatorBlackHolesAccretion
+  
+  interface nodeOperatorBlackHolesAccretion
+     !!{
+     Constructors for the {\normalfont \ttfamily blackHolesAccretion} node operator class.
+     !!}
+     module procedure blackHolesAccretionConstructorParameters
+     module procedure blackHolesAccretionConstructorInternal
+  end interface nodeOperatorBlackHolesAccretion
+  
+contains
+
+  function blackHolesAccretionConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily starFormation} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type (nodeOperatorBlackHolesAccretion)                :: self
+    type (inputParameters                ), intent(inout) :: parameters
+    class(blackHoleAccretionRateClass    ), pointer       :: blackHoleAccretionRate_
+    class(accretionDisksClass            ), pointer       :: accretionDisks_
+
+    !![
+    <objectBuilder class="blackHoleAccretionRate" name="blackHoleAccretionRate_" source="parameters"/>
+    <objectBuilder class="accretionDisks"         name="accretionDisks_"         source="parameters"/>
+    !!]
+    self=nodeOperatorBlackHolesAccretion(blackHoleAccretionRate_,accretionDisks_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="blackHoleAccretionRate_"/>
+    <objectDestructor name="accretionDisks_"        />
+    !!]
+    return
+  end function blackHolesAccretionConstructorParameters
+
+  function blackHolesAccretionConstructorInternal(blackHoleAccretionRate_,accretionDisks_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily blackHolesAccretion} node operator class.
+    !!}
+    implicit none
+    type (nodeOperatorBlackHolesAccretion)                        :: self
+    class(blackHoleAccretionRateClass    ), intent(in   ), target :: blackHoleAccretionRate_
+    class(accretionDisksClass            ), intent(in   ), target :: accretionDisks_
+    !![
+    <constructorAssign variables="*blackHoleAccretionRate_, *accretionDisks_"/>
+    !!]
+    
+    return
+  end function blackHolesAccretionConstructorInternal
+
+  subroutine blackHolesAccretionDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily blackHolesAccretion} node operator class.
+    !!}
+    implicit none
+    type(nodeOperatorBlackHolesAccretion), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%blackHoleAccretionRate_"/>
+    <objectDestructor name="self%accretionDisks_"        />
+    !!]
+    return
+  end subroutine blackHolesAccretionDestructor
+
+  subroutine blackHolesAccretionDifferentialEvolution(self,node,interrupt,functionInterrupt,propertyType)
+    !!{
+    Account for accretion onto black holes.
+    !!}
+    use :: Galacticus_Nodes            , only : nodeComponentBlackHole, nodeComponentSpheroid, nodeComponentHotHalo
+    use :: Numerical_Constants_Physical, only : speedLight
+    use :: Numerical_Constants_Prefixes, only : kilo
+    implicit none
+    class           (nodeOperatorBlackHolesAccretion), intent(inout), target  :: self
+    type            (treeNode                       ), intent(inout), target  :: node
+    logical                                          , intent(inout)          :: interrupt
+    procedure       (interruptTask                  ), intent(inout), pointer :: functionInterrupt
+    integer                                          , intent(in   )          :: propertyType
+    class           (nodeComponentBlackHole         )               , pointer :: blackHole
+    class           (nodeComponentSpheroid          )               , pointer :: spheroid
+    class           (nodeComponentHotHalo           )               , pointer :: hotHalo
+    integer                                                                   :: countBlackHole       , indexBlackHole
+    double precision                                                          :: rateAccretionSpheroid, rateAccretionHotHalo, &
+         &                                                                       efficiencyRadiative  , efficiencyJet       , &
+         &                                                                       rateAccretion        , rateSpinUp
+    !$GLC attributes unused :: interrupt, functionInterrupt, propertyType
+
+    ! If there are no black holes in this node, we have nothing to do - return immediately.
+    countBlackHole=node%blackHoleCount()
+    if (countBlackHole < 1) return
+    ! Get spheroid and hot halo components so that accreted mass can be removed from them.
+    spheroid => node%spheroid()
+    hotHalo  => node%hotHalo ()
+    ! Iterate over all black holes in the node.
+    do indexBlackHole=1,countBlackHole
+       ! Find the accretion rate onto this black hole.
+       blackHole => node%blackHole(instance=indexBlackHole)
+       call self%blackHoleAccretionRate_%rateAccretion(blackHole,rateAccretionSpheroid,rateAccretionHotHalo)
+       rateAccretion=+rateAccretionSpheroid &
+            &        +rateAccretionHotHalo
+       ! Find the radiative and jet efficiencies - these will be subtracted from the black hole mass growth rate.
+       if (rateAccretion > 0.0d0) then
+          efficiencyRadiative=+self%accretionDisks_%efficiencyRadiative(blackHole,rateAccretion)
+          efficiencyJet      =+self%accretionDisks_%powerJet           (blackHole,rateAccretion) &
+               &              /                                                   rateAccretion  &
+               &              /                     speedLight**2/kilo**2
+       else
+          efficiencyRadiative=+0.0d0
+          efficiencyJet      =+0.0d0
+       end if
+       ! Find the spin-up rate for this black hole.
+       rateSpinUp         =+self%accretionDisks_%rateSpinUp         (blackHole,rateAccretion)
+       ! Accumulate rates of mass accretion/loss to the relevant components.
+       call blackHole%       massRate(+rateAccretion        *(1.0d0-efficiencyRadiative-efficiencyJet)                            )
+       call spheroid %massGasSinkRate(-rateAccretionSpheroid                                                                      )
+       call hotHalo  %   massSinkRate(-rateAccretionHotHalo                                           ,interrupt,functionInterrupt)
+       ! Set spin-up rate due to accretion.
+       call blackHole%       spinRate(+rateSpinUp                                                                                 )
+     end do
+    return
+  end subroutine blackHolesAccretionDifferentialEvolution
+  

--- a/source/nodes.operators.physics.black_holes.winds.F90
+++ b/source/nodes.operators.physics.black_holes.winds.F90
@@ -1,0 +1,132 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a node operator class that implements winds driven by accretion onto black holes.
+  !!}
+
+  use :: Black_Hole_Winds, only : blackHoleWindClass
+
+  !![
+  <nodeOperator name="nodeOperatorBlackHolesWinds">
+   <description>A node operator class that implements winds driven by accretion onto black holes.</description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorBlackHolesWinds
+     !!{
+     A node operator class that implements winds driven by accretion onto black holes.
+     !!}
+     private
+     class(blackHoleWindClass), pointer :: blackHoleWind_ => null()
+   contains
+     final     ::                          blackHolesWindsDestructor
+     procedure :: differentialEvolution => blackHolesWindsDifferentialEvolution
+  end type nodeOperatorBlackHolesWinds
+  
+  interface nodeOperatorBlackHolesWinds
+     !!{
+     Constructors for the {\normalfont \ttfamily blackHolesWinds} node operator class.
+     !!}
+     module procedure blackHolesWindsConstructorParameters
+     module procedure blackHolesWindsConstructorInternal
+  end interface nodeOperatorBlackHolesWinds
+  
+contains
+
+  function blackHolesWindsConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily starFormation} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type (nodeOperatorBlackHolesWinds)                :: self
+    type (inputParameters            ), intent(inout) :: parameters
+    class(blackHoleWindClass         ), pointer       :: blackHoleWind_
+    
+    !![
+    <objectBuilder class="blackHoleWind" name="blackHoleWind_" source="parameters"/>
+    !!]
+    self=nodeOperatorBlackHolesWinds(blackHoleWind_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="blackHoleWind_"/>
+    !!]
+    return
+  end function blackHolesWindsConstructorParameters
+
+  function blackHolesWindsConstructorInternal(blackHoleWind_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily blackHolesWinds} node operator class.
+    !!}
+    implicit none
+    type (nodeOperatorBlackHolesWinds)                        :: self
+    class(blackHoleWindClass         ), intent(in   ), target :: blackHoleWind_
+    !![
+    <constructorAssign variables="*blackHoleWind_"/>
+    !!]
+    
+    return
+  end function blackHolesWindsConstructorInternal
+
+  subroutine blackHolesWindsDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily blackHolesWinds} node operator class.
+    !!}
+    implicit none
+    type(nodeOperatorBlackHolesWinds), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%blackHoleWind_"/>
+    !!]
+    return
+  end subroutine blackHolesWindsDestructor
+
+  subroutine blackHolesWindsDifferentialEvolution(self,node,interrupt,functionInterrupt,propertyType)
+    !!{
+    Account for winds driven by accretion onto black holes.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentBlackHole, nodeComponentSpheroid
+    implicit none
+    class           (nodeOperatorBlackHolesWinds), intent(inout), target  :: self
+    type            (treeNode                   ), intent(inout), target  :: node
+    logical                                      , intent(inout)          :: interrupt
+    procedure       (interruptTask              ), intent(inout), pointer :: functionInterrupt
+    integer                                      , intent(in   )          :: propertyType
+    class           (nodeComponentBlackHole     )               , pointer :: blackHole
+    class           (nodeComponentSpheroid      )               , pointer :: spheroid
+    integer                                                               :: countBlackHole   , indexBlackHole
+    double precision                                                      :: powerWind
+    !$GLC attributes unused :: interrupt, functionInterrupt, propertyType
+
+    ! If there are no black holes in this node, we have nothing to do - return immediately.
+    countBlackHole=node%blackHoleCount()
+    if (countBlackHole < 1) return
+    ! Get the spheroid halo component so that wind energy can be injected into it.
+    spheroid => node%spheroid()
+    ! Iterate over all black holes in the node.
+    do indexBlackHole=1,countBlackHole
+       ! Find the wind power from this black hole.
+       blackHole => node%blackHole           (instance=indexBlackHole)
+       powerWind =  self%blackHoleWind_%power(              blackHole)
+       ! Inject this energy into the spheroid.
+       call spheroid%energyGasInputRate(+powerWind)
+    end do
+    return
+  end subroutine blackHolesWindsDifferentialEvolution
+  

--- a/source/objects.nodes.components.black_hole.standard.F90
+++ b/source/objects.nodes.components.black_hole.standard.F90
@@ -25,20 +25,18 @@ module Node_Component_Black_Hole_Standard
   !!{
   Implement black hole tree node methods.
   !!}
-  use :: Accretion_Disks                     , only : accretionDisksClass
   use :: Black_Hole_Binary_Initial_Separation, only : blackHoleBinaryInitialSeparationClass
   use :: Black_Hole_Binary_Mergers           , only : blackHoleBinaryMergerClass
   use :: Black_Hole_Binary_Recoil_Velocities , only : blackHoleBinaryRecoilClass
-  use :: Black_Hole_Accretion_Rates          , only : blackHoleAccretionRateClass
   use :: Black_Hole_Seeds                    , only : blackHoleSeedsClass
   use :: Cosmology_Parameters                , only : cosmologyParametersClass
   use :: Dark_Matter_Halo_Scales             , only : darkMatterHaloScaleClass
   implicit none
   private
-  public :: Node_Component_Black_Hole_Standard_Rate_Compute       , Node_Component_Black_Hole_Standard_Scale_Set    , &
-       &    Node_Component_Black_Hole_Standard_Thread_Uninitialize, Node_Component_Black_Hole_Standard_Post_Evolve  , &
+  public :: Node_Component_Black_Hole_Standard_Thread_Uninitialize, Node_Component_Black_Hole_Standard_Post_Evolve  , &
        &    Node_Component_Black_Hole_Standard_Thread_Initialize  , Node_Component_Black_Hole_Standard_Initialize   , &
-       &    Node_Component_Black_Hole_Standard_State_Store        , Node_Component_Black_Hole_Standard_State_Restore
+       &    Node_Component_Black_Hole_Standard_State_Store        , Node_Component_Black_Hole_Standard_State_Restore, &
+       &    Node_Component_Black_Hole_Standard_Scale_Set  
 
   !![
   <component>
@@ -74,18 +72,6 @@ module Node_Component_Black_Hole_Standard
       <rank>0</rank>
       <attributes isSettable="true" isGettable="true" isEvolvable="false" />
     </property>
-    <property>
-      <name>accretionRate</name>
-      <attributes isSettable="false" isGettable="true" isEvolvable="false" isDeferred="get" isVirtual="true" />
-      <type>double</type>
-      <rank>0</rank>
-    </property>
-    <property>
-      <name>radiativeEfficiency</name>
-      <attributes isSettable="false" isGettable="true" isEvolvable="false" isDeferred="get" isVirtual="true" />
-      <type>double</type>
-      <rank>0</rank>
-    </property>
    </properties>
    <bindings>
     <binding method="massDistribution" function="Node_Component_Black_Hole_Standard_Mass_Distribution" bindsTo="component"/>
@@ -96,26 +82,12 @@ module Node_Component_Black_Hole_Standard
   !!]
 
   ! Objects used by this component.
-  class(accretionDisksClass                  ), pointer :: accretionDisks_
   class(blackHoleBinaryRecoilClass           ), pointer :: blackHoleBinaryRecoil_
-  class(blackHoleAccretionRateClass          ), pointer :: blackHoleAccretionRate_
   class(blackHoleBinaryInitialSeparationClass), pointer :: blackHoleBinaryInitialSeparation_
   class(blackHoleBinaryMergerClass           ), pointer :: blackHoleBinaryMerger_
   class(blackHoleSeedsClass                  ), pointer :: blackHoleSeeds_
   class(darkMatterHaloScaleClass             ), pointer :: darkMatterHaloScale_
-  !$omp threadprivate(accretionDisks_,blackHoleAccretionRate_,blackHoleBinaryRecoil_,blackHoleBinaryInitialSeparation_,blackHoleBinaryMerger_,blackHoleSeeds_,darkMatterHaloScale_)
-
-  ! Accretion model parameters.
-  ! Enhancement factors for the accretion rate.
-  double precision :: bondiHoyleAccretionEnhancementHotHalo , bondiHoyleAccretionEnhancementSpheroid
-  ! Temperature of accreting gas.
-  double precision :: bondiHoyleAccretionTemperatureSpheroid
-  ! Control for hot mode only accretion.
-  logical          :: bondiHoyleAccretionHotModeOnly
-
-  ! Feedback parameters.
-  double precision :: efficiencyWind                        , efficiencyRadioMode
-  logical          :: heatsHotHalo                          , efficiencyWindScalesWithEfficiencyRadiative
+  !$omp threadprivate(blackHoleBinaryRecoil_,blackHoleBinaryInitialSeparation_,blackHoleBinaryMerger_,blackHoleSeeds_,darkMatterHaloScale_)
 
   ! Output options.
   logical          :: outputMergers
@@ -142,74 +114,10 @@ contains
     use :: Input_Parameters, only : inputParameter         , inputParameters
     implicit none
     type(inputParameters               ), intent(inout) :: parameters
-    type(nodeComponentBlackHoleStandard)                :: blackHoleStandardComponent
     type(inputParameters               )                :: subParameters
 
     ! Find our parameters.
     subParameters=parameters%subParameters('componentBlackHole')
-    ! Get accretion rate enhancement factors.
-    !![
-    <inputParameter>
-      <name>bondiHoyleAccretionEnhancementSpheroid</name>
-      <defaultValue>5.0d0</defaultValue>
-      <description>The factor by which the Bondi-Hoyle accretion rate of spheroid gas onto black holes in enhanced.</description>
-      <source>subParameters</source>
-    </inputParameter>
-    <inputParameter>
-      <name>bondiHoyleAccretionEnhancementHotHalo</name>
-      <defaultValue>6.0d0</defaultValue>
-      <description>The factor by which the Bondi-Hoyle accretion rate of hot halo gas onto black holes in enhanced.</description>
-      <source>subParameters</source>
-    </inputParameter>
-    <inputParameter>
-      <name>bondiHoyleAccretionHotModeOnly</name>
-      <defaultValue>.true.</defaultValue>
-      <description>Determines whether accretion from the hot halo should only occur if the halo is in the hot accretion mode.</description>
-      <source>subParameters</source>
-    </inputParameter>
-    !!]
-
-    ! Get temperature of accreting gas.
-    !![
-    <inputParameter>
-      <name>bondiHoyleAccretionTemperatureSpheroid</name>
-      <defaultValue>1.0d2</defaultValue>
-      <description>The assumed temperature (in Kelvin) of gas in the spheroid when computing Bondi-Hoyle accretion rates onto black holes.</description>
-      <source>subParameters</source>
-    </inputParameter>
-    !!]
-
-    ! Get wind efficiency and scaling.
-    !![
-    <inputParameter>
-      <name>efficiencyWind</name>
-      <defaultValue>2.4d-3</defaultValue>
-      <description>The efficiency of the black hole-driven wind: $L_\mathrm{wind} = \epsilon_\mathrm{wind} \dot{M}_\bullet \clight^2$.</description>
-      <source>subParameters</source>
-    </inputParameter>
-    <inputParameter>
-      <name>efficiencyWindScalesWithEfficiencyRadiative</name>
-      <defaultValue>.false.</defaultValue>
-      <description>Specifies whether the black hole wind efficiency should scale with the radiative efficiency of the accretion disk.</description>
-      <source>subParameters</source>
-    </inputParameter>
-    !!]
-
-    ! Options controlling AGN feedback.
-    !![
-    <inputParameter>
-      <name>heatsHotHalo</name>
-      <defaultValue>.true.</defaultValue>
-      <description>Specifies whether or not the black hole launched jets should heat the hot halo.</description>
-      <source>subParameters</source>
-    </inputParameter>
-    <inputParameter>
-      <name>efficiencyRadioMode</name>
-      <defaultValue>1.0d0</defaultValue>
-      <description>Efficiency with which radio-mode feedback is coupled to the hot halo.</description>
-      <source>subParameters</source>
-    </inputParameter>
-    !!]
 
     ! Get options controlling output.
     !![
@@ -223,9 +131,6 @@ contains
 
     ! Check if cold mode is explicitly tracked.
     coldModeTracked=defaultHotHaloComponent%massColdIsGettable()
-    ! Bind deferred functions.
-    call blackHoleStandardComponent%      accretionRateFunction(Node_Component_Black_Hole_Standard_Accretion_Rate      )
-    call blackHoleStandardComponent%radiativeEfficiencyFunction(Node_Component_Black_Hole_Standard_Radiative_Efficiency)
     return
   end subroutine Node_Component_Black_Hole_Standard_Initialize
 
@@ -252,8 +157,6 @@ contains
        ! Find our parameters.
        subParameters=parameters%subParameters('componentBlackHole')
        !![
-       <objectBuilder class="accretionDisks"                   name="accretionDisks_"                   source="subParameters"/>
-       <objectBuilder class="blackHoleAccretionRate"           name="blackHoleAccretionRate_"           source="subParameters"/>
        <objectBuilder class="blackHoleSeeds"                   name="blackHoleSeeds_"                   source="subParameters"/>
        <objectBuilder class="blackHoleBinaryRecoil"            name="blackHoleBinaryRecoil_"            source="subParameters"/>
        <objectBuilder class="blackHoleBinaryInitialSeparation" name="blackHoleBinaryInitialSeparation_" source="subParameters"/>
@@ -280,8 +183,6 @@ contains
     if (defaultBlackHoleComponent%standardIsActive()) then
        if (satelliteMergerEvent%isAttached(thread,satelliteMerger)) call satelliteMergerEvent%detach(thread,satelliteMerger)
        !![
-       <objectDestructor name="accretionDisks_"                  />
-       <objectDestructor name="blackHoleAccretionRate_"          />
        <objectDestructor name="blackHoleSeeds_"                  />
        <objectDestructor name="blackHoleBinaryRecoil_"           />
        <objectDestructor name="blackHoleBinaryInitialSeparation_"/>
@@ -291,131 +192,6 @@ contains
     end if
     return
   end subroutine Node_Component_Black_Hole_Standard_Thread_Uninitialize
-
-  !![
-  <rateComputeTask>
-   <unitName>Node_Component_Black_Hole_Standard_Rate_Compute</unitName>
-  </rateComputeTask>
-  !!]
-  subroutine Node_Component_Black_Hole_Standard_Rate_Compute(node,interrupt,interruptProcedure,propertyType)
-    !!{
-    Compute the black hole node mass rate of change.
-    !!}
-    use :: Error                           , only : Error_Report
-    use :: Galacticus_Nodes                , only : defaultBlackHoleComponent, interruptTask        , nodeComponentBasic, nodeComponentBlackHole, &
-          &                                         nodeComponentHotHalo     , nodeComponentSpheroid, propertyInactive  , treeNode
-    use :: Numerical_Constants_Astronomical, only : gigaYear                 , megaParsec
-    use :: Numerical_Constants_Atomic      , only : massHydrogenAtom
-    use :: Numerical_Constants_Math        , only : Pi
-    use :: Numerical_Constants_Physical    , only : boltzmannsConstant       , speedLight
-    use :: Numerical_Constants_Prefixes    , only : kilo
-    implicit none
-    type            (treeNode              ), intent(inout)            :: node
-    logical                                 , intent(inout)            :: interrupt
-    procedure       (interruptTask         ), intent(inout), pointer   :: interruptProcedure
-    integer                                 , intent(in   )            :: propertyType
-    class           (nodeComponentBlackHole)               , pointer   :: blackHoleCentral                                                                                                                                   , blackHole
-    class           (nodeComponentSpheroid )               , pointer   :: spheroid
-    class           (nodeComponentHotHalo  )               , pointer   :: hotHalo
-    class           (nodeComponentBasic    )               , pointer   :: basic
-    double precision                                       , parameter :: windVelocity                =1.0d4                                                                                                                                                     !    Velocity of disk wind.
-    double precision                                       , parameter :: ismTemperature              =1.0d4                                                                                                                                                     !    Temperature of the ISM.
-    double precision                                       , parameter :: criticalDensityNormalization=2.0d0*massHydrogenAtom*speedLight**2*megaParsec/3.0d0/Pi/boltzmannsConstant/gigaYear/ismTemperature/kilo/windVelocity
-    integer                                                            :: iInstance                                                                                                                                          , instanceCount
-    double precision                                                   :: accretionRateHotHalo                                                                                                                               , accretionRateSpheroid                                          , &
-         &                                                                criticalDensityRadius2                                                                                                                            , energyInputRate                                                , &
-         &                                                                heatingRate                                                                                                                                       , jetEfficiency                                                  , &
-         &                                                                massAccretionRate                                                                                                                                 , radiativeEfficiency                                            , &
-         &                                                                restMassAccretionRate                                                                                                                             , spheroidDensityOverCriticalDensity                             , &
-         &                                                                spheroidDensityRadius2                                                                                                                            , massGasSpheroid                                                , &
-         &                                                                radiusSpheroid                                                                                                                                    , windEfficiencyNet                                              , &
-         &                                                                windFraction
-
-    ! Return immediately if inactive variables are requested.
-    if (propertyInactive(propertyType)) return
-    if (defaultBlackHoleComponent%standardIsActive()) then
-       ! Get a count of the number of black holes associated with this node.
-       instanceCount=node%blackHoleCount()
-       ! Get the central black hole.
-       blackHoleCentral => node%blackHole(instance=1)
-       ! Get the basic, spheroid, and hot halo components.
-       basic    => node%basic   ()
-       spheroid => node%spheroid()
-       hotHalo  => node%hotHalo ()
-       ! Iterate over instances.
-       do iInstance=1,max(instanceCount,1)
-          ! Get the black hole.
-          blackHole => node%blackHole(instance=iInstance)
-          ! Find the rate of rest mass accretion onto the black hole.
-          call blackHoleAccretionRate_%rateAccretion(blackHole,accretionRateSpheroid,accretionRateHotHalo)
-          restMassAccretionRate=accretionRateSpheroid+accretionRateHotHalo
-          ! Finish if there is no accretion.
-          if (restMassAccretionRate <= 0.0d0) cycle
-          ! Find the radiative efficiency of the accretion.
-          radiativeEfficiency=accretionDisks_%efficiencyRadiative(blackHole,restMassAccretionRate)
-          ! Find the jet efficiency.
-          if (restMassAccretionRate > 0.0d0) then
-             jetEfficiency=accretionDisks_%powerJet(blackHole,restMassAccretionRate)/restMassAccretionRate/(speedLight&
-                  &/kilo)**2
-          else
-             jetEfficiency=0.0d0
-          end if
-          ! Find the rate of increase in mass of the black hole.
-          massAccretionRate=restMassAccretionRate*(1.0d0-radiativeEfficiency-jetEfficiency)
-          ! If no black hole component currently exists and we have some accretion then this is an error - we can not have
-          ! accretion onto a non-existent black hole.
-          if (instanceCount == 0 .and. massAccretionRate /= 0.0d0) call Error_Report('accretion onto non-existent black hole'//{introspection:location})
-          ! Skip to the next black hole if this one has non-positive mass and a negative accretion rate.
-          if (blackHole%mass() <= 0.0d0 .and. massAccretionRate < 0.0d0) cycle
-          ! Add the accretion to the black hole.
-          call blackHole%massRate       ( massAccretionRate                                 )
-          ! Remove the accreted mass from the spheroid component.
-          call spheroid %massGasSinkRate(-accretionRateSpheroid                             )
-          ! Remove the accreted mass from the hot halo component.
-          call hotHalo  %   massSinkRate(-accretionRateHotHalo ,interrupt,interruptProcedure)
-          ! Set spin-up rate due to accretion.
-          if (restMassAccretionRate > 0.0d0) call blackHole%spinRate(accretionDisks_%rateSpinUp(blackHole,restMassAccretionRate))
-          ! Add heating to the hot halo component.
-          if (heatsHotHalo) then
-             ! Get jet power.
-             heatingRate=efficiencyRadioMode*jetEfficiency*restMassAccretionRate*(speedLight/kilo)**2
-             ! Pipe this power to the hot halo.
-             call hotHalo%heatSourceRate(heatingRate,interrupt,interruptProcedure)
-          end if
-          ! Add energy to the spheroid component.
-          if (efficiencyWind > 0.0d0) then
-             massGasSpheroid=spheroid%massGas()
-             if (massGasSpheroid > 0.0d0) then
-                radiusSpheroid=spheroid%radius()
-                if (radiusSpheroid > 0.0d0) then
-                   spheroidDensityRadius2=3.0d0*massGasSpheroid/4.0d0/Pi/radiusSpheroid
-                   criticalDensityRadius2=criticalDensityNormalization*efficiencyWind*restMassAccretionRate
-                   ! Construct an interpolating factor such that the energy input from the wind drops to zero below half of the
-                   ! critical density.
-                   spheroidDensityOverCriticalDensity=spheroidDensityRadius2/criticalDensityRadius2-0.5d0
-                   if (spheroidDensityOverCriticalDensity <= 0.0d0) then
-                      ! No energy input below half of critical density.
-                      windFraction=0.0d0
-                   else if (spheroidDensityOverCriticalDensity >= 1.0d0) then
-                      ! Full energy input above 1.5 times critical density.
-                      windFraction=1.0d0
-                   else
-                      ! Smooth polynomial interpolating function between these limits.
-                      windFraction=3.0d0*spheroidDensityOverCriticalDensity**2-2.0d0*spheroidDensityOverCriticalDensity**3
-                   end if
-                   ! Include scaling with radiative efficiency if requested,
-                   windEfficiencyNet=windFraction*efficiencyWind
-                   if (efficiencyWindScalesWithEfficiencyRadiative) windEfficiencyNet=windEfficiencyNet*radiativeEfficiency
-                   ! Compute the energy input and send it down the spheroid gas energy input pipe.
-                   energyInputRate=windEfficiencyNet*restMassAccretionRate*(speedLight/kilo)**2
-                   call spheroid%energyGasInputRate(energyInputRate)
-                end if
-             end if
-          end if
-       end do
-    end if
-    return
-  end subroutine Node_Component_Black_Hole_Standard_Rate_Compute
 
   !![
   <scaleSetTask>
@@ -638,32 +414,6 @@ contains
     return
   end subroutine Node_Component_Black_Hole_Standard_Output_Merger
 
-  double precision function Node_Component_Black_Hole_Standard_Accretion_Rate(self)
-    !!{
-    Return the rest mass accretion rate onto a standard black hole.
-    !!}
-    use :: Galacticus_Nodes, only : nodeComponentBlackHoleStandard
-    implicit none
-    class           (nodeComponentBlackHoleStandard), intent(inout) :: self
-    double precision                                                :: accretionRateSpheroid, accretionRateHotHalo
-    
-    call blackHoleAccretionRate_%rateAccretion(self,accretionRateSpheroid,accretionRateHotHalo)
-    Node_Component_Black_Hole_Standard_Accretion_Rate=accretionRateSpheroid+accretionRateHotHalo
-    return
-  end function Node_Component_Black_Hole_Standard_Accretion_Rate
-
-  double precision function Node_Component_Black_Hole_Standard_Radiative_Efficiency(self)
-    !!{
-    Return the radiative efficiency of a standard black hole.
-    !!}
-    use :: Galacticus_Nodes, only : nodeComponentBlackHoleStandard
-    implicit none
-    class(nodeComponentBlackHoleStandard), intent(inout) :: self
-
-    Node_Component_Black_Hole_Standard_Radiative_Efficiency=accretionDisks_%efficiencyRadiative(self,self%accretionRate())
-    return
-  end function Node_Component_Black_Hole_Standard_Radiative_Efficiency
-
   !![
   <postStepTask>
     <unitName>Node_Component_Black_Hole_Standard_Post_Evolve</unitName>
@@ -731,7 +481,7 @@ contains
 
     call displayMessage('Storing state for: componentBlackHole -> standard',verbosity=verbosityLevelInfo)
     !![
-    <stateStore variables="accretionDisks_ blackHoleBinaryRecoil_ blackHoleBinaryInitialSeparation_ blackHoleBinaryMerger_ blackHoleSeeds_ blackHoleAccretionRate_ darkMatterHaloScale_"/>
+    <stateStore variables="blackHoleBinaryRecoil_ blackHoleBinaryInitialSeparation_ blackHoleBinaryMerger_ blackHoleSeeds_ darkMatterHaloScale_"/>
     !!]
     return
   end subroutine Node_Component_Black_Hole_Standard_State_Store
@@ -754,7 +504,7 @@ contains
 
     call displayMessage('Retrieving state for: componentBlackHole -> standard',verbosity=verbosityLevelInfo)
     !![
-    <stateRestore variables="accretionDisks_ blackHoleBinaryRecoil_ blackHoleBinaryInitialSeparation_ blackHoleBinaryMerger_ blackHoleSeeds_ blackHoleAccretionRate_ darkMatterHaloScale_"/>
+    <stateRestore variables="blackHoleBinaryRecoil_ blackHoleBinaryInitialSeparation_ blackHoleBinaryMerger_ blackHoleSeeds_ darkMatterHaloScale_"/>
     !!]
     return
   end subroutine Node_Component_Black_Hole_Standard_State_Restore

--- a/source/radiation.intergalactic_background.internal.F90
+++ b/source/radiation.intergalactic_background.internal.F90
@@ -21,7 +21,6 @@
   Implements a class for intergalactic background light which computes the background internally.
   !!}
 
-  use :: Accretion_Disk_Spectra                , only : accretionDiskSpectraClass
   use :: Atomic_Cross_Sections_Ionization_Photo, only : atomicCrossSectionIonizationPhotoClass
   use :: Cosmology_Functions                   , only : cosmologyFunctionsClass
   use :: Cosmology_Parameters                  , only : cosmologyParametersClass
@@ -36,6 +35,12 @@
   !![
   <radiationField name="radiationFieldIntergalacticBackgroundInternal">
    <description>A radiation field class for intergalactic background light with properties computed internally.</description>
+   <stateStore>
+     <stateStore variables="accretionDiskSpectra_" store="accretionDiskSpectraStateStore_" restore="accretionDiskSpectraStateRestore_" module="Functions_Global"/>
+   </stateStore>
+   <deepCopy>
+     <ignore variables="accretionDiskSpectra_"/>
+   </deepCopy>
   </radiationField>
   !!]
   type, extends(radiationFieldIntergalacticBackground) :: radiationFieldIntergalacticBackgroundInternal
@@ -47,7 +52,7 @@
      class           (cosmologyFunctionsClass               ), pointer                     :: cosmologyFunctions_                => null()
      class           (intergalacticMediumStateClass         ), pointer                     :: intergalacticMediumState_          => null()
      class           (atomicCrossSectionIonizationPhotoClass), pointer                     :: atomicCrossSectionIonizationPhoto_ => null()
-     class           (accretionDiskSpectraClass             ), pointer                     :: accretionDiskSpectra_              => null()
+     class           (*                                     ), pointer                     :: accretionDiskSpectra_              => null()
      class           (starFormationRateDisksClass           ), pointer                     :: starFormationRateDisks_            => null()
      class           (starFormationRateSpheroidsClass       ), pointer                     :: starFormationRateSpheroids_        => null()
      class           (stellarPopulationSelectorClass        ), pointer                     :: stellarPopulationSelector_         => null()
@@ -79,6 +84,9 @@
      procedure :: timeSet           => intergalacticBackgroundInternalTimeSet
      procedure :: timeDependentOnly => intergalacticBackgroundInternalTimeDependentOnly
      procedure :: autoHook          => intergalacticBackgroundInternalAutoHook
+     procedure :: deepCopy          => intergalacticBackgroundInternalDeepCopy
+     procedure :: deepCopyReset     => intergalacticBackgroundInternalDeepCopyReset
+     procedure :: deepCopyFinalize  => intergalacticBackgroundInternalDeepCopyFinalize
   end type radiationFieldIntergalacticBackgroundInternal
 
   interface radiationFieldIntergalacticBackgroundInternal
@@ -108,7 +116,8 @@ contains
     !!{
     Constructor for the {\normalfont \ttfamily intergalacticBackgroundInternal} radiation field class which takes a parameter list as input.
     !!}
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters, only : inputParameter                , inputParameters
+    use :: Functions_Global, only : accretionDiskSpectraConstruct_, accretionDiskSpectraDestruct_
     implicit none
     type            (radiationFieldIntergalacticBackgroundInternal)                :: self
     type            (inputParameters                              ), intent(inout) :: parameters
@@ -116,7 +125,7 @@ contains
     class           (cosmologyFunctionsClass                      ), pointer       :: cosmologyFunctions_
     class           (intergalacticMediumStateClass                ), pointer       :: intergalacticMediumState_
     class           (atomicCrossSectionIonizationPhotoClass       ), pointer       :: atomicCrossSectionIonizationPhoto_
-    class           (accretionDiskSpectraClass                    ), pointer       :: accretionDiskSpectra_
+    class           (*                                            ), pointer       :: accretionDiskSpectra_
     class           (starFormationRateDisksClass                  ), pointer       :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass              ), pointer       :: starFormationRateSpheroids_
     class           (stellarPopulationSelectorClass               ), pointer       :: stellarPopulationSelector_
@@ -166,25 +175,25 @@ contains
     <objectBuilder class="cosmologyFunctions"                name="cosmologyFunctions_"                source="parameters"/>
     <objectBuilder class="intergalacticMediumState"          name="intergalacticMediumState_"          source="parameters"/>
     <objectBuilder class="atomicCrossSectionIonizationPhoto" name="atomicCrossSectionIonizationPhoto_" source="parameters"/>
-    <objectBuilder class="accretionDiskSpectra"              name="accretionDiskSpectra_"              source="parameters"/>
     <objectBuilder class="starFormationRateDisks"            name="starFormationRateDisks_"            source="parameters"/>
     <objectBuilder class="starFormationRateSpheroids"        name="starFormationRateSpheroids_"        source="parameters"/>
     <objectBuilder class="stellarPopulationSelector"         name="stellarPopulationSelector_"         source="parameters"/>
     <objectBuilder class="outputTimes"                       name="outputTimes_"                       source="parameters"/>
     !!]
+    call accretionDiskSpectraConstruct_(parameters,accretionDiskSpectra_)
     self=radiationFieldIntergalacticBackgroundInternal(wavelengthMinimum,wavelengthMaximum,wavelengthCountPerDecade,redshiftMinimum,redshiftMaximum,timeCountPerDecade,cosmologyParameters_,cosmologyFunctions_,intergalacticMediumState_,atomicCrossSectionIonizationPhoto_,accretionDiskSpectra_,starFormationRateDisks_,starFormationRateSpheroids_,stellarPopulationSelector_,outputTimes_)
     !![
-    <inputParametersValidate source="parameters"/>
+    <inputParametersValidate source="parameters" extraAllowedNames="accretionDiskSpectra"/>
     <objectDestructor name="cosmologyParameters_"              />
     <objectDestructor name="cosmologyFunctions_"               />
     <objectDestructor name="intergalacticMediumState_"         />
     <objectDestructor name="atomicCrossSectionIonizationPhoto_"/>
-    <objectDestructor name="accretionDiskSpectra_"             />
     <objectDestructor name="starFormationRateDisks_"           />
     <objectDestructor name="starFormationRateSpheroids_"       />
     <objectDestructor name="stellarPopulationSelector_"        />
     <objectDestructor name="outputTimes_"                      />
     !!]
+    if (associated(accretionDiskSpectra_)) call accretionDiskSpectraDestruct_(accretionDiskSpectra_)
     return
   end function intergalacticBackgroundInternalConstructorParameters
 
@@ -203,7 +212,7 @@ contains
     class           (cosmologyFunctionsClass                      ), intent(in   ), target :: cosmologyFunctions_
     class           (intergalacticMediumStateClass                ), intent(in   ), target :: intergalacticMediumState_
     class           (atomicCrossSectionIonizationPhotoClass       ), intent(in   ), target :: atomicCrossSectionIonizationPhoto_
-    class           (accretionDiskSpectraClass                    ), intent(in   ), target :: accretionDiskSpectra_
+    class           (*                                            ), intent(in   ), target :: accretionDiskSpectra_
     class           (starFormationRateDisksClass                  ), intent(in   ), target :: starFormationRateDisks_
     class           (starFormationRateSpheroidsClass              ), intent(in   ), target :: starFormationRateSpheroids_
     class           (stellarPopulationSelectorClass               ), intent(in   ), target :: stellarPopulationSelector_
@@ -306,7 +315,8 @@ contains
     !!{
     Destructor for the {\normalfont \ttfamily intergalacticBackgroundInternal} radiation field class.
     !!}
-    use :: Events_Hooks, only : universePreEvolveEventGlobal
+    use :: Events_Hooks    , only : universePreEvolveEventGlobal
+    use :: Functions_Global, only : accretionDiskSpectraDestruct_
     implicit none
     type(radiationFieldIntergalacticBackgroundInternal), intent(inout) :: self
 
@@ -315,12 +325,12 @@ contains
     <objectDestructor name="self%cosmologyFunctions_"               />
     <objectDestructor name="self%intergalacticMediumState_"         />
     <objectDestructor name="self%atomicCrossSectionIonizationPhoto_"/>
-    <objectDestructor name="self%accretionDiskSpectra_"             />
     <objectDestructor name="self%starFormationRateDisks_"           />
     <objectDestructor name="self%starFormationRateSpheroids_"       />
     <objectDestructor name="self%stellarPopulationSelector_"        />
     <objectDestructor name="self%outputTimes_"                      />
     !!]
+    if (associated(self%accretionDiskSpectra_)) call accretionDiskSpectraDestruct_(self%accretionDiskSpectra_)
     !$omp master
     if (universePreEvolveEventGlobal%isAttached(self,intergalacticBackgroundInternalUniversePreEvolve)) call universePreEvolveEventGlobal%detach(self,intergalacticBackgroundInternalUniversePreEvolve)
     !$omp end master
@@ -458,13 +468,14 @@ contains
     !!{
     Update the radiation background for a given universe.
     !!}
-    use            :: Abundances_Structure        , only : abundances                   , max
+    use            :: Abundances_Structure        , only : abundances                       , max
     use            :: Arrays_Search               , only : searchArrayClosest
-    use            :: Display                     , only : displayIndent                , displayMessage          , displayUnindent
+    use            :: Display                     , only : displayIndent                    , displayMessage          , displayUnindent
     use            :: Error                       , only : Error_Report
+    use            :: Functions_Global            , only : accretionDiskSpectraSpectrumNode_
     use            :: Output_HDF5                 , only : outputFile
-    use            :: Galacticus_Nodes            , only : defaultDiskComponent         , defaultSpheroidComponent, mergerTreeList , nodeComponentBasic, &
-          &                                                nodeComponentDisk            , nodeComponentSpheroid   , treeNode       , universe          , &
+    use            :: Galacticus_Nodes            , only : defaultDiskComponent             , defaultSpheroidComponent, mergerTreeList , nodeComponentBasic, &
+          &                                                nodeComponentDisk                , nodeComponentSpheroid   , treeNode       , universe          , &
           &                                                universeEvent
     use            :: HDF5_Access                 , only : hdf5Access
     use            :: IO_HDF5                     , only : hdf5Object
@@ -472,9 +483,9 @@ contains
     use            :: ISO_Varying_String          , only : varying_string
     use            :: Merger_Tree_Walkers         , only : mergerTreeWalkerAllNodes
     use            :: Numerical_Constants_Math    , only : Pi
-    use            :: Numerical_Constants_Physical, only : plancksConstant              , speedLight
+    use            :: Numerical_Constants_Physical, only : plancksConstant                  , speedLight
     use            :: Numerical_Constants_Prefixes, only : centi
-    use            :: Numerical_Constants_Units   , only : angstromsPerMeter            , ergs
+    use            :: Numerical_Constants_Units   , only : angstromsPerMeter                , ergs
     use            :: Numerical_Integration       , only : integrator
     use            :: Numerical_ODE_Solvers       , only : odeSolver
     use            :: Stellar_Population_Spectra  , only : stellarPopulationSpectraClass
@@ -582,10 +593,10 @@ contains
                               &   )                                  &
                               &  *node%hostTree%volumeWeight
                          ! Add AGN emission. This accumulates only to the the current time.
-                         if (firstTime)                                                                                               &
-                              & self%emissivity  (iWavelength,iTime)=+self%emissivity                        (iWavelength,iTime     ) &
-                              &                                      +self%accretionDiskSpectra_%spectrum    (node       ,wavelength) &
-                              &                                      *node%hostTree             %volumeWeight
+                         if (firstTime)                                                                                                                                  &
+                              & self%emissivity  (iWavelength,iTime)=+self         %emissivity                       (                                iWavelength,iTime) &
+                              &                                      +              accretionDiskSpectraSpectrumNode_(self%accretionDiskSpectra_,node, wavelength      ) &
+                              &                                      *node%hostTree%volumeWeight
                       end do
                       firstTime=.false.
                    end do
@@ -807,3 +818,71 @@ contains
     intergalacticBackgroundInternalTimeDependentOnly=.false.
     return
   end function intergalacticBackgroundInternalTimeDependentOnly
+
+  subroutine intergalacticBackgroundInternalDeepCopyReset(self)
+    !!{
+    Perform a deep copy reset of the object.
+    !!}
+    use :: Functions_Global, only : accretionDiskSpectraDeepCopyReset_
+    implicit none
+    class(radiationFieldIntergalacticBackgroundInternal), intent(inout) :: self
+    
+    self%copiedSelf => null()
+    if (associated(self%cosmologyParameters_              )) call self%cosmologyParameters_              %deepCopyReset()
+    if (associated(self%cosmologyFunctions_               )) call self%cosmologyFunctions_               %deepCopyReset()
+    if (associated(self%intergalacticMediumState_         )) call self%intergalacticMediumState_         %deepCopyReset()
+    if (associated(self%atomicCrossSectionIonizationPhoto_)) call self%atomicCrossSectionIonizationPhoto_%deepCopyReset()
+    if (associated(self%starFormationRateDisks_           )) call self%starFormationRateDisks_           %deepCopyReset()
+    if (associated(self%starFormationRateSpheroids_       )) call self%starFormationRateSpheroids_       %deepCopyReset()
+    if (associated(self%stellarPopulationSelector_        )) call self%stellarPopulationSelector_        %deepCopyReset()
+    if (associated(self%outputTimes_                      )) call self%outputTimes_                      %deepCopyReset()
+    if (associated(self%accretionDiskSpectra_             )) call accretionDiskSpectraDeepCopyReset_(self%accretionDiskSpectra_)
+    return
+  end subroutine intergalacticBackgroundInternalDeepCopyReset
+  
+  subroutine intergalacticBackgroundInternalDeepCopyFinalize(self)
+    !!{
+    Finalize a deep reset of the object.
+    !!}
+    use :: Functions_Global, only : accretionDiskSpectraDeepCopyFinalize_
+    implicit none
+    class(radiationFieldIntergalacticBackgroundInternal), intent(inout) :: self
+    
+    if (associated(self%cosmologyParameters_              )) call self%cosmologyParameters_              %deepCopyFinalize()
+    if (associated(self%cosmologyFunctions_               )) call self%cosmologyFunctions_               %deepCopyFinalize()
+    if (associated(self%intergalacticMediumState_         )) call self%intergalacticMediumState_         %deepCopyFinalize()
+    if (associated(self%atomicCrossSectionIonizationPhoto_)) call self%atomicCrossSectionIonizationPhoto_%deepCopyFinalize()
+    if (associated(self%starFormationRateDisks_           )) call self%starFormationRateDisks_           %deepCopyFinalize()
+    if (associated(self%starFormationRateSpheroids_       )) call self%starFormationRateSpheroids_       %deepCopyFinalize()
+    if (associated(self%stellarPopulationSelector_        )) call self%stellarPopulationSelector_        %deepCopyFinalize()
+    if (associated(self%outputTimes_                      )) call self%outputTimes_                      %deepCopyFinalize()
+    if (associated(self%accretionDiskSpectra_             )) call accretionDiskSpectraDeepCopyFinalize_(self%accretionDiskSpectra_)
+    return
+  end subroutine intergalacticBackgroundInternalDeepCopyFinalize
+  
+  subroutine intergalacticBackgroundInternalDeepCopy(self,destination)
+    !!{
+    Perform a deep copy of the object.
+    !!}
+    use :: Functions_Global, only : accretionDiskSpectraDeepCopy_
+    implicit none
+    class(radiationFieldIntergalacticBackgroundInternal), intent(inout), target :: self
+    class(radiationFieldClass                          ), intent(inout)         :: destination
+
+    call self%deepCopy_(destination)
+    select type (destination)
+    type is (radiationFieldIntergalacticBackgroundInternal)
+       nullify(destination%accretionDiskSpectra_)
+       if (associated(self%accretionDiskSpectra_)) then
+          allocate(destination%accretionDiskSpectra_,mold=self%accretionDiskSpectra_)
+          call accretionDiskSpectraDeepCopy_(self%accretionDiskSpectra_,destination%accretionDiskSpectra_)
+#ifdef OBJECTDEBUG
+          if (debugReporting.and.mpiSelf%isMaster()) call displayMessage(var_str('functionClass[own] (class : ownerName : ownerLoc : objectLoc : sourceLoc): galacticstructure : [destination] : ')//loc(destination)//' : '//loc(destination%accretionDiskSpectra_)//' : '//{introspection:location:compact},verbosityLevelSilent)
+#endif
+       end if
+    class default
+       call Error_Report('destination and source types do not match'//{introspection:location})
+    end select
+    return
+  end subroutine intergalacticBackgroundInternalDeepCopy
+

--- a/testSuite/parameters/activeLuminosities.xml
+++ b/testSuite/parameters/activeLuminosities.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -167,6 +159,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -184,6 +184,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -262,12 +269,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Output options -->

--- a/testSuite/parameters/benchmark-quickTest.xml
+++ b/testSuite/parameters/benchmark-quickTest.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -173,6 +165,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -190,6 +190,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -250,12 +257,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/bolshoiTestTreesGLC.xml
+++ b/testSuite/parameters/bolshoiTestTreesGLC.xml
@@ -8,17 +8,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <growthRatioToStellarSpheroid value="1.0d-3"/>
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.001"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <outputMergers value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="1.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="1.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -194,6 +184,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.001"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true" />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -211,8 +209,13 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  1.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  1.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <!-- Satellite orbit options -->
 
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
@@ -271,12 +274,16 @@
     </nodeOperator>
     <!-- Shift preset named N-body properties -->
     <nodeOperator value="presetNamedShift"/>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/bug745815.xml
+++ b/testSuite/parameters/bug745815.xml
@@ -40,6 +40,4 @@
     </massDistributionSpheroid>
   </componentSpheroid>
   <componentSpin value="scalar"/>
-
-
 </parameters>

--- a/testSuite/parameters/checkpointingCheckpoints.xml
+++ b/testSuite/parameters/checkpointingCheckpoints.xml
@@ -334,7 +334,13 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  <blackHoleHeatsHotHalo value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
 
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
@@ -352,14 +358,13 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <blackHoleSeedMass value="100"/>
-  <blackHoleWindEfficiency value="0.0024"/>
-  <blackHoleWindEfficiencyScalesWithRadiativeEfficiency value="true"/>
-  <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-  <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-  <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-  <bondiHoyleAccretionHotModeOnly value="true"/>
 
   <!-- Galaxy merger options -->
   <mergerMassMovements value="simple">
@@ -445,12 +450,16 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Merger tree evolution -->

--- a/testSuite/parameters/checkpointingNoCheckpoints.xml
+++ b/testSuite/parameters/checkpointingNoCheckpoints.xml
@@ -333,7 +333,13 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  <blackHoleHeatsHotHalo value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
 
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
@@ -351,14 +357,13 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <blackHoleSeedMass value="100"/>
-  <blackHoleWindEfficiency value="0.0024"/>
-  <blackHoleWindEfficiencyScalesWithRadiativeEfficiency value="true"/>
-  <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-  <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-  <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-  <bondiHoyleAccretionHotModeOnly value="true"/>
 
   <!-- Galaxy merger options -->
   <mergerMassMovements value="simple">
@@ -444,12 +449,16 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Merger tree evolution -->

--- a/testSuite/parameters/checkpointingResume.xml
+++ b/testSuite/parameters/checkpointingResume.xml
@@ -333,7 +333,13 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  <blackHoleHeatsHotHalo value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
 
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
@@ -351,14 +357,13 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <blackHoleSeedMass value="100"/>
-  <blackHoleWindEfficiency value="0.0024"/>
-  <blackHoleWindEfficiencyScalesWithRadiativeEfficiency value="true"/>
-  <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-  <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-  <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-  <bondiHoyleAccretionHotModeOnly value="true"/>
 
   <!-- Galaxy merger options -->
   <mergerMassMovements value="simple">
@@ -444,12 +449,16 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Merger tree evolution -->

--- a/testSuite/parameters/constrainedMilkyWay.xml
+++ b/testSuite/parameters/constrainedMilkyWay.xml
@@ -8,15 +8,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -256,6 +248,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -273,6 +273,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -332,12 +339,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/duplicatedOutputPropertyName.xml
+++ b/testSuite/parameters/duplicatedOutputPropertyName.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -173,6 +165,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -189,7 +189,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -249,12 +256,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/galacticStructureStateDeallocateBug.xml
+++ b/testSuite/parameters/galacticStructureStateDeallocateBug.xml
@@ -8,12 +8,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <growthRatioToStellarSpheroid value="2.32959186797031"/>
-    <heatsHotHalo value="true"/>
-    <efficiencyHeating value="0.00140338137883176"/>
-    <efficiencyWind value="0.211884639031352"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -297,6 +292,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.211884639031352"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <stellarWinds value="leitherer1992"/>
   <initialMassForSupernovaTypeII value="8.0"/>
   <supernovaeIa value="nagashima"/>
@@ -304,11 +307,13 @@
   <stellarFeedback value="standard"/>
   
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <blackHoleEfficiency value="0.213288020410184"/>
-  <blackHoleJetFraction value="0.00657974778017468"/>
-
-  <!-- Satellite orbit options -->
 
   <!-- Galaxy merger options -->
   <virialOrbit value="li2020">
@@ -413,12 +418,16 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/parameters/impulsiveHeating.xml
+++ b/testSuite/parameters/impulsiveHeating.xml
@@ -16,15 +16,7 @@
   <!-- Component selection -->
   <!-- Baryonic components are set to null since we are not modeling them here. -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <massDistributionDisk value="exponentialDisk">
@@ -315,6 +307,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -331,7 +331,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <mergerMassMovements value="simple">
     <destinationGasMinorMerger value="spheroid"/>
@@ -419,12 +426,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Merger tree evolution -->

--- a/testSuite/parameters/inactiveLuminosities.xml
+++ b/testSuite/parameters/inactiveLuminosities.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -167,6 +159,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -183,7 +183,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -264,12 +271,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Output options -->

--- a/testSuite/parameters/inactiveNumerics.xml
+++ b/testSuite/parameters/inactiveNumerics.xml
@@ -300,6 +300,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.213288020410184"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"             />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="0.00657974778017468"/>
+  </blackHoleCGMHeating>
+
   <stellarWinds value="leitherer1992"/>
   <initialMassForSupernovaTypeII value="8.0"/>
   <supernovaeIa value="nagashima"/>
@@ -307,11 +315,12 @@
   <stellarFeedback value="standard"/>
   
   <!-- Black hole options -->
-  <blackHoleBinaryMerger value="rezzolla2008"/>
-  <blackHoleEfficiency value="0.213288020410184"/>
-  <blackHoleJetFraction value="0.00657974778017468"/>
-
-  <!-- Satellite orbit options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
 
   <!-- Galaxy merger options -->
   <virialOrbit value="li2020">
@@ -419,12 +428,16 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/parameters/interoutputStarFormationRate.xml
+++ b/testSuite/parameters/interoutputStarFormationRate.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -161,6 +153,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -178,6 +178,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -222,12 +229,16 @@
         </stellarFeedbackOutflows>
       </stellarFeedbackOutflows>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/memoryLeakFormationHalos.xml
+++ b/testSuite/parameters/memoryLeakFormationHalos.xml
@@ -9,15 +9,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -175,6 +167,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -192,6 +192,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -255,12 +262,16 @@
     <nodeOperator value="nodeFormationTimeCole2000">
       <massFactorReformation value="2.0"/>      
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/mergerTreeEvolverThreaded.xml
+++ b/testSuite/parameters/mergerTreeEvolverThreaded.xml
@@ -15,15 +15,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -191,6 +183,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -208,11 +208,15 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
-  <!-- <satelliteMergingTimescales value="jiang2008"> -->
-  <!--   <timescaleMultiplier value="0.75"/> -->
-  <!-- </satelliteMergingTimescales> -->
   <satelliteMergingTimescales value="infinite"/>
   <mergerMassMovements value="simple">
     <destinationGasMinorMerger value="spheroid"/>
@@ -267,12 +271,16 @@
     	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
+++ b/testSuite/parameters/mostMassiveProgenitorIsSubhalo.xml
@@ -56,7 +56,22 @@
     <allowBranchJumps value="true"/>
     <presetSubhaloIndices value="false"/>
   </mergerTreeConstructor>
-  
+
+  <!-- Black hole physics -->
+    <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <nodePropertyExtractor value="multi">
     <nodePropertyExtractor value="massAccretionHistory"/>
     <nodePropertyExtractor value="nodeIndices"/>
@@ -68,12 +83,16 @@
     <nodeOperator value="DMOInterpolate"/>    
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
   
   <outputFileName value="testSuite/outputs/mostMassiveProgenitorIsSubhalo.hdf5"/>

--- a/testSuite/parameters/noninstantaneous_recycling.xml
+++ b/testSuite/parameters/noninstantaneous_recycling.xml
@@ -6,8 +6,7 @@
   <formatVersion>2</formatVersion>
   <lastModified revision="165490f4968c699f7e5bb73ef60bcb7e626f51e6"/>
 
-
-<verbosityLevel value="working"/>
+  <verbosityLevel value="working"/>
 
   <!-- Task and work control -->
   <task value="evolveForests">
@@ -272,8 +271,6 @@
     </starFormationTimescale>
   </starFormationRateSpheroids>
   
- 
-
   <!-- Stellar populations options -->
   <stellarPopulationProperties value="noninstantaneous">
     <countHistoryTimes value="100"/>
@@ -281,11 +278,16 @@
   <stellarPopulationSpectra value="FSPS"/>
   <stellarPopulationSelector value="fixed"/>
   <initialMassFunction value="chabrier2001"/>
- 
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  <blackHoleHeatsHotHalo value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.211884639031352"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"             />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="00140338137883176"/>
+  </blackHoleCGMHeating>
 
   <stellarWinds value="leitherer1992"/>
   <initialMassForSupernovaTypeII value="8.0"/>
@@ -294,15 +296,13 @@
   <stellarFeedback value="standard"/>
   
   <!-- Black hole options -->
-  <blackHoleSeedMass value="100"/>
-  <blackHoleToSpheroidStellarGrowthRatio value="2.32959186797031"/>
-  <blackHoleHeatingEfficiency value="0.00140338137883176"/>
-  <blackHoleWindEfficiency value="0.211884639031352"/>
+   <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <blackHoleEfficiency value="0.213288020410184"/>
-  <blackHoleJetFraction value="0.00657974778017468"/>
-
-  <!-- Satellite orbit options -->
 
   <!-- Galaxy merger options -->
   <virialOrbit value="li2020">
@@ -416,12 +416,16 @@
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
 
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/parameters/outputDatasetSuffixes.xml
+++ b/testSuite/parameters/outputDatasetSuffixes.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -174,6 +166,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -190,7 +190,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -250,12 +257,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/outputSelector.xml
+++ b/testSuite/parameters/outputSelector.xml
@@ -8,15 +8,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <inactiveLuminositiesStellar value="true"/>
@@ -194,6 +186,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -210,7 +210,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -275,12 +282,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Evolvers -->

--- a/testSuite/parameters/outputTreeContiguosity.xml
+++ b/testSuite/parameters/outputTreeContiguosity.xml
@@ -8,15 +8,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <inactiveLuminositiesStellar value="true"/>
@@ -194,6 +186,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -210,7 +210,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -275,12 +282,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Evolvers -->

--- a/testSuite/parameters/parametersDiff1.xml
+++ b/testSuite/parameters/parametersDiff1.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -178,6 +170,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -194,7 +194,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -253,12 +260,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/parametersDiff2.xml
+++ b/testSuite/parameters/parametersDiff2.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0023"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -178,6 +170,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0023"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -195,6 +195,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -253,12 +260,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/parametersExtract.xml
+++ b/testSuite/parameters/parametersExtract.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -173,6 +165,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -189,7 +189,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -249,12 +256,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/setProperties.xml
+++ b/testSuite/parameters/setProperties.xml
@@ -14,15 +14,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -176,6 +168,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -192,7 +192,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -252,12 +259,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/test-mass-conservation-coldMode.xml
+++ b/testSuite/parameters/test-mass-conservation-coldMode.xml
@@ -19,15 +19,7 @@
 
     <!-- Component selection -->
     <componentBasic value="standard"/>
-    <componentBlackHole value="standard">
-      <heatsHotHalo value="false"/>
-      <efficiencyWind value="0.0024"/>
-      <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-      <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-      <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-      <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-      <bondiHoyleAccretionHotModeOnly value="true"/>
-    </componentBlackHole>
+    <componentBlackHole value="standard"/>
     <componentDarkMatterProfile value="scale"/>
     <componentDisk value="standard">
       <toleranceAbsoluteMass value="1.0e-6"/>
@@ -233,6 +225,14 @@
 
     <!-- AGN feedback options -->
     <hotHaloExcessHeatDrivesOutflow value="true"/>
+    <blackHoleWind value="ciotti2009">
+      <efficiencyWind                              value="0.0024"/>
+      <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+    </blackHoleWind>
+    <blackHoleCGMHeating value="jetPower">
+      <efficiencyRadioMode value="1.0"/>
+    </blackHoleCGMHeating>
+
     <!-- Accretion disk properties -->
     <accretionDisks value="switched">
       <accretionRateThinDiskMaximum value="0.30"/>
@@ -249,7 +249,14 @@
     </accretionDisks>
 
     <!-- Black hole options -->
+    <blackHoleAccretionRate value="standard">
+      <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+      <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+      <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+      <bondiHoyleAccretionHotModeOnly         value="true"/>
+    </blackHoleAccretionRate>
     <blackHoleBinaryMerger value="rezzolla2008"/>
+
     <!-- Galaxy merger options -->
     <virialOrbit value="benson2005"/>
     <satelliteMergingTimescales value="jiang2008">
@@ -308,12 +315,16 @@
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
       </nodeOperator>
+      <!-- Black hole physics -->
       <nodeOperator value="blackHolesSeed" iterable="no">
 	<blackHoleSeeds value="fixed">
-	  <mass value="0"/>
-	  <spin value="0"/>
+          <mass value="100"/>
+          <spin value="0"/>
 	</blackHoleSeeds>
       </nodeOperator>
+      <nodeOperator value="blackHolesAccretion" iterable="no"/>
+      <nodeOperator value="blackHolesWinds" iterable="no"/>
+      <nodeOperator value="blackHolesCGMHeating" iterable="no"/>
     </nodeOperator>
 
     <!-- Numerical tolerances -->

--- a/testSuite/parameters/test-mass-conservation-standard.xml
+++ b/testSuite/parameters/test-mass-conservation-standard.xml
@@ -19,15 +19,7 @@
 
     <!-- Component selection -->
     <componentBasic value="standard"/>
-    <componentBlackHole value="standard">
-      <heatsHotHalo value="false"/>
-      <efficiencyWind value="0.0024"/>
-      <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-      <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-      <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-      <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-      <bondiHoyleAccretionHotModeOnly value="true"/>
-    </componentBlackHole>
+    <componentBlackHole value="standard"/>
     <componentDarkMatterProfile value="scale"/>
     <componentDisk value="standard">
       <toleranceAbsoluteMass value="1.0e-6"/>
@@ -233,6 +225,14 @@
 
     <!-- AGN feedback options -->
     <hotHaloExcessHeatDrivesOutflow value="true"/>
+    <blackHoleWind value="ciotti2009">
+      <efficiencyWind                              value="0.0024"/>
+      <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+    </blackHoleWind>
+    <blackHoleCGMHeating value="jetPower">
+      <efficiencyRadioMode value="1.0"/>
+    </blackHoleCGMHeating>
+
     <!-- Accretion disk properties -->
     <accretionDisks value="switched">
       <accretionRateThinDiskMaximum value="0.30"/>
@@ -251,6 +251,13 @@
 
     <!-- Black hole options -->
     <blackHoleBinaryMerger value="rezzolla2008"/>
+    <blackHoleAccretionRate value="standard">
+      <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+      <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+      <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+      <bondiHoyleAccretionHotModeOnly         value="true"/>
+    </blackHoleAccretionRate>
+
     <!-- Galaxy merger options -->
     <virialOrbit value="benson2005"/>
     <satelliteMergingTimescales value="jiang2008">
@@ -310,12 +317,16 @@
 	  <stabilityThresholdStellar value="1.1"/>
 	</galacticDynamicsBarInstability>
       </nodeOperator>
+      <!-- Black hole physics -->
       <nodeOperator value="blackHolesSeed" iterable="no">
 	<blackHoleSeeds value="fixed">
-	  <mass value="0"/>
-	  <spin value="0"/>
+          <mass value="100"/>
+          <spin value="0"/>
 	</blackHoleSeeds>
       </nodeOperator>
+      <nodeOperator value="blackHolesAccretion" iterable="no"/>
+      <nodeOperator value="blackHolesWinds" iterable="no"/>
+      <nodeOperator value="blackHolesCGMHeating" iterable="no"/>
     </nodeOperator>
 
     <!-- Numerical tolerances -->

--- a/testSuite/parameters/test-output-times.xml
+++ b/testSuite/parameters/test-output-times.xml
@@ -14,15 +14,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -177,6 +169,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -194,7 +194,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -253,12 +260,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/test-output.xml
+++ b/testSuite/parameters/test-output.xml
@@ -14,15 +14,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -177,6 +169,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -195,6 +195,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -253,12 +260,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/test-star-formation-histories-adaptive.xml
+++ b/testSuite/parameters/test-star-formation-histories-adaptive.xml
@@ -10,15 +10,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -176,6 +168,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -192,7 +192,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -252,12 +259,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/test-star-formation-histories-inSitu.xml
+++ b/testSuite/parameters/test-star-formation-histories-inSitu.xml
@@ -10,15 +10,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -176,6 +168,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -192,7 +192,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -252,12 +259,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/validation/default-valid.xml
+++ b/testSuite/parameters/validation/default-valid.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -168,6 +160,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -184,7 +184,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -243,12 +250,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/validation/duplicate-parameter-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-parameter-invalid.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -172,6 +164,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Supernovae feedback options -->
   <starFormationFeedbackDisks value="powerLaw">
     <velocityCharacteristic value="250.0"/>
@@ -198,7 +198,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbits value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -238,12 +245,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
   
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/validation/duplicate-subparameter-valid.xml
+++ b/testSuite/parameters/validation/duplicate-subparameter-valid.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -170,6 +162,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -186,7 +186,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbits value="Benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -245,12 +252,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/validation/duplicate-value-invalid.xml
+++ b/testSuite/parameters/validation/duplicate-value-invalid.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -171,6 +163,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -187,7 +187,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbits value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -246,12 +253,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/validation/missing-value-invalid.xml
+++ b/testSuite/parameters/validation/missing-value-invalid.xml
@@ -7,15 +7,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -165,6 +157,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -181,7 +181,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbits value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -240,12 +247,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/regressions/adaptiveSFHLengths.xml
+++ b/testSuite/regressions/adaptiveSFHLengths.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-
-<!-- Model used to test that adaptive SFHsall have the same lengths -->
+<!-- Model used to test that adaptive SFHs all have the same lengths -->
 
 <parameters>
   <formatVersion>2</formatVersion>
@@ -304,7 +302,13 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  <blackHoleHeatsHotHalo value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.211884639031352"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="0.00140338137883176"/>
+  </blackHoleCGMHeating>
 
   <stellarWinds value="leitherer1992"/>
   <initialMassForSupernovaTypeII value="8.0"/>
@@ -313,15 +317,13 @@
   <stellarFeedback value="standard"/>
   
   <!-- Black hole options -->
-  <blackHoleSeedMass value="100"/>
-  <blackHoleToSpheroidStellarGrowthRatio value="2.32959186797031"/>
-  <blackHoleHeatingEfficiency value="0.00140338137883176"/>
-  <blackHoleWindEfficiency value="0.211884639031352"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <blackHoleEfficiency value="0.213288020410184"/>
-  <blackHoleJetFraction value="0.00657974778017468"/>
-
-  <!-- Satellite orbit options -->
 
   <!-- Galaxy merger options -->
   <virialOrbit value="li2020">
@@ -442,12 +444,16 @@
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
 
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/regressions/barInstabilityFPE.xml
+++ b/testSuite/regressions/barInstabilityFPE.xml
@@ -284,19 +284,24 @@
 
   <!-- Stellar populations options -->
   <stellarPopulationProperties value="instantaneous"/>
- 
   <stellarPopulationSpectra value="FSPS"/>
   <stellarPopulationSelector value="fixed"/>
   <initialMassFunction value="chabrier2001"/>
   <stellarPopulation value="standard">
     <recycledFraction value="0.128400314266335"/>
     <metalYield value="0.00721512185415169"/>
-  </stellarPopulation>
-  <!-- <elementsToTrack    value="O"    /> -->
- 
+  </stellarPopulation> 
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.213288020410184"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"             />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="0.00657974778017468"/>
+  </blackHoleCGMHeating>
+
   <stellarWinds value="leitherer1992"/>
   <initialMassForSupernovaTypeII value="8.0"/>
   <supernovaeIa value="nagashima"/>
@@ -304,9 +309,13 @@
   <stellarFeedback value="standard"/>
   
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <blackHoleEfficiency value="0.213288020410184"/>
-  <blackHoleJetFraction value="0.00657974778017468"/>
 
   <!-- Galaxy merger options -->
   <virialOrbit value="li2020">
@@ -412,12 +421,16 @@
      <beta value="0.01"/>
      </tidalStripping>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/regressions/bug711424.xml
+++ b/testSuite/regressions/bug711424.xml
@@ -78,12 +78,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <cosmologicalMassVariance value="filteredPower">
@@ -108,12 +112,7 @@
   </mergerTreeBuildMasses>
   <cosmologyFunctions value="matterLambda"/>
   <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
-  <componentBlackHole value="standard">
-    <efficiencyWind value="0.001"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="1"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="1"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentSpheroid value="standard">
     <efficiencyEnergeticOutflow value="1"/>
     <toleranceAbsoluteMass value="1e-06"/>
@@ -234,6 +233,19 @@
   </outputTimes>
 
   <coolingRadius value="simple"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  1.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  1.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.001"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true" />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
   <blackHoleBinaryMerger value="rezzolla2008"/>
   <galacticStructureSolver value="equilibrium"/>
   <mergerTreeConstructor value="build">

--- a/testSuite/regressions/bug725315.xml
+++ b/testSuite/regressions/bug725315.xml
@@ -77,12 +77,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <cosmologicalMassVariance value="filteredPower">
@@ -113,12 +117,7 @@
   </mergerTreeBuildMasses>
   <cosmologyFunctions value="matterLambda"/>
   <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
-  <componentBlackHole value="standard">
-    <efficiencyWind value="0.001"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="1"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="1"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentSpheroid value="standard">
     <efficiencyEnergeticOutflow value="1"/>
     <toleranceAbsoluteMass value="1e-06"/>
@@ -243,6 +242,19 @@
   </outputTimes>
 
   <coolingRadius value="simple"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  1.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  1.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.001"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true" />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
   <blackHoleBinaryMerger value="rezzolla2008"/>
   <galacticStructureSolver value="equilibrium"/>
   <mergerTreeConstructor value="build">

--- a/testSuite/regressions/coincidentMergerAndBranchJump.xml
+++ b/testSuite/regressions/coincidentMergerAndBranchJump.xml
@@ -10,14 +10,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="1.5"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="420.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -185,6 +178,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -201,8 +202,13 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="420.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  1.5"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <!-- Satellite orbit options -->
 
   <!-- Node evolution and physics -->
   <nodeOperator value="multi">
@@ -249,12 +255,16 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Galaxy merger options -->

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee.xml
@@ -74,6 +74,21 @@
     <darkMatterProfileScaleRadius value="concentration"/>
   </darkMatterProfileScaleRadius>
 
+  <!-- Black hole physics -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Node evolution and physics -->
   <nodeOperator value="multi">
     <!-- Cosmological epoch -->
@@ -116,12 +131,16 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
 </parameters>

--- a/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
+++ b/testSuite/regressions/deadlockMergeTargetInDescendentOfMergee2.xml
@@ -75,6 +75,21 @@
     <darkMatterProfileScaleRadius value="concentration"/>
   </darkMatterProfileScaleRadius>
 
+  <!-- Black hole physics -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Node evolution and physics -->
   <nodeOperator value="multi">
     <!-- Cosmological epoch -->
@@ -117,12 +132,16 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
 </parameters>

--- a/testSuite/regressions/issue142.xml
+++ b/testSuite/regressions/issue142.xml
@@ -31,15 +31,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -262,6 +254,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -278,7 +278,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <satelliteMergingTimescales value="jiang2008">
     <timescaleMultiplier value="0.75"/>
@@ -349,12 +356,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- End baryonic physics -->

--- a/testSuite/regressions/linearGrowthForFutureModel.xml
+++ b/testSuite/regressions/linearGrowthForFutureModel.xml
@@ -16,15 +16,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -175,6 +167,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -191,7 +191,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -250,12 +257,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/regressions/outputRank2ExtendSegFault.xml
+++ b/testSuite/regressions/outputRank2ExtendSegFault.xml
@@ -288,8 +288,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
-  <blackHoleHeatsHotHalo value="true"/>
-
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.211884639031352"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="false"            />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="0.00140338137883176"/>
+  </blackHoleCGMHeating>
+ 
   <stellarWinds value="leitherer1992"/>
   <initialMassForSupernovaTypeII value="8.0"/>
   <supernovaeIa value="nagashima"/>
@@ -297,15 +303,13 @@
   <stellarFeedback value="standard"/>
   
   <!-- Black hole options -->
-  <blackHoleSeedMass value="100"/>
-  <blackHoleToSpheroidStellarGrowthRatio value="2.32959186797031"/>
-  <blackHoleHeatingEfficiency value="0.00140338137883176"/>
-  <blackHoleWindEfficiency value="0.211884639031352"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <blackHoleEfficiency value="0.213288020410184"/>
-  <blackHoleJetFraction value="0.00657974778017468"/>
-
-  <!-- Satellite orbit options -->
 
   <!-- Galaxy merger options -->
   <virialOrbit value="li2020">
@@ -368,7 +372,7 @@
         <timescaleOutflowFractionalMinimum value="0.103745531708515"/>
         <stellarFeedbackOutflows value="powerLaw">
           <velocityCharacteristic value="151.06489745284"/>
-          <exponent value="0.33561921242039"/><!--0.23561921242039-->
+          <exponent value="0.33561921242039"/> <!--0.23561921242039-->
         </stellarFeedbackOutflows>
       </stellarFeedbackOutflows>
     </nodeOperator>
@@ -406,12 +410,16 @@
     <nodeOperator value="indexShift"/>
     <nodeOperator value="indexLastHost"/>
     <nodeOperator value="timeFirstInfall"/>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
   
   <starFormationHistory value="adaptive">

--- a/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
+++ b/testSuite/regressions/preInfallEvolutionNotOnMainBranch.xml
@@ -16,15 +16,7 @@
   <!-- Component selection -->
   <!-- Baryonic components are set to null since we are not modeling them here. -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-  <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
   <massDistributionDisk value="exponentialDisk">
@@ -342,6 +334,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -358,7 +358,14 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMergers value="rezzolla2008"/>
+
   <!-- Galaxy merger options -->
   <mergerMassMovements value="simple">
     <destinationGasMinorMerger value="spheroid"/>
@@ -448,12 +455,16 @@
     <nodeOperator value="nodeFormationTimeMassFraction">
       <fractionMassFormation value="0.5"/>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
   
   <!-- Merger tree evolution -->

--- a/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
+++ b/testSuite/regressions/treeWithInitialSatelliteInProgenitorlessHost.xml
@@ -10,14 +10,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="1.5"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="420.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -183,6 +176,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -199,8 +200,13 @@
   </accretionDisks>
 
   <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="420.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  1.5"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
   <blackHoleBinaryMerger value="rezzolla2008"/>
-  <!-- Satellite orbit options -->
 
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
@@ -261,12 +267,16 @@
     </nodeOperator>
     <!-- Halo positions -->
     <nodeOperator value="positionDiscrete"/>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/test-methods-base.xml
+++ b/testSuite/test-methods-base.xml
@@ -52,6 +52,10 @@
         </stellarFeedbackOutflows>
       </stellarFeedbackOutflows>
     </nodeOperator>
+    <!-- Black hole physics -->
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
 </parameters>

--- a/testSuite/test-methods.xml
+++ b/testSuite/test-methods.xml
@@ -633,6 +633,19 @@
     <formatVersion>2</formatVersion>
     <lastModified revision="165490f4968c699f7e5bb73ef60bcb7e626f51e6"/>
     <componentBlackHole value="nonCentral"/>
+    <blackHoleAccretionRate value="standard">
+      <bondiHoyleAccretionEnhancementSpheroid value="5.0e0"/>
+      <bondiHoyleAccretionEnhancementHotHalo value="6.0e0"/>
+      <bondiHoyleAccretionHotModeOnly value="true"/>
+      <bondiHoyleAccretionTemperatureSpheroid value="1.0e2"/>
+    </blackHoleAccretionRate>
+    <blackHoleWind value="ciotti2009">
+      <efficiencyWind value="2.4e-3"/>
+      <efficiencyWindScalesWithEfficiencyRadiative value="false"/>
+    </blackHoleWind>
+    <blackHoleCGMHeating value="jetPower">
+      <efficiencyRadioMode value="1.0"/>
+    </blackHoleCGMHeating>
     <blackHoleBinaryInitialSeparation value="spheroidRadiusFraction"/>
     <blackHoleBinaryInitialSeparation value="tidalRadius">
       <blackHoleBinaryRecoil value="zero" parameterLevel="top"/>
@@ -737,12 +750,22 @@
 
   </parameters>
   
-  <!-- Black hole comopnents. -->
+  <!-- Black hole components. -->
   <parameters>
     <formatVersion>2</formatVersion>
     <lastModified revision="165490f4968c699f7e5bb73ef60bcb7e626f51e6"/>
     <componentBlackHole value="standard"/>
-    <componentBlackHole value="simple"/>
+    <componentBlackHole value="simple">
+      <blackHoleAccretionRate value="spheroidTracking" parameterLevel="top">
+	<growthRatioToStellarSpheroid value="1.0e-3"/>
+      </blackHoleAccretionRate>
+      <blackHoleWind value="simple" parameterLevel="top">
+	<efficiencyWind value="2.2157e-3"/>
+      </blackHoleWind>
+      <blackHoleCGMHeating value="quasistatic" parameterLevel="top">
+	<efficiencyHeating value="1.0e-3"/>
+      </blackHoleCGMHeating>
+    </componentBlackHole>
   </parameters>
   
   <!-- Infall and freefall radii. -->

--- a/testSuite/test-model-integration-default.xml
+++ b/testSuite/test-model-integration-default.xml
@@ -12,15 +12,7 @@
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
-  <componentBlackHole value="standard">
-    <heatsHotHalo value="true"/>
-    <efficiencyWind value="0.0024"/>
-    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
-    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
-    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
-    <bondiHoyleAccretionTemperatureSpheroid value="100"/>
-    <bondiHoyleAccretionHotModeOnly value="true"/>
-  </componentBlackHole>
+  <componentBlackHole value="standard"/>
   <componentDarkMatterProfile value="scale"/>
   <componentDisk value="standard">
     <toleranceAbsoluteMass value="1.0e-6"/>
@@ -181,6 +173,14 @@
 
   <!-- AGN feedback options -->
   <hotHaloExcessHeatDrivesOutflow value="true"/>
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind                              value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"  />
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
   <!-- Accretion disk properties -->
   <accretionDisks value="switched">
     <accretionRateThinDiskMaximum value="0.30"/>
@@ -198,6 +198,13 @@
 
   <!-- Black hole options -->
   <blackHoleBinaryMerger value="rezzolla2008"/>
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="  5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo  value="  6.0"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+    <bondiHoyleAccretionHotModeOnly         value="true"/>
+  </blackHoleAccretionRate>
+
   <!-- Galaxy merger options -->
   <virialOrbit value="benson2005"/>
   <satelliteMergingTimescales value="jiang2008">
@@ -257,12 +264,16 @@
 	<stabilityThresholdStellar value="1.1"/>
       </galacticDynamicsBarInstability>
     </nodeOperator>
+    <!-- Black hole physics -->
     <nodeOperator value="blackHolesSeed">
       <blackHoleSeeds value="fixed">
         <mass value="100"/>
         <spin value="0"/>
       </blackHoleSeeds>
     </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <nodeOperator value="blackHolesCGMHeating"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/validate-milkyWay.py
+++ b/testSuite/validate-milkyWay.py
@@ -9,7 +9,7 @@ import validate
 
 # Create output path.
 try:
-    os.mkdir("outputs/idealizedSubhaloSimulations")
+    os.mkdir("outputs")
 except FileExistsError:
     pass
 


### PR DESCRIPTION
Accretion, winds, and CGM heating now all operate via `nodeOperators`. Associated classes for black hole winds and CGM heating are added. Includes migration rules for changed parameters.