### PR TITLE
Correct source file comments where the file no longer contains a `module`

### DIFF
--- a/source/dark_matter.particle.cold_dark_matter.F90
+++ b/source/dark_matter.particle.cold_dark_matter.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a cold dark matter particle class.
+Implements a cold dark matter particle class.
 !!}
 
 

--- a/source/dark_matter.particle.decaying.F90
+++ b/source/dark_matter.particle.decaying.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a decaying dark matter particle class.
+Implements a decaying dark matter particle class.
 !!}
 
   !![

--- a/source/dark_matter.particle.fuzzy_dark_matter.F90
+++ b/source/dark_matter.particle.fuzzy_dark_matter.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a fuzzy dark matter particle class.
+Implements a fuzzy dark matter particle class.
 !!}
 
   !![

--- a/source/dark_matter.particle.self_interacting.F90
+++ b/source/dark_matter.particle.self_interacting.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a selfInteracting dark matter particle class.
+Implements a selfInteracting dark matter particle class.
 !!}
 
   !![

--- a/source/dark_matter.particle.warm_dark_matter.thermal.F90
+++ b/source/dark_matter.particle.warm_dark_matter.thermal.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a thermal warm dark matter particle class.
+Implements a thermal warm dark matter particle class.
 !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/galactic.filter.null.F90
+++ b/source/galactic.filter.null.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a null filter.
+Implements a null filter.
 !!}
 
   !![

--- a/source/galactic.filters.ISM_mass.F90
+++ b/source/galactic.filters.ISM_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic high-pass filter for total ISM mass.
+Implements a galactic high-pass filter for total ISM mass.
 !!}
 
   !![

--- a/source/galactic.filters.all.F90
+++ b/source/galactic.filters.all.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter class which is the ``all'' combination of a set of other filters.
+Implements a galactic filter class which is the ``all'' combination of a set of other filters.
 !!}
 
   !![

--- a/source/galactic.filters.always.F90
+++ b/source/galactic.filters.always.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter which always passes.
+Implements a galactic filter which always passes.
 !!}
 
   !![

--- a/source/galactic.filters.any.F90
+++ b/source/galactic.filters.any.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter class which is the ``any'' combination of a set of other filters.
+Implements a galactic filter class which is the ``any'' combination of a set of other filters.
 !!}
 
   !![

--- a/source/galactic.filters.any_descendant_node.F90
+++ b/source/galactic.filters.any_descendant_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a galactic filter which applies another filter to all descendant nodes of the given node and
+  Implements a galactic filter which applies another filter to all descendant nodes of the given node and
   passes if any descendant passes.
   !!}
   

--- a/source/galactic.filters.basic_mass.F90
+++ b/source/galactic.filters.basic_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic high-pass filter for the default ``basic'' halo mass.
+Implements a galactic high-pass filter for the default ``basic'' halo mass.
 !!}
 
   !![

--- a/source/galactic.filters.branch_most_massive.F90
+++ b/source/galactic.filters.branch_most_massive.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only the most massive branch halo.
+Implements a filter which passes only the most massive branch halo.
 !!}
 
   !![

--- a/source/galactic.filters.child_node.F90
+++ b/source/galactic.filters.child_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter which applies another filter to a child node of the given node.
+Implements a galactic filter which applies another filter to a child node of the given node.
 !!}
   
   !![

--- a/source/galactic.filters.constrained_branch.F90
+++ b/source/galactic.filters.constrained_branch.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only constrained branch halos.
+Implements a filter which passes only constrained branch halos.
 !!}
 
   !![

--- a/source/galactic.filters.descendant_node.F90
+++ b/source/galactic.filters.descendant_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter which applies another filter to a descendant node of the given node.
+Implements a galactic filter which applies another filter to a descendant node of the given node.
 !!}
   
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/galactic.filters.formation_time.F90
+++ b/source/galactic.filters.formation_time.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter which removes recently-formed halos.
+Implements a galactic filter which removes recently-formed halos.
 !!}
 
   !![

--- a/source/galactic.filters.gas_fraction_ISM.F90
+++ b/source/galactic.filters.gas_fraction_ISM.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic high-pass filter for ISM gas fraction (i.e. ISM gas mass to stellar mass ratio).
+Implements a galactic high-pass filter for ISM gas fraction (i.e. ISM gas mass to stellar mass ratio).
 !!}
 
   !![

--- a/source/galactic.filters.halo_always_isolated.F90
+++ b/source/galactic.filters.halo_always_isolated.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only halos that have always been isolated.
+Implements a filter which passes only halos that have always been isolated.
 !!}
 
   !![

--- a/source/galactic.filters.halo_isolated.F90
+++ b/source/galactic.filters.halo_isolated.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only isolated halos.
+Implements a filter which passes only isolated halos.
 !!}
 
   !![

--- a/source/galactic.filters.halo_mass.F90
+++ b/source/galactic.filters.halo_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic high-pass filter for halo mass under a given definition.
+Implements a galactic high-pass filter for halo mass under a given definition.
 !!}
 
   use :: Cosmology_Parameters   , only : cosmologyParametersClass

--- a/source/galactic.filters.halo_mass_range.F90
+++ b/source/galactic.filters.halo_mass_range.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter for halo mass under a given definition.
+Implements a galactic filter for halo mass under a given definition.
 !!}
 
   use :: Cosmology_Parameters   , only : cosmologyParametersClass

--- a/source/galactic.filters.halo_not_isolated.F90
+++ b/source/galactic.filters.halo_not_isolated.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only non-isolated halos.
+Implements a filter which passes only non-isolated halos.
 !!}
 
   !![

--- a/source/galactic.filters.hierarchy_depth_maximum.F90
+++ b/source/galactic.filters.hierarchy_depth_maximum.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only halos below a specified hierarchy depth.
+Implements a filter which passes only halos below a specified hierarchy depth.
 !!}
 
   !![

--- a/source/galactic.filters.high_pass.F90
+++ b/source/galactic.filters.high_pass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a high-pass filter on any node property.
+Implements a high-pass filter on any node property.
 !!}
 
   use :: Node_Property_Extractors, only : nodePropertyExtractorScalar

--- a/source/galactic.filters.interval_pass.F90
+++ b/source/galactic.filters.interval_pass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an interval pass filter on any node property.
+Implements an interval pass filter on any node property.
 !!}
 
   use :: Node_Property_Extractors, only : nodePropertyExtractorScalar

--- a/source/galactic.filters.isolated_host_node.F90
+++ b/source/galactic.filters.isolated_host_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter which applies another filter to the isolated host node of the given node.
+Implements a galactic filter which applies another filter to the isolated host node of the given node.
 !!}
   
   !![

--- a/source/galactic.filters.lightcone.F90
+++ b/source/galactic.filters.lightcone.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter on lightcone geometry.
+Implements a galactic filter on lightcone geometry.
 !!}
 
   use :: Geometry_Lightcones, only : geometryLightconeClass

--- a/source/galactic.filters.low_pass.F90
+++ b/source/galactic.filters.low_pass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a low-pass filter on any node property.
+Implements a low-pass filter on any node property.
 !!}
 
   use :: Node_Property_Extractors, only : nodePropertyExtractorScalar

--- a/source/galactic.filters.main_branch.F90
+++ b/source/galactic.filters.main_branch.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only main branch halos.
+Implements a filter which passes only main branch halos.
 !!}
 
   !![

--- a/source/galactic.filters.major_node_merger.recent.F90
+++ b/source/galactic.filters.major_node_merger.recent.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic low-pass filter for time since the last major node merger.
+Implements a galactic low-pass filter for time since the last major node merger.
 !!}
 
   !![

--- a/source/galactic.filters.merger_ratio.F90
+++ b/source/galactic.filters.merger_ratio.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an interval pass filter on halo merger ratio.
+Implements an interval pass filter on halo merger ratio.
 !!}
 
   !![

--- a/source/galactic.filters.not.F90
+++ b/source/galactic.filters.not.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an inverting filter.
+Implements an inverting filter.
 !!}
 
   !![

--- a/source/galactic.filters.parent_node.F90
+++ b/source/galactic.filters.parent_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic filter which applies another filter to a parent node of the given node.
+Implements a galactic filter which applies another filter to a parent node of the given node.
 !!}
   
   !![

--- a/source/galactic.filters.primary_descendant_node.F90
+++ b/source/galactic.filters.primary_descendant_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a galactic filter which applies another filter to all descendant nodes of the given node and
+  Implements a galactic filter which applies another filter to all descendant nodes of the given node and
   passes if any primary descendant passes.  
   !!}
   

--- a/source/galactic.filters.root_node.F90
+++ b/source/galactic.filters.root_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only nodes that are roots of their merger tree.
+Implements a filter which passes only nodes that are roots of their merger tree.
 !!}
 
   !![

--- a/source/galactic.filters.spheroid_stellar_mass.F90
+++ b/source/galactic.filters.spheroid_stellar_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic high-pass filter for spheroid stellar mass.
+Implements a galactic high-pass filter for spheroid stellar mass.
 !!}
 
   !![

--- a/source/galactic.filters.star_formation_rate.F90
+++ b/source/galactic.filters.star_formation_rate.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic high-pass filter for total star formation rate.
+Implements a galactic high-pass filter for total star formation rate.
 !!}
 
   use :: Star_Formation_Rates_Disks                , only : starFormationRateDisksClass

--- a/source/galactic.filters.stellar_absolute_magnitudes.F90
+++ b/source/galactic.filters.stellar_absolute_magnitudes.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic low-pass (i.e. bright-pass) filter for stellar absolute magnitudes.
+Implements a galactic low-pass (i.e. bright-pass) filter for stellar absolute magnitudes.
 !!}
 
   !![

--- a/source/galactic.filters.stellar_apparent_magnitudes.F90
+++ b/source/galactic.filters.stellar_apparent_magnitudes.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic low-pass (i.e. bright-pass) filter for stellar apparent magnitudes.
+Implements a galactic low-pass (i.e. bright-pass) filter for stellar apparent magnitudes.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/galactic.filters.stellar_mass.F90
+++ b/source/galactic.filters.stellar_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic high-pass filter for total stellar mass.
+Implements a galactic high-pass filter for total stellar mass.
 !!}
 
   !![

--- a/source/galactic.filters.stellar_mass_morphology.F90
+++ b/source/galactic.filters.stellar_mass_morphology.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galactic high-pass filter for stellar mass-weighted morphology (i.e. spheroid-to-total ratio).
+Implements a galactic high-pass filter for stellar mass-weighted morphology (i.e. spheroid-to-total ratio).
 !!}
 
   !![

--- a/source/galactic.filters.survey_geometry.F90
+++ b/source/galactic.filters.survey_geometry.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only nodes that lie within a survey geometry.
+Implements a filter which passes only nodes that lie within a survey geometry.
 !!}
 
   use :: Geometry_Surveys        , only : surveyGeometryClass

--- a/source/galactic.filters.tree_hosted.F90
+++ b/source/galactic.filters.tree_hosted.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a filter which passes only nodes that are hosted in a merger tree.
+Implements a filter which passes only nodes that are hosted in a merger tree.
 !!}
 
   !![

--- a/source/merger_trees.build.controller.branchless.F90
+++ b/source/merger_trees.build.controller.branchless.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree build controller class which builds branchless trees.
+Implements a merger tree build controller class which builds branchless trees.
 !!}
 
   !![

--- a/source/merger_trees.build.controller.constrained.F90
+++ b/source/merger_trees.build.controller.constrained.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree build controller class which builds constrained trees.
+Implements a merger tree build controller class which builds constrained trees.
 !!}
 
   use :: Cosmology_Functions               , only : cosmologyFunctionsClass

--- a/source/merger_trees.build.controller.filtered.F90
+++ b/source/merger_trees.build.controller.filtered.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree build controller class which follows branches only if they pass a filter.
+Implements a merger tree build controller class which follows branches only if they pass a filter.
 !!}
   
   use :: Galactic_Filters, only : galacticFilterClass

--- a/source/merger_trees.build.controller.single_step.F90
+++ b/source/merger_trees.build.controller.single_step.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree build controller class which limits tree building to a single step.
+Implements a merger tree build controller class which limits tree building to a single step.
 !!}
   
   use :: Cosmology_Functions       , only : cosmologyFunctionsClass

--- a/source/merger_trees.build.controller.subsample.F90
+++ b/source/merger_trees.build.controller.subsample.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree build controller class which performs subsampling of branches.
+Implements a merger tree build controller class which performs subsampling of branches.
 !!}
 
   ! Options controlling when to destroy stub branches.

--- a/source/merger_trees.build.controller.uncontrolled.F90
+++ b/source/merger_trees.build.controller.uncontrolled.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree build controller class which provides no control.
+Implements a merger tree build controller class which provides no control.
 !!}
 
   !![

--- a/source/merger_trees.filter.all.F90
+++ b/source/merger_trees.filter.all.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree filter class which is the ``all'' combination of a set of other filters.
+Implements a merger tree filter class which is the ``all'' combination of a set of other filters.
 !!}
 
   !![

--- a/source/merger_trees.filter.always.F90
+++ b/source/merger_trees.filter.always.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree filter which always passes.
+Implements a merger tree filter which always passes.
 !!}
 
   !![

--- a/source/merger_trees.filter.any.F90
+++ b/source/merger_trees.filter.any.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree filter class which is the ``any'' combination of a set of other filters.
+Implements a merger tree filter class which is the ``any'' combination of a set of other filters.
 !!}
 
   !![

--- a/source/merger_trees.filter.any_node.F90
+++ b/source/merger_trees.filter.any_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree filter which passes if any node in the tree passes the given galactic filter.
+Implements a merger tree filter which passes if any node in the tree passes the given galactic filter.
 !!}
 
   use :: Galactic_Filters, only : galacticFilterClass

--- a/source/merger_trees.filter.base_node.F90
+++ b/source/merger_trees.filter.base_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree filter which passes if the base node in the tree passes the given galactic filter.
+Implements a merger tree filter which passes if the base node in the tree passes the given galactic filter.
 !!}
 
   use :: Galactic_Filters, only : galacticFilterClass

--- a/source/merger_trees.operators.assign_orbits.F90
+++ b/source/merger_trees.operators.assign_orbits.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree operator which assigns orbits to non-primary progenitor nodes.
+Implements a merger tree operator which assigns orbits to non-primary progenitor nodes.
 !!}
 
   use :: Satellite_Merging_Timescales, only : satelliteMergingTimescales, satelliteMergingTimescalesClass

