### PR TITLE
Restore the previous behavior for concentrations in the reference model

### DIFF
--- a/parameters/reference/darkMatterHalosStructure.xml
+++ b/parameters/reference/darkMatterHalosStructure.xml
@@ -32,13 +32,9 @@
 	<darkMatterProfileConcentration value="diemerJoyce2019">
 	  <!-- Use the Diemer & Joyce (2019; ApJ; 871; 168; http://adsabs.harvard.edu/abs/2019ApJ...871..168D) model for
 	       concentrations. -->
-	  <scatter               value="0.16"/>
-	  <truncateConcentration value="true"/>
-	  <!-- Do not include the high mass upturn in concentrations. It remains dubious whether this is real, and it can cause
-	       problems if applied in models with truncated power spectra where we use the Schneider et al. (2015;
-	       http://adsabs.harvard.edu/abs/2015MNRAS.451.3117S) for concentrations which maps the concentrations of low mass
-	       halos in such models to very high mass halos in CDM. -->
-	  <includeUpturn         value="false"/>
+	  <scatter               value="0.0"  />
+	  <truncateConcentration value="false"/>
+	  <includeUpturn         value="true" />
 	</darkMatterProfileConcentration>
       </darkMatterProfileScaleRadius>
     </darkMatterProfileScaleRadius>

--- a/parameters/reference/powerSpectraSuppressed.xml
+++ b/parameters/reference/powerSpectraSuppressed.xml
@@ -70,7 +70,15 @@
   </change>
   
   <!-- Change the concentration model to use one appropriate for WDM -->
-  <!-- First, copy the existing concentration model into a temporary location so that we can later use it in our reference
+  <!-- First, make changes to the Dimemer & Joyce (2019) concentration model to make it better behaved for suppressed power spectra. -->
+  <!-- Do not include the high mass upturn in concentrations. It remains dubious whether this is real, and it can cause
+       problems if applied in models with truncated power spectra where we use the Schneider et al. (2015;
+       http://adsabs.harvard.edu/abs/2015MNRAS.451.3117S) for concentrations which maps the concentrations of low mass
+       halos in such models to very high mass halos in CDM. -->
+  <change type="update" path="darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileConcentration/includeUpturn"         value="false"/>
+  <change type="update" path="darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileConcentration/truncateConcentration" value="true" />
+
+  <!-- Next, copy the existing concentration model into a temporary location so that we can later use it in our reference
        model. -->
   <change type="append" path="">
     <concentrationTmp>

--- a/parameters/reference/powerSpectraSuppressed.xml
+++ b/parameters/reference/powerSpectraSuppressed.xml
@@ -70,15 +70,7 @@
   </change>
   
   <!-- Change the concentration model to use one appropriate for WDM -->
-  <!-- First, make changes to the Dimemer & Joyce (2019) concentration model to make it better behaved for suppressed power spectra. -->
-  <!-- Do not include the high mass upturn in concentrations. It remains dubious whether this is real, and it can cause
-       problems if applied in models with truncated power spectra where we use the Schneider et al. (2015;
-       http://adsabs.harvard.edu/abs/2015MNRAS.451.3117S) for concentrations which maps the concentrations of low mass
-       halos in such models to very high mass halos in CDM. -->
-  <change type="update" path="darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileConcentration/includeUpturn"         value="false"/>
-  <change type="update" path="darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileConcentration/truncateConcentration" value="true" />
-
-  <!-- Next, copy the existing concentration model into a temporary location so that we can later use it in our reference
+  <!-- First, copy the existing concentration model into a temporary location so that we can later use it in our reference
        model. -->
   <change type="append" path="">
     <concentrationTmp>

--- a/source/nodes.property_extractor.halo_collapse_epoch.F90
+++ b/source/nodes.property_extractor.halo_collapse_epoch.F90
@@ -32,7 +32,7 @@
      \cite{schneider_structure_2015}, which is based on the conditional first crossing distribution from excursion set theory:     
      \begin{equation}
       \delta_\mathrm{c}(z_\mathrm{c}) = \left( {\pi \over 2} \left[ \sigma^2(f M) - \sigma^2(M) \right]
-      \right)^{1/2}+\delta_\mathrm{c})(z_0),
+      \right)^{1/2}+\delta_\mathrm{c}(z_0),
     \end{equation}
     where $\delta_\mathrm{c}(z)$ is the critical overdensity for collapse at redshift $z$, and $f$ is the fraction of a halo's
     mass assembled at formation time (given by the {\normalfont \ttfamily [massFractionFormation]} parameter.

--- a/testSuite/validate-concentrationConvergence.py
+++ b/testSuite/validate-concentrationConvergence.py
@@ -78,6 +78,8 @@ parser.add_argument('--factorMassTrust'            ,action='store'     ,default=
 parser.add_argument('--countSampleEnergyUnresolved',action='store'                                              ,help='the number of samples in Monte Carlo estimates of unresolved energy in the Johnson et al. (2021) model'             )
 parser.add_argument('--acceptUnboundOrbits'        ,action='store'     ,default="false"    ,type=restricted_bool,help='if true, allow unbound orbits in the Johnson et al. (2021) model'                                                   )
 parser.add_argument('--includeUnresolvedVariance'  ,action='store'     ,default="false"    ,type=restricted_bool,help='if true, include variance in the energy of unresolved orbits in the Johnson et al. (2021) model'                    )
+parser.add_argument('--includeUpturn'              ,action='store'     ,default="true"     ,type=restricted_bool,help='if true, include the high mass upturn in concentration in the Diemer & Joyce (2017) concentration model'            )
+parser.add_argument('--truncateConcentration'      ,action='store'     ,default="false"    ,type=restricted_bool,help='if true, truncate the concentration in the Diemer & Joyce (2017) concentration model'                               )
 parser.add_argument('--orbitModel'                 ,action='store'     ,default="unchanged"                     ,help='the orbit model to use in the Johnson et al. (2021) model (or "unchanged" to leave it unchanged)'                   )
 parser.add_argument('--mainBranchOnly'             ,action='store_true'                                         ,help='if present apply to model to the main branch only'                                                                  )
 parser.add_argument('--removeConcentrationLimits'  ,action='store_true'                                         ,help='if present remove any imposed limits on concentration'                                                              )
@@ -633,6 +635,16 @@ for massTrees in massesTree:
                 change.attrib['type' ] = "update"
                 change.attrib['path' ] = "darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/countSampleEnergyUnresolved"
                 change.attrib['value'] = args.countSampleEnergyUnresolved
+            if args.includeUpturn is not None:
+                change                 = ET.SubElement(parameters,'change')
+                change.attrib['type' ] = "update"
+                change.attrib['path' ] = "darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileConcentration/includeUpturn"
+                change.attrib['value'] = args.includeUpturn
+            if args.truncateConcentration is not None:
+                change                 = ET.SubElement(parameters,'change')
+                change.attrib['type' ] = "update"
+                change.attrib['path' ] = "darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileScaleRadius/darkMatterProfileConcentration/truncateConcentration"
+                change.attrib['value'] = args.truncateConcentration
             if args.orbitModel                  is not None:
                 if args.orbitModel == "unchanged":
                     # Nothing to do.


### PR DESCRIPTION
Commit 0917f7ca17 change the settings of the Diemer & Joyce (2019) concentration model used in reference models to have:
```
	  <truncateConcentration value="true" />
	  <includeUpturn         value="false"/>
```
Previously these had not been specified, and so took on the default values - which were the opposites of the above.

This revision reverts this, and now explicitly sets these to:
```
	  <truncateConcentration value="false"/>
	  <includeUpturn         value="true" />
```
in the reference model parameter files.

They _are_ inverted for models with suppressed power spectra as the upturn is problematic in such case.