### PR TITLE
Add a kinematics class for the cusp-NFW profile

### DIFF
--- a/source/dark_matter_profiles_DMO.cusp-NFW.F90
+++ b/source/dark_matter_profiles_DMO.cusp-NFW.F90
@@ -147,8 +147,8 @@ contains
     Return the dark matter mass distribution for the given {\normalfont \ttfamily node}.
     !!}
     use :: Galacticus_Nodes          , only : nodeComponentBasic         , nodeComponentDarkMatterProfile
-    use :: Galactic_Structure_Options, only : componentTypeDarkHalo      , massTypeDark                                , weightByMass
-    use :: Mass_Distributions        , only : massDistributionCuspNFW    , kinematicsDistributionCollisionlessTabulated, massDistributionNFW, kinematicsDistributionNFW, &
+    use :: Galactic_Structure_Options, only : componentTypeDarkHalo      , massTypeDark                  , weightByMass
+    use :: Mass_Distributions        , only : massDistributionCuspNFW    , kinematicsDistributionCuspNFW , massDistributionNFW, kinematicsDistributionNFW, &
          &                                    kinematicsDistributionClass
     implicit none
     class           (massDistributionClass         ), pointer                 :: massDistribution_
@@ -174,12 +174,12 @@ contains
     amplitudeCuspScaleFree =  darkMatterProfile%floatRank0MetaPropertyGet(self%promptCuspNFWYID)
     if (amplitudeCuspScaleFree <= 0.0d0) then
        ! For halos with no cusp, use an NFW mass distribution.
-       allocate(massDistributionNFW                          :: massDistribution_      )
-       allocate(kinematicsDistributionNFW                    :: kinematicsDistribution_)
+       allocate(massDistributionNFW           :: massDistribution_      )
+       allocate(kinematicsDistributionNFW     :: kinematicsDistribution_)
     else
        ! For halos with a cusp, use the cusp-NFW distribution.
-       allocate(massDistributionCuspNFW                      :: massDistribution_      )
-       allocate(kinematicsDistributionCollisionlessTabulated :: kinematicsDistribution_)
+       allocate(massDistributionCuspNFW       :: massDistribution_      )
+       allocate(kinematicsDistributionCuspNFW :: kinematicsDistribution_)
     end if
     select type(massDistribution_)
     type is (massDistributionCuspNFW)
@@ -198,14 +198,14 @@ contains
        </referenceConstruct>
        !!]
        select type (kinematicsDistribution_)
-       type is (kinematicsDistributionCollisionlessTabulated)
+       type is (kinematicsDistributionCuspNFW)
           !![
 	  <referenceConstruct object="kinematicsDistribution_">
 	    <constructor>
-              kinematicsDistributionCollisionlessTabulated(                                                                                            &amp;
-               &amp;                                       toleranceRelativeVelocityDispersion       =self%toleranceRelativeVelocityDispersion       , &amp; 
-               &amp;                                       toleranceRelativeVelocityDispersionMaximum=self%toleranceRelativeVelocityDispersionMaximum  &amp; 
-	       &amp;                                      )
+              kinematicsDistributionCuspNFW(                                                                                            &amp;
+               &amp;                        toleranceRelativeVelocityDispersion       =self%toleranceRelativeVelocityDispersion       , &amp; 
+               &amp;                        toleranceRelativeVelocityDispersionMaximum=self%toleranceRelativeVelocityDispersionMaximum  &amp; 
+	       &amp;                       )
 	    </constructor>
 	  </referenceConstruct>
           !!]

--- a/source/kinematic_distributions.collisionless.cusp-NFW.F90
+++ b/source/kinematic_distributions.collisionless.cusp-NFW.F90
@@ -142,7 +142,7 @@ contains
                   &               *massDistributionEmbedding%y            **2
              if (radiusScaleFree < radiusScaleFreeSmall) then
                 ! Small radius. Use the tabulated solution at the small radius boundary, extrapolated to the actual
