### PR TITLE
In the `nodeOperatorCoolingEnergyRadiated` class, avoid attempting to set cooling scales in non-existant hot halos

### DIFF
--- a/source/nodes.operators.physics.cooling_energy_radiated.F90
+++ b/source/nodes.operators.physics.cooling_energy_radiated.F90
@@ -174,11 +174,16 @@ contains
     class           (nodeComponentBasic               ), pointer       :: basic
     double precision                                                   :: massVirial                      , velocityVirial
    
-    basic         => node                      %basic         (    )
-    hotHalo       => node                      %hotHalo       (    )
-    massVirial    =  basic                     %mass          (    )
-    velocityVirial=  self %darkMatterHaloScale_%velocityVirial(node)
-    call hotHalo%floatRank0MetaPropertyScale(self%energyRadiatedID,unitEnergyRadiated*massVirial*velocityVirial**2*scaleRelative)
+    hotHalo => node%hotHalo()
+    select type (hotHalo)
+    type is (nodeComponentHotHalo)
+       ! Hot halo does not exist - nothing to do here.
+    class default
+       basic         => node                      %basic         (    )
+       massVirial    =  basic                     %mass          (    )
+       velocityVirial=  self %darkMatterHaloScale_%velocityVirial(node)
+       call hotHalo%floatRank0MetaPropertyScale(self%energyRadiatedID,unitEnergyRadiated*massVirial*velocityVirial**2*scaleRelative)
+    end select
     return
   end subroutine coolingEnergyRadiatedDifferentialEvolutionScales
   
@@ -222,7 +227,7 @@ contains
     hotHalo      =>  node   %hotHalo      ()
     select type (hotHalo)
     type is (nodeComponentHotHalo)
-       ! Hot halo does not exists - nothing to do here.
+       ! Hot halo does not exist - nothing to do here.
     class default
        basic             =>  node             %basic           (                         )
        massDistribution_ =>  node             %massDistribution(massType=massTypeGalactic)
@@ -350,10 +355,15 @@ contains
     ! We do not add the energy radiated from this node to that of its parent, as we assume that, on merging, the hot halo gas of
     ! this node is shock heated to the virial temperature of the parent, effectively negating the energy radiated.
     hotHalo => node%hotHalo()
-    call hotHalo%floatRank0MetaPropertySet(                        &
-         &                                  self%energyRadiatedID, &
-         &                                 +0.0d0                  &
-         &                                )
+    select type (hotHalo)
+    type is (nodeComponentHotHalo)
+       ! Hot halo does not exist - nothing to do here.
+    class default
+       call hotHalo%floatRank0MetaPropertySet(                        &
+            &                                  self%energyRadiatedID, &
+            &                                 +0.0d0                  &
+            &                                )
+    end select
     return
   end subroutine coolingEnergyRadiatedGalaxiesMerge
   


### PR DESCRIPTION
This patch checks that a hot halo component exists before setting the relevant scale for the radiated cooling energy. This situation can occur in models using N-body merger trees in which a halo can be a subhalo at its first appearance, so it never has a hot halo component created in it.