### PR TITLE
Correct calculation of merger tree evolution timesteps when using the `starFormationHistoryFixedAges` class

### DIFF
--- a/source/star_formation.histories.F90
+++ b/source/star_formation.histories.F90
@@ -112,6 +112,21 @@ module Star_Formation_Histories
       if (present(timeStart)) timeStart=0.0d0
     </code>
    </method>
+   <method name="timeNext">
+     <description></description>
+     <type>double precision</type>
+     <pass>yes</pass>
+     <argument>type(treeNode), intent(inout) :: node                </argument>
+     <argument>type(history ), intent(in   ) :: starFormationHistory</argument>
+     <modules>Galacticus_Nodes Arrays_Search</modules>
+     <code>
+       class  (nodeComponentBasic), pointer :: basic
+       integer(c_size_t          )          :: i
+       basic                        => node%basic()
+       i                            =  searchArray(starFormationHistory%time,basic%time())
+       starFormationHistoryTimeNext =  starFormationHistory%time(i+1)
+     </code>
+   </method>
    <method name="masses" >
     <description>Return an array of masses of stars formed for this history.</description>
     <type>double precision, allocatable, dimension(:,:)</type>


### PR DESCRIPTION
Adds a new method, `timeNext()`, to the `starFormationHistory` class, which computes the time of the next star formation history time bin boundary for a given node. A default implementation is provided, which assumes that the times stored in the star formation history objects are actual times. For the `starFormationHistoryFixedAges` class, its own implementation is provided, which accounts for the fact that the "times" stored in histories by this class are actually negative ages, and must be corrected to actual times, _and_ compared across all crossing times.