### PR TITLE
Use the dark matter only executable for dark matter only validation and benchmark models

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -687,11 +687,11 @@ jobs:
       - run: echo "This job's status is ${{ job.status }}."
   # Benchmarks
   Benchmark-Dark-Matter-Only-Subhalos:
-    needs: Build-Executable-Linux
+    needs: Build-Executable-DMO-Linux
     uses: ./.github/workflows/testModel.yml
     with:
       file: benchmark-darkMatterOnlySubhalos.pl
-      artifact: galacticus-exec
+      artifact: galacticus-exec-dmo
       runPath: ./testSuite
       cacheData: 0
       install: time
@@ -762,12 +762,12 @@ jobs:
       name: milkyWay_SIDM
   # Validation
   Validate-Dark-Matter-Only-Subhalos:
-    needs: Build-Executable-Linux
+    needs: Build-Executable-DMO-Linux
     uses: ./.github/workflows/testModel.yml
     with:
       install: python3 python3-h5py python3-numpy python3-git
       file: validate-darkMatterOnlySubhalos.py
-      artifact: galacticus-exec
+      artifact: galacticus-exec-dmo
       runPath: ./testSuite
       cacheData: 0
       uploadFile: ./testSuite/outputs/*.json
@@ -822,12 +822,12 @@ jobs:
       uploadName: validate-idealizedSubhaloSimulations
     secrets: inherit
   Validate-Decaying-Dark-Matter-Only-Subhalos:
-    needs: Build-Executable-Linux
+    needs: Build-Executable-DMO-Linux
     uses: ./.github/workflows/testModel.yml
     with:
       install: python3 python3-h5py python3-numpy python3-git
       file: validate-darkMatterOnlySubhalos-decayingDarkMatter.py
-      artifact: galacticus-exec
+      artifact: galacticus-exec-dmo
       runPath: ./testSuite
       cacheData: 0
       uploadFile: ./testSuite/outputs/*.json


### PR DESCRIPTION
This should result in lower CPU and memory requirements for these models.