### PR TITLE
Set the mass of the central black hole correctly after a merger

### DIFF
--- a/source/objects.nodes.components.black_hole.standard.F90
+++ b/source/objects.nodes.components.black_hole.standard.F90
@@ -308,10 +308,10 @@ contains
              massBlackHoleNew=0.0d0
              spinBlackHoleNew=0.0d0
           end if
-          ! Move the black hole to the host.
+          ! Set the new black hole mass in the host.
           call Node_Component_Black_Hole_Standard_Output_Merger(node,massBlackHole1,massBlackHole2)
-          call blackHoleHostCentral%massSet(blackHoleSeeds_%mass(node))
-          call blackHoleHostCentral%spinSet(blackHoleSeeds_%spin(node))
+          call blackHoleHostCentral%massSet(massBlackHoleNew)
+          call blackHoleHostCentral%spinSet(spinBlackHoleNew)
        end do
     else
        ! Adjust the radii of the black holes in the satellite galaxy.


### PR DESCRIPTION
A bug was introduced that caused the mass of the central black hole to be reset to the seed mass after any merger, instead of to the mass of the merged black hole.