### PR TITLE
Set merger tree seeds using a dedicated class

### DIFF
--- a/doc/Advanced.tex
+++ b/doc/Advanced.tex
@@ -259,6 +259,8 @@ galacticus.hdf5
  |    |    |
  |    |    +-> mergerTreeIndex                Dataset {<treeCount>}
  |    |    |
+ |    |    +-> mergerTreeSeed                 Dataset {<treeCount>}
+ |    |    |
  |    |    +-> mergerTreeStartIndex           Dataset {<treeCount>}
  |    |    |
  |    |    +-> mergerTreeWeight               Dataset {<treeCount>}
@@ -387,7 +389,7 @@ The {\normalfont \ttfamily nodeData} group contains all data from nodes in all m
 
 \subsubsection{mergerTree datasets}\label{sec:mergerTreeDatasets}
 
-To allow locating of nodes belonging to a given merger tree in the datasets in the {\normalfont \ttfamily nodeData} group, the {\normalfont \ttfamily mergerTreeStartIndex} and {\normalfont \ttfamily mergerTreeCount} datasets list the starting index of each tree's nodes in the {\normalfont \ttfamily nodeData} datasets, and the number of nodes belonging to each tree respectively. Additionally, the {\normalfont \ttfamily mergerTreeWeight} dataset lists the {\normalfont \ttfamily volumeWeight} property for each tree (see \S\ref{sec:mergerTreeSubgroups}) which gives the weight (in Mpc$^{-3}$) which should be assigned to this tree (and all nodes in it) to create a volume-averaged sample (see \S\ref{sec:volumeLimitedSamples}). Finally, the {\normalfont \ttfamily mergerTreeIndex} dataset gives the index of each tree stored in the {\normalfont \ttfamily nodeData} datasets.
+To allow locating of nodes belonging to a given merger tree in the datasets in the {\normalfont \ttfamily nodeData} group, the {\normalfont \ttfamily mergerTreeStartIndex} and {\normalfont \ttfamily mergerTreeCount} datasets list the starting index of each tree's nodes in the {\normalfont \ttfamily nodeData} datasets, and the number of nodes belonging to each tree respectively. Additionally, the {\normalfont \ttfamily mergerTreeWeight} dataset lists the {\normalfont \ttfamily volumeWeight} property for each tree (see \S\ref{sec:mergerTreeSubgroups}) which gives the weight (in Mpc$^{-3}$) which should be assigned to this tree (and all nodes in it) to create a volume-averaged sample (see \S\ref{sec:volumeLimitedSamples}). The {\normalfont \ttfamily mergerTreeIndex} dataset gives the index of each tree stored in the {\normalfont \ttfamily nodeData} datasets. Finally, the {\normalfont \ttfamily mergerTreeSeed} dataset gives the seed used by this tree when generating random numbers.
 
 \subsubsection{mergerTree subgroups}\label{sec:mergerTreeSubgroups}
 

--- a/doc/Running.tex
+++ b/doc/Running.tex
@@ -86,6 +86,7 @@ In this case there is only a single output, corresponding to $z=0$, we can explo
 $ h5ls galacticus.hdf5/Outputs/Output1
 mergerTreeCount          Dataset {6/Inf}
 mergerTreeIndex          Dataset {6/Inf}
+mergerTreeSeed           Dataset {6/Inf}
 mergerTreeStartIndex     Dataset {6/Inf}
 mergerTreeWeight         Dataset {6/Inf}
 nodeData                 Group

--- a/source/merger_trees.outputter.standard.F90
+++ b/source/merger_trees.outputter.standard.F90
@@ -319,10 +319,11 @@ contains
              call currentTree%hdf5Group%close()
           end if
           ! Store the start position and length of the node data for this tree, along with its volume weight.
