### PR TITLE
Refactor cold-mode starvation from the component file to a `nodeOperator`

### DIFF
--- a/source/nodes.operators.physics.circumgalactic_medium.accretion.F90
+++ b/source/nodes.operators.physics.circumgalactic_medium.accretion.F90
@@ -274,7 +274,7 @@ contains
     !!}
     use :: Abundances_Structure         , only : abundances        , zeroAbundances        , operator(*)
     use :: Chemical_Abundances_Structure, only : chemicalAbundances, zeroChemicalAbundances, operator(*)      , operator(>)
-    use :: Accretion_Halos              , only : accretionModeHot  , accretionModeTotal
+    use :: Accretion_Halos              , only : accretionModeHot  , accretionModeTotal    , accretionModeCold
     use :: Galacticus_Nodes             , only : nodeComponentBasic, nodeComponentHotHalo  , nodeComponentSpin
     implicit none
     class           (nodeOperatorCGMAccretion), intent(inout) :: self
@@ -291,7 +291,8 @@ contains
     logical                                                   :: massTotalNonZero
     double precision                                          :: massAccreted           , massUnaccreted           , &
          &                                                       fractionAccreted       , massReaccreted           , &
-         &                                                       angularMomentumAccreted, massAccretedHot
+         &                                                       angularMomentumAccreted, massAccretedHot          , &
+         &                                                       massAccretedCold
 
     ! Get the hot halo component.
     hotHalo => node%hotHalo()
@@ -315,12 +316,13 @@ contains
        end if
        ! Since the parent node is undergoing mass growth through this merger we potentially return some of the unaccreted
        ! gas to the hot phase.
-       !! First, find the masses of hot and failed mass the node would have if it formed instantaneously.
+       !! First, find the masses of hot, cold and failed mass the node would have if it formed instantaneously.
        massAccretedHot =self%accretionHalo_%      accretedMass(nodeParent,accretionModeHot  )
+       massAccretedCold=self%accretionHalo_%      accretedMass(nodeParent,accretionModeCold )
        massAccreted    =self%accretionHalo_%      accretedMass(nodeParent,accretionModeTotal)
        massUnaccreted  =self%accretionHalo_%failedAccretedMass(nodeParent,accretionModeTotal)
        massTotalNonZero=+massAccreted+massUnaccreted > 0.0d0
