### PR TITLE
 Add new options for parameter change files

### DIFF
--- a/doc/Advanced.tex
+++ b/doc/Advanced.tex
@@ -186,6 +186,9 @@ An example change file can be found \href{https://raw.githubusercontent.com/gala
     </stellarFeedbackOutflows>
   </change>
 
+  <!-- Replace a parameter with a different parameter-->
+  <change type="replace" path="nodeOperator/nodeOperator[@value='stellarFeedbackSpheroids']/stellarFeedbackOutflows/stellarFeedbackOutflows" target="nodeOperator/nodeOperator[@value='stellarFeedbackDisks']/stellarFeedbackOutflows/stellarFeedbackOutflows"/>
+
   <!-- Replace or append a parameter -->
   <change type="replaceOrAppend" path="starFormationRateSpheroids/starFormationTimescale/efficiency">
     <efficiency value="0.06"/>
@@ -197,17 +200,18 @@ An example change file can be found \href{https://raw.githubusercontent.com/gala
 
 </changes>
 \end{verbatim}
-A parameter change file should contain one or more change elements. Each change element must have a path attribute which gives an \href{http://www.w3schools.com/Xml/xpath_syntax.asp}{XPath} expression that identifies a parameter in the parameter file that will be acted upon by the change. (Note that currently only a limited set of XPath functionality is supported - matching of element names and single attributes only.) An empty path indicates the top-level section of the parameter file.
+A parameter change file should contain one or more change elements. Each change element must have a {\normalfont \ttfamily path} attribute which gives an \href{http://www.w3schools.com/Xml/xpath_syntax.asp}{XPath} expression that identifies a parameter in the parameter file that will be acted upon by the change. (Note that currently only a limited set of XPath functionality is supported - matching of element names and single attributes only.) An empty path indicates the top-level section of the parameter file.
 
-Each change element must also have a type attribute which specifies the type of change to be made. Supported types are:
+Each change element must also have a {\normalfont \ttfamily type} attribute which specifies the type of change to be made. Supported types are:
 \begin{description}
-\item[{\normalfont \ttfamily append}:] This will append all parameters enclosed within the change element to the children of the parameter specified by the path attribute.
-\item[{\normalfont \ttfamily insertBefore}:] This will insert all parameters enclosed within the change element before the parameter specified by the path attribute.
-\item[{\normalfont \ttfamily insertAfter}:] This will insert all parameters enclosed within the change element after the parameter specified by the path attribute.
-\item[{\normalfont \ttfamily replace}:] This will replace the parameter specified by the path attribute with all parameters enclosed within the change element.
-\item[{\normalfont \ttfamily replaceOrAppend}:] This will replace the parameter specified by the path attribute, if it exists, with all parameters enclosed within the change element. If the parameter does not exist, instead all parameters enclosed within the change element will be appended to the children of the parent element.
-\item[{\normalfont \ttfamily remove}:] This will remove the parameter specified by the path attribute.
-\item[{\normalfont \ttfamily update}:] This will update the value of the parameter specified by the path attribute with that given by the value attribute of the change element.
+\item[{\normalfont \ttfamily append}:] This will append all parameters enclosed within the change element to the children of the parameter specified by the {\normalfont \ttfamily path} attribute.
+\item[{\normalfont \ttfamily insertBefore}:] This will insert all parameters enclosed within the change element before the parameter specified by the {\normalfont \ttfamily path} attribute.
+\item[{\normalfont \ttfamily insertAfter}:] This will insert all parameters enclosed within the change element after the parameter specified by the {\normalfont \ttfamily path} attribute.
+\item[{\normalfont \ttfamily replace}:] This will replace the parameter specified by the {\normalfont \ttfamily path} attribute with all parameters enclosed within the change element.
+\item[{\normalfont \ttfamily replaceWith}:] This will replace the parameter specified by the {\normalfont \ttfamily path} attribute with the parameter (and all children) from the parameter file at the path specified by the {\normalfont \ttfamily target} attribute (note that the parameter identified by the {\normalfont \ttfamily target} attribute is not removed)
+\item[{\normalfont \ttfamily replaceOrAppend}:] This will replace the parameter specified by the {\normalfont \ttfamily path} attribute, if it exists, with all parameters enclosed within the change element. If the parameter does not exist, instead all parameters enclosed within the change element will be appended to the children of the parent element.
+\item[{\normalfont \ttfamily remove}:] This will remove the parameter specified by the {\normalfont \ttfamily path} attribute.
+\item[{\normalfont \ttfamily update}:] This will update the value of the parameter specified by the {\normalfont \ttfamily path} attribute with that given by the {\normalfont \ttfamily value} attribute of the change element.
 \end{description}
 
 \section{General Structure of Output File}\label{sec:outputFile}

--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -351,7 +351,8 @@ contains
     use :: File_Utilities    , only : File_Exists
     use :: FoX_dom           , only : node                             , getAttribute, setAttribute          , getParentNode, &
          &                            removeChild                      , getNodeName , hasAttribute          , appendChild  , &
-         &                            importNode                       , insertBefore, getNextSibling        , destroy
+         &                            importNode                       , insertBefore, getNextSibling        , destroy      , &
+         &                            getExceptionCode                 , inException , DOMException          , cloneNode
     use :: Error             , only : Error_Report
     use :: IO_XML            , only : XML_Get_First_Element_By_Tag_Name, XML_Parse   , XML_Get_Child_Elements, xmlNodeList  , &
          &                            XML_Path_Exists
@@ -368,10 +369,17 @@ contains
          &                                                               changesDoc           , childNode        , &
          &                                                               changeNode           , changeNodeParent , &
          &                                                               changesNode          , importedNode     , &
-         &                                                               newNode              , changeSiblingNode
+         &                                                               newNode              , changeSiblingNode, &
+         &                                                               targetNode           , clonedNode
     integer                                                           :: errorStatus          , i                , &
-         &                                                               j                    , k
-    type     (varying_string )                                        :: changePath
+         &                                                               j                    , k                , &
+         &                                                               exceptionCode
+    type     (DOMException   )                                        :: exception
+    type     (varying_string )                                        :: errorMessage         , fileNameFailed
+    logical                                                           :: parseSuccess         , isException      , &
+         &                                                               append
+    type     (varying_string )                                        :: changePath           , targetPath       , &
+         &                                                               valueUpdated
     character(len=32         )                                        :: changeType
 
     ! Check that the file exists.
@@ -460,9 +468,20 @@ contains
                 changeNode       => removeChild  (changeNodeParent,changeNode)
              case ("update")
                 ! Update the value of the identified node.
-                if (.not.hasAttribute(changeNode,"value")) call Error_Report('can not update the `value` in a parameter that has no `value`'//{introspection:location})
-                if (.not.hasAttribute(childNode ,"value")) call Error_Report('`change` element must have the `value` attribute'             //{introspection:location})
-                call setAttribute(changeNode,"value",getAttribute(childNode,"value"))
+                if (.not.hasAttribute(changeNode,"value" )) call Error_Report('can not update the `value` in a parameter that has no `value`'//{introspection:location})
+                if (.not.hasAttribute(childNode ,"value" )) call Error_Report('`change` element must have the `value` attribute'             //{introspection:location})
+                if (     hasAttribute(childNode ,"append")) then
+                   append=getAttribute(childNode,"append") == "true"
+                else
+                   append=.false.
+                end if
+                if (append) then
+                   valueUpdated=getAttribute(changeNode,"value")
+                else
+                   valueUpdated=""
+                end if
+                valueUpdated=valueUpdated//getAttribute(childNode,"value")
+                call setAttribute(changeNode,"value",char(valueUpdated))
              case ("append")
                 ! Append new parameters.
                 call XML_Get_Child_Elements(childNode,newNodes)
@@ -490,6 +509,16 @@ contains
                    end if
                 end do
                 if (trim(changeType) == "replace") changeNode => removeChild(changeNodeParent,changeNode)
+             case ("replaceWith")
+                ! Replace a parameter with another parameter.
+                if (.not.hasAttribute(childNode,"target")) call Error_Report('`change` element with `type="replaceWith"` must have the `target` attribute'//{introspection:location})
+                targetPath=getAttribute(childNode,"target")
+                if (.not.XML_Path_Exists(parameterNode,char(targetPath))) call Error_Report("target path does not exist"//{introspection:location})
+                targetNode       => XML_Get_First_Element_By_Tag_Name(parameterNode,char(targetPath),directChildrenOnly=.true.)
+                clonedNode       => cloneNode    (targetNode                            ,deep=.true.)
+                changeNodeParent => getParentNode(                            changeNode            )
+                clonedNode       => insertBefore (changeNodeParent,clonedNode,changeNode            )
+                changeNode       => removeChild  (changeNodeParent           ,changeNode            )
              case default
                 call Error_Report("unknown change type `"//trim(changeType)//"`"//{introspection:location})
              end select


### PR DESCRIPTION
Adds a `replaceWith` change type that allows one parameter to be replaced by another. Also adds an `append` option to the `update` change type.