-          call self%outputGroups(indexOutput)%hdf5Group%writeDataset([currentTree%index]       ,"mergerTreeIndex"     ,"Index of each merger tree."                                  ,appendTo=.true.)
-          call self%outputGroups(indexOutput)%hdf5Group%writeDataset(referenceStart            ,"mergerTreeStartIndex","Index in nodeData datasets at which each merger tree begins.",appendTo=.true.)
-          call self%outputGroups(indexOutput)%hdf5Group%writeDataset(referenceLength           ,"mergerTreeCount"     ,"Number of nodes in nodeData datasets for each merger tree."  ,appendTo=.true.)
-          call self%outputGroups(indexOutput)%hdf5Group%writeDataset([currentTree%volumeWeight],"mergerTreeWeight"    ,"Number density of each tree [Mpc⁻³]."                        ,appendTo=.true.)
+          call self%outputGroups(indexOutput)%hdf5Group%writeDataset([currentTree%index]                        ,"mergerTreeIndex"     ,"Index of each merger tree."                                  ,appendTo=.true.)
+          call self%outputGroups(indexOutput)%hdf5Group%writeDataset(referenceStart                             ,"mergerTreeStartIndex","Index in nodeData datasets at which each merger tree begins.",appendTo=.true.)
+          call self%outputGroups(indexOutput)%hdf5Group%writeDataset(referenceLength                            ,"mergerTreeCount"     ,"Number of nodes in nodeData datasets for each merger tree."  ,appendTo=.true.)
+          call self%outputGroups(indexOutput)%hdf5Group%writeDataset([currentTree%volumeWeight                 ],"mergerTreeWeight"    ,"Number density of each tree [Mpc⁻³]."                        ,appendTo=.true.)
+          call self%outputGroups(indexOutput)%hdf5Group%writeDataset([currentTree%randomNumberGenerator_%seed()],"mergerTreeSeed"      ,"Random number seed of each merger tree."                     ,appendTo=.true.)
           !$ call hdf5Access%unset()
           if (treeLock%ownedByThread()) call treeLock%unset()
        end if

--- a/source/merger_trees.seeds.F90
+++ b/source/merger_trees.seeds.F90
@@ -1,0 +1,46 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which set random number seeds in merger trees.
+!!}
+
+module Merger_Tree_Seeds
+  !!{
+  Implements a class for setting random number seeds in merger trees.
+  !!}
+  use :: Galacticus_Nodes, only : mergerTree
+  private
+
+  !![
+  <functionClass>
+   <name>mergerTreeSeeds</name>
+   <descriptiveName>Merger Tree Random Number Seeds</descriptiveName>
+   <description>Class implementing setting of random number seeds in merger trees.</description>
+   <default>incremental</default>
+   <method name="set" >
+    <description>Set the random number seed in the given {\normalfont \ttfamily tree}.</description>
+    <type>void</type>
+    <pass>yes</pass>
+    <argument>type(mergerTree), intent(inout) :: tree</argument>
+   </method>
+  </functionClass>
+  !!]
+
+end module Merger_Tree_Seeds

--- a/source/merger_trees.seeds.incremental.F90
+++ b/source/merger_trees.seeds.incremental.F90
@@ -23,7 +23,15 @@ Implements a merger tree random number seed in which the seed increases incremen
 
   !![
   <mergerTreeSeeds name="mergerTreeSeedsIncremental">
-   <description>A merger tree random number seed in which the seed increases incrementally with tree index.</description>
+    <description>
+      A merger tree random number seed in which the seed increases incrementally with tree index. Specifically, the seed will be
+      set to the tree index offset by whatever seed was originally specified for the \refClass{randomNumberGeneratorClass} object
+      in the parameter file. Note that this means that, if tree indices are consecutive, then changing the seed of the
+      \refClass{randomNumberGeneratorClass} object in the parameter file by incrementing by a small number (e.g. 1, or any number
+      less than the total number of trees simulated) will result in significant overlap in seed values for trees between the two
+      models. To avoid this, either increment the random seed by a number larger than the total number of trees run, or consider
+      using the \refClass{mergerTreeSeedsRandom} class to generate seeds instead.
+    </description>
   </mergerTreeSeeds>
   !!]
   type, extends(mergerTreeSeedsClass) :: mergerTreeSeedsIncremental