-       !! Find the fraction of mass that would be successfully accreted.
+       !! Find the fraction of hot mass that would be successfully accreted.
        if (massAccretedHot > 0.0d0) then
           if (.not.massTotalNonZero) call Error_Report('mass of hot-mode gas accreted is non-zero, but total mass is zero'//{introspection:location})
           fractionAccreted=+  massAccretedHot &
@@ -381,6 +383,49 @@ contains
                &                  /basicParent     %          mass()
           !! Reaccrete the chemicals.
           call hotHaloParent%chemicalsSet(hotHaloParent%chemicals()+massChemicalsReaccreted)
+       end if
+       !! Find the fraction of cold mass that would be successfully accreted.
+       if (massAccretedCold > 0.0d0) then
+          if (.not.massTotalNonZero) call Error_Report('mass of cold-mode gas accreted is non-zero, but total mass is zero'//{introspection:location})
+          fractionAccreted=+  massAccretedCold &
+               &           /(                  &
+               &             +massAccreted     &
+               &             +massUnaccreted   &
+               &            )
+          !! Find the change in the unaccreted mass.
+          massReaccreted=+hotHaloParent   %unaccretedMass() &
+               &         *fractionAccreted                  &
+               &         *basic           %          mass() &
+               &         /basicParent     %          mass()
+          !! Reaccrete the gas,
+          call hotHaloParent%unaccretedMassSet(hotHaloParent%unaccretedMass()-massReaccreted)
+          call hotHaloParent%      massColdSet(hotHaloParent%      massCold()+massReaccreted)
+          ! Compute the reaccreted metals.
+          if (hotHaloParent%unaccretedAbundancesIsSettable()) then
+             !! First, find the metal mass the node would have if it formed instantaneously.
+             massMetalsAccreted=self%accretionHalo_%accretedMassMetals(nodeParent,accretionModeCold)
+             !! Find the mass fraction of metals that would be successfully accreted.
+             fractionMetalsAccreted=+  massMetalsAccreted &
+                  &                 /(                    &
+                  &                   +massAccreted       &
+                  &                   +massUnaccreted     &
+                  &                  )
+             !! Find the change in the unaccreted mass.
+             massMetalsReaccreted=+hotHaloParent   %unaccretedMass() &
+                  &               *fractionMetalsAccreted            &
+                  &               *basic           %          mass() &
+                  &               /basicParent     %          mass()
+             !! Reaccrete the metals.
+             call hotHaloParent%unaccretedAbundancesSet(hotHaloParent%unaccretedAbundances()-massMetalsReaccreted)
+             call hotHaloParent%      abundancesColdSet(hotHaloParent%      abundancesCold()+massMetalsReaccreted)
+          end if
+          ! Compute the reaccreted angular momentum.
+          if (hotHaloParent%angularMomentumColdIsSettable()) then
+             angularMomentumAccreted=+            massReaccreted    &
+                  &                  *spinParent %angularMomentum() &
+                  &                  /basicParent%mass           ()
+             call hotHaloParent%angularMomentumColdSet(hotHaloParent%angularMomentumCold()+angularMomentumAccreted)
+          end if
        end if
     end select
     return

--- a/source/nodes.operators.physics.circumgalactic_medium.starvation.F90
+++ b/source/nodes.operators.physics.circumgalactic_medium.starvation.F90
@@ -131,7 +131,7 @@ contains
     Update the \gls{cgm} content of a node as a result of a merger.
     !!}
     use :: Abundances_Structure         , only : zeroAbundances
-    use :: Accretion_Halos              , only : accretionModeHot      , accretionModeTotal
+    use :: Accretion_Halos              , only : accretionModeHot      , accretionModeTotal  , accretionModeCold
     use :: Chemical_Abundances_Structure, only : zeroChemicalAbundances
     use :: Galactic_Structure_Options   , only : componentTypeAll      , massTypeBaryonic
     use :: Galacticus_Nodes             , only : nodeComponentBasic    , nodeComponentHotHalo, nodeComponentSpin
@@ -146,7 +146,7 @@ contains
     class           (nodeComponentSpin        ), pointer       :: spinParent
     class           (massDistributionClass    ), pointer       :: massDistribution_
     double precision                                           :: baryonicMassCurrent, baryonicMassMaximum, &
-         &                                                        fractionRemove        
+         &                                                        fractionRemove     , massCGMTotal
 
     ! Get the hot halo component.
     hotHalo => node%hotHalo()
@@ -166,12 +166,24 @@ contains
                &                                                 hotHaloParent%mass                    () &
                &                                                +hotHalo      %mass                    () &
                &                                               )
-          if (hotHaloParent%angularMomentumIsSettable())                                                  &
+          if (hotHaloParent%    angularMomentumIsSettable())                                              &
                & call hotHaloParent%         angularMomentumSet(                                          &
                &                                                 hotHaloParent%angularMomentum         () &
                &                                                +hotHalo      %mass                    () &
                &                                                *spinParent   %angularMomentum         () &
                &                                                /basicParent  %mass                    () &
+               &                                               )
+          if (hotHaloParent%           massColdIsSettable())                                              &
+               & call hotHaloParent%                massColdSet(                                          &
+               &                                                 hotHaloParent %massCold               () &
+               &                                                +hotHalo       %massCold               () &
+               &                                               )
+          if (hotHaloParent%angularMomentumColdIsSettable())                                              &
+               & call hotHaloParent%     angularMomentumColdSet(                                          &
+               &                                                 hotHaloParent %angularMomentumCold    () &
+               &                                                +hotHalo       %massCold               () &
+               &                                                *spinParent    %angularMomentum        () &
+               &                                                /basicParent   %mass                   () &
                &                                               )
        end if
        if (hotHaloParent%           outflowedMassIsSettable()                                     )       &