--- a/source/merger_trees.operators.augment.F90
+++ b/source/merger_trees.operators.augment.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an augmenting operator on merger trees.
+  Implements an augmenting operator on merger trees.
   !!}
   use            :: Cosmology_Functions  , only : cosmologyFunctionsClass
   use, intrinsic :: ISO_C_Binding        , only : c_size_t

--- a/source/merger_trees.operators.conditional_mass_function.F90
+++ b/source/merger_trees.operators.conditional_mass_function.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which accumulates conditional mass functions for trees.
+  Implements a merger tree operator which accumulates conditional mass functions for trees.
   !!}
 
   use    :: Cosmology_Functions              , only : cosmologyFunctionsClass

--- a/source/merger_trees.operators.deforest.F90
+++ b/source/merger_trees.operators.deforest.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a deforestation operator on merger trees (i.e. removes all but the most massive tree in a forest).
+Implements a deforestation operator on merger trees (i.e. removes all but the most massive tree in a forest).
 !!}
 
   !![

--- a/source/merger_trees.operators.dump_to_GraphViz.F90
+++ b/source/merger_trees.operators.dump_to_GraphViz.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a dump to \gls{graphviz} operator on merger trees.
+Implements a dump to \gls{graphviz} operator on merger trees.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/merger_trees.operators.export.F90
+++ b/source/merger_trees.operators.export.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which exports merger trees to
+  Implements a merger tree operator which exports merger trees to
   file.
   !!}
 

--- a/source/merger_trees.operators.information_content.F90
+++ b/source/merger_trees.operators.information_content.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which computes the cladistic
+  Implements a merger tree operator which computes the cladistic
   information content \cite{thorley_information_1998} of merger trees.
   !!}
 

--- a/source/merger_trees.operators.mass_accretion_history.F90
+++ b/source/merger_trees.operators.mass_accretion_history.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which outputs mass accretion
+  Implements a merger tree operator which outputs mass accretion
   histories.
   !!}
 

--- a/source/merger_trees.operators.monotonize_mass_growth.F90
+++ b/source/merger_trees.operators.monotonize_mass_growth.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which makes mass growth along
+  Implements a merger tree operator which makes mass growth along
   branch monotonically increasing.
   !!}
 

--- a/source/merger_trees.operators.null.F90
+++ b/source/merger_trees.operators.null.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a null operator on merger trees.
+Implements a null operator on merger trees.
 !!}
 
   !![

--- a/source/merger_trees.operators.output_root_masses.F90
+++ b/source/merger_trees.operators.output_root_masses.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which outputs a file of tree root masses (and weights).
+  Implements a merger tree operator which outputs a file of tree root masses (and weights).
   !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctions, cosmologyFunctionsClass

--- a/source/merger_trees.operators.particulate.F90
+++ b/source/merger_trees.operators.particulate.F90
@@ -20,7 +20,7 @@
   !+    Contributions to this file made by: Xiaolong Du, Andrew Benson.
 
   !!{
-  Contains a module which implements a merger tree operator which creates particle representations of \glc\ halos.
+  Implements a merger tree operator which creates particle representations of \glc\ halos.
   !!}
 
   use :: Cosmology_Functions     , only : cosmologyFunctionsClass

--- a/source/merger_trees.operators.perturb_masses.F90
+++ b/source/merger_trees.operators.perturb_masses.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which perturbs halo masses by some error model.
+  Implements a merger tree operator which perturbs halo masses by some error model.
   !!}
 
   use :: Statistics_Distributions         , only : distributionFunction1DNormal

--- a/source/merger_trees.operators.profiler.F90
+++ b/source/merger_trees.operators.profiler.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which profiles tree structure.
+  Implements a merger tree operator which profiles tree structure.
   !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/merger_trees.operators.prune_baryons.F90
+++ b/source/merger_trees.operators.prune_baryons.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a pruning operator on merger trees that removes all branches that can not contain any baryons.
+Implements a pruning operator on merger trees that removes all branches that can not contain any baryons.
 !!}
 
   use :: Accretion_Halos        , only : accretionHalo        , accretionHaloClass

--- a/source/merger_trees.operators.prune_branch_complement.F90
+++ b/source/merger_trees.operators.prune_branch_complement.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which prunes all but a specified branch.
+  Implements a merger tree operator which prunes all but a specified branch.
   !!}
 
   use :: Kind_Numbers, only : kind_int8

--- a/source/merger_trees.operators.prune_branch_tips.F90
+++ b/source/merger_trees.operators.prune_branch_tips.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which prunes tips of branches (i.e. sections from the leaf node to
+  Implements a merger tree operator which prunes tips of branches (i.e. sections from the leaf node to
   the first node with a sibling).
   !!}
 

--- a/source/merger_trees.operators.prune_by_mass.F90
+++ b/source/merger_trees.operators.prune_by_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a pruning-by-mass operator on merger trees.
+Implements a pruning-by-mass operator on merger trees.
 !!}
 
   !![

--- a/source/merger_trees.operators.prune_by_time.F90
+++ b/source/merger_trees.operators.prune_by_time.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which prunes branches to end at a fixed time.
+  Implements a merger tree operator which prunes branches to end at a fixed time.
   !!}
 
   !![

--- a/source/merger_trees.operators.prune_clones.F90
+++ b/source/merger_trees.operators.prune_clones.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a pruning-by-mass operator on merger trees.
+Implements a pruning-by-mass operator on merger trees.
 !!}
 
   !![

--- a/source/merger_trees.operators.prune_hierarchy.F90
+++ b/source/merger_trees.operators.prune_hierarchy.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which prunes branches below a
+  Implements a merger tree operator which prunes branches below a
   given level in the substructure hierarchy.
   !!}
 

--- a/source/merger_trees.operators.prune_lightcone.F90
+++ b/source/merger_trees.operators.prune_lightcone.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a prune-by-lightcone operator on merger trees.
+  Implements a prune-by-lightcone operator on merger trees.
   !!}
   
   use :: Geometry_Lightcones           , only : geometryLightconeClass

--- a/source/merger_trees.operators.prune_non_essential.F90
+++ b/source/merger_trees.operators.prune_non_essential.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which prunes all branches which do not contain an ``essential''
+  Implements a merger tree operator which prunes all branches which do not contain an ``essential''
   node.
   !!}
 

--- a/source/merger_trees.operators.regrid_times.F90
+++ b/source/merger_trees.operators.regrid_times.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a merger tree operator which restructures the tree onto a fixed grid of timesteps.
+  Implements a merger tree operator which restructures the tree onto a fixed grid of timesteps.
   !!}
 
   use :: Output_Times, only : outputTimesClass

--- a/source/merger_trees.operators.render.F90
+++ b/source/merger_trees.operators.render.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree operator which dumps tree data to a file suitable for 3D rendering.
+Implements a merger tree operator which dumps tree data to a file suitable for 3D rendering.
 !!}
 
   use :: Cosmology_Functions    , only : cosmologyFunctionsClass

--- a/source/merger_trees.operators.select_within_range.F90
+++ b/source/merger_trees.operators.select_within_range.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a select-within-range operator on the base nodes of merger trees.
+Implements a select-within-range operator on the base nodes of merger trees.
 !!}
 
   !![

--- a/source/merger_trees.operators.sequence.F90
+++ b/source/merger_trees.operators.sequence.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a sequence of operators on merger trees.
+Implements a sequence of operators on merger trees.
 !!}
 
   !![

--- a/source/merger_trees.walkers.all_and_formation_nodes.F90
+++ b/source/merger_trees.walkers.all_and_formation_nodes.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a depth-first merger tree walker over all nodes including formation nodes.
+Implements a depth-first merger tree walker over all nodes including formation nodes.
 !!}
 
   !![

--- a/source/merger_trees.walkers.all_nodes.F90
+++ b/source/merger_trees.walkers.all_nodes.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a depth-first merger tree walker over all all nodes.
+  Implements a depth-first merger tree walker over all all nodes.
   !!}
   use :: Galacticus_Nodes, only : mergerTree, treeNode
 

--- a/source/merger_trees.walkers.all_nodes.branch.F90
+++ b/source/merger_trees.walkers.all_nodes.branch.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a depth-first merger tree walker over all all nodes in a given branch.
+Implements a depth-first merger tree walker over all all nodes in a given branch.
 !!}
 
   !![

--- a/source/merger_trees.walkers.isolated_nodes.F90
+++ b/source/merger_trees.walkers.isolated_nodes.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a depth-first merger tree walker over all isolated nodes.
+Implements a depth-first merger tree walker over all isolated nodes.
 !!}
 
   !![

--- a/source/merger_trees.walkers.isolated_nodes.branch.F90
+++ b/source/merger_trees.walkers.isolated_nodes.branch.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a depth-first merger tree walker over all isolated nodes in a given branch.
+Implements a depth-first merger tree walker over all isolated nodes in a given branch.
 !!}
 
   !![

--- a/source/merger_trees.walkers.tree_construction.F90
+++ b/source/merger_trees.walkers.tree_construction.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a tree walker for trees under construction.
+  Implements a tree walker for trees under construction.
   !!}
   use :: Galacticus_Nodes, only : mergerTree, treeNode
 

--- a/source/meta.tree_processing_times.file.F90
+++ b/source/meta.tree_processing_times.file.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree processing time estimator using a polynomial relation read from file.
+Implements a merger tree processing time estimator using a polynomial relation read from file.
 !!}
 
   !![

--- a/source/nBody.import.GadgetBinary.F90
+++ b/source/nBody.import.GadgetBinary.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data importer for Gadget binary files.
+Implements an N-body data importer for Gadget binary files.
 !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/nBody.import.GadgetHDF5.F90
+++ b/source/nBody.import.GadgetHDF5.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data importer for Gadget HDF5 files.
+Implements an N-body data importer for Gadget HDF5 files.
 !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/nBody.import.IRATE.F90
+++ b/source/nBody.import.IRATE.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data importer for IRATE files.
+Implements an N-body data importer for IRATE files.
 !!}
 
   use :: Cosmology_Functions , only : cosmologyFunctionsClass

--- a/source/nBody.import.Millennium_CSV.F90
+++ b/source/nBody.import.Millennium_CSV.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data importer for Millennium database CSV files.
+Implements an N-body data importer for Millennium database CSV files.
 !!}
 
   use :: Cosmology_Functions , only : cosmologyFunctionsClass

--- a/source/nBody.import.Rockstar.F90
+++ b/source/nBody.import.Rockstar.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data importer for Rockstar files.
+Implements an N-body data importer for Rockstar files.
 !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/nBody.import.merge.F90
+++ b/source/nBody.import.merge.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data importer which merges data from other importers.
+Implements an N-body data importer which merges data from other importers.
 !!}
   
   !![

--- a/source/nBody.import.multiple.F90
+++ b/source/nBody.import.multiple.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data importer which imports using multiple other importers.
+Implements an N-body data importer which imports using multiple other importers.
 !!}
   
   !![

--- a/source/nBody.import.random.F90
+++ b/source/nBody.import.random.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data importer which generates random points.
+Implements an N-body data importer which generates random points.
 !!}
 
   use :: Numerical_Random_Numbers, only : randomNumberGeneratorClass

--- a/source/nBody.operator.add_attributes.F90
+++ b/source/nBody.operator.add_attributes.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which adds attributes to the data.
+Implements an N-body data operator which adds attributes to the data.
 !!}
 
   !![

--- a/source/nBody.operator.angular_momentum.F90
+++ b/source/nBody.operator.angular_momentum.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which determines the mean angular momentum of particles.
+Implements an N-body data operator which determines the mean angular momentum of particles.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.concentration_distribution_function.F90
+++ b/source/nBody.operator.concentration_distribution_function.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an N-body data operator which computes mass functions.
+  Implements an N-body data operator which computes mass functions.
   !!}
   
   use            :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/nBody.operator.convex_hull.F90
+++ b/source/nBody.operator.convex_hull.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which constructs the convex hull of the particles.
+Implements an N-body data operator which constructs the convex hull of the particles.
 !!}
   
   !![

--- a/source/nBody.operator.convex_hull.overdensity.F90
+++ b/source/nBody.operator.convex_hull.overdensity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes the overdensity within the convex hull of the particles.
+Implements an N-body data operator which computes the overdensity within the convex hull of the particles.
 !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass 

--- a/source/nBody.operator.convex_hull.volume.F90
+++ b/source/nBody.operator.convex_hull.volume.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes the convex hull volume of the particles.
+Implements an N-body data operator which computes the convex hull volume of the particles.
 !!}
   
   !![

--- a/source/nBody.operator.delete_properties.F90
+++ b/source/nBody.operator.delete_properties.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which deletes named properties from the simulation.
+Implements an N-body data operator which deletes named properties from the simulation.
 !!}
 
   !![

--- a/source/nBody.operator.distance_from_point.F90
+++ b/source/nBody.operator.distance_from_point.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes the distance of each particle from a point.
+Implements an N-body data operator which computes the distance of each particle from a point.
 !!}
 
   !![

--- a/source/nBody.operator.energy_tensors.F90
+++ b/source/nBody.operator.energy_tensors.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which determines the kinetic and Chandrasekhar potential energy tensors.
+Implements an N-body data operator which determines the kinetic and Chandrasekhar potential energy tensors.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.environmental_overdensity.F90
+++ b/source/nBody.operator.environmental_overdensity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which determines the environmental overdensity around particles.
+Implements an N-body data operator which determines the environmental overdensity around particles.
 !!}
 
   use, intrinsic :: ISO_C_Binding, only : c_size_t

--- a/source/nBody.operator.export.IRATE.F90
+++ b/source/nBody.operator.export.IRATE.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which exports N-body data to IRATE format.
+Implements an N-body data operator which exports N-body data to IRATE format.
 !!}
 
   use :: Cosmology_Functions , only : cosmologyFunctionsClass

--- a/source/nBody.operator.filter_ID.F90
+++ b/source/nBody.operator.filter_ID.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which filters particles by ID.
+Implements an N-body data operator which filters particles by ID.
 !!}
   
   !![

--- a/source/nBody.operator.filter_box.F90
+++ b/source/nBody.operator.filter_box.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which filters particles outside a cuboid region.
+Implements an N-body data operator which filters particles outside a cuboid region.
 !!}
   
   !![

--- a/source/nBody.operator.filter_convex_hull.F90
+++ b/source/nBody.operator.filter_convex_hull.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which filters particles outside of a convex hull.
+Implements an N-body data operator which filters particles outside of a convex hull.
 !!}
   
   !![

--- a/source/nBody.operator.filter_properties.F90
+++ b/source/nBody.operator.filter_properties.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which filters out particles based on a property range.
+Implements an N-body data operator which filters out particles based on a property range.
 !!}
 
   use :: NBody_Simulation_Data, only : enumerationPropertyTypeType

