### PR TITLE
Add an error handler when evaluating likelihood in the `posteriorSampleLikelihoodGalaxyPopulation` class

### DIFF
--- a/aux/words.dict
+++ b/aux/words.dict
@@ -360,6 +360,7 @@ declinations
 decrement
 dereference
 dereferenced
+deregister
 descendantless
 deserialization
 deserialize

--- a/source/Galacticus.F90
+++ b/source/Galacticus.F90
@@ -32,7 +32,7 @@ program Galacticus
   use    :: Functions_Global_Utilities, only : Functions_Global_Set
   use    :: Display_Banner            , only : Display_Banner_Show
   use    :: Error                     , only : Error_Handler_Register           , Error_Report         , errorStatusSuccess
-  use    :: Error_Wait                , only : Error_Wait_Set_From_Parameters
+  use    :: Error_Utilities           , only : Error_Wait_Set_From_Parameters
   use    :: Output_HDF5_Open          , only : Output_HDF5_Close_File           , Output_HDF5_Open_File, Output_HDF5_Completion_Status
   use    :: ISO_Varying_String        , only : assignment(=)                    , varying_string
   use    :: Input_Parameters          , only : inputParameter                   , inputParameters

--- a/source/error.utilities.F90
+++ b/source/error.utilities.F90
@@ -18,17 +18,52 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which handles setting of error wait times.
+Contains a module which provides error handling utilities.
 !!}
 
-module Error_Wait
+module Error_Utilities
   !!{
-  Handle setting of error wait times.
+  Provides error handling utilities.
   !!}
   implicit none
   private
   public :: Error_Wait_Set_From_Parameters
 
+  ! Enumeration of signal numbers.
+  !![
+  <enumeration>
+    <name>signal</name>
+    <description>Enumeration of UNIX signal numbers.</description>
+    <decodeFunction>yes</decodeFunction>
+    <visibility>public</visibility>
+    <indexing>1</indexing>
+    <entry label="SIGHUP"   /> <!--  1 -->
+    <entry label="SIGINT"   /> <!--  2 -->
+    <entry label="SIGQUIT"  /> <!--  3 -->
+    <entry label="SIGILL"   /> <!--  4 -->
+    <entry label="SIGTRAP"  /> <!--  5 -->
+    <entry label="SIGABRT"  /> <!--  6 -->
+    <entry label="SIGBUS"   /> <!--  7 -->
+    <entry label="SIGFPE"   /> <!--  8 -->
+    <entry label="SIGKILL"  /> <!--  9 -->
+    <entry label="SIGUSR1"  /> <!-- 10 -->
+    <entry label="SIGSEGV"  /> <!-- 11 -->
+    <entry label="SIGUSR2"  /> <!-- 12 -->
+    <entry label="SIGPIPE"  /> <!-- 13 -->
+    <entry label="SIGALRM"  /> <!-- 14 -->
+    <entry label="SIGTERM"  /> <!-- 15 -->
+    <entry label="SIGSTKFLT"/> <!-- 16 -->
+    <entry label="SIGCHLD"  /> <!-- 17 -->
+    <entry label="SIGCONT"  /> <!-- 18 -->
+    <entry label="SIGSTOP"  /> <!-- 19 -->
+    <entry label="SIGTSTP"  /> <!-- 20 -->
+    <entry label="SIGTTIN"  /> <!-- 21 -->
+    <entry label="SIGTTOU"  /> <!-- 22 -->
+    <entry label="SIGURG"   /> <!-- 23 -->
+    <entry label="SIGXCPU"  /> <!-- 24 -->
+  </enumeration>
+  !!]
+  
 contains
 
   subroutine Error_Wait_Set_From_Parameters(parameters)
@@ -54,4 +89,4 @@ contains
     return
   end subroutine Error_Wait_Set_From_Parameters
 
-end module Error_Wait
+end module Error_Utilities