--- a/source/merger_trees.seeds.incremental.F90
+++ b/source/merger_trees.seeds.incremental.F90
@@ -1,0 +1,75 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Implements a merger tree random number seed in which the seed increases incrementally with tree index.
+!!}
+
+  !![
+  <mergerTreeSeeds name="mergerTreeSeedsIncremental">
+   <description>A merger tree random number seed in which the seed increases incrementally with tree index.</description>
+  </mergerTreeSeeds>
+  !!]
+  type, extends(mergerTreeSeedsClass) :: mergerTreeSeedsIncremental
+     !!{
+     A merger tree random number seed in which the seed increases incrementally with tree index.
+     !!}
+     private
+   contains
+     procedure :: set => incrementalSet
+  end type mergerTreeSeedsIncremental
+
+  interface mergerTreeSeedsIncremental
+     !!{
+     Constructors for the {\normalfont \ttfamily incremental} merger tree seed class.
+     !!}
+     module procedure incrementalConstructorParameters
+  end interface mergerTreeSeedsIncremental
+
+contains
+
+  function incrementalConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily incremental} merger tree seed class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type(mergerTreeSeedsIncremental)                :: self
+    type(inputParameters           ), intent(inout) :: parameters
+
+    self=mergerTreeSeedsIncremental()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function incrementalConstructorParameters
+
+  subroutine incrementalSet(self,tree)
+    !!{
+    Set the random number seed in the given {\normalfont \ttfamily tree}.
+    !!}
+    implicit none
+    class(mergerTreeSeedsIncremental), intent(inout) :: self
+    type (mergerTree                ), intent(inout) :: tree
+    !$GLC attributes unused :: self
+
+    ! Set the seed to the tree index, offset by the original seed.
+    call tree%randomNumberGenerator_%seedSet(seed=tree%index,offset=.true.)
+    return
+  end subroutine incrementalSet

