### PR TITLE
Force the use of dense attribute storage for the `Parameters` group

### DIFF
--- a/source/tests.IO.HDF5.F90
+++ b/source/tests.IO.HDF5.F90
@@ -31,7 +31,7 @@ program Tests_IO_HDF5
   use :: Unit_Tests        , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
   implicit none
   type            (hdf5Object     ), target                                 :: datasetObject                  , fileObject           , &
-       &                                                                       groupObject
+       &                                                                       groupObject                    , groupObject2
   integer                                                                   :: iPass                          , integerValue         , &
        &                                                                       integerValueReread             , i                    , &
        &                                                                       j                              , k
@@ -83,7 +83,7 @@ program Tests_IO_HDF5
   do iPass=1,2
 
      ! Open an HDF5 file.
-     call fileObject%openFile("testSuite/outputs/test.IO.HDF5.hdf5",overWrite=.true.,objectsOverwritable=.true.)
+     call fileObject%openFile("testSuite/outputs/test.IO.HDF5.hdf5",overWrite=.true.,objectsOverwritable=.true.,useLatestFormat=.true.)
 
      ! Open an HDF5 group.
      select case (iPass)
@@ -841,7 +841,15 @@ program Tests_IO_HDF5
         allocate(doubleValueArray4dReread(600,100,100,100))
         call fileObject%writeDataset(doubleValueArray4dReread,'bigDataset','A dataset larger than 4GB.',chunkSize=1024_hsize_t)
      end if
-     
+
+     ! Write an attribute of length >64KB by forcing dense storage of
+     ! attributes in s group.
+     groupObject2=fileObject%openGroup("myGroup64k",comment="This is my group for 64k attributes.",objectsOverwritable=.true.,chunkSize=1024_hsize_t&
+             &,compressionLevel=9,attributesCompactMaxiumum=0)
+     varStringValue=repeat("rain day happy calm dog joy joy over bright falls rain lazy shin ",1025)
+     call groupObject2%writeAttribute(varStringValue,"varStringAttribute64k")
+     call groupObject2%close()
+
      ! Close the group.
      call groupObject%close()
 

--- a/source/utility.IO.HDF5.F90
+++ b/source/utility.IO.HDF5.F90
@@ -1037,12 +1037,12 @@ contains
     !!}
     use :: File_Utilities    , only : File_Exists
     use :: Error             , only : Error_Report
