### PR TITLE
Add a subhalo emulation test workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1414,6 +1414,71 @@ jobs:
       runPath: ./testSuite
       options: --mpi 1
     secrets: inherit
+  ## Emulation
+  Emulation-Subhalos:
+    runs-on: ubuntu-latest
+    container: ghcr.io/galacticusorg/buildenv:latest
+    needs: Build-Executable-DMO-Linux
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server."
+      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: Check out repository datasets
+        uses: actions/checkout@v4      
+        with:
+          repository: galacticusorg/datasets
+          path: datasets
+      - name: Check out repository emulation
+        uses: actions/checkout@v4      
+        with:
+          repository: galacticusorg/emulation
+          path: emulation
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
+          echo "PYTHONPATH=$GITHUB_WORKSPACE/python" >> $GITHUB_ENV
+      - name: Install Python
+        run: |
+          apt -y update && apt -y upgrade
+          apt -y install python3-dev python3-pip python3-venv
+      - name: Create VirtualEnv
+        run: |
+	  python3 -m venv virtualenv
+	  source virtualenv/bin/activate
+      - name: Install Python packages
+        run: |
+	  pip3 install --upgrade pip
+	  pip3 install --upgrade TensorFlow tensorflow_probability tf_keras matplotlib scipy lenstronomy tqdm colossus mcfit
+      - name: Install Samana
+        run: |
+	  git clone https://github.com/dangilman/samana.git
+	  cd samana
+	  python3 setup.py install
+	  cd -
+      - name: Install pyHalo
+        run: |
+	  git clone https://github.com/dangilman/pyHalo.git
+	  cd pyHalo
+	  python3 setup.py install
+	  cd -
+      - name: Generate training data
+        run: |
+	  mkdir -p testSuite/outputs/emulation-subhalos
+	  ./Galacticus.exe testSuite/parameters/emulation-lensSubhalos.xml
+      - name: Train the emulator
+        run: python3 scripts/emulation/emulatorSubhalosTraining.py testSuite/outputs/emulation-lensSubhalos.hdf5 --outputDirectory testSuite/outputs/emulation-subhalos
+      - name: Perform a test inference
+        run: python3 scripts/emulation/emulatorSubhaloQuadLensingInference.py --outputDirectory testSuite/outputs/emulation-subhalos
+      - name: Upload plots
+        uses: actions/upload-artifact@v4
+        with:
+          name: emulation-subhalos
+          path: ./testSuite/outputs/emulation-subhalos/*.pdf
+      - run: echo "This job's status is ${{ job.status }}."
   ## Python Interface
   Python-Interface:
     runs-on: ubuntu-latest

--- a/parameters/reference/mergerTrees.xml
+++ b/parameters/reference/mergerTrees.xml
@@ -13,7 +13,7 @@
     <!-- Use a 'filter' constructor here. It will default to an 'always' filter (making it inactive), but this allows models to
          impose a filter if they wish to do so. -->
     <mergerTreeConstructor value="build">
-      <redshiftBase value="0.0"/>
+      <redshiftBase value="=[mergerTreeRedshiftBase|0.0]"/>
     </mergerTreeConstructor>
   </mergerTreeConstructor>
   <mergerTreeBuilder     value="cole2000">

--- a/python/emulator_utils.py
+++ b/python/emulator_utils.py
@@ -1,0 +1,128 @@
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+from tensorflow.keras import regularizers
+import numpy as np
+import tensorflow_probability as tfp
+from scipy import stats
+
+# This function transforms data from normalized coordinates to hypercube coordinates
+def norm_transform(data, min_val, max_val):
+    data_min = np.nanmin(data, axis = 0)
+    data_max = np.nanmax(data, axis = 0)
+    sigma_data = (data - data_min)/(data_max - data_min)
+    return data_min, data_max, sigma_data*(max_val - min_val) + min_val
+
+# This function transforms data from hypercube coordinates to normalized coordinates
+def norm_transform_inv(norm_data, data_min, data_max, min_val, max_val):
+    sigma_data = (norm_data - min_val)/(max_val - min_val)
+    return sigma_data*(data_max - data_min) + data_min
+
+### CREATING EMULATOR CLASSES/FUNCTIONS ###
+
+# Creating an individual coupling layer with keras API.
+def Coupling(input_shape, output_dim = 256, reg = 0.01):
+    input = keras.layers.Input(shape=(input_shape,))
+
+    t_layer_1 = keras.layers.Dense(
+        output_dim, activation="relu", kernel_regularizer=regularizers.l2(reg)
+    )(input)
+    t_layer_2 = keras.layers.Dense(
+        output_dim, activation="relu", kernel_regularizer=regularizers.l2(reg)
+    )(t_layer_1)
+    t_layer_3 = keras.layers.Dense(
+        output_dim, activation="relu", kernel_regularizer=regularizers.l2(reg)
+    )(t_layer_2)
+    t_layer_4 = keras.layers.Dense(
+        output_dim, activation="relu", kernel_regularizer=regularizers.l2(reg)
+    )(t_layer_3)
+    t_layer_5 = keras.layers.Dense(
+        input_shape, activation="tanh", kernel_regularizer=regularizers.l2(reg)
+    )(t_layer_4)
+
+    s_layer_1 = keras.layers.Dense(
+        output_dim, activation="relu", kernel_regularizer=regularizers.l2(reg)
+    )(input)
+    s_layer_2 = keras.layers.Dense(
+        output_dim, activation="relu", kernel_regularizer=regularizers.l2(reg)
+    )(s_layer_1)
+    s_layer_3 = keras.layers.Dense(
+        output_dim, activation="relu", kernel_regularizer=regularizers.l2(reg)
+    )(s_layer_2)
+    s_layer_4 = keras.layers.Dense(
+        output_dim, activation="relu", kernel_regularizer=regularizers.l2(reg)
+    )(s_layer_3)
+    s_layer_5 = keras.layers.Dense(
+        input_shape, activation="tanh", kernel_regularizer=regularizers.l2(reg)
+    )(s_layer_4)
+
+    return keras.Model(inputs=input, outputs=[s_layer_5, t_layer_5])
+
+# Defining the type of normalizing flows model used. This model uses real-valued non-volume preserving (RealNVP) transformations
+class RealNVP(keras.Model):
+    def __init__(self, num_coupling_layers):
+        super(RealNVP, self).__init__()
+
+        self.num_coupling_layers = num_coupling_layers
+
+        self.distribution = tfp.distributions.MultivariateNormalDiag(
+            loc=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], scale_diag= [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+        )
+        self.masks = np.array(
+            [[1, 0, 1, 0, 1, 0], [0, 1, 0, 1, 0, 1], [1, 0, 1, 0, 1, 0], [0, 1, 0, 1, 0, 1], [1, 0, 1, 0, 1, 0], [0, 1, 0, 1, 0, 1], ] * (num_coupling_layers // 2), dtype="float32"
+        )
+        self.loss_tracker = keras.metrics.Mean(name="loss")
+        self.layers_list = [Coupling(6) for i in range(num_coupling_layers)]
+
+    @property
+    def metrics(self):
+        """List of the model's metrics.
+        We make sure the loss tracker is listed as part of `model.metrics`
+        so that `fit()` and `evaluate()` are able to `reset()` the loss tracker
+        at the start of each epoch and at the start of an `evaluate()` call.
+        """
+        return [self.loss_tracker]
+
+    def call(self, x, training=True):
+        log_det_inv = 0
+        direction = 1
+        if training:
+            direction = -1
+        for i in range(self.num_coupling_layers)[::direction]:
+            x_masked = x * self.masks[i]
+            reversed_mask = 1 - self.masks[i]
+            s, t = self.layers_list[i](x_masked)
+            s *= reversed_mask
+            t *= reversed_mask
+            gate = (direction - 1) / 2
+            x = (
+                reversed_mask
+                * (x * tf.exp(direction * s) + direction * t * tf.exp(gate * s))
+                + x_masked
+            )
+            log_det_inv += gate * tf.reduce_sum(s, [1])
+
+        return x, log_det_inv
+
+    def log_loss(self, data):
+        x = data[:,0:-1]
+        m = data[:,0]
+        y, logdet = self(x)
+        log_likelihood = self.distribution.log_prob(y) + logdet
+        return -tf.reduce_mean(log_likelihood)
+
+    def train_step(self, data):
+        with tf.GradientTape() as tape:
+            loss = self.log_loss(data)
+
+        g = tape.gradient(loss, self.trainable_variables)
+        self.optimizer.apply_gradients(zip(g, self.trainable_variables))
+        self.loss_tracker.update_state(loss)
+
+        return {"loss": self.loss_tracker.result()}
+
+    def test_step(self, data):
+        loss = self.log_loss(data)
+        self.loss_tracker.update_state(loss)
+
+        return {"loss": self.loss_tracker.result()}

--- a/scripts/emulation/emulatorSubhaloQuadLensingInference.py
+++ b/scripts/emulation/emulatorSubhaloQuadLensingInference.py
@@ -1,0 +1,123 @@
+# Use a subhalo emulator to perform inference on a quad-lensing system.
+import argparse
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+from tensorflow.keras import regularizers
+import numpy as np
+import tensorflow_probability as tfp
+import h5py
+from samana.forward_model import forward_model
+import os
+import sys
+import random
+from scipy import stats
+from emulator_utils import norm_transform_inv, Coupling, RealNVP
+
+# Parse command line arguments.
+parser = argparse.ArgumentParser(prog='emulatorSubhaloQuadLensingInference.py',description='Use an emulator to perform inference on a quad-lensing system.')
+parser.add_argument('--outputDirectory', action='store',default='.',help='the directory to which emulator weights (and plots) were output and to which results should be output')
+args = parser.parse_args()
+
+# Reading in the data and converting it from a string to a list of lists and floats.
+with h5py.File(args.outputDirectory+'/normalizationData.hdf5', 'r') as normalizationFile:
+    minArray          = normalizationFile['minArray'][:]
+    maxArray          = normalizationFile['maxArray'][:]
+    massTree          = normalizationFile.attrs['massTree'         ]
+    redshiftTree      = normalizationFile.attrs['redshiftTree'     ]
+    radiusVirialHost  = normalizationFile.attrs['radiusVirialHost' ]
+    massResolution    = normalizationFile.attrs['massResolution'   ]
+    countSubhalosMean = normalizationFile.attrs['countSubhalosMean']
+
+# Build an emulator and read in weights.
+emulator = RealNVP(num_coupling_layers=12)
+emulator.build(input_shape= (6))
+emulator.load_weights(args.outputDirectory+'/emulator.weights.h5')
+
+# Creating function that takes emulator weights (and other required data) to produce a population of un-normalized emulated subhalos.
+def emulator_data(emulator = emulator, minArray = minArray, maxArray = maxArray, massTree = massTree, massResolution = massResolution, radiusVirialHost = radiusVirialHost, countSubhalosMean = countSubhalosMean, count_iterations = 1):
+
+    # Define properties of the negative binomial distribution used to sample the number of subhalos.
+    widthIntrinsic     = 0.18
+    probabilitySuccess = 1.0/(1.0+countSubhalosMean*widthIntrinsic**2)
+    rateStopping       = 1.0/widthIntrinsic**2
+    countSubhalos      = np.arange(stats.nbinom.ppf(0, rateStopping, probabilitySuccess),stats.nbinom.ppf(0.9999999999999999, rateStopping, probabilitySuccess))
+    countSubhalosPMF   = np.nan_to_num(stats.nbinom.pmf(countSubhalos,rateStopping,probabilitySuccess))
+    # Sample a number of subhalos.
+    countSubhalo       = int(np.random.choice(countSubhalos, p = countSubhalosPMF))
+    # Build a sample of subhalos.
+    iteration          =  0
+    iterationsMaximum  = 10
+    data               = np.empty((0,6))
+    while len(data) < countSubhalo and iteration < iterationsMaximum:
+        samples    = emulator.distribution.sample(countSubhalo)
+        x, _       = emulator.predict(samples, batch_size=65336)
+        xt         = norm_transform_inv(x, minArray, maxArray, -1, 1)
+        filter     = (xt[:,0] > np.log10(2.0*massResolution/massTree)) & (xt[:,2] <= 0.0) & (xt[:,2] > -xt[:,0]+np.log10(massResolution/massTree)) & (xt[:,3] >= redshiftTree) & (xt[:,2] < np.log10(1e9/(massTree*10**xt[:,0])))
+        data       = np.vstack((data,xt[filter]))
+        increment += 1
+    if len(data) < countSubhalo:
+        sys.exit('failed to generate sufficient subhalos')
+    # Truncate the number of subhalos to the required number.
+    data = data[:countSubhalo]
+    # Extract unnormalized subhalo properties.
+    massInfall       = massTree        *(10.0**data[:,0])
+    concentration    =                         data[:,1]
+    massBound        = massInfall      *(10.0**data[:,2])
+    redshift         =                         data[:,3]
+    radiusTruncation = radiusVirialHost*(10.0**data[:,4])
+    radiusProjected  = radiusVirialHost*(10.0**data[:,5])
+
+    # Find (x,y) coordinates.
+    phi   = 2.0*np.pi*np.random.uniform(size=len(radiusProjected))
+    x     = radiusProjected*np.cos(phi)
+    y     = radiusProjected*np.sin(phi)
+
+    return massInfall, concentration, massBound, redshift, radiusTruncation, x, y
+
+# Construct input parameters for the forward_model() function of samana.
+job_index                   = 1
+n_keep                      = 2
+summary_statistic_tolerance = 1e5
+
+from samana.Data.Mocks.baseline_smooth_mock import BaselineSmoothMockModel
+from samana.Data.Mocks.baseline_smooth_mock import BaselineSmoothMock
+data_class        = BaselineSmoothMock()
+model             = BaselineSmoothMockModel
+preset_model_name = 'DMEmulator'
+
+# Sample options.
+kwargs_sample_realization = {}
+kwargs_sample_realization['LOS_normalization'        ] = ['FIXED',  0.0         ]
+kwargs_sample_realization['log_m_host'               ] = ['FIXED', 13.3         ]
+kwargs_sample_realization['cone_opening_angle_arcsec'] = ['FIXED',  8.0         ]
+kwargs_sample_realization['log_mlow'                 ] = ['FIXED',  6.0         ]
+kwargs_sample_realization['log_mhigh'                ] = ['FIXED',  9.0         ]
+kwargs_sample_realization['sigma_sub'                ] = ['FIXED',  0.0         ]
+kwargs_sample_realization['log_mc'                   ] = ['FIXED',  4.0         ]
+kwargs_sample_realization['emulator_input'           ] = ['FIXED', emulator_data]
+
+# Source options.
+kwargs_sample_source      = {'source_size_pc': ['FIXED', 5]}
+kwargs_sample_macro_fixed = {
+    'a4_a':         ['FIXED'   , 0.0              ], 
+    'a3_a':         ['FIXED'   , 0.0              ],
+    'delta_phi_m3': ['GAUSSIAN', -np.pi/6, np.pi/6]
+}
+kwargs_model_class = {'shapelets_order': 10}
+
+# Run the forward model analysis.
+forward_model(args.outputDirectory+"/", job_index, n_keep, data_class, model, preset_model_name, 
+              kwargs_sample_realization, kwargs_sample_source, kwargs_sample_macro_fixed,
+              tolerance=summary_statistic_tolerance, log_mlow_mass_sheets = 6.0, kwargs_model_class = kwargs_model_class, verbose=False, test_mode=False)
+
+fluxes = np.genfromtxt(args.outputDirectory+'/job_'+str(job_index)+'/fluxes.txt')
+print('Flux ratios:')
+for i in range(len(fluxes)):
+    f2f1 = fluxes[i][1]/fluxes[i][0]
+    f3f1 = fluxes[i][2]/fluxes[i][0]
+    f4f1 = fluxes[i][3]/fluxes[i][0]
+    print(f'   {f2f1}, {f3f1}, {f4f1}')
+
+
+print('SUCCESS')

--- a/scripts/emulation/emulatorSubhalosTraining.py
+++ b/scripts/emulation/emulatorSubhalosTraining.py
@@ -1,0 +1,301 @@
+# Train a normalizing flow emulator on Galacticus subhalo populations.
+import argparse
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+from tensorflow.keras import regularizers
+import numpy as np
+import matplotlib.pyplot as plt
+import tensorflow_probability as tfp
+import h5py
+from scipy import stats
+from emulator_utils import norm_transform, norm_transform_inv, Coupling, RealNVP
+
+# Parse command line arguments.
+parser = argparse.ArgumentParser(prog='emulatorSubhalosTraining.py',description='Train an emulator on Galacticus subhalo populations.')
+parser.add_argument('filename',nargs='+')
+parser.add_argument('--outputDirectory', action='store',default='.',help='the directory to which emulator weights (and plots) should be output')
+args = parser.parse_args()
+
+# Read all training data from file.
+## Initialize arrays that will accumulate training data.
+countSubhalosMean_             = np.array([])
+weights                        = np.array([])
+massInfallNormalized           = np.array([])
+concentrationNormalized        = np.array([])
+massBoundNormalized            = np.array([])
+redshiftLastIsolatedNormalized = np.array([])
+truncationRadiusNormalized     = np.array([])
+projectedRadiusNormalized      = np.array([])
+# Readi in Galacticus data from each file.
+for fileName in args.filename:
+    model                      = h5py.File(fileName, 'r')
+    mergerTreeConstructorGroup = model['Parameters/mergerTreeConstructor/mergerTreeConstructor']
+    mergerTreeBuildMassesGroup = model['Parameters/mergerTreeBuildMasses'                      ]
+    massResolutionGroup        = model['Parameters/mergerTreeMassResolution'                   ]
+    outputGroup                = model['Outputs/Output1/nodeData'                              ]
+    # Get masses and counts of trees.
+    massTree              = mergerTreeBuildMassesGroup.attrs['massTree'      ][0]
+    countTree             = mergerTreeBuildMassesGroup.attrs['treeCount'     ][0]
+    redshiftTree          = mergerTreeConstructorGroup.attrs['redshiftBase'  ]
+    massResolution        = massResolutionGroup       .attrs['massResolution']
+    # Read all required properties.
+    weight                = outputGroup['nodeSubsamplingWeight'       ][:]
+    treeIndex             = outputGroup['mergerTreeIndex'             ][:]
+    isCentral             = outputGroup['nodeIsIsolated'              ][:]
+    massInfall            = outputGroup['massHaloEnclosedCurrent'     ][:]
+    massBound             = outputGroup['satelliteBoundMass'          ][:]
+    concentration         = outputGroup['concentration'               ][:]
+    truncationRadius      = outputGroup['radiusTidalTruncationNFW'    ][:]
+    scaleRadius           = outputGroup['darkMatterProfileScale'      ][:]
+    redshiftLastIsolated  = outputGroup['redshiftLastIsolated'        ][:]
+    positionOrbitalX      = outputGroup['positionOrbitalX'            ][:]
+    positionOrbitalY      = outputGroup['positionOrbitalY'            ][:]
+    positionOrbitalZ      = outputGroup['positionOrbitalZ'            ][:]
+    radiusVirial          = outputGroup['darkMatterOnlyRadiusVirial'  ][:]
+    velocityVirial        = outputGroup['darkMatterOnlyVelocityVirial'][:]
+    # Compute derived quantities.
+    radiusProjected       = np.sqrt(positionOrbitalX**2+positionOrbitalY**2                    )
+    radiusOrbital         = np.sqrt(positionOrbitalX**2+positionOrbitalY**2+positionOrbitalZ**2)
+    # Identify centrals and subhalos.
+    subhalos              = (isCentral == 0) & (massInfall > 2.0*massResolution)
+    centrals              = (isCentral == 1)
+    # Count subhalos per tree, and find the mean.
+    countSubhalos         = np.zeros(countTree)
+    for j in range(countTree):
+        selectTree       = (isCentral == 0) & (massInfall > 2.0*massResolution) & (treeIndex == j+1)
+        countSubhalos[j] = np.sum(weight[selectTree])
+    # Fix any overmassive subhalos to their infall mass. This can happen (rarely) because of the choice of halo mass definition.
+    overMassive            = (massBound > massInfall)
+    massBound[overMassive] = massInfall[overMassive]
+    # Compute normalized quantities.
+    radiusVirialHost_               = radiusVirial[centrals][0]
+    massInfallNormalized_           = np.log10(massInfall          [subhalos]/massTree                   )
+    massBoundNormalized_            = np.log10(massBound           [subhalos]/massInfall       [subhalos])
+    concentrationNormalized_        =          concentration       [subhalos]
+    redshiftLastIsolatedNormalized_ =          redshiftLastIsolated[subhalos]
+    radiusOrbitalNormalized_        = np.log10(radiusOrbital       [subhalos]/radiusVirialHost_          )
+    truncationRadiusNormalized_     = np.log10(truncationRadius    [subhalos]/radiusVirialHost_          )
+    projectedRadiusNormalized_      = np.log10(radiusProjected     [subhalos]/radiusVirialHost_          )
+    weight_                         = weight[subhalos]
+    # Accumulate normalized quantities.
+    countSubhalosMean_              = np.append(countSubhalosMean_            , countSubhalos                  )
+    weights                         = np.append(weights                       , weight_                        )
+    massInfallNormalized            = np.append(massInfallNormalized          , massInfallNormalized_          )
+    concentrationNormalized         = np.append(concentrationNormalized       , concentrationNormalized_       )
+    massBoundNormalized             = np.append(massBoundNormalized           , massBoundNormalized_           )
+    redshiftLastIsolatedNormalized  = np.append(redshiftLastIsolatedNormalized, redshiftLastIsolatedNormalized_)
+    truncationRadiusNormalized      = np.append(truncationRadiusNormalized    , truncationRadiusNormalized_    )
+    projectedRadiusNormalized       = np.append(projectedRadiusNormalized     , projectedRadiusNormalized_     )
+
+# Find the number number of subhalos per tree.
+countSubhalosMean = np.mean(countSubhalosMean_)
+    
+# Pack all subhalo data into a 6D array.
+data = np.array(
+    list(
+        zip(
+            massInfallNormalized          ,
+            concentrationNormalized       ,
+            massBoundNormalized           ,
+            redshiftLastIsolatedNormalized,
+            truncationRadiusNormalized    ,
+            projectedRadiusNormalized
+        )
+    )
+)
+
+# Shift the data into a unit cube, append the weights, and shuffle.
+data_min, data_max, dataNormalized = norm_transform(data,-1,1)
+dataNormalizedWeighted             = np.hstack((dataNormalized, np.expand_dims(weights,1)))
+np.random.shuffle(dataNormalizedWeighted)
+
+# Store normalization data to a file. This will be used to un-normalize the emulator output during inference.
+minArray = np.nanmin(data, axis = 0)
+maxArray = np.nanmax(data, axis = 0)
+with h5py.File(args.outputDirectory+'/normalizationData.hdf5', 'w') as normalizationFile:
+    normalizationFile.create_dataset("minArray",data=minArray)
+    normalizationFile.create_dataset("maxArray",data=maxArray)
+    normalizationFile.attrs['massTree'         ] = massTree
+    normalizationFile.attrs['redshiftTree'     ] = redshiftTree
+    normalizationFile.attrs['radiusVirialHost' ] = radiusVirialHost_
+    normalizationFile.attrs['massResolution'   ] = massResolution
+    normalizationFile.attrs['countSubhalosMean'] = countSubhalosMean
+
+# Train the emulator.
+model = RealNVP(num_coupling_layers=12)
+model.compile(optimizer=keras.optimizers.Adam(learning_rate=0.0001))
+history = model.fit(
+    dataNormalizedWeighted, batch_size=256, epochs=50, verbose=2, validation_split=0.2
+)
+model.save_weights(args.outputDirectory+'/emulator.weights.h5')
+
+# Build a new emulator from the training weights.
+emulator = RealNVP(num_coupling_layers=12)
+emulator.build(input_shape= (6))
+emulator.load_weights(args.outputDirectory+'/emulator.weights.h5')
+
+# Specify the number of subhalos to sample.
+countSample = 500
+
+# Generate a sample of subhalos from the emulator, an unnormalize.
+samples = emulator.distribution.sample(countSample)
+x, _    = emulator.predict(samples)
+xt      = norm_transform_inv(x, minArray, maxArray, -1, 1)
+
+# Extract to named arrays for convenience.
+massInfallNormalized           = xt[:,0]
+concentrationNormalized        = xt[:,1]
+massBoundNormalized            = xt[:,2]
+redshiftLastIsolatedNormalized = xt[:,3]
+truncationRadiusNormalized     = xt[:,4]
+projectedRadiusNormalized      = xt[:,5]
+
+# Create a filter to impose physical constraints on emulator halos.
+filter =                                                                                          \
+    (massInfallNormalized           >   np.log10(2.0*massResolution/massTree)                 ) & \
+    (massBoundNormalized            <   np.log10(1.0e9/(massTree*10.0**massInfallNormalized ))) & \
+    (massBoundNormalized            <=  0.0                                                   ) & \
+    (massBoundNormalized            >  -massInfallNormalized+np.log10(massResolution/massTree)) & \
+    (redshiftLastIsolatedNormalized >=  redshiftTree                                          )
+
+# Generate a weighted subsample of the original data with same number of subhalos as emulator subhalo population after filter is applied
+weight_   = weight[subhalos]
+selection = np.arange(0, weight_.size, 1, dtype=int)
+subsample = np.random.choice(selection, size=countSample, replace=True, p=weight_/np.sum(weight_))
+
+# Plot the loss function vs. training epoch.
+plt.figure()
+plt.plot(history.history["loss"    ])
+plt.plot(history.history["val_loss"])
+plt.legend(["train", "validation"], loc="upper right")
+plt.ylabel("loss function", fontsize = 'large')
+plt.xlabel("epoch"        , fontsize = 'large')
+plt.savefig(args.outputDirectory+'/lossFunction.pdf')
+plt.clf()
+
+# Plot CDF of concentrations.
+concentrations = np.linspace(3, 15, 100)
+cdfGalacticus  = []
+cdfEmulator    = []
+for concentration in concentrations:
+    cdfGalacticus.append(np.sum(data                   [subsample, 1] < concentration))
+    cdfEmulator  .append(np.sum(concentrationNormalized[filter      ] < concentration))
+cdfGalacticus                  = np.array(cdfGalacticus)/len(data                   [subsample, 1])
+cdfEmulator                    = np.array(cdfEmulator  )/len(concentrationNormalized[filter      ])
+concentrationDifferenceMaximum = concentrations[np.argmax(np.abs(cdfGalacticus-cdfEmulator))]
+plt.figure()
+plt.plot(concentrations, cdfGalacticus, 'k-', label = 'Galacticus')
+plt.plot(concentrations, cdfEmulator  , 'r-', label = 'Emulator'  )
+plt.axvline(x = concentrationDifferenceMaximum, linestyle = '--', color = 'grey')
+plt.ylim(0, 1)
+plt.xlabel('Concentration', fontsize = 'large')
+plt.ylabel('CDF'          , fontsize = 'large')
+plt.legend()
+plt.savefig(args.outputDirectory+'/concentrationCDF.pdf')
+plt.clf()
+
+# Compute two-sample K-S tests for each property.
+print('Two-sample K-S tests:')
+print('        infall mass: ', stats.ks_2samp(data[subsample, 0], xt[filter, 1]))
+print('      concentration: ', stats.ks_2samp(data[subsample, 1], xt[filter, 1]))
+print('         bound mass: ', stats.ks_2samp(data[subsample, 2], xt[filter, 2]))
+print('    infall redshift: ', stats.ks_2samp(data[subsample, 3], xt[filter, 3]))
+print('  truncation radius: ', stats.ks_2samp(data[subsample, 4], xt[filter, 4]))
+print('   projected radius: ', stats.ks_2samp(data[subsample, 5], xt[filter, 5]))
+
+# Make 2D density plots.
+from scipy.stats import gaussian_kde
+## Concentration.
+concentration_density_galacticus     = np.vstack([data[:, 0][subsample], data[:,1][subsample]])
+concentration_density_emulated       = np.vstack([xt[filter, 0], xt[filter, 1]])
+z1_galacticus                        = gaussian_kde(concentration_density_galacticus)(concentration_density_galacticus)
+z1_emulated                          = gaussian_kde(concentration_density_emulated)(concentration_density_emulated)
+## Bound mass.
+mass_bound_density_galacticus        = np.vstack([data[:, 0][subsample], data[:, 2][subsample]])
+mass_bound_density_emulated          = np.vstack([xt[filter, 0], xt[filter, 2]])
+z2_galacticus                        = gaussian_kde(mass_bound_density_galacticus)(mass_bound_density_galacticus)
+z2_emulated                          = gaussian_kde(mass_bound_density_emulated)(mass_bound_density_emulated)
+## Infall redshift.
+redshift_infall_density_galacticus   = np.vstack([data[:, 0][subsample], data[:, 3][subsample]])
+redshift_infall_density_emulated     = np.vstack([xt[filter, 0], xt[filter, 3]])
+z3_galacticus                        = gaussian_kde(redshift_infall_density_galacticus)(redshift_infall_density_galacticus)
+z3_emulated                          = gaussian_kde(redshift_infall_density_emulated)(redshift_infall_density_emulated)
+## Projected radius.
+orbital_radius_density_galacticus    = np.vstack([data[:, 0][subsample], data[:, 4][subsample]])
+orbital_radius_density_emulated      = np.vstack([xt[filter, 0], xt[filter, 4]])
+z4_galacticus                        = gaussian_kde(orbital_radius_density_galacticus)(orbital_radius_density_galacticus)
+z4_emulated                          = gaussian_kde(orbital_radius_density_emulated)(orbital_radius_density_emulated)
+## Truncation radius.
+truncation_radius_density_galacticus = np.vstack([data[:, 0][subsample], data[:, 5][subsample]])
+truncation_radius_density_emulated   = np.vstack([xt[filter, 0], xt[filter, 5]])
+z5_galacticus                        = gaussian_kde(truncation_radius_density_galacticus)(truncation_radius_density_galacticus)
+z5_emulated                          = gaussian_kde(truncation_radius_density_emulated)(truncation_radius_density_emulated)
+## Create the plot.
+f, axes = plt.subplots(5, 2)
+f.set_size_inches(15, 18)
+axes[0, 0].scatter(data[:, 0][subsample], data[:, 1][subsample], c = z1_galacticus, s=9)
+axes[0, 0].set(title="Galacticus", xlabel="mass infall", ylabel="concentration")
+axes[0, 1].scatter(xt[filter, 0], xt[filter, 1], c = z1_emulated, s=9)
+axes[0, 1].set(title="Generated", xlabel="mass infall", ylabel="concentration")
+axes[1, 0].scatter(data[:, 0][subsample], data[:, 2][subsample], c = z2_galacticus, s=9)
+axes[1, 0].set(title="Galacticus", xlabel="mass infall", ylabel="mass bound")
+axes[1, 1].scatter(xt[filter, 0], xt[filter, 2], c = z2_emulated, s=9)
+axes[1, 1].set(title="Generated", xlabel="mass infall", ylabel="mass bound")
+axes[2, 0].scatter(data[:, 0][subsample], data[:, 3][subsample], c = z3_galacticus, s=9)
+axes[2, 0].set(title="Galacticus", xlabel="mass infall", ylabel="redshift infall")
+axes[2, 1].scatter(xt[filter, 0], xt[filter, 3], c = z3_emulated, s=9)
+axes[2, 1].set(title="Generated", xlabel="mass infall", ylabel="redshift infall")
+axes[3, 0].scatter(data[:, 0][subsample], data[:, 4][subsample], c = z4_galacticus, s=9)
+axes[3, 0].set(title="Galacticus", xlabel="mass infall", ylabel="orbital radius")
+axes[3, 1].scatter(xt[filter, 0], xt[filter, 4], c = z4_emulated, s=9)
+axes[3, 1].set(title="Generated", xlabel= "mass infall", ylabel="orbital radius")
+axes[4, 0].scatter(data[:, 0][subsample], data[:, 5][subsample], c = z5_galacticus, s=9)
+axes[4, 0].set(title="Galacticus", xlabel="mass infall", ylabel="truncation radius")
+axes[4, 0].set_ylim([-4.0, 0])
+axes[4, 1].scatter(xt[filter, 0], xt[filter, 5], c = z5_emulated, s=9)
+axes[4, 1].set(title="Generated", xlabel="mass infall", ylabel="truncation radius")
+axes[4, 1].set_ylim([-4.0, 0])
+plt.savefig(args.outputDirectory+'/density2D.pdf')
+plt.clf()
+
+# Make 1D PDF plots.
+f, axes = plt.subplots(6)
+f.set_size_inches(15, 20)
+axes[0].hist(data[:     , 0][subsample], bins = 70, range = (-5, 0), label = 'Galacticus', fill = True , edgecolor = 'blue'  )
+axes[0].hist(xt  [filter, 0]           , bins = 70, range = (-5, 0), label = 'Emulated'  , fill = False, edgecolor = 'orange')
+axes[0].set(title = 'Infall Mass'      )
+axes[0].legend()
+axes[1].hist(data[:     , 1][subsample], bins = 70, range = (0, 30), label = 'Galacticus', fill = True , edgecolor = 'blue'  )
+axes[1].hist(xt  [filter, 1]           , bins = 70, range = (0, 30), label = 'Emulated'  , fill = False, edgecolor = 'orange')
+axes[1].set(title = 'Concentration'    )
+axes[1].legend()
+axes[2].hist(data[:     , 2][subsample], bins = 70, range = (-4, 0), label = 'Galacticus', fill = True , edgecolor = 'blue'  )
+axes[2].hist(xt  [filter, 2]           , bins = 70, range = (-4, 0), label = 'Emulated'  , fill = False, edgecolor = 'orange')
+axes[2].set(title = 'Bound Mass'       )
+axes[2].legend()
+axes[3].hist(data[:     , 3][subsample], bins = 70, range = (0, 10), label = 'Galacticus', fill = True , edgecolor = 'blue'  )
+axes[3].hist(xt  [filter, 3]           , bins = 70, range = (0, 10), label = 'Emulated'  , fill = False, edgecolor = 'orange')
+axes[3].set(title = 'Infall Redshift'  )
+axes[3].legend()
+axes[4].hist(data[:     , 4][subsample], bins = 70, range = (-2, 2), label = 'Galacticus', fill = True , edgecolor = 'blue'  )
+axes[4].hist(xt  [filter, 4]           , bins = 70, range = (-2, 2), label = 'Emulated'  , fill = False, edgecolor = 'orange')
+axes[4].set(title = 'Orbital radius'   )
+axes[4].legend()
+axes[5].hist(data[:     , 5][subsample], bins = 70, range = (-4, 0), label = 'Galacticus', fill = True , edgecolor = 'blue'  )
+axes[5].hist(xt  [filter, 5]           , bins = 70, range = (-4, 0), label = 'Emulated'  , fill = False, edgecolor = 'orange')
+axes[5].set(title = 'Truncation radius')
+axes[5].legend()
+plt.savefig(args.outputDirectory+'/density1D.pdf')
+plt.clf()
+
+# Make a plot showing the negative binomial distribution for subhalo numbers.
+widthIntrinsic     = 0.18
+probabilitySuccess = 1.0/(1.0+countSubhalosMean*widthIntrinsic**2)
+rateStopping       = 1.0/widthIntrinsic**2
+count              = np.arange(stats.nbinom.ppf(0.01, rateStopping, probabilitySuccess),stats.nbinom.ppf(0.99, rateStopping, probabilitySuccess))
+plt.plot(count, stats.nbinom.pmf(count, rateStopping, probabilitySuccess), 'ko', label='Negative binomial PMF')
+plt.savefig(args.outputDirectory+'/countSubhaloPMF.pdf')
+plt.clf()
+
+print('SUCCESS: subhalo emulator training')

--- a/testSuite/parameters/emulation-lensSubhalos.xml
+++ b/testSuite/parameters/emulation-lensSubhalos.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Dark matter subhalo evolution model -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="e9236b11f17f9c96b0cdac005d7945ac0febe7d5"/>
+
+  <verbosityLevel value="working"/>
+
+  <!-- Include required parameters -->
+  <xi:include href="../../parameters/reference/darkMatterParticleCDM.xml"       xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  <xi:include href="../../parameters/reference/cosmologyDarkMatterOnly.xml"     xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  <xi:include href="../../parameters/reference/powerSpectrum.xml"               xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  <xi:include href="../../parameters/reference/structureFormation.xml"          xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  <xi:include href="../../parameters/reference/darkMatterHalosProfile.xml"      xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  <xi:include href="../../parameters/reference/darkMatterHalosTidalHeating.xml" xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  <xi:include href="../../parameters/reference/darkMatterHalosStructure.xml"    xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  <xi:include href="../../parameters/reference/subhaloOrbits.xml"               xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  <xi:include href="../../parameters/reference/mergerTrees.xml"                 xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+  <xi:include href="../../parameters/reference/evolutionDarkMatterOnly.xml"     xpointer="xpointer(parameters/*)" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+
+  <!-- Random number generation -->
+  <randomNumberGenerator value="GSL">
+    <seed value="8122"/>
+  </randomNumberGenerator>
+
+  <!-- Task -->
+  <task                   value="evolveForests"/>
+  <evolveForestsWorkShare value="cyclic"       />
+
+  <!-- Tree masses and resolution -->
+  <mergerTreeRedshiftBase value="0.5"/>
+  <mergerTreeBuildMasses value="fixedMass">
+    <massTree  value="1.995e13"/>
+    <treeCount value="64"       />
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e8"/>
+  </mergerTreeMassResolution>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/emulation-subhalos/emulation-lensSubhalos.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+    <galacticFilter value="intervalPass">
+      <nodePropertyExtractor value="radiusOrbitalProjected"/>
+      <thresholdLow value="0.0"/>
+      <thresholdHigh value="20.0e-3"/>
+    </galacticFilter>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <redshifts value="0.5"/>
+  </outputTimes>
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="nodeIndices"           />
+    <nodePropertyExtractor value="virialProperties"      />
+    <nodePropertyExtractor value="tidallyTruncatedNFWFit"/>
+    <nodePropertyExtractor value="indicesTree"           />
+    <nodePropertyExtractor value="redshiftLastIsolated"  />
+    <nodePropertyExtractor value="positionOrbital"       />
+    <!-- Output halo properties under a virial definition consistent with that used by pyHalo -->
+    <nodePropertyExtractor value="massHalo">
+      <useLastIsolatedTime value="true"/>
+      <darkMatterProfileDMO value="NFW"/>
+      <virialDensityContrastDefinition value="fixed">
+        <densityType value="critical"/>
+        <densityContrastValue value="200.0"/>
+        <turnAroundOverVirialRadius value="2.0"/>
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="concentration">
+      <useLastIsolatedTime value="true"/>
+      <darkMatterProfileDMO value="NFW"/>
+      <virialDensityContrastDefinition value="fixed">
+        <densityType value="critical"/>
+        <densityContrastValue value="200.0"/>
+        <turnAroundOverVirialRadius value="2.0"/>
+      </virialDensityContrastDefinition>
+    </nodePropertyExtractor>
+  </nodePropertyExtractor>
+
+</parameters>


### PR DESCRIPTION
Generates a small sample of subhalos using Galacticus, trains an emulator on them, and uses that emulator to produce subhalo populations for use in [`pyHalo`](https://github.com/dangilman/pyHalo) to compute flux ratio statistics.