### PR TITLE
Add analytic solution for soliton and NFW mass profile

### DIFF
--- a/source/mass_distributions.spherical.solition_NFW.F90
+++ b/source/mass_distributions.spherical.solition_NFW.F90
@@ -318,7 +318,6 @@ contains
       class           (massDistributionSolitonNFW), intent(inout) :: self
       class           (coordinate                ), intent(in   ) :: coordinates
       double precision                                            :: radiusScaleFree, radiusCoreFree
-      double precision                            , parameter     :: A_soliton = 0.091d0
 
       radiusScaleFree=+coordinates%rSpherical()/self%radiusScale
       radiusCoreFree =+coordinates%rSpherical()/self%radiusCore

--- a/source/mass_distributions.spherical.solition_NFW.F90
+++ b/source/mass_distributions.spherical.solition_NFW.F90
@@ -281,7 +281,7 @@ contains
         &            -3465.0d0*   radiusCore**12
        atanterm    = +3465.0d0*atan(sqrt(A)*r/radiusCore)
        prefactor   = +Pi*densitySolitonCentral*radiusCore**3/(53760.0d0*A**1.5d0)
-       f           = +prefactor*(atanterm-term*poly)
+       f           = +prefactor*(atanterm+term*poly)
     end if
     return
    end function SolitonMass


### PR DESCRIPTION
At small radii, a third-order Taylor expansion (retaining terms up to r^7) is applied to improve numerical stability. The relative error of this approximation is estimated to be below 10^{-6} at r/r_c=0.1, using FDM halo parameters adopted in Chowdhury et al. (2021).