### PR TITLE
Use the correct mass distribution when undecorating kinematics distributions

### DIFF
--- a/source/kinematic_distributions.undecorator.F90
+++ b/source/kinematic_distributions.undecorator.F90
@@ -121,7 +121,7 @@ contains
         ! For the case of a self-gravitating distribution we can use the undecorated kinematic distribution in its own mass distribution.
        select type (massDistributionEmbedding)
        class is (massDistributionSphericalDecorator)
-          velocityDispersion=self%kinematicsDistribution_%velocityDispersion1D(coordinates,massDistribution_,massDistributionEmbedding%massDistribution_)
+          velocityDispersion=self%kinematicsDistribution_%velocityDispersion1D(coordinates,massDistributionEmbedding%massDistribution_,massDistributionEmbedding%massDistribution_)
        class default
           velocityDispersion=+0.0d0
           call Error_Report('mass distribution must be of the `massDistributionSphericalDecorator` class but found `'//char(massDistributionEmbedding%objectType())//'`'//{introspection:location})


### PR DESCRIPTION
When computing the velocity dispersion in self-gravitating decorated mass distributions, and the undecorated distribution can be used, we were previously undecorating only the embedding mass distribution, not the target mass distribution. This resulted in a mismatch between target and embedding mass distributions, which caused incorrect results and slow-downs (as analytic solutions for self-gravitating systems could not be used).