### PR TITLE
Fix problems in halo spin distribution classes

### DIFF
--- a/source/dark_matter_halos.spins.distributions.lognormal.F90
+++ b/source/dark_matter_halos.spins.distributions.lognormal.F90
@@ -27,8 +27,11 @@
   !![
   <haloSpinDistribution name="haloSpinDistributionLogNormal">
    <description>
-    A halo spin distribution class in which the spin is drawn from a lognormal distribution with median {\normalfont \ttfamily
-    [median]} and width {\normalfont \ttfamily [sigma]}.
+    A halo spin distribution class in which the spin is drawn from a lognormal distribution with median $\bar{\lambda}=${\normalfont \ttfamily
+    [median]} and width $\sigma=${\normalfont \ttfamily [sigma]}. Specifically, the distribution function for spin, $\lambda$, is
+    \begin{equation}
+    p(\lambda) = \frac{1}{\sqrt{2 \pi} \sigma \lambda} \exp\left[ - \frac{1}{2} \left(\frac{\log\lambda-\log\bar{\lambda}}{\sigma}\right)^2\right].
+    \end{equation}
    </description>
   </haloSpinDistribution>
   !!]
@@ -135,11 +138,10 @@ contains
     implicit none
     class(haloSpinDistributionLogNormal), intent(inout) :: self
     type (treeNode                     ), intent(inout) :: node
-    !$GLC attributes unused :: node
 
     logNormalSample=exp(                                                             &
-         &              +self%median                                                 &
-         &              +self%sigma                                                  &
+         &              +log(self%median)                                            &
+         &              +    self%sigma                                              &
          &              *node%hostTree%randomNumberGenerator_%standardNormalSample() &
          &             )
     return
@@ -151,7 +153,7 @@ contains
     assuming a log-normal distribution.
     !!}
     use :: Dark_Matter_Halo_Spins  , only : Dark_Matter_Halo_Angular_Momentum_Scale
-    use :: Galacticus_Nodes        , only : nodeComponentSpin                       , treeNode
+    use :: Galacticus_Nodes        , only : nodeComponentSpin                      , treeNode
     use :: Numerical_Constants_Math, only : Pi
     implicit none
     class           (haloSpinDistributionLogNormal), intent(inout) :: self
@@ -162,19 +164,19 @@ contains
     spin                  =>  node%spin           ()
     spin_                 =  +spin%angularMomentum()                                                 &
          &                  /Dark_Matter_Halo_Angular_Momentum_Scale(node,self%darkMatterHaloScale_)
-    logNormalDistribution =  +exp(               &
-         &                        -(             &
-         &                          +log(spin_)  &
-         &                          -self%median &
-         &                         )**2          &
-         &                        /2.0d0         &
-         &                        /self%sigma**2 &
-         &                       )               &
-         &                   /sqrt(              &
-         &                         +2.0d0        &
-         &                         *Pi           &
-         &                        )              &
-         &                   /self%sigma         &
+    logNormalDistribution =  +exp(                    &
+         &                        -(                  &
+         &                          +log(     spin_ ) &
+         &                          -log(self%median) &
+         &                         )**2               &
+         &                        /2.0d0              &
+         &                        /self%sigma**2      &
+         &                       )                    &
+         &                   /sqrt(                   &
+         &                         +2.0d0             &
+         &                         *Pi                &
+         &                        )                   &
+         &                   /self%sigma              &
          &                   /spin_
     return
   end function logNormalDistribution


### PR DESCRIPTION
* In the `haloSpinDistributionBett2007` class the range of tabulation is now automatically adjusted to ensure that the distribution function is always invertible. Specifically, a large initial maximum spin is tried - if the CDF reaches 1 (to machine precision) before this maximum, the maximum spin is reduced to just before the spin at which the CDF first reaches 1.0, and the table is rebuilt.

* In the `haloSpinDistributionLogNormal` class the median spin was incorrectly used directly in the distribution function - the logarithm of this value should be used instead.