--- a/source/models.likelihoods.F90
+++ b/source/models.likelihoods.F90
@@ -39,6 +39,7 @@ module Models_Likelihoods
     <description>Evaluate the likelihood.</description>
     <type>double precision</type>
     <pass>yes</pass>
+    <selfTarget>yes</selfTarget>
     <argument>class           (posteriorSampleStateClass      ), intent(inout)               :: simulationState</argument>
     <argument>type            (modelParameterList             ), intent(inout), dimension(:) :: modelParametersActive_, modelParametersInactive_</argument>
     <argument>class           (posteriorSampleConvergenceClass), intent(inout)               :: simulationConvergence</argument>

--- a/source/models.likelihoods.SED_fit.F90
+++ b/source/models.likelihoods.SED_fit.F90
@@ -265,7 +265,7 @@ contains
           &                                                     stellarSpectraDustAttenuationClass  , stellarSpectraDustAttenuationGordon2003  , stellarSpectraDustAttenuationWittGordon2000, stellarSpectraDustAttenuationZero           , &
           &                                                     wittGordon2000ModelMilkyWayShellTau3
     implicit none
-    class           (posteriorSampleLikelihoodSEDFit   ), intent(inout)                 :: self
+    class           (posteriorSampleLikelihoodSEDFit   ), intent(inout), target         :: self
     class           (posteriorSampleStateClass         ), intent(inout)                 :: simulationState
     type            (modelParameterList                ), intent(inout), dimension(:  ) :: modelParametersActive_                          , modelParametersInactive_
     class           (posteriorSampleConvergenceClass   ), intent(inout)                 :: simulationConvergence

--- a/source/models.likelihoods.galaxy_population.F90
+++ b/source/models.likelihoods.galaxy_population.F90
@@ -55,6 +55,11 @@
      module procedure galaxyPopulationConstructorInternal
   end interface posteriorSampleLikelihoodGalaxyPopulation
 
+  ! Sub-module-scope pointer to self, used to allow writing of current parameters in case of failures.
+  class  (posteriorSampleLikelihoodGalaxyPopulation), pointer :: self_
+  integer                                                     :: iRank_
+  !$omp threadprivate(self_,iRank_)
+  
 contains
 
   function galaxyPopulationConstructorParameters(parameters) result(self)
@@ -179,7 +184,7 @@ contains
     use :: Display                       , only : displayIndent                  , displayMessage               , displayUnindent             , displayVerbosity, &
           &                                       displayVerbositySet            , verbosityLevelSilent         , verbosityLevelStandard
     use :: Functions_Global              , only : Tasks_Evolve_Forest_Construct_ , Tasks_Evolve_Forest_Destruct_, Tasks_Evolve_Forest_Perform_
