### PR TITLE
Fix a class name conflict

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -353,7 +353,8 @@ jobs:
         run: |
           cd $GALACTICUS_EXEC_PATH
           git config --global --add safe.directory $GALACTICUS_EXEC_PATH
-          ./scripts/doc/Build_Documentation.sh -f yes -p 2
+          ./scripts/doc/Build_Documentation.sh -f yes -p 2 2>&1 | tee docBuild.log
+          grep -vqzi 'warning: missing method descriptions in class' docBuild.log || (echo "FAIL: issing method description warnings found in docBuild.log" && false)
       - name: Upload docs
         uses: actions/upload-artifact@v4
         with:

--- a/source/nodes.property_extractor.galaxy_merger_tree.objects.F90
+++ b/source/nodes.property_extractor.galaxy_merger_tree.objects.F90
@@ -31,13 +31,13 @@
     ! `nodePropertyExtractor` classes. It is necessitated by the fact that we don't have a good way for objects defined in the
     ! parameter file to communicate their behavior.
 
-    type, public :: nodePropertyExtractorList
+    type, public :: nodePropertyExtractorListWrapper
        class(*), pointer :: extractor_ => null()
-    end type nodePropertyExtractorList
+    end type nodePropertyExtractorListWrapper
      
     ! Public-scope pointer to the extractor used in galaxy merger trees.
-    integer                                                      , public :: nodePropertyExtractorGalaxyMergerTreeCount
-    type   (nodePropertyExtractorList), allocatable, dimension(:), public :: nodePropertyExtractorGalaxyMergerTree_
+    integer                                                             , public :: nodePropertyExtractorGalaxyMergerTreeCount
+    type   (nodePropertyExtractorListWrapper), allocatable, dimension(:), public :: nodePropertyExtractorGalaxyMergerTree_
     !$omp threadprivate(nodePropertyExtractorGalaxyMergerTreeCount,nodePropertyExtractorGalaxyMergerTree_)
   
   end module Node_Property_Extractor_Galaxy_Merger_Trees


### PR DESCRIPTION
Caused erroneous warnings due to missing class method descriptors.