### PR TITLE
Enforce a limit on r₋₂ in prompt cusp calculations to ensure that a solution can be found

### DIFF
--- a/source/tests.prompt_cusps.F90
+++ b/source/tests.prompt_cusps.F90
@@ -250,6 +250,7 @@ program Test_Prompt_Cusps
   <referenceConstruct object="nodeOperator_"                      >
    <constructor>
     nodeOperatorDarkMatterProfilePromptCusps                      (                                                                                                              &amp;
+     &amp;                                                         nonConvergenceIsFatal                     =.true.                                                           , &amp;
      &amp;                                                         alpha                                     =24.0d0                                                           , &amp;
      &amp;                                                         beta                                      = 7.3d0                                                           , &amp;
      &amp;                                                         kappa                                     = 4.5d0                                                           , &amp;
@@ -269,6 +270,7 @@ program Test_Prompt_Cusps
   <referenceConstruct object="nodePropertyExtractor_"             >
    <constructor>
     nodePropertyExtractorPromptCusps                              (                                                                                                              &amp;
+     &amp;                                                         darkMatterHaloScale_                      =darkMatterHaloScale_                                               &amp;
      &amp;                                                        )
    </constructor>
   </referenceConstruct>
@@ -314,7 +316,7 @@ program Test_Prompt_Cusps
   !!]
   call Assert("A"  ,amplitudeCusp         ,+1.13266d+11,relTol=2.5d-3)
   call Assert("m"  ,massCusp              ,+1.56615d+06,relTol=3.0d-2)
-  call Assert("y"  ,yCusp                 ,+2.25290d-01,relTol=3.0d-3)
+  call Assert("y"  ,yCusp                 ,+2.25290d-01,relTol=4.0d-3)
   call Assert("rₛ" ,radiusScale            ,+1.14456d-03,relTol=1.0d-3)
   call Assert("ρₛ" ,densityScale           ,+1.29838d+16,relTol=1.0d-3)
   call Assert("α₋₂",densitySlopeLogarithmic,-2.00000d+00,relTol=1.0d-3)


### PR DESCRIPTION
This is essentially the limit from the equation in footnote 9 of [Delos (2025)](https://ui.adsabs.harvard.edu/abs/2025arXiv250603240D), and ensures that a solution can be found for the scale radius without violating the $y < 1$ condition.

Also adds extraction of the prompt cusp profile $r_{-2}$ and $\rho_\mathrm{s}$ parameters.
