### PR TITLE
Catch unphysical states in the hot halo when using the `coolingTimeAvailableBensonBower2010` class

### DIFF
--- a/source/cooling.specific_angular_momentum.constant_rotation.F90
+++ b/source/cooling.specific_angular_momentum.constant_rotation.F90
@@ -272,21 +272,21 @@ contains
        ! Return the computed value.
        if (self%useInteriorMean) then
           ! Find the specific angular momentum interior to the specified radius.
-          massDistribution_                       =>  node             %massDistribution               (componentType=componentTypeHotHalo,massType=massTypeGaseous)
-          constantRotationAngularMomentumSpecific =  +self             %angularMomentumSpecificPrevious               &
-               &                                     *massDistribution_%densityRadialMoment            (3.0d0,radius) &
-               &                                     /massDistribution_%densityRadialMoment            (2.0d0,radius)
+          massDistribution_                       =>  node             %massDistribution               (componentType=componentTypeHotHalo,massType     =massTypeGaseous)
+          constantRotationAngularMomentumSpecific =  +self             %angularMomentumSpecificPrevious                                                                   &
+               &                                     *massDistribution_%densityRadialMoment            (moment       =3.0d0               ,radiusMaximum=radius         ) &
+               &                                     /massDistribution_%densityRadialMoment            (moment       =2.0d0               ,radiusMaximum=radius         )
           !![
 	  <objectDestructor name="massDistribution_"/>
           !!]          
        else
           ! Find the specific angular momentum at the specified radius.
-          constantRotationAngularMomentumSpecific =  +self             %angularMomentumSpecificPrevious               &
-               &                                     *                                                        radius
+          constantRotationAngularMomentumSpecific =  +self             %angularMomentumSpecificPrevious                                                                   &
+               &                                     *                                                                                                   radius
        end if
     else
        ! Radius is non-positive - return zero.
-       constantRotationAngularMomentumSpecific=0.0d0
+       constantRotationAngularMomentumSpecific    =  +0.0d0
     end if
     return
   end function constantRotationAngularMomentumSpecific

--- a/source/cooling.time_available.Benson_Bower_2010.F90
+++ b/source/cooling.time_available.Benson_Bower_2010.F90
@@ -138,7 +138,7 @@ contains
     use :: Abundances_Structure             , only : abundances
     use :: Chemical_Abundances_Structure    , only : chemicalAbundances                  , Chemicals_Property_Count
     use :: Chemical_Reaction_Rates_Utilities, only : Chemicals_Mass_To_Density_Conversion
-    use :: Mass_Distributions               , only : massDistributionClass               , kinematicsDistributionClass
+    use :: Mass_Distributions               , only : massDistributionClass               , kinematicsDistributionClass, massDistributionZero
     use :: Coordinates                      , only : coordinateSpherical                 , assignment(=)
     use :: Galactic_Structure_Options       , only : componentTypeHotHalo                , massTypeGaseous            , massTypeGalactic
     use :: Numerical_Constants_Astronomical , only : gigaYear                            , massSolar                  , megaParsec
@@ -176,8 +176,18 @@ contains
        return
     end if
     ! Get the mass distribution.
-    massDistribution_       => node             %massDistribution      (componentType=componentTypeHotHalo,massType=massTypeGaseous)      
+    massDistribution_       => node             %massDistribution      (componentType=componentTypeHotHalo,massType=massTypeGaseous)
     kinematicsDistribution_ => massDistribution_%kinematicsDistribution(                                                           )
+    select type (massDistribution_)
+    type is (massDistributionZero)
+       ! No mass distribution exists for the hot halo (most likely it is in an unphysical state).
+       bensonBower2010TimeAvailable=0.0d0
+       !![
+       <objectDestructor name="massDistribution_"      />
+       <objectDestructor name="kinematicsDistribution_"/>
+       !!]
+       return
+    end select
     ! Compute the mean density and temperature of the hot halo.
     density    =+massNotional             &
          &      *3.0d0                    &


### PR DESCRIPTION
Unphysical hot halo states (e.g., negative mass or radius) result in a `massDistributionZero` being returned. Catch such cases, and assume zero cooling rate in such instances.

Also, for the `coolingSpecificAngularMomentumConstantRotation` class, previously arguments to the `radialDensityMoment` class were unnamed, which resulted in these radii being interpretted as minimum radii. This is now corrected.