### PR TITLE
Update core mass calculation and add tidal heating model of the soliton

### DIFF
--- a/doc/Galacticus.bib
+++ b/doc/Galacticus.bib
@@ -8671,3 +8671,24 @@ ADS Bibcode: 2022MNRAS.511..943C},
 	pages = {943--952},
 	file = {Full Text PDF:/home/abensonca/.mozilla/firefox/f54gqgdx.default/zotero/storage/6Q2EWPG5/Chan et al. - 2022 - The diversity of core-halo structure in the fuzzy .pdf:application/pdf},
 }
+
+@article{du_tidal_2018,
+       author = {{Du}, Xiaolong and {Schwabe}, Bodo and {Niemeyer}, Jens C. and {B{\"u}rger}, David},
+        title = "{Tidal disruption of fuzzy dark matter subhalo cores}",
+      journal = {\prd},
+     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Cosmology and Nongalactic Astrophysics, General Relativity and Quantum Cosmology, High Energy Physics - Phenomenology},
+         year = 2018,
+        month = mar,
+       volume = {97},
+       number = {6},
+          eid = {063507},
+        pages = {063507},
+          doi = {10.1103/PhysRevD.97.063507},
+archivePrefix = {arXiv},
+       eprint = {1801.04864},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018PhRvD..97f3507D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+

--- a/source/dark_matter_profiles_DMO.soliton_NFW.F90
+++ b/source/dark_matter_profiles_DMO.soliton_NFW.F90
@@ -322,7 +322,7 @@ contains
     use :: Galacticus_Nodes                , only : treeNode           , nodeComponentBasic       , nodeComponentDarkMatterProfile
     use :: Numerical_Constants_Math        , only : Pi
     use :: Numerical_Constants_Units       , only : electronVolt
-    use :: Numerical_Constants_Astronomical, only : megaParsec         , MpcPerKmPerSToGyr
+    use :: Numerical_Constants_Astronomical, only : megaParsec
     use :: Numerical_Constants_Physical    , only : speedLight         , plancksConstant
     use :: Numerical_Constants_Prefixes    , only : kilo
     use :: Cosmology_Parameters            , only : hubbleUnitsStandard, hubbleUnitsLittleH
@@ -350,7 +350,6 @@ contains
          &                                                             OmegaMatter                         , densityMatter              , &
          &                                                             zeta_0                              , zeta_z                     , &
          &                                                             randomOffset                        , massCoreNormal
-    double precision                                                :: massCoretest
     double precision                                , parameter     :: alpha             =0.515            , beta               =8.0d6  , &
          &                                                             gamma             =10.0d0**(-5.73d0)                                 ! Best-fitting parameters from Chan et al. (2022; MNRAS; 551; 943; https://ui.adsabs.harvard.edu/abs/2022MNRAS.511..943C).
     integer                                                         :: status                              , sampleCount                , &

--- a/source/dark_matter_profiles_DMO.soliton_NFW.F90
+++ b/source/dark_matter_profiles_DMO.soliton_NFW.F90
@@ -150,9 +150,9 @@ contains
     double precision                                , intent(in)         :: toleranceRelativeVelocityDispersion, toleranceRelativeVelocityDispersionMaximum
     !![
     <constructorAssign variables="*darkMatterHaloScale_, *darkMatterParticle_, *cosmologyFunctions_, *cosmologyParameters_, *virialDensityContrast_, toleranceRelativeVelocityDispersion, toleranceRelativeVelocityDispersionMaximum"/>
-    <addMetaProperty component="darkMatterProfile" name="randomOffset" id="self%randomOffsetID" isEvolvable="no" isCreator="yes"/>
-    <addMetaProperty component="basic"             name="densityCore"  id="self%densityCoreID"  isEvolvable="no" isCreator="yes"/>
-    <addMetaProperty component="basic"             name="radiusCore"   id="self%radiusCoreID"   isEvolvable="no" isCreator="yes"/>
+    <addMetaProperty component="darkMatterProfile" name="randomOffset"         id="self%randomOffsetID"         isEvolvable="no"  isCreator="yes"/>
+    <addMetaProperty component="basic"             name="densityCore"          id="self%densityCoreID"          isEvolvable="no"  isCreator="yes"/>
+    <addMetaProperty component="basic"             name="radiusCore"           id="self%radiusCoreID"           isEvolvable="no"  isCreator="yes"/>
     <addMetaProperty component="basic"             name="densityCoreAccretion" id="self%densityCoreAccretionID" isEvolvable="yes" isCreator="no"/>
     !!]
 

--- a/source/nodes.operators.physics.dark_matter_profile.soliton.F90
+++ b/source/nodes.operators.physics.dark_matter_profile.soliton.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  !+    Contributions to this file made by: Yu Zhao
+
   !!{
      Implements a node operator class that evaluates the \gls{fdm} solitonic core–halo relation, following Equation (15) of \cite{chan_diversity_2022}, with modifications to include time differentiation and integration to track the evolution of the core mass.
   !!}

--- a/source/nodes.operators.physics.dark_matter_profile.soliton.F90
+++ b/source/nodes.operators.physics.dark_matter_profile.soliton.F90
@@ -1,0 +1,340 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+     Implements a node operator class that evaluates the \gls{fdm} solitonic core–halo relation, following Equation (15) of \cite{chan_diversity_2022}, with modifications to include time differentiation and integration to track the evolution of the core mass.
+  !!}
+
+  use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScaleClass
+  use :: Dark_Matter_Particles  , only : darkMatterParticleClass
+  use :: Cosmology_Functions    , only : cosmologyFunctionsClass
+  use :: Cosmology_Parameters   , only : cosmologyParametersClass
+  use :: Virial_Density_Contrast, only : virialDensityContrastClass
+
+  !![
+  <nodeOperator name="nodeOperatorDarkMatterProfileSoliton">
+   <description>
+     A node operator class that evaluates the \gls{fdm} solitonic core–halo relation,
+     following Equation (15) of \cite{chan_diversity_2022}, with modifications to
+     include time differentiation and integration to track the evolution of the core mass.
+   </description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorDarkMatterProfileSoliton
+     !!{
+     A node operator class implementing the time-evolved solitonic core–halo relation following \cite{chan_diversity_2022}.
+     !!}
+     private
+     class           (darkMatterHaloScaleClass  ), pointer :: darkMatterHaloScale_  => null()
+     class           (darkMatterParticleClass   ), pointer :: darkMatterParticle_   => null()
+     class           (cosmologyFunctionsClass   ), pointer :: cosmologyFunctions_   => null()
+     class           (cosmologyParametersClass  ), pointer :: cosmologyParameters_  => null()
+     class           (virialDensityContrastClass), pointer :: virialDensityContrast_=> null()
+     integer                                               :: densityCoreAccretionID
+     double precision                                      :: massParticle
+   contains
+     final     ::                                darkMatterProfileSolitonDestructor
+     procedure :: nodeTreeInitialize          => darkMatterProfileSolitonNodeTreeInitialize
+     procedure :: differentialEvolution       => darkMatterProfileSolitonDifferentialEvolution
+     procedure :: differentialEvolutionScales => darkMatterProfileSolitonDifferentialEvolutionScales
+  end type nodeOperatorDarkMatterProfileSoliton
+  
+  interface nodeOperatorDarkMatterProfileSoliton
+     !!{
+     Constructors for the \refClass{nodeOperatorDarkMatterProfileSoliton} node operator class.
+     !!}
+     module procedure darkMatterProfileSolitonConstructorParameters
+     module procedure darkMatterProfileSolitonConstructorInternal
+  end interface nodeOperatorDarkMatterProfileSoliton
+  
+contains
+
+  function darkMatterProfileSolitonConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the \refClass{nodeOperatorDarkMatterProfileSoliton} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type            (nodeOperatorDarkMatterProfileSoliton )                :: self
+    type            (inputParameters                      ), intent(inout) :: parameters
+    class           (darkMatterHaloScaleClass             ), pointer       :: darkMatterHaloScale_
+    class           (darkMatterParticleClass              ), pointer       :: darkMatterParticle_
+    class           (cosmologyFunctionsClass              ), pointer       :: cosmologyFunctions_
+    class           (cosmologyParametersClass             ), pointer       :: cosmologyParameters_
+    class           (virialDensityContrastClass           ), pointer       :: virialDensityContrast_
+
+    !![
+    <objectBuilder class="darkMatterHaloScale"   name="darkMatterHaloScale_"   source="parameters"/>
+    <objectBuilder class="darkMatterParticle"    name="darkMatterParticle_"    source="parameters"/>
+    <objectBuilder class="cosmologyFunctions"    name="cosmologyFunctions_"    source="parameters"/>
+    <objectBuilder class="cosmologyParameters"   name="cosmologyParameters_"   source="parameters"/>
+    <objectBuilder class="virialDensityContrast" name="virialDensityContrast_" source="parameters"/>
+    !!]
+     self=nodeOperatorDarkMatterProfileSoliton(darkMatterHaloScale_,darkMatterParticle_,cosmologyFunctions_,cosmologyParameters_,virialDensityContrast_)
+    !![
+    <inputParametersValidate source="parameters"            />
+    <objectDestructor        name  ="darkMatterHaloScale_"  />
+    <objectDestructor        name  ="darkMatterParticle_"   />
+    <objectDestructor        name  ="cosmologyFunctions_"   />
+    <objectDestructor        name  ="cosmologyParameters_"  />
+    <objectDestructor        name  ="virialDensityContrast_"/>
+    !!]
+    return
+  end function darkMatterProfileSolitonConstructorParameters
+
+  function darkMatterProfileSolitonConstructorInternal(darkMatterHaloScale_,darkMatterParticle_,cosmologyFunctions_,cosmologyParameters_,virialDensityContrast_) result(self)
+    !!{
+    Internal constructor for the \refClass{nodeOperatorDarkMatterProfileSoliton} node operator class.
+    !!}
+    use :: Dark_Matter_Particles           , only : darkMatterParticleFuzzyDarkMatter
+    use :: Numerical_Constants_Prefixes    , only : kilo
+    implicit none
+    type            (nodeOperatorDarkMatterProfileSoliton)                     :: self
+    class           (darkMatterHaloScaleClass            ), intent(in), target :: darkMatterHaloScale_
+    class           (darkMatterParticleClass             ), intent(in), target :: darkMatterParticle_
+    class           (cosmologyFunctionsClass             ), intent(in), target :: cosmologyFunctions_
+    class           (cosmologyParametersClass            ), intent(in), target :: cosmologyParameters_
+    class           (virialDensityContrastClass          ), intent(in), target :: virialDensityContrast_
+    !![
+    <constructorAssign variables="*darkMatterHaloScale_,*darkMatterParticle_,*cosmologyFunctions_,*cosmologyParameters_,*virialDensityContrast_"/>
+    <addMetaProperty component="basic" name="densityCoreAccretion" id="self%densityCoreAccretionID" isEvolvable="yes" isCreator="yes"/>
+    !!]
+
+    select type (darkMatterParticle__ => self%darkMatterParticle_)
+    class is (darkMatterParticleFuzzyDarkMatter)
+       self%massParticle=+darkMatterParticle__%mass()*kilo
+    class default
+       call Error_Report('expected a `darkMatterParticleFuzzyDarkMatter` dark matter particle object'//{introspection:location})
+    end select
+    return
+  end function darkMatterProfileSolitonConstructorInternal
+
+  subroutine darkMatterProfileSolitonDestructor(self)
+    !!{
+    Destructor for the \refClass{nodeOperatorDarkMatterProfileSoliton} node operator class.
+    !!}
+    implicit none
+    type            (nodeOperatorDarkMatterProfileSoliton), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%darkMatterHaloScale_"  />
+    <objectDestructor name="self%darkMatterParticle_"   />
+    <objectDestructor name="self%cosmologyFunctions_"   />
+    <objectDestructor name="self%cosmologyParameters_"  />
+    <objectDestructor name="self%virialDensityContrast_"/>
+    !!]
+
+    return
+  end subroutine darkMatterProfileSolitonDestructor
+
+  subroutine darkMatterProfileSolitonDifferentialEvolutionScales(self,node)
+    !!{
+    Set absolute ODE solver scale for the energy radiated from the hot halo due to cooling following the model of \cite{benson_galaxy_2010-1}.
+    !!}
+    use :: Galacticus_Nodes                , only : nodeComponentBasic
+    implicit none
+    class           (nodeOperatorDarkMatterProfileSoliton), intent(inout) :: self
+    type            (treeNode                            ), intent(inout) :: node
+    double precision                                      , parameter     :: scaleRelative     =+1.0d-1
+    class           (nodeComponentBasic                  ), pointer       :: basic
+
+    basic=>node%basic()
+    call basic%floatRank0MetaPropertyScale(self%densityCoreAccretionID, scaleRelative)
+
+    return
+  end subroutine darkMatterProfileSolitonDifferentialEvolutionScales
+
+  subroutine darkMatterProfileSolitonDifferentialEvolution(self,node,interrupt,functionInterrupt,propertyType)
+    !!{
+    Accumulates an estimate of the energy radiated from the hot halo due to cooling following the model of \cite{benson_galaxy_2010-1}.
+    !!}
+    use :: Galacticus_Nodes                , only : treeNode           , nodeComponentBasic       , nodeComponentDarkMatterProfile
+    use :: Numerical_Constants_Math        , only : Pi
+    use :: Numerical_Constants_Units       , only : electronVolt
+    use :: Numerical_Constants_Physical    , only : plancksConstant
+    use :: Cosmology_Parameters            , only : hubbleUnitsStandard, hubbleUnitsLittleH
+    implicit none
+    class           (nodeOperatorDarkMatterProfileSoliton), intent   (inout), target  :: self
+    type            (treeNode                            ), intent   (inout), target  :: node
+    class           (nodeComponentBasic                  ), pointer                   :: basic
+    class           (nodeComponentDarkMatterProfile      ), pointer                   :: darkMatterProfile
+    logical                                               , intent   (inout)          :: interrupt
+    procedure       (interruptTask                       ), intent   (inout), pointer :: functionInterrupt
+    integer                                               , intent   (in   )          :: propertyType
+    double precision                                      , parameter                 :: plancksConstantBar=+plancksConstant                                & ! ℏ in units of eV s.
+         &                                                                                                  /2.0d0                                          &
+         &                                                                                                  /Pi                                             &
+         &                                                                                                  /electronVolt
+    double precision                                                                  :: massHalo                            , expansionFactor            , &
+         &                                                                               redshift                            , concentration              , &
+         &                                                                               hubbleConstant                      , hubbleConstantLittle       , &
+         &                                                                               OmegaMatter                         , densityMatter              , &
+         &                                                                               zeta_0                              , zeta_z                     , &
+         &                                                                               radiusVirial                        , radiusScale                , &
+         &                                                                               massCoreRate                        , densityScale               , &
+         &                                                                               expansionRate                       , zetaRate
+    double precision                                      , parameter                 :: alpha             =0.515            , beta               =8.0d6  , &
+         &                                                                               gamma             =10.0d0**(-5.73d0)                                 ! Best-fitting parameters from Chan et al. (2022; MNRAS; 551; 943; https://ui.adsabs.harvard.edu/abs/2022MNRAS.511..943C).
+    double precision                                                                  :: A                                   , K0                         , & ! first term of Equation 15 from Chan et al. (2022; MNRAS; 551; 943; https://ui.adsabs.harvard.edu/abs/2022MNRAS.511..943C).
+         &                                                                               K1                                                                   ! second term of Equation 15 from Chan et al. (2022; MNRAS; 551; 943; https://ui.adsabs.harvard.edu/abs/2022MNRAS.511..943C).
+    !$GLC attributes unused :: interrupt, functionInterrupt, propertyType
+
+    ! Get required components.
+    basic             => node%basic            ()
+    darkMatterProfile => node%darkMatterProfile()
+    ! Extract basic properties of the node.
+    expansionFactor=+self             %cosmologyFunctions_ %expansionFactor            (basic%time           ())
+    expansionRate  =+self             %cosmologyFunctions_ %expansionRate              (expansionFactor        )
+    redshift       =+self             %cosmologyFunctions_ %redshiftFromExpansionFactor(expansionFactor        )
+    massHalo       =+basic                                 %mass                       (                       )
+    radiusScale    =+darkMatterProfile                     %scale                      (                       )
+    radiusVirial   =+self             %darkMatterHaloScale_%radiusVirial               (node                   )
+    concentration  =+                                       radiusVirial                                         &
+         &          /                                       radiusScale
+    densityScale   =+1.0d0                                    &
+         &          /4.0d0                                    &
+         &          /Pi                                       &
+         &          *massHalo                                 &
+         &          /radiusScale**3                           &
+         &          /(                                        &
+         &            +              log(1.0d0+concentration) &
+         &            -concentration/   (1.0d0+concentration) &
+         &          )
+    ! Extract cosmological parameters for later use.
+    hubbleConstant      =+self%cosmologyParameters_%HubbleConstant (hubbleUnitsStandard)
+    hubbleConstantLittle=+self%cosmologyParameters_%HubbleConstant (hubbleUnitsLittleH )
+    OmegaMatter         =+self%cosmologyParameters_%OmegaMatter    (                   )
+    densityMatter       =+self%cosmologyParameters_%densityCritical(                   ) &
+         &                      *                   OmegaMatter
+    zeta_0              =+self%virialDensityContrast_%densityContrast            (massHalo,expansionFactor=1.0d0          )
+    zeta_z              =+self%virialDensityContrast_%densityContrast            (massHalo,expansionFactor=expansionFactor)
+    zetaRate            =+self%virialDensityContrast_%densityContrastRateofChange(massHalo,expansionFactor=expansionFactor)
+
+    A                   =+self%massParticle         &
+         &               /8.0d-23
+    K0                  =+beta                      &
+         &               *A**(-1.5d0)
+    K1                  =(sqrt(                     &
+         &                     +zeta_z              &
+         &                     /zeta_0              &
+         &                    )                     &
+         &                *massHalo                 &
+         &                /gamma                    &
+         &               )**alpha                   &
+         &               *A**(1.5d0*(alpha-1.0d0))
+    massCoreRate        =-0.5d0                     &
+         &               *expansionFactor**(-0.5d0) &
+         &               *expansionRate             &
+         &               *(K0+K1)                   &
+         &               +alpha                     &
+         &               *expansionFactor**(-0.5d0) &
+         &               *K1                        &
+         &               *(+0.5d0                   &
+         &                 *zetaRate                &
+         &                 /zeta_z                  &
+         &                 +basic%accretionRate()   &
+         &                 /massHalo                &
+         &                )
+    call basic%floatRank0MetaPropertyRate(                             &
+         &                                self%densityCoreAccretionID, &
+         &                                massCoreRate                 &
+         &                               )
+    return
+  end subroutine darkMatterProfileSolitonDifferentialEvolution
+
+  subroutine darkMatterProfileSolitonNodeTreeInitialize(self,node)
+    use :: Galacticus_Nodes                , only : treeNode           , nodeComponentBasic       , nodeComponentDarkMatterProfile
+    use :: Numerical_Constants_Math        , only : Pi
+    use :: Numerical_Constants_Units       , only : electronVolt
+    use :: Numerical_Constants_Physical    , only : plancksConstant
+    use :: Cosmology_Parameters            , only : hubbleUnitsStandard, hubbleUnitsLittleH
+    implicit none
+    class           (nodeOperatorDarkMatterProfileSoliton), intent(inout), target :: self
+    type            (treeNode                            ), intent(inout), target :: node
+    class           (nodeComponentBasic                  ), pointer               :: basic
+    class           (nodeComponentDarkMatterProfile      ), pointer               :: darkMatterProfile
+    double precision                                      , parameter             :: plancksConstantBar=+plancksConstant                                & ! ℏ in units of eV s.
+         &                                                                                              /2.0d0                                          &
+         &                                                                                              /Pi                                             &
+         &                                                                                              /electronVolt
+    double precision                                                              :: massHalo                            , expansionFactor            , &
+         &                                                                           redshift                            , concentration              , &
+         &                                                                           hubbleConstant                      , hubbleConstantLittle       , &
+         &                                                                           OmegaMatter                         , densityMatter              , &
+         &                                                                           zeta_0                              , zeta_z                     , &
+         &                                                                           radiusVirial                        , radiusScale                , &
+         &                                                                           massCoreNormal                      , densityScale
+    double precision                                      , parameter             :: alpha             =0.515            , beta               =8.0d6  , &
+         &                                                                           gamma             =10.0d0**(-5.73d0)                                 ! Best-fitting parameters from Chan et al. (2022; MNRAS; 551; 943; https://ui.adsabs.harvard.edu/abs/2022MNRAS.511..943C).
+
+    ! Get required components.
+    basic             => node%basic            ()
+    darkMatterProfile => node%darkMatterProfile()
+    ! Extract basic properties of the node.
+    expansionFactor=+self             %cosmologyFunctions_% expansionFactor            (basic%time           ())
+    redshift       =+self             %cosmologyFunctions_ %redshiftFromExpansionFactor(      expansionFactor  )
+    massHalo       =+basic                                 %mass                       (                       )
+    radiusScale    =+darkMatterProfile                     %scale                      (                       )
+    radiusVirial   =+self             %darkMatterHaloScale_%radiusVirial               (node                   )
+    concentration  =+                                       radiusVirial                                         &
+         &          /                                       radiusScale
+    densityScale   =+1.0d0                                    &
+         &          /4.0d0                                    &
+         &          /Pi                                       &
+         &          *massHalo                                 &
+         &          /radiusScale**3                           &
+         &          /(                                        &
+         &            +              log(1.0d0+concentration) &
+         &            -concentration/   (1.0d0+concentration) &
+         &          )
+    ! Extract cosmological parameters for later use.
+    hubbleConstant      =+self%cosmologyParameters_%HubbleConstant (hubbleUnitsStandard)
+    hubbleConstantLittle=+self%cosmologyParameters_%HubbleConstant (hubbleUnitsLittleH )
+    OmegaMatter         =+self%cosmologyParameters_%OmegaMatter    (                   )
+    densityMatter       =+self%cosmologyParameters_%densityCritical(                   ) &
+         &                      *                   OmegaMatter
+    zeta_0             =+self%virialDensityContrast_%densityContrast(massHalo,expansionFactor=1.0d0          )
+    zeta_z             =+self%virialDensityContrast_%densityContrast(massHalo,expansionFactor=expansionFactor)
+
+    massCoreNormal     =+(                          & ! Equation (15) of Chan et al. (2022; MNRAS; 551; 943; https://ui.adsabs.harvard.edu/abs/2022MNRAS.511..943C).
+         &                +beta                     &
+         &                *(                        &
+         &                  +self%massParticle      &
+         &                  /8.0d-23                &
+         &                 )**(-1.5d0)              &
+         &                +(                        &
+         &                  +sqrt(                  &
+         &                        +zeta_z           &
+         &                        /zeta_0           &
+         &                       )                  &
+         &                  *massHalo               &
+         &                  /gamma                  &
+         &                 )**alpha                 &
+         &                *(                        &
+         &                  +self%massParticle      &
+         &                  /8.0d-23                &
+         &                 )**(1.5d0*(alpha-1.0d0)) &
+         &               )&
+         &              /sqrt(expansionFactor)
+    call basic%floatRank0MetaPropertySet(                             &
+         &                               self%densityCoreAccretionID, &
+         &                               massCoreNormal               &
+         &                              )
+    return
+  end subroutine darkMatterProfileSolitonNodeTreeInitialize

--- a/source/nodes.operators.physics.satellite.mass_loss.soliton.F90
+++ b/source/nodes.operators.physics.satellite.mass_loss.soliton.F90
@@ -1,0 +1,227 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{Du_tidal_2018}.
+  !!}
+
+  use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScaleClass
+
+  !![
+  <nodeOperator name="nodeOperatorSatelliteSolitonMassLoss">
+   <description>A node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{Du_tidal_2018}.</description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorSatelliteSolitonMassLoss
+     !!{
+     A node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{Du_tidal_2018}.
+     !!}
+     private
+     class  (darkMatterHaloScaleClass               ), pointer :: darkMatterHaloScale_ => null()
+     integer                                                   :: densityCoreEvolutionID
+     integer                                                   :: densityCoreID
+   contains
+     final     ::                                tidalMassLossSolitonDestructor
+     procedure :: differentialEvolution       => tidalMassLossSolitonDifferentialEvolution
+     procedure :: differentialEvolutionScales => tidalMassLossSolitonDifferentialEvolutionScales
+     procedure :: galaxiesMerge               => tidalMassLossSolitonGalaxiesMerge
+  end type nodeOperatorSatelliteSolitonMassLoss
+  
+  interface nodeOperatorSatelliteSolitonMassLoss
+     !!{
+     Constructors for the \refClass{nodeOperatorSatelliteSolitonMassLoss} node operator class.
+     !!}
+     module procedure tidalMassLossSolitonConstructorParameters
+     module procedure tidalMassLossSolitonConstructorInternal
+  end interface nodeOperatorSatelliteSolitonMassLoss
+  
+contains
+
+  function tidalMassLossSolitonConstructorParameters(parameters) result(self)
+    !!{
+    Constructor for the \refClass{nodeOperatorSatelliteSolitonMassLoss} node operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type (nodeOperatorSatelliteSolitonMassLoss )                :: self
+    type (inputParameters                      ), intent(inout) :: parameters
+    class(darkMatterHaloScaleClass             ), pointer       :: darkMatterHaloScale_
+
+    !![
+    <objectBuilder class="darkMatterHaloScale" name="darkMatterHaloScale_" source="parameters"/>
+    !!]
+     self=nodeOperatorSatelliteSolitonMassLoss(darkMatterHaloScale_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="darkMatterHaloScale_"/>
+    !!]
+    return
+  end function tidalMassLossSolitonConstructorParameters
+
+  function tidalMassLossSolitonConstructorInternal(darkMatterHaloScale_) result(self)
+    !!{
+    Internal constructor for the \refClass{nodeOperatorSatelliteSolitonMassLoss} node operator class.
+    !!}
+    implicit none
+    type (nodeOperatorSatelliteSolitonMassLoss)                        :: self
+    class(darkMatterHaloScaleClass            ), intent(in   ), target :: darkMatterHaloScale_
+    !![
+    <constructorAssign variables="*darkMatterHaloScale_"/>
+    <addMetaProperty component="basic" name="densityCoreEvolution" id="self%densityCoreEvolutionID" isEvolvable="yes" isCreator="yes"/>
+    <addMetaProperty component="basic" name="densityCore"          id="self%densityCoreID"          isEvolvable="no" isCreator="no"/>
+    !!]
+    return
+  end function tidalMassLossSolitonConstructorInternal
+
+  subroutine tidalMassLossSolitonDestructor(self)
+    !!{
+    Destructor for the \refClass{nodeOperatorSatelliteSolitonMassLoss} node operator class.
+    !!}
+    implicit none
+    type(nodeOperatorSatelliteSolitonMassLoss), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%darkMatterHaloScale_"/>
+    !!]
+    return
+  end subroutine tidalMassLossSolitonDestructor
+
+  subroutine tidalMassLossSolitonDifferentialEvolutionScales(self,node)
+    !!{
+    Set absolute ODE solver scale for the energy radiated from the hot halo due to cooling following the model of \cite{benson_galaxy_2010-1}.
+    !!}
+    use :: Galacticus_Nodes                , only : nodeComponentBasic
+    implicit none
+    class           (nodeOperatorSatelliteSolitonMassLoss), intent(inout) :: self
+    type            (treeNode                            ), intent(inout) :: node
+    double precision                                      , parameter     :: scaleRelative     =+1.0d-1
+    class           (nodeComponentBasic                  ), pointer       :: basic
+
+    basic=>node%basic()
+    call basic%floatRank0MetaPropertyScale(self%densityCoreEvolutionID, scaleRelative)
+
+    return
+  end subroutine tidalMassLossSolitonDifferentialEvolutionScales
+
+  subroutine tidalMassLossSolitonDifferentialEvolution(self,node,interrupt,functionInterrupt,propertyType)
+    !!{
+    Accumulates an estimate of the energy radiated from the hot halo due to cooling following the model of \cite{benson_galaxy_2010-1}.
+    !!}
+    use :: Galacticus_Nodes                , only : nodeComponentBasic    , nodeComponentSatellite, treeNode
+    use :: Mass_Distributions              , only : massDistributionClass
+    use :: Numerical_Constants_Astronomical, only : gigaYear              , megaParsec
+    use :: Numerical_Constants_Math        , only : Pi
+    use :: Numerical_Constants_Prefixes    , only : kilo
+    use :: Vectors                         , only : Vector_Magnitude      , Vector_Product
+    implicit none
+    class           (nodeOperatorSatelliteSolitonMassLoss), intent   (inout), target  :: self    
+    type            (treeNode                            ), intent   (inout), target  :: node
+    logical                                               , intent   (inout)          :: interrupt
+    procedure       (interruptTask                       ), intent   (inout), pointer :: functionInterrupt
+    integer                                               , intent   (in   )          :: propertyType
+    class           (nodeComponentSatellite              ), pointer                   :: satellite
+    class           (nodeComponentBasic                  ), pointer                   :: basic
+    class           (massDistributionClass               ), pointer                   :: massDistribution_
+    double precision                                      , dimension(3    )          :: position                      , velocity
+    double precision                                      , parameter                 :: frequencyFractionalTiny=1.0d-6
+    double precision                                      , parameter                 :: a=5.89794d-5                  , b=-8.72733d-2   , &
+         &                                                                               c=1.6774d0                    , gamma=1.5d0
+    double precision                                                                  :: frequencyAngular              , frequencyRadial , &
+         &                                                                               periodOrbital                 , radius          , &
+         &                                                                               densityCore                   , densityHost     , &
+         &                                                                               massHost                      , energyIm        , &
+         &                                                                               frequencyOrbital              , densityRatio
+    !$GLC attributes unused :: interrupt, functionInterrupt, propertyType
+
+    ! Get required quantities from the satellite node.
+    satellite          =>  node     %satellite (        )
+    position           =   satellite%position  (        )
+    velocity           =   satellite%velocity  (        )
+    radius             =   Vector_Magnitude    (position)
+    ! Compute the orbital frequency. We use the larger of the angular and radial frequencies to avoid numerical problems for purely
+    ! radial or purely circular orbits.
+    frequencyAngular   =  +Vector_Magnitude(Vector_Product(position,velocity)) &
+         &                /radius**2                                           &
+         &                *kilo                                                &
+         &                *gigaYear                                            &
+         &                /megaParsec
+    frequencyRadial    =  +abs             (   Dot_Product(position,velocity)) &
+         &                /radius**2                                           &
+         &                *kilo                                                &
+         &                *gigaYear                                            &
+         &                /megaParsec
+    ! Find the orbital frequency. We use the larger of the angular and radial frequencies to avoid numerical problems for purely
+    ! radial or purely circular orbits.
+    frequencyOrbital   =  max(                  &
+         &                    frequencyAngular, &
+         &                    frequencyRadial   &
+         &                   )
+    ! Find the orbital period.
+    periodOrbital      =  +2.0d0                &
+         &                *Pi                   &
+         &                /frequencyOrbital
+
+    massDistribution_  => node%massDistribution()
+    massHost           =  max(0.0d0,massDistribution_%massEnclosedBySphere(radius))
+    densityHost        =  3.0d0*massHost/(4.0d0*Pi*radius**3)
+
+    basic              => node%basic           ()
+    densityCore        =  basic%floatRank0MetaPropertyGet(self%densityCoreID)
+
+    ! Compute the density ratio between the central density of the soliton and the average density of the host within the orbital radius
+    densityRatio       =  densityCore/densityHost
+
+    if (densityRatio>300.0d0) then
+        densityRatio = 300.0d0
+    end if
+
+    ! Compute the imaginary part of the energy eigenvalue E, using the fitting formula, Equation (7) of Du et al. (2018; PRD; 97; 3507; https://ui.adsabs.harvard.edu/abs/2018PhRvD..97f3507D/abstract).
+    energyIm           =  -exp(+a*(3.0d0*densityRatio/2.0d0/gamma)**2  &
+         &                     +b*(3.0d0*densityRatio/2.0d0/gamma)     &
+         &                     +c                                      &
+         &                    )/periodOrbital
+    
+    ! Set the rate to be integrated by Galacticus for the soliton core density evolution. From Du et al. (2018), equation (17) can be written as: d(log ρ_c) / dt = 2 Im(E)
+    ! Im(E) is given by their fitting formula (eq. 7) as a function of densityRatio = ρ_c / ρ̄_host(<r_orbit) and the orbital period T_orbit.
+    ! Here we evaluate the instantaneous rate 2*Im(E), which will be integrated over time to obtain Δlog ρ_c(t) = ∫ [2 Im(E)] dt.
+    call basic%floatRank0MetaPropertyRate(                             &
+         &                                self%densityCoreEvolutionID, &
+         &                                +2.0d0                       &
+         &                                *energyIm                    &
+         &                               )
+    return
+  end subroutine tidalMassLossSolitonDifferentialEvolution
+
+  subroutine tidalMassLossSolitonGalaxiesMerge(self,node)
+    !!{
+    Zero the soliton core density evolution rate for a subhalo that is about to merge.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentBasic
+    implicit none
+    class           (nodeOperatorSatelliteSolitonMassLoss), intent(inout) :: self
+    type            (treeNode                            ), intent(inout) :: node
+    class           (nodeComponentBasic                  ), pointer       :: basic
+
+    basic=>node%basic()
+    call basic%floatRank0MetaPropertySet(                             &
+         &                               self%densityCoreEvolutionID, &
+         &                               +0.0d0                       &
+         &                              )
+    return
+  end subroutine tidalMassLossSolitonGalaxiesMerge

--- a/source/nodes.operators.physics.satellite.mass_loss.soliton.F90
+++ b/source/nodes.operators.physics.satellite.mass_loss.soliton.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  !+    Contributions to this file made by: Yu Zhao
+
   !!{
   Implements a node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{du_tidal_2018}.
   !!}

--- a/source/nodes.operators.physics.satellite.mass_loss.soliton.F90
+++ b/source/nodes.operators.physics.satellite.mass_loss.soliton.F90
@@ -18,19 +18,19 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Implements a node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{Du_tidal_2018}.
+  Implements a node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{du_tidal_2018}.
   !!}
 
   use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScaleClass
 
   !![
   <nodeOperator name="nodeOperatorSatelliteSolitonMassLoss">
-   <description>A node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{Du_tidal_2018}.</description>
+   <description>A node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{du_tidal_2018}.</description>
   </nodeOperator>
   !!]
   type, extends(nodeOperatorClass) :: nodeOperatorSatelliteSolitonMassLoss
      !!{
-     A node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{Du_tidal_2018}.
+     A node operator class that accumulates the tidal-heating source term from the FDM solitonic core, following the model of \cite{du_tidal_2018}.
      !!}
      private
      class  (darkMatterHaloScaleClass               ), pointer :: darkMatterHaloScale_ => null()


### PR DESCRIPTION
This PR introduces the implementation of core–halo mass relation time integration based on Chan et al. (2022):
Added support for evolving massCore using the time derivative formulation.
Verified consistency against the original expression (Eq. 15 in Chan et al. 2022): Maximum relative difference ~ 0.01% and Minimum difference ~0.0002%.

Soliton tidal heating model (Du et al. 2018):
This operator accumulates the tidal-heating source term from the FDM solitonic core.

These changes improve the fidelity of soliton core evolution and enable tidal-heating modeling for subhalos.