-    use :: HDF5              , only : H5F_ACC_RDONLY_F     , H5F_ACC_RDWR_F        , H5F_ACC_TRUNC_F       , H5F_CLOSE_SEMI_F       , &
-          &                           H5F_LIBVER_EARLIEST_F, H5F_LIBVER_LATEST_F   , H5P_FILE_ACCESS_F     , h5fcreate_f            , &
-          &                           h5fopen_f            , h5pclose_f            , h5pcreate_f           , h5pset_cache_f         , &
-          &                           h5pset_fapl_stdio_f  , h5pset_fclose_degree_f, h5pset_libver_bounds_f, h5pset_sieve_buf_size_f, &
-          &                           hid_t                , hsize_t               , size_t
-    use :: ISO_Varying_String, only : assignment(=)        , len                   , operator(//)
+    use :: HDF5              , only : H5F_ACC_RDONLY_F   , H5F_ACC_RDWR_F        , H5F_ACC_TRUNC_F       , H5F_CLOSE_SEMI_F       , &
+          &                           H5F_LIBVER_V18_F  , H5F_LIBVER_LATEST_F   , H5P_FILE_ACCESS_F     , h5fcreate_f            , &
+          &                           h5fopen_f          , h5pclose_f            , h5pcreate_f           , h5pset_cache_f         , &
+          &                           h5pset_fapl_stdio_f, h5pset_fclose_degree_f, h5pset_libver_bounds_f, h5pset_sieve_buf_size_f, &
+          &                           hid_t              , hsize_t               , size_t
+    use :: ISO_Varying_String, only : assignment(=)      , len                   , operator(//)
     implicit none
     class    (hdf5Object    ), intent(inout)           :: fileObject
     character(len=*         ), intent(in   ), optional :: fileName
@@ -1103,14 +1103,16 @@ contains
     ! Set file format.
     if (present(useLatestFormat)) then
        if (useLatestFormat) then
-          call h5pset_libver_bounds_f(accessList,H5F_LIBVER_LATEST_F  ,H5F_LIBVER_LATEST_F,errorCode)
+          call h5pset_libver_bounds_f(accessList,H5F_LIBVER_LATEST_F,H5F_LIBVER_LATEST_F,errorCode)
        else
-          call h5pset_libver_bounds_f(accessList,H5F_LIBVER_EARLIEST_F,H5F_LIBVER_LATEST_F,errorCode)
+          call h5pset_libver_bounds_f(accessList,H5F_LIBVER_V18_F   ,H5F_LIBVER_LATEST_F,errorCode)
        end if
-       if (errorCode /= 0) then
-          message="failed to set file format for HDF5 file '"//fileObject%objectName//"'"
-          call Error_Report(message//{introspection:location})
-       end if
+    else
+       call    h5pset_libver_bounds_f(accessList,H5F_LIBVER_V18_F   ,H5F_LIBVER_LATEST_F,errorCode)
+    end if
+    if (errorCode /= 0) then
+       message="failed to set file format for HDF5 file '"//fileObject%objectName//"'"
+       call Error_Report(message//{introspection:location})
     end if
     if (present(cacheElementsCount).or.present(cacheSizeBytes)) then
        if (.not.(present(cacheElementsCount).and.present(cacheSizeBytes))) call Error_Report('both or neither of "cacheElementsCount" and "cacheSizeBytes" must be specified'//{introspection:location})
@@ -1196,14 +1198,15 @@ contains
 
   !! Group routines.
 
-  function IO_HDF5_Open_Group(inObject,groupName,comment,objectsOverwritable,overwriteOverride,chunkSize,compressionLevel) result (groupObject)
+  function IO_HDF5_Open_Group(inObject,groupName,comment,objectsOverwritable,overwriteOverride,chunkSize,compressionLevel,attributesCompactMaxiumum) result (groupObject)
     !!{
     Open an HDF5 group and return an appropriate HDF5 object. The group name can be provided as an input parameter or, if
     not provided, will be taken from the stored object name in {\normalfont \ttfamily groupObject}. The location at which to open the group is
     taken from either {\normalfont \ttfamily inObject} or {\normalfont \ttfamily inPath}.
     !!}
     use :: Error             , only : Error_Report
-    use :: HDF5              , only : HID_T        , h5gcreate_f , h5gopen_f, hsize_t
+    use :: HDF5              , only : HID_T        , h5gcreate_f               , h5gopen_f , hsize_t            , &
+         &                            h5pcreate_f  , h5pset_attr_phase_change_f, h5pclose_f, H5P_GROUP_CREATE_F
     use :: ISO_Varying_String, only : assignment(=), operator(//)
     implicit none
     type     (hdf5Object    )                          :: groupObject
@@ -1211,7 +1214,7 @@ contains
     character(len=*         ), intent(in   ), optional :: comment
     logical                  , intent(in   ), optional :: objectsOverwritable, overwriteOverride
     integer  (hsize_t       ), intent(in   ), optional :: chunkSize
-    integer                  , intent(in   ), optional :: compressionLevel
+    integer                  , intent(in   ), optional :: compressionLevel   , attributesCompactMaxiumum
     class    (hdf5Object    ), intent(in   ), target   :: inObject
     ! <HDF5> Why are "message" and "locationPath" saved? Because if they are not then they get dynamically allocated on the stack, which results
     ! in an invalid pointer error. According to valgrind, this happens because the wrong deallocation function is used (delete
@@ -1219,7 +1222,7 @@ contains
     ! deallocated. This is not an elegant solution, but it works.
     type     (varying_string), save                    :: locationPath       , message
     integer                                            :: errorCode
-    integer  (kind=HID_T    )                          :: locationID
+    integer  (kind=HID_T    )                          :: locationID         , propertyList
 
     ! Check that this module is initialized.
     call IO_HDF_Assert_Is_Initialized
@@ -1248,10 +1251,31 @@ contains
        end if
     else
        ! Create a group.
-       call h5gcreate_f(locationID,trim(groupName),groupObject%objectID,errorCode)
+       call h5pcreate_f(H5P_GROUP_CREATE_F,propertyList,errorCode)
+       if (errorCode < 0) then
+          message="unable to create property list for group '"//trim(groupName)//"'"
+          call Error_Report(message//groupObject%locationReport()//{introspection:location})
+       end if
+       ! Set the number of attributes allowed in compact
+       ! storage. (Setting this to zero will force dense storage for
+       ! all attributes, which enable storing of attributes with
+       ! length exceeding 64KB.)
+       if (present(attributesCompactMaxiumum)) then
+          call h5pset_attr_phase_change_f(propertyList,attributesCompactMaxiumum,attributesCompactMaxiumum,errorCode)
+          if (errorCode /= 0) then
+             message="failed to set attribute phase change for group '"//trim(groupName)
+             call Error_Report(message//groupObject%locationReport()//{introspection:location})
+          end if
+       end if
+       call h5gcreate_f(locationID,trim(groupName),groupObject%objectID,errorCode,gcpl_id=propertyList)
        if (errorCode < 0) then
           message="failed to make group '"//trim(groupName)//"' at "//locationPath
           call Error_Report(message//inObject%locationReport()//{introspection:location})
+       end if
+       call h5pclose_f(propertyList,errorCode)
+       if (errorCode /= 0) then
+          message="failed to close property list for group '"//trim(groupName)//"'"
+          call Error_Report(message//groupObject%locationReport()//{introspection:location})
        end if
     end if
 

--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -653,7 +653,7 @@ contains
     ! Set a pointer to HDF5 object to which to write parameters.
     if (present(outputParametersGroup)) then
        !$ call hdf5Access%  set()
-       self%outputParameters         =outputParametersGroup%openGroup('Parameters')
+       self%outputParameters         =outputParametersGroup%openGroup('Parameters',attributesCompactMaxiumum=0)
        self%outputParametersCopied   =.false.
        self%outputParametersTemporary=.false.
        !$ call hdf5Access%unset()
@@ -673,7 +673,7 @@ contains
             &                                                               )             &
             &                                            )                                &
             &                                      )
-       self%outputParameters         =self%outputParametersContainer%openGroup('Parameters')
+       self%outputParameters         =self%outputParametersContainer%openGroup('Parameters',attributesCompactMaxiumum=0)
        self%outputParametersCopied   =.false.
        self%outputParametersTemporary=.true.
        !$ call hdf5Access%unset()
@@ -1542,11 +1542,11 @@ contains
        call self%outputParameters         %close()
        call self%outputParametersContainer%close()
        call File_Remove(char(fileNameTemporary))
-       self%outputParameters=outputGroup%openGroup('Parameters')
+       self%outputParameters=outputGroup%openGroup('Parameters',attributesCompactMaxiumum=0)
        self%outputParametersTemporary=.false.
     else
        if (self%outputParameters%isOpen()) call self%outputParameters%close()
-       self%outputParameters      =outputGroup%openGroup('Parameters')
+       self%outputParameters      =outputGroup%openGroup('Parameters',attributesCompactMaxiumum=0)
     end if
     !$ call hdf5Access%unset()
     self%outputParametersCopied=.false.


### PR DESCRIPTION
This allows storing parameter values with lengths exceeding 64KB.