--- a/source/nBody.operator.filter_uncontaminated_sphere.F90
+++ b/source/nBody.operator.filter_uncontaminated_sphere.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which filters particles to select those within a sphere such that the
+Implements an N-body data operator which filters particles to select those within a sphere such that the
 contamination by particles of non-preferred type is below a specified level.
 !!}
   

--- a/source/nBody.operator.flag_always_isolated.F90
+++ b/source/nBody.operator.flag_always_isolated.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which flags particles that have been always isolated.
+Implements an N-body data operator which flags particles that have been always isolated.
 !!}
 
   !![

--- a/source/nBody.operator.hosted_root_ID.F90
+++ b/source/nBody.operator.hosted_root_ID.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an N-body data operator which determines an ID of the root halo found by following hosts.
+  Implements an N-body data operator which determines an ID of the root halo found by following hosts.
   !!}
 
   !![

--- a/source/nBody.operator.identify_flybys.MansfieldKravtsov2020.F90
+++ b/source/nBody.operator.identify_flybys.MansfieldKravtsov2020.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which identifies flyby halos following the algorithm of \cite{mansfield_three_2020}.
+Implements an N-body data operator which identifies flyby halos following the algorithm of \cite{mansfield_three_2020}.
 !!}
 
   !![

--- a/source/nBody.operator.inertia_tensor.F90
+++ b/source/nBody.operator.inertia_tensor.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes the inertia tensor eigenvalues and eigenvectors, along with axis ratios.
+Implements an N-body data operator which computes the inertia tensor eigenvalues and eigenvectors, along with axis ratios.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.mass_function.F90
+++ b/source/nBody.operator.mass_function.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes mass functions.
+Implements an N-body data operator which computes mass functions.
 !!}
 
   use            :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/nBody.operator.mass_total.F90
+++ b/source/nBody.operator.mass_total.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes the total mass of particles.
+Implements an N-body data operator which computes the total mass of particles.
 !!}
 
   !![

--- a/source/nBody.operator.mean_position.F90
+++ b/source/nBody.operator.mean_position.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which determines the mean position and velocity of particles.
+Implements an N-body data operator which determines the mean position and velocity of particles.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.merger_rates.F90
+++ b/source/nBody.operator.merger_rates.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes merger rates of halos.
+Implements an N-body data operator which computes merger rates of halos.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/nBody.operator.null.F90
+++ b/source/nBody.operator.null.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a null N-body data operator.
+Implements a null N-body data operator.
 !!}
 
   !![

--- a/source/nBody.operator.pair_counts.F90
+++ b/source/nBody.operator.pair_counts.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes pair counts in bins of separation.
+Implements an N-body data operator which computes pair counts in bins of separation.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.pairwise_velocity_statistics.F90
+++ b/source/nBody.operator.pairwise_velocity_statistics.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes pairwise velocity statistics in bins of separation.
+Implements an N-body data operator which computes pairwise velocity statistics in bins of separation.
 !!}
 
   use            :: Cosmology_Functions     , only : cosmologyFunctionsClass

--- a/source/nBody.operator.physical_to_comoving.F90
+++ b/source/nBody.operator.physical_to_comoving.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which converts physical to comoving coordinates.
+Implements an N-body data operator which converts physical to comoving coordinates.
 !!}
 
   !![

--- a/source/nBody.operator.potential_energy.F90
+++ b/source/nBody.operator.potential_energy.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which determines the potential energy of each particle.
+Implements an N-body data operator which determines the potential energy of each particle.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.progenitor_mass_function.F90
+++ b/source/nBody.operator.progenitor_mass_function.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes progenitor mass functions.
+Implements an N-body data operator which computes progenitor mass functions.
 !!}
 
   use            :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/nBody.operator.rotation_curve.F90
+++ b/source/nBody.operator.rotation_curve.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes the rotation curve at a set of given radii.
+Implements an N-body data operator which computes the rotation curve at a set of given radii.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.select_properties.F90
+++ b/source/nBody.operator.select_properties.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an N-body data operator which selects particles matching a list of integer properties.
+  Implements an N-body data operator which selects particles matching a list of integer properties.
   !!}
   
   !![

--- a/source/nBody.operator.self_bound.Barnes_Hut.F90
+++ b/source/nBody.operator.self_bound.Barnes_Hut.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which determines the subset of particles that are self-bound. The potential is computed using a tree method following \cite{barnes_hierarchical_1986}.
+Implements an N-body data operator which determines the subset of particles that are self-bound. The potential is computed using a tree method following \cite{barnes_hierarchical_1986}.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.self_bound.F90
+++ b/source/nBody.operator.self_bound.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which determines the subset of particles that are self-bound.
+Implements an N-body data operator which determines the subset of particles that are self-bound.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.self_friction_acceleration.F90
+++ b/source/nBody.operator.self_friction_acceleration.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which determines the acceleration of self-bound particles from unbound ones. The interaction between particles is computed using a tree method following \cite{barnes_hierarchical_1986}.
+Implements an N-body data operator which determines the acceleration of self-bound particles from unbound ones. The interaction between particles is computed using a tree method following \cite{barnes_hierarchical_1986}.
 !!}
 
   use, intrinsic :: ISO_C_Binding, only : c_size_t

--- a/source/nBody.operator.sequence.F90
+++ b/source/nBody.operator.sequence.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which applies a sequence of other operators.
+Implements an N-body data operator which applies a sequence of other operators.
 !!}
 
   type, public :: nbodyOperatorList

--- a/source/nBody.operator.set_box_size.F90
+++ b/source/nBody.operator.set_box_size.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an N-body data operator which sets the box size of the data set.
+  Implements an N-body data operator which sets the box size of the data set.
   !!}
   
   !![

--- a/source/nBody.operator.shift_property.F90
+++ b/source/nBody.operator.shift_property.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an N-body data operator which shifts values of a property by an integer amount.
+  Implements an N-body data operator which shifts values of a property by an integer amount.
   !!}
   
   !![

--- a/source/nBody.operator.simulation_selector.F90
+++ b/source/nBody.operator.simulation_selector.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which applies some other operator to a selected simulation.
+Implements an N-body data operator which applies some other operator to a selected simulation.
 !!}
   
   !![

--- a/source/nBody.operator.spin_distribution_function.F90
+++ b/source/nBody.operator.spin_distribution_function.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an N-body data operator which computes mass functions.
+  Implements an N-body data operator which computes mass functions.
   !!}
   
   use            :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/nBody.operator.subsample.F90
+++ b/source/nBody.operator.subsample.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which subsamples points at a given rate.
+Implements an N-body data operator which subsamples points at a given rate.
 !!}
 
   use :: Numerical_Random_Numbers, only : randomNumberGeneratorClass

--- a/source/nBody.operator.velocity_dispersion.F90
+++ b/source/nBody.operator.velocity_dispersion.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes the velocity dispersion in a set of given spherical shells.
+Implements an N-body data operator which computes the velocity dispersion in a set of given spherical shells.
 !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/nBody.operator.virial_crossing_orbit_statistics.F90
+++ b/source/nBody.operator.virial_crossing_orbit_statistics.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body data operator which computes virial crossing orbit statistics in bins of separation.
+Implements an N-body data operator which computes virial crossing orbit statistics in bins of separation.
 !!}
   
   use            :: Cosmology_Functions     , only : cosmologyFunctionsClass

--- a/source/nodes.operators.filtered.F90
+++ b/source/nodes.operators.filtered.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a filtered node operator class.
+  Implements a filtered node operator class.
   !!}
 
   use :: Galactic_Filters, only : galacticFilterClass

--- a/source/nodes.operators.multi.F90
+++ b/source/nodes.operators.multi.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a multi node operator class.
+  Implements a multi node operator class.
   !!}
 
   type, public :: multiProcessList

--- a/source/nodes.operators.null.F90
+++ b/source/nodes.operators.null.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a null node operator class.
+Implements a null node operator class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.ICM_SZ.F90
+++ b/source/nodes.property_extractor.ICM_SZ.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an intracluster medium Sunyaev-Zeldovich Compton-y parameter property extractor class.
+Implements an intracluster medium Sunyaev-Zeldovich Compton-y parameter property extractor class.
 !!}
   use :: Chemical_States        , only : chemicalState      , chemicalStateClass
   use :: Cosmology_Functions    , only : cosmologyFunctions , cosmologyFunctionsClass , enumerationDensityCosmologicalType

--- a/source/nodes.property_extractor.ICM_Xray_luminosity.F90
+++ b/source/nodes.property_extractor.ICM_Xray_luminosity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an intracluster medium X-ray luminosity property extractor class.
+Implements an intracluster medium X-ray luminosity property extractor class.
 !!}
 
   use :: Cooling_Functions      , only : coolingFunction    , coolingFunctionClass

--- a/source/nodes.property_extractor.ICM_Xray_temperature.F90
+++ b/source/nodes.property_extractor.ICM_Xray_temperature.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an intracluster medium X-ray luminosity-weighted temperature property extractor class.
+Implements an intracluster medium X-ray luminosity-weighted temperature property extractor class.
 !!}
 
   use :: Cooling_Functions      , only : coolingFunction    , coolingFunctionClass

--- a/source/nodes.property_extractor.ICM_cooling_power_in_band.F90
+++ b/source/nodes.property_extractor.ICM_cooling_power_in_band.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an intracluster medium cooling power in band property extractor class.
+Implements an intracluster medium cooling power in band property extractor class.
 !!}
 
   use :: Cooling_Functions      , only : coolingFunction    , coolingFunctionClass

--- a/source/nodes.property_extractor.ICM_optical_depth_LymanAlpha.F90
+++ b/source/nodes.property_extractor.ICM_optical_depth_LymanAlpha.F90
@@ -17,8 +17,10 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!% Contains a module which implements an intracluster medium cooling power in band property extractor class.
-
+  !!{
+  Implements an intracluster medium cooling power in band property extractor class.
+  !!}
+  
   use :: Cosmology_Functions    , only : cosmologyFunctions , cosmologyFunctionsClass
   use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScale, darkMatterHaloScaleClass
   

--- a/source/nodes.property_extractor.SED.F90
+++ b/source/nodes.property_extractor.SED.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property extractor class for the SED of a component.
+  Implements a property extractor class for the SED of a component.
   !!}
   use :: Cosmology_Functions                   , only : cosmologyFunctionsClass
   use :: Galactic_Structure_Options            , only : enumerationComponentTypeType

--- a/source/nodes.property_extractor.bar_instability_timescale.F90
+++ b/source/nodes.property_extractor.bar_instability_timescale.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a property extractor class for bar instability timescales.
+Implements a property extractor class for bar instability timescales.
 !!}
 
   use :: Galactic_Dynamics_Bar_Instabilities, only : galacticDynamicsBarInstabilityClass

--- a/source/nodes.property_extractor.black_hole.formation_channel.F90
+++ b/source/nodes.property_extractor.black_hole.formation_channel.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a node property extractor which reports the formation channel for the central black hole of a given node.
+  Implements a node property extractor which reports the formation channel for the central black hole of a given node.
   !!}
 
   !![

--- a/source/nodes.property_extractor.bound_mass_radius.F90
+++ b/source/nodes.property_extractor.bound_mass_radius.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a property extractor class that extracts the radius enclosing the current bound mass.
+Implements a property extractor class that extracts the radius enclosing the current bound mass.
 !!}
 
   !![

--- a/source/nodes.property_extractor.cold_mode_infall_rate.F90
+++ b/source/nodes.property_extractor.cold_mode_infall_rate.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a cold mode infall rate property extractor class.
+Implements a cold mode infall rate property extractor class.
 !!}
 
   use :: Cooling_Cold_Mode_Infall_Rates, only : coldModeInfallRate, coldModeInfallRateClass

--- a/source/nodes.property_extractor.concentration.F90
+++ b/source/nodes.property_extractor.concentration.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a concentration output analysis property extractor class.
+Implements a concentration output analysis property extractor class.
 !!}
 
   use :: Cosmology_Functions     , only : cosmologyFunctionsClass

--- a/source/nodes.property_extractor.constrained_branch.F90
+++ b/source/nodes.property_extractor.constrained_branch.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a node property extractor which reports if a node is drawn from the constrained branching rate solution.
+  Implements a node property extractor which reports if a node is drawn from the constrained branching rate solution.
   !!}
 
   !![

--- a/source/nodes.property_extractor.cooling_radius.F90
+++ b/source/nodes.property_extractor.cooling_radius.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a radiusCooling property extractor class.
+Implements a radiusCooling property extractor class.
 !!}
 
   use :: Cooling_Radii, only : coolingRadius, coolingRadiusClass

--- a/source/nodes.property_extractor.cooling_rate.F90
+++ b/source/nodes.property_extractor.cooling_rate.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a cooling rate property extractor class.
+Implements a cooling rate property extractor class.
 !!}
 
   use :: Cooling_Rates, only : coolingRate, coolingRateClass

--- a/source/nodes.property_extractor.dark_matter_profile.SIDM_interaction_radius.F90
+++ b/source/nodes.property_extractor.dark_matter_profile.SIDM_interaction_radius.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a dark matter profile SIDM interaction radius property extractor class.
+Implements a dark matter profile SIDM interaction radius property extractor class.
 !!}
 
   use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMO, darkMatterProfileDMOClass

--- a/source/nodes.property_extractor.dark_matter_profile.scale_radius.F90
+++ b/source/nodes.property_extractor.dark_matter_profile.scale_radius.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a dark matter profile scale radius output analysis property extractor class.
+Implements a dark matter profile scale radius output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.dark_matter_profile.shape_parameter.F90
+++ b/source/nodes.property_extractor.dark_matter_profile.shape_parameter.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a dark matter profile scale radius output analysis property extractor class.
+Implements a dark matter profile scale radius output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.density.F90
+++ b/source/nodes.property_extractor.density.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property extractor class for the density at a set of radii.
+  Implements a property extractor class for the density at a set of radii.
   !!}
   use :: Dark_Matter_Halo_Scales             , only : darkMatterHaloScale   , darkMatterHaloScaleClass
   use :: Galactic_Structure_Radii_Definitions, only : radiusSpecifier

--- a/source/nodes.property_extractor.density_contrasts.F90
+++ b/source/nodes.property_extractor.density_contrasts.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a property extractor class for the mass and radii of spheres are specified density contrast.
+Implements a property extractor class for the mass and radii of spheres are specified density contrast.
 !!}
 
   use :: Cosmology_Functions       , only : cosmologyFunctions     , cosmologyFunctionsClass , enumerationDensityCosmologicalType