@@ -194,6 +206,14 @@ contains
                & call hotHalo      %         angularMomentumSet(                                          &
                &                                                 0.0d0                                    &
                &                                               )
+          if (hotHalo%                   massColdIsSettable())                                            &
+               & call hotHalo      %                massColdSet(                                          &
+               &                                                 0.0d0                                    &
+               &                                               )
+          if (hotHalo%        angularMomentumColdIsSettable())                                            &
+               & call hotHalo      %     angularMomentumColdSet(                                          &
+               &                                                 0.0d0                                    &
+               &                                               )
        end if
        if (hotHalo%                  outflowedMassIsSettable()                                   )        &
             & call    hotHalo      %           outflowedMassSet(                                          &
@@ -204,13 +224,22 @@ contains
             &                                                    0.0d0                                    &
             &                                                  )
        if (                                                     .not.self%starveOutflowsOnly) then
-          call hotHaloParent%              abundancesSet(                                          &
-               &                                          hotHaloParent%abundances              () &
-               &                                         +hotHalo      %abundances              () &
-               &                                        )
-          call hotHalo      %              abundancesSet(                                          &
-               &                                          zeroAbundances                           &
-               &                                        )
+          call    hotHaloParent%    abundancesSet(                                 &
+               &                                   hotHaloParent%abundances     () &
+               &                                  +hotHalo      %abundances     () &
+               &                                 )
+          call    hotHalo      %    abundancesSet(                                 &
+               &                                   zeroAbundances                  &
+               &                                 )
+          if (hotHalo%abundancesColdIsSettable())  then
+             call hotHaloParent%abundancesColdSet(                                 &
+                  &                                hotHaloParent %abundancesCold() &
+                  &                               +hotHalo       %abundancesCold() &
+                  &                              )
+             call hotHalo      %abundancesColdSet(                                 &
+                  &                                zeroAbundances                  &
+                  &                              )
+          end if          
        end if
        if (hotHaloParent%outflowedAbundancesIsSettable()                                    ) then
           call hotHaloParent%     outflowedAbundancesSet(                                          &
@@ -248,23 +277,30 @@ contains
                &                 *self             %cosmologyParameters_%omegaBaryon     (                         ) &
                &                 /self             %cosmologyParameters_%omegaMatter     (                         )
           baryonicMassCurrent =  +massDistribution_                     %massTotal       (                         )
+          massCGMTotal        =  +hotHaloParent                         %mass            (                         ) &
+               &                 +hotHaloParent                         %massCold        (                         )
           !![
 	  <objectDestructor name="massDistribution_"/>
 	  !!]
           if (baryonicMassCurrent > baryonicMassMaximum .and. hotHaloParent%mass() > 0.0d0) then
-             fractionRemove=min((baryonicMassCurrent-baryonicMassMaximum)/hotHaloParent%massTotal(),1.0d0)
-             call hotHaloParent%      unaccretedMassSet(                                                             &
-                  &                                      hotHaloParent%unaccretedMass      ()                        &
-                  &                                     +hotHaloParent%mass                ()*       fractionRemove  &
-                  &                                    )
-             call hotHaloParent%unaccretedAbundancesSet(                                                             &
-                  &                                      hotHaloParent%unaccretedAbundances()                        &
-                  &                                     +hotHaloParent%abundances          ()*       fractionRemove  &
-                  &                                    )
-             call hotHaloParent%                massSet( hotHaloParent%mass                ()*(1.0d0-fractionRemove))
-             call hotHaloParent%     angularMomentumSet( hotHaloParent%angularMomentum     ()*(1.0d0-fractionRemove))
-             call hotHaloParent%          abundancesSet( hotHaloParent%abundances          ()*(1.0d0-fractionRemove))
-             call hotHaloParent%          chemicalsSet ( hotHaloParent%chemicals           ()*(1.0d0-fractionRemove))
+             fractionRemove=min((baryonicMassCurrent-baryonicMassMaximum)/massCGMTotal,1.0d0)
+             call    hotHaloParent%      unaccretedMassSet(                                                             &
+                  &                                         hotHaloParent%unaccretedMass      ()                        &
+                  &                                        +hotHaloParent%mass                ()*       fractionRemove  &
+                  &                                       )
+             call    hotHaloParent%unaccretedAbundancesSet(                                                             &
+                  &                                         hotHaloParent%unaccretedAbundances()                        &
+                  &                                        +hotHaloParent%abundances          ()*       fractionRemove  &
+                  &                                       )
+             call    hotHaloParent%                massSet( hotHaloParent%mass                ()*(1.0d0-fractionRemove))
+             call    hotHaloParent%     angularMomentumSet( hotHaloParent%angularMomentum     ()*(1.0d0-fractionRemove))
+             call    hotHaloParent%          abundancesSet( hotHaloParent%abundances          ()*(1.0d0-fractionRemove))
+             call    hotHaloParent%          chemicalsSet ( hotHaloParent%chemicals           ()*(1.0d0-fractionRemove))
+             if (hotHaloParent%massColdIsSettable()) then
+                call hotHaloParent%            massColdSet( hotHaloParent%massCold            ()*(1.0d0-fractionRemove))
+                call hotHaloParent% angularMomentumColdSet( hotHaloParent%angularMomentumCold ()*(1.0d0-fractionRemove))
+                call hotHaloParent%      abundancesColdSet( hotHaloParent%abundancesCold      ()*(1.0d0-fractionRemove))
+             end if
           end if
        end if
     end select

--- a/source/objects.nodes.components.hot_halo.cold_mode.F90
+++ b/source/objects.nodes.components.hot_halo.cold_mode.F90
@@ -28,15 +28,14 @@ module Node_Component_Hot_Halo_Cold_Mode
   reservoir.
   !!}
   use :: Accretion_Halos                      , only : accretionHaloClass
