### PR TITLE
Use `readOnly=.true.` when reading excursion set files

### DIFF
--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
@@ -1312,7 +1312,7 @@ contains
     if (.not.File_Exists(self%fileName)) return
     ! Open the data file.
     !$ call hdf5Access%set()
-    call dataFile%openFile(self%fileName)
+    call dataFile%openFile(self%fileName,readOnly=.true.)
     ! Check if the standard table is populated.
     if (dataFile%hasGroup('probability')) then
        ! Deallocate arrays if necessary.


### PR DESCRIPTION
This avoids lock conflicts in the HDF5 library.