--- a/source/nodes.property_extractor.descendant_node.F90
+++ b/source/nodes.property_extractor.descendant_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an output analysis property extractor class that extracts a property from a descendant node of the given node.
+Implements an output analysis property extractor class that extracts a property from a descendant node of the given node.
 !!}
   
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/nodes.property_extractor.descendants.F90
+++ b/source/nodes.property_extractor.descendants.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an ISM mass output analysis property extractor class.
+Implements an ISM mass output analysis property extractor class.
 !!}
 
   use :: Output_Times, only : outputTimes, outputTimesClass

--- a/source/nodes.property_extractor.final_descandent.F90
+++ b/source/nodes.property_extractor.final_descandent.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an ISM mass output analysis property extractor class.
+Implements an ISM mass output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.half_light_properties.F90
+++ b/source/nodes.property_extractor.half_light_properties.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a half-light radii property extractor class.
+Implements a half-light radii property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.halo_bias.F90
+++ b/source/nodes.property_extractor.halo_bias.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an ISM mass output analysis property extractor class.
+Implements an ISM mass output analysis property extractor class.
 !!}
 
   use :: Dark_Matter_Halo_Biases, only : darkMatterHaloBias, darkMatterHaloBiasClass

--- a/source/nodes.property_extractor.halo_environment.F90
+++ b/source/nodes.property_extractor.halo_environment.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a node property extractor class for halo environment.
+Implements a node property extractor class for halo environment.
 !!}
 
   use :: Cosmological_Density_Field, only : haloEnvironment, haloEnvironmentClass

--- a/source/nodes.property_extractor.host_mass.F90
+++ b/source/nodes.property_extractor.host_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a massHost property extractor class.
+Implements a massHost property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.host_node.F90
+++ b/source/nodes.property_extractor.host_node.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an output analysis property extractor class that extracts a property from the host node of the given node.
+Implements an output analysis property extractor class that extracts a property from the host node of the given node.
 !!}
   
   !![

--- a/source/nodes.property_extractor.hosts.F90
+++ b/source/nodes.property_extractor.hosts.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a host index output analysis property extractor class.
+Implements a host index output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.hot_mode_accretion_fraction.F90
+++ b/source/nodes.property_extractor.hot_mode_accretion_fraction.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a hot mode accretion fraction rate property extractor class.
+Implements a hot mode accretion fraction rate property extractor class.
 !!}
 
   use :: Accretion_Halos, only : accretionHalo, accretionHaloClass

--- a/source/nodes.property_extractor.index_branch_tip.F90
+++ b/source/nodes.property_extractor.index_branch_tip.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a node branch tip index property extractor.
+Implements a node branch tip index property extractor.
 !!}
 
   !![

--- a/source/nodes.property_extractor.index_last_host.F90
+++ b/source/nodes.property_extractor.index_last_host.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a node property extractor for the index of the last host node.
+Implements a node property extractor for the index of the last host node.
 !!}
 
   !![

--- a/source/nodes.property_extractor.luminosity_emission_line.F90
+++ b/source/nodes.property_extractor.luminosity_emission_line.F90
@@ -20,7 +20,7 @@
   !+    Contributions to this file made by: Sachi Weerasooriya
 
   !!{
-  Contains a module which implements a property extractor class for the emission line luminosity of a component.
+  Implements a property extractor class for the emission line luminosity of a component.
   !!}
   use, intrinsic :: ISO_C_Binding                  , only : c_size_t
   use            :: Galactic_Structure_Options     , only : enumerationComponentTypeType

--- a/source/nodes.property_extractor.luminosity_stellar.F90
+++ b/source/nodes.property_extractor.luminosity_stellar.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass output analysis property extractor class.
+Implements a stellar mass output analysis property extractor class.
 !!}
 
   use :: ISO_Varying_String, only : varying_string

--- a/source/nodes.property_extractor.luminosity_stellar.dust.CharlotFall2000.F90
+++ b/source/nodes.property_extractor.luminosity_stellar.dust.CharlotFall2000.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar luminosity output analysis property extractor class which applies the dust model of \cite{charlot_simple_2000}.
+Implements a stellar luminosity output analysis property extractor class which applies the dust model of \cite{charlot_simple_2000}.
 !!}
 
   use :: ISO_Varying_String, only : varying_string

--- a/source/nodes.property_extractor.luminosity_stellar_from_SED.F90
+++ b/source/nodes.property_extractor.luminosity_stellar_from_SED.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass output analysis property extractor class.
+Implements a stellar mass output analysis property extractor class.
 !!}
 
   use :: ISO_Varying_String     , only : varying_string

--- a/source/nodes.property_extractor.main_branch.F90
+++ b/source/nodes.property_extractor.main_branch.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a node property extractor which reports if a node is on the main branch of its merger
+  Implements a node property extractor which reports if a node is on the main branch of its merger
   tree.
   !!}
 

--- a/source/nodes.property_extractor.mass_ISM.F90
+++ b/source/nodes.property_extractor.mass_ISM.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an ISM mass output analysis property extractor class.
+Implements an ISM mass output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.mass_accretion_history.Hearin2021.F90
+++ b/source/nodes.property_extractor.mass_accretion_history.Hearin2021.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a node property extractor class for parameters of the \cite{hearin_differentiable_2021} mass accretion history model.
+Implements a node property extractor class for parameters of the \cite{hearin_differentiable_2021} mass accretion history model.
 !!}!
 
   !![

--- a/source/nodes.property_extractor.mass_basic.F90
+++ b/source/nodes.property_extractor.mass_basic.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an output analysis property extractor class that extracts the basic mass.
+Implements an output analysis property extractor class that extracts the basic mass.
 !!}
 
   !![

--- a/source/nodes.property_extractor.mass_black_hole.F90
+++ b/source/nodes.property_extractor.mass_black_hole.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a black hole mass output analysis property extractor class.
+Implements a black hole mass output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.mass_bound.F90
+++ b/source/nodes.property_extractor.mass_bound.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an output analysis property extractor class that extracts the bound mass.
+Implements an output analysis property extractor class that extracts the bound mass.
 !!}
 
   !![

--- a/source/nodes.property_extractor.mass_halo.F90
+++ b/source/nodes.property_extractor.mass_halo.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a halo mass output analysis property extractor class.
+Implements a halo mass output analysis property extractor class.
 !!}
 
   use :: Cosmology_Parameters    , only : cosmologyParametersClass

--- a/source/nodes.property_extractor.mass_profile.F90
+++ b/source/nodes.property_extractor.mass_profile.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property extractor class for the enclosed mass at a set of radii.
+  Implements a property extractor class for the enclosed mass at a set of radii.
   !!}
   use :: Dark_Matter_Halo_Scales             , only : darkMatterHaloScaleClass
   use :: Galactic_Structure_Radii_Definitions, only : radiusSpecifier

--- a/source/nodes.property_extractor.mass_stellar.F90
+++ b/source/nodes.property_extractor.mass_stellar.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass property extractor class.
+Implements a stellar mass property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.mass_stellar_morphology.F90
+++ b/source/nodes.property_extractor.mass_stellar_morphology.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass-weighted morphology output analysis property extractor class.
+Implements a stellar mass-weighted morphology output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.mass_stellar_spheroid.F90
+++ b/source/nodes.property_extractor.mass_stellar_spheroid.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a spheroid stellar mass output analysis property extractor class.
+Implements a spheroid stellar mass output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.metallicity_ISM.F90
+++ b/source/nodes.property_extractor.metallicity_ISM.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an ISM metallicity output analysis property extractor class.
+Implements an ISM metallicity output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.metallicity_stellar.F90
+++ b/source/nodes.property_extractor.metallicity_stellar.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an ISM metallicity output analysis property extractor class.
+Implements an ISM metallicity output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.most_massive_progenitor.F90
+++ b/source/nodes.property_extractor.most_massive_progenitor.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a node property extractor for the most massive progenitor.
+Implements a node property extractor for the most massive progenitor.
 !!}
 
   !![

--- a/source/nodes.property_extractor.multi.F90
+++ b/source/nodes.property_extractor.multi.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a multi node property extractor class.
+  Implements a multi node property extractor class.
   !!}
 
   use :: Hashes, only : doubleHash, rank1DoubleHash

--- a/source/nodes.property_extractor.node_indices.F90
+++ b/source/nodes.property_extractor.node_indices.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a property extractor for basic node indices.
+Implements a property extractor for basic node indices.
 !!}
 
   !![

--- a/source/nodes.property_extractor.null.F90
+++ b/source/nodes.property_extractor.null.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a null output analysis class.
+Implements a null output analysis class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.orbital_adiabatic_ratio.disk.F90
+++ b/source/nodes.property_extractor.orbital_adiabatic_ratio.disk.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a property extractor class for the orbital adiabatic ratio of disks.
+Implements a property extractor class for the orbital adiabatic ratio of disks.
 !!}
 
   use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScaleClass

--- a/source/nodes.property_extractor.position_orbital.F90
+++ b/source/nodes.property_extractor.position_orbital.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an orbital position output analysis property extractor class.
+Implements an orbital position output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.projected_density.F90
+++ b/source/nodes.property_extractor.projected_density.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property extractor class for the projected density at a set of radii.
+  Implements a property extractor class for the projected density at a set of radii.
   !!}
   use :: Dark_Matter_Halo_Scales             , only : darkMatterHaloScale   , darkMatterHaloScaleClass
   use :: Galactic_Structure_Radii_Definitions, only : radiusSpecifier

--- a/source/nodes.property_extractor.projected_mass.F90
+++ b/source/nodes.property_extractor.projected_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property extractor class for the projected density at a set of radii.
+  Implements a property extractor class for the projected density at a set of radii.
   !!}
   use :: Dark_Matter_Halo_Scales             , only : darkMatterHaloScale, darkMatterHaloScaleClass
   use :: Galactic_Structure_Radii_Definitions, only : radiusSpecifier

--- a/source/nodes.property_extractor.radius.half_mass.galactic.F90
+++ b/source/nodes.property_extractor.radius.half_mass.galactic.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a half-galactic mass radius output analysis property extractor class.
+Implements a half-galactic mass radius output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.radius.half_mass.stellar.F90
+++ b/source/nodes.property_extractor.radius.half_mass.stellar.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a half-stellar mass radius output analysis property extractor class.
+Implements a half-stellar mass radius output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.radius_orbital.F90
+++ b/source/nodes.property_extractor.radius_orbital.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an orbital radius output analysis property extractor class.
+Implements an orbital radius output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.radius_virial.F90
+++ b/source/nodes.property_extractor.radius_virial.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a virial radius output analysis property extractor class.
+Implements a virial radius output analysis property extractor class.
 !!}
 
   use :: Cosmology_Parameters    , only : cosmologyParametersClass

--- a/source/nodes.property_extractor.ratio.F90
+++ b/source/nodes.property_extractor.ratio.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a ratio output analysis property extractor class.
+Implements a ratio output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.redshift.F90
+++ b/source/nodes.property_extractor.redshift.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a redshift property extractor class.
+Implements a redshift property extractor class.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctions, cosmologyFunctionsClass

--- a/source/nodes.property_extractor.redshift_last_isolated.F90
+++ b/source/nodes.property_extractor.redshift_last_isolated.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a redshiftLastIsolated property extractor class.
+Implements a redshiftLastIsolated property extractor class.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctions, cosmologyFunctionsClass

--- a/source/nodes.property_extractor.rotation_curve.F90
+++ b/source/nodes.property_extractor.rotation_curve.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property extractor class for the rotation curve at a set of radii.
+  Implements a property extractor class for the rotation curve at a set of radii.
   !!}
   use :: Dark_Matter_Halo_Scales             , only : darkMatterHaloScale, darkMatterHaloScaleClass
   use :: Galactic_Structure_Radii_Definitions, only : radiusSpecifier

--- a/source/nodes.property_extractor.satellite_orbital_extrema.F90
+++ b/source/nodes.property_extractor.satellite_orbital_extrema.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements satellite orbital extrema property extractor class.
+Implements satellite orbital extrema property extractor class.
 !!}
 
   use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScaleClass

--- a/source/nodes.property_extractor.satellite_status.F90
+++ b/source/nodes.property_extractor.satellite_status.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an ISM mass output analysis property extractor class.
+Implements an ISM mass output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.scalarizer.F90
+++ b/source/nodes.property_extractor.scalarizer.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an output analysis property extractor class that scalarizes one element from an array node property extractor.
+Implements an output analysis property extractor class that scalarizes one element from an array node property extractor.
 !!}
 
   !![

--- a/source/nodes.property_extractor.speed_orbital.F90
+++ b/source/nodes.property_extractor.speed_orbital.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an orbital speed output analysis property extractor class.
+Implements an orbital speed output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.spin_Bullock.F90
+++ b/source/nodes.property_extractor.spin_Bullock.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a node property extractor class for the \cite{bullock_profiles_2001} definition of spin parameter.
+Implements a node property extractor class for the \cite{bullock_profiles_2001} definition of spin parameter.
 !!}
 
   use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScale, darkMatterHaloScaleClass

--- a/source/nodes.property_extractor.spin_parameter.F90
+++ b/source/nodes.property_extractor.spin_parameter.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a spin parameter output analysis property extractor class.
+Implements a spin parameter output analysis property extractor class.
 !!}
   
   use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScaleClass

--- a/source/nodes.property_extractor.star_formation_history_masses.F90
+++ b/source/nodes.property_extractor.star_formation_history_masses.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property extractor class for the star formation history of a component.
+  Implements a property extractor class for the star formation history of a component.
   !!}
   
   use :: Galactic_Structure_Options, only : enumerationComponentTypeType

--- a/source/nodes.property_extractor.star_formation_history_times.F90
+++ b/source/nodes.property_extractor.star_formation_history_times.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property extractor class for the star formation history of a component.
+  Implements a property extractor class for the star formation history of a component.
   !!}
   
   use :: Galactic_Structure_Options, only : enumerationComponentTypeType

--- a/source/nodes.property_extractor.star_formation_rate.F90
+++ b/source/nodes.property_extractor.star_formation_rate.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a star formation rate property extractor class.
+Implements a star formation rate property extractor class.
 !!}
 
   use :: Star_Formation_Rates_Disks                , only : starFormationRateDisksClass

--- a/source/nodes.property_extractor.stellar_feedback_outflow_rate.F90
+++ b/source/nodes.property_extractor.stellar_feedback_outflow_rate.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a stellar feedback mass outflow rate property extractor class.
+  Implements a stellar feedback mass outflow rate property extractor class.
   !!}
 
   use :: Stellar_Feedback_Outflows     , only : stellarFeedbackOutflowsClass

