### PR TITLE
Fix mass conversion

### DIFF
--- a/source/structure_formation.transfer_function.BBKS.WDM.F90
+++ b/source/structure_formation.transfer_function.BBKS.WDM.F90
@@ -213,6 +213,8 @@ contains
          &              /self%lengthFreeStreaming
     matterDensity      =+self%cosmologyParameters_%OmegaMatter    () &
          &              *self%cosmologyParameters_%densityCritical()
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     bbksWDMHalfModeMass=+4.0d0                &
          &              *Pi                   &
          &              /3.0d0                &

--- a/source/structure_formation.transfer_function.Bode2001.F90
+++ b/source/structure_formation.transfer_function.Bode2001.F90
@@ -389,6 +389,8 @@ contains
 
     matterDensity       =+self%cosmologyParameters_%OmegaMatter    () &
          &               *self%cosmologyParameters_%densityCritical()
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     bode2001HalfModeMass=+4.0d0                                 &
          &               *Pi                                    &
          &               /3.0d0                                 &
@@ -415,6 +417,8 @@ contains
 
     matterDensity          =+self%cosmologyParameters_%OmegaMatter    () &
          &                  *self%cosmologyParameters_%densityCritical()
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     bode2001QuarterModeMass=+4.0d0                                 &
          &                  *Pi                                    &
          &                  /3.0d0                                 &
@@ -442,6 +446,8 @@ contains
 
     matterDensity           =+self%cosmologyParameters_%OmegaMatter    ()    &
          &                   *self%cosmologyParameters_%densityCritical()
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     bode2001FractionModeMass=+4.0d0                                          &
          &                   *Pi                                             &
          &                   /3.0d0                                          &

--- a/source/structure_formation.transfer_function.ETHOS.F90
+++ b/source/structure_formation.transfer_function.ETHOS.F90
@@ -559,6 +559,8 @@ contains
     wavenumberFractionMode  =   finder%find(rootGuess=1.0d-2/self%alpha)
     matterDensity           =  +self%cosmologyParameters_%OmegaMatter    () &
          &                     *self%cosmologyParameters_%densityCritical()
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     ETHOSDMFractionModeMass =  +4.0d0                    &
          &                     *Pi                       &
          &                     /3.0d0                    &

--- a/source/structure_formation.transfer_function.Hu2000.FDM.F90
+++ b/source/structure_formation.transfer_function.Hu2000.FDM.F90
@@ -227,6 +227,8 @@ contains
     wavenumberHalfMode   =+1.108d0                 &
          &                *4.5d0                   &
          &                *self%m22**(4.0d0/9.0d0)
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     hu2000FDMHalfModeMass=+4.0d0                &
          &                *Pi                   &
          &                /3.0d0                &
@@ -256,6 +258,8 @@ contains
     wavenumberQuarterMode   =+1.230d0                 &
          &                   *4.5d0                   &
          &                   *self%m22**(4.0d0/9.0d0)
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     hu2000FDMQuarterModeMass=+4.0d0                   &
          &                   *Pi                      &
          &                   /3.0d0                   &

--- a/source/structure_formation.transfer_function.Murgia2017.F90
+++ b/source/structure_formation.transfer_function.Murgia2017.F90
@@ -229,6 +229,8 @@ function murgia2017ConstructorParameters(parameters) result(self)
          &                     -1.0d0                 &
          &                    )**(1.0d0/self%beta)    &
          &                  )
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     murgia2017HalfModeMass=+4.0d0                &
          &                 *Pi                   &
          &                 /3.0d0                &
@@ -268,6 +270,8 @@ function murgia2017ConstructorParameters(parameters) result(self)
          &                        -1.0d0                 &
          &                       )**(1.0d0/self%beta)    &
          &                     )
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     murgia2017QuarterModeMass=+4.0d0                   &
          &                    *Pi                      &
          &                    /3.0d0                   &

--- a/source/structure_formation.transfer_function.envelope.F90
+++ b/source/structure_formation.transfer_function.envelope.F90
@@ -314,6 +314,8 @@ contains
        wavenumberFractionMode  = finder%find(rootGuess=1.0d0)
        matterDensity           =+self%cosmologyParameters_%OmegaMatter    () &
             &                   *self%cosmologyParameters_%densityCritical()
+       ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+       ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
        envelopeFractionModeMass=+4.0d0                    &
             &                   *Pi                       &
             &                   /3.0d0                    &

--- a/source/structure_formation.transfer_function.file.F90
+++ b/source/structure_formation.transfer_function.file.F90
@@ -582,7 +582,8 @@ contains
                      &          *(+self%transfer%x              (j)-self%transfer%x            (j-1)) &
                      &          +                                   self%transfer%x            (j-1)  &
                      &         )
