### PR TITLE
Fix a bug that prevented the file name being reported in HDF5 file open errors

### DIFF
--- a/source/utility.IO.HDF5.F90
+++ b/source/utility.IO.HDF5.F90
@@ -1150,7 +1150,7 @@ contains
        ! Attempt to open the file.
        call h5fopen_f(fileName,fileAccess,fileObject%objectID,errorCode,access_prp=accessList)
        if (errorCode /= 0) then
-          message="failed to open HDF5 file '"//fileObject%objectName//"'"
+          message="failed to open HDF5 file '"//fileObject%objectFile//"'"
           call Error_Report(message//{introspection:location})
        end if
     else


### PR DESCRIPTION
The error messages used the older `objectName` attribute (which is not set for files) instead of `objectFile`.