### PR TITLE
Allow the `serializeASCII` method of the `treeNode` class to take a verbosity argument

### DIFF
--- a/perl/Galacticus/Build/Components/Classes/Serialization.pm
+++ b/perl/Galacticus/Build/Components/Classes/Serialization.pm
@@ -45,14 +45,20 @@ sub Class_Serialize_ASCII {
 		 type       => "nodeComponent".ucfirst($code::class->{'name'}),
 		 attributes => [ "intent(in   )" ],
 		 variables  => [ "self" ]
+	     },
+	     {
+		 intrinsic  => "type",
+		 type       => "enumerationVerbosityLevelType",
+		 variables  => [ "verbosityLevel" ],
+		 attributes => [ "intent(in   )" ]
 	     }
 	    ]
     };
     $code::padding = " " x ($fullyQualifiedNameLengthMax-length($code::class->{'name'}));
     $function->{'content'}  = fill_in_string(<<'CODE', PACKAGE => 'code');
 !$GLC attributes unused :: self
-call displayIndent('{$class->{'name'}}: {$padding}generic')
-call displayUnindent('done')
+call displayIndent('{$class->{'name'}}: {$padding}generic',verbosityLevel)
+call displayUnindent('done',verbosityLevel)
 CODE
     # Insert a type-binding for this function.
     push(

--- a/source/objects.abundances.F90
+++ b/source/objects.abundances.F90
@@ -293,26 +293,27 @@ contains
     return
   end subroutine Abundances_Builder
 
-  subroutine Abundances_Dump(self)
+  subroutine Abundances_Dump(self,verbosityLevel)
     !!{
-    Reset an abundances object.
+    Dump properties of an abundances object.
     !!}
-    use :: Display           , only : displayMessage
-    use :: ISO_Varying_String, only : assignment(=) , operator(//), varying_string
+    use :: Display           , only : displayMessage, enumerationVerbosityLevelType
+    use :: ISO_Varying_String, only : assignment(=) , operator(//)                 , varying_string
     implicit none
-    class    (abundances    ), intent(in   ) :: self
-    integer                                  :: i
-    character(len=22        )                :: label
-    type     (varying_string)                :: message
+    class    (abundances                   ), intent(in   ) :: self
+    type     (enumerationVerbosityLevelType), intent(in   ) :: verbosityLevel
+    integer                                                 :: i
+    character(len=22                       )                :: label
+    type     (varying_string               )                :: message
 
     write (label,'(e22.16)') self%metallicityValue
     message='metallicity: '//label
-    call displayMessage(message)
+    call displayMessage(message,verbosityLevel)
     if (elementsCount > 0) then
        do i=1,elementsCount
           write (label,'(e22.16)') self%elementalValue(i)
           message=elementsToTrack(i)//':          '//label
-          call displayMessage(message)
+          call displayMessage(message,verbosityLevel)
        end do
     end if
     return

--- a/source/objects.chemical_abundances.F90
+++ b/source/objects.chemical_abundances.F90
@@ -515,23 +515,24 @@ contains
     return
   end subroutine Chemicals_Builder
 
-  subroutine Chemicals_Dump(chemicals)
+  subroutine Chemicals_Dump(chemicals,verbosityLevel)
     !!{
     Dump all chemical values.
     !!}
-    use :: Display           , only : displayMessage
+    use :: Display           , only : displayMessage, enumerationVerbosityLevelType
     use :: ISO_Varying_String, only : len           , operator(//)
     implicit none
-    class    (chemicalAbundances), intent(in   ) :: chemicals
-    integer                                      :: i
-    character(len=22            )                :: label
-    type     (varying_string    )                :: message
+    class    (chemicalAbundances           ), intent(in   ) :: chemicals
+    type     (enumerationVerbosityLevelType), intent(in   ) :: verbosityLevel
+    integer                                                 :: i
+    character(len=22                       )                :: label
+    type     (varying_string               )                :: message
 
     if (allocated(chemicals%chemicalValue)) then
        do i=1,chemicalsCount
           write (label,'(e22.16)') chemicals%chemicalValue(i)
           message=chemicalsToTrack(i)//': '//repeat(" ",chemicalNameLengthMaximum-len(chemicalsToTrack(i)))//label
-          call displayMessage(message)
+          call displayMessage(message,verbosityLevel)
        end do
     end if
     return

--- a/source/objects.history.F90
+++ b/source/objects.history.F90
@@ -295,17 +295,18 @@ contains
     return
   end subroutine History_Long_Integer_Builder
 
-  subroutine History_Dump(self)
+  subroutine History_Dump(self,verbosityLevel)
     !!{
     Dumps a history object.
     !!}
-    use :: Display           , only : displayMessage
-    use :: ISO_Varying_String, only : assignment(=) , operator(//), varying_string
+    use :: Display           , only : displayMessage, enumerationVerbosityLevelType
+    use :: ISO_Varying_String, only : assignment(=) , operator(//)                 , varying_string
     implicit none
-    class    (history       ), intent(in   ) :: self
-    integer                                  :: i      , j
-    type     (varying_string)                :: message
-    character(len=22        )                :: label
+    class    (history                      ), intent(in   ) :: self
+    type     (enumerationVerbosityLevelType), intent(in   ) :: verbosityLevel
+    integer                                                 :: i             , j
+    type     (varying_string               )                :: message
+    character(len=22                       )                :: label
 
     if (allocated(self%time)) then
        do i=1,size(self%time)
@@ -317,7 +318,7 @@ contains
              write (label,'(e22.16)') self%data(i,j)
              message=message//" "//label
           end do
-          call displayMessage(message)
+          call displayMessage(message,verbosityLevel)
        end do
     end if
     return
@@ -374,17 +375,18 @@ contains
     return
   end subroutine History_Reset
 
-  subroutine History_Long_Integer_Dump(self)
+  subroutine History_Long_Integer_Dump(self,verbosityLevel)
     !!{
     Dumps a history object.
     !!}
-    use :: Display           , only : displayMessage
-    use :: ISO_Varying_String, only : assignment(=) , operator(//), varying_string
+    use :: Display           , only : displayMessage, enumerationVerbosityLevelType
+    use :: ISO_Varying_String, only : assignment(=) , operator(//)                 , varying_string
     implicit none
-    class    (longIntegerHistory), intent(in   ) :: self
-    integer                                      :: i      , j
-    type     (varying_string    )                :: message
-    character(len=22            )                :: label
+    class    (longIntegerHistory           ), intent(in   ) :: self
+    type     (enumerationVerbosityLevelType), intent(in   ) :: verbosityLevel
+    integer                                                 :: i             , j
+    type     (varying_string               )                :: message
+    character(len=22                       )                :: label
 
     if (allocated(self%time)) then
        do i=1,size(self%time)
@@ -396,7 +398,7 @@ contains
              write (label,'(i16)') self%data(i,j)
              message=message//" "//label
           end do
-          call displayMessage(message)
+          call displayMessage(message,verbosityLevel)
        end do
     end if
     return

--- a/source/objects.kepler_orbits.F90
+++ b/source/objects.kepler_orbits.F90
@@ -290,69 +290,70 @@ contains
     return
   end subroutine Kepler_Orbits_Builder
 
-  subroutine Kepler_Orbits_Dump(self)
+  subroutine Kepler_Orbits_Dump(self,verbosityLevel)
     !!{
     Reset an orbit to a null state.
     !!}
-    use :: Display           , only : displayMessage
+    use :: Display           , only : displayMessage, enumerationVerbosityLevelType
     use :: ISO_Varying_String, only : assignment(=) , varying_string
     implicit none
-    class    (keplerOrbit   ), intent(in   ) :: self
-    character(len=22        )                :: label
-    type     (varying_string)                :: message
+    class    (keplerOrbit                  ), intent(in   ) :: self
+    type     (enumerationVerbosityLevelType), intent(in   ) :: verbosityLevel
+    character(len=22                       )                :: label
+    type     (varying_string               )                :: message
 
     if (self%massesIsSet             ) then
        write (label,'(e22.16)') self%massHostValue
        message='host mass:             '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
        write (label,'(e22.16)') self%specificReducedMassValue
        message='specific reduced mass: '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     if (self%radiusIsSet             ) then
        write (label,'(e22.16)') self%radiusValue
        message='radius:                '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     if (self%radiusPericenterIsSet   ) then
        write (label,'(e22.16)') self%radiusPericenterValue
        message='radius pericenter:     '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     if (self%radiusApocenterIsSet   ) then
        write (label,'(e22.16)') self%radiusApocenterValue
        message='radius apocenter:      '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     if (self%velocityRadialIsSet    ) then
        write (label,'(e22.16)') self%velocityRadialValue
        message='velocity radial:       '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     if (self%velocityTangentialIsSet) then
        write (label,'(e22.16)') self%velocityTangentialValue
        message='velocity tangential:   '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     if (self%angularMomentumIsSet   ) then
        write (label,'(e22.16)') self%angularMomentumValue
        message='angular momentum:      '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     if (self%energyIsSet            ) then
        write (label,'(e22.16)') self%energyValue
        message='energy:                '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     if (self%eccentricityIsSet      ) then
        write (label,'(e22.16)') self%eccentricityValue
        message='eccentricity:          '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     if (self%semimajorAxisIsSet     ) then
        write (label,'(e22.16)') self%semimajorAxisValue
        message='semi-major axis:       '//label
-       call displayMessage(message)
+       call displayMessage(message,verbosityLevel)
     end if
     return
   end subroutine Kepler_Orbits_Dump

--- a/source/objects.nodes.F90
+++ b/source/objects.nodes.F90
@@ -1123,13 +1123,15 @@ module Galacticus_Nodes
     return
   end subroutine Node_Component_ODE_Step_Initialize_Null
 
-  subroutine Node_Component_Dump_Null(self)
+  subroutine Node_Component_Dump_Null(self,verbosityLevel)
     !!{
     Dump a generic tree node component.
     !!}
+    use :: Display, only : enumerationVerbosityLevelType
     implicit none
-    class(nodeComponent), intent(in   ) :: self
-    !$GLC attributes unused :: self
+    class(nodeComponent                ), intent(in   ) :: self
+    type (enumerationVerbosityLevelType), intent(in   ) :: verbosityLevel 
+    !$GLC attributes unused :: self, verbosityLevel
 
     return
   end subroutine Node_Component_Dump_Null

--- a/source/objects.stellar_luminosities.F90
+++ b/source/objects.stellar_luminosities.F90
@@ -503,17 +503,18 @@ contains
     return
   end subroutine Stellar_Luminosities_Builder
 
-  subroutine Stellar_Luminosities_Dump(self)
+  subroutine Stellar_Luminosities_Dump(self,verbosityLevel)
     !!{
     Dump a stellar luminosities object.
     !!}
-    use :: Display           , only : displayMessage
+    use :: Display           , only : displayMessage, enumerationVerbosityLevelType
     use :: ISO_Varying_String, only : operator(//)
     implicit none
-    class    (stellarLuminosities), intent(in   ) :: self
-    integer                                       :: i
-    character(len=22             )                :: label
-    type     (varying_string     )                :: message
+    class    (stellarLuminosities          ), intent(in   ) :: self
+    type     (enumerationVerbosityLevelType), intent(in   ) :: verbosityLevel
+    integer                                                 :: i
+    character(len=22                       )                :: label
+    type     (varying_string               )                :: message
 
     ! Dump the contents.
     if (luminosityCount > 0) then
@@ -524,7 +525,7 @@ contains
              label="pruned"
           end if
           message=luminosityName(i)//':          '//label
-          call displayMessage(message)
+          call displayMessage(message,verbosityLevel)
        end do
     end if
     return

--- a/source/objects.tensors.F90
+++ b/source/objects.tensors.F90
@@ -29,6 +29,7 @@ module Tensors
   !!}
   use, intrinsic :: ISO_C_Binding, only : c_size_t
   use            :: FoX_DOM      , only : node
+  use            :: Display      , only : enumerationVerbosityLevelType
   implicit none
   private
   public :: tensorRank2Dimension3Symmetric, assignment(=), operator(*), max
@@ -165,11 +166,12 @@ module Tensors
        class(tensorRank2Dimension3Symmetric), intent(inout)              :: self
        type (node                          ), intent(in   ), pointer     :: tensorDefinition
      end subroutine Tensor_R2_D3_Sym_Builder
-     module subroutine Tensor_R2_D3_Sym_Dump(self)
+     module subroutine Tensor_R2_D3_Sym_Dump(self,verbosityLevel)
        !!{
        Reset a {\normalfont \ttfamily tensorRank2Dimension3Symmetric} symmetric object.
        !!}
        class(tensorRank2Dimension3Symmetric), intent(in   ) :: self
+       type (enumerationVerbosityLevelType ), intent(in   ) :: verbosityLevel
      end subroutine Tensor_R2_D3_Sym_Dump
      module subroutine Tensor_R2_D3_Sym_Dump_Raw(self,fileHandle)
        !!{

--- a/source/objects.tensors.rank2.dimension3.symmetric.F90
+++ b/source/objects.tensors.rank2.dimension3.symmetric.F90
@@ -126,7 +126,7 @@ contains
 
   module procedure Tensor_R2_D3_Sym_Dump
     !!{
-    Reset a {\normalfont \ttfamily tensorRank2Dimension3Symmetric} symmetric object.
+    Dump properties of a {\normalfont \ttfamily tensorRank2Dimension3Symmetric} symmetric object.
     !!}
     use :: Display           , only : displayMessage
     use :: ISO_Varying_String, only : assignment(=) , varying_string
@@ -136,22 +136,22 @@ contains
 
     write (label,'(e22.16)') self%x00
     message='x00: '//label
-    call displayMessage(message)
+    call displayMessage(message,verbosityLevel)
     write (label,'(e22.16)') self%x01
     message='x01: '//label
-    call displayMessage(message)
+    call displayMessage(message,verbosityLevel)
     write (label,'(e22.16)') self%x02
     message='x02: '//label
-    call displayMessage(message)
+    call displayMessage(message,verbosityLevel)
     write (label,'(e22.16)') self%x11
     message='x11: '//label
-    call displayMessage(message)
+    call displayMessage(message,verbosityLevel)
     write (label,'(e22.16)') self%x12
     message='x12: '//label
-    call displayMessage(message)
+    call displayMessage(message,verbosityLevel)
     write (label,'(e22.16)') self%x22
     message='x22: '//label
-    call displayMessage(message)
+    call displayMessage(message,verbosityLevel)
     return
   end procedure Tensor_R2_D3_Sym_Dump
 

--- a/source/satellites.merging.remnant_sizes.Cole2000.F90
+++ b/source/satellites.merging.remnant_sizes.Cole2000.F90
@@ -216,7 +216,7 @@ contains
     !!{
     Compute the size of the merger remnant for {\normalfont \ttfamily node} using the \cite{cole_hierarchical_2000} algorithm.
     !!}
-    use :: Display                         , only : displayMessage
+    use :: Display                         , only : displayMessage                , verbosityLevelSilent
     use :: Galactic_Structure_Options      , only : massTypeDark
     use :: Error                           , only : Error_Report
     use :: Mass_Distributions              , only : massDistributionClass
@@ -301,7 +301,7 @@ contains
                 joinString=", "
              end if
              message=message//' (radius:mass:massSpheroid='//trim(dataString)//')'
-             call displayMessage(message)
+             call displayMessage(message,verbosityLevelSilent)
              errorCondition=.true.
           end if
           if     (                                             &
@@ -331,12 +331,12 @@ contains
                 joinString=", "
              end if
              message=message//' (radius:mass:massSpheroid='//trim(dataString)//')'
-             call displayMessage(message)
+             call displayMessage(message,verbosityLevelSilent)
              errorCondition=.true.
           end if
           if (errorCondition) then
-             call node    %serializeASCII()
-             call nodeHost%serializeASCII()
+             call node    %serializeASCII(verbosityLevelSilent)
+             call nodeHost%serializeASCII(verbosityLevelSilent)
              call Error_Report('error condition detected'//{introspection:location})
           end if
           ! Check if host has finite mass.


### PR DESCRIPTION
This allows for the serialization of nodes in error messages to always be displayed, even if verbosity is set to silent.