### PR TITLE
Change the MPI wait-on-error time to zero

### DIFF
--- a/source/error.utilities.F90
+++ b/source/error.utilities.F90
@@ -76,11 +76,10 @@ contains
     type   (inputParameters), intent(inout) :: parameters
     integer                                 :: errorWaitTime
 
-    ! Get the verbosity level parameter.
     !![
     <inputParameter>
       <name>errorWaitTime</name>
-      <defaultValue>86400</defaultValue>
+      <defaultValue>0</defaultValue>
       <description>The time, in seconds, for which \glc\ should sleep after a fatal error when running under MPI.</description>
       <source>parameters</source>
     </inputParameter>


### PR DESCRIPTION
This seems more useful as errors will now cause immediate termination (and notification) of the job. A non-zero wait time can then be set if such is useful for debugging.