### PR TITLE
Use OpenMP locks instead of `critical` sections

### DIFF
--- a/source/interface.Cloudy.collisional_ionization_equilibrium.F90
+++ b/source/interface.Cloudy.collisional_ionization_equilibrium.F90
@@ -40,7 +40,8 @@ contains
     !!}
     use :: Display                         , only : displayCounter                     , displayCounterClear           , displayIndent       , displayMessage, &
           &                                         displayUnindent                    , verbosityLevelWorking
-    use :: File_Utilities                  , only : File_Exists                        , File_Lock                     , File_Remove         , File_Unlock
+    use :: File_Utilities                  , only : File_Exists                        , File_Lock                     , File_Remove         , File_Unlock   , &
+         &                                          Directory_Make                     , File_Path
     use :: Error                           , only : Error_Report
     use :: HDF5_Access                     , only : hdf5Access
     use :: IO_HDF5                         , only : hdf5Object
@@ -76,7 +77,8 @@ contains
          &                                                               temperatureCount                       , cloudyScript                         , &
          &                                                               iMetallicity                           , inputFile                            , &
          &                                                               iTemperature                           , status                               , &
-         &                                                               energyCount                            , iEnergy
+         &                                                               energyCount                            , iEnergy                              , &
+         &                                                               i
     type            (varying_string)                                  :: cloudyPath                             , cloudyVersion                        , &
          &                                                               fileNameTempCooling                    , fileNameTempOverview                 , &
          &                                                               fileNameTempContinuum
@@ -89,231 +91,238 @@ contains
     <optionalArgument name="includeContinuum" defaultsTo=".false."/>
     !!]
     
