### PR TITLE
Remove workaround for "Assignment to an allocatable polymorphic variable is not yet supported"

### DIFF
--- a/perl/Galacticus/Build/Components/TreeNodes/Utils.pm
+++ b/perl/Galacticus/Build/Components/TreeNodes/Utils.pm
@@ -8,7 +8,6 @@ use Cwd;
 use lib $ENV{'GALACTICUS_EXEC_PATH'}."/perl";
 use Text::Template 'fill_in_string';
 use List::ExtraUtils;
-use Galacticus::Build::Components::Utils qw($workaround);
 use Galacticus::Build::Components::DataTypes;
 
 # Insert hooks for our functions.
@@ -75,37 +74,11 @@ if (skipFormationNodeActual) targetNode%formationNode => null()
 if (skipEventActual        ) targetNode%event         => null()
 CODE
     # Loop over all component classes
-    if ( $workaround == 1 ) { # Workaround "Assignment to an allocatable polymorphic variable is not yet supported"
-	foreach $code::class ( &List::ExtraUtils::hashList($build->{'componentClasses'}) ) {
-	    next
-		unless ( grep {$code::class->{'name'} eq $_} @{$build->{'componentClassListActive'}} );
-	    $function->{'content'} .= fill_in_string(<<'CODE', PACKAGE => 'code');
-if (allocated(targetNode%component{ucfirst($class->{'name'})})) deallocate(targetNode%component{ucfirst($class->{'name'})})
-allocate(targetNode%component{ucfirst($class->{'name'})}(size(self%component{ucfirst($class->{'name'})})),source=self%component{ucfirst($class->{'name'})}(1))
-do i=1,size(self%component{ucfirst($class->{'name'})})
-CODE
-	    foreach $code::member ( @{$code::class->{'members'}} ) {
-		$function->{'content'} .= fill_in_string(<<'CODE', PACKAGE => 'code');
-   select type (from => self%component{ucfirst($class->{'name'})})
-   type is (nodeComponent{ucfirst($class->{'name'}).ucfirst($member->{'name'})})
-     select type (to => targetNode%component{ucfirst($class->{'name'})})
-     type is (nodeComponent{ucfirst($class->{'name'}).ucfirst($member->{'name'})})
-       to=from
-     end select
-   end select
-CODE
-	    }
-	    $function->{'content'} .= fill_in_string(<<'CODE', PACKAGE => 'code');
-end do
-CODE
-	}
-    } else {
-	foreach $code::component ( &List::ExtraUtils::hashList($build->{'componentClasses'}) ) {
-	    next
-		unless ( grep {$code::class->{'name'} eq $_} @{$build->{'componentClassListActive'}} );
-	    $function->{'content'} .=
-		join("",map {"targetNode%component".ucfirst($_->{'name'})." = self%component".ucfirst($_->{'name'})."\n"} &List::ExtraUtils::hashList($build->{'componentClasses'}));
-	}
+    foreach $code::component ( &List::ExtraUtils::hashList($build->{'componentClasses'}) ) {
+	next
+	    unless ( grep {$code::class->{'name'} eq $_} @{$build->{'componentClassListActive'}} );
+	$function->{'content'} .=
+	    join("",map {"targetNode%component".ucfirst($_->{'name'})." = self%component".ucfirst($_->{'name'})."\n"} &List::ExtraUtils::hashList($build->{'componentClasses'}));
     }
     # Update target node pointers.
     $function->{'content'} .= fill_in_string(<<'CODE', PACKAGE => 'code');

--- a/perl/Galacticus/Build/Components/Utils.pm
+++ b/perl/Galacticus/Build/Components/Utils.pm
@@ -8,7 +8,7 @@ use Data::Dumper;
 use List::Util qw(max);
 use Exporter qw(import);
 our $VERSION = 1.00;
-our @EXPORT_OK = qw($verbosityLevel $workaround @booleanLabel %intrinsicTypes %intrinsicNulls %outputTypeMap $classNameLengthMax $implementationNameLengthMax $fullyQualifiedNameLengthMax $propertyNameLengthMax $implementationPropertyNameLengthMax $linkedDataNameLengthMax applyDefaults isIntrinsic isOutputIntrinsic offsetName padClass padImplementation padFullyQualified padPropertyName padImplementationPropertyName padLinkedData);
+our @EXPORT_OK = qw($verbosityLevel @booleanLabel %intrinsicTypes %intrinsicNulls %outputTypeMap $classNameLengthMax $implementationNameLengthMax $fullyQualifiedNameLengthMax $propertyNameLengthMax $implementationPropertyNameLengthMax $linkedDataNameLengthMax applyDefaults isIntrinsic isOutputIntrinsic offsetName padClass padImplementation padFullyQualified padPropertyName padImplementationPropertyName padLinkedData);
 
 # Define a hash into which modules can insert their hooks.
 %Galacticus::Build::Component::Utils::componentUtils = 
@@ -21,9 +21,6 @@ our @EXPORT_OK = qw($verbosityLevel $workaround @booleanLabel %intrinsicTypes %i
 	     ]
      }
     );
-
-# Switch on compiler bug workarounds?
-our $workaround     = 1;
 
 # Global verbosity level.
 our $verbosityLevel = 1;

--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -1017,7 +1017,7 @@ CODE
 				    for(my $i=0;$i<$parameterCount;++$i) {
 					# <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336">
 					#   <description>
-					#     Array constructors are not correctly finalized. So, avoid using thme
+					#     Array constructors are not correctly finalized. So, avoid using them.
 					#   </description>
 					# $allowedParametersCode .= "       if (.not.any(trim(allowedParameters) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."')) countNew=countNew+1\n";
 					$allowedParametersCode .= "       isNew=.true.\n";
@@ -1038,7 +1038,7 @@ CODE
 				    for(my $i=0;$i<$parameterCount;++$i) {
 					# <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336">
 					#   <description>
-					#     Array constructors are not correctly finalized. So, avoid using thme
+					#     Array constructors are not correctly finalized. So, avoid using them.
 					#   </description>
 					# $allowedParametersCode .= "         if (.not.any(trim(allowedParameters(1:size(allowedParameters)-countNew)) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'classes'}->[$i]."')) then\n";
 					$allowedParametersCode .= "       isNew=.true.\n";
@@ -1075,7 +1075,7 @@ CODE
 				    for(my $i=0;$i<$parameterCount;++$i) {
 					# <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336">
 					#   <description>
-					#     Array constructors are not correctly finalized. So, avoid using thme
+					#     Array constructors are not correctly finalized. So, avoid using them.
 					#   </description>
 					# $allowedParametersCode .= "       if (.not.any(trim(allowedParameters) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'all'}->[$i]."')) countNew=countNew+1\n";
 					$allowedParametersCode .= "       isNew=.true.\n";
@@ -1095,7 +1095,7 @@ CODE
 				    for(my $i=0;$i<$parameterCount;++$i) {
 					# <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336">
 					#   <description>
-					#     Array constructors are not correctly finalized. So, avoid using thme
+					#     Array constructors are not correctly finalized. So, avoid using them.
 					#   </description>
 					# $allowedParametersCode .= "         if (.not.any(trim(allowedParameters(1:size(allowedParameters)-countNew)) == '".$allowedParameters->{$className}->{'parameters'}->{$source}->{'all'}->[$i]."')) then\n";
 					$allowedParametersCode .= "       isNew=.true.\n";


### PR DESCRIPTION
This is now supported, so a workaround is no longer needed.