### PR TITLE
Correct the maximum filter name length

### DIFF
--- a/source/objects.stellar_luminosities.F90
+++ b/source/objects.stellar_luminosities.F90
@@ -1162,7 +1162,7 @@ contains
        end if
     end do
     if (luminosityCount > 0) then
-       lengthNameMaximum =max(4,maxval(len(luminosityFilter)))
+       lengthNameMaximum =max(4,max(len(filterName),maxval(len(luminosityFilter))))
        countDigitsMaximum=int(log10(dble(luminosityCount)))+1
     else
        lengthNameMaximum =4


### PR DESCRIPTION
Previously the missing filter name (in an error report) was not accounted for.