### PR TITLE
Make the absolute ODE tolerance scale for `starFormationHistory*` classes user-settable

### DIFF
--- a/source/star_formation.histories.adaptive.F90
+++ b/source/star_formation.histories.adaptive.F90
@@ -75,7 +75,7 @@
      private
      class           (outputTimesClass), pointer                   :: outputTimes_          => null()
      double precision                                              :: timeStepMinimum                , metallicityMaximum, &
-          &                                                           metallicityMinimum
+          &                                                           metallicityMinimum             , massScaleAbsolute
      integer         (c_size_t        )                            :: countTimeStepsMaximum          , countMetallicities
      double precision                  , allocatable, dimension(:) :: metallicityTable
      type            (timeIntervals   ), allocatable, dimension(:) :: intervals
@@ -115,7 +115,7 @@ contains
     class           (outputTimesClass            ), pointer                     :: outputTimes_
     double precision                              , allocatable  , dimension(:) :: metallicityBoundaries
     double precision                                                            :: timeStepMinimum      , metallicityMinimum   , &
-         &                                                                         metallicityMaximum
+         &                                                                         metallicityMaximum   , massScaleAbsolute
     integer         (c_size_t)                                                  :: countMetallicities   , countTimeStepsMaximum
 
     !![
@@ -129,6 +129,12 @@ contains
       <name>countTimeStepsMaximum</name>
       <defaultValue>10_c_size_t</defaultValue>
       <description>The maximum number of timesteps to track in any star formation history.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>massScaleAbsolute</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>The absolute tolerance scale (for the mass in each bin of star formation history) to use during ODE solution.</description>
       <source>parameters</source>
     </inputParameter>
     !!]
@@ -171,7 +177,7 @@ contains
     !![
     <objectBuilder class="outputTimes" name="outputTimes_" source="parameters"/>
     <conditionalCall>
-     <call>self=starFormationHistoryAdaptive(outputTimes_,timeStepMinimum,countTimeStepsMaximum{conditions})</call>
+     <call>self=starFormationHistoryAdaptive(outputTimes_,timeStepMinimum,countTimeStepsMaximum,massScaleAbsolute{conditions})</call>
      <argument name="metallicityBoundaries" value="metallicityBoundaries" condition="     parameters%isPresent('metallicityBoundaries')"/>
      <argument name="countMetallicities"    value="countMetallicities"    condition=".not.parameters%isPresent('metallicityBoundaries')"/>
      <argument name="metallicityMinimum"    value="metallicityMinimum"    condition=".not.parameters%isPresent('metallicityBoundaries')"/>
@@ -183,7 +189,7 @@ contains
     return
   end function adaptiveConstructorParameters
 
-  function adaptiveConstructorInternal(outputTimes_,timeStepMinimum,countTimeStepsMaximum,metallicityBoundaries,countMetallicities,metallicityMinimum,metallicityMaximum) result(self)
+  function adaptiveConstructorInternal(outputTimes_,timeStepMinimum,countTimeStepsMaximum,massScaleAbsolute,metallicityBoundaries,countMetallicities,metallicityMinimum,metallicityMaximum) result(self)
     !!{
     Internal constructor for the \refClass{starFormationHistoryAdaptive} star formation history class.
     !!}
@@ -199,7 +205,7 @@ contains
     type            (starFormationHistoryAdaptive)                                        :: self
     double precision                              , intent(in   ), dimension(:), optional :: metallicityBoundaries
     double precision                              , intent(in   )              , optional :: metallicityMinimum   , metallicityMaximum
-    double precision                              , intent(in   )                         :: timeStepMinimum
+    double precision                              , intent(in   )                         :: timeStepMinimum      , massScaleAbsolute
     integer         (c_size_t                    ), intent(in   )                         :: countTimeStepsMaximum
     integer         (c_size_t                    ), intent(in   )              , optional :: countMetallicities
     class           (outputTimesClass            ), intent(in   ), target                 :: outputTimes_
@@ -216,7 +222,7 @@ contains
     type            (lockDescriptor              )                                        :: fileLock
     character       (len=16                      )                                        :: name
     !![
-    <constructorAssign variables="timeStepMinimum, countTimeStepsMaximum, metallicityMinimum, metallicityMaximum, countMetallicities, *outputTimes_"/>
+    <constructorAssign variables="timeStepMinimum, countTimeStepsMaximum, metallicityMinimum, metallicityMaximum, countMetallicities, massScaleAbsolute, *outputTimes_"/>
     !!]
 
     ! Validate metallicity argument and construct the table of metallicities.
@@ -483,7 +489,8 @@ contains
     integer(c_size_t                    )                        :: iStart              , iEnd, &
          &                                                          i
     type    (history                    )                        :: newHistory
-    !$GLC attributes unused :: node                                                                                                                                                                                     
+    !$GLC attributes unused :: node
+
     ! If another output exists map the existing star formation history to the time bins of the next output.
     if (historyStarFormation%exists() .and. indexOutput < size(self%intervals)) then
        call newHistory%create(int(self%countMetallicities+1),size(self%intervals(indexOutput+1)%time))
@@ -514,11 +521,10 @@ contains
     !!}
     implicit none
     class           (starFormationHistoryAdaptive), intent(inout)               :: self