--- a/source/merger_trees.seeds.random.F90
+++ b/source/merger_trees.seeds.random.F90
@@ -1,0 +1,153 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Implements a merger tree random number seed in which the seed is chosen at random (without repetition) from the available range.
+!!}
+
+  use, intrinsic :: ISO_C_Binding           , only : c_long
+  use            :: Numerical_Random_Numbers, only : randomNumberGeneratorClass
+
+  !![
+  <mergerTreeSeeds name="mergerTreeSeedsRandom">
+   <description>A merger tree random number seed in which the seed is chosen at random (without repetition) from the available range.</description>
+  </mergerTreeSeeds>
+  !!]
+  type, extends(mergerTreeSeedsClass) :: mergerTreeSeedsRandom
+     !!{
+     A merger tree random number seed in which the seed is chosen at random (without repetition) from the available range.
+     !!}
+     private
+     class  (randomNumberGeneratorClass), pointer                   :: randomNumberGenerator_ => null()
+     integer(c_long                    ), allocatable, dimension(:) :: seeds
+     integer(c_long                    )                            :: rangeMinimum                    , rangeMaximum
+   contains
+     final     ::        randomDestructor
+     procedure :: set => randomSet
+  end type mergerTreeSeedsRandom
+
+  interface mergerTreeSeedsRandom
+     !!{
+     Constructors for the {\normalfont \ttfamily random} merger tree seed class.
+     !!}
+     module procedure randomConstructorParameters
+     module procedure randomConstructorInternal
+  end interface mergerTreeSeedsRandom
+
+  integer(c_long), parameter :: seedMaximum=2_c_long**31
+  
+contains
+
+  function randomConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the {\normalfont \ttfamily random} merger tree seed class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type (mergerTreeSeedsRandom     )                :: self
+    type (inputParameters           ), intent(inout) :: parameters
+    class(randomNumberGeneratorClass), pointer       :: randomNumberGenerator_
+    
+    !![
+    <objectBuilder class="randomNumberGenerator" name="randomNumberGenerator_" source="parameters"/>
+    !!]
+    self=mergerTreeSeedsRandom(randomNumberGenerator_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="randomNumberGenerator_"/>
+    !!]
+    return
+  end function randomConstructorParameters
+
+  function randomConstructorInternal(randomNumberGenerator_) result(self)
+    !!{
+    Internal constructor for the {\normalfont \ttfamily random} merger tree seed class.
+    !!}
+    implicit none
+    type (mergerTreeSeedsRandom     )                        :: self
+    class(randomNumberGeneratorClass), intent(inout), target :: randomNumberGenerator_
+
+    ! Make a copy of the random number generator. We want to ensure that we have a copy to ourself here, so that no other class
+    ! can use it (and potentially de-synchronize the random number sequence between threads/processes).
+    allocate(self%randomNumberGenerator_,mold=randomNumberGenerator_)
+    !![
+    <deepCopyReset    variables="randomNumberGenerator_"/>
+    <deepCopy         source="randomNumberGenerator_" destination="self%randomNumberGenerator_"/>
+    <deepCopyFinalize variables="self%randomNumberGenerator_"/>
+    !!]    
+    ! Check that we have non-independent random numbers across threads and processes.
+    if (self%randomNumberGenerator_%mpiIndependent   ()) call Error_Report('random number generator produces different sequences on each MPI process - uniqueness of seeds can not be guaranteed'  //{introspection:location})
+    if (self%randomNumberGenerator_%openMPIndependent()) call Error_Report('random number generator produces different sequences on each OpenMP thread - uniqueness of seeds can not be guaranteed'//{introspection:location})
+    ! Check that the random number generator has sufficient range.
+    self%rangeMinimum=self%randomNumberGenerator_%rangeMinimum()
+    self%rangeMaximum=self%randomNumberGenerator_%rangeMaximum()
+    if (self%rangeMaximum-self%rangeMinimum < seedMaximum) call Error_Report('random number generator has insufficient range to produce seeds'//{introspection:location})
+    return
+  end function randomConstructorInternal
+
+  subroutine randomDestructor(self)
+    !!{
+    Destructor for the {\normalfont \ttfamily random} merger tree seed class.
+    !!}
+    implicit none
+    type(mergerTreeSeedsRandom), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%randomNumberGenerator_"/>
+    !!]
+    return
+  end subroutine randomDestructor
+
+  subroutine randomSet(self,tree)
+    !!{
+    Set the random number seed in the given {\normalfont \ttfamily tree}.
+    !!}
+    !$ use :: omp_lib, only : omp_get_thread_num
+    implicit none
+    class  (mergerTreeSeedsRandom), intent(inout)               :: self
+    type   (mergerTree           ), intent(inout)               :: tree
+    integer(c_long               ), allocatable  , dimension(:) :: seedsTmp
+    integer(c_size_t             )                              :: countSeedsPrevious, i
+
+    if (allocated(self%seeds)) then
+       countSeedsPrevious=size(self%seeds)
+       if (tree%index > size(self%seeds)) then
+          call move_alloc(self%seeds,seedsTmp)
+          allocate(self%seeds(tree%index))
+          self%seeds(1:countSeedsPrevious)=seedsTmp
+       end if
+    else
+       countSeedsPrevious=0_c_size_t
+       allocate(self%seeds(tree%index))
+    end if
+    do i=countSeedsPrevious+1,tree%index
+       if (i == 1) then
+          ! This is the first seed - choose any number.
+          self%seeds   (i)=self%randomNumberGenerator_%sample(seedMaximum)+1_c_long
+       else
+          ! For subsequent seeds check that we do not duplicate any prior seed.
+          self%seeds(i)=self%seeds(i-1)
+          do while (any(self%seeds(i) == self%seeds(1:i-1)))
+             self%seeds(i)=self%randomNumberGenerator_%sample(seedMaximum)+1_c_long
+          end do
+       end if
+    end do
+    call tree%randomNumberGenerator_%seedSet(seed=self%seeds(tree%index),offset=.false.)
+    return
+  end subroutine randomSet

--- a/source/merger_trees.seeds.random.F90
+++ b/source/merger_trees.seeds.random.F90
@@ -26,7 +26,23 @@ Implements a merger tree random number seed in which the seed is chosen at rando
 
   !![
   <mergerTreeSeeds name="mergerTreeSeedsRandom">
-   <description>A merger tree random number seed in which the seed is chosen at random (without repetition) from the available range.</description>
+    <description>
+      A merger tree random number seed in which the seed is chosen at random (without repetition) from the available
+      range. Specifically, a list of random numbers are selected in the range $1$ to $2^{31}$ without repetition. For a tree with
+      index {\normalfont \ttfamily i}, the {\normalfont \ttfamily i}$^\mathrm{th}$ entry from that list is used as its seed. The
+      list is extended as needed given the tree index.
+
+      Changing the seed of the \refClass{randomNumberGeneratorClass} object specified in the parameter file will ensure a
+      completely different random set of seeds being chosen, such that there will be no correlation between sets of trees produced
+      by different random seeds\footnote{Of course, it is possible that two different seeds for the
+      \refClass{randomNumberGeneratorClass} object in the parameter file will happen to generate the same seed for one or more
+      merger trees. However, this is unlikely unless the number of trees is a significant fraction of $2^{31}$ and, in any case,
+      these identical seeds would likely be assigned to trees of very different masses, making any correlation minor.}.
+      
+      Note that this is intended for cases where tree indices increment from 1. If used, for example, for trees from N-body
+      simulations where the index may be a very large number, this approach will likely be extremely inefficient in both memory
+      and time.
+    </description>
   </mergerTreeSeeds>
   !!]
   type, extends(mergerTreeSeedsClass) :: mergerTreeSeedsRandom

--- a/source/numerical.random_numbers.F90
+++ b/source/numerical.random_numbers.F90
@@ -18,7 +18,7 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which provieds a class that implements random number generators.
+Contains a module which provides a class that implements random number generators.
 !!}
 
 module Numerical_Random_Numbers
@@ -44,6 +44,22 @@ module Numerical_Random_Numbers
     <type>logical</type>
     <pass>yes</pass>
    </method>
+   <method name="rangeMinimum" >
+    <description>Return the smallest integer in the range for this generator.</description>
+    <type>integer(c_long)</type>
+    <pass>yes</pass>
+   </method>
+   <method name="rangeMaximum" >
+    <description>Return the largest integer in the range for this generator.</description>
+    <type>integer(c_long)</type>
+    <pass>yes</pass>
+   </method>
+   <method name="sample" >
+    <description>Return a random integer. If the optional argument {\normalfont \ttfamily n} is supplied the random integer will lie in the range 0 to  {\normalfont \ttfamily n}-1 inclusive (with all integers being equally likely). Otherwise, the integer will be drawn from the full range provided by the generator.</description>
+    <type>integer(c_long)</type>
+    <pass>yes</pass>
+    <argument>integer(c_long), intent(in   ), optional :: n</argument>
+   </method>
    <method name="uniformSample" >
     <description>Return a random number drawn from a uniform distribution on [0,1).</description>
     <type>double precision</type>
@@ -66,6 +82,11 @@ module Numerical_Random_Numbers
     <pass>yes</pass>
     <argument>integer(c_long), intent(in   ) :: seed</argument>
     <argument>logical        , intent(in   ) :: offset</argument>
+   </method>
+   <method name="seed" >
+    <description>Return the seed for this random number generator.</description>
+    <type>integer(c_long)</type>
+    <pass>yes</pass>
    </method>
   </functionClass>
   !!]