--- a/source/nodes.property_extractor.tidal_radius.F90
+++ b/source/nodes.property_extractor.tidal_radius.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a tidal radius property extractor class.
+Implements a tidal radius property extractor class.
 !!}
 
   use :: Satellite_Tidal_Stripping_Radii, only : satelliteTidalStrippingRadiusClass

--- a/source/nodes.property_extractor.time.F90
+++ b/source/nodes.property_extractor.time.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a cosmic time output analysis property extractor class.
+Implements a cosmic time output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.time_first_infall.F90
+++ b/source/nodes.property_extractor.time_first_infall.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a cosmic time output analysis property extractor class.
+Implements a cosmic time output analysis property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.tree_indices.F90
+++ b/source/nodes.property_extractor.tree_indices.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements merger tree index property extractor class.
+Implements merger tree index property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.tree_weight.F90
+++ b/source/nodes.property_extractor.tree_weight.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a merger tree weight property extractor class.
+Implements a merger tree weight property extractor class.
 !!}
 
   !![

--- a/source/nodes.property_extractor.uniqueID_branch_tip.F90
+++ b/source/nodes.property_extractor.uniqueID_branch_tip.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a node branch tip index property extractor.
+Implements a node branch tip index property extractor.
 !!}
 
   !![

--- a/source/nodes.property_extractor.velocity_dispersion.F90
+++ b/source/nodes.property_extractor.velocity_dispersion.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property extractor class for the velocity dispersion at a set of radii.
+  Implements a property extractor class for the velocity dispersion at a set of radii.
   !!}
   use :: Dark_Matter_Halo_Scales             , only : darkMatterHaloScale    , darkMatterHaloScaleClass
   use :: Galactic_Structure_Radii_Definitions, only : radiusSpecifier

--- a/source/nodes.property_extractor.velocity_maximum.F90
+++ b/source/nodes.property_extractor.velocity_maximum.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a cooling rate property extractor class.
+Implements a cooling rate property extractor class.
 !!}
 
   use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMO, darkMatterProfileDMOClass

--- a/source/nodes.property_extractor.velocity_orbital.F90
+++ b/source/nodes.property_extractor.velocity_orbital.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an orbital velocity output analysis property extractor class.
+Implements an orbital velocity output analysis property extractor class.
 !!}
 
   !![

--- a/source/output.analyses.HI_vs_halo_mass_relation.ALFALFA_Padmanabhan_2017.F90
+++ b/source/output.analyses.HI_vs_halo_mass_relation.ALFALFA_Padmanabhan_2017.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an HI vs halo mass relation analysis class.
+  Implements an HI vs halo mass relation analysis class.
   !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/output.analyses.ICM_Xray_luminosity_temperature.F90
+++ b/source/output.analyses.ICM_Xray_luminosity_temperature.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an ICM X-ray luminosity-temperature relation output analysis class.
+  Implements an ICM X-ray luminosity-temperature relation output analysis class.
   !!}
 
   !![

--- a/source/output.analyses.Local_Group.mass_metallicity_relation.F90
+++ b/source/output.analyses.Local_Group.mass_metallicity_relation.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class that computes mass-metallicity relations for Local Group satellite
+  Implements an output analysis class that computes mass-metallicity relations for Local Group satellite
   galaxies.
   !!}
 

--- a/source/output.analyses.Local_Group.mass_size_relation.F90
+++ b/source/output.analyses.Local_Group.mass_size_relation.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class that computes mass-size relations for Local Group satellite
+  Implements an output analysis class that computes mass-size relations for Local Group satellite
   galaxies.
   !!}
 

--- a/source/output.analyses.Local_Group.mass_velocity_dispersion_relation.F90
+++ b/source/output.analyses.Local_Group.mass_velocity_dispersion_relation.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class that computes mass-velocity dispersion relations for Local Group
+  Implements an output analysis class that computes mass-velocity dispersion relations for Local Group
   satellite galaxies.
   !!}
 

--- a/source/output.analyses.Local_Group.occupation_fraction.F90
+++ b/source/output.analyses.Local_Group.occupation_fraction.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class that computes the stellar mass-halo mass relation in the Local
+  Implements an output analysis class that computes the stellar mass-halo mass relation in the Local
   Group.
   !!}
 

--- a/source/output.analyses.Local_Group.stellar_mass_function.F90
+++ b/source/output.analyses.Local_Group.stellar_mass_function.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class that computes mass functions for Local Group satellite galaxies.
+  Implements an output analysis class that computes mass functions for Local Group satellite galaxies.
   !!}
 
   !![

--- a/source/output.analyses.Local_Group.stellar_mass_halo_mass_relation.F90
+++ b/source/output.analyses.Local_Group.stellar_mass_halo_mass_relation.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class that computes the stellar mass-halo mass relation in the Local
+  Implements an output analysis class that computes the stellar mass-halo mass relation in the Local
   Group.
   !!}
 

--- a/source/output.analyses.black_hole_bulge_relation.F90
+++ b/source/output.analyses.black_hole_bulge_relation.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a black hole-bulge mass relation analysis class.
+  Implements a black hole-bulge mass relation analysis class.
   !!}
 
   !![

--- a/source/output.analyses.color_distribution.SDSS.F90
+++ b/source/output.analyses.color_distribution.SDSS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a color distribution output analysis class for SDSS data.
+Implements a color distribution output analysis class for SDSS data.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/output.analyses.concentration_distribution.CDM.COCO.F90
+++ b/source/output.analyses.concentration_distribution.CDM.COCO.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a concentration distribution output analysis class for COCO CDM data.
+  Implements a concentration distribution output analysis class for COCO CDM data.
   !!}
 
   !![

--- a/source/output.analyses.concentration_distribution.F90
+++ b/source/output.analyses.concentration_distribution.F90
@@ -20,7 +20,7 @@
   use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMOClass
 
   !!{
-  Contains a module which implements a concentration distribution output analysis class.
+  Implements a concentration distribution output analysis class.
   !!}
 
   !![

--- a/source/output.analyses.concentration_vs_mass_relation.CDM.Ludlow_2016.F90
+++ b/source/output.analyses.concentration_vs_mass_relation.CDM.Ludlow_2016.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a concentration vs. halo mass analysis class matched to the
+  Implements a concentration vs. halo mass analysis class matched to the
   \cite{ludlow_mass-concentration-redshift_2016} CDM sample.
   !!}
 

--- a/source/output.analyses.correlation_function.F90
+++ b/source/output.analyses.correlation_function.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a generic two-point correlation function output analysis class.
+Implements a generic two-point correlation function output analysis class.
 !!}
 
   use               :: Cosmology_Functions                   , only : cosmologyFunctionsClass

--- a/source/output.analyses.correlation_function.Hearin2014_SDSS.F90
+++ b/source/output.analyses.correlation_function.Hearin2014_SDSS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a correlation function output analysis class for the \cite{hearin_dark_2013} analysis.
+Implements a correlation function output analysis class for the \cite{hearin_dark_2013} analysis.
 !!}
 
   !![

--- a/source/output.analyses.cross_correlator_1d.F90
+++ b/source/output.analyses.cross_correlator_1d.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a generic 1D volume function (i.e. number density of objects binned by some property, e.g. a
+Implements a generic 1D volume function (i.e. number density of objects binned by some property, e.g. a
 mass function) output analysis class.
 !!}
 

--- a/source/output.analyses.distribution_normalizer.bin_width.F90
+++ b/source/output.analyses.distribution_normalizer.bin_width.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a bin width output analysis distribution normalizer class.
+  Implements a bin width output analysis distribution normalizer class.
   !!}
 
   !![

--- a/source/output.analyses.distribution_normalizer.identity.F90
+++ b/source/output.analyses.distribution_normalizer.identity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an identity output analysis distribution normalizer class.
+  Implements an identity output analysis distribution normalizer class.
   !!}
 
   !![

--- a/source/output.analyses.distribution_normalizer.log10_to_log.F90
+++ b/source/output.analyses.distribution_normalizer.log10_to_log.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a $\log_{10}\rightarrow \log$ output analysis distribution normalizer class.
+  Implements a $\log_{10}\rightarrow \log$ output analysis distribution normalizer class.
   !!}
 
   !![

--- a/source/output.analyses.distribution_normalizer.sequence.F90
+++ b/source/output.analyses.distribution_normalizer.sequence.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a sequence of normalizers on on-the-fly outputs.
+  Implements a sequence of normalizers on on-the-fly outputs.
   !!}
 
   !![

--- a/source/output.analyses.distribution_normalizer.unitarity.F90
+++ b/source/output.analyses.distribution_normalizer.unitarity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a unitarity output analysis distribution normalizer class.
+  Implements a unitarity output analysis distribution normalizer class.
   !!}
 
   !![

--- a/source/output.analyses.distribution_operator.disk_size_inclination.F90
+++ b/source/output.analyses.distribution_operator.disk_size_inclination.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements the effects of inclination on disk size in an output analysis distribution operator class.
+  Implements the effects of inclination on disk size in an output analysis distribution operator class.
   !!}
 
   use :: Tables, only : table1D, table1DLinearLinear

--- a/source/output.analyses.distribution_operator.gravitational_lensing.F90
+++ b/source/output.analyses.distribution_operator.gravitational_lensing.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a gravitational lensing output analysis distribution operator class.
+Implements a gravitational lensing output analysis distribution operator class.
 !!}
 
   use :: Gravitational_Lensing, only : gravitationalLensingClass

--- a/source/output.analyses.distribution_operator.identity.F90
+++ b/source/output.analyses.distribution_operator.identity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a identity output analysis distribution operator class.
+  Implements a identity output analysis distribution operator class.
   !!}
 
   !![

--- a/source/output.analyses.distribution_operator.mass_incompleteness.F90
+++ b/source/output.analyses.distribution_operator.mass_incompleteness.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements the effects of incompleteness as a function of mass on the distribution.
+  Implements the effects of incompleteness as a function of mass on the distribution.
   !!}
 
   use :: Mass_Function_Incompletenesses, only : massFunctionIncompletenessClass

--- a/source/output.analyses.distribution_operator.mass_ratio_N-body.F90
+++ b/source/output.analyses.distribution_operator.mass_ratio_N-body.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an N-body halo mass ratio output analysis distribution operator class.
+  Implements an N-body halo mass ratio output analysis distribution operator class.
   !!}
   
   use :: Statistics_NBody_Halo_Mass_Errors, only : nbodyHaloMassErrorClass

--- a/source/output.analyses.distribution_operator.random_error.F90
+++ b/source/output.analyses.distribution_operator.random_error.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a random error output analysis distribution operator class.
+Implements a random error output analysis distribution operator class.
 !!}
   !![
   <outputAnalysisDistributionOperator name="outputAnalysisDistributionOperatorRandomError" abstract="yes">

--- a/source/output.analyses.distribution_operator.random_error.HI_mass_ALFALFA.F90
+++ b/source/output.analyses.distribution_operator.random_error.HI_mass_ALFALFA.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a random error output analysis distribution operator class providing errors in HI mass for
+  Implements a random error output analysis distribution operator class providing errors in HI mass for
   the ALFALFA survey.
   !!}
 

--- a/source/output.analyses.distribution_operator.random_error.N-body_concentration.F90
+++ b/source/output.analyses.distribution_operator.random_error.N-body_concentration.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a random error output analysis distribution operator class providing errors in $\log_{10}$
+  Implements a random error output analysis distribution operator class providing errors in $\log_{10}$
   of N-body halo concentration.
   !!}
 

--- a/source/output.analyses.distribution_operator.random_error.N-body_mass.F90
+++ b/source/output.analyses.distribution_operator.random_error.N-body_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a random error output analysis distribution operator class providing errors in $\log_{10}$
+  Implements a random error output analysis distribution operator class providing errors in $\log_{10}$
   of N-body halo mass.
   !!}
 

--- a/source/output.analyses.distribution_operator.random_error.fixed.F90
+++ b/source/output.analyses.distribution_operator.random_error.fixed.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a random error output analysis distribution operator class.
+Implements a random error output analysis distribution operator class.
 !!}
   !![
   <outputAnalysisDistributionOperator name="outputAnalysisDistributionOperatorRandomErrorFixed">

--- a/source/output.analyses.distribution_operator.random_error.polynomial.F90
+++ b/source/output.analyses.distribution_operator.random_error.polynomial.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a random error output analysis distribution operator class with an error magnitude that is
+  Implements a random error output analysis distribution operator class with an error magnitude that is
   a polynomial function of the property value.
   !!}
 

--- a/source/output.analyses.distribution_operator.sequence.F90
+++ b/source/output.analyses.distribution_operator.sequence.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a sequence output analysis distribution operator class.
+Implements a sequence output analysis distribution operator class.
 !!}
 
   type, public :: distributionOperatorList

--- a/source/output.analyses.distribution_operator.spin_N-body_errors.F90
+++ b/source/output.analyses.distribution_operator.spin_N-body_errors.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis distribution operator class to account for errors on N-body measurements of halo spin.
+  Implements an output analysis distribution operator class to account for errors on N-body measurements of halo spin.
   !!}
 
   use :: Halo_Spin_Distributions, only : haloSpinDistributionClass

--- a/source/output.analyses.galaxy_sizes_SDSS.F90
+++ b/source/output.analyses.galaxy_sizes_SDSS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a galaxy size output analysis class for SDSS data.
+Implements a galaxy size output analysis class for SDSS data.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/output.analyses.luminosity_function.F90
+++ b/source/output.analyses.luminosity_function.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a luminosity function output analysis class.
+Implements a luminosity function output analysis class.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/output.analyses.luminosity_function.Halpha.F90
+++ b/source/output.analyses.luminosity_function.Halpha.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a luminosity function output analysis class.
+Implements a luminosity function output analysis class.
 !!}
 
   use :: Cosmology_Functions              , only : cosmologyFunctionsClass

--- a/source/output.analyses.luminosity_function.Halpha.Gunawardhana2013.SDSS.F90
+++ b/source/output.analyses.luminosity_function.Halpha.Gunawardhana2013.SDSS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class.
+Implements a stellar mass function output analysis class.
 !!}
 
 

--- a/source/output.analyses.luminosity_function.Halpha.Sobral2013.HiZELS.F90
+++ b/source/output.analyses.luminosity_function.Halpha.Sobral2013.HiZELS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class.
+Implements a stellar mass function output analysis class.
 !!}
 
 

