### PR TITLE
fix: correct Perl string repetition bug in ModuleUses symbol assignment

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Parse/ModuleUses.pm
+++ b/perl/Galacticus/Build/SourceTree/Parse/ModuleUses.pm
@@ -226,7 +226,7 @@ sub AddUses {
 		$usesNode->{'moduleUse'}->{$moduleName}->{'all'} = 1;
 		delete($usesNode->{'moduleUse'}->{$moduleName}->{'only'});
 	    } else {
-		$usesNode->{'moduleUse'}->{$moduleName}->{'only'}->{$_} = 1x2
+		$usesNode->{'moduleUse'}->{$moduleName}->{'only'}->{$_} = 1
 		    foreach ( sort(keys(%{$moduleUses->{'moduleUse'}->{$moduleName}->{'only'}})) );
 	    }
 	}


### PR DESCRIPTION
In MergeUses(), the 'only' symbol hash values were being set to `1x2`
(Perl's string repetition operator, evaluating to "11") instead of the
correct boolean-truthy value `1`. The parallel code in the same file at
line 67 correctly uses `1`. This fixes a latent type mismatch that could
affect numeric comparisons on these values.

https://claude.ai/code/session_015EMDUMGh1RzfGUj1EYJnLs