-    double precision                              , intent(in   )               :: massStellar               , massGas
+    double precision                              , intent(in   )               :: massStellar         , massGas
     type            (abundances                  ), intent(in   )               :: abundancesStellar
     type            (history                     ), intent(inout)               :: historyStarFormation
     type            (treeNode                    ), intent(inout)               :: node
-    double precision                              , parameter                   :: massMinimum         =1.0d0
     double precision                              , allocatable  , dimension(:) :: timeSteps
     integer         (c_size_t                    )                              :: iMetallicity
     !$GLC attributes unused :: abundancesStellar, node
@@ -526,7 +532,7 @@ contains
     if (.not.historyStarFormation%exists()) return
     call historyStarFormation%timeSteps(timeSteps)
     forall(iMetallicity=1:self%countMetallicities+1)
-       historyStarFormation%data(:,iMetallicity)=+max(massStellar+massGas,massMinimum)                            &
+       historyStarFormation%data(:,iMetallicity)=+max(massStellar+massGas,self%massScaleAbsolute)                 &
             &                                    *                     timeSteps                                  &
             &                                    /historyStarFormation%time     (size(historyStarFormation%time))
     end forall

--- a/source/star_formation.histories.fixed_ages.F90
+++ b/source/star_formation.histories.fixed_ages.F90
@@ -64,7 +64,8 @@
      class           (geometryLightconeClass       ), pointer                   :: geometryLightcone_  => null()
      class           (cosmologyFunctionsClass      ), pointer                   :: cosmologyFunctions_ => null()
      double precision                                                           :: ageMinimum                   , ageMaximum        , &
-          &                                                                        metallicityMaximum           , metallicityMinimum
+          &                                                                        metallicityMaximum           , metallicityMinimum, &
+          &                                                                        massScaleAbsolute
      integer         (c_size_t                     )                            :: countAges                    , countMetallicities
      integer                                                                    :: timesCrossingID              , countRetain       , &
           &                                                                        createdInID
@@ -114,7 +115,7 @@ contains
     class           (cosmologyFunctionsClass      )               , pointer     :: cosmologyFunctions_
     double precision                               , dimension(:) , allocatable :: metallicityBoundaries
     double precision                                                            :: metallicityMinimum   , metallicityMaximum, &
-         &                                                                         ageMinimum
+         &                                                                         ageMinimum           , massScaleAbsolute
     integer         (c_size_t)                                                  :: countMetallicities   , countAges
 
     !![
@@ -130,6 +131,12 @@ contains
       <name>countAges</name>
       <defaultValue>10_c_size_t</defaultValue>
       <description>The maximum number of ages to track in any star formation history.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>massScaleAbsolute</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>The absolute tolerance scale (for the mass in each bin of star formation history) to use during ODE solution.</description>
       <source>parameters</source>
     </inputParameter>
     !!]