-    use :: Error                         , only : errorStatusSuccess
+    use :: Error                         , only : errorStatusSuccess             , signalHandlerRegister        , signalHandlerDeregister     , signalHandlerInterface
     use :: ISO_Varying_String            , only : char                           , operator(//)                 , var_str
     use :: Kind_Numbers                  , only : kind_int8
     use :: MPI_Utilities                 , only : mpiBarrier                     , mpiSelf
@@ -190,7 +195,7 @@ contains
     use :: Posterior_Sampling_State      , only : posteriorSampleStateClass
     use :: String_Handling               , only : String_Count_Words             , String_Join                  , String_Split_Words          , operator(//)
     implicit none
-    class           (posteriorSampleLikelihoodGalaxyPopulation), intent(inout)                 :: self
+    class           (posteriorSampleLikelihoodGalaxyPopulation), intent(inout), target         :: self
     class           (posteriorSampleStateClass                ), intent(inout)                 :: simulationState
     type            (modelParameterList                       ), intent(inout), dimension(:  ) :: modelParametersActive_, modelParametersInactive_
     class           (posteriorSampleConvergenceClass          ), intent(inout)                 :: simulationConvergence
@@ -201,6 +206,7 @@ contains
     logical                                                    , intent(inout), optional       :: forceAcceptance
     double precision                                           , allocatable  , dimension(:  ) :: logPriorsProposed
     double precision                                           , allocatable  , dimension(:,:) :: stateVector
+    procedure       (signalHandlerInterface                   ), pointer                       :: handler
     integer                                                                                    :: iRank                 , status                  , &
          &                                                                                        rankStart             , rankStop
     type            (enumerationVerbosityLevelType            )                                :: verbosityLevel
@@ -211,6 +217,10 @@ contains
     logical                                                                                    :: isActive
     !$GLC attributes unused :: logPriorCurrent, logLikelihoodCurrent, forceAcceptance, temperature, simulationConvergence
 
+    ! Register an error handler.
+    self_   => self
+    handler => posteriorSampleLikelihoodGalaxyPopulationSignalHandler
+    call signalHandlerRegister(handler)
     ! Switch verbosity level.
     verbosityLevel=displayVerbosity()
     call displayVerbositySet(self%evolveForestsVerbosity)
@@ -236,6 +246,7 @@ contains
     end if
     ! Iterate over all chains.
     do iRank=rankStart,rankStop
+       iRank_=iRank
        ! Determine if this is the active rank.
        isActive=iRank == mpiSelf%rank() .or. .not.self%collaborativeMPI
        ! If prior probability is impossible, then no need to waste time evaluating the likelihood.
@@ -314,6 +325,8 @@ contains
     end if
     ! Restore verbosity level.
     call displayVerbositySet(verbosityLevel)
+    ! Deregister our error handler.
+    call signalHandlerDeregister(handler)
     return
   end function galaxyPopulationEvaluate
 
@@ -348,3 +361,24 @@ contains
     galaxyPopulationWillEvaluate=(logPriorProposed > logImpossible)
     return
   end function galaxyPopulationWillEvaluate
+
+  subroutine posteriorSampleLikelihoodGalaxyPopulationSignalHandler(signal)
+    !!{
+    Write out current parameters if a signal was caught during model evaluation.
+    !!}
+    use :: Display           , only : displayMessage         , displayBold   , displayRed, displayReset, &
+         &                            verbosityLevelSilent
+    use :: ISO_Varying_String, only : operator(//)           , varying_string
+    use :: String_Handling   , only : operator(//)
+    use :: Error_Utilities   , only : enumerationSignalDecode
+    implicit none
+    integer                , intent(in   ) :: signal
+    type   (varying_string)                :: fileName
+    
+    ! Dump the failed parameter set to file.
+    fileName=self_%failedParametersFileName//"."//iRank_//"."//enumerationSignalDecode(signal,includePrefix=.false.)
+    call displayMessage(displayRed()//displayBold()//"Error condition:"//displayReset()//" `posteriorSampleLikelihoodGalaxyPopulation` parameter state will be written to '"//fileName//"'",verbosityLevelSilent)
+    call self_%parametersModel%serializeToXML(fileName)
+    return
+  end subroutine posteriorSampleLikelihoodGalaxyPopulationSignalHandler
+  

--- a/source/models.likelihoods.gaussian_regression.F90
+++ b/source/models.likelihoods.gaussian_regression.F90
@@ -336,7 +336,7 @@ contains
     use :: Posterior_Sampling_State      , only : posteriorSampleStateClass      , posteriorSampleStateCorrelation
     use :: String_Handling               , only : operator(//)
     implicit none
-    class           (posteriorSampleLikelihoodGaussianRegression), intent(inout)                   :: self
+    class           (posteriorSampleLikelihoodGaussianRegression), intent(inout), target           :: self
     class           (posteriorSampleStateClass                  ), intent(inout)                   :: simulationState
     type            (modelParameterList                         ), intent(inout), dimension(:)     :: modelParametersActive_                    , modelParametersInactive_
     class           (posteriorSampleConvergenceClass            ), intent(inout)                   :: simulationConvergence

--- a/source/models.likelihoods.halo_mass_function.F90
+++ b/source/models.likelihoods.halo_mass_function.F90
@@ -295,7 +295,7 @@ contains
     use :: Statistics_NBody_Halo_Mass_Errors, only : nbodyHaloMassErrorClass         , nbodyHaloMassErrorPowerLaw         , nbodyHaloMassErrorSOHaloFinder, nbodyHaloMassErrorTrenti2010
     use :: Factorials                       , only : Logarithmic_Factorial
     implicit none
-    class           (posteriorSampleLikelihoodHaloMassFunction), intent(inout)               :: self
+    class           (posteriorSampleLikelihoodHaloMassFunction), intent(inout), target       :: self
     class           (posteriorSampleStateClass                ), intent(inout)               :: simulationState
     type            (modelParameterList                       ), intent(inout), dimension(:) :: modelParametersActive_        , modelParametersInactive_
     class           (posteriorSampleConvergenceClass          ), intent(inout)               :: simulationConvergence

--- a/source/models.likelihoods.independent_likelihoods.F90
+++ b/source/models.likelihoods.independent_likelihoods.F90
@@ -226,7 +226,7 @@ contains
     use :: Error                       , only : Error_Report
     use :: Models_Likelihoods_Constants, only : logImpossible
     implicit none
-    class           (posteriorSampleLikelihoodIndependentLikelihoods), intent(inout)               :: self
+    class           (posteriorSampleLikelihoodIndependentLikelihoods), intent(inout), target       :: self
     class           (posteriorSampleStateClass                      ), intent(inout)               :: simulationState
     type            (modelParameterList                             ), intent(inout), dimension(:) :: modelParametersActive_, modelParametersInactive_
     class           (posteriorSampleConvergenceClass                ), intent(inout)               :: simulationConvergence

--- a/source/models.likelihoods.independent_likelihoods.sequential.F90
+++ b/source/models.likelihoods.independent_likelihoods.sequential.F90
@@ -152,7 +152,7 @@ contains
     use :: Models_Likelihoods_Constants, only : logImpossible , logImprobable
     use :: String_Handling             , only : operator(//)
     implicit none
-    class           (posteriorSampleLikelihoodIndpndntLklhdsSqntl), intent(inout)               :: self
+    class           (posteriorSampleLikelihoodIndpndntLklhdsSqntl), intent(inout), target       :: self
     class           (posteriorSampleStateClass                   ), intent(inout)               :: simulationState
     type            (modelParameterList                          ), intent(inout), dimension(:) :: modelParametersActive_, modelParametersInactive_
     class           (posteriorSampleConvergenceClass             ), intent(inout)               :: simulationConvergence

--- a/source/models.likelihoods.mass_function.F90
+++ b/source/models.likelihoods.mass_function.F90
@@ -280,7 +280,7 @@ contains
     use :: Posterior_Sampling_Convergence, only : posteriorSampleConvergenceClass
     use :: Posterior_Sampling_State      , only : posteriorSampleStateClass
     implicit none
-    class           (posteriorSampleLikelihoodMassFunction      ), intent(inout)               :: self
+    class           (posteriorSampleLikelihoodMassFunction      ), intent(inout), target       :: self
     class           (posteriorSampleStateClass                  ), intent(inout)               :: simulationState
     type            (modelParameterList                         ), intent(inout), dimension(:) :: modelParametersActive_         , modelParametersInactive_
     class           (posteriorSampleConvergenceClass            ), intent(inout)               :: simulationConvergence

--- a/source/models.likelihoods.multivariate_normal.F90
+++ b/source/models.likelihoods.multivariate_normal.F90
@@ -126,7 +126,7 @@ contains
     use :: Posterior_Sampling_Convergence, only : posteriorSampleConvergenceClass
     use :: Posterior_Sampling_State      , only : posteriorSampleStateClass
     implicit none
-    class           (posteriorSampleLikelihoodMultivariateNormal), intent(inout)               :: self
+    class           (posteriorSampleLikelihoodMultivariateNormal), intent(inout), target       :: self
     class           (posteriorSampleStateClass                  ), intent(inout)               :: simulationState
     type            (modelParameterList                         ), intent(inout), dimension(:) :: modelParametersActive_, modelParametersInactive_
     class           (posteriorSampleConvergenceClass            ), intent(inout)               :: simulationConvergence

--- a/source/models.likelihoods.multivariate_normal.stochastic.F90
+++ b/source/models.likelihoods.multivariate_normal.stochastic.F90
@@ -154,7 +154,7 @@ contains
     use :: Posterior_Sampling_Convergence, only : posteriorSampleConvergenceClass
     use :: Posterior_Sampling_State      , only : posteriorSampleStateClass
     implicit none
-    class           (posteriorSampleLikelihoodMltiVrtNormalStochastic), intent(inout)                 :: self
+    class           (posteriorSampleLikelihoodMltiVrtNormalStochastic), intent(inout), target         :: self
     class           (posteriorSampleStateClass                       ), intent(inout)                 :: simulationState
     type            (modelParameterList                              ), intent(inout), dimension(:)   :: modelParametersActive_, modelParametersInactive_
     class           (posteriorSampleConvergenceClass                 ), intent(inout)                 :: simulationConvergence

--- a/source/models.likelihoods.posterior_as_prior.F90
+++ b/source/models.likelihoods.posterior_as_prior.F90
@@ -296,7 +296,7 @@ contains
     use :: Posterior_Sampling_Convergence, only : posteriorSampleConvergenceClass
     use :: Posterior_Sampling_State      , only : posteriorSampleStateClass
     implicit none
-    class           (posteriorSampleLikelihoodPosteriorAsPrior), intent(inout)               :: self
+    class           (posteriorSampleLikelihoodPosteriorAsPrior), intent(inout), target       :: self
     class           (posteriorSampleStateClass                ), intent(inout)               :: simulationState
     type            (modelParameterList                       ), intent(inout), dimension(:) :: modelParametersActive_, modelParametersInactive_
     class           (posteriorSampleConvergenceClass          ), intent(inout)               :: simulationConvergence

--- a/source/models.likelihoods.projected_correlation_function.F90
+++ b/source/models.likelihoods.projected_correlation_function.F90
@@ -254,7 +254,7 @@ contains
     use :: Posterior_Sampling_Convergence   , only : posteriorSampleConvergenceClass
     use :: Posterior_Sampling_State         , only : posteriorSampleStateClass
     implicit none
-    class           (posteriorSampleLikelihoodPrjctdCorrelationFunction), intent(inout)               :: self
+    class           (posteriorSampleLikelihoodPrjctdCorrelationFunction), intent(inout), target       :: self
     class           (posteriorSampleStateClass                         ), intent(inout)               :: simulationState
     type            (modelParameterList                                ), intent(inout), dimension(:) :: modelParametersActive_  , modelParametersInactive_
     class           (posteriorSampleConvergenceClass                   ), intent(inout)               :: simulationConvergence

--- a/source/models.likelihoods.spin_distribution.F90
+++ b/source/models.likelihoods.spin_distribution.F90
@@ -247,7 +247,7 @@ contains
     use :: Posterior_Sampling_Convergence, only : posteriorSampleConvergenceClass
     use :: Posterior_Sampling_State      , only : posteriorSampleStateClass
     implicit none
-    class           (posteriorSampleLikelihoodSpinDistribution), intent(inout)               :: self
+    class           (posteriorSampleLikelihoodSpinDistribution), intent(inout), target       :: self
     class           (posteriorSampleStateClass                ), intent(inout)               :: simulationState
     type            (modelParameterList                       ), intent(inout), dimension(:) :: modelParametersActive_, modelParametersInactive_
     class           (posteriorSampleConvergenceClass          ), intent(inout)               :: simulationConvergence


### PR DESCRIPTION
This allows writing of the current state as a parameter file when an error is caught.

To enable this, this PR allows arbitrary functions to be called when error signals are caught. Functions can be registered/deregistered and will be called when any fatal signal is caught. The intent is to allow for additional error-reporting functionality.
