### PR TITLE
Make evaluation of UniverseMachine fits more robust

### DIFF
--- a/source/nodes.operators.empirical.central_disk.F90
+++ b/source/nodes.operators.empirical.central_disk.F90
@@ -79,12 +79,12 @@ contains
     <inputParameter>
       <name>angularMomentumSpecificFinal</name>
       <source>parameters</source>
-      <description>The final specific pseudo-angular momentum of the disk galaxy.</description>
+      <description>The final specific angular momentum of the disk galaxy.</description>
     </inputParameter>
     <inputParameter>
       <name>rateAngularMomentumSpecificSpecific</name>
       <source>parameters</source>
-      <description>The specific growth rate of the specific pseudo-angular momentum of the disk galaxy.</description>
+      <description>The specific growth rate of the specific angular momentum of the disk galaxy.</description>
     </inputParameter>
     !!]
     self=nodeOperatorEmpiricalCentralDisk(massStellarFinal,rateStarFormationSpecific,angularMomentumSpecificFinal,rateAngularMomentumSpecificSpecific)

--- a/testSuite/parameters/test-UniverseMachine.xml
+++ b/testSuite/parameters/test-UniverseMachine.xml
@@ -136,6 +136,8 @@
     <nodeOperator value="satelliteMergingTime"/>
     <nodeOperator value="satelliteMassLoss"   />
     <nodeOperator value="empiricalGalaxyUniverseMachine">
+      <redshiftMaximum value="1.0e6"/>
+      <massHaloMinimum value="0.0e0"/>
       <massStellarFinal value="-1.0d0" />
       <fractionMassSpheroid value="1.0d0" />
       <fractionMassDisk value="0.0d0" />


### PR DESCRIPTION
The order of evaluations is changed to avoid floating overflows.
    
This revision also introduces parameters that control the maximum redshift and minimum halo mass for which UniverseMachine fits will be applied. These default to sensible values for which the UniverseMachine was calibrated, avoiding applying the model in regions where the fits may be unreliable.
