### PR TITLE
Allow output of observed positions in lightcones

### DIFF
--- a/testSuite/parameters/testPruneLightconePruned.xml
+++ b/testSuite/parameters/testPruneLightconePruned.xml
@@ -457,6 +457,7 @@
       <failIfNotInLightcone value="true"/>
       <includeAngularCoordinates value="true"/>
       <includeObservedRedshift value="true"/>
+      <includeObservedPosition value="true"/>
     </nodePropertyExtractor>
   </nodePropertyExtractor>
   <outputTimes value="list">


### PR DESCRIPTION
Adds an option `includeObservedPosition` to the `nodePropertyExtractorLightcone` class, which causes additional output of the "observed" $(x,y,z)$ position - i.e. that which would be inferred from the observed redshift (including the effects of line of sight velocity) and angular position. Specifically: 
```math
\mathbf{x}_\mathrm{observed} = \mathbf{x}_\mathrm{true} \frac{D_\chi(z_\mathrm{observed})}{D_\chi(z_\mathrm{true})},
```
where $`\mathbf{x}_\mathrm{true}`$ is the true comoving position of the galaxy, $D_\chi(z)$ is the comoving distance to redshift $z$, $z_\mathrm{true}$ is the true cosmological redshift of the galaxy, and $z_\mathrm{observed}$ is the observed redshift including line of sight velocity effects.