### PR TITLE
Add functionality to mark component properties as non-negative

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1192,7 +1192,8 @@ jobs:
                 test-duplicatedOutputPropertyName.pl,
                 test-decayingDM-caustic.py,
                 test-decayingDM-profile.py,
-                test-decayingDM-shell-crossing-capture.py ]
+                test-decayingDM-shell-crossing-capture.py,
+                test-enforceNonNegativity.py ]
     uses: ./.github/workflows/testModel.yml
     with:
       file: ${{ matrix.file }}

--- a/.github/workflows/testModel.yml
+++ b/.github/workflows/testModel.yml
@@ -158,7 +158,7 @@ jobs:
            apt -y install python3-numpy python3-h5py python3-lxml python3-blessings python3-matplotlib
            cd ${{ inputs.runPath }}
            chmod u=wrx ./${{ inputs.file }}
-           ./${{ inputs.file }} ${{ inputs.options }} 2>&1 | tee test.log
+           LD_LIBRARY_PATH= ./${{ inputs.file }} ${{ inputs.options }} 2>&1 | tee test.log
           else
            echo Unrecognized file extension
            false

--- a/.github/workflows/testModel.yml
+++ b/.github/workflows/testModel.yml
@@ -155,7 +155,7 @@ jobs:
             false
            fi
            apt -y update && apt -y upgrade
-           apt -y install python3-numpy python3-h5py python3-lxml python3-blessings
+           apt -y install python3-numpy python3-h5py python3-lxml python3-blessings python3-matplotlib
            cd ${{ inputs.runPath }}
            chmod u=wrx ./${{ inputs.file }}
            ./${{ inputs.file }} ${{ inputs.options }} 2>&1 | tee test.log

--- a/.github/workflows/testModel.yml
+++ b/.github/workflows/testModel.yml
@@ -158,7 +158,7 @@ jobs:
            apt -y install python3-numpy python3-h5py python3-lxml python3-blessings python3-matplotlib
            cd ${{ inputs.runPath }}
            chmod u=wrx ./${{ inputs.file }}
-           LD_LIBRARY_PATH= ./${{ inputs.file }} ${{ inputs.options }} 2>&1 | tee test.log
+           ./${{ inputs.file }} ${{ inputs.options }} 2>&1 | tee test.log
           else
            echo Unrecognized file extension
            false

--- a/doc/Methods.tex
+++ b/doc/Methods.tex
@@ -77,43 +77,41 @@ Component definition itself takes the form of an embedded XML document. The foll
   !#     <name>massStellar</name>
   !#     <type>real</type>
   !#     <rank>0</rank>
-  !#     <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+  !#     <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
   !#     <output unitsInSI="massSolar" comment="Mass of stars in the exponential disk."/>
   !#   </property>
   !#   <property>
   !#     <name>abundancesStellar</name>
   !#     <type>abundances</type>
   !#     <rank>0</rank>
-  !#     <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+  !#     <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
   !#     <output unitsInSI="massSolar" comment="Mass of metals in the stellar phase of the exponential disk."/>
   !#   </property>
   !#   <property>
   !#     <name>massGas</name>
   !#     <type>real</type>
   !#     <rank>0</rank>
-  !#     <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" makeGeneric="true" />
+  !#     <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" makeGeneric="true" isNonNegative="true" />
   !#     <output unitsInSI="massSolar" comment="Mass of gas in the exponential disk."/>
   !#   </property>
   !#   <property>
   !#     <name>coolingMass</name>
-  !#     <attributes isSettable="false" isGettable="false" isEvolvable="true" isDeferred="rate" bindsTo="top" />
+  !#     <attributes isSettable="false" isGettable="false" isEvolvable="true" isDeferred="rate" isVirtual="true" bindsTo="top" />
   !#     <type>real</type>
   !#     <rank>0</rank>
-  !#     <isVirtual>yes</isVirtual>
   !#   </property>
   !#   <property>
   !#     <name>halfMassRadius</name>
-  !#     <attributes isSettable="false" isGettable="true" isEvolvable="false" />
+  !#     <attributes isSettable="false" isGettable="true" isEvolvable="false" isVirtual="true" />
   !#     <type>real</type>
   !#     <rank>0</rank>
-  !#     <isVirtual>yes</isVirtual>
   !#     <getFunction>Node_Component_Disk_Exponential_Half_Mass_Radius</getFunction>
   !#   </property>
   !#   <property>
   !#     <name>luminositiesStellar</name>
   !#     <type>real</type>
   !#     <rank>1</rank>
