### PR TITLE
Determine the repo for Docker builds from the `github` context

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -333,6 +333,7 @@ jobs:
           tags: ghcr.io/galacticusorg/galacticus:latest
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
+            REPO=${{ github.repository }}
             BRANCH=${{ github.head_ref || github.ref_name }}          
   ### Documentation
   Build-Documentation-Linux:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 
 ARG TAG=latest
 FROM ghcr.io/galacticusorg/buildenv:${TAG} as build
+ARG REPO=galacticusorg/galacticus
 ARG BRANCH=master
 
 # Set build options.
@@ -19,7 +20,7 @@ RUN     pwd && ls
 
 # Clone datasets.
 RUN     cd /opt &&\
-	git clone --depth 1 -b ${BRANCH} https://github.com/galacticusorg/galacticus.git galacticus &&\
+	git clone --depth 1 -b ${BRANCH} https://github.com/${REPO}.git galacticus &&\
 	git clone --depth 1 https://github.com/galacticusorg/datasets.git datasets
 
 # Build Galacticus.


### PR DESCRIPTION
Should allow PR-triggered builds to use the correct repo.