--- a/source/output.analyses.luminosity_function.Montero-Dorta2009.SDSS.F90
+++ b/source/output.analyses.luminosity_function.Montero-Dorta2009.SDSS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class.
+Implements a stellar mass function output analysis class.
 !!}
 
   !![

--- a/source/output.analyses.mass_function_HI.ALFALFA_Martin2010.F90
+++ b/source/output.analyses.mass_function_HI.ALFALFA_Martin2010.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an ALFALFA HI mass function output analysis class.
+Implements an ALFALFA HI mass function output analysis class.
 !!}
 
 

--- a/source/output.analyses.mass_function_HI.F90
+++ b/source/output.analyses.mass_function_HI.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an HI mass function output analysis class.
+Implements an HI mass function output analysis class.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/output.analyses.mass_function_stellar.Bernardi_SDSS.F90
+++ b/source/output.analyses.mass_function_stellar.Bernardi_SDSS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an output analysis class for the \cite{bernardi_massive_2013} stellar mass function.
+Implements an output analysis class for the \cite{bernardi_massive_2013} stellar mass function.
 !!}
 
 

--- a/source/output.analyses.mass_function_stellar.F90
+++ b/source/output.analyses.mass_function_stellar.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class.
+Implements a stellar mass function output analysis class.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/output.analyses.mass_function_stellar.GAMA.F90
+++ b/source/output.analyses.mass_function_stellar.GAMA.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an output analysis class for the \cite{baldry_galaxy_2012} stellar mass function.
+Implements an output analysis class for the \cite{baldry_galaxy_2012} stellar mass function.
 !!}
 
   !![

--- a/source/output.analyses.mass_function_stellar.PRIMUS.F90
+++ b/source/output.analyses.mass_function_stellar.PRIMUS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class for the PRIMUS survey of \cite{moustakas_primus:_2013}.
+Implements a stellar mass function output analysis class for the PRIMUS survey of \cite{moustakas_primus:_2013}.
 !!}
 
 

--- a/source/output.analyses.mass_function_stellar.SDSS.F90
+++ b/source/output.analyses.mass_function_stellar.SDSS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class.
+Implements a stellar mass function output analysis class.
 !!}
 
 

--- a/source/output.analyses.mass_function_stellar.UKIDSS_UDS.F90
+++ b/source/output.analyses.mass_function_stellar.UKIDSS_UDS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class for the UKIDSS UDS survey of \cite{caputi_stellar_2011}.
+Implements a stellar mass function output analysis class for the UKIDSS UDS survey of \cite{caputi_stellar_2011}.
 !!}
 
 

--- a/source/output.analyses.mass_function_stellar.ULTRAVISTA.F90
+++ b/source/output.analyses.mass_function_stellar.ULTRAVISTA.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class for the ULTRAVISTA survey of \cite{muzzin_evolution_2013}.
+Implements a stellar mass function output analysis class for the ULTRAVISTA survey of \cite{muzzin_evolution_2013}.
 !!}
 
 

--- a/source/output.analyses.mass_function_stellar.VIPERS.F90
+++ b/source/output.analyses.mass_function_stellar.VIPERS.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class for the VIPERS survey of \cite{davidzon_vimos_2013}.
+Implements a stellar mass function output analysis class for the VIPERS survey of \cite{davidzon_vimos_2013}.
 !!}
 
 

--- a/source/output.analyses.mass_function_stellar.ZFOURGE.F90
+++ b/source/output.analyses.mass_function_stellar.ZFOURGE.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a stellar mass function output analysis class for the ZFOURGE survey of \cite{tomczak_galaxy_2014}.
+Implements a stellar mass function output analysis class for the ZFOURGE survey of \cite{tomczak_galaxy_2014}.
 !!}
 
 

--- a/source/output.analyses.mass_metallicity_relation.Andrews2013.F90
+++ b/source/output.analyses.mass_metallicity_relation.Andrews2013.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a mass-metallicity relation analysis class.
+  Implements a mass-metallicity relation analysis class.
   !!}
 
   !![

--- a/source/output.analyses.mass_metallicity_relation.Blanc2019.F90
+++ b/source/output.analyses.mass_metallicity_relation.Blanc2019.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a gas-phase mass-metallicity relation analysis class using the observational results of \cite{blanc_characteristic_2019}.
+  Implements a gas-phase mass-metallicity relation analysis class using the observational results of \cite{blanc_characteristic_2019}.
   !!}
 
   !![

--- a/source/output.analyses.mean_function_1d.F90
+++ b/source/output.analyses.mean_function_1d.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a generic 1D mean function (i.e. mean value of some property weighted by number density of
+  Implements a generic 1D mean function (i.e. mean value of some property weighted by number density of
   objects binned by some property) output analysis class.
   !!}
 

--- a/source/output.analyses.molecular_ratio.Obreschkow2009.F90
+++ b/source/output.analyses.molecular_ratio.Obreschkow2009.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a molecular ratio class that assumes the model of \cite{obreschkow_simulation_2009}.
+Implements a molecular ratio class that assumes the model of \cite{obreschkow_simulation_2009}.
 !!}
 
   !![

--- a/source/output.analyses.morphological_fraction.GAMA_Moffett2016.F90
+++ b/source/output.analyses.morphological_fraction.GAMA_Moffett2016.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a stellar vs halo mass relation analysis class.
+  Implements a stellar vs halo mass relation analysis class.
   !!}
 
   !![

--- a/source/output.analyses.null.F90
+++ b/source/output.analyses.null.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a null output analysis class.
+Implements a null output analysis class.
 !!}
 
   !![

--- a/source/output.analyses.progenitor_mass_functions.F90
+++ b/source/output.analyses.progenitor_mass_functions.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a concentration distribution output analysis class for dark matter halo progenitor mass functions.
+  Implements a concentration distribution output analysis class for dark matter halo progenitor mass functions.
   !!}
   
   use :: Dark_Matter_Profiles_DMO        , only : darkMatterProfileDMOClass

--- a/source/output.analyses.property_operator.HI_mass.F90
+++ b/source/output.analyses.property_operator.HI_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a conversion of ISM mass to HI mass analysis property operator class.
+Implements a conversion of ISM mass to HI mass analysis property operator class.
 !!}
 
   use :: Output_Analysis_Molecular_Ratios, only : outputAnalysisMolecularRatioClass

--- a/source/output.analyses.property_operator.antiLog10.F90
+++ b/source/output.analyses.property_operator.antiLog10.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an anti-$\log_{10}()$ output analysis property operator class.
+Implements an anti-$\log_{10}()$ output analysis property operator class.
 !!}
 
   !![

--- a/source/output.analyses.property_operator.boolean.F90
+++ b/source/output.analyses.property_operator.boolean.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a boolean analysis property operator class.
+Implements a boolean analysis property operator class.
 !!}
 
   !![

--- a/source/output.analyses.property_operator.cosmology.angular_distance.F90
+++ b/source/output.analyses.property_operator.cosmology.angular_distance.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a cosmological angular distance corrector analysis property operator class.
+Implements a cosmological angular distance corrector analysis property operator class.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/output.analyses.property_operator.cosmology.luminosity_distance.F90
+++ b/source/output.analyses.property_operator.cosmology.luminosity_distance.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a cosmological luminosity distance corrector analysis property operator class.
+Implements a cosmological luminosity distance corrector analysis property operator class.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/output.analyses.property_operator.filter.high_pass.F90
+++ b/source/output.analyses.property_operator.filter.high_pass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a high-pass filter analysis property operator class.
+Implements a high-pass filter analysis property operator class.
 !!}
 
   !![

--- a/source/output.analyses.property_operator.identity.F90
+++ b/source/output.analyses.property_operator.identity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an identity output analysis property operator class.
+Implements an identity output analysis property operator class.
 !!}
 
   !![

--- a/source/output.analyses.property_operator.log10.F90
+++ b/source/output.analyses.property_operator.log10.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an log10 output analysis property operator class.
+Implements an log10 output analysis property operator class.
 !!}
 
   !![

--- a/source/output.analyses.property_operator.magnitude.F90
+++ b/source/output.analyses.property_operator.magnitude.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an output analysis property operator class which converts luminosity to absolute magnitude.
+Implements an output analysis property operator class which converts luminosity to absolute magnitude.
 !!}
 
   !![

--- a/source/output.analyses.property_operator.metallicity.Solar_relative.F90
+++ b/source/output.analyses.property_operator.metallicity.Solar_relative.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property operator class which converts a metallicity, assumed to be a mass ratio of a
+  Implements a property operator class which converts a metallicity, assumed to be a mass ratio of a
   given element to hydrogen, to $[\mathrm{N}/\mathrm{H}]$ form.
   !!}
 

--- a/source/output.analyses.property_operator.metallicity.offset_form.F90
+++ b/source/output.analyses.property_operator.metallicity.offset_form.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property operator class which converts a metallicity, assumed to be a mass ratio of a
+  Implements a property operator class which converts a metallicity, assumed to be a mass ratio of a
   given element to hydrogen, to $12+\log_{10}(\mathrm{N}/\mathrm{H})$ form.
   !!}
 

--- a/source/output.analyses.property_operator.minmax.F90
+++ b/source/output.analyses.property_operator.minmax.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a min-max analysis property operator class.
+Implements a min-max analysis property operator class.
 !!}
 
   !![

--- a/source/output.analyses.property_operator.multiply.F90
+++ b/source/output.analyses.property_operator.multiply.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a multiplication analysis property operator class.
+Implements a multiplication analysis property operator class.
 !!}
 
   !![

--- a/source/output.analyses.property_operator.normal.F90
+++ b/source/output.analyses.property_operator.normal.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a property operator class in which the property value is replaced with an integral over a
+  Implements a property operator class in which the property value is replaced with an integral over a
   normal distribution between given limits, using the property value at the mean of the distribution.
   !!}
 

--- a/source/output.analyses.property_operator.sequence.F90
+++ b/source/output.analyses.property_operator.sequence.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a sequence output analysis property operator class.
+Implements a sequence output analysis property operator class.
 !!}
 
   type, public :: propertyOperatorList

--- a/source/output.analyses.property_operator.square.F90
+++ b/source/output.analyses.property_operator.square.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a square output analysis property operator class.
+Implements a square output analysis property operator class.
 !!}
 
   !![

--- a/source/output.analyses.property_operator.systematic.polynomial.F90
+++ b/source/output.analyses.property_operator.systematic.polynomial.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a polynomial systematic shift output analysis property operator class.
+Implements a polynomial systematic shift output analysis property operator class.
 !!}
 
   !![

--- a/source/output.analyses.quiescent_fraction.F90
+++ b/source/output.analyses.quiescent_fraction.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a quiescent fraction output analysis class.
+  Implements a quiescent fraction output analysis class.
   !!}
 
   use :: Cosmology_Functions                       , only : cosmologyFunctionsClass

--- a/source/output.analyses.quiescent_fraction.Wagner2016.F90
+++ b/source/output.analyses.quiescent_fraction.Wagner2016.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class for the quiescent fraction measurements of \cite{wagner_evolution_2016}.
+  Implements an output analysis class for the quiescent fraction measurements of \cite{wagner_evolution_2016}.
   !!}
 
   use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMOClass

--- a/source/output.analyses.scatter_function_1d.F90
+++ b/source/output.analyses.scatter_function_1d.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a generic 1D scatter function (i.e. the scatter of some property weighted by number density of
+  Implements a generic 1D scatter function (i.e. the scatter of some property weighted by number density of
   objects binned by some property) output analysis class.
   !!}
 

--- a/source/output.analyses.spin_distribution.Bett2007.F90
+++ b/source/output.analyses.spin_distribution.Bett2007.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a spin parameter distribution output analysis class.
+Implements a spin parameter distribution output analysis class.
 !!}
 
   use :: Dark_Matter_Profile_Scales, only : darkMatterProfileScaleRadius, darkMatterProfileScaleRadiusClass

--- a/source/output.analyses.spin_distribution.F90
+++ b/source/output.analyses.spin_distribution.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a spin parameter distribution output analysis class.
+  Implements a spin parameter distribution output analysis class.
   !!}
   
   use :: Dark_Matter_Profile_Scales, only : darkMatterProfileScaleRadius, darkMatterProfileScaleRadiusClass

--- a/source/output.analyses.star_forming_main_sequence.F90
+++ b/source/output.analyses.star_forming_main_sequence.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a star forming main sequence output analysis class.
+  Implements a star forming main sequence output analysis class.
   !!}
 
   use :: Cosmology_Functions                       , only : cosmologyFunctionsClass

--- a/source/output.analyses.star_forming_main_sequence.Schreiber2015.F90
+++ b/source/output.analyses.star_forming_main_sequence.Schreiber2015.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class for the star forming main sequence measurements of \cite{schreiber_herschel_2015}.
+  Implements an output analysis class for the star forming main sequence measurements of \cite{schreiber_herschel_2015}.
   !!}
 
   !![

--- a/source/output.analyses.star_forming_main_sequence.Wagner2016.F90
+++ b/source/output.analyses.star_forming_main_sequence.Wagner2016.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class for the star forming main sequence measurements of \cite{wagner_evolution_2016}.
+  Implements an output analysis class for the star forming main sequence measurements of \cite{wagner_evolution_2016}.
   !!}
 
   use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMOClass

--- a/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
+++ b/source/output.analyses.stellar_vs_halo_mass_relation.COSMOS_Leauthaud2012.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a stellar vs halo mass relation analysis class.
+  Implements a stellar vs halo mass relation analysis class.
   !!}
 
   use, intrinsic :: ISO_C_Binding           , only : c_size_t

--- a/source/output.analyses.subhalo_mass_function.F90
+++ b/source/output.analyses.subhalo_mass_function.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class that computes subhalo mass functions.
+  Implements an output analysis class that computes subhalo mass functions.
   !!}
   
   use :: Cosmology_Functions     , only : cosmologyFunctionsClass

--- a/source/output.analyses.subhalo_radial_distribution.F90
+++ b/source/output.analyses.subhalo_radial_distribution.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class that computes subhalo radial distributions.
+  Implements an output analysis class that computes subhalo radial distributions.
   !!}
   
   use :: Cosmology_Functions     , only : cosmologyFunctionsClass

--- a/source/output.analyses.subhalo_velocity_maximum_vs_mass.F90
+++ b/source/output.analyses.subhalo_velocity_maximum_vs_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an output analysis class that computes subhalo mean maximum velocity as a function of mass.
+  Implements an output analysis class that computes subhalo mean maximum velocity as a function of mass.
   !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/output.analyses.volume_function_1d.F90
+++ b/source/output.analyses.volume_function_1d.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a generic 1D volume function (i.e. number density of objects binned by some property, e.g. a
+Implements a generic 1D volume function (i.e. number density of objects binned by some property, e.g. a
 mass function) output analysis class.
 !!}
 