@@ -171,7 +178,7 @@ contains
     end if
     !![
     <conditionalCall>
-     <call>self=starFormationHistoryFixedAges(cosmologyFunctions_,geometryLightcone_,ageMinimum,countAges{conditions})</call>
+     <call>self=starFormationHistoryFixedAges(cosmologyFunctions_,geometryLightcone_,ageMinimum,countAges,massScaleAbsolute{conditions})</call>
      <argument name="metallicityBoundaries" value="metallicityBoundaries" condition="     parameters%isPresent('metallicityBoundaries')"/>
      <argument name="countMetallicities"    value="countMetallicities"    condition=".not.parameters%isPresent('metallicityBoundaries')"/>
      <argument name="metallicityMinimum"    value="metallicityMinimum"    condition=".not.parameters%isPresent('metallicityBoundaries')"/>
@@ -184,7 +191,7 @@ contains
     return
   end function fixedAgesConstructorParameters
 
-  recursive function fixedAgesConstructorInternal(cosmologyFunctions_,geometryLightcone_,ageMinimum,countAges,metallicityBoundaries,countMetallicities,metallicityMinimum,metallicityMaximum) result(self)
+  recursive function fixedAgesConstructorInternal(cosmologyFunctions_,geometryLightcone_,ageMinimum,countAges,massScaleAbsolute,metallicityBoundaries,countMetallicities,metallicityMinimum,metallicityMaximum) result(self)
     !!{
     Internal constructor for the \refClass{starFormationHistoryFixedAges} star formation history class.
     !!}
@@ -195,14 +202,14 @@ contains
     type            (starFormationHistoryFixedAges)                                        :: self
     double precision                               , intent(in   ), dimension(:), optional :: metallicityBoundaries
     double precision                               , intent(in   )              , optional :: metallicityMinimum   , metallicityMaximum
-    double precision                               , intent(in   )                         :: ageMinimum
+    double precision                               , intent(in   )                         :: ageMinimum           , massScaleAbsolute
     integer         (c_size_t                     ), intent(in   )                         :: countAges
     integer         (c_size_t                     ), intent(in   )              , optional :: countMetallicities
     class           (cosmologyFunctionsClass      ), intent(in   ), target                 :: cosmologyFunctions_
     class           (geometryLightconeClass       ), intent(in   ), target                 :: geometryLightcone_
     
     !![
-    <constructorAssign variables="ageMinimum, countAges, metallicityMinimum, metallicityMaximum, countMetallicities, *cosmologyFunctions_, *geometryLightcone_"/>
+    <constructorAssign variables="ageMinimum, countAges, metallicityMinimum, metallicityMaximum, countMetallicities, massScaleAbsolute, *cosmologyFunctions_, *geometryLightcone_"/>
     !!]
 
     ! Validate metallicity argument and construct the table of metallicities.
@@ -625,14 +632,13 @@ contains
     use :: Galacticus_Nodes, only : nodeComponentBasic
     implicit none
     class           (starFormationHistoryFixedAges), intent(inout)               :: self
-    double precision                               , intent(in   )               :: massStellar               , massGas
+    double precision                               , intent(in   )               :: massStellar         , massGas
     type            (abundances                   ), intent(in   )               :: abundancesStellar
     type            (history                      ), intent(inout)               :: historyStarFormation
     type            (treeNode                     ), intent(inout)               :: node
     class           (nodeComponentBasic           ), pointer                     :: basic
-    double precision                               , parameter                   :: massMinimum         =1.0d0
-    double precision                               , allocatable  , dimension(:) :: timeSteps                 , timesCrossing
-    integer         (c_size_t                     )                              :: i                         , j
+    double precision                               , allocatable  , dimension(:) :: timeSteps           , timesCrossing
+    integer         (c_size_t                     )                              :: i                   , j
     !$GLC attributes unused :: abundancesStellar
 
     ! Call the recursive copy if needed.
@@ -651,8 +657,8 @@ contains
           do j=1,self%countMetallicities+1
              ! The scale is set to a representative stellar mass scale multiplied by the fraction of the total history time in
              ! each time bin.
-             historyStarFormation%data(:,(i-1)*(self%countMetallicities+1)+j)=+max(massStellar+massGas,massMinimum) &
-                  &                                                           *timeSteps                            &
+             historyStarFormation%data(:,(i-1)*(self%countMetallicities+1)+j)=+max(massStellar+massGas,self%massScaleAbsolute) &
+                  &                                                           *timeSteps                                       &
                   &                                                           /timesCrossing(i)
           end do
        end do

--- a/source/star_formation.histories.metallicity_split.F90
+++ b/source/star_formation.histories.metallicity_split.F90
@@ -56,7 +56,7 @@ Implements a star formation histories class which records star formation split b
      integer                                                       :: countMetallicities
      double precision                                              :: timeStep                         , timeStepFine          , &
           &                                                           timeFine                         , metallicityMaximum    , &
-          &                                                           metallicityMinimum
+          &                                                           metallicityMinimum               , massScaleAbsolute
      double precision                  , allocatable, dimension(:) :: metallicityTable                 , metallicityBoundaries_
      logical                                                       :: metallicityTableWritten
    contains
@@ -109,7 +109,7 @@ contains
     double precision                                      , allocatable  , dimension(:) :: metallicityBoundaries
     double precision                                                                    :: timeStep             , timeStepFine      , &
          &                                                                                 timeFine             , metallicityMinimum, &
-         &                                                                                 metallicityMaximum
+         &                                                                                 metallicityMaximum   , massScaleAbsolute
     integer                                                                             :: countMetallicities
 
     !![
@@ -129,6 +129,12 @@ contains
       <name>timeFine</name>
       <defaultValue>0.1d0</defaultValue>
       <description>The period prior to each output for which the fine time step is used in tabulations of star formation histories [Gyr].</description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter>
+      <name>massScaleAbsolute</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>The absolute tolerance scale (for the mass in each bin of star formation history) to use during ODE solution.</description>
       <source>parameters</source>
     </inputParameter>
     !!]
@@ -170,7 +176,7 @@ contains
     !![
     <objectBuilder class="outputTimes" name="outputTimes_" source="parameters"/>
     <conditionalCall>
-     <call>self=starFormationHistoryMetallicitySplit(outputTimes_,timeStep,timeStepFine,timeFine{conditions})</call>
+     <call>self=starFormationHistoryMetallicitySplit(outputTimes_,timeStep,timeStepFine,timeFine,massScaleAbsolute{conditions})</call>
      <argument name="metallicityBoundaries" value="metallicityBoundaries" condition="     parameters%isPresent('metallicityBoundaries')"/>
      <argument name="countMetallicities"    value="countMetallicities"    condition=".not.parameters%isPresent('metallicityBoundaries')"/>
      <argument name="metallicityMinimum"    value="metallicityMinimum"    condition=".not.parameters%isPresent('metallicityBoundaries')"/>
@@ -182,7 +188,7 @@ contains
     return
   end function metallicitySplitConstructorParameters
 
-  function metallicitySplitConstructorInternal(outputTimes_,timeStep,timeStepFine,timeFine,metallicityBoundaries,countMetallicities,metallicityMinimum,metallicityMaximum) result(self)
+  function metallicitySplitConstructorInternal(outputTimes_,timeStep,timeStepFine,timeFine,massScaleAbsolute,metallicityBoundaries,countMetallicities,metallicityMinimum,metallicityMaximum) result(self)
     !!{
     Internal constructor for the \refClass{starFormationHistoryMetallicitySplit} star formation history class.
     !!}
@@ -193,11 +199,11 @@ contains
     double precision                                      , intent(in   ), dimension(:), optional :: metallicityBoundaries
     double precision                                      , intent(in   )              , optional :: metallicityMinimum   , metallicityMaximum
     double precision                                      , intent(in   )                         :: timeStep             , timeStepFine, &
-         &                                                                                           timeFine
+         &                                                                                           timeFine             , massScaleAbsolute
     integer                                               , intent(in   )              , optional :: countMetallicities
     class           (outputTimesClass                    ), intent(in   ), target                 :: outputTimes_
     !![
-    <constructorAssign variables="timeStep, timeStepFine, timeFine, metallicityMinimum, metallicityMaximum, countMetallicities, *outputTimes_"/>
+    <constructorAssign variables="timeStep, timeStepFine, timeFine, massScaleAbsolute, metallicityMinimum, metallicityMaximum, countMetallicities, *outputTimes_"/>
     !!]
 
     if (present(metallicityBoundaries)) then
@@ -358,11 +364,10 @@ contains
     !!}
     implicit none
     class           (starFormationHistoryMetallicitySplit), intent(inout)               :: self
-    double precision                                      , intent(in   )               :: massStellar                , massGas    
+    double precision                                      , intent(in   )               :: massStellar         , massGas    
     type            (abundances                          ), intent(in   )               :: abundancesStellar
     type            (history                             ), intent(inout)               :: historyStarFormation
     type            (treeNode                            ), intent(inout)               :: node
-    double precision                                      , parameter                   :: massMinimum          =1.0d0
     double precision                                      , allocatable  , dimension(:) :: timeSteps
     integer                                                                             :: iMetallicity
     !$GLC attributes unused :: abundancesStellar, node
@@ -370,7 +375,7 @@ contains
     if (.not.historyStarFormation%exists()) return
     call historyStarFormation%timeSteps(timeSteps)
     forall(iMetallicity=1:self%countMetallicities+1)
-       historyStarFormation%data(:,iMetallicity)=+max(massStellar+massGas,massMinimum)                            &
+       historyStarFormation%data(:,iMetallicity)=+max(massStellar+massGas,self%massScaleAbsolute)                 &
             &                                    *                     timeSteps                                  &
             &                                    /historyStarFormation%time     (size(historyStarFormation%time))
     end forall


### PR DESCRIPTION
## Summary
- The minimum mass scale for bins in the star formation history previously defaulted to $1 \mathrm{M}_\odot$ (scaled by the size of the bin timestep). This can be too small for some models, resulting in step size underflow. Make this scale user-settable in all relevant `starFormationHistory*` classes via a new parameter `massScaleAbsolute`.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- 

## Checklist
- [x] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
