### PR TITLE
Avoid persistence of temporary parameter files on error

### DIFF
--- a/source/utility.input_parameters.F90
+++ b/source/utility.input_parameters.F90
@@ -583,7 +583,7 @@ contains
     !!}
     use            :: Display           , only : displayGreen                     , displayMessage  , displayMagenta  , displayReset  , &
          &                                       verbosityLevelSilent
-    use            :: File_Utilities    , only : File_Name_Temporary
+    use            :: File_Utilities    , only : File_Name_Temporary              , File_Remove
     use            :: FoX_dom           , only : getOwnerDocument                 , node            , setLiveNodeLists, getTextContent, &
          &                                       hasAttribute                     , getAttributeNode
     use            :: Error             , only : Error_Report
@@ -677,6 +677,7 @@ contains
        self%outputParametersCopied   =.false.
        self%outputParametersTemporary=.true.
        !$ call hdf5Access%unset()
+       call File_Remove(char(self%outputParametersContainer%name()))
     end if
     ! Get allowed parameter names.
     if (.not.allocated(allowedParameterNamesGlobal)) &
@@ -1025,7 +1026,6 @@ contains
     !!{
     Finalizer for the {\normalfont \ttfamily inputParameters} class.
     !!}
-    use :: File_Utilities    , only : File_Remove
     use :: FoX_dom           , only : destroy
     use :: HDF5_Access       , only : hdf5Access
     use :: ISO_Varying_String, only : char
@@ -1053,7 +1053,6 @@ contains
           call self%outputParametersContainer%close  ()
           call self%outputParameters         %destroy()
           call self%outputParametersContainer%destroy()
-          call File_Remove(char(fileNameTemporary))
        else
           ! Simply close our parameters group.
           call self%outputParameters%close  ()
@@ -1526,7 +1525,6 @@ contains
     !!{
     Open an output group for parameters in the given HDF5 object.
     !!}
-    use :: File_Utilities    , only : File_Remove
     use :: HDF5_Access       , only : hdf5Access
     use :: ISO_Varying_String, only : char
     implicit none
@@ -1541,7 +1539,6 @@ contains
        fileNameTemporary=self%outputParametersContainer%name()
        call self%outputParameters         %close()
        call self%outputParametersContainer%close()
-       call File_Remove(char(fileNameTemporary))
        self%outputParameters=outputGroup%openGroup('Parameters')
        self%outputParametersTemporary=.false.
     else


### PR DESCRIPTION
Previously, temporary parameter data was written to `/dev/shm/glcTmp*` files. These files were removed once the main file was opened and ready to receive parameters. If an error occurred during parameter reading the temporary file would be left in place, leading to an accumulation of these files.

This revision calls `unlink()` immediately after opening the temporary file. This removes the link to the file in the file system, but keeps it usable. Once the file is closed, the kernel then removes the data associated with the file. If the code crashes, the kernel cleans up any open file handles, also resulting in the data associated with the file being removed. This avoids accumulation of these files.