-  !#     <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+  !#     <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
   !#     <classDefault modules="Stellar_Population_Properties_Luminosities" count="Stellar_Population_Luminosities_Count()">0.0d0</classDefault>
   !#     <output labels="':'//Stellar_Population_Luminosities_Name({i})" count="Stellar_Population_Luminosities_Count()" condition="Stellar_Population_Luminosities_Output({i},time)" modules="Stellar_Population_Properties_Luminosities" unitsInSI="luminosityZeroPointAB" comment="Luminosity of disk stars."/>
   !#   </property>
@@ -172,7 +170,8 @@ Additional attributes are required for array properties:
 \item [{\normalfont \ttfamily labels}] This can be an array, declared as ``{\normalfont \ttfamily [$L_1$,\ldots,$L_N$]}'', specifying the suffix to be added to the property name for each component of the array in the output, or a function which returns the suffix. In the case of a function the construct ``{\normalfont \ttfamily \{i\}}'' can be used to pass the index of the element for which the suffix is required.
 \item [{\normalfont \ttfamily count}] A statement which evaluates the the number of elements to be output (i.e. the length of the array).
 \end{description}
-\item [{\normalfont \ttfamily isVirtual}] \emph{[Optional]} If present and set to ``{\normalfont \ttfamily yes}'', this property is a virtual property. A virtual property has no data associated with it and must supply its own functions for getting, setting and adjusting its rate of change (if allowed by the property's attributes). Virtual properties are used for quantities which are derived from actual properties of the component implementation (for example, a star formation rate could be a virtual property if it is derived from an actual gas mass property) or for adjusting the rates of several actual properties simultaneously.
+\item [{\normalfont \ttfamily isVirtual}] \emph{[Optional]} If present and set to ``{\normalfont \ttfamily true}'', this property is a virtual property. A virtual property has no data associated with it and must supply its own functions for getting, setting and adjusting its rate of change (if allowed by the property's attributes). Virtual properties are used for quantities which are derived from actual properties of the component implementation (for example, a star formation rate could be a virtual property if it is derived from an actual gas mass property) or for adjusting the rates of several actual properties simultaneously.
+\item [{\normalfont \ttfamily isNonNegative}] \emph{[Optional]} If present and set to ``{\normalfont \ttfamily true}'', this property should always be non-negative (i.e. zero or positive). This is typically the case for quantities such as masses for example. This attribute is informative only---it may or may not be taking into account by the class responsible for evolving the component properties. For example, the \refClass{mergerTreeNodeEvolverStandard} class will evolve properties marked as non-negative in such a way as to ensure they remain non-negative, but only if its parameter {\normalfont \ttfamily [enforceNonNegativity]=true}.
 \item [{\normalfont \ttfamily getFunction}] \emph{[Optional]} Specifies the function to be used for getting the value of the property, overriding the default get function. The function must be included in the \href{https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/Galacticus_Source.pdf#source.objects_nodes_F90:galacticus_nodes}{\normalfont \ttfamily Galacticus\_Nodes} module by use of the {\normalfont \ttfamily functions} element described below. Note that this function, by virtue of its privileged access to the internal structure of node components, can access the value of the data associated with the property using:
 \begin{verbatim}
 myComponent%<property>Data%value

--- a/perl/Galacticus/Build/Components/Components.pm
+++ b/perl/Galacticus/Build/Components/Components.pm
@@ -78,6 +78,14 @@ sub Build_Node_Component_Class {
 	 },
 	 {
 	     type        => "procedure"                                                                                            ,
+	     name        => "serializeNonNegative"                                                                                 ,
+	     function    => "Node_Component_Serialize_NonNegative_Null"                                                            ,
+	     description => "Serialize the non-negative status of evolvable quantities to an array."                               ,
+	     returnType  => "\\void"                                                                                               ,
+	     arguments   => "\\logicalone\\ array\\argout"
+	 },
+	 {
+	     type        => "procedure"                                                                                            ,
 	     name        => "deserializeRaw"                                                                                       ,
 	     function    => "Node_Component_Read_Raw_Null"                                                                         ,
 	     description => "Read properties from raw file."                                                                       ,

--- a/perl/Galacticus/Build/Components/Properties.pm
+++ b/perl/Galacticus/Build/Components/Properties.pm
@@ -63,6 +63,7 @@ sub Property_Defaults {
 			 bindsTo        => "component"   ,
 			 createIfNeeded => "booleanFalse",
 			 isDeferred     => "false"       ,
+			 isNonNegative  => "booleanFalse",
 			 makeGeneric    => "booleanFalse"
 		     }
 		 }

--- a/schema/componentSchema.xsd
+++ b/schema/componentSchema.xsd
@@ -81,6 +81,7 @@
 		      <xs:attribute name="makeGeneric"    type="xs:boolean"               />
 		      <xs:attribute name="isVirtual"      type="xs:boolean"               />
 		      <xs:attribute name="isDeferred"     type="xs:string"                />
+		      <xs:attribute name="isNonNegative"  type="xs:string"                />
 		      <xs:attribute name="bindsTo"        type="level"                    />
 		    </xs:complexType>
 		  </xs:element>

--- a/source/gslODEInitVal2/driver2.c
+++ b/source/gslODEInitVal2/driver2.c
@@ -106,7 +106,7 @@ gsl_odeiv2_driver_alloc_scaled2_new (const gsl_odeiv2_system * sys,
                                     const double hstart,
                                     const double epsabs, const double epsrel,
                                     const double a_y, const double a_dydt,
-                                    const double scale_abs[])
+				    const double scale_abs[], const int is_non_negative[])
 {
   /* Initializes an ODE driver system with control object of type
      scaled_new. 
@@ -122,7 +122,7 @@ gsl_odeiv2_driver_alloc_scaled2_new (const gsl_odeiv2_system * sys,
   if (epsabs >= 0.0 && epsrel >= 0.0)
     {
       state->c = gsl_odeiv2_control_scaled2_new (epsabs, epsrel, a_y, a_dydt,
-                                                scale_abs, sys->dimension);
+						 scale_abs, is_non_negative, sys->dimension);
 
       if (state->c == NULL)
         {

--- a/source/gslODEInitVal2/gsl_odeiv2.h
+++ b/source/gslODEInitVal2/gsl_odeiv2.h
@@ -45,6 +45,7 @@ gsl_odeiv2_control *gsl_odeiv2_control_scaled2_new (double eps_abs,
 						    double eps_rel, double a_y,
 						    double a_dydt,
 						    const double scale_abs[],
+						    const int is_non_negative[],
 						    size_t dim);
 
 int gsl_odeiv2_driver2_apply (gsl_odeiv2_driver * d, double *t,

--- a/source/merger_trees.evolve.profiler.simple.F90
+++ b/source/merger_trees.evolve.profiler.simple.F90
@@ -184,7 +184,7 @@ contains
     if (           all(self%timestepCount == 0)) return
     ! If this object was deep-copied from some other object, reduce back onto that object.
     if (associated(self%deepCopiedFrom)) then
-       call self%reduceLock%set()
+       call self%deepCopiedFrom%reduceLock%set()
        self%deepCopiedFrom%timeStepCount             =+self%deepCopiedFrom%timeStepCount              &
             &                                         +self               %timeStepCount
        self%deepCopiedFrom%evaluationCount           =+self%deepCopiedFrom%evaluationCount            &
@@ -215,7 +215,7 @@ contains
              call self%deepCopiedFrom%propertyHits%set(self%propertyHits%key(i),self%propertyHits%value(i)                                          )
           end if
        end do       
-       call self%reduceLock%unset()
+       call self%deepCopiedFrom%reduceLock%unset()
     else
        ! Store meta-data to the output file.
        !$ call hdf5Access%set  ()

--- a/source/nodes.operators.physics.stellar_feedback.disks.F90
+++ b/source/nodes.operators.physics.stellar_feedback.disks.F90
@@ -113,7 +113,7 @@ contains
   
   subroutine stellarFeedbackDisksDifferentialEvolution(self,node,interrupt,functionInterrupt,propertyType)
     !!{
-    Perform star formation in a disk.
+    Perform feedback from stars in a disk.
     !!}
     use :: Abundances_Structure          , only : abundances         , zeroAbundances
     use :: Galacticus_Nodes              , only : propertyInactive   , nodeComponentDisk, nodeComponentHotHalo

--- a/source/nodes.operators.physics.stellar_feedback.spheroids.F90
+++ b/source/nodes.operators.physics.stellar_feedback.spheroids.F90
@@ -113,7 +113,7 @@ contains
   
   subroutine stellarFeedbackSpheroidsDifferentialEvolution(self,node,interrupt,functionInterrupt,propertyType)
     !!{
-    Perform star formation in a spheroid.
+    Perform feedback from stars in a spheroid.
     !!}
     use :: Abundances_Structure          , only : abundances         , zeroAbundances
     use :: Galacticus_Nodes              , only : propertyInactive   , nodeComponentSpheroid, nodeComponentHotHalo

--- a/source/objects.nodes.F90
+++ b/source/objects.nodes.F90
@@ -1262,6 +1262,18 @@ module Galacticus_Nodes
     return
   end subroutine Node_Component_Serialize_Null
 
+  subroutine Node_Component_Serialize_NonNegative_Null(self,array)
+    !!{
+    Serialize the non-negative status for a generic tree node component.
+    !!}
+    implicit none
+    class  (nodeComponent)              , intent(in   ) :: self
+    logical               , dimension(:), intent(  out) :: array
+    !$GLC attributes unused :: self, array
+
+    return
+  end subroutine Node_Component_Serialize_NonNegative_Null
+
   subroutine Node_Component_Deserialize_Null(self,array,propertyType)
     !!{
     Deserialize a generic tree node component.

--- a/source/objects.nodes.components.black_hole.standard.F90
+++ b/source/objects.nodes.components.black_hole.standard.F90
@@ -49,14 +49,14 @@ module Node_Component_Black_Hole_Standard
       <name>mass</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of the black hole."/>
     </property>
     <property>
       <name>spin</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
       <getFunction>Node_Component_Black_Hole_Standard_Spin</getFunction>
       <output unitsInSI="0.0d0" comment="Spin of the black hole."/>
     </property>

--- a/source/objects.nodes.components.disk.standard.F90
+++ b/source/objects.nodes.components.disk.standard.F90
@@ -54,47 +54,47 @@ module Node_Component_Disk_Standard
       <name>massStellar</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of stars in the standard disk."/>
     </property>
     <property>
       <name>massStellarFormed</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
     </property>
     <property>
       <name>fractionMassRetained</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
     </property>
     <property>
       <name>abundancesStellar</name>
       <type>abundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of metals in the stellar phase of the standard disk."/>
     </property>
     <property>
       <name>massGas</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" makeGeneric="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" makeGeneric="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of gas in the standard disk."/>
     </property>
     <property>
       <name>abundancesGas</name>
       <type>abundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" makeGeneric="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" makeGeneric="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of metals in the gas phase of the standard disk."/>
     </property>
     <property>
       <name>angularMomentum</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" makeGeneric="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" makeGeneric="true" isNonNegative="true" />
       <output unitsInSI="massSolar*megaParsec*kilo" comment="Angular momentum of the standard disk."/>
     </property>
     <property>
@@ -122,7 +122,7 @@ module Node_Component_Disk_Standard
       <name>luminositiesStellar</name>
       <type>stellarLuminosities</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
       <output unitsInSI="luminosityZeroPointAB" comment="Luminosity of disk stars."/>
     </property>
     <property>
@@ -135,7 +135,7 @@ module Node_Component_Disk_Standard
       <name>starFormationHistory</name>
       <type>history</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
     </property>
    </properties>
    <bindings>

--- a/source/objects.nodes.components.hot_halo.standard.F90
+++ b/source/objects.nodes.components.hot_halo.standard.F90
@@ -67,56 +67,56 @@ module Node_Component_Hot_Halo_Standard
       <name>mass</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of gas in the hot halo."/>
     </property>
     <property>
       <name>abundances</name>
       <type>abundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of metals in the hot phase of the hot halo."/>
     </property>
     <property>
       <name>chemicals</name>
       <type>chemicalAbundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of chemicals in the hot phase of the hot halo."/>
     </property>
     <property>
       <name>angularMomentum</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true" />
       <output unitsInSI="massSolar*megaParsec*kilo" comment="Angular momentum of gas in the hot halo."/>
     </property>
     <property>
       <name>outflowedMass</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of outflowed gas in the hot halo."/>
     </property>
     <property>
       <name>outflowedAngularMomentum</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
       <output unitsInSI="massSolar*megaParsec*kilo" comment="Angular momentum of outflowed gas in the hot halo."/>
     </property>
     <property>
       <name>outflowedAbundances</name>
       <type>abundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of metals in the outflowed phase of the hot halo."/>
     </property>
     <property>
       <name>outflowedChemicals</name>
       <type>chemicalAbundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of chemicals in the outflowed phase of the hot halo."/>
     </property>
     <property>
@@ -141,40 +141,40 @@ module Node_Component_Hot_Halo_Standard
       <name>unaccretedMass</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of gas that failed to accrete into the hot halo."/>
     </property>
     <property>
       <name>unaccretedAbundances</name>
       <type>abundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of metals that failed to accrete into the hot halo."/>
     </property>
     <property>
       <name>outerRadius</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" isDeferred="get" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isDeferred="get" isNonNegative="true" />
       <output unitsInSI="megaParsec" comment="Outer radius of the hot halo."/>
     </property>
     <property>
       <name>strippedMass</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
     </property>
     <property>
       <name>strippedAbundances</name>
       <type>abundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
     </property>
     <property>
       <name>strippedChemicals</name>
       <type>chemicalAbundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
     </property>
     <property>
       <name>hotHaloCoolingMass</name>
@@ -1348,7 +1348,7 @@ contains
     class           (nodeComponentHotHaloStandard), intent(inout) :: self
     type            (treeNode                    ), pointer       :: node
     double precision                                              :: ramPressureRadius, outerRadius
-
+    
     ! Compute the outer radius growth rate if necessary.
     if (.not.gotOuterRadiusGrowthRate) then
        node              => self                        %hostNode

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -57,41 +57,41 @@ module Node_Component_Spheroid_Standard
       <name>massStellar</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true"/>
       <output unitsInSI="massSolar" comment="Mass of stars in the standard spheroid."/>
     </property>
     <property>
       <name>massStellarFormed</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isNonNegative="true" />
     </property>
     <property>
       <name>abundancesStellar</name>
       <type>abundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of metals in the stellar phase of the standard spheroid."/>
     </property>
     <property>
       <name>massGas</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true"/>
       <output unitsInSI="massSolar" comment="Mass of gas in the standard spheroid."/>
     </property>
     <property>
       <name>abundancesGas</name>
       <type>abundances</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true" />
       <output unitsInSI="massSolar" comment="Mass of metals in the gas phase of the standard spheroid."/>
     </property>
     <property>
       <name>angularMomentum</name>
       <type>double</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true"/>
       <output unitsInSI="massSolar*megaParsec*kilo" comment="Angular momentum of the standard spheroid."/>
     </property>
     <property>
@@ -119,7 +119,7 @@ module Node_Component_Spheroid_Standard
       <name>luminositiesStellar</name>
       <type>stellarLuminosities</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" isNonNegative="true" />
       <output unitsInSI="luminosityZeroPointAB" comment="Luminosity of spheroid stars."/>
     </property>
     <property>
@@ -132,7 +132,7 @@ module Node_Component_Spheroid_Standard
       <name>starFormationHistory</name>
       <type>history</type>
       <rank>0</rank>
-      <attributes isSettable="true" isGettable="true" isEvolvable="true" isDeferred="rate" createIfNeeded="true" />
+      <attributes isSettable="true" isGettable="true" isEvolvable="true" isDeferred="rate" createIfNeeded="true" isNonNegative="true" />
     </property>
     <property>
       <name>massGasSink</name>

--- a/source/stellar_feedback.outflows.fixed.F90
+++ b/source/stellar_feedback.outflows.fixed.F90
@@ -89,7 +89,7 @@ contains
     !!}
     implicit none
     type            (stellarFeedbackOutflowsFixed)                :: self
-    double precision                             , intent(in   ) :: fraction
+    double precision                              , intent(in   ) :: fraction
 
     !![
     <constructorAssign variables="fraction"/>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletion.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletion.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="e9236b11f17f9c96b0cdac005d7945ac0febe7d5"/>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentHotHalo value="null"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <postStepZeroNegativeMasses value="false"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentSatellite value="null"/>
+  <componentSpheroid value="standard">
+    <postStepZeroNegativeMasses value="false"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.0"/>
+    <OmegaMatter value="0.3"/>
+    <OmegaDarkEnergy value="0.7"/>
+    <OmegaBaryon value="0.05"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="1.000"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="Tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/enforceNonNegativity/tree.xml"/>
+  </mergerTreeConstructor>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="simple"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="0.25"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="0.25"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard">
+    <metalYield value="0.025"/>
+    <recycledFraction value="0.4"/>
+  </stellarPopulation>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+    <nodeOperator value="starFormationSpheroids"/>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="fixed">
+        <fraction value="1.0"/>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="fixed">
+        <fraction value="10.0"/>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.1"/>
+    <odeToleranceRelative value="0.1"/>
+    <reuseODEStepSize value="true"/>
+    <enforceNonNegativity value="false"/>
+    <profileOdeEvolver value="true"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolveProfiler value="simple">
+  </mergerTreeEvolveProfiler>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.000"/>
+    <timestepHostRelative value="0.100"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+
+  <!-- Output file -->
+  <outputTimes value="uniformSpacingInTime">
+    <timeMinimum value="12.47"/>
+    <timeMaximum value="13.47"/>
+    <countTimes value="4"/>
+  </outputTimes>
+  <outputFileName value="rapidDepletion.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.0001.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.0001.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="true">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="0.0001">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="0.0001">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.0001.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.001.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.001.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="true">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="0.001">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="0.001">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.001.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.01.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.01.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="true">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="0.01">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="0.01">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.01.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.1.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.1.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="true">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="0.1">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="0.1">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol0.1.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol1e-6.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol1e-6.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="true">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="1e-6">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="1e-6">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol1e-6.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol1e-9.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol1e-9.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="true">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="1e-9">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="1e-9">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionEnforceNonNegativityODETol1e-9.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol0.0001.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol0.0001.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Do not enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="false">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="0.0001">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="0.0001">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionODETol0.0001.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol0.001.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol0.001.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Do not enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="false">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="0.001">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="0.001">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionODETol0.001.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol0.01.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol0.01.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Do not enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="false">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="0.01">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="0.01">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionODETol0.01.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol0.1.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol0.1.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Do not enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="false">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="0.1">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="0.1">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionODETol0.1.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol1e-6.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol1e-6.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Do not enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="false">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="1e-6">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="1e-6">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionODETol1e-6.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol1e-9.xml
+++ b/testSuite/parameters/enforceNonNegativity/rapidDepletionODETol1e-9.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Enforce non-negativity -->
+<changes>
+
+  <!-- Do not enforce non-negativity -->
+  <change type="update" path="mergerTreeNodeEvolver/enforceNonNegativity" value="false">
+  </change>
+
+  <!-- Set ODE tolerances -->
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceAbsolute" value="1e-9">
+  </change>
+  <change type="update" path="mergerTreeNodeEvolver/odeToleranceRelative" value="1e-9">
+  </change>
+
+  <!-- Change the output file name -->
+  <change type="update" path="outputFileName" value="testSuite/outputs/enforceNonNegativity/rapidDepletionODETol1e-9.hdf5">
+  </change>
+
+</changes>

--- a/testSuite/parameters/enforceNonNegativity/tree.xml
+++ b/testSuite/parameters/enforceNonNegativity/tree.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test of bar instability spheroid creation -->
+<!-- 25-July-2018                              -->
+<tree>
+  <node>
+    <index>1</index>
+    <parent>2</parent>
+    <firstChild>-1</firstChild>
+    <sibling>-1</sibling>
+    <basic>
+      <time>12.47</time>
+      <mass>1.0e12</mass>
+    </basic>
+    <spin>
+      <angularMomentum>1.635e12</angularMomentum>
+    </spin>
+    <disk>
+      <massStellar>1.0e11</massStellar>
+      <massGas>1.0e10</massGas>
+      <abundancesStellar>
+	<metals>0.0</metals>
+      </abundancesStellar>
+      <abundancesGas>
+	<metals>0.0</metals>
+      </abundancesGas>
+      <angularMomentum>7.7e10</angularMomentum>
+    </disk>
+    <spheroid>
+      <massStellar>0.0</massStellar>
+      <massGas>1.0e9</massGas>
+      <abundancesStellar>
+	<metals>0.0</metals>
+      </abundancesStellar>
+      <abundancesGas>
+	<metals>0.0</metals>
+      </abundancesGas>
+      <angularMomentum>7.7e8</angularMomentum>
+    </spheroid>
+  </node>
+  <node>
+    <index>2</index>
+    <parent>-1</parent>
+    <firstChild>1</firstChild>
+    <sibling>-1</sibling>
+    <basic>
+      <time>13.47</time>
+      <mass>1.0e12</mass>
+    </basic>
+    <spin>
+      <angularMomentum>1.635e12</angularMomentum>
+    </spin>
+  </node>
+</tree>

--- a/testSuite/test-enforceNonNegativity.py
+++ b/testSuite/test-enforceNonNegativity.py
@@ -10,6 +10,7 @@ import argparse
 # Parse command line arguments.
 parser = argparse.ArgumentParser(prog='test-enforceNonNegativity.py',description='Test non-negative evolution.')
 parser.add_argument('--makeplots', action='store_true',help='make plots showing mass evolution')
+args = parser.parse_args()
 
 # Create output path.
 try:

--- a/testSuite/test-enforceNonNegativity.py
+++ b/testSuite/test-enforceNonNegativity.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Plot expected evolution of disk/spheroid gas/stellar masses for a model with non-negative evolution.
+import numpy as np
+import h5py
+import matplotlib.pyplot as plt
+import subprocess
+import sys
+import os
+
+# Create output path.
+try:
+    os.mkdir("outputs/enforceNonNegativity")
+except FileExistsError:
+    pass
+
+# Inintialize status.
+testStatus = "SUCCESS: no negative values found when enforcing"
+
+# Iterate over model variations.
+for variation in ( "ODETol0.1", "ODETol0.01", "ODETol0.001", "ODETol0.0001", "ODETol1e-6", "ODETol1e-9", "EnforceNonNegativityODETol0.1", "EnforceNonNegativityODETol0.01", "EnforceNonNegativityODETol0.001", "EnforceNonNegativityODETol0.0001", "EnforceNonNegativityODETol1e-6", "EnforceNonNegativityODETol1e-9" ):
+
+    # Run the model.
+    status = subprocess.run("cd ..; ./Galacticus.exe testSuite/parameters/enforceNonNegativity/rapidDepletion.xml testSuite/parameters/enforceNonNegativity/rapidDepletion"+variation+".xml",shell=True)
+    if status.returncode != 0:
+        print("FAILED: model failed to run")
+        sys.exit()
+        
+    # Begin a figure showing evolution of masses with time.
+    figure, axes = plt.subplots(tight_layout=True)
+    axes.set_yscale('log'                         )
+    axes.set_xlabel('$t/$Gyr'                     )
+    axes.set_ylabel('$M/\mathrm{M}_\odot$'        )
+    axes.set_title (f'ODE evolution ({variation})')
+    # Initialize arrays that will hold times and masses.
+    time                      = np.array([])
+    massGasSpheroid           = np.array([])
+    massStellarSpheroid       = np.array([])
+    massMetalsGasSpheroid     = np.array([])
+    massMetalsStellarSpheroid = np.array([])
+    
+    # Access the model.
+    model = h5py.File("outputs/enforceNonNegativity/rapidDepletion"+variation+".hdf5","r")
+    ## Extract parameters needed for analytic solution.
+    parameters             = model     ['Parameters'                                           ]
+    recycledFraction       = parameters['stellarPopulation'                                    ].attrs['recycledFraction'    ]
+    metalYield             = parameters['stellarPopulation'                                    ].attrs['metalYield'          ]
+    timescaleStarFormation = parameters['starFormationRateSpheroids/starFormationTimescale'    ].attrs['timescale'           ]
+    massLoading            = parameters['nodeOperator/nodeOperator[10]/stellarFeedbackOutflows'].attrs['fraction'            ]
+    enforcing              = parameters['mergerTreeNodeEvolver'                                ].attrs['enforceNonNegativity'].decode("utf-8")
+    ## Extract meta-data on number of evaluations required.
+    countEvaluations       = np.sum(model['metaData']['evolverProfiler']['evaluationCount'][:])
+    axes.text(12.5,0.01,f'$N_\mathrm{{eval}}={countEvaluations}$')
+    ## Iterate over all outputs.
+    outputs = model['Outputs']
+    for outputName in outputs:
+        output                    = outputs[outputName]
+        nodes                     = output ['nodeData']
+        time                      = np.append(time                     ,output.attrs['outputTime'                     ]   )
+        massGasSpheroid           = np.append(massGasSpheroid          ,nodes       ['spheroidMassGas'                ][0])
+        massStellarSpheroid       = np.append(massStellarSpheroid      ,nodes       ['spheroidMassStellar'            ][0])
+        massMetalsGasSpheroid     = np.append(massMetalsGasSpheroid    ,nodes       ['spheroidAbundancesGasMetals'    ][0])
+        massMetalsStellarSpheroid = np.append(massMetalsStellarSpheroid,nodes       ['spheroidAbundancesStellarMetals'][0])
+        
+    # Determine the correct time-ordering of model points.
+    order = np.argsort(time)
+
+    # Test for negative values if enforcing.
+    if enforcing == "true":
+        if np.any(massGasSpheroid           < 0.0):
+            testStatus = "FAIL: negative gas mass detected"
+        if np.any(massStellarSpheroid       < 0.0):
+            testStatus = "FAIL: negative stellar mass detected"
+        if np.any(massMetalsGasSpheroid     < 0.0):
+            testStatus = "FAIL: negative gas metal mass detected"
+        if np.any(massMetalsStellarSpheroid < 0.0):
+            testStatus = "FAIL: negative stellar metal mass detected"
+    
+    # Evaluate analytic solutions (Cole et al.; 2000; https://ui.adsabs.harvard.edu/abs/2000MNRAS.319..168C; equations B2-B8).
+    timescaleStarFormationEffective   = timescaleStarFormation/(1.0-recycledFraction+massLoading)
+    timeFine                          = np.arange(time[order][0],time[order][-1],0.001)
+    timeDelta                         = timeFine-timeFine[0]
+    massGasSpheroidAnalytic           =                                                                         massGasSpheroid[order][0]*                                                     np.exp(-timeDelta/timescaleStarFormationEffective)
+    massStellarSpheroidAnalytic       =            (1.0-recycledFraction)/(1.0-recycledFraction+massLoading)   *massGasSpheroid[order][0]*(1.0-                                                np.exp(-timeDelta/timescaleStarFormationEffective))
+    massMetalsStellarSpheroidAnalytic = metalYield*(1.0-recycledFraction)/(1.0-recycledFraction+massLoading)**2*massGasSpheroid[order][0]*(1.0-(1.0+timeDelta/timescaleStarFormationEffective)*np.exp(-timeDelta/timescaleStarFormationEffective))
+    massMetalsGasSpheroidAnalytic     = metalYield/(1.0-recycledFraction)*massStellarSpheroidAnalytic-(1.0-recycledFraction+massLoading)/(1.0-recycledFraction)*massMetalsStellarSpheroidAnalytic
+    
+    # Plot model results.
+    ## Gas mass.
+    positive = massGasSpheroid           >= 0.0
+    negative = massGasSpheroid           <  0.0
+    axes.plot(time    [order][positive],+massGasSpheroid                  [order][positive],marker='o',linestyle='' ,label="$M_\mathrm{gas}$"    ,markerfacecolor="burlywood" ,markeredgecolor="burlywood" ,markersize=8)
+    axes.plot(time    [order][negative],-massGasSpheroid                  [order][negative],marker='o',linestyle='' ,label=""                    ,markerfacecolor="burlywood" ,markeredgecolor="burlywood" ,markersize=2)
+    axes.plot(timeFine                 , massGasSpheroidAnalytic                           ,marker='' ,linestyle='-',label=""                    ,color          ="burlywood"                                           )
+    ## Stellar mass.
+    positive = massStellarSpheroid       >= 0.0
+    negative = massStellarSpheroid       <  0.0
+    axes.plot(time    [order][positive],+massStellarSpheroid              [order][positive],marker='*',linestyle='' ,label="$M_\star$"           ,markerfacecolor="dodgerblue",markeredgecolor="dodgerblue",markersize=8)
+    axes.plot(time    [order][negative],+massStellarSpheroid              [order][negative],marker='*',linestyle='' ,label=""                    ,markerfacecolor="dodgerblue",markeredgecolor="dodgerblue",markersize=2)
+    axes.plot(timeFine                 , massStellarSpheroidAnalytic                       ,marker='' ,linestyle='-',label=""                    ,color          ="dodgerblue"                                          )
+    ## Gas metal mass.
+    positive = massMetalsGasSpheroid     >= 0.0
+    negative = massMetalsGasSpheroid     <  0.0
+    axes.plot(time    [order][positive],+massMetalsGasSpheroid            [order][positive],marker='d',linestyle='' ,label="$M_{Z,\mathrm{gas}}$",markerfacecolor="lightcoral",markeredgecolor="lightcoral",markersize=8)
+    axes.plot(time    [order][negative],+massMetalsGasSpheroid            [order][negative],marker='d',linestyle='' ,label=""                    ,markerfacecolor="lightcoral",markeredgecolor="lightcoral",markersize=2)
+    axes.plot(timeFine                 , massMetalsGasSpheroidAnalytic                     ,marker='' ,linestyle='-',label=""                    ,color          ="lightcoral"                                          )
+    ## Stellar metal mass.
+    positive = massMetalsStellarSpheroid >= 0.0
+    negative = massMetalsStellarSpheroid <  0.0
+    axes.plot(time    [order][positive],+massMetalsStellarSpheroid        [order][positive],marker='H',linestyle='' ,label="$M_{Z,\star}$"       ,markerfacecolor="plum"      ,markeredgecolor="plum"      ,markersize=8)
+    axes.plot(time    [order][negative],+massMetalsStellarSpheroid        [order][negative],marker='H',linestyle='' ,label=""                    ,markerfacecolor="plum"      ,markeredgecolor="plum"      ,markersize=2)
+    axes.plot(timeFine                 , massMetalsStellarSpheroidAnalytic                 ,marker='' ,linestyle='-',label=""                    ,color          ="plum"                                                )
+    
+    # Finalize the plot.
+    axes.legend(loc='upper center',bbox_to_anchor=(0.4,0.12),fancybox=True,shadow=True,ncol=4)
+    plt.savefig('outputs/enforceNonNegativity/massEvolution'+variation+'.pdf')
+    plt.clf()
+
+# Report status.
+print(testStatus)


### PR DESCRIPTION
The standard node evolver gains an option `enforceNonNegativity` which ensures that such properties remain non-negative throughout ODE evolution. Includes a test case for a spheroid with a short gas depletion timescale.