-                ! Compute the mode mass.
+                ! Compute the mode mass. As a default choice, the wavenumber is converted to a length scale assuming
+                ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
                 modeFound           =.true.
                 fileFractionModeMass=+4.0d0         &
                      &               *Pi            &

--- a/source/structure_formation.transfer_function.file.fuzzy_dark_matter.F90
+++ b/source/structure_formation.transfer_function.file.fuzzy_dark_matter.F90
@@ -297,6 +297,8 @@ contains
           wavenumberHalfMode             =+1.108d0              &
                &                          *4.5d0                &
                &                          *m22**(4.0d0/9.0d0)
+          ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+          ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
           fileFuzzyDarkMatterHalfModeMass=+4.0d0                &
                &                          *Pi                   &
                &                          /3.0d0                &
@@ -342,6 +344,8 @@ contains
           wavenumberQuarterMode             =+1.230d0                 &
                &                             *4.5d0                   &
                &                             *m22**(4.0d0/9.0d0)
+          ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+          ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
           fileFuzzyDarkMatterQuarterModeMass=+4.0d0                   &
                &                             *Pi                      &
                &                             /3.0d0                   &

--- a/source/structure_formation.transfer_function.fuzzyDM.Passaglia2022.F90
+++ b/source/structure_formation.transfer_function.fuzzyDM.Passaglia2022.F90
@@ -266,6 +266,8 @@ contains
     self%solvingForMode                  =   .false.
     matterDensity                        =  +self%cosmologyParameters_%OmegaMatter    () &
          &                                  *self%cosmologyParameters_%densityCritical()
+    ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+    ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
     fuzzyDMPassaglia2022FractionModeMass =  +4.0d0         &
          &                                  *Pi            &
          &                                  /3.0d0         &

--- a/source/tasks.power_spectrum.F90
+++ b/source/tasks.power_spectrum.F90
@@ -294,13 +294,17 @@ contains
             &                                                                                           )
        ! Iterate over all wavenumbers computing power spectrum and related quantities.
        do iWavenumber=1,wavenumberCount
-          ! Compute corresponding mass scale.
+          ! Compute corresponding mass scale. As a default choice, the wavenumber is converted to a length scale assuming
+          ! R = λ/2 = π/k [see Eq.(9) of \cite{schneider_non-linear_2012}].
           massScale                (iWavenumber        )=+4.0d0                                       &
                &                                         /3.0d0                                       &
                &                                         *Pi                                          &
                &                                         *self%cosmologyParameters_%OmegaMatter    () &
                &                                         *self%cosmologyParameters_%densityCritical() &
-               &                                         /                                                                                                                    wavenumber(iWavenumber) **3
+               &                                         *(                                           &
+               &                                           +Pi                                        &
+               &                                           /wavenumber(iWavenumber)                   &
+               &                                          )**3
           ! Compute linear growth factors.
           growthFactor             (iWavenumber,iOutput)=self%linearGrowth_             %value                               (time=self%outputTimes_%time(iOutput),wavenumber=wavenumber(iWavenumber))
           growthFactorLogDerivative(iWavenumber,iOutput)=self%linearGrowth_             %logarithmicDerivativeExpansionFactor(time=self%outputTimes_%time(iOutput),wavenumber=wavenumber(iWavenumber))


### PR DESCRIPTION
In Galacticus, sometimes we need to convert the wavenumber to a corresponding mass scale. It can be defined in different ways. For example, when computing the halo mass function, one usually applies a top-hat filter to get the density field smoothed on certain scales. There is a natural length scale, i.e. the smoothing scale $R$ in the window function. Then a mass scale can be defined as $M(R)=\frac{4}{3} \pi \rho_m R^3$ with $\rho_m$ the mean matter density. One choice of defining a mass scale corresponding to a wavenumber $k$ is to let $R=\frac{\lambda}{2}=\frac{\pi}{k}$. This is the default definition in Galacticus, e.g. when defining the half-mode mass scale for models with a suppressed power spectrum on small scales.

NOTE: For some non-CDM models, using a sharp k-space filter can give a halo mass function that better reproduces the suppression or enhancement in halo mass function. For the sharp k-space filter, the window function is truncated at a wavenumber $k_{\rm cutoff}$ in $k$ space, but there is not a well defined smoothing length scale in real space. So one needs to set $R = C / k_{\rm cutoff}$ and find the value of $C$ by fitting the halo mass function to N-body simulations. This is not to be confused with the above definition.