### PR TITLE
Operate correctly for `galacticStructureRadiusSolvers` that do not require the specific angular momentum of each component

### DIFF
--- a/source/objects.nodes.components.disk.standard.F90
+++ b/source/objects.nodes.components.disk.standard.F90
@@ -1172,16 +1172,12 @@ contains
                   &                                  )                                                 &
                   )
           end if
-          ! Associate the pointers with the appropriate property routines.
-          Radius_Get   => Node_Component_Disk_Standard_Radius_Solve
-          Radius_Set   => Node_Component_Disk_Standard_Radius_Solve_Set
-          Velocity_Get => Node_Component_Disk_Standard_Velocity
-          Velocity_Set => Node_Component_Disk_Standard_Velocity_Set
-       else
-          call Node_Component_Disk_Standard_Radius_Solve_Set(node,0.0d0)
-          call Node_Component_Disk_Standard_Velocity_Set    (node,0.0d0)
-          componentActive=.false.
        end if
+       ! Associate the pointers with the appropriate property routines.
+       Radius_Get   => Node_Component_Disk_Standard_Radius_Solve
+       Radius_Set   => Node_Component_Disk_Standard_Radius_Solve_Set
+       Velocity_Get => Node_Component_Disk_Standard_Velocity
+       Velocity_Set => Node_Component_Disk_Standard_Velocity_Set
     end select
     return
   end subroutine Node_Component_Disk_Standard_Radius_Solver

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -1406,16 +1406,12 @@ contains
              end if
              specificAngularMomentum=ratioAngularMomentumScaleRadius*specificAngularMomentumMean
           end if
-          ! Associate the pointers with the appropriate property routines.
-          Radius_Get   => Node_Component_Spheroid_Standard_Radius_Solve
-          Radius_Set   => Node_Component_Spheroid_Standard_Radius_Solve_Set
-          Velocity_Get => Node_Component_Spheroid_Standard_Velocity_Solve
-          Velocity_Set => Node_Component_Spheroid_Standard_Velocity_Solve_Set
-       else
-          call Node_Component_Spheroid_Standard_Radius_Solve_Set  (node,0.0d0)
-          call Node_Component_Spheroid_Standard_Velocity_Solve_Set(node,0.0d0)
-          componentActive=.false.
        end if
+       ! Associate the pointers with the appropriate property routines.
+       Radius_Get   => Node_Component_Spheroid_Standard_Radius_Solve
+       Radius_Set   => Node_Component_Spheroid_Standard_Radius_Solve_Set
+       Velocity_Get => Node_Component_Spheroid_Standard_Velocity_Solve
+       Velocity_Set => Node_Component_Spheroid_Standard_Velocity_Solve_Set
     end select
     return
   end subroutine Node_Component_Spheroid_Standard_Radius_Solver

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -732,7 +732,7 @@ contains
     starFormationHistory=self%starFormationHistory()
     ! Check if the range of this history is sufficient.
     if (starFormationHistory_%rangeIsSufficient(starFormationHistory,rate)) then
-       ! Range is sufficient, call the intrinsinc rate function.
+       ! Range is sufficient, call the intrinsic rate function.
        select type (self)
        class is (nodeComponentSpheroidStandard)
           call self%starFormationHistoryRateIntrinsic(rate)


### PR DESCRIPTION
When the specific angular momentum was not required in radius solver calculations, the standard disk and spheroid components incorrectly indicated that the component was not active, resulting in no size calculation being performed.