--- a/source/tasks.evolve_forests.F90
+++ b/source/tasks.evolve_forests.F90
@@ -26,6 +26,7 @@
   use            :: Merger_Tree_Operators          , only : mergerTreeOperatorClass
   use            :: Merger_Tree_Outputters         , only : mergerTreeOutputter        , mergerTreeOutputterClass
   use            :: Merger_Trees_Evolve            , only : mergerTreeEvolver          , mergerTreeEvolverClass
+  use            :: Merger_Tree_Seeds              , only : mergerTreeSeedsClass
   use            :: Nodes_Operators                , only : nodeOperatorClass
   use            :: Numerical_Random_Numbers       , only : randomNumberGeneratorClass
   use            :: Output_Times                   , only : outputTimesClass
@@ -65,6 +66,7 @@
      class           (outputTimesClass           ), pointer :: outputTimes_                  => null()
      class           (universeOperatorClass      ), pointer :: universeOperator_             => null()
      class           (randomNumberGeneratorClass ), pointer :: randomNumberGenerator_        => null()
+     class           (mergerTreeSeedsClass       ), pointer :: mergerTreeSeeds_              => null()
      ! Pointer to the parameters for this task.
      type            (inputParameters            ), pointer :: parameters                    => null()
      logical                                                :: initialized                   =  .false., nodeComponentsInitialized=.false.