--- a/source/output.analyses.weight_operator.N-body_mass.F90
+++ b/source/output.analyses.weight_operator.N-body_mass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a weight operator class in which the weight is multiplied by an integral over the N-body
+Implements a weight operator class in which the weight is multiplied by an integral over the N-body
 halo mass distribution.
 !!}
 

--- a/source/output.analyses.weight_operator.cosmology.volume.F90
+++ b/source/output.analyses.weight_operator.cosmology.volume.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a cosmological volume corrector analysis weight operator class.
+Implements a cosmological volume corrector analysis weight operator class.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctionsClass

--- a/source/output.analyses.weight_operator.filter.high_pass.F90
+++ b/source/output.analyses.weight_operator.filter.high_pass.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a high-pass filter analysis weight operator class.
+Implements a high-pass filter analysis weight operator class.
 !!}
 
   !![

--- a/source/output.analyses.weight_operator.identity.F90
+++ b/source/output.analyses.weight_operator.identity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an identity analysis weight operator class.
+Implements an identity analysis weight operator class.
 !!}
 
   !![

--- a/source/output.analyses.weight_operator.normal.F90
+++ b/source/output.analyses.weight_operator.normal.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a weight operator class in which the weight is multiplied by an integral over a normal distribution.
+Implements a weight operator class in which the weight is multiplied by an integral over a normal distribution.
 !!}
 
   use :: Node_Property_Extractors          , only : nodePropertyExtractorClass

--- a/source/output.analyses.weight_operator.property.F90
+++ b/source/output.analyses.weight_operator.property.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an analysis weight operator class which weights by a property value.
+Implements an analysis weight operator class which weights by a property value.
 !!}
   use :: Node_Property_Extractors          , only : nodePropertyExtractorClass
   use :: Output_Analysis_Property_Operators, only : outputAnalysisPropertyOperatorClass

--- a/source/output.analyses.weight_operator.sequence.F90
+++ b/source/output.analyses.weight_operator.sequence.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a sequence output analysis weight operator class.
+Implements a sequence output analysis weight operator class.
 !!}
 
   type, public :: weightOperatorList

--- a/source/output.analyses.weight_operator.subsampling.F90
+++ b/source/output.analyses.weight_operator.subsampling.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a subsampling weight operator class.
+Implements a subsampling weight operator class.
 !!}
 
   !![

--- a/source/satellites.tidal_fields.spherical_symmetry.F90
+++ b/source/satellites.tidal_fields.spherical_symmetry.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a model of the tidal field acting on a satellite assuming spherical symmetry in the host.
+  Implements a model of the tidal field acting on a satellite assuming spherical symmetry in the host.
   !!}
 
   use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScaleClass

--- a/source/star_formation.histories.adaptive.F90
+++ b/source/star_formation.histories.adaptive.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a star formation histories class which records star formation in adaptively sized time
+  Implements a star formation histories class which records star formation in adaptively sized time
   bins and split by metallicity.
   !!}
 

--- a/source/star_formation.histories.fixed_ages.F90
+++ b/source/star_formation.histories.fixed_ages.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a star formation histories class which records star formation in logarithmically-sized time
+  Implements a star formation histories class which records star formation in logarithmically-sized time
   bins of fixed age and split by metallicity.
   !!}
 

--- a/source/star_formation.histories.metallicity_split.F90
+++ b/source/star_formation.histories.metallicity_split.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a star formation histories class which records star formation split by metallicity.
+Implements a star formation histories class which records star formation split by metallicity.
 !!}
 
   use :: Output_Times, only : outputTimes, outputTimesClass

--- a/source/star_formation.histories.null.F90
+++ b/source/star_formation.histories.null.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a null star formation histories class.
+Implements a null star formation histories class.
 !!}
 
   !![

--- a/source/statistics.Nbody.halos.mass_errors.SO_halo_finder.F90
+++ b/source/statistics.Nbody.halos.mass_errors.SO_halo_finder.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body dark matter halo mass error class which
+Implements an N-body dark matter halo mass error class which
 implements a model for errors in spherical overdensity halo finders.
 !!}
 

--- a/source/statistics.Nbody.halos.mass_errors.Trenti2010.F90
+++ b/source/statistics.Nbody.halos.mass_errors.Trenti2010.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body dark matter halo mass error class using the model of \cite{trenti_how_2010}.
+Implements an N-body dark matter halo mass error class using the model of \cite{trenti_how_2010}.
 !!}
 
   use :: Cosmology_Functions, only : cosmologyFunctions, cosmologyFunctionsClass

--- a/source/statistics.Nbody.halos.mass_errors.friends-of-friends.F90
+++ b/source/statistics.Nbody.halos.mass_errors.friends-of-friends.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an N-body dark matter halo mass error class using a fit appropriate for friends-of-friends
+  Implements an N-body dark matter halo mass error class using a fit appropriate for friends-of-friends
   group finders.
   !!}
 

--- a/source/statistics.Nbody.halos.mass_errors.null.F90
+++ b/source/statistics.Nbody.halos.mass_errors.null.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a null N-body dark matter halo mass error class.
+Implements a null N-body dark matter halo mass error class.
 !!}
 
   !![

--- a/source/statistics.Nbody.halos.mass_errors.power_law.F90
+++ b/source/statistics.Nbody.halos.mass_errors.power_law.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an N-body dark matter halo mass error class in which
+Implements an N-body dark matter halo mass error class in which
 errors are a power-law in halo mass.
 !!}
 

--- a/source/structure_formation.correlation_function.two_point.power_spectrum_transform.F90
+++ b/source/structure_formation.correlation_function.two_point.power_spectrum_transform.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a two-point correlation function class in which the correlation function is found by Fourier
+Implements a two-point correlation function class in which the correlation function is found by Fourier
 transforming a power spectrum.
 !!}
   

--- a/source/structure_formation.critical_overdensity.Kitayama_Suto1996.F90
+++ b/source/structure_formation.critical_overdensity.Kitayama_Suto1996.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a critical overdensity class based on the fitting functions of
+  Implements a critical overdensity class based on the fitting functions of
   \cite{kitayama_semianalytic_1996}.
   !!}
 

--- a/source/structure_formation.critical_overdensity.Marsh2016.FDM.F90
+++ b/source/structure_formation.critical_overdensity.Marsh2016.FDM.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a critical overdensity for collapse using the \gls{fdm} modifier of \cite{marsh_warmAndFuzzy_2016}.
+  Implements a critical overdensity for collapse using the \gls{fdm} modifier of \cite{marsh_warmAndFuzzy_2016}.
   !!}
   use :: Cosmology_Parameters   , only : cosmologyParametersClass
   use :: Dark_Matter_Particles  , only : darkMatterParticleClass

--- a/source/structure_formation.critical_overdensity.environmental.F90
+++ b/source/structure_formation.critical_overdensity.environmental.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an environmental critical overdensity class.
+Implements an environmental critical overdensity class.
 !!}
 
   !![

--- a/source/structure_formation.critical_overdensity.fixed.F90
+++ b/source/structure_formation.critical_overdensity.fixed.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an fixed critical overdensity class.
+Implements an fixed critical overdensity class.
 !!}
 
   !![

--- a/source/structure_formation.critical_overdensity.peak_background_split.F90
+++ b/source/structure_formation.critical_overdensity.peak_background_split.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an peak-background split critical overdensity class.
+Implements an peak-background split critical overdensity class.
 !!}
 
   !![

--- a/source/structure_formation.critical_overdensity.renormalized.F90
+++ b/source/structure_formation.critical_overdensity.renormalized.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a critical overdensity class which renormalizes another class based on the ratio of two mass
+Implements a critical overdensity class which renormalizes another class based on the ratio of two mass
 variance classes. This is intended to allow different window functions to be used for $\sigma(M)$ while retaining the same ratio
 $\delta_\mathrm{c}/\sigma(M)$ (and, therefore, the same halo mass function) on a mass scale $M_\mathrm{match}$.
 !!}

--- a/source/structure_formation.critical_overdensity.warm_dark_matter.F90
+++ b/source/structure_formation.critical_overdensity.warm_dark_matter.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a critical overdensity for collapse the \gls{wdm} modifier of \cite{barkana_constraints_2001}.
+Implements a critical overdensity for collapse the \gls{wdm} modifier of \cite{barkana_constraints_2001}.
 !!}
   use :: Cosmology_Parameters   , only : cosmologyParametersClass
   use :: Dark_Matter_Particles  , only : darkMatterParticleClass

--- a/source/structure_formation.excursion_sets.barrier.critical_overdensity.F90
+++ b/source/structure_formation.excursion_sets.barrier.critical_overdensity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a critical overdensity excursion set barrier class.
+Implements a critical overdensity excursion set barrier class.
 !!}
 
   use :: Cosmological_Density_Field, only : cosmologicalMassVarianceClass, criticalOverdensityClass

--- a/source/structure_formation.excursion_sets.barrier.linear.F90
+++ b/source/structure_formation.excursion_sets.barrier.linear.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a linear excursion set barrier class.
+Implements a linear excursion set barrier class.
 !!}
 
   !![

--- a/source/structure_formation.excursion_sets.barrier.quadratic.F90
+++ b/source/structure_formation.excursion_sets.barrier.quadratic.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a quadratic excursion set barrier class.
+Implements a quadratic excursion set barrier class.
 !!}
 
   !![

--- a/source/structure_formation.excursion_sets.barrier.remap.Sheth-Mo-Tormen.F90
+++ b/source/structure_formation.excursion_sets.barrier.remap.Sheth-Mo-Tormen.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements an excursion set barrier class which remaps another class using the \cite{sheth_ellipsoidal_2001} ellipsoidal collapse parameterization.
+  Implements an excursion set barrier class which remaps another class using the \cite{sheth_ellipsoidal_2001} ellipsoidal collapse parameterization.
   !!}
 
   !![

--- a/source/structure_formation.excursion_sets.barrier.remap.scale.F90
+++ b/source/structure_formation.excursion_sets.barrier.remap.scale.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an excursion set barrier class which remaps another class by multiplying by a constant.
+Implements an excursion set barrier class which remaps another class by multiplying by a constant.
 !!}
 
   !![

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
@@ -20,7 +20,7 @@
 !+    Contributions to this file made by: Arya Farahi, Andrew Benson, Christoph Behrens, Xiaolong Du.
 
 !!{
-Contains a module which implements a excursion set first crossing statistics class using the algorithm of \cite{benson_dark_2012}.
+Implements a excursion set first crossing statistics class using the algorithm of \cite{benson_dark_2012}.
 !!}
 
   use :: Cosmological_Density_Field, only : cosmologicalMassVarianceClass

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Zhang_Hui.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Zhang_Hui.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a excursion set first crossing statistics class utilizing the algorithm of \cite{zhang_random_2006}.
+  Implements a excursion set first crossing statistics class utilizing the algorithm of \cite{zhang_random_2006}.
   !!}
 
   use :: Excursion_Sets_Barriers, only : excursionSetBarrierClass

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Zhang_Hui_high_order.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Zhang_Hui_high_order.F90
@@ -20,7 +20,7 @@
   !+    Contributions to this file made by: Arya Farahi, Andrew Benson.
 
   !!{
-  Contains a module which implements a excursion set first crossing statistics class utilizing a higher order generalization of
+  Implements a excursion set first crossing statistics class utilizing a higher order generalization of
   the algorithm of \cite{zhang_random_2006}.
   !!}
 

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.linear_barrier.Brownian_bridge.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.linear_barrier.Brownian_bridge.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a excursion set first crossing statistics class for linear barriers with constrained branching
+Implements a excursion set first crossing statistics class for linear barriers with constrained branching
 described by a Brownian bridge solution.
 !!}
 

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.linear_barrier.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.linear_barrier.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a excursion set first crossing statistics class for linear barriers.
+Implements a excursion set first crossing statistics class for linear barriers.
 !!}
 
   use :: Cosmological_Density_Field, only : cosmologicalMassVarianceClass

--- a/source/structure_formation.halo_environment.fixed.F90
+++ b/source/structure_formation.halo_environment.fixed.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a fixed halo environment.
+Implements a fixed halo environment.
 !!}
 
   use :: Cosmology_Functions       , only : cosmologyFunctionsClass

--- a/source/structure_formation.halo_environment.lognormal.F90
+++ b/source/structure_formation.halo_environment.lognormal.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a log-normal halo environment.
+Implements a log-normal halo environment.
 !!}
 
   use :: Cosmology_Functions     , only : cosmologyFunctionsClass

--- a/source/structure_formation.halo_environment.normal.F90
+++ b/source/structure_formation.halo_environment.normal.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a normally-distributed halo environment.
+Implements a normally-distributed halo environment.
 !!}
 
   use :: Cosmology_Functions       , only : cosmologyFunctionsClass

--- a/source/structure_formation.halo_environment.uniform.F90
+++ b/source/structure_formation.halo_environment.uniform.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a uniform halo environment.
+Implements a uniform halo environment.
 !!}
 
   !![

--- a/source/structure_formation.halo_mass_function.Bhattacharya2011.F90
+++ b/source/structure_formation.halo_mass_function.Bhattacharya2011.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a \cite{bhattacharya_mass_2011} dark matter halo mass function class.
+  Implements a \cite{bhattacharya_mass_2011} dark matter halo mass function class.
   !!}
 
   use :: Cosmological_Density_Field, only : cosmologicalMassVarianceClass, criticalOverdensityClass

--- a/source/structure_formation.halo_mass_function.Despali_2015.F90
+++ b/source/structure_formation.halo_mass_function.Despali_2015.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a \cite{despali_universality_2015} dark matter halo mass function class.
+Implements a \cite{despali_universality_2015} dark matter halo mass function class.
 !!}
 
   use :: Cosmology_Functions    , only : cosmologyFunctionsClass

--- a/source/structure_formation.halo_mass_function.Ondaro-Mallea2021.F90
+++ b/source/structure_formation.halo_mass_function.Ondaro-Mallea2021.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements the dark matter halo mass function class of \cite{ondaro-mallea_non-universality_2022} for non-universal
+Implements the dark matter halo mass function class of \cite{ondaro-mallea_non-universality_2022} for non-universal
 primordial power spectra and structure growth rates.
 !!}
   use :: Cosmological_Density_Field, only : cosmologicalMassVarianceClass

--- a/source/structure_formation.halo_mass_function.Press-Schechter.F90
+++ b/source/structure_formation.halo_mass_function.Press-Schechter.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a \cite{press_formation_1974} dark matter halo mass function class.
+Implements a \cite{press_formation_1974} dark matter halo mass function class.
 !!}
   use :: Cosmological_Density_Field    , only : cosmologicalMassVarianceClass
   use :: Excursion_Sets_First_Crossings, only : excursionSetFirstCrossingClass

