### PR TITLE
Make the `darkMatterProfileScaleRadiusJohnson2021` class get mass distributions directly from the `darkMatterProfileDMO` object

### DIFF
--- a/source/dark_matter_profiles.structure.scale.Johnson2021.F90
+++ b/source/dark_matter_profiles.structure.scale.Johnson2021.F90
@@ -22,6 +22,7 @@
   !!}
   
   use :: Dark_Matter_Halo_Scales           , only : darkMatterHaloScaleClass
+  use :: Dark_Matter_Profiles_DMO          , only : darkMatterProfileDMOClass
   use :: Galacticus_Nodes                  , only : nodeComponentDarkMatterProfile
   use :: Virial_Orbits                     , only : virialOrbitClass
   use :: Merger_Trees_Build_Mass_Resolution, only : mergerTreeMassResolutionClass
@@ -42,6 +43,7 @@
      private
      class           (darkMatterProfileScaleRadiusClass), pointer :: darkMatterProfileScaleRadius_ => null()
      class           (darkMatterHaloScaleClass         ), pointer :: darkMatterHaloScale_          => null()
+     class           (darkMatterProfileDMOClass        ), pointer :: darkMatterProfileDMO_         => null()
      class           (virialOrbitClass                 ), pointer :: virialOrbit_                  => null()
      class           (mergerTreeMassResolutionClass    ), pointer :: mergerTreeMassResolution_     => null()
      double precision                                             :: massExponent                           , energyBoost, &
@@ -79,6 +81,7 @@ contains
     type            (inputParameters                        ), intent(inout) :: parameters
     class           (darkMatterProfileScaleRadiusClass      ), pointer       :: darkMatterProfileScaleRadius_
     class           (darkMatterHaloScaleClass               ), pointer       :: darkMatterHaloScale_
+    class           (darkMatterProfileDMOClass              ), pointer       :: darkMatterProfileDMO_
     class           (virialOrbitClass                       ), pointer       :: virialOrbit_
     class           (mergerTreeMassResolutionClass          ), pointer       :: mergerTreeMassResolution_
     double precision                                                         :: massExponent                 , energyBoost, &
@@ -110,19 +113,21 @@ contains
     <objectBuilder class="darkMatterHaloScale"          name="darkMatterHaloScale_"          source="parameters"/>
     <objectBuilder class="virialOrbit"                  name="virialOrbit_"                  source="parameters"/>
     <objectBuilder class="mergerTreeMassResolution"     name="mergerTreeMassResolution_"     source="parameters"/>
+    <objectBuilder class="darkMatterProfileDMO"         name="darkMatterProfileDMO_"         source="parameters"/>
     !!]
-    self=darkMatterProfileScaleRadiusJohnson2021(massExponent,energyBoost,unresolvedEnergy,darkMatterProfileScaleRadius_,darkMatterHaloScale_,virialOrbit_,mergerTreeMassResolution_)
+    self=darkMatterProfileScaleRadiusJohnson2021(massExponent,energyBoost,unresolvedEnergy,darkMatterProfileScaleRadius_,darkMatterHaloScale_,darkMatterProfileDMO_,virialOrbit_,mergerTreeMassResolution_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="darkMatterProfileScaleRadius_"/>
     <objectDestructor name="darkMatterHaloScale_"         />
     <objectDestructor name="virialOrbit_"                 />
     <objectDestructor name="mergerTreeMassResolution_"    />
+    <objectDestructor name="darkMatterProfileDMO_"        />
     !!]
     return
   end function darkMatterProfileScaleJohnson2021ConstructorParameters
 
-  function darkMatterProfileScaleJohnson2021ConstructorInternal(massExponent,energyBoost,unresolvedEnergy,darkMatterProfileScaleRadius_,darkMatterHaloScale_,virialOrbit_,mergerTreeMassResolution_) result(self)
+  function darkMatterProfileScaleJohnson2021ConstructorInternal(massExponent,energyBoost,unresolvedEnergy,darkMatterProfileScaleRadius_,darkMatterHaloScale_,darkMatterProfileDMO_,virialOrbit_,mergerTreeMassResolution_) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily randomWalk} dark matter profile scale radius class.
     !!}
@@ -132,10 +137,11 @@ contains
     class           (darkMatterHaloScaleClass               ), intent(in   ), target :: darkMatterHaloScale_
     class           (virialOrbitClass                       ), intent(in   ), target :: virialOrbit_
     class           (mergerTreeMassResolutionClass          ), intent(in   ), target :: mergerTreeMassResolution_
+    class           (darkMatterProfileDMOClass              ), intent(in   ), target :: darkMatterProfileDMO_
     double precision                                         , intent(in   )         :: massExponent                 , energyBoost, &
          &                                                                              unresolvedEnergy
     !![
-    <constructorAssign variables="massExponent, energyBoost, unresolvedEnergy, *darkMatterProfileScaleRadius_, *darkMatterHaloScale_, *virialOrbit_, *mergerTreeMassResolution_"/>
+    <constructorAssign variables="massExponent, energyBoost, unresolvedEnergy, *darkMatterProfileScaleRadius_, *darkMatterHaloScale_, *darkMatterProfileDMO_, *virialOrbit_, *mergerTreeMassResolution_"/>
     !!]
 
     return
