### PR TITLE
Correct axis labels for the star formation rate analysis class

### DIFF
--- a/source/output.analyses.star_formation_rate_function.F90
+++ b/source/output.analyses.star_formation_rate_function.F90
@@ -412,7 +412,7 @@ contains
          &                                covarianceBinomialMassHaloMinimum                                                   , &
          &                                covarianceBinomialMassHaloMaximum                                                   , &
          &                                .false.                                                                             , &
-         &                                var_str('$\log_{10}(\dot{M}_\star/\mathrm{M}_\odot) \hbox{Gyr}^{-1}$'              ), &
+         &                                var_str('$\log_{10}(\dot{M}_\star/\mathrm{M}_\odot) \mathrm{Gyr}^{-1}$'              ), &
          &                                var_str('$\mathrm{d}n/\mathrm{d}\log_\mathrm{e} \dot{M}_\star / \mathrm{Mpc}^{-3}$'), &
          &                                .true.                                                                              , &
          &                                .true.                                                                              , &


### PR DESCRIPTION
Axis labels had the wrong variables and units - this patch correct them.