-                ! radius using the reuslt for a power-law ρ(r) ∝ r^{-3/2} profile.
+                ! radius using the result for a power-law ρ(r) ∝ r^{-3/2} profile.
                 coordinatesReference=[radiusScaleFreeSmall*massDistributionEmbedding%radiusScale,0.0d0,0.0d0]
                 velocityDispersion  =+massDistributionEmbedding%velocityDispersion1D         (coordinatesReference                                            ) &
                      &               *(                                                                                                                         &

--- a/source/kinematic_distributions.collisionless.cusp-NFW.F90
+++ b/source/kinematic_distributions.collisionless.cusp-NFW.F90
@@ -1,0 +1,167 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implementation of a kinematic distribution class for the cusp-NFW \citep{delos_cusp-halo_2025} mass distribution.
+  !!}
+
+  !![
+  <kinematicsDistribution name="kinematicsDistributionCuspNFW">
+   <description>A kinematic distribution class for the cusp-NFW \citep{delos_cusp-halo_2025} mass distribution.</description>
+  </kinematicsDistribution>
+  !!]
+  type, public, extends(kinematicsDistributionCollisionlessTabulated) :: kinematicsDistributionCuspNFW
+     !!{
+     A kinematics distribution for the cusp-NFW \citep{delos_cusp-halo_2025} mass distribution.
+     !!}
+   contains
+     procedure :: velocityDispersion1D => cuspNFWKinematicsVelocityDispersion1D
+  end type kinematicsDistributionCuspNFW
+
+  interface kinematicsDistributionCuspNFW
+     !!{
+     Constructors for the \refClass{kinematicsDistributionCuspNFW} kinematic distribution class.
+     !!}
+     module procedure cuspNFWKinematicsConstructorParameters
+     module procedure cuspNFWKinematicsConstructorInternal
+     module procedure cuspNFWKinematicsConstructorDecorated
+  end interface kinematicsDistributionCuspNFW
+
+contains
+
+  function cuspNFWKinematicsConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the \refClass{kinematicsDistributionCuspNFW} kinematic distribution class which builds the object from a parameter
+    set.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (kinematicsDistributionCuspNFW)                :: self
+    type            (inputParameters              ), intent(inout) :: parameters
+    double precision                                               :: toleranceRelativeVelocityDispersion, toleranceRelativeVelocityDispersionMaximum
+
+    !![
+    <inputParameter>
+      <name>toleranceRelativeVelocityDispersion</name>
+      <defaultValue>1.0d-6</defaultValue>
+      <source>parameters</source>
+      <description>The relative tolerance to use in numerical solutions for the velocity dispersion in dark-matter-only density profiles.</description>
+    </inputParameter>
+    <inputParameter>
+      <name>toleranceRelativeVelocityDispersionMaximum</name>
+      <defaultValue>1.0d-3</defaultValue>
+      <source>parameters</source>
+      <description>The maximum relative tolerance to use in numerical solutions for the velocity dispersion in dark-matter-only density profiles.</description>
+    </inputParameter>
+    !!]
+    self=kinematicsDistributionCuspNFW(toleranceRelativeVelocityDispersion,toleranceRelativeVelocityDispersionMaximum)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function cuspNFWKinematicsConstructorParameters
+
+  function cuspNFWKinematicsConstructorInternal(toleranceRelativeVelocityDispersion,toleranceRelativeVelocityDispersionMaximum) result(self)
+    !!{
+    Internal constructor for the \refClass{kinematicsDistributionCuspNFW} kinematic distribution class.
+    !!}
+    implicit none
+    type            (kinematicsDistributionCuspNFW)                          :: self
+    double precision                               , intent(in   ), optional :: toleranceRelativeVelocityDispersion, toleranceRelativeVelocityDispersionMaximum
+    !![
+    <constructorAssign variables="toleranceRelativeVelocityDispersion, toleranceRelativeVelocityDispersionMaximum"/>
+    !!]
+
+    return
+  end function cuspNFWKinematicsConstructorInternal
+  
+  function cuspNFWKinematicsConstructorDecorated(kinematicsDistribution_) result(self)
+    !!{
+    Internal constructor for the \refClass{kinematicsDistributionCuspNFW} kinematic distribution class.
+    !!}
+    implicit none
+    type (kinematicsDistributionCuspNFW)                :: self
+    class(kinematicsDistributionClass  ), intent(in   ) :: kinematicsDistribution_
+
+    self%toleranceRelativeVelocityDispersion       =kinematicsDistribution_%toleranceRelativeVelocityDispersion
+    self%toleranceRelativeVelocityDispersionMaximum=kinematicsDistribution_%toleranceRelativeVelocityDispersionMaximum
+    return
+  end function cuspNFWKinematicsConstructorDecorated
+  
+  logical function cuspNFWKinematicsIsCollisional(self)
+    !!{
+    Return false indicating that the cusp-NFW distribution represents collisionless particles.
+    !!}
+    implicit none
+    class(kinematicsDistributionCuspNFW), intent(inout) :: self
+    !$GLC attributes unused :: self
+    
+    cuspNFWKinematicsIsCollisional=.false.
+    return
+  end function cuspNFWKinematicsIsCollisional
+
+  double precision function cuspNFWKinematicsVelocityDispersion1D(self,coordinates,massDistribution_,massDistributionEmbedding) result(velocityDispersion)
+    !!{
+    Return the 1D velocity dispersion at the specified {\normalfont \ttfamily coordinates} in a cusp-NFW kinematic distribution.
+    !!}
+    use :: Error      , only : Error_Report
+    use :: Coordinates, only : coordinateSpherical, assignment(=)
+    implicit none
+    class           (kinematicsDistributionCuspNFW), intent(inout)          :: self
+    class           (coordinate                   ), intent(in   )          :: coordinates
+    class           (massDistributionClass        ), intent(inout), target  :: massDistribution_          , massDistributionEmbedding
+    class           (massDistributionClass        )               , pointer :: massDistribution__
+    double precision                                , parameter             :: fractionSmall       =1.0d-2
+    double precision                                                        :: radiusScaleFree            , radiusScaleFreeSmall
+    type            (coordinateSpherical          )                         :: coordinatesReference
+
+    massDistribution__ => massDistribution_
+    if (associated(massDistribution__,massDistributionEmbedding)) then
+       select type (massDistributionEmbedding)
+       class is (massDistributionCuspNFW)
+          if (.not.massDistributionEmbedding%isTabulating()) then
+             radiusScaleFree     =+coordinates              %rSpherical ()    &
+                  &               /massDistributionEmbedding%radiusScale
+             radiusScaleFreeSmall=+fractionSmall                              &
+                  &               *massDistributionEmbedding%y            **2
+             if (radiusScaleFree < radiusScaleFreeSmall) then
+                ! Small radius. Use the tabulated solution at the small radius boundary, extrapolated to the actual
+                ! radius using the reuslt for a power-law ρ(r) ∝ r^{-3/2} profile.
+                coordinatesReference=[radiusScaleFreeSmall*massDistributionEmbedding%radiusScale,0.0d0,0.0d0]
+                velocityDispersion  =+massDistributionEmbedding%velocityDispersion1D         (coordinatesReference                                            ) &
+                     &               *(                                                                                                                         &
+                     &                 +radiusScaleFree                                                                                                         &
+                     &                 /radiusScaleFreeSmall                                                                                                    &
+                     &                )**0.25d0
+             else
+                velocityDispersion  =+massDistributionEmbedding%velocityDispersion1D         (coordinates                                                     )
+             end if
+          else
+             velocityDispersion     =+self                     %velocityDispersion1DNumerical(coordinates         ,massDistribution_,massDistributionEmbedding)
+          end if
+       class default
+          velocityDispersion        =+0.0d0
+          call Error_Report('expecting a cusp-NFW mass distribution, but received '//char(massDistributionEmbedding%objectType())//{introspection:location})
+       end select
+    else
+       ! Our tabulated distribution is embedded in another distribution. We must compute the velocity dispersion numerically.
+       velocityDispersion           =+self                     %velocityDispersion1DNumerical(coordinates         ,massDistribution_,massDistributionEmbedding)
+    end if
+    return
+  end function cuspNFWKinematicsVelocityDispersion1D

--- a/source/kinematic_distributions.collisionless.tabulated.F90
+++ b/source/kinematic_distributions.collisionless.tabulated.F90
@@ -111,6 +111,7 @@ contains
     !!}
     implicit none
     class(kinematicsDistributionCollisionlessTabulated), intent(inout) :: self