@@ -153,6 +159,7 @@ contains
     <objectDestructor name="self%darkMatterHaloScale_"         />
     <objectDestructor name="self%virialOrbit_"                 />
     <objectDestructor name="self%mergerTreeMassResolution_"    />
+    <objectDestructor name="self%darkMatterProfileDMO_"        />
     !!]
     return
   end subroutine darkMatterProfileScaleJohnson2021Destructor
@@ -169,7 +176,6 @@ contains
     use :: Beta_Functions                  , only : Beta_Function                  , Beta_Function_Incomplete_Normalized
     use :: Hypergeometric_Functions        , only : Hypergeometric_2F1
     use :: Mass_Distributions              , only : massDistributionClass
-    use :: Galactic_Structure_Options      , only : componentTypeDarkMatterOnly    , massTypeDark
     implicit none
     class           (darkMatterProfileScaleRadiusJohnson2021), intent(inout), target    :: self
     type            (treeNode                               ), intent(inout), target    :: node
@@ -221,10 +227,10 @@ contains
        massUnresolved          =  +basic                 %mass             () &
             &                     -basicChild            %mass             ()       
        ! Iterate over progenitors and sum their energies.
-       nodeSibling       =>                                                      nodeChild
-       massDistribution_ => nodeSibling      %massDistribution                  (componentTypeDarkMatterOnly,massTypeDark     )
-       radiusVirial      =  self             %darkMatterHaloScale_ %radiusVirial(nodeSibling                                  )
-       energyTotal       =  massDistribution_%energy                            (radiusVirial               ,massDistribution_)
+       nodeSibling       =>                                                       nodeChild
+       massDistribution_ => self             %darkMatterProfileDMO_ %get         (nodeSibling                   )
+       radiusVirial      =  self             %darkMatterHaloScale_  %radiusVirial(nodeSibling                   )
+       energyTotal       =  massDistribution_%energy                             (radiusVirial,massDistribution_)
        !![
        <objectDestructor name="massDistribution_"/>
        !!]
@@ -233,7 +239,7 @@ contains
           basicSibling             =>  nodeSibling       %basic                             (                                        )
           darkMatterProfileSibling =>  nodeSibling       %darkMatterProfile                 (                                        )
           satelliteSibling         =>  nodeSibling       %satellite                         (autoCreate=.true.                       )
-          massDistribution_        =>  nodeSibling       %massDistribution                  (componentTypeDarkMatterOnly,massTypeDark)
+          massDistribution_        =>  self              %darkMatterProfileDMO_%get         (nodeSibling                             )
           radiusVirial             =   self              %darkMatterHaloScale_ %radiusVirial(nodeSibling                             )
           orbit                    =   satelliteSibling  %virialOrbit                       (                                        )
           massRatio                =  +basicSibling      %mass                              (                                        ) &
@@ -323,7 +329,7 @@ contains
                &                                                                    8.0d0/3.0d0-(massFunctionSlopeLogarithmic+energyInternalFormFactorSlopeLogarithmic)   &
                &                              )
           ! Determine the orbital and internal energies.
-          massDistribution_ => nodeUnresolved%massDistribution(componentTypeDarkMatterOnly,massTypeDark)
+          massDistribution_ => self%darkMatterProfileDMO_%get         (nodeUnresolved)
           radiusVirial      =  self%darkMatterHaloScale_ %radiusVirial(nodeUnresolved)
           energyKinetic     =  +0.5d0                                                                       &
                &               *self%virialOrbit_%velocityTotalRootMeanSquared(nodeUnresolved,nodeChild)**2 &
@@ -382,18 +388,17 @@ contains
     !!{
     Function used in root-finding to compute the scale radius of a dark matter profile as a given energy.
     !!}
-    use :: Calculations_Resets       , only : Calculations_Reset
-    use :: Mass_Distributions        , only : massDistributionClass
-    use :: Galactic_Structure_Options, only : componentTypeDarkMatterOnly, massTypeDark
+    use :: Calculations_Resets, only : Calculations_Reset
+    use :: Mass_Distributions , only : massDistributionClass
     implicit none
     double precision                       , intent(in   ) :: radiusScale
     class           (massDistributionClass), pointer       :: massDistribution_
     
     call darkMatterProfile_%scaleSet(radiusScale)
     call Calculations_Reset(node_)
-    massDistribution_ =>  node_             %massDistribution(componentTypeDarkMatterOnly,massTypeDark)
-    radiusScaleRoot    =  +                  energyTotal                                                                        &
-         &                -massDistribution_%energy          (self_%darkMatterHaloScale_%radiusVirial(node_),massDistribution_)
+    massDistribution_ =>  self_%darkMatterProfileDMO_%get        (                                        node_                   )
+    radiusScaleRoot    =  +                           energyTotal                                                                   &
+         &                -     massDistribution_    %energy     (self_%darkMatterHaloScale_%radiusVirial(node_),massDistribution_)
     !![
     <objectDestructor name="massDistribution_"/>
     !!]


### PR DESCRIPTION
This allows a different density profile (e.g. NFW) to be provided for these calculations.