### PR TITLE
Correct file locking logic for two classes

### DIFF
--- a/source/geometry.mangle.F90
+++ b/source/geometry.mangle.F90
@@ -114,7 +114,7 @@ contains
     message='found '
     message=message//self%polygonCount//' polygons'
     call displayMessage(message)
-     allocate(self%polygons       (self%polygonCount))
+    allocate(self%polygons       (self%polygonCount))
     allocate(solidAngle          (self%polygonCount))
     allocate(self%solidAngleIndex(self%polygonCount))
     ! Read each polygon.
@@ -271,7 +271,8 @@ contains
     !!{
     Compute the solid angle of a \textsc{mangle} geometry.
     !!}
-    use :: File_Utilities          , only : File_Exists       , File_Name_Temporary
+   use :: File_Utilities           , only : File_Exists       , File_Name_Temporary, File_Lock         , File_Unlock  , &
+        &                                   lockDescriptor
     use :: Error                   , only : Error_Report
     use :: HDF5_Access             , only : hdf5Access
     use :: IO_HDF5                 , only : hdf5Object
@@ -292,14 +293,17 @@ contains
     double precision                                                            :: multiplier              , subSolidAngle, &
          &                                                                         w00
     type            (hdf5Object    )                                            :: solidAngleFile
+    type            (lockDescriptor)                                            :: fileLock
 
     ! Check for pre-existing calculation.
     if (present(solidAngleFileName).and.File_Exists(solidAngleFileName)) then
+       call File_Lock(solidAngleFileName,fileLock,lockIsShared=.true.)
        !$ call hdf5Access%set  ()
-       call solidAngleFile%openFile         (solidAngleFileName,overWrite=.false.                 )
-       call solidAngleFile%readDatasetStatic('solidAngle'      ,          geometryMangleSolidAngle)
-       call solidAngleFile%close            (                                                     )
+       call solidAngleFile%openFile         (solidAngleFileName,overWrite=.false.                 ,readOnly=.true.)
+       call solidAngleFile%readDatasetStatic('solidAngle'      ,          geometryMangleSolidAngle                )
+       call solidAngleFile%close            (                                                                     )
        !$ call hdf5Access%unset()
+       call File_Unlock(fileLock)
        return
     end if
     ! Ensure mangle is available.
@@ -333,6 +337,7 @@ contains
     end do
     ! Store the solid angle to file.
     if (present(solidAngleFileName)) then
+       call File_Lock(solidAngleFileName,fileLock,lockIsShared=.false.)
        !$ call hdf5Access%set  ()
        call solidAngleFile%openFile      (            solidAngleFileName           ,overWrite=.true.      )
        call solidAngleFile%writeAttribute(String_Join(fileNames               ,":"),          'files'     )
@@ -340,6 +345,7 @@ contains
        call solidAngleFile%flush         (                                                                )
        call solidAngleFile%close         (                                                                )
        !$ call hdf5Access%unset()
+       call File_Unlock(fileLock)
     end if
     return
   end function geometryMangleSolidAngle
@@ -348,7 +354,8 @@ contains
     !!{
     Compute the angular power spectra of a \textsc{mangle} geometry.
     !!}
-    use :: File_Utilities    , only : File_Exists       , File_Name_Temporary
+    use :: File_Utilities    , only : File_Exists       , File_Name_Temporary, File_Lock         , File_Unlock, &
+         &                            lockDescriptor
     use :: Error             , only : Error_Report
     use :: HDF5_Access       , only : hdf5Access
     use :: IO_HDF5           , only : hdf5Object
@@ -373,11 +380,13 @@ contains
          &                                                                                                                                       p                         , q
     double precision                                                                                                                          :: multiplier                , weight
     type            (hdf5Object    )                                                                                                          :: angularPowerFile
+    type            (lockDescriptor)                                                                                                          :: fileLock
 
     ! Read the angular power from file if possible.
     if (present(angularPowerFileName).and.File_Exists(angularPowerFileName)) then
+       call File_Lock(angularPowerFileName,fileLock,lockIsShared=.true.)
        !$ call hdf5Access%set  ()
-       call angularPowerFile      %openFile         (angularPowerFileName                                           )
+       call angularPowerFile      %openFile         (angularPowerFileName                   ,readOnly=.true.        )
        l=0
        do p=1,size(fileNames)
           do q=p,size(fileNames)
@@ -388,6 +397,7 @@ contains
        call angularPowerFile      %flush            (                                                               )
        call angularPowerFile      %close            (                                                               )
        !$ call hdf5Access%unset()
+       call File_Unlock(fileLock)
        return
     end if
     ! Ensure mangle is available.
@@ -449,6 +459,7 @@ contains
     end do
     ! Store the angular power to file.
     if (present(angularPowerFileName)) then
+       call File_Lock(angularPowerFileName,fileLock,lockIsShared=.false.)
        !$ call hdf5Access%set  ()
        call angularPowerFile      %openFile      (            angularPowerFileName                ,overWrite=.true.                                 )
        call angularPowerFile      %writeAttribute(String_Join(fileNames                      ,":"),          'files'                                )
@@ -462,6 +473,7 @@ contains
        call angularPowerFile      %flush         (                                                                                                  )
        call angularPowerFile      %close         (                                                                                                  )
        !$ call hdf5Access%unset()
+       call File_Unlock(fileLock)
     end if
     return
   end function geometryMangleAngularPower

--- a/source/star_formation.histories.adaptive.F90
+++ b/source/star_formation.histories.adaptive.F90
@@ -258,9 +258,9 @@ contains
     fileName=inputPath(pathTypeDataDynamic)//"starFormation/"//self%objectType()//"_"//self%hashedDescriptor(includeSourceDigest=.true.)//".hdf5"
     allocate(self%intervals(self%outputTimes_%count()))
     if (File_Exists(fileName)) then
-       call File_Lock(char(fileName),fileLock,lockIsShared=.true.)
+       call File_Lock(fileName,fileLock,lockIsShared=.true.)
        !$ call hdf5Access%set()
-       call file%openFile(char(fileName))
+       call file%openFile(fileName,readOnly=.true.)
        do iOutput=1,self%outputTimes_%count()
           write (name,'(a,i4.4)') 'times'   ,iOutput
           call file%readDataset(name,self%intervals(iOutput)%time    )


### PR DESCRIPTION
## Summary
- Corrects file locking logic for two classes. In the `starFormationHistoryAdaptive` class read access to the HDF5 file is now marked `readOnly=.true.` since we have only a shared lock on the file - this avoids the HDF5 library complaining about access violations. In the `mangle` geometry class, locking was missing altogether - now added to avoid thread conflicts when accessing the files.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- 

## Checklist
- [x] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
