### PR TITLE
Correct the calculation of cross-covariance in the `outputAnalysisCrossCorrelator1D` class

### DIFF
--- a/source/output.analyses.cross_correlator_1d.F90
+++ b/source/output.analyses.cross_correlator_1d.F90
@@ -408,14 +408,18 @@ contains
                &  +self    %weightMainBranch     ( :             ,indexHaloMass)      &
                &  +         distribution         (1:self%binCount)                    &
                &  *         sqrt(                                                     &
-               &                 +weightValue1                                        &
-               &                 *weightValue2                                        &
+               &                 abs(                                                 &
+               &                     +weightValue1                                    &
+               &                     *weightValue2                                    &
+               &                    )                                                 &
                &                )
           self             %weightMainBranchCross(                indexHaloMass)=     &
                &  +    self%weightMainBranchCross(                indexHaloMass)      &
                &  +sum(     distribution          (1:self%binCount              ))**2 &
-               &  *         weightValue1                                              &
-               &  *         weightValue2
+               &  *abs(                                                               &
+               &       +    weightValue1                                              &
+               &       *    weightValue2                                              &
+               &      )
        end if
     else
        ! Construct contribution to the covariance matrix assuming Poisson statistics.

--- a/source/output.analyses.cross_correlator_1d.F90
+++ b/source/output.analyses.cross_correlator_1d.F90
@@ -407,7 +407,10 @@ contains
           self             %weightMainBranch     ( :             ,indexHaloMass)=     &
                &  +self    %weightMainBranch     ( :             ,indexHaloMass)      &
                &  +         distribution         (1:self%binCount)                    &
-               &  *         weightValue1
+               &  *         sqrt(                                                     &
+               &                 +weightValue1                                        &
+               &                 *weightValue2                                        &
+               &                )
           self             %weightMainBranchCross(                indexHaloMass)=     &
                &  +    self%weightMainBranchCross(                indexHaloMass)      &
                &  +sum(     distribution          (1:self%binCount              ))**2 &


### PR DESCRIPTION
## Summary
- The accumulated main branch covariances correctly used the product of the two weights (for which cross-correlation is being computed), but the accumulation for the expectation used only one of these weights - it should use the geometric mean of the two weights for consistency with the covariance accumulation.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- 

## Checklist
- [ ] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