+    !$GLC attributes unused :: self
     
     collisionlessTabulatedIsCollisional=.false.
     return

--- a/source/mass_distributions.F90
+++ b/source/mass_distributions.F90
@@ -1210,8 +1210,7 @@ contains
                 if (status /= errorStatusSuccess) then
                    block
                      integer                   :: line
-                     type     (varying_string) :: reason , file, &
-                          &                       message
+                     type     (varying_string) :: reason, file
                      character(len=24        ) :: label
                      call GSL_Error_Details(reason,file,line,status)
                      call displayIndent('Jeans equation integration failure report')

--- a/source/mass_distributions.F90
+++ b/source/mass_distributions.F90
@@ -89,6 +89,15 @@ module Mass_Distributions
         end if
       </code>
    </method>
+   <method name="describe" >
+    <description>Display a description of the mass distribution.</description>
+    <type>void</type>
+    <pass>yes</pass>
+    <modules>Display</modules>
+    <code>
+     call displayMessage('unknown')
+    </code>
+   </method>
    <method name="matches" >
     <description>Return true if this mass distribution matches the specified component and mass type.</description>
     <type>logical</type>
@@ -1069,6 +1078,7 @@ contains
     Solve the Jeans equation numerically to find the 1D velocity dispersion.
     !!}
     use, intrinsic :: ISO_C_Binding          , only : c_size_t
