### PR TITLE
Use fixed extrapolation in the Cloudy tables for the `nodePropertyExtractorLmnstyEmssnLinePanuzzo2003` class

### DIFF
--- a/source/nodes.property_extractor.luminosity_emission_line.Panuzzo2003.F90
+++ b/source/nodes.property_extractor.luminosity_emission_line.Panuzzo2003.F90
@@ -183,6 +183,7 @@ contains
     use            :: Output_Times                  , only : outputTimesClass
     use            :: Stellar_Luminosities_Structure, only : unitStellarLuminosities
     use            :: String_Handling               , only : String_Join            , char
+    use            :: Table_Labels                  , only : extrapolationTypeFix
     implicit none
     type            (nodePropertyExtractorLmnstyEmssnLinePanuzzo2003)                                        :: self
     double precision                                                 , intent(in   )                         :: depthOpticalISMCoefficient
@@ -261,11 +262,11 @@ contains
     self%filterExtent(:,ionizingContinuumOxygen  %ID)=Filter_Extent(Filter_Get_Index(var_str('OxygenContinuum')))
     ! Initialize interpolators.
     allocate(self%interpolator_(5))
-    self%interpolator_(interpolantMetallicity%ID)=interpolator(self%metallicity                 )
-    self%interpolator_(interpolantDensity    %ID)=interpolator(self%densityHydrogen             )
-    self%interpolator_(interpolantHydrogen   %ID)=interpolator(self%ionizingFluxHydrogen        )
-    self%interpolator_(interpolantHelium     %ID)=interpolator(self%ionizingFluxHeliumToHydrogen)
-    self%interpolator_(interpolantOxygen     %ID)=interpolator(self%ionizingFluxOxygenToHelium  )
+    self%interpolator_(interpolantMetallicity%ID)=interpolator(self%metallicity                 ,extrapolationType=extrapolationTypeFix)
+    self%interpolator_(interpolantDensity    %ID)=interpolator(self%densityHydrogen             ,extrapolationType=extrapolationTypeFix)
+    self%interpolator_(interpolantHydrogen   %ID)=interpolator(self%ionizingFluxHydrogen        ,extrapolationType=extrapolationTypeFix)
+    self%interpolator_(interpolantHelium     %ID)=interpolator(self%ionizingFluxHeliumToHydrogen,extrapolationType=extrapolationTypeFix)
+    self%interpolator_(interpolantOxygen     %ID)=interpolator(self%ionizingFluxOxygenToHelium  ,extrapolationType=extrapolationTypeFix)
     !$ call OMP_Init_Lock(self%interpolateLock)
     ! Construct name and description.
     self%name_       ="luminosityEmissionLine:"//String_Join(lineNames,"+")


### PR DESCRIPTION
Extrapolation is later limited to not extend outside of the table anyway, but failing to set fixed extrapolation in the interpolators results in errors.