### PR TITLE
Fix excursion set file name expansion

### DIFF
--- a/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.Farahi.F90
@@ -371,7 +371,7 @@ contains
   end function farahiConstructorInternal
 
   subroutine farahiFileNameInitialize(self)
-    use :: File_Utilities, only : Directory_Make, File_Path
+    use :: File_Utilities, only : Directory_Make, File_Path          , File_Name_Expand
     use :: Input_Paths   , only : inputPath     , pathTypeDataDynamic
     implicit none
     class(excursionSetFirstCrossingFarahi), intent(inout) :: self
@@ -380,6 +380,8 @@ contains
     ! Build an automatic file name based on the descriptor for this object.
     if (self%fileName == "auto") &
          & self%fileName=inputPath(pathTypeDataDynamic)//'largeScaleStructure/excursionSets/'//self%objectType()//'_'//self%hashedDescriptor(includeSourceDigest=.true.,includeFileModificationTimes=.true.)//'.hdf5'
+    ! Expand the file name.
+    self%fileName=File_Name_Expand(self%fileName)
     ! Ensure directory exists.
     call Directory_Make(File_Path(self%fileName))
     self%fileNameInitialized=.true.

--- a/source/utility.files.F90
+++ b/source/utility.files.F90
@@ -86,6 +86,14 @@ module File_Utilities
      module procedure File_Name_VarStr
   end interface File_Name
 
+  interface File_Name_Expand
+     !!{
+     Generic interface for functions that return the name of a file.
+     !!}
+     module procedure File_Name_Expand_Char
+     module procedure File_Name_Expand_VarStr
+  end interface File_Name_Expand
+
   interface File_Remove
      !!{
      Generic interface for functions that remove a file.
@@ -697,6 +705,19 @@ contains
     end if
     return
   end subroutine Directory_Remove_Char
+
+  function File_Name_Expand_VarStr(fileNameIn) result(fileNameOut)
+    !!{
+    Expands placeholders for Galacticus paths in file names.
+    !!}
+    use :: ISO_Varying_String, only : char
+    implicit none
+    type(varying_string)                :: fileNameOut
+    type(varying_string), intent(in   ) :: fileNameIn
+
+    fileNameOut=File_Name_Expand(char(fileNameIn))
+    return
+  end function File_Name_Expand_VarStr
   
   subroutine File_Rename(nameOld,nameNew,overwrite)
     !!{
@@ -718,7 +739,7 @@ contains
     return
   end subroutine File_Rename
 
-  function File_Name_Expand(fileNameIn) result(fileNameOut)
+  function File_Name_Expand_Char(fileNameIn) result(fileNameOut)
     !!{
     Expands placeholders for Galacticus paths in file names.
     !!}
@@ -777,7 +798,7 @@ contains
       return
     end subroutine variableRetrieve
     
-  end function File_Name_Expand
+  end function File_Name_Expand_Char
 
   function File_Modification_Time_VarStr(fileName,status) result(timeModification)
     !!{


### PR DESCRIPTION
Expand file name on initialization. This is necessary to ensure the correct file name is used in locking and existance checks.