### PR TITLE
Add missing closing `)` in emitted Fortran for `logical`/`statefulLogical` `inputParameters`

### DIFF
--- a/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
+++ b/perl/Galacticus/Build/SourceTree/Process/FunctionClass.pm
@@ -1889,7 +1889,7 @@ sub buildDescriptorMethods {
 					    $descriptorCode .= " parameterValues=parameterValues//".$function."(self%".$parameter->{'name'}."(".join(",",map {"i".$_} 1..$rank)."))\n";
 					} else {
 					    if ( $isLogical ) {
-						$descriptorCode .= "if (self%".$parameter->{'name'}."(".join(",",map {"i".$_} 1..$rank).") then\n";
+						$descriptorCode .= "if (self%".$parameter->{'name'}."(".join(",",map {"i".$_} 1..$rank).")) then\n";
 						$descriptorCode .= "  parameterLabel='true'\n";
 						$descriptorCode .= "else\n";
 						$descriptorCode .= "  parameterLabel='false'\n";
@@ -1994,7 +1994,7 @@ sub buildDescriptorMethods {
 					}
 					$descriptorCode .= "if (self%".$parameter->{'name'}."(".join(",",map {"i".$_} 1..$rank).")%isSet) then\n";
 					if ( $isLogical ) {
-					    $descriptorCode .= "if (self%".$parameter->{'name'}."(".join(",",map {"i".$_} 1..$rank)."%value) then\n";
+					    $descriptorCode .= "if (self%".$parameter->{'name'}."(".join(",",map {"i".$_} 1..$rank).")%value) then\n";
 					    $descriptorCode .= "  parameterLabel='true'\n";
 					    $descriptorCode .= "else\n";
 					    $descriptorCode .= "  parameterLabel='false'\n";

--- a/python/Galacticus/Build/SourceTree/Process/FunctionClass/__init__.py
+++ b/python/Galacticus/Build/SourceTree/Process/FunctionClass/__init__.py
@@ -1040,13 +1040,9 @@ def _build_descriptor_methods(directive, non_abstract_classes, classes,
                                     )
                                 else:
                                     if is_logical:
-                                        # Perl emits a malformed line here
-                                        # ("if (self%X(i1,i2) then") — we
-                                        # preserve it verbatim for byte
-                                        # identity with the Perl port.
                                         descriptor_code += (
                                             f"if (self%{parameter['name']}"
-                                            f"({idx}) then\n"
+                                            f"({idx})) then\n"
                                         )
                                         descriptor_code += (
                                             "  parameterLabel='true'\n")
@@ -1237,11 +1233,9 @@ def _build_descriptor_methods(directive, non_abstract_classes, classes,
                                     f"({idx})%isSet) then\n"
                                 )
                                 if is_logical:
-                                    # Perl emits a malformed line; preserve
-                                    # it verbatim.
                                     descriptor_code += (
                                         f"if (self%{parameter['name']}"
-                                        f"({idx}%value) then\n"
+                                        f"({idx})%value) then\n"
                                     )
                                     descriptor_code += (
                                         "  parameterLabel='true'\n")


### PR DESCRIPTION
## Summary
- Closing parentheses were missing in the emitted Fortran - add them here so that the emitted code is valid.
- Also fixed in the Python port of this module.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- 

## Checklist
- [x] I ran relevant tests (or explain why not): Tested that build still works - no `inputParameter` actually exercised this bug, so the branch is never used anyway. (But still good to fix this of course!)
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