-    !$omp critical(cloudyCIEFileLock)
     ! Ensure the requested file format version is compatible.
     if (versionFileFormat /= versionFileFormatCurrent) call Error_Report(var_str("this interface supports file format version ")//versionFileFormatCurrent//" but version "//versionFileFormat//" was requested"//{introspection:location})
     ! Determine if we need to compute cooling functions.
+    call Directory_Make(char(File_Path(char(fileNameCoolingFunction))))
+    call Directory_Make(char(File_Path(char(fileNameChemicalState  ))))
     computeCoolingFunctions=.false.
-    if (File_Exists(fileNameCoolingFunction)) then
-       !$ call hdf5Access%set     (                                             )
-       call    outputFile%openFile(char(fileNameCoolingFunction),readOnly=.true.)
-       if (outputFile%hasAttribute('fileFormat')) then
-          call outputFile%readAttribute('fileFormat',fileFormatFile)
-          if (fileFormatFile /= versionFileFormatCurrent) computeCoolingFunctions=.true.
-       end if
-       call    outputFile%close()
-       !$ call hdf5Access%unset()
-    else
-       computeCoolingFunctions=.true.
-    end if
-    ! Determine if we need to compute chemical states.
-    computeChemicalStates=.false.
-    if (File_Exists(fileNameChemicalState)) then
-       !$ call hdf5Access%set     (                                           )
-       call    outputFile%openFile(char(fileNameChemicalState),readOnly=.true.)
-       if (outputFile%hasAttribute('fileFormat')) then
-          call outputFile%readAttribute('fileFormat',fileFormatFile)
-          if (fileFormatFile /= versionFileFormatCurrent) computeChemicalStates=.true.
-       end if
-       call    outputFile%close()
-       !$ call hdf5Access%unset()
-    else
-       computeChemicalStates=.true.
-    end if
-    ! Perform calculations if necessary.
-    if (computeCoolingFunctions .or. computeChemicalStates) then
-       ! Open and lock the cooling function and chemical state files.
-       ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
-       call File_Lock(char(fileNameCoolingFunction),fileLockCoolingFunction)
-       call File_Lock(char(fileNameChemicalState  ),fileLockChemicalState  )
-       ! Generate metallicity and temperature arrays.
-       metallicityCount        =int(     (+metallicityMaximumLogarithmic-metallicityMinimumLogarithmic)/     metallicityStepLogarithmic+1.5d0)
-       temperatureCount        =int(     (+temperatureMaximumLogarithmic-temperatureMinimumLogarithmic)/     temperatureStepLogarithmic+1.5d0)
-       energyCount             =int(log10(+energyMaximum                /energyMinimum                )*dble(energyBinsPerDecade      )+1    )
-       allocate   (metallicitiesLogarithmic        (metallicityCount+1                             ))
-       allocate   (temperaturesLogarithmic         (                   temperatureCount            ))
-       allocate   (coolingFunction                 (metallicityCount+1,temperatureCount            ))
-       allocate   (densityElectron                 (metallicityCount+1,temperatureCount            ))
-       allocate   (densityHydrogenI                (metallicityCount+1,temperatureCount            ))
-       allocate   (densityHydrogenII               (metallicityCount+1,temperatureCount            ))
-       if (includeContinuum_) then
-          allocate(energyContinuum                 (                                    energyCount))
-          allocate(powerEmittedFractionalCumulative(metallicityCount+1,temperatureCount,energyCount))
-          powerEmittedFractionalCumulative=0.0d0
-       end if
-       metallicitiesLogarithmic(1                   )=metallicityZeroLogarithmic
-       metallicitiesLogarithmic(2:metallicityCount+1)=Make_Range(metallicityMinimumLogarithmic,metallicityMaximumLogarithmic,metallicityCount,rangeTypeLinear     )
-       temperaturesLogarithmic                       =Make_Range(temperatureMinimumLogarithmic,temperatureMaximumLogarithmic,temperatureCount,rangeTypeLinear     )
-       energyContinuum                               =Make_Range(energyMinimum                ,energyMaximum                ,energyCount     ,rangeTypeLogarithmic)
-       ! Initialize Cloudy.
-       call Interface_Cloudy_Initialize(cloudyPath,cloudyVersion)
-       ! Specify file names for temporary Cloudy data.
-       fileNameTempCooling  ="cloudy_cooling.tmp"
-       fileNameTempOverview ="cloudy_overview.tmp"
-       fileNameTempContinuum="cloudy_continuum.tmp"
-       ! Begin iterating over metallicities.
-       call displayIndent("Computing cooling functions and chemical states using Cloudy (this may take a long time)....",verbosityLevelWorking)
-       do iMetallicity=1,metallicityCount+1
-          if (metallicitiesLogarithmic(iMetallicity) <= metallicityZeroLogarithmic) then
-             write (label,'(a)'   ) '  -∞'
-          else
-             write (label,'(f8.3)') metallicitiesLogarithmic(iMetallicity)
+    computeChemicalStates  =.false.
+    do i=1,2
+       call File_Lock(char(fileNameCoolingFunction),fileLockCoolingFunction,lockIsShared=i == 1 .or. .not.computeCoolingFunctions)
+       call File_Lock(char(fileNameChemicalState  ),fileLockChemicalState  ,lockIsShared=i == 1 .or. .not.computeChemicalStates  )
+       computeCoolingFunctions=.false.
+       computeChemicalStates  =.false.
+       if (File_Exists(fileNameCoolingFunction)) then
+          !$ call hdf5Access%set     (                                             )
+          call    outputFile%openFile(char(fileNameCoolingFunction),readOnly=.true.)
+          if (outputFile%hasAttribute('fileFormat')) then
+             call outputFile%readAttribute('fileFormat',fileFormatFile)
+             if (fileFormatFile /= versionFileFormatCurrent) computeCoolingFunctions=.true.
           end if
-          call displayMessage("Computing for log₁₀(Z/Z☉)="//trim(label),verbosityLevelWorking)
-          call displayCounter(int(100.0d0*dble(iMetallicity-1)/dble(metallicityCount+1)),iMetallicity==0,verbosityLevelWorking)
-          ! Generate an input file for Cloudy.
-          open(newUnit=cloudyScript,file=char(cloudyPath//'/source/input.in'),status='unknown',form='formatted')
-          write (cloudyScript,'(a)') 'print off'
-          write (cloudyScript,'(a)') 'background, z=0'            ! Use a very low level incident continuum.
-          write (cloudyScript,'(a)') 'cosmic rays background'     ! Include cosmic ray background ionization rate.
-          write (cloudyScript,'(a)') 'stop zone 1'                ! Stop after a single zone.
-          write (cloudyScript,'(a)') 'no photoionization'         ! Set no photoionization.
-          write (cloudyScript,'(a)') 'hden 0.0'
-          if (metallicitiesLogarithmic(iMetallicity) <= metallicityZeroLogarithmic) then
-             write (cloudyScript,'(a)') 'abundances primordial'
-          else
-             write (cloudyScript,'(a,f6.3)') 'metals _log ',metallicitiesLogarithmic(iMetallicity)
-             ! Assume a linear growth of helium abundance with metallicity.
-             abundanceHelium=heliumToHydrogenAbundancePrimordial+(heliumToHydrogenAbundanceSolar-heliumToHydrogenAbundancePrimordial)*(10.0d0**metallicitiesLogarithmic(iMetallicity))
-             write (cloudyScript,'(a,f6.3)') 'element abundance linear helium ',abundanceHelium
+          call    outputFile%close()
+          !$ call hdf5Access%unset()
+       else
+          computeCoolingFunctions=.true.
+       end if
+       ! Determine if we need to compute chemical states.
+       if (File_Exists(fileNameChemicalState)) then
+          !$ call hdf5Access%set     (                                           )
+          call    outputFile%openFile(char(fileNameChemicalState),readOnly=.true.)
+          if (outputFile%hasAttribute('fileFormat')) then
+             call outputFile%readAttribute('fileFormat',fileFormatFile)
+             if (fileFormatFile /= versionFileFormatCurrent) computeChemicalStates=.true.
           end if
-          write        (cloudyScript,'(a,f6.3,a)') 'constant temper ',temperatureMinimumLogarithmic,' vary'
-          write        (cloudyScript,'(a,f6.3,a,f6.3,a,f6.3)') 'grid ',temperatureMinimumLogarithmic,' to ',temperatureMaximumLogarithmic,' step ',temperatureStepLogarithmic
-          write        (cloudyScript,'(a)') 'no molecules'
-          write        (cloudyScript,'(a)') 'set trim -20'
-          write        (cloudyScript,'(a)') 'save cooling "'                     //char(fileNameTempCooling  )//'"'
-          write        (cloudyScript,'(a)') 'save overview "'                    //char(fileNameTempOverview )//'"'
-          if (includeContinuum_) &
-               & write (cloudyScript,'(a)') 'save emitted continuum units _keV "'//char(fileNameTempContinuum)//'"'
-          close(cloudyScript)
-          call System_Command_Do("cd "//cloudyPath//"/source; cloudy.exe -r input",status);
-          if (status /= 0) call Error_Report('Cloudy failed'//{introspection:location})
-          ! Extract the cooling rate.
-          open(newUnit=inputFile,file=char(cloudyPath//"/source/"//fileNameTempCooling),status='old')
-          read (inputFile,*) ! Skip the header line.
-          do iTemperature=1,temperatureCount
-             read (inputFile,*) dummy,dummy,dummy,coolingFunction(iMetallicity,iTemperature)
-             read (inputFile,*)
-          end do
-          close(inputFile)
-          call File_Remove(cloudyPath//"/source/"//fileNameTempCooling)
-          ! Extract the electron and hydrogen density.
-          open(newUnit=inputFile,file=char(cloudyPath//"/source/"//fileNameTempOverview),status='old')
-          read (inputFile,*) ! Skip the header line.
-          do iTemperature=1,temperatureCount
-             read (inputFile,*) dummy,dummy,dummy,dummy,densityElectron(iMetallicity,iTemperature),dummy,densityHydrogenI(iMetallicity,iTemperature),densityHydrogenII(iMetallicity,iTemperature)
-             read (inputFile,*)
-          end do
-          close(inputFile)
-          call File_Remove(cloudyPath//"/source/"//fileNameTempOverview)
-          ! Extract the emitted continuum. The continuum is given in units of ν f_ν [ergs cm⁻² s⁻¹], and frequencies are
-          ! spaced uniformly in their logarithm. Therefore, to find the total power emitted we can simply sum the column
-          ! values. We sum these into bins of energy, while also accumulating the total power. After reading all lines we
-          ! normalize by the total power and cumulate to get the fraction of power emitted up to a given energy.
+          call    outputFile%close()
+          !$ call hdf5Access%unset()
+       else
+          computeChemicalStates=.true.
+       end if
+       if ((computeCoolingFunctions .or. computeChemicalStates) .and. i == 1) then
+          call File_Unlock(fileLockCoolingFunction,sync=.false.)
+          call File_Unlock(fileLockChemicalState  ,sync=.false.)
+          cycle
+       end if
+       ! Perform calculations if necessary.
+       if (computeCoolingFunctions .or. computeChemicalStates) then
+          ! Generate metallicity and temperature arrays.
+          metallicityCount        =int(     (+metallicityMaximumLogarithmic-metallicityMinimumLogarithmic)/     metallicityStepLogarithmic+1.5d0)
+          temperatureCount        =int(     (+temperatureMaximumLogarithmic-temperatureMinimumLogarithmic)/     temperatureStepLogarithmic+1.5d0)
+          energyCount             =int(log10(+energyMaximum                /energyMinimum                )*dble(energyBinsPerDecade      )+1    )
+          allocate   (metallicitiesLogarithmic        (metallicityCount+1                             ))
+          allocate   (temperaturesLogarithmic         (                   temperatureCount            ))
+          allocate   (coolingFunction                 (metallicityCount+1,temperatureCount            ))
+          allocate   (densityElectron                 (metallicityCount+1,temperatureCount            ))
+          allocate   (densityHydrogenI                (metallicityCount+1,temperatureCount            ))
+          allocate   (densityHydrogenII               (metallicityCount+1,temperatureCount            ))
           if (includeContinuum_) then
-             open(newUnit=inputFile,file=char(cloudyPath//"/source/"//fileNameTempContinuum),status='old')
-             read (inputFile,*,iostat=status) ! Skip the header line.
-             iTemperature=1
-             iEnergy     =1
-             powerTotal  =0.0d0
-             do while (status == 0)
-                read (inputFile,'(a)',iostat=status) line
-                if (status /= 0) exit
-                if (line(1:1) == "#") then
-                   ! New iteration reached.
-                   !! Normalize and cumulate the power
-                   powerEmittedFractionalCumulative(iMetallicity,iTemperature,:)=+powerEmittedFractionalCumulative(iMetallicity,iTemperature,:) &
-                        &                                                        /powerTotal
-                   do iEnergy=2,energyCount
-                      powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy)=+powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy  ) &
-                           &                                                              +powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy-1)
-                   end do
-                   !! Move to the next temperature.
-                   iTemperature=iTemperature+1
-                   iEnergy     =             1
-                   powerTotal  =             0.0d0
-                else
-                   read (line,*) energy,dummy,intensity
-                   do while (energy > energyContinuum(iEnergy))
-                      iEnergy=iEnergy+1
-                      if (iEnergy > energyCount) exit
-                   end do
-                   if (iEnergy < energyCount) &
-                        powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy)=powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy)+intensity
-                   powerTotal=powerTotal+intensity
-                end if
+             allocate(energyContinuum                 (                                    energyCount))
+             allocate(powerEmittedFractionalCumulative(metallicityCount+1,temperatureCount,energyCount))
+             powerEmittedFractionalCumulative=0.0d0
+          end if
+          metallicitiesLogarithmic(1                   )=metallicityZeroLogarithmic
+          metallicitiesLogarithmic(2:metallicityCount+1)=Make_Range(metallicityMinimumLogarithmic,metallicityMaximumLogarithmic,metallicityCount,rangeTypeLinear     )
+          temperaturesLogarithmic                       =Make_Range(temperatureMinimumLogarithmic,temperatureMaximumLogarithmic,temperatureCount,rangeTypeLinear     )
+          energyContinuum                               =Make_Range(energyMinimum                ,energyMaximum                ,energyCount     ,rangeTypeLogarithmic)
+          ! Initialize Cloudy.
+          call Interface_Cloudy_Initialize(cloudyPath,cloudyVersion)
+          ! Specify file names for temporary Cloudy data.
+          fileNameTempCooling  ="cloudy_cooling.tmp"
+          fileNameTempOverview ="cloudy_overview.tmp"
+          fileNameTempContinuum="cloudy_continuum.tmp"
+          ! Begin iterating over metallicities.
+          call displayIndent("Computing cooling functions and chemical states using Cloudy (this may take a long time)....",verbosityLevelWorking)
+          do iMetallicity=1,metallicityCount+1
+             if (metallicitiesLogarithmic(iMetallicity) <= metallicityZeroLogarithmic) then
+                write (label,'(a)'   ) '  -∞'
+             else
+                write (label,'(f8.3)') metallicitiesLogarithmic(iMetallicity)
+             end if
+             call displayMessage("Computing for log₁₀(Z/Z☉)="//trim(label),verbosityLevelWorking)
+             call displayCounter(int(100.0d0*dble(iMetallicity-1)/dble(metallicityCount+1)),iMetallicity==0,verbosityLevelWorking)
+             ! Generate an input file for Cloudy.
+             open(newUnit=cloudyScript,file=char(cloudyPath//'/source/input.in'),status='unknown',form='formatted')
+             write (cloudyScript,'(a)') 'print off'
+             write (cloudyScript,'(a)') 'background, z=0'            ! Use a very low level incident continuum.
+             write (cloudyScript,'(a)') 'cosmic rays background'     ! Include cosmic ray background ionization rate.
+             write (cloudyScript,'(a)') 'stop zone 1'                ! Stop after a single zone.
+             write (cloudyScript,'(a)') 'no photoionization'         ! Set no photoionization.
+             write (cloudyScript,'(a)') 'hden 0.0'
+             if (metallicitiesLogarithmic(iMetallicity) <= metallicityZeroLogarithmic) then
+                write (cloudyScript,'(a)') 'abundances primordial'
+             else
+                write (cloudyScript,'(a,f6.3)') 'metals _log ',metallicitiesLogarithmic(iMetallicity)
+                ! Assume a linear growth of helium abundance with metallicity.
+                abundanceHelium=heliumToHydrogenAbundancePrimordial+(heliumToHydrogenAbundanceSolar-heliumToHydrogenAbundancePrimordial)*(10.0d0**metallicitiesLogarithmic(iMetallicity))
+                write (cloudyScript,'(a,f6.3)') 'element abundance linear helium ',abundanceHelium
+             end if
+             write        (cloudyScript,'(a,f6.3,a)') 'constant temper ',temperatureMinimumLogarithmic,' vary'
+             write        (cloudyScript,'(a,f6.3,a,f6.3,a,f6.3)') 'grid ',temperatureMinimumLogarithmic,' to ',temperatureMaximumLogarithmic,' step ',temperatureStepLogarithmic
+             write        (cloudyScript,'(a)') 'no molecules'
+             write        (cloudyScript,'(a)') 'set trim -20'
+             write        (cloudyScript,'(a)') 'save cooling "'                     //char(fileNameTempCooling  )//'"'
+             write        (cloudyScript,'(a)') 'save overview "'                    //char(fileNameTempOverview )//'"'
+             if (includeContinuum_) &
+                  & write (cloudyScript,'(a)') 'save emitted continuum units _keV "'//char(fileNameTempContinuum)//'"'
+             close(cloudyScript)
+             call System_Command_Do("cd "//cloudyPath//"/source; cloudy.exe -r input",status);
+             if (status /= 0) call Error_Report('Cloudy failed'//{introspection:location})
+             ! Extract the cooling rate.
+             open(newUnit=inputFile,file=char(cloudyPath//"/source/"//fileNameTempCooling),status='old')
+             read (inputFile,*) ! Skip the header line.
+             do iTemperature=1,temperatureCount
+                read (inputFile,*) dummy,dummy,dummy,coolingFunction(iMetallicity,iTemperature)
+                read (inputFile,*)
              end do
              close(inputFile)
-             call File_Remove(cloudyPath//"/source/"//fileNameTempContinuum)
+             call File_Remove(cloudyPath//"/source/"//fileNameTempCooling)
+             ! Extract the electron and hydrogen density.
+             open(newUnit=inputFile,file=char(cloudyPath//"/source/"//fileNameTempOverview),status='old')
+             read (inputFile,*) ! Skip the header line.
+             do iTemperature=1,temperatureCount
+                read (inputFile,*) dummy,dummy,dummy,dummy,densityElectron(iMetallicity,iTemperature),dummy,densityHydrogenI(iMetallicity,iTemperature),densityHydrogenII(iMetallicity,iTemperature)
+                read (inputFile,*)
+             end do
+             close(inputFile)
+             call File_Remove(cloudyPath//"/source/"//fileNameTempOverview)
+             ! Extract the emitted continuum. The continuum is given in units of ν f_ν [ergs cm⁻² s⁻¹], and frequencies are
+             ! spaced uniformly in their logarithm. Therefore, to find the total power emitted we can simply sum the column
+             ! values. We sum these into bins of energy, while also accumulating the total power. After reading all lines we
+             ! normalize by the total power and cumulate to get the fraction of power emitted up to a given energy.
+             if (includeContinuum_) then
+                open(newUnit=inputFile,file=char(cloudyPath//"/source/"//fileNameTempContinuum),status='old')
+                read (inputFile,*,iostat=status) ! Skip the header line.
+                iTemperature=1
+                iEnergy     =1
+                powerTotal  =0.0d0
+                do while (status == 0)
+                   read (inputFile,'(a)',iostat=status) line
+                   if (status /= 0) exit
+                   if (line(1:1) == "#") then
+                      ! New iteration reached.
+                      !! Normalize and cumulate the power
+                      powerEmittedFractionalCumulative(iMetallicity,iTemperature,:)=+powerEmittedFractionalCumulative(iMetallicity,iTemperature,:) &
+                           &                                                        /powerTotal
+                      do iEnergy=2,energyCount
+                         powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy)=+powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy  ) &
+                              &                                                              +powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy-1)
+                      end do
+                      !! Move to the next temperature.
+                      iTemperature=iTemperature+1
+                      iEnergy     =             1
+                      powerTotal  =             0.0d0
+                   else
+                      read (line,*) energy,dummy,intensity
+                      do while (energy > energyContinuum(iEnergy))
+                         iEnergy=iEnergy+1
+                         if (iEnergy > energyCount) exit
+                      end do
+                      if (iEnergy < energyCount) &
+                           powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy)=powerEmittedFractionalCumulative(iMetallicity,iTemperature,iEnergy)+intensity
+                      powerTotal=powerTotal+intensity
+                   end if
+                end do
+                close(inputFile)
+                call File_Remove(cloudyPath//"/source/"//fileNameTempContinuum)
+             end if
+          end do
+          call displayCounterClear(verbosityLevelWorking)
+          ! Output cooling functions to an HDF5 file.
+          if (computeCoolingFunctions) then
+             !$ call hdf5Access%set           (                                                                                                                     )
+             call    outputFile%openFile      (char(fileNameCoolingFunction)                                                                                        )
+             ! Store data.
+             call    outputFile%writeDataset  (metallicitiesLogarithmic                                  ,'metallicity'                     ,datasetReturned=dataset)
+             call    dataset   %writeAttribute('fix'                                                     ,'extrapolateLow'                                          )
+             call    dataset   %writeAttribute('fix'                                                     ,'extrapolateHigh'                                         )
+             call    dataset   %writeAttribute('K'                                                       ,'units'                                                   )
+             call    dataset   %writeAttribute(1.0d0                                                     ,'unitsInSI'                                               )
+             call    dataset   %close         (                                                                                                                     )
+             call    outputFile%writeDataset  (10.0d0**temperaturesLogarithmic                           ,'temperature'                     ,datasetReturned=dataset)
+             call    dataset   %writeAttribute('powerLaw'                                                ,'extrapolateLow'                                          )
+             call    dataset   %writeAttribute('powerLaw'                                                ,'extrapolateHigh'                                         )
+             call    dataset   %close         (                                                                                                                     )
+             call    outputFile%writeDataset  (coolingFunction                                           ,'coolingRate'                     ,datasetReturned=dataset)
+             call    dataset   %close         (                                                                                                                     )
+             if (includeContinuum_) then
+                call outputFile%writeDataset  (energyContinuum                                           ,'energyContinuum'                 ,datasetReturned=dataset)
+                call dataset   %writeAttribute('powerLaw'                                                ,'extrapolateLow'                                          )
+                call dataset   %writeAttribute('powerLaw'                                                ,'extrapolateHigh'                                         )
+                call dataset   %writeAttribute('keV'                                                     ,'units'                                                   )
+                call dataset   %writeAttribute(kilo*electronVolt                                         ,'unitsInSI'                                               )
+                call dataset   %close         (                                                                                                                     )
+                call outputFile%writeDataset  (powerEmittedFractionalCumulative                          ,'powerEmittedFractionalCumulative',datasetReturned=dataset)
+                call dataset   %close         (                                                                                                                     )
+             end if
+             ! Add attributes.
+             call    outputFile%writeAttribute("CIE cooling functions computed by Cloudy "//cloudyVersion,'description'                                             )
+             call    outputFile%writeAttribute(versionFileFormatCurrent                                  ,'fileFormat'                                              )
+             call    outputFile%close         (                                                                                                                     )
+             !$ call hdf5Access%unset         (                                                                                                                     )
           end if
-       end do
-       call displayCounterClear(verbosityLevelWorking)
-       ! Output cooling functions to an HDF5 file.
-       if (computeCoolingFunctions) then
-          !$ call hdf5Access%set           (                                                                                                                     )
-          call    outputFile%openFile      (char(fileNameCoolingFunction)                                                                                        )
-          ! Store data.
-          call    outputFile%writeDataset  (metallicitiesLogarithmic                                  ,'metallicity'                     ,datasetReturned=dataset)
-          call    dataset   %writeAttribute('fix'                                                     ,'extrapolateLow'                                          )
-          call    dataset   %writeAttribute('fix'                                                     ,'extrapolateHigh'                                         )
-          call    dataset   %writeAttribute('K'                                                       ,'units'                                                   )
-          call    dataset   %writeAttribute(1.0d0                                                     ,'unitsInSI'                                               )
-          call    dataset   %close         (                                                                                                                     )
-          call    outputFile%writeDataset  (10.0d0**temperaturesLogarithmic                           ,'temperature'                     ,datasetReturned=dataset)
-          call    dataset   %writeAttribute('powerLaw'                                                ,'extrapolateLow'                                          )
-          call    dataset   %writeAttribute('powerLaw'                                                ,'extrapolateHigh'                                         )
-          call    dataset   %close         (                                                                                                                     )
-          call    outputFile%writeDataset  (coolingFunction                                           ,'coolingRate'                     ,datasetReturned=dataset)
-          call    dataset   %close         (                                                                                                                     )
-          if (includeContinuum_) then
-             call outputFile%writeDataset  (energyContinuum                                           ,'energyContinuum'                 ,datasetReturned=dataset)
-             call dataset   %writeAttribute('powerLaw'                                                ,'extrapolateLow'                                          )
-             call dataset   %writeAttribute('powerLaw'                                                ,'extrapolateHigh'                                         )
-             call dataset   %writeAttribute('keV'                                                     ,'units'                                                   )
-             call dataset   %writeAttribute(kilo*electronVolt                                         ,'unitsInSI'                                               )
-             call dataset   %close         (                                                                                                                     )
-             call outputFile%writeDataset  (powerEmittedFractionalCumulative                          ,'powerEmittedFractionalCumulative',datasetReturned=dataset)
-             call dataset   %close         (                                                                                                                     )
+          ! Output chemical states to an HDF5 file.
+          if (computeChemicalStates) then
+             !$ call hdf5Access%set           (                                                                                                    )
+             call    outputFile%openFile      (char(fileNameChemicalState)                                                                         )
+             ! Store data.
+             call    outputFile%writeDataset  (metallicitiesLogarithmic                                  ,'metallicity'    ,datasetReturned=dataset)
+             call    dataset   %writeAttribute('fix'                                                     ,'extrapolateLow'                         )
+             call    dataset   %writeAttribute('fix'                                                     ,'extrapolateHigh'                        )
+             call    dataset   %writeAttribute('K'                                                       ,'units'                                  )
+             call    dataset   %writeAttribute(1.0d0                                                     ,'unitsInSI'                              )
+             call    dataset   %close         (                                                                                                    )
+             call    outputFile%writeDataset  (10.0d0**temperaturesLogarithmic                           ,'temperature'    ,datasetReturned=dataset)
+             call    dataset   %writeAttribute('powerLaw'                                                ,'extrapolateLow'                         )
+             call    dataset   %writeAttribute('powerLaw'                                                ,'extrapolateHigh'                        )
+             call    dataset   %close         (                                                                                                    )
+             call    outputFile%writeDataset  (densityElectron                                           ,'electronDensity',datasetReturned=dataset)
+             call    dataset   %close         (                                                                                                    )
+             call    outputFile%writeDataset  (densityHydrogenI                                          ,'hiDensity'      ,datasetReturned=dataset)
+             call    dataset   %close         (                                                                                                    )
+             call    outputFile%writeDataset  (densityHydrogenII                                         ,'hiiDensity'     ,datasetReturned=dataset)
+             call    dataset   %close         (                                                                                                    )
+             ! Add attributes.
+             call    outputFile%writeAttribute("CIE ionization states computed by Cloudy "//cloudyVersion,'description'                            )
+             call    outputFile%writeAttribute(versionFileFormatCurrent                                  ,'fileFormat'                             )
+             call    outputFile%close         (                                                                                                    )
+             !$ call hdf5Access%unset         (                                                                                                    )
           end if
-          ! Add attributes.
-          call    outputFile%writeAttribute("CIE cooling functions computed by Cloudy "//cloudyVersion,'description'                                             )
-          call    outputFile%writeAttribute(versionFileFormatCurrent                                  ,'fileFormat'                                              )
-          call    outputFile%close         (                                                                                                                     )
-          !$ call hdf5Access%unset         (                                                                                                                     )
+          call File_Unlock(fileLockChemicalState  )
+          call File_Unlock(fileLockCoolingFunction)
+          ! Write message.
+          call displayUnindent("...done",verbosityLevelWorking)
        end if
-       ! Output chemical states to an HDF5 file.
-       if (computeChemicalStates) then
-          !$ call hdf5Access%set           (                                                                                                    )
-          call    outputFile%openFile      (char(fileNameChemicalState)                                                                         )
-          ! Store data.
-          call    outputFile%writeDataset  (metallicitiesLogarithmic                                  ,'metallicity'    ,datasetReturned=dataset)
-          call    dataset   %writeAttribute('fix'                                                     ,'extrapolateLow'                         )
-          call    dataset   %writeAttribute('fix'                                                     ,'extrapolateHigh'                        )
-          call    dataset   %writeAttribute('K'                                                       ,'units'                                  )
-          call    dataset   %writeAttribute(1.0d0                                                     ,'unitsInSI'                              )
-          call    dataset   %close         (                                                                                                    )
-          call    outputFile%writeDataset  (10.0d0**temperaturesLogarithmic                           ,'temperature'    ,datasetReturned=dataset)
-          call    dataset   %writeAttribute('powerLaw'                                                ,'extrapolateLow'                         )
-          call    dataset   %writeAttribute('powerLaw'                                                ,'extrapolateHigh'                        )
-          call    dataset   %close         (                                                                                                    )
-          call    outputFile%writeDataset  (densityElectron                                           ,'electronDensity',datasetReturned=dataset)
-          call    dataset   %close         (                                                                                                    )
-          call    outputFile%writeDataset  (densityHydrogenI                                          ,'hiDensity'      ,datasetReturned=dataset)
-          call    dataset   %close         (                                                                                                    )
-          call    outputFile%writeDataset  (densityHydrogenII                                         ,'hiiDensity'     ,datasetReturned=dataset)
-          call    dataset   %close         (                                                                                                    )
-          ! Add attributes.
-          call    outputFile%writeAttribute("CIE ionization states computed by Cloudy "//cloudyVersion,'description'                            )
-          call    outputFile%writeAttribute(versionFileFormatCurrent                                  ,'fileFormat'                             )
-          call    outputFile%close         (                                                                                                    )
-          !$ call hdf5Access%unset         (                                                                                                    )
-       end if
-       call File_Unlock(fileLockChemicalState  )
-       call File_Unlock(fileLockCoolingFunction)
-       ! Write message.
-       call displayUnindent("...done",verbosityLevelWorking)
-    end if
-    !$omp end critical(cloudyCIEFileLock)
+    end do
     return
   end subroutine Interface_Cloudy_CIE_Tabulate
 

--- a/source/merger_trees.operators.particulate.F90
+++ b/source/merger_trees.operators.particulate.F90
@@ -364,6 +364,7 @@ contains
     use    :: HDF5_Access               , only : hdf5Access
     use    :: IO_HDF5                   , only : hdf5Object
     use    :: ISO_Varying_String        , only : varying_string                   , var_str
+    use    :: Locks                     , only : ompLock
     use    :: Mass_Distributions        , only : massDistributionClass
     use    :: Merger_Tree_Walkers       , only : mergerTreeWalkerAllNodes
     use    :: Node_Components           , only : Node_Components_Thread_Initialize, Node_Components_Thread_Uninitialize
@@ -389,6 +390,7 @@ contains
     integer                                        , dimension(6  )              :: particleCounts
     double precision                               , dimension(:,:), allocatable :: particlePosition                     , particleVelocity
     integer         (kind_int8                    ), dimension(  :), allocatable :: particleIDs
+    type            (ompLock                      )                              :: lockSampling
     type            (mergerTreeWalkerAllNodes     )                              :: treeWalker
     double precision                                                             :: particleCountMean                    , distributionFunction       , &
          &                                                                          radiusVirial                         , radiusTruncate             , &
@@ -509,6 +511,7 @@ contains
           counter             =0
           positionRandomOffset=0.0d0
           velocityRandomOffset=0.0d0
+          lockSampling        =ompLock()
           !$omp parallel private(i,j,positionSpherical,positionCartesian,velocitySpherical,velocityCartesian,energy,energyPotential,speed,speedEscape,speedPrevious,distributionFunction,distributionFunctionMaximum,keepSample,radiusEnergy,positionVector,velocityVector,randomDeviates) copyin(node_,radiusTruncate_,lengthSoftening_,softeningKernel)
           call Node_Components_Thread_Initialize(self%parameters)
           allocate(self_,mold=self)
@@ -530,7 +533,7 @@ contains
              ! Sample particle positions from the halo density distribution. Currently, we assume that halos are spherically
              ! symmetric.
              randomDeviates=-1.0d0
-             !$omp critical (mergerTreeOperatorParticulateSample)
+             call lockSampling%set()
              do j=1,3
                 ! Ensure that the third random deviate (the enclosed mass fraction) is never precisely zero.
                 do while (                                           &
@@ -541,7 +544,7 @@ contains
                    randomDeviates(j)=tree%randomNumberGenerator_%uniformSample()
                 end do
              end do
-             !$omp end critical (mergerTreeOperatorParticulateSample)
+             call lockSampling%unset()
              call positionSpherical%  phiSet(     2.0d0*Pi       *randomDeviates(1)       )
              call positionSpherical%thetaSet(acos(2.0d0          *randomDeviates(2)-1.0d0))
              call positionSpherical%    rSet(     radiusTruncate_*randomDeviates(3)       )
@@ -603,19 +606,17 @@ contains
              keepSample=.false.
              do while (.not.keepSample)
                 ! Draw a speed uniformly at random between zero and the escape velocity.
-                !$omp critical (mergerTreeOperatorParticulateSample)
+                call lockSampling%set()
                 speed               =+tree%randomNumberGenerator_%uniformSample() &
                      &               *speedEscape
-                !$omp end critical (mergerTreeOperatorParticulateSample)
+                call lockSampling%unset()
                 energy              =+energyPotential    &
                      &               -0.5d0              &
                      &               *speed          **2
-                !$omp critical (mergerTreeOperatorParticulateRadius)
                 radiusEnergy        =+radiusDistribution%interpolate        (                                           &
                      &                                                             energy                             , &
                      &                                                       table=energyDistributionTablePotential     &
                      &                                                      )
-                !$omp end critical (mergerTreeOperatorParticulateRadius)
                 distributionFunction=+speed**2                                                                          &
                      &               *energyDistribution%interpolateGradient(                                           &
                      &                                                             radiusEnergy                       , &
@@ -633,18 +634,18 @@ contains
                    message=message//displayGreen()//'HELP:'//displayReset()//' the issue is probably caused by an inaccurate estimation of the maximum of the distribution function from tabulated values. To resolve this issue, increase the parameter [energyDistributionPointsPerDecade].'//char(10)
                    call Error_Report(message//{introspection:location})
                 end if
-                !$omp critical (mergerTreeOperatorParticulateSample)
+                call lockSampling%set()
                 keepSample=  +tree%randomNumberGenerator_%uniformSample() &
                      &      <                                             &
                      &       +distributionFunction                        &
                      &       /distributionFunctionMaximum
-                !$omp end critical (mergerTreeOperatorParticulateSample)
+                call lockSampling%unset()
              end do
              ! Choose a velocity vector in spherical coordinates with velocity chosen to give the required kinetic energy.
-             !$omp critical (mergerTreeOperatorParticulateSample)
+             call lockSampling%set()
              call velocitySpherical%  phiSet(     2.0d0*Pi*tree%randomNumberGenerator_%uniformSample()       )
              call velocitySpherical%thetaSet(acos(2.0d0   *tree%randomNumberGenerator_%uniformSample()-1.0d0))
-             !$omp end critical (mergerTreeOperatorParticulateSample)
+             call lockSampling%unset()
              call velocitySpherical%    rSet(speed                                                           )
              ! Get the corresponding cartesian coordinates.
              velocityCartesian=velocitySpherical


### PR DESCRIPTION
This avoids:

- inter-thread waits when not needed, and also provides better locking between processes;
- locking between different instances of the `mergerTreeOperatorParticulate` class.