### PR TITLE
Prevent hydrogen and helium mass fractions exceeding primordial values for negative metallicities

### DIFF
--- a/source/objects.abundances.F90
+++ b/source/objects.abundances.F90
@@ -818,8 +818,16 @@ contains
     class           (abundances), intent(in   ) :: self
     double precision            , parameter     :: massFractionMinimum=0.7d0
 
-    Abundances_Hydrogen_Mass_Fraction=max((self%metallicityValue/metallicitySolar)*(hydrogenByMassSolar&
-         &-hydrogenByMassPrimordial)+hydrogenByMassPrimordial,massFractionMinimum)
+    Abundances_Hydrogen_Mass_Fraction=min(                                                      &
+         &                                max(                                                  &
+         &                                    +self%metallicityValue                            &
+         &                                    /     metallicitySolar                            &
+         &                                    *(+hydrogenByMassSolar-hydrogenByMassPrimordial)  &
+         &                                    +                      hydrogenByMassPrimordial , &
+         &                                    +                      massFractionMinimum        &
+         &                                   )                                                , &
+         &                                    +                      hydrogenByMassPrimordial   &
+         &                               )
     return
   end function Abundances_Hydrogen_Mass_Fraction
 
@@ -831,8 +839,13 @@ contains
     implicit none
     class(abundances), intent(in   ) :: self
 
-    Abundances_Helium_Mass_Fraction=(self%metallicityValue/metallicitySolar)*(heliumByMassSolar-heliumByMassPrimordial)&
-         &+heliumByMassPrimordial
+    Abundances_Helium_Mass_Fraction=min(                                              &
+         &                              +self%metallicityValue                        &
+         &                              /     metallicitySolar                        &
+         &                              *(+heliumByMassSolar-heliumByMassPrimordial)  &
+         &                              +                    heliumByMassPrimordial , &
+         &                              +                    heliumByMassPrimordial   &
+         &                             )
     return
   end function Abundances_Helium_Mass_Fraction
 

--- a/testSuite/test-reproducibility.pl
+++ b/testSuite/test-reproducibility.pl
@@ -28,7 +28,7 @@ my @tests =
      		  name              => "hot halo mass"            ,
      		  output            => 1                          ,
      		  property          => "hotHaloMass"              ,
-                  values            => pdl ( 8.00140056433672e10 ),
+                  values            => pdl ( 7.99799857410098e10 ),
      		  toleranceRelative => 4.0e-6
      	      }
      	     ]


### PR DESCRIPTION
If metallicity is negative (due to ODE solver inaccuracies), do not allow the hydrogen or helium mass fraction to exceed the primordial value.