### PR TITLE
Do not mark nodes as physically implausible because of negative disk/spheroid masses

### DIFF
--- a/source/galactic_structure.radius_solver.fixed.F90
+++ b/source/galactic_structure.radius_solver.fixed.F90
@@ -298,7 +298,7 @@ contains
     !!}
     implicit none
     class(galacticStructureSolverFixed), intent(inout) :: self
-    type (treeNode                     ), intent(inout) :: node
+    type (treeNode                    ), intent(inout) :: node
     !$GLC attributes unused :: self, node
 
     return

--- a/source/objects.nodes.components.disk.standard.F90
+++ b/source/objects.nodes.components.disk.standard.F90
@@ -1018,32 +1018,22 @@ contains
     ! Determine the plausibility of the current disk.
     disk => node%disk()
     select type (disk)
-       class is (nodeComponentDiskStandard)
-       if      (disk%angularMomentum()                <                   0.0d0) &
-            & node%isPhysicallyPlausible=.false.
-       if      (disk%massStellar    ()+disk%massGas() <  -toleranceAbsoluteMass) then
-          node%isPhysicallyPlausible=.false.
-       else if (disk%massStellar    ()+disk%massGas() >=                  0.0d0) then
-          if      (                                                              &
-               &   disk%angularMomentum() < 0.0d0                                &
-               &  ) then
+    class is (nodeComponentDiskStandard)
+       if (disk%massStellar()+disk%massGas() >= 0.0d0 .and. disk%angularMomentum() > 0.0d0) then
+          angularMomentumScale=(                                           &
+               &                 disk%massStellar()                        &
+               &                +disk%massGas    ()                        &
+               &               )                                           &
+               &               * darkMatterHaloScale_%radiusVirial  (node) &
+               &               * darkMatterHaloScale_%velocityVirial(node)
+          if     (                                                                      &
+               &   disk%angularMomentum() > angularMomentumMaximum*angularMomentumScale &
+               &  .or.                                                                  &
+               &   disk%angularMomentum() < angularMomentumMinimum*angularMomentumScale &
+               & ) then
+             ! Ignore disks with angular momenta greatly exceeding that which would be expected if they had a radius comparable to the
+             ! virial radius of their halo.
              node%isPhysicallyPlausible=.false.
-          else
-             angularMomentumScale=(                                           &
-                  &                 disk%massStellar()                        &
-                  &                +disk%massGas    ()                        &
-                  &               )                                           &
-                  &               * darkMatterHaloScale_%radiusVirial  (node) &
-                  &               * darkMatterHaloScale_%velocityVirial(node)
-             if     (                                                                      &
-                  &   disk%angularMomentum() > angularMomentumMaximum*angularMomentumScale &
-                  &  .or.                                                                  &
-                  &   disk%angularMomentum() < angularMomentumMinimum*angularMomentumScale &
-                  & ) then
-                ! Ignore disks with angular momenta greatly exceeding that which would be expected if they had a radius comparable to the
-                ! virial radius of their halo.
-                node%isPhysicallyPlausible=.false.
-             end if
           end if
        end if
     end select

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -1274,35 +1274,23 @@ contains
     spheroid => node%spheroid()
     select type (spheroid)
     class is (nodeComponentSpheroidStandard)
-       ! Determine the plausibility of the current spheroid.
-       if      (spheroid%angularMomentum()                    <                  0.0d0) &
-            & node%isPhysicallyPlausible=.false.
-       if      (spheroid%massStellar    ()+spheroid%massGas() <  -toleranceAbsoluteMass) then
-          node%isPhysicallyPlausible=.false.
-       else if (spheroid%massStellar    ()+spheroid%massGas() >=                 0.0d0) then
-          if      (                                                                     &
-               &   spheroid%angularMomentum() < 0.0d0                                   &
-               &  ) then
+       if (spheroid%massStellar()+spheroid%massGas() >= 0.0d0 .and. spheroid%angularMomentum() > 0.0d0) then
+          angularMomentumScale=(                                           &
+               &                 spheroid%massStellar()                    &
+               &                +spheroid%massGas    ()                    &
+               &               )                                           &
+               &               * darkMatterHaloScale_%radiusVirial  (node) &
+               &               * darkMatterHaloScale_%velocityVirial(node)
+          if     (                                                                          &
+               &   spheroid%angularMomentum() > angularMomentumMaximum*angularMomentumScale &
+               &  .or.                                                                      &
+               &   spheroid%angularMomentum() < angularMomentumMinimum*angularMomentumScale &
+               & ) then
+             ! Ignore spheroids with angular momenta greatly exceeding that which would be expected if they had a radius
+             ! comparable to the virial radius of their halo.
              node%isPhysicallyPlausible=.false.
-          else
-             angularMomentumScale=(                                           &
-                  &                 spheroid%massStellar()                    &
-                  &                +spheroid%massGas    ()                    &
-                  &               )                                           &
-                  &               * darkMatterHaloScale_%radiusVirial  (node) &
-                  &               * darkMatterHaloScale_%velocityVirial(node)
-             if     (                                                                          &
-                  &   spheroid%angularMomentum() > angularMomentumMaximum*angularMomentumScale &
-                  &  .or.                                                                      &
-                  &   spheroid%angularMomentum() < angularMomentumMinimum*angularMomentumScale &
-                  & ) then
-                ! Ignore spheroids with angular momenta greatly exceeding that which would be expected if they had a radius
-                ! comparable to the virial radius of their halo.
-                node%isPhysicallyPlausible=.false.
-             end if
           end if
        end if
-
     end select
     return
   end subroutine Node_Component_Spheroid_Standard_Radius_Solver_Plausibility

--- a/testSuite/parameters/starFormationHistoryAdaptive.xml
+++ b/testSuite/parameters/starFormationHistoryAdaptive.xml
@@ -9,7 +9,7 @@
   <componentBasic value="standard"/>
   <componentHotHalo value="null"/>
   <componentBlackHole value="null"/>
-  <componentDarkMatterProfile value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
   <componentDisk value="standard">
     <massDistributionDisk value="exponentialDisk">
       <dimensionless value="true"/>
@@ -87,6 +87,8 @@
     <nodeOperator value="cosmicTime"/>
     <!-- DMO evolution -->
     <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
     <!-- Halo spins -->
     <nodeOperator value="haloAngularMomentumInterpolate"/>
     <!-- Satellite evolution -->

--- a/testSuite/parameters/starFormationHistoryMetallicitySplit.xml
+++ b/testSuite/parameters/starFormationHistoryMetallicitySplit.xml
@@ -9,7 +9,7 @@
   <componentBasic value="standard"/>
   <componentHotHalo value="null"/>
   <componentBlackHole value="null"/>
-  <componentDarkMatterProfile value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
   <componentDisk value="standard">
     <massDistributionDisk value="exponentialDisk">
       <dimensionless value="true"/>
@@ -87,6 +87,8 @@
     <nodeOperator value="cosmicTime"/>
     <!-- DMO evolution -->
     <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
     <!-- Halo spins -->
     <nodeOperator value="haloAngularMomentumInterpolate"/>
     <!-- Satellite evolution -->


### PR DESCRIPTION
Doing so causes calculation of sizes to be suspended, resulting in sizes being frozen at the value that they had when all components last had positive masses. Removing this allows sizes of components with positive masses to continue to be updated. Those with negative masses are simply ignored during size determination, so have no effect on the results.