### PR TITLE
Scale weights in all trees in a forest

### DIFF
--- a/source/merger_trees.operators.scale_weight.F90
+++ b/source/merger_trees.operators.scale_weight.F90
@@ -89,10 +89,15 @@ contains
     Scale the weight of a merger tree by a fixed factor.
     !!}
     implicit none
-    class(mergerTreeOperatorScaleWeight), intent(inout), target :: self
-    type (mergerTree                   ), intent(inout), target :: tree
+    class(mergerTreeOperatorScaleWeight), intent(inout), target  :: self
+    type (mergerTree                   ), intent(inout), target  :: tree
+    type (mergerTree                   )               , pointer :: treeCurrent
 
-    tree%volumeWeight=+tree%volumeWeight &
-         &            *self%scaleFactor
+    treeCurrent => tree
+    do while (associated(treeCurrent))
+       treeCurrent%volumeWeight = +treeCurrent%volumeWeight &
+            &                     *self       %scaleFactor
+       treeCurrent             =>  treeCurrent%nextTree
+    end do
     return
   end subroutine scaleFactorOperatePreInitialization


### PR DESCRIPTION
The `mergerTreeOperatorScaleWeight` class previously scaled the weight of only the first tree in a forest, missing any subsequent trees. This patch fixes that so that all trees in the forest have their weights scaled.