### PR TITLE
Avoid missing function error if the `FFTLog` tool can not be downloaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,10 @@ source/FFTlog/fftlog.f:
 	 echo "      stop 'FFTlog was not downloaded - to try again" >> source/FFTlog/fftlog.f; \
 	 echo "     & remove the source/FFTlog directory'"           >> source/FFTlog/fftlog.f; \
 	 echo "      end subroutine fhti"                            >> source/FFTlog/fftlog.f; \
+	 echo "      subroutine fftl(n,ft,norm,dir,ws)"              >> source/FFTlog/fftlog.f; \
+	 echo "      stop 'FFTlog was not downloaded - to try again" >> source/FFTlog/fftlog.f; \
+	 echo "     & remove the source/FFTlog directory'"           >> source/FFTlog/fftlog.f; \
+	 echo "      end subroutine fftl"                            >> source/FFTlog/fftlog.f; \
 	 touch source/FFTlog/cdgamma.f; \
 	 touch source/FFTlog/drfftb.f; \
 	 touch source/FFTlog/drfftf.f; \


### PR DESCRIPTION
If the `FFTLog` tool can not be downloaded, we inject dummy functions for the top-level functions of the tool, such that the code will still compile, but any attempt to call the tool will issue a warning. One top-level function was missing; we now inject a dummy function for that one as well.