+    use            :: Display                , only : displayIndent       , displayUnindent     , displayMessage
     use            :: Error                  , only : Error_Report        , errorStatusSuccess  , GSL_Error_Details
     use            :: Numerical_Integration  , only : integrator
     use            :: Numerical_Ranges       , only : Make_Range          , rangeTypeLogarithmic
@@ -1199,9 +1209,28 @@ contains
                 end do
                 if (status /= errorStatusSuccess) then
                    block
-                     integer                 :: line
-                     type   (varying_string) :: reason, file
+                     integer                   :: line
+                     type     (varying_string) :: reason , file, &
+                          &                       message
+                     character(len=24        ) :: label
                      call GSL_Error_Details(reason,file,line,status)
+                     call displayIndent('Jeans equation integration failure report')
+                     call displayMessage(var_str('radius ')//i//' of '//countRadii)
+                     write (label,'(e24.16)') radiusLowerJeansEquation
+                     call displayMessage('radiusLowerJeansEquation = '//trim(label)//' Mpc')
+                     write (label,'(e24.16)') radiusUpperJeansEquation
+                     call displayMessage('radiusUpperJeansEquation = '//trim(label)//' Mpc')
+                     write (label,'(e24.16)') radiusOuter_
+                     call displayMessage('radiusOuter              = '//trim(label)//' Mpc')
+                     call displayIndent('Mass distribution properties:')
+                     call displayMessage('Type: '//massDistribution_%objectType())
+                     call massDistribution_        %describe()
+                     call displayUnindent('done')
+                     call displayIndent('Mass distribution embedding properties:')
+                     call displayMessage('Type: '//massDistributionEmbedding%objectType())
+                     call massDistributionEmbedding%describe()
+                     call displayUnindent('done')
+                     call displayUnindent('done')
                      call Error_Report(var_str('integration of Jeans equation failed - GSL Error ')//status//': "'//reason//'" at line '//line//' of file "'//file//'"'//{introspection:location})
                    end block
                 end if

--- a/source/mass_distributions.spherical.cusp-NFW.F90
+++ b/source/mass_distributions.spherical.cusp-NFW.F90
@@ -42,6 +42,7 @@
      double precision :: densityNormalization, radiusScale, &
           &              y
    contains
+     procedure :: describe              => cuspNFWDescribe
      procedure :: density               => cuspNFWDensity
      procedure :: densityGradientRadial => cuspNFWDensityGradientRadial
      procedure :: massEnclosedBySphere  => cuspNFWMassEnclosedBySphere
@@ -436,3 +437,21 @@ contains
     suffix=String_C_To_Fortran(massDistributionCuspNFWSourceDigest)
     return
   end function cuspNFWSuffix
+
+  subroutine cuspNFWDescribe(self)
+    !!{
+    Return a suffix for tabulated file names.
+    !!}
+    use :: Display, only : displayMessage
+    implicit none
+    class    (massDistributionCuspNFW), intent(inout) :: self
+    character(len=24                 )                :: label
+
+    write (label,'(e24.16)') self%densityNormalization
+    call displayMessage('densityNormalization = '//trim(label))
+    write (label,'(e24.16)') self%radiusScale
+    call displayMessage('radiusScale          = '//trim(label))
+    write (label,'(e24.16)') self%y
+    call displayMessage('y                    = '//trim(label))
+    return
+  end subroutine cuspNFWDescribe


### PR DESCRIPTION
Uses an analytic extrapolation to small radii for the velocity dispersion. This prevents the need to tabulate velocity dispersions to extremely small radii.