### PR TITLE
Correct the density profile normalization for tidally-truncated NFW profile fits

### DIFF
--- a/source/nodes.property_extractor.tidally_truncated_NFW_fit.F90
+++ b/source/nodes.property_extractor.tidally_truncated_NFW_fit.F90
@@ -184,7 +184,7 @@ contains
     massDistribution_                =>  self               %darkMatterProfileDMO_   %get              (node       )
     massDistributionNFW              =>  self               %darkMatterProfileDMONFW_%get              (node       )
     coordinates                      =  [darkMatterProfile%scale(),0.0d0,0.0d0]
-    tidallyTruncatedNFWFitExtract(3) =  +4.0d0                                                                       &
+    tidallyTruncatedNFWFitExtract(3) =  +4.0d0                                                                       & ! ρ(rₛ)=ρₛ/4, so multiply by 4 to recover ρₛ.
          &                              *massDistributionNFW                         %density          (coordinates)
     if (node%isSatellite()) then
        ! Extract required properties.

--- a/source/nodes.property_extractor.tidally_truncated_NFW_fit.F90
+++ b/source/nodes.property_extractor.tidally_truncated_NFW_fit.F90
@@ -180,11 +180,12 @@ contains
     !$GLC attributes unused :: instance
 
     allocate(tidallyTruncatedNFWFitExtract(3))
-    darkMatterProfile                => node                                        %darkMatterProfile(            )
-    massDistribution_                => self               %darkMatterProfileDMO_   %get              (node        )
-    massDistributionNFW              => self               %darkMatterProfileDMONFW_%get              (node        )
-    coordinates                      = [darkMatterProfile%scale(),0.0d0,0.0d0]
-    tidallyTruncatedNFWFitExtract(3) =  massDistributionNFW                         %density          (coordinates)
+    darkMatterProfile                =>  node                                        %darkMatterProfile(           )
+    massDistribution_                =>  self               %darkMatterProfileDMO_   %get              (node       )
+    massDistributionNFW              =>  self               %darkMatterProfileDMONFW_%get              (node       )
+    coordinates                      =  [darkMatterProfile%scale(),0.0d0,0.0d0]
+    tidallyTruncatedNFWFitExtract(3) =  +4.0d0                                                                       &
+         &                              *massDistributionNFW                         %density          (coordinates)
     if (node%isSatellite()) then
        ! Extract required properties.
        radiusVirial =  self             %darkMatterHaloScale_%radiusVirial        (       node                                )


### PR DESCRIPTION
## Summary
- The density normalization is found by evaluating the density at the NFW scale radius, $r_\mathrm{s}$. For an untruncated NFW profile the density is:

$$
\rho(r) = \frac{\rho_\mathrm{s}}{(r/r_\mathrm{s})[1+(r/r_\mathrm{s})]^2}.
$$

Therefore, $\rho(r_\mathrm{s}) = \rho_\mathrm{s}/4$, implying $\rho_\mathrm{s} = 4 \rho(r_\mathrm{s})$. Previously that factor of 4 was neglected when fitting tidally-truncated density profiles, meaning that the reported normalizations were too low by a factor of 4. This _did not_ affect the tidal truncation radius fit.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- 

## Checklist
- [x] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
