### PR TITLE
Make patching of FSPS source more robust

### DIFF
--- a/source/interface.FSPS.F90
+++ b/source/interface.FSPS.F90
@@ -63,11 +63,12 @@ contains
     use :: System_Command    , only : System_Command_Do
     use :: System_Download   , only : download
     use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran
+    use :: System_Which      , only : which
     implicit none
     type     (varying_string), intent(  out)           :: fspsPath, fspsVersion
     logical                  , intent(in   ), optional :: static
-    integer                                            :: status
-    type     (varying_string)                          :: lockPath
+    integer                                            :: status  , statusUnit
+    type     (varying_string)                          :: lockPath, patch
     !![
     <optionalArgument name="static" defaultsTo=".false." />
     !!]
@@ -92,19 +93,23 @@ contains
           if (status /= 0 .or. .not.File_Exists(fspsPath)) call Error_Report('failed to unpack FSPS code'//{introspection:location})
        end if
        ! Patch the code if not already patched.
-       if (.not.File_Exists(fspsPath//"/src/galacticus_IMF.f90")) then
-          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/galacticus_IMF.f90 "//fspsPath//"/src/"                                                    ,status)
+       if (.not.File_Exists(fspsPath//"/src/patched.status")) then
+          patch=which('patch')
+          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/galacticus_IMF.f90 "//fspsPath//"/src/"                                                          ,status)
           if (status /= 0) call Error_Report("failed to copy FSPS patch 'galacticus_IMF.f90'"//{introspection:location})
-          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/imf.f90.patch "     //fspsPath//"/src/; cd "//fspsPath//"/src/; patch < imf.f90.patch"     ,status)
+          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/imf.f90.patch "     //fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < imf.f90.patch"     ,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'imf.f90'"           //{introspection:location})
-          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/ssp_gen.f90.patch " //fspsPath//"/src/; cd "//fspsPath//"/src/; patch < ssp_gen.f90.patch" ,status)
+          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/ssp_gen.f90.patch " //fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < ssp_gen.f90.patch" ,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'ssp_gen.f90'"       //{introspection:location})
-          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/sps_vars.f90.patch "//fspsPath//"/src/; cd "//fspsPath//"/src/; patch < sps_vars.f90.patch",status)
+          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/sps_vars.f90.patch "//fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < sps_vars.f90.patch",status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'sps_vars.f90'"      //{introspection:location})
-          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/autosps.f90.patch " //fspsPath//"/src/; cd "//fspsPath//"/src/; patch < autosps.f90.patch" ,status)
+          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/autosps.f90.patch " //fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < autosps.f90.patch" ,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'autosps.f90'"       //{introspection:location})
-          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/Makefile.patch "    //fspsPath//"/src/; cd "//fspsPath//"/src/; patch < Makefile.patch"    ,status)
+          call System_Command_Do("cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/Makefile.patch "    //fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < Makefile.patch"    ,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'Makefile'"          //{introspection:location})
+          open(newUnit=statusUnit,file=char(fspsPath//"/src/patched.status"),status='unknown',form='formatted')
+          write (statusUnit,'(a)') "success"
+          close(statusUnit)
           call File_Remove(fspsPath//"/src/autosps.exe")
        end if
        call displayMessage("compiling autosps.exe code",verbosityLevelWorking)

--- a/source/system.which.F90
+++ b/source/system.which.F90
@@ -1,0 +1,86 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module which wraps the system \mono{which} command to allow finding of other tools.
+!!}
+
+module System_Which
+  !!{
+  Wraps the system \mono{which} command to allow finding of other tools.
+  !!}
+  implicit none
+  private
+  public :: which
+
+  interface which
+     module procedure whichChar
+     module procedure whichVarStr
+  end interface which
+
+contains
+
+  function whichVarStr(command,status) result(commandFull)
+    !!{
+    Find the path to the given \mono{command}, optionally returning status.
+    !!}
+    use :: ISO_Varying_String, only : char, varying_string
+    implicit none
+    type   (varying_string)                          :: commandFull
+    type   (varying_string), intent(in   )           :: command
+    integer                , intent(  out), optional :: status
+    
+    commandFull=which(char(command),status)
+    return
+  end function whichVarStr
+
+  function whichChar(command,status) result(commandFull)
+    !!{
+    Find the path to the given \mono{command}, optionally returning status.
+    !!}
+    use :: Error             , only : Error_Report       , errorStatusFail, errorStatusSuccess
+    use :: System_Command    , only : System_Command_Do
+    use :: File_Utilities    , only : File_Name_Temporary, File_Remove
+    use :: ISO_Varying_String, only : varying_string     , char           , trim              , assignment(=)
+    implicit none
+    type     (varying_string)                          :: commandFull
+    character(len=*         ), intent(in   )           :: command
+    integer                  , intent(  out), optional :: status
+    character(len=1024      )                          :: commandFull_
+    integer                                            :: status_     , commandUnit
+    type     (varying_string)                          :: tempFile
+    
+    if (present(status)) status=errorStatusSuccess
+    tempFile=File_Name_Temporary("which")
+    call System_Command_Do('which '//trim(command)//' > '//char(tempFile),status_)
+    if (status_ == 0) then
+       open(newUnit=commandUnit,file=char(tempFile),status='unknown',form='formatted')
+       read (commandUnit,'(a)') commandFull_ 
+       close(commandUnit)
+       commandFull=trim(commandFull_)
+    else
+       commandFull=""
+    end if
+    call File_Remove(tempFile)
+    if (     present(status)                   ) status=status_
+    if (.not.present(status) .and. status_ /= 0) call Error_Report("command '"//trim(command)//"' does not exist"//{introspection:location})
+    return
+  end function whichChar
+
+end module System_Which


### PR DESCRIPTION
## Summary
- Patching is now attempted unless a `patched.status` file exists in the FSPS `src/` folder. This file is written only after patching has succeeded. Additionally, a new helper function, `which()`, is provided to find system tools (in this case, it is used to find `patch`) and report an error if the tool does not exist.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- 

## Checklist
- [x] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