@@ -127,6 +129,7 @@ contains
     class           (mergerTreeOutputterClass   ), pointer               :: mergerTreeOutputter_
     class           (mergerTreeInitializorClass ), pointer               :: mergerTreeInitializor_
     class           (randomNumberGeneratorClass ), pointer               :: randomNumberGenerator_
+    class           (mergerTreeSeedsClass       ), pointer               :: mergerTreeSeeds_
     type            (inputParameters            ), pointer               :: parametersRoot
     logical                                                              :: evolveForestsInParallel, suspendToRAM
     integer         (kind_int8                  )                        :: walltimeMaximum        , timeIntervalCheckpoint
@@ -208,12 +211,13 @@ contains
     <objectBuilder class="mergerTreeEvolver"      name="mergerTreeEvolver_"      source="parameters"/>
     <objectBuilder class="mergerTreeOutputter"    name="mergerTreeOutputter_"    source="parameters"/>
     <objectBuilder class="mergerTreeInitializor"  name="mergerTreeInitializor_"  source="parameters"/>
-    <objectBuilder class="randomNumberGenerator" name="randomNumberGenerator_"  source="parameters"/>
+    <objectBuilder class="randomNumberGenerator"  name="randomNumberGenerator_"  source="parameters"/>
+    <objectBuilder class="mergerTreeSeeds"        name="mergerTreeSeeds_"        source="parameters"/>
     !!]
     if (associated(parametersRoot)) then
-       self=taskEvolveForests(evolveForestsInParallel,countForestsMaximum,walltimeMaximum,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,parametersRoot)
+       self=taskEvolveForests(evolveForestsInParallel,countForestsMaximum,walltimeMaximum,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,mergerTreeSeeds_,parametersRoot)
     else
-       self=taskEvolveForests(evolveForestsInParallel,countForestsMaximum,walltimeMaximum,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,parameters    )
+       self=taskEvolveForests(evolveForestsInParallel,countForestsMaximum,walltimeMaximum,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,mergerTreeSeeds_,parameters    )
     end if
     self%nodeComponentsInitialized=.true.
     !![
@@ -228,11 +232,12 @@ contains
     <objectDestructor name="mergerTreeOutputter_"   />
     <objectDestructor name="mergerTreeInitializor_" />
     <objectDestructor name="randomNumberGenerator_" />
+    <objectDestructor name="mergerTreeSeeds_"       />
     !!]
     return
   end function evolveForestsConstructorParameters
 
-  function evolveForestsConstructorInternal(evolveForestsInParallel,countForestsMaximum,walltimeMaximum,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,parameters) result(self)
+  function evolveForestsConstructorInternal(evolveForestsInParallel,countForestsMaximum,walltimeMaximum,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,mergerTreeSeeds_,parameters) result(self)
     !!{
     Internal constructor for the {\normalfont \ttfamily evolveForests} task class.
     !!}
@@ -254,11 +259,12 @@ contains
     class           (mergerTreeOutputterClass   ), intent(in   ), target :: mergerTreeOutputter_
     class           (mergerTreeInitializorClass ), intent(in   ), target :: mergerTreeInitializor_
     class           (randomNumberGeneratorClass ), intent(in   ), target :: randomNumberGenerator_
+    class           (mergerTreeSeedsClass       ), intent(in   ), target :: mergerTreeSeeds_
     type            (inputParameters            ), intent(in   ), target :: parameters
     integer         (c_size_t                   )                        :: i
     double precision                                                     :: timeStepMinimum
     !![
-    <constructorAssign variables="evolveForestsInParallel, countForestsMaximum, walltimeMaximum, suspendToRAM, suspendPath, timeIntervalCheckpoint, fileNameCheckpoint, *mergerTreeConstructor_, *mergerTreeOperator_, *nodeOperator_, *evolveForestsWorkShare_, *outputTimes_, *universeOperator_, *mergerTreeEvolver_, *mergerTreeOutputter_, *mergerTreeInitializor_, *randomNumberGenerator_"/>
+    <constructorAssign variables="evolveForestsInParallel, countForestsMaximum, walltimeMaximum, suspendToRAM, suspendPath, timeIntervalCheckpoint, fileNameCheckpoint, *mergerTreeConstructor_, *mergerTreeOperator_, *nodeOperator_, *evolveForestsWorkShare_, *outputTimes_, *universeOperator_, *mergerTreeEvolver_, *mergerTreeOutputter_, *mergerTreeInitializor_, *randomNumberGenerator_, *mergerTreeSeeds_"/>
     !!]
 
     self%parameters  => parameters
