### PR TITLE
Add a radiusEnclosingDensity function and scatter to core-Mass relation for the Soliton-NFW profile 

### DIFF
--- a/doc/Galacticus.bib
+++ b/doc/Galacticus.bib
@@ -8652,3 +8652,22 @@ larger scales.},
         abstract={Cold dark matter (CDM) is a well established paradigm to describe cosmological structure formation, and works extraordinarily well on large, linear, scales. Progressing further in dark matter physics requires being able to understand structure formation in the non-linear regime, both for CDM and its alternatives. This short note describes a calculation, and accompanying code, WarmAndFuzzy, incorporating the popular models of warm and fuzzy dark matter (WDM and FDM) into the standard halo model to compute the non-linear matter power spectrum. The FDM halo model power spectrum has not been computed before. The FDM implementation models ultralight axions and other scalar fields with $m_a\approx 10^{-22}$ eV. The WDM implementation models thermal WDM with mass $m_X\approx 1$ keV. The halo model shows that differences between WDM, FDM, and CDM survive at low redshifts in the quasi-linear and fully non-linear regimes. The code uses analytic transfer functions for the linear power spectrum, modified collapse barriers in the halo mass function, and a modified concentration-mass relationship for the halo density profiles. Modified halo density profiles (for example, cores) are not included, but are under development. Cores are expected to have very minor effects on the power spectrum on observable scales. Applications of this code to the Lyman-α forest flux power spectrum and the cosmic microwavv
 e background lensing power spectrum will be discussed in companion papers. \textsc{WarmAndFuzzy} is available online at \url{https://github.com/DoddyPhysics/HMcode}, where collaboration in development is welcomed.}
 }
+
+@article{chan_diversity_2022,
+	title = {The diversity of core-halo structure in the fuzzy dark matter model},
+	volume = {511},
+	issn = {0035-8711},
+	url = {https://ui.adsabs.harvard.edu/abs/2022MNRAS.511..943C},
+	doi = {10.1093/mnras/stac063},
+	abstract = {In the fuzzy dark matter (FDM) model, gravitationally collapsed objects always consist of a solitonic core located within a virialized halo. Although various numerical simulations have confirmed that the collapsed structure can be described by a cored Navarro-Frenk-White-like density profile, there is still disagreement about the relation between the core mass and the halo mass. To fully understand this relation, we have assembled a large sample of cored haloes based on both idealized soliton mergers and cosmological simulations with various box sizes. We find that there exists a sizeable dispersion in the core-halo mass relation that increases with halo mass, indicating that the FDM model allows cores and haloes to coexist in diverse configurations. We provide a new empirical equation for a core-halo mass relation with uncertainties that can encompass all previously found relations in the dispersion, and emphasize that any observational constraints on the particle mass m using a tight one-to-one core-halo mass relation should suffer from an additional uncertainty of the order of 50 per cent for halo masses \$\{rsim\} 10{\textasciicircum}9 {\textbackslash}, [8{\textbackslash}times 10{\textasciicircum}\{-23\} {\textbackslash}, {\textbackslash}mathrm\{eV\}/(mc{\textasciicircum}2)]{\textasciicircum}\{3/2\} {\textbackslash}, {\textbackslash}mathrm\{M\}\_{\textbackslash}odot\$. We suggest that tidal stripping may be one of the effects contributing to the scatter in the relation.},
+	urldate = {2025-08-13},
+	journal = {Monthly Notices of the Royal Astronomical Society},
+	author = {Chan, Hei Yin Jowett and Ferreira, Elisa G. M. and May, Simon and Hayashi, Kohei and Chiba, Masashi},
+	month = mar,
+	year = {2022},
+	note = {Publisher: OUP
+ADS Bibcode: 2022MNRAS.511..943C},
+	keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics, cosmology: theory, dark matter, galaxies: haloes, methods: numerical, software: simulations},
+	pages = {943--952},
+	file = {Full Text PDF:/home/abensonca/.mozilla/firefox/f54gqgdx.default/zotero/storage/6Q2EWPG5/Chan et al. - 2022 - The diversity of core-halo structure in the fuzzy .pdf:application/pdf},
+}

--- a/source/dark_matter_profiles_DMO.soliton_NFW.F90
+++ b/source/dark_matter_profiles_DMO.soliton_NFW.F90
@@ -257,13 +257,13 @@ contains
     if (node%uniqueID() /= self%lastUniqueID) call self%calculationReset(node,node%uniqueID())
     if (self%radiusCorePrevious < 0.0d0) then
        call self%computeProperties(node,radiusVirial,radiusScale,radiusCore,radiusSoliton,densityCore,densityScale,massCore)
-       self%radiusVirialPrevious    =radiusVirial
-       self%radiusScalePrevious     =radiusScale
-       self%radiusCorePrevious      =radiusCore
-       self%radiusSolitonPrevious   =radiusSoliton
-       self%densityCorePrevious     =densityCore
-       self%densityScalePrevious    =densityScale
-       self%massCorePrevious        =massCore
+       self%radiusVirialPrevious =radiusVirial
+       self%radiusScalePrevious  =radiusScale
+       self%radiusCorePrevious   =radiusCore
+       self%radiusSolitonPrevious=radiusSoliton
+       self%densityCorePrevious  =densityCore
+       self%densityScalePrevious =densityScale
+       self%massCorePrevious     =massCore
     end if
     radiusVirial =self%radiusVirialPrevious
     radiusScale  =self%radiusScalePrevious

--- a/source/dark_matter_profiles_DMO.soliton_NFW.F90
+++ b/source/dark_matter_profiles_DMO.soliton_NFW.F90
@@ -157,7 +157,6 @@ contains
     self%alphaNormal = distributionFunction1DNormal(mean=0.326d0,variance=1.0d-2)
     self%massCoreScatter = distributionFunction1DNormal(mean=0.0d0,variance = log10(1.5d0)**2) ! 50% log-normal scatter from Eq.(15) of Chan et al. (2022; MNRAS; 551; 943; https://ui.adsabs.harvard.edu/abs/2022MNRAS.511..943C).
 
-
     select type (darkMatterParticle__ => self%darkMatterParticle_)
     class is (darkMatterParticleFuzzyDarkMatter)
        self%massParticle=+darkMatterParticle__%mass()*kilo

--- a/source/mass_distributions.spherical.solition_NFW.F90
+++ b/source/mass_distributions.spherical.solition_NFW.F90
@@ -433,7 +433,7 @@ contains
     if (density >= self%densitySolitonCentral) then
        radius=0.0d0
     else
-       radius=self%massDistributionClass%radiusEnclosingDensity(density,radiusGuess)
+       radius=self%radiusEnclosingDensityNumerical(density,radiusGuess)
     end if
 
     return

--- a/source/mass_distributions.spherical.solition_NFW.F90
+++ b/source/mass_distributions.spherical.solition_NFW.F90
@@ -424,7 +424,6 @@ contains
     !!{
     Computes the radius enclosing a given mean density for soliton NFW mass distributions.
     !!}
-    use :: Numerical_Ranges, only : Make_Range, rangeTypeLogarithmic
     implicit none
     class           (massDistributionSolitonNFW), intent(inout), target   :: self
     double precision                            , intent(in   )           :: density
@@ -433,7 +432,7 @@ contains
     if (density >= self%densitySolitonCentral) then
        radius=0.0d0
     else
-       radius=self%radiusEnclosingDensityNumerical(density,radiusGuess)
+       radius=sphericalTabulatedRadiusEnclosingDensity(self,density,radiusGuess)
     end if
 
     return

--- a/source/mass_distributions.spherical.solition_NFW.F90
+++ b/source/mass_distributions.spherical.solition_NFW.F90
@@ -267,7 +267,10 @@ contains
       double precision                            , intent(in   )         :: radius
       double precision                                                    :: termLogarithmic, termInverse
 
-      if (radius < self%radiusSoliton) then
+      if (radius <= 0.0d0) then
+         !Zero radius.
+         mass           =+0.0d0
+      else if (radius < self%radiusSoliton) then
          ! Soliton regime.
          mass           =+massSoliton(radius)
       else
@@ -302,10 +305,6 @@ contains
         double precision, parameter     :: fractionRadiusSmall=0.1d0
         double precision                :: termArcTangent           , termPrefactor , &
              &                             termCore                 , termPolynomial
-        
-        if (radius_ <= 0.0d0) then
-           print *, "WARNING: radius <= 0 in massEnclosedBySphere, returning 0."
-        end if
 
         if (radius_ < fractionRadiusSmall*self%radiusCore) then
            ! At small radii use a Taylor series for numerical accuracy.
@@ -355,13 +354,13 @@ contains
       class           (coordinate                ), intent(in   ) :: coordinates
       double precision                                            :: radiusScaleFree, radiusCoreFree
 
-      if (coordinates%rSpherical() <= 0.0d0) then
-           print *, "WARNING: radius <= 0 in Density, returning 0."
-      end if
-
       radiusScaleFree=+coordinates%rSpherical()/self%radiusScale
       radiusCoreFree =+coordinates%rSpherical()/self%radiusCore
-      if (coordinates%rSpherical() < self%radiusSoliton) then
+      
+      if (coordinates%rSpherical() <= 0.0d0) then
+         ! Zero radius.
+         density=+self%densitySolitonCentral
+      else if (coordinates%rSpherical() < self%radiusSoliton) then
          ! Soliton regime.
          density=+self%densitySolitonCentral                  /(+1.0d0+coefficientCore*radiusCoreFree**2)**8
       else
@@ -384,13 +383,13 @@ contains
       <optionalArgument name="logarithmic" defaultsTo=".false."/>
       !!]
 
-      if (coordinates%rSpherical() <= 0.0d0) then
-           print *, "WARNING: radius <= 0 in DensityGradientRadial, returning 0."
-      end if
-
       radiusScaleFree=+coordinates%rSpherical()/self%radiusScale
       radiusCoreFree =+coordinates%rSpherical()/self%radiusCore
-      if (coordinates%rSpherical() < self%radiusSoliton) then
+
+      if (coordinates%rSpherical() <= 0.0d0) then
+         ! Zero radius.
+         densityGradient   =0.0d0
+      else if (coordinates%rSpherical() < self%radiusSoliton) then
          ! Soliton regime.
          if (logarithmic) then
             densityGradient=-16.0d0                                       &

--- a/source/mass_distributions.spherical.solition_NFW.F90
+++ b/source/mass_distributions.spherical.solition_NFW.F90
@@ -44,14 +44,14 @@
           &              radiusVirial           , radiusCoreScaleFree    , &
           &              radiusSolitonScaleFree , densitySolitonScaleFree
    contains
-     procedure :: massEnclosedBySphere  => solitonNFWMassEnclosedBySphere
-     procedure :: density               => solitonNFWDensity
-     procedure :: densityGradientRadial => solitonNFWDensityGradientRadial
-     procedure :: radiusEnclosingDensity=> solitonNFWRadiusEnclosingDensity
-     procedure :: parameters            => solitonNFWParameters
-     procedure :: factoryTabulation     => solitonNFWFactoryTabulation
-     procedure :: descriptor            => solitonNFWDescriptor
-     procedure :: suffix                => solitonNFWSuffix
+     procedure :: massEnclosedBySphere   => solitonNFWMassEnclosedBySphere
+     procedure :: density                => solitonNFWDensity
+     procedure :: densityGradientRadial  => solitonNFWDensityGradientRadial
+     procedure :: radiusEnclosingDensity => solitonNFWRadiusEnclosingDensity
+     procedure :: parameters             => solitonNFWParameters
+     procedure :: factoryTabulation      => solitonNFWFactoryTabulation
+     procedure :: descriptor             => solitonNFWDescriptor
+     procedure :: suffix                 => solitonNFWSuffix
   end type massDistributionSolitonNFW
   
    interface massDistributionSolitonNFW

--- a/source/mass_distributions.spherical.solition_NFW.F90
+++ b/source/mass_distributions.spherical.solition_NFW.F90
@@ -268,7 +268,7 @@ contains
       double precision                                                    :: termLogarithmic, termInverse
 
       if (radius <= 0.0d0) then
-         !Zero radius.
+         ! Zero radius.
          mass           =+0.0d0
       else if (radius < self%radiusSoliton) then
          ! Soliton regime.


### PR DESCRIPTION
Added radiusEnclosingDensity function to the Soliton-NFW profile.
Update Soliton-NFW profile with new core-mass relation and fix tests.dark_matter_profiles.fuzzy_dark_matter accordingly.
Updated core-mass relation based on Chan et al. 2022, [https://ui.adsabs.harvard.edu/abs/2022MNRAS.511..943C].