--- a/source/structure_formation.halo_mass_function.Reed2007.F90
+++ b/source/structure_formation.halo_mass_function.Reed2007.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a \cite{reed_halo_2007} dark matter halo mass function class.
+  Implements a \cite{reed_halo_2007} dark matter halo mass function class.
   !!}
 
   use :: Cosmological_Density_Field, only : cosmologicalMassVarianceClass, criticalOverdensityClass

--- a/source/structure_formation.halo_mass_function.Rodriguez-Puebla2016.F90
+++ b/source/structure_formation.halo_mass_function.Rodriguez-Puebla2016.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a \cite{tinker_towardhalo_2008} dark matter halo mass function class.
+  Implements a \cite{tinker_towardhalo_2008} dark matter halo mass function class.
   !!}
 
   !![

--- a/source/structure_formation.halo_mass_function.Sheth-Tormen.F90
+++ b/source/structure_formation.halo_mass_function.Sheth-Tormen.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a \cite{sheth_ellipsoidal_2001} dark matter halo mass function class.
+Implements a \cite{sheth_ellipsoidal_2001} dark matter halo mass function class.
 !!}
   use :: Cosmological_Density_Field, only : cosmologicalMassVarianceClass, criticalOverdensityClass
 

--- a/source/structure_formation.halo_mass_function.Tinker2008.F90
+++ b/source/structure_formation.halo_mass_function.Tinker2008.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a \cite{tinker_towardhalo_2008} dark matter halo mass function class.
+  Implements a \cite{tinker_towardhalo_2008} dark matter halo mass function class.
   !!}
   use :: Tables                 , only : table1DGeneric
   use :: Virial_Density_Contrast, only : virialDensityContrastClass

--- a/source/structure_formation.halo_mass_function.Tinker2008Form.F90
+++ b/source/structure_formation.halo_mass_function.Tinker2008Form.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a \cite{tinker_towardhalo_2008} dark matter halo mass function class.
+  Implements a \cite{tinker_towardhalo_2008} dark matter halo mass function class.
   !!}
   use :: Cosmological_Density_Field, only : cosmologicalMassVarianceClass
   use :: Cosmology_Functions       , only : cosmologyFunctionsClass

--- a/source/structure_formation.halo_mass_function.Tinker2008Generic.F90
+++ b/source/structure_formation.halo_mass_function.Tinker2008Generic.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a \cite{tinker_towardhalo_2008} dark matter halo mass function class with user-specified parameters.
+  Implements a \cite{tinker_towardhalo_2008} dark matter halo mass function class with user-specified parameters.
   !!}
 
   !![

--- a/source/structure_formation.halo_mass_function.environment_averaged.F90
+++ b/source/structure_formation.halo_mass_function.environment_averaged.F90
@@ -18,8 +18,8 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a dark matter halo mass function class which averages another (presumably
-environment-dependent) mass function over environment.
+Implements a dark matter halo mass function class which averages another (presumably environment-dependent) mass function over
+environment.
 !!}
 
   use :: Cosmological_Density_Field, only : haloEnvironmentClass

--- a/source/structure_formation.halo_mass_function.environmental.F90
+++ b/source/structure_formation.halo_mass_function.environmental.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a dark matter halo mass function class which handles the transition through the environment
+Implements a dark matter halo mass function class which handles the transition through the environment
 mass scale.
 !!}
 

--- a/source/structure_formation.halo_mass_function.error_convolved.F90
+++ b/source/structure_formation.halo_mass_function.error_convolved.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a dark matter halo mass function class which modifies another mass function by convolving
+Implements a dark matter halo mass function class which modifies another mass function by convolving
 with a mass-dependent error.
 !!}
 

--- a/source/structure_formation.halo_mass_function.simple_systematic.F90
+++ b/source/structure_formation.halo_mass_function.simple_systematic.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a dark matter halo mass function class which modifies another mass function using a simple model for systematics.
+Implements a dark matter halo mass function class which modifies another mass function using a simple model for systematics.
 !!}
 
   !![

--- a/source/structure_formation.power_spectrum.nonlinear.CosmicEmu.F90
+++ b/source/structure_formation.power_spectrum.nonlinear.CosmicEmu.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a nonlinear power spectrum class in which the nonlinear power spectrum is computed using the
+Implements a nonlinear power spectrum class in which the nonlinear power spectrum is computed using the
 code of \cite{lawrence_coyote_2010}.
 !!}
 

--- a/source/structure_formation.power_spectrum.nonlinear.PeacockDodds1996.F90
+++ b/source/structure_formation.power_spectrum.nonlinear.PeacockDodds1996.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a nonlinear power spectrum class in which the nonlinear power spectrum is computed using the
+Implements a nonlinear power spectrum class in which the nonlinear power spectrum is computed using the
 algorithm of \cite{peacock_non-linear_1996}.
 !!}
 

--- a/source/structure_formation.power_spectrum.nonlinear.Smith2003.F90
+++ b/source/structure_formation.power_spectrum.nonlinear.Smith2003.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a nonlinear power spectrum class in which the nonlinear power spectrum is computed using the
+Implements a nonlinear power spectrum class in which the nonlinear power spectrum is computed using the
 algorithm of \cite{smith_stable_2003}.
 !!}
 

--- a/source/structure_formation.power_spectrum.nonlinear.linear.F90
+++ b/source/structure_formation.power_spectrum.nonlinear.linear.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a nonlinear power spectrum class in which the nonlinear power spectrum is just the linear
+Implements a nonlinear power spectrum class in which the nonlinear power spectrum is just the linear
 power spectrum. Intended primarily for testing purposes.
 !!}
 

--- a/source/structure_formation.power_spectrum.standard.F90
+++ b/source/structure_formation.power_spectrum.standard.F90
@@ -18,8 +18,8 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a linear theory power spectrum class in which the power spectrum is just the transferred
-primordial power spectrum correctly normalized to $z=0$.
+Implements a linear theory power spectrum class in which the power spectrum is just the transferred primordial power spectrum
+correctly normalized to $z=0$.
 !!}
 
   use :: Cosmological_Density_Field          , only : cosmologicalMassVarianceClass

--- a/source/structure_formation.power_spectrum.variance.window_function.Lagrangian_Chan2017.F90
+++ b/source/structure_formation.power_spectrum.variance.window_function.Lagrangian_Chan2017.F90
@@ -18,8 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which provides a power spectrum window function class that implements the Lagrangian filter of
-  \cite{chan_effective_2017}.
+  Provides a power spectrum window function class that implements the Lagrangian filter of \cite{chan_effective_2017}.
   !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/structure_formation.power_spectrum.variance.window_function.hyperbolic_tangent.F90
+++ b/source/structure_formation.power_spectrum.variance.window_function.hyperbolic_tangent.F90
@@ -20,7 +20,7 @@
 !+    Contributions to this file made by: Xiaolong Du
 
   !!{
-  Contains a module which implements a hyperbolic tangent power spectrum window function class.
+  Implements a hyperbolic tangent power spectrum window function class.
   !!}
   use :: Cosmology_Parameters, only : cosmologyParametersClass
 

--- a/source/structure_formation.power_spectrum.variance.window_function.sharp_kSpace.F90
+++ b/source/structure_formation.power_spectrum.variance.window_function.sharp_kSpace.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a sharp $k$-space power spectrum window function class.
+Implements a sharp $k$-space power spectrum window function class.
 !!}
   use :: Cosmology_Parameters, only : cosmologyParametersClass
 

--- a/source/structure_formation.power_spectrum.variance.window_function.smooth_k_space.F90
+++ b/source/structure_formation.power_spectrum.variance.window_function.smooth_k_space.F90
@@ -20,8 +20,7 @@
   !+    Contributions to this file made by: Omid Sameie.
 
   !!{
-  Contains a module which provides a power spectrum window function class that implements the smooth-$k$ space filter of
-  \cite{leo_new_2018}.
+  Provides a power spectrum window function class that implements the smooth-$k$ space filter of \cite{leo_new_2018}.
   !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/structure_formation.power_spectrum.variance.window_function.top_hat.F90
+++ b/source/structure_formation.power_spectrum.variance.window_function.top_hat.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a top-hat power spectrum window function class.
+  Implements a top-hat power spectrum window function class.
   !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/structure_formation.power_spectrum.variance.window_function.top_hat_generalized.F90
+++ b/source/structure_formation.power_spectrum.variance.window_function.top_hat_generalized.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a generalized top-hat power spectrum window function class \citep{brown_towards_2022}.
+  Implements a generalized top-hat power spectrum window function class \citep{brown_towards_2022}.
   !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/structure_formation.power_spectrum.variance.window_function.top_hat_kspace_sharp_hybrid.F90
+++ b/source/structure_formation.power_spectrum.variance.window_function.top_hat_kspace_sharp_hybrid.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a hybrid top-hat/sharp $k$-space power spectrum window function class.
+  Implements a hybrid top-hat/sharp $k$-space power spectrum window function class.
   !!}
   
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/structure_formation.power_spectrum.variance.window_function.top_hat_smoothed.F90
+++ b/source/structure_formation.power_spectrum.variance.window_function.top_hat_smoothed.F90
@@ -20,7 +20,7 @@
   !+ Contributions to this file made by: Ivan Esteban
 
   !!{
-  Contains a module which implements a top-hat power spectrum window function class, convoluted with a Gaussian.
+  Implements a top-hat power spectrum window function class, convoluted with a Gaussian.
   !!}
 
   use :: Cosmology_Parameters, only : cosmologyParametersClass

--- a/source/structure_formation.transfer_function.AxionCAMB.F90
+++ b/source/structure_formation.transfer_function.AxionCAMB.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a transfer function class using the AxionCAMB code.
+  Implements a transfer function class using the AxionCAMB code.
   !!}
 
   use :: Dark_Matter_Particles, only : darkMatterParticleClass

--- a/source/structure_formation.transfer_function.BBKS.F90
+++ b/source/structure_formation.transfer_function.BBKS.F90
@@ -18,8 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements the transfer function fitting function of
-  \cite{bardeen_statistics_1986}.
+  Implements the transfer function fitting function of \cite{bardeen_statistics_1986}.
   !!}
 
   use :: Cosmology_Functions  , only : cosmologyFunctionsClass

--- a/source/structure_formation.transfer_function.BBKS.WDM.F90
+++ b/source/structure_formation.transfer_function.BBKS.WDM.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a transfer function class based on the \gls{wdm} modifier of \cite{bardeen_statistics_1986}.
+Implements a transfer function class based on the \gls{wdm} modifier of \cite{bardeen_statistics_1986}.
 !!}
 
   use :: Cosmology_Parameters , only : cosmologyParametersClass

--- a/source/structure_formation.transfer_function.Bode2001.F90
+++ b/source/structure_formation.transfer_function.Bode2001.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a transfer function class based on the thermal \gls{wdm} modifier of \cite{bode_halo_2001}.
+Implements a transfer function class based on the thermal \gls{wdm} modifier of \cite{bode_halo_2001}.
 !!}
 
   use :: Cosmology_Functions  , only : cosmologyFunctionsClass

--- a/source/structure_formation.transfer_function.CAMB.F90
+++ b/source/structure_formation.transfer_function.CAMB.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a transfer function class using the CAMB code.
+Implements a transfer function class using the CAMB code.
 !!}
 
   use :: Dark_Matter_Particles, only : darkMatterParticleClass

--- a/source/structure_formation.transfer_function.CLASS_CDM.F90
+++ b/source/structure_formation.transfer_function.CLASS_CDM.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements a transfer function class using the CLASS code.
+Implements a transfer function class using the CLASS code.
 !!}
 
   use :: Dark_Matter_Particles, only : darkMatterParticleClass

--- a/source/structure_formation.transfer_function.Eisenstein_Hu1998.F90
+++ b/source/structure_formation.transfer_function.Eisenstein_Hu1998.F90
@@ -18,8 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a transfer function class using the fitting function of
-  \cite{eisenstein_baryonic_1998}.
+  Implements a transfer function class using the fitting function of \cite{eisenstein_baryonic_1998}.
   !!}
 
   use :: Cosmology_Functions  , only : cosmologyFunctionsClass

--- a/source/structure_formation.transfer_function.Eisenstein_Hu1999.F90
+++ b/source/structure_formation.transfer_function.Eisenstein_Hu1999.F90
@@ -20,8 +20,7 @@
 !+    Contributions to this file made by:  Anthony Pullen, Andrew Benson.
 
   !!{
-  Contains a module which implements a transfer function class using the fitting function of
-  \cite{eisenstein_power_1999}.
+  Implements a transfer function class using the fitting function of \cite{eisenstein_power_1999}.
   !!}
 
   use :: Cosmology_Functions  , only : cosmologyFunctionsClass

--- a/source/structure_formation.transfer_function.Hu2000.FDM.F90
+++ b/source/structure_formation.transfer_function.Hu2000.FDM.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a transfer function class based on the fuzzy dark matter modifier of \cite{hu_fuzzy_2000}.
+  Implements a transfer function class based on the fuzzy dark matter modifier of \cite{hu_fuzzy_2000}.
   !!}
 
   use :: Cosmology_Functions  , only : cosmologyFunctionsClass

--- a/source/structure_formation.transfer_function.Murgia2017.F90
+++ b/source/structure_formation.transfer_function.Murgia2017.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a transfer function class based on the non-cold dark matter fitting function of
+  Implements a transfer function class based on the non-cold dark matter fitting function of
   \cite{murgia_non-cold_2017}.
   !!}
 

--- a/source/structure_formation.transfer_function.fuzzyDM.Murgia2017.F90
+++ b/source/structure_formation.transfer_function.fuzzyDM.Murgia2017.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a transfer function class for fuzzy dark matter using the fitting function of
+  Implements a transfer function class for fuzzy dark matter using the fitting function of
   \cite{murgia_non-cold_2017}.
   !!}
 

--- a/source/structure_formation.transfer_function.fuzzyDM.Passaglia2022.F90
+++ b/source/structure_formation.transfer_function.fuzzyDM.Passaglia2022.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Contains a module which implements a transfer function class for fuzzy dark matter using the fitting function of
+  Implements a transfer function class for fuzzy dark matter using the fitting function of
   \cite{passaglia_accurate_2022}.
   !!}
 

--- a/source/structure_formation.transfer_function.identity.F90
+++ b/source/structure_formation.transfer_function.identity.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which implements an identity transfer function class.
+Implements an identity transfer function class.
 !!}
 
   !![


### PR DESCRIPTION
Many files referred to a contained `module`—this was a holdover from when each class was its own module. This is no longer the case, so the comments have been updated.