@@ -389,6 +395,7 @@ contains
     <objectDestructor name="self%mergerTreeOutputter_"   />
     <objectDestructor name="self%mergerTreeInitializor_" />
     <objectDestructor name="self%randomNumberGenerator_" />
+    <objectDestructor name="self%mergerTreeSeeds_"       />
     !!]
     if (stateStoreEventGlobal  %isAttached(self,evolveForestsStateStore  )) call stateStoreEventGlobal  %detach(self,evolveForestsStateStore  )
     if (stateRestoreEventGlobal%isAttached(self,evolveForestsStateRestore)) call stateRestoreEventGlobal%detach(self,evolveForestsStateRestore)
@@ -555,7 +562,7 @@ contains
              tree => null()
           else
              allocate(tree)
-             call mergerTreeStateFromFile(tree,char(self%fileNameCheckpoint),self%randomNumberGenerator_,deleteAfterRead=.false.)
+             call mergerTreeStateFromFile(tree,char(self%fileNameCheckpoint),self%randomNumberGenerator_,self%mergerTreeSeeds_,deleteAfterRead=.false.)
              checkpointRestored=.true.
           end if
        else
@@ -972,7 +979,7 @@ contains
        ! Generate the file name.
        fileName=self%suspendPath//'/suspendedTree_'//tree%index
        ! Read the tree from file.
-       call mergerTreeStateFromFile(tree,char(fileName),self%randomNumberGenerator_,deleteAfterRead=.true.)
+       call mergerTreeStateFromFile(tree,char(fileName),self%randomNumberGenerator_,self%mergerTreeSeeds_,deleteAfterRead=.true.)
     end if
     return
   end subroutine evolveForestsResumeTree

--- a/source/tests.mass_accretion_history.Hearin2021_stochastic.F90
+++ b/source/tests.mass_accretion_history.Hearin2021_stochastic.F90
@@ -99,7 +99,7 @@ program Test_Hearin2021_Stochastic_MAH
   allocate(randomNumberGeneratorGSL :: treeEarly%randomNumberGenerator_)
   select type (randomNumberGenerator_ => treeEarly%randomNumberGenerator_)
   type is (randomNumberGeneratorGSL)
-     randomNumberGenerator_=randomNumberGeneratorGSL(seed=8322_c_long)
+     randomNumberGenerator_=randomNumberGeneratorGSL(seed_=8322_c_long)
   end select
   call treeEarly%randomNumberGenerator_%seedSet   (seed=treeEarly%index,offset=.true.)
   call treeEarly%properties            %initialize(                                  )
@@ -114,7 +114,7 @@ program Test_Hearin2021_Stochastic_MAH
   allocate(randomNumberGeneratorGSL :: treeLate %randomNumberGenerator_)
   select type (randomNumberGenerator_ => treeLate %randomNumberGenerator_)
   type is (randomNumberGeneratorGSL)
-     randomNumberGenerator_=randomNumberGeneratorGSL(seed=8322_c_long)
+     randomNumberGenerator_=randomNumberGeneratorGSL(seed_=8322_c_long)
   end select
   call treeLate %randomNumberGenerator_%seedSet   (seed=treeLate %index,offset=.true.)
   call treeLate %properties            %initialize(                                  )


### PR DESCRIPTION
The default implementation uses incrementing seeds based on tree index (matching the prior behavior).
    
A new `mergerTreeSeedsRandom` implementation chooses seeds based on a non-repeating random sequence. This is intended to allow a simple change by 1 in the seed given in the parameter file to generate a completely new set of trees.

Also outputs random number seeds for all trees. This can be useful for recreating a specific tree in a separate run.
