### PR TITLE
Switch to using `System::CPU`

### DIFF
--- a/perl/Galacticus/Launch/Local.pm
+++ b/perl/Galacticus/Launch/Local.pm
@@ -6,7 +6,7 @@ use warnings;
 use Config;
 use lib $ENV{'GALACTICUS_EXEC_PATH'}."/perl";
 use Data::Dumper;
-use Sys::CPU;
+use System::CPU;
 use Clone qw(clone);
 use Galacticus::Launch::Hooks;
 use Galacticus::Launch::PostProcess;
@@ -50,9 +50,9 @@ sub Validate {
 	unless ( exists($launchScript->{'local'}->{$_}) );
     }
     # Determine how many threads to launch.
-    $launchScript->{'local'}->{'threadCount'} = Sys::CPU::cpu_count() 
+    $launchScript->{'local'}->{'threadCount'} = System::CPU::get_ncpu() 
 	if ( $launchScript->{'local'}->{'threadCount'} eq "maximum" );
-    $launchScript->{'local'}->{'ompThreads'} = Sys::CPU::cpu_count() 
+    $launchScript->{'local'}->{'ompThreads'} = System::CPU::get_ncpu() 
 	if ( $launchScript->{'local'}->{'ompThreads'} eq "maximum" );
 }
 
@@ -137,7 +137,7 @@ sub jobArrayLaunch {
     # Find the appropriate PBS section.
     my $localConfig = &Galacticus::Options::Config("local");
     # Determine maximum number allowed in queue at once.
-    my $jobMaximum = Sys::CPU::cpu_count() ;
+    my $jobMaximum = System::CPU::get_ncpu() ;
     $jobMaximum = $localConfig->{'jobMaximum'}
        if ( exists($localConfig->{'jobMaximum'}) );
     $jobMaximum = $arguments{'threadMaximum'}

--- a/perl/Galacticus/Launch/MonolithicPBS.pm
+++ b/perl/Galacticus/Launch/MonolithicPBS.pm
@@ -6,7 +6,7 @@ use warnings;
 use Cwd;
 use lib $ENV{'GALACTICUS_EXEC_PATH'}."/perl";
 use Data::Dumper;
-use Sys::CPU;
+use System::CPU;
 use Galacticus::Launch::Hooks;
 use Galacticus::Launch::PostProcess;
 use Galacticus::Launch::PBS;
@@ -31,13 +31,13 @@ sub Validate {
     # Set defaults.
     my %defaults = 
 	(
-	 mpiRun               => "mpirun"             ,
-	 mpiOptions           => ""                   ,
-	 nodes                => 1                    ,
-	 threadsPerNode       => Sys::CPU::cpu_count(),
-	 ompThreads           => Sys::CPU::cpu_count(),
-	 shell                => "bash"               ,
-	 analyze              => "yes"                ,
+	 mpiRun               => "mpirun"               ,
+	 mpiOptions           => ""                     ,
+	 nodes                => 1                      ,
+	 threadsPerNode       => System::CPU::get_ncpu(),
+	 ompThreads           => System::CPU::get_ncpu(),
+	 shell                => "bash"                 ,
+	 analyze              => "yes"                  ,
 	 jobWaitSleepDuration => 60
 	);
     # Attempt to detect MPI implementation.

--- a/perl/Galacticus/Launch/PBS.pm
+++ b/perl/Galacticus/Launch/PBS.pm
@@ -6,7 +6,6 @@ use warnings;
 use Cwd;
 use lib $ENV{'GALACTICUS_EXEC_PATH'}."/perl";
 use Data::Dumper;
-use Sys::CPU;
 use File::Which;
 use Galacticus::Options;
 use Galacticus::Launch::Hooks;

--- a/perl/Galacticus/Launch/Slurm.pm
+++ b/perl/Galacticus/Launch/Slurm.pm
@@ -6,7 +6,6 @@ use warnings;
 use Cwd;
 use lib $ENV{'GALACTICUS_EXEC_PATH'}."/perl";
 use Data::Dumper;
-use Sys::CPU;
 use Cwd;
 use File::Which;
 use Galacticus::Launch::Hooks;


### PR DESCRIPTION
The older `Sys::CPU` module is no longer available on CPAN. This allows us to move toward deprecating it.