-  use :: Cosmology_Parameters                 , only : cosmologyParametersClass
   use :: Dark_Matter_Halo_Scales              , only : darkMatterHaloScaleClass
   use :: Hot_Halo_Cold_Mode_Mass_Distributions, only : hotHaloColdModeMassDistributionClass
   implicit none
   private
-  public :: Node_Component_Hot_Halo_Cold_Mode_Initialize       , Node_Component_Hot_Halo_Cold_Mode_Node_Merger        , &
+  public :: Node_Component_Hot_Halo_Cold_Mode_Initialize       , Node_Component_Hot_Halo_Cold_Mode_State_Restore      , &
        &    Node_Component_Hot_Halo_Cold_Mode_Scale_Set        , Node_Component_Hot_Halo_Cold_Mode_Tree_Initialize    , &
        &    Node_Component_Hot_Halo_Cold_Mode_Thread_Initialize, Node_Component_Hot_Halo_Cold_Mode_Thread_Uninitialize, &
-       &    Node_Component_Hot_Halo_Cold_Mode_State_Store      , Node_Component_Hot_Halo_Cold_Mode_State_Restore
+       &    Node_Component_Hot_Halo_Cold_Mode_State_Store
 
   !![
   <component>
@@ -69,13 +68,6 @@ module Node_Component_Hot_Halo_Cold_Mode
       <attributes isSettable="true" isGettable="true" isEvolvable="true" createIfNeeded="true" />
       <output unitsInSI="massSolar*megaParsec*kilo" comment="Angular momentum of cold-mode gas in the hot halo."/>
     </property>
-    <property>
-      <name>massTotal</name>
-      <attributes isSettable="false" isGettable="true" isEvolvable="false" isVirtual="true" />
-      <type>double</type>
-      <rank>0</rank>
-      <getFunction>Node_Component_Hot_Halo_Cold_Mode_Mass_Total</getFunction>
-    </property>
    </properties>
    <bindings>
      <binding method="massDistribution" isDeferred="true" >
@@ -99,10 +91,9 @@ module Node_Component_Hot_Halo_Cold_Mode
 
   ! Objects used by this component.
   class(accretionHaloClass                  ), pointer :: accretionHalo_
-  class(cosmologyParametersClass            ), pointer :: cosmologyParameters_
   class(darkMatterHaloScaleClass            ), pointer :: darkMatterHaloScale_
   class(hotHaloColdModeMassDistributionClass), pointer :: hotHaloColdModeMassDistribution_
-  !$omp threadprivate(accretionHalo_,cosmologyParameters_,darkMatterHaloScale_,hotHaloColdModeMassDistribution_)
+  !$omp threadprivate(accretionHalo_,darkMatterHaloScale_,hotHaloColdModeMassDistribution_)
 
   ! Internal count of abundances.
   integer :: abundancesCount
@@ -167,7 +158,6 @@ contains
        ! Find our parameters.
        subParameters=parameters%subParameters('componentHotHalo')
        !![
-       <objectBuilder class="cosmologyParameters"             name="cosmologyParameters_"             source="subParameters"/>
        <objectBuilder class="darkMatterHaloScale"             name="darkMatterHaloScale_"             source="subParameters"/>
        <objectBuilder class="accretionHalo"                   name="accretionHalo_"                   source="subParameters"/>
        <objectBuilder class="hotHaloColdModeMassDistribution" name="hotHaloColdModeMassDistribution_" source="subParameters"/>
@@ -193,7 +183,6 @@ contains
 
     if (defaultHotHaloComponent%coldModeIsActive()) then
        !![
-       <objectDestructor name="cosmologyParameters_"            />
        <objectDestructor name="darkMatterHaloScale_"            />
        <objectDestructor name="accretionHalo_"                  />
        <objectDestructor name="hotHaloColdModeMassDistribution_"/>
@@ -299,144 +288,6 @@ contains
     end if
     return
   end subroutine Node_Component_Hot_Halo_Cold_Mode_Tree_Initialize
-
-  !![
-  <nodeMergerTask function="Node_Component_Hot_Halo_Cold_Mode_Node_Merger" before="Node_Component_Hot_Halo_Standard_Node_Merger"/>
-  !!]
-  subroutine Node_Component_Hot_Halo_Cold_Mode_Node_Merger(node)
-    !!{
-    Starve \mono{node} by transferring its hot halo to its parent.
-    !!}
-    use :: Abundances_Structure                 , only : abundances                     , operator(*)            , zeroAbundances
-    use :: Accretion_Halos                      , only : accretionModeCold              , accretionModeTotal
-    use :: Galactic_Structure_Options           , only : componentTypeAll               , massTypeBaryonic
-    use :: Galacticus_Nodes                     , only : nodeComponentBasic             , nodeComponentHotHalo   , nodeComponentHotHaloColdMode, nodeComponentSpin, &
-          &                                              treeNode                       , defaultHotHaloComponent
-    use :: Node_Component_Hot_Halo_Standard_Data, only : fractionBaryonLimitInNodeMerger, starveSatellites
-    use :: Mass_Distributions                   , only : massDistributionClass
-    implicit none
-    type            (treeNode             ), intent(inout) :: node
-    type            (treeNode             ), pointer       :: nodeParent
-    class           (nodeComponentHotHalo ), pointer       :: hotHaloParent          , hotHalo
-    class           (nodeComponentSpin    ), pointer       :: spinParent
-    class           (nodeComponentBasic   ), pointer       :: basicParent            , basic
-    class           (massDistributionClass), pointer       :: massDistribution_
-    double precision                                       :: baryonicMassCurrent    , baryonicMassMaximum   , &
-         &                                                    fractionRemove         , massAccretedCold      , &
-         &                                                    massAccreted           , massUnaccreted        , &
-         &                                                    angularMomentumAccreted, massReaccreted        , &
-         &                                                    fractionAccreted
-    type            (abundances           ), save          :: massMetalsAccreted     , fractionMetalsAccreted, &
-         &                                                    massMetalsReaccreted
-    !$omp threadprivate(massMetalsAccreted,fractionMetalsAccreted,massMetalsReaccreted)
-
-    ! Return immediately if this class is not in use.
-    if (.not.defaultHotHaloComponent%coldModeIsActive()) return
-    ! Get the hot halo component.
-    hotHalo => node%hotHalo()
-    ! Ensure that it is of cold mode class.
-    select type (hotHalo)
-    class is (nodeComponentHotHaloColdMode)
-       ! Find the parent node and its hot halo and angular momentum components.
-       nodeParent    => node      %parent
-       hotHaloParent => nodeParent%hotHalo(autoCreate=.true.)
-       spinParent    => nodeParent%spin   (                 )
-       basicParent   => nodeParent%basic  (                 )
-       basic         => node      %basic  (                 )
-       ! Since the parent node is undergoing mass growth through this merger we potentially return some of the unaccreted gas to
-       ! the hot phase.
-       !! First, find the masses of hot and failed mass the node would have if it formed instantaneously.
-       massAccretedCold=accretionHalo_%      accretedMass(nodeParent,accretionModeCold )
-       massAccreted    =accretionHalo_%      accretedMass(nodeParent,accretionModeTotal)
-       massUnaccreted  =accretionHalo_%failedAccretedMass(nodeParent,accretionModeTotal)
-       !! Find the fraction of mass that would be successfully accreted.
-       fractionAccreted=+  massAccretedCold &
-            &           /(                  &
-            &             +massAccreted     &
-            &             +massUnaccreted   &
-            &            )
-       !! Find the change in the unaccreted mass.
-       massReaccreted=+hotHaloParent   %unaccretedMass() &
-            &         *fractionAccreted                  &
-            &         *basic           %          mass() &
-            &         /basicParent     %          mass()
-       !! Reaccrete the gas.
-       call hotHaloParent%unaccretedMassSet(hotHaloParent%unaccretedMass()-massReaccreted)
-       call hotHaloParent%      massColdSet(hotHaloParent%      massCold()+massReaccreted)
-       ! Compute the reaccreted angular momentum.
-       angularMomentumAccreted=+            massReaccreted    &
-            &                  *spinParent %angularMomentum() &
-            &                  /basicParent%mass           ()
-       call hotHaloParent%angularMomentumColdSet(hotHaloParent%angularMomentumCold()+angularMomentumAccreted)
-       ! Compute the reaccreted metals.
-       !! First, find the metal mass the node would have if it formed instantaneously.
-       massMetalsAccreted=accretionHalo_%accretedMassMetals(nodeParent,accretionModeCold)
-       !! Find the mass fraction of metals that would be successfully accreted.
-       fractionMetalsAccreted=+  massMetalsAccreted &
-            &                 /(                    &
-            &                   +massAccreted       &
-            &                   +massUnaccreted     &
-            &                  )
-       !! Find the change in the unaccreted mass.
-       massMetalsReaccreted=+hotHaloParent         %unaccretedMass() &
-            &               *fractionMetalsAccreted                  &
-            &               *basic                 %          mass() &
-            &               /basicParent           %          mass()
-       !! Reaccrete the metals.
-       call hotHaloParent%abundancesColdSet(hotHaloParent%abundancesCold()+massMetalsReaccreted)
-       ! Determine if starvation is to be applied.
-       if (starveSatellites) then
-          ! Move the hot halo to the parent. We leave the hot halo in place even if it is starved, since outflows will accumulate to
-          ! this hot halo (and will be moved to the parent at the end of the evolution timestep).
-          call hotHaloParent%           massColdSet(                                      &
-               &                                     hotHaloParent %massCold           () &
-               &                                    +hotHalo       %massCold           () &
-               &                                   )
-          call hotHaloParent%angularMomentumColdSet(                                      &
-               &                                     hotHaloParent %angularMomentumCold() &
-               &                                    +hotHalo       %massCold           () &
-               &                                    *spinParent    %angularMomentum    () &
-               &                                    /basicParent   %mass               () &
-               &                                   )
-          call hotHalo      %           massColdSet(                                      &
-               &                                     0.0d0                                &
-               &                                   )
-          call hotHalo      %angularMomentumColdSet(                                      &
-               &                                     0.0d0                                &
-               &                                   )
-          call hotHaloParent%     abundancesColdSet(                                      &
-               &                                     hotHaloParent %abundancesCold     () &
-               &                                    +hotHalo       %abundancesCold     () &
-               &                                   )
-          call hotHalo      %     abundancesColdSet(                                      &
-               &                                     zeroAbundances                       &
-               &                                   )
-          ! Check if the baryon fraction in the parent hot halo exceeds the universal value. If it does, mitigate this by moving
-          ! some of the mass to the failed accretion reservoir.
-          if (fractionBaryonLimitInNodeMerger) then
-             massDistribution_   =>  nodeParent          %massDistribution(massType=massTypeBaryonic)
-             baryonicMassMaximum =  +basicParent         %mass            (                         ) &
-                  &                 *cosmologyParameters_%omegaBaryon     (                         ) &
-                  &                 /cosmologyParameters_%omegaMatter     (                         )
-             baryonicMassCurrent =  +massDistribution_   %massTotal       (                         )
-             !![
-	     <objectDestructor name="massDistribution_"/>
-	     !!]
-             if (baryonicMassCurrent > baryonicMassMaximum .and. hotHaloParent%mass()+hotHaloParent%massCold() > 0.0d0) then
-                fractionRemove=min((baryonicMassCurrent-baryonicMassMaximum)/hotHaloParent%massTotal(),1.0d0)
-                call hotHaloParent%     unaccretedMassSet(                                                            &
-                     &                                     hotHaloParent%unaccretedMass     ()                        &
-                     &                                    +hotHaloParent%massCold           ()*       fractionRemove  &
-                     &                                   )
-                call hotHaloParent%           massColdSet( hotHaloParent%massCold           ()*(1.0d0-fractionRemove))
-                call hotHaloParent%angularMomentumColdSet( hotHaloParent%angularMomentumCold()*(1.0d0-fractionRemove))
-                call hotHaloParent%     abundancesColdSet( hotHaloParent%abundancesCold     ()*(1.0d0-fractionRemove))
-             end if
-          end if
-       end if
-    end select
-    return
-  end subroutine Node_Component_Hot_Halo_Cold_Mode_Node_Merger
 
   subroutine satelliteMerger(self,node)
     !!{
@@ -594,7 +445,7 @@ contains
 
     call displayMessage('Storing state for: componentHotHalo -> coldMode',verbosity=verbosityLevelInfo)
     !![
-    <stateStore variables="accretionHalo_ cosmologyParameters_ hotHaloColdModeMassDistribution_"/>
+    <stateStore variables="accretionHalo_ hotHaloColdModeMassDistribution_"/>
     !!]
     return
   end subroutine Node_Component_Hot_Halo_Cold_Mode_State_Store
@@ -615,7 +466,7 @@ contains
 
     call displayMessage('Retrieving state for: componentHotHalo -> coldMode',verbosity=verbosityLevelInfo)
     !![
-    <stateRestore variables="accretionHalo_ cosmologyParameters_ hotHaloColdModeMassDistribution_"/>
+    <stateRestore variables="accretionHalo_ hotHaloColdModeMassDistribution_"/>
     !!]
     return
   end subroutine Node_Component_Hot_Halo_Cold_Mode_State_Restore

--- a/source/objects.nodes.components.hot_halo.cold_mode.bound_functions.Inc
+++ b/source/objects.nodes.components.hot_halo.cold_mode.bound_functions.Inc
@@ -21,17 +21,6 @@
 Contains custom functions for the cold mode hot halo component.
 !!}
 
-double precision function Node_Component_Hot_Halo_Cold_Mode_Mass_Total(self)
-  !!{
-  Return the total active mass in the hot halo.
-  !!}
-  implicit none
-  class(nodeComponentHotHaloColdMode), intent(inout) :: self
-
-  Node_Component_Hot_Halo_Cold_Mode_Mass_Total=self%mass()+self%massCold()
-  return
-end function Node_Component_Hot_Halo_Cold_Mode_Mass_Total
-
 double precision function Node_Component_Hot_Halo_Cole_Mode_Mass_Baryonic(self) result(massBaryonic)
   !!{
   Return the baryonic mass for the very simple disk component.

--- a/source/objects.nodes.components.hot_halo.standard.F90
+++ b/source/objects.nodes.components.hot_halo.standard.F90
@@ -180,13 +180,6 @@ module Node_Component_Hot_Halo_Standard
       <type>double</type>
       <rank>0</rank>
     </property>
-    <property>
-      <name>massTotal</name>
-      <attributes isSettable="false" isGettable="true" isEvolvable="false" isVirtual="true" />
-      <type>double</type>
-      <rank>0</rank>
-      <getFunction>Node_Component_Hot_Halo_Standard_Mass_Total</getFunction>
-    </property>
    </properties>
    <bindings>
      <binding method="massDistribution" isDeferred="true" >

--- a/source/objects.nodes.components.hot_halo.standard.bound_functions.Inc
+++ b/source/objects.nodes.components.hot_halo.standard.bound_functions.Inc
@@ -21,17 +21,6 @@
 Contains custom functions for the standard hot halo component.
 !!}
 
-double precision function Node_Component_Hot_Halo_Standard_Mass_Total(self)
-  !!{
-  Return the total active mass in the hot halo.
-  !!}
-  implicit none
-  class(nodeComponentHotHaloStandard), intent(inout) :: self
-
-  Node_Component_Hot_Halo_Standard_Mass_Total=self%mass()
-  return
-end function Node_Component_Hot_Halo_Standard_Mass_Total
-
 double precision function Node_Component_Hot_Halo_Standard_Mass_Baryonic(self) result(massBaryonic)
   !!{
   Return the baryonic mass for the hot halo standard component.

--- a/source/stellar_populations.standard.F90
+++ b/source/stellar_populations.standard.F90
@@ -426,7 +426,7 @@ contains
     use            :: Abundances_Structure            , only : Abundances_Get_Metallicity
     use            :: Dates_and_Times                 , only : Formatted_Date_and_Time
     use            :: Display                         , only : displayCounter                   , displayCounterClear , displayIndent, displayUnindent, &
-          &                                                    verbosityLevelWorking
+          &                                                    verbosityLevelWorking            , displayMessage
     use            :: File_Utilities                  , only : Directory_Make                   , File_Exists         , File_Lock    , File_Path      , &
           &                                                    File_Unlock                      , lockDescriptor
     use            :: Error                           , only : Error_Report
@@ -596,7 +596,7 @@ contains
           call    file      %writeDataset(property%property,char(property%label))
           call    file      %close       (                                      )
           !$ call hdf5Access%unset       (                                      )
-          call displayIndent('Storing to file: '//fileName,verbosityLevelWorking)
+          call displayMessage('Storing to file: '//fileName,verbosityLevelWorking)
        end if
        call File_Unlock(lock)
        ! Build interpolators.


### PR DESCRIPTION
## Summary
- Refactor cold-mode starvation from the component file to a `nodeOperator`.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [x] Other: Part of the ongoing refactor to move physics out of components and into `nodeOperator`s.

## How to test
- 

## Checklist
- [x] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
