### PR TITLE
Fix incorrect spheroid mass used in determining morphology

### DIFF
--- a/source/nodes.property_extractor.mass_stellar_morphology.F90
+++ b/source/nodes.property_extractor.mass_stellar_morphology.F90
@@ -78,10 +78,10 @@ contains
     double precision                                                                      :: massStellarDisk     , massStellarSpheroid
     !$GLC attributes unused :: self, instance
 
-    massDistributionDisk     => node                %massDistribution(massType=massTypeStellar,componentType=componentTypeDisk    )
-    massDistributionSpheroid => node                %massDistribution(massType=massTypeStellar,componentType=componentTypeSpheroid)
-    massStellarDisk          =  massDistributionDisk%massTotal       (                                                            )
-    massStellarSpheroid      =  massDistributionDisk%massTotal       (                                                            )
+    massDistributionDisk     => node                    %massDistribution(massType=massTypeStellar,componentType=componentTypeDisk    )
+    massDistributionSpheroid => node                    %massDistribution(massType=massTypeStellar,componentType=componentTypeSpheroid)
+    massStellarDisk          =  massDistributionDisk    %massTotal       (                                                            )
+    massStellarSpheroid      =  massDistributionSpheroid%massTotal       (                                                            )
     if (massStellarDisk+massStellarSpheroid > 0.0d0) then
        massStellarMorphologyExtract=+  massStellarSpheroid &
             &                       /(                     &


### PR DESCRIPTION
The disk mass was incorrectly used for the spheroid mass when computing stellar mass spheroid-to-total ratios, resulting in the ratio always being 0.5.