### PR TITLE
Support 1D arrays of varying_string and polymorphic-list types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -566,7 +566,7 @@ $(BUILDPATH)/%.m : ./source/%.F90
 
 # Library.
 -include $(BUILDPATH)/Makefile_Library_Dependencies
-$(BUILDPATH)/Makefile_Library_Dependencies: $(BUILDPATH)/libgalacticus.Inc
+$(BUILDPATH)/Makefile_Library_Dependencies: $(BUILDPATH)/libgalacticus.Inc ./scripts/build/libraryInterfacesDependencies.py
 	./scripts/build/libraryInterfacesDependencies.py
 $(BUILDPATH)/libgalacticus.Inc: $(BUILDPATH)/directiveLocations.xml $(BUILDPATH)/stateStorables.xml ./source/libraryClasses.xml ./scripts/build/libraryInterfaces.py ./python/LibraryInterfaces/Pipeline.py ./python/LibraryInterfaces/Emitters.py ./python/LibraryInterfaces/ArgSpec.py
 	./scripts/build/libraryInterfaces.py

--- a/python/LibraryInterfaces/ArgSpec.py
+++ b/python/LibraryInterfaces/ArgSpec.py
@@ -52,6 +52,27 @@ class ArgSpec:
                                        # character arrays (`character(len=N),
                                        # dimension(:)`); 0 otherwise.
 
+    # Marker for `type(varying_string), dimension(:)` arrays.  These can't
+    # be packed at codegen time (no fixed per-element length), so the
+    # Python wrapper computes the maximum encoded length at runtime, pads
+    # to that width, and ships it through a flat byte buffer plus two
+    # c_size_t companions (count + per-element length).  The Fortran
+    # wrapper repacks into `type(varying_string), dimension(:)`.
+    varying_string_array: bool = False
+
+    # Marker for `type(<className>List), dimension(:)` arrays — Galacticus's
+    # idiom for "array of class(<className>Class)" (Fortran disallows arrays
+    # of polymorphic types directly).  Each element holds a `class(...)`
+    # pointer to a registered functionClass, so the Python wrapper ships
+    # parallel arrays of object pointers and class IDs (one pair per
+    # element); the Fortran wrapper rebuilds the list locally via the
+    # GetPtr helper, the same machinery the scalar `class(FooClass)` arg
+    # path uses.
+    polymorphic_list_array:    bool = False
+    polymorphic_list_class:    str  = ''   # e.g. 'modelParameter' (registered functionClass)
+    polymorphic_list_type:     str  = ''   # e.g. 'modelParameterList' (the wrapper struct)
+    polymorphic_list_component: str = ''   # e.g. 'modelParameter_' (component on the wrapper)
+
     # ctypes
     ctype:         str  = ''    # e.g. 'c_double', 'c_void_p', 'c_char_p', 'c_int'
     ctype_pointer: bool = False  # wrap as POINTER(ctype) — set by assign_c_attributes

--- a/python/LibraryInterfaces/Pipeline.py
+++ b/python/LibraryInterfaces/Pipeline.py
@@ -60,6 +60,8 @@ _SHARED_TYPE_MODULES = {
     'abundances'                                  : 'Abundances_Structure',
     'chemicalAbundances'                          : 'Chemical_Abundances_Structure',
     'multiExtractorList'                          : 'Node_Property_Extractors',
+    'modelParameterList'                          : 'Model_Parameters',
+    'stellarPopulationSpectraPostprocessorList'   : 'Stellar_Population_Spectra_Postprocess',
     'enumerationFrameType'                        : 'Stellar_Luminosities_Structure',
     'enumerationDestroyStubsType'                 : 'Merger_Tree_Build_Controllers',
     'enumerationComponentTypeType'                : 'Galactic_Structure_Options',
@@ -84,6 +86,34 @@ _DIM_FIXED_RX = re.compile(r'^dimension\s*\(\s*(\d+)\s*\)$')
 # Variable-length forms (`len=*`, `len=:`) deliberately don't match — we
 # can't pack those into a fixed-stride byte buffer at the Python boundary.
 _CHAR_LEN_RX = re.compile(r'^len\s*=\s*(\d+)$')
+
+
+def _make_id_array_companion(name):
+    """Build a hidden 1D ``integer(c_int), dimension(*)`` companion ArgSpec
+    for a ``polymorphic_list_array`` argument — the parallel buffer carrying
+    each element's concrete class ID.  Mirrors the scalar functionClass
+    arg path's ``_ID`` companion (set up inside ``assign_c_types``), only
+    1D and never optional.
+
+    The companion participates in ``assign_c_attributes`` like any other
+    deferred-shape numeric input — ``dimension(:)`` is rewritten to
+    ``dimension(*)`` and ``ctype_pointer`` becomes True so ctypes
+    receives ``POINTER(c_int)`` and the Python side hands over a
+    ``(c_int * count)(*ids)`` ctypes array.
+    """
+    return ArgSpec(
+        name                  = name,
+        intrinsic             = 'integer',
+        type_spec             = '',
+        attributes            = ['intent(in)', 'dimension(:)'],
+        ctype                 = 'c_int',
+        fort_type             = 'integer(c_int)',
+        fort_is_present       = True,
+        py_is_present         = False,
+        galacticus_is_present = False,
+        is_optional           = False,
+        is_function_class     = False,
+    )
 
 
 def _make_count_companion(name):
@@ -194,12 +224,60 @@ def assign_c_types(argument_list, lib_function_classes):
                 arg.fort_type = 'character(c_char)'
         elif intrinsic == 'type':
             if type_spec_val == 'varying_string':
-                arg.ctype     = 'c_char_p'
-                arg.fort_type = 'character(c_char)'
+                if 'dimension(:)' in arg.attributes:
+                    # `type(varying_string), dimension(:)`.  No fixed
+                    # per-element width is known at codegen time, so we
+                    # ship a flat `character(c_char), dimension(*)` byte
+                    # buffer plus a count companion AND a per-element
+                    # length companion (both c_size_t, by value).  The
+                    # Python wrapper picks the max ASCII-encoded length
+                    # at runtime, pads each element to that width, and
+                    # passes the contiguous buffer; the Fortran wrapper
+                    # repacks into `type(varying_string), dimension(:)`
+                    # via element-wise assignment from a per-element
+                    # `character(len=:), allocatable` scratch buffer.
+                    arg.ctype                = 'c_char'
+                    arg.fort_type            = 'character(c_char)'
+                    arg.varying_string_array = True
+                    # Fall through to the array-detection block below;
+                    # it handles the deferred-shape branch and inserts
+                    # the (single) count companion.  The second
+                    # per-element-length companion is inserted there too
+                    # so its position is fixed relative to the count.
+                else:
+                    arg.ctype     = 'c_char_p'
+                    arg.fort_type = 'character(c_char)'
             elif re.match(r'^enumeration[a-z0-9_]+type$', type_spec_val, re.IGNORECASE):
                 # Enumeration types map to C int.
                 arg.ctype     = 'c_int'
                 arg.fort_type = 'integer(c_int)'
+            elif (type_spec_val.endswith('List')
+                  and type_spec_val[:-4] in lib_function_classes
+                  and 'dimension(:)' in arg.attributes):
+                # `type(<class>List), dimension(:)` — Galacticus's idiom
+                # for "array of class(<class>Class)".  Each element wraps
+                # a `class(<class>Class), pointer` whose component name is
+                # `<class>_` (universal convention; see e.g.
+                # modelParameterList in models.parameters.F90 or
+                # stellarPopulationSpectraPostprocessorList in
+                # stellar_populations.spectra.postprocess.F90).  We ship
+                # parallel buffers of object pointers + class IDs and
+                # rebuild the list inside the bind(c) wrapper using the
+                # registered class's GetPtr helper — same machinery as
+                # the scalar `class(FooClass)` arg path.
+                stem                          = type_spec_val[:-4]
+                arg.ctype                     = 'c_void_p'
+                arg.fort_type                 = 'type(c_ptr)'
+                arg.polymorphic_list_array    = True
+                arg.polymorphic_list_class    = stem
+                arg.polymorphic_list_type     = type_spec_val
+                arg.polymorphic_list_component = stem + '_'
+                # Insert the IDs array companion (sits between the
+                # parent and the count once the count is added below).
+                # Order at the end of this iteration: parent, count, IDs.
+                new_list.insert(0, _make_id_array_companion(arg.name + '_IDs'))
+                # Fall through to the array-detection block below; it
+                # marks is_array and inserts the count companion.
             else:
                 arg.ctype     = 'c_void_p'
                 arg.fort_type = 'type(c_ptr)'
@@ -250,12 +328,22 @@ def assign_c_types(argument_list, lib_function_classes):
         # scalar path and is_array stays False).
         is_numeric_array_candidate = intrinsic in ('double precision', 'integer')
         is_char_array_candidate    = intrinsic == 'character' and arg.char_len > 0
-        if is_numeric_array_candidate or is_char_array_candidate:
+        is_vstr_array_candidate    = arg.varying_string_array
+        is_list_array_candidate    = arg.polymorphic_list_array
+        if (is_numeric_array_candidate or is_char_array_candidate
+                or is_vstr_array_candidate or is_list_array_candidate):
             if 'dimension(:)' in arg.attributes:
                 arg.is_array   = True
                 arg.array_size = None
                 count_arg = _make_count_companion(arg.name + '_count')
                 new_list.insert(0, count_arg)
+                if is_vstr_array_candidate:
+                    # Per-element ASCII byte length (decided at runtime by
+                    # the Python wrapper from the input list's max length);
+                    # placed AFTER the count companion in bind(c) order, so
+                    # we insert it first while iterating in reverse.
+                    char_len_arg = _make_count_companion(arg.name + '_charLen')
+                    new_list.insert(1, char_len_arg)
             elif is_numeric_array_candidate and 'dimension(:,:)' in arg.attributes:
                 # 2D deferred-shape numeric array: two count companions,
                 # one per axis.  The wrapper passes a flat C buffer plus
@@ -431,6 +519,89 @@ def build_python_reassignments(argument_list):
                 )
             new_list.insert(0, count_arg_2)
             new_list.insert(0, count_arg_1)
+        elif arg.is_array and arg.varying_string_array:
+            # `type(varying_string), dimension(:)`: encode each element to
+            # ASCII, pad to the max encoded length, and ship as a flat
+            # contiguous `S{N}` numpy buffer.  N is decided at *runtime*
+            # (we can't know it at codegen), so the count companion's
+            # `py_pass_as` reads `.size` and the per-element-length
+            # companion reads `.itemsize` — numpy's `S{N}` dtype packs
+            # each element exactly N bytes wide, which is what the
+            # bind(c) buffer expects.  Empty / all-empty lists fall back
+            # to N=1 so the dtype is well-formed.  Optional-arg handling
+            # mirrors the fixed-len-character-array branch below.
+            safe = python_safe_name(arg.name)
+            count_arg    = new_list.pop(0)
+            char_len_arg = new_list.pop(0)
+            encode_block = (
+                f"[(s if isinstance(s,(bytes,bytearray)) else str(s).encode('ascii'))"
+                f" for s in {safe}]"
+            )
+            if arg.is_optional:
+                arg.py_reassignment = (
+                    f"    if {safe} is not None:\n"
+                    f"        {safe}_glcStrs_ = {encode_block}\n"
+                    f"        {safe}_glcLen_ = max((len(b) for b in {safe}_glcStrs_), default=1) or 1\n"
+                    f"        {safe} = np.ascontiguousarray("
+                    f"np.array({safe}_glcStrs_, dtype=f'S{{{safe}_glcLen_}}'))\n"
+                )
+                count_arg.py_pass_as    = f'{safe}.size if {safe} is not None else 0'
+                char_len_arg.py_pass_as = f'{safe}.itemsize if {safe} is not None else 0'
+                arg.py_pass_as = (
+                    f'{safe}.ctypes.data_as(POINTER(c_char)) if {safe} is not None else None'
+                )
+            else:
+                arg.py_reassignment = (
+                    f"    {safe}_glcStrs_ = {encode_block}\n"
+                    f"    {safe}_glcLen_ = max((len(b) for b in {safe}_glcStrs_), default=1) or 1\n"
+                    f"    {safe} = np.ascontiguousarray("
+                    f"np.array({safe}_glcStrs_, dtype=f'S{{{safe}_glcLen_}}'))\n"
+                )
+                count_arg.py_pass_as    = f'c_size_t({safe}.size)'
+                char_len_arg.py_pass_as = f'c_size_t({safe}.itemsize)'
+                arg.py_pass_as = (
+                    f'{safe}.ctypes.data_as(POINTER(c_char))'
+                )
+            new_list.insert(0, char_len_arg)
+            new_list.insert(0, count_arg)
+        elif arg.is_array and arg.polymorphic_list_array:
+            # `type(<class>List), dimension(:)`: ship parallel ctypes
+            # arrays of object pointers + class IDs, one per element,
+            # built from the `_glcObj` / `_classID` fields the Python
+            # wrapper attaches to every constructor-built functionClass
+            # instance.  The bind(c) signature receives the pointer
+            # buffer as `type(c_ptr), dimension(*)` (see
+            # assign_c_attributes; ctypes side is `POINTER(c_void_p)`)
+            # and the IDs companion as `integer(c_int), dimension(*)`.
+            # Optional-arg handling matches the other array branches.
+            safe         = python_safe_name(arg.name)
+            count_arg    = new_list.pop(0)
+            ids_arg      = new_list.pop(0)
+            if arg.is_optional:
+                arg.py_reassignment = (
+                    f'    if {safe} is not None:\n'
+                    f'        {safe}_glcN_    = len({safe})\n'
+                    f'        {safe}_glcPtrs_ = (c_void_p * {safe}_glcN_)('
+                    f'*[x._glcObj for x in {safe}])\n'
+                    f'        {safe}_glcIDs_  = (c_int    * {safe}_glcN_)('
+                    f'*[x._classID for x in {safe}])\n'
+                )
+                count_arg.py_pass_as = f'{safe}_glcN_ if {safe} is not None else 0'
+                ids_arg.py_pass_as   = f'{safe}_glcIDs_ if {safe} is not None else None'
+                arg.py_pass_as       = f'{safe}_glcPtrs_ if {safe} is not None else None'
+            else:
+                arg.py_reassignment = (
+                    f'    {safe}_glcN_    = len({safe})\n'
+                    f'    {safe}_glcPtrs_ = (c_void_p * {safe}_glcN_)('
+                    f'*[x._glcObj for x in {safe}])\n'
+                    f'    {safe}_glcIDs_  = (c_int    * {safe}_glcN_)('
+                    f'*[x._classID for x in {safe}])\n'
+                )
+                count_arg.py_pass_as = f'c_size_t({safe}_glcN_)'
+                ids_arg.py_pass_as   = f'{safe}_glcIDs_'
+                arg.py_pass_as       = f'{safe}_glcPtrs_'
+            new_list.insert(0, ids_arg)
+            new_list.insert(0, count_arg)
         elif arg.is_array and arg.intrinsic == 'character':
             # Fixed-length character array: build a contiguous count*N
             # byte buffer.  Each input element is `str()`-coerced,
@@ -618,6 +789,111 @@ def build_fortran_reassignments(argument_list, func_class, implementation,
                 )
             arg.fort_reassignment = reassign
             arg.fort_pass_as = f'{name}_F_'
+        elif arg.is_array and arg.varying_string_array:
+            # `type(varying_string), dimension(:)`.  bind(c) declares the
+            # buffer as a flat `character(c_char), dimension(*)` block of
+            # `name_count * name_charLen` bytes; the inner Galacticus
+            # method wants `type(varying_string), dimension(:)`.  Walk
+            # the buffer element-by-element, copy each N-byte slice into
+            # a `character(len=:)` scratch local, then assign to the
+            # varying_string element (with `trim()` to drop the
+            # right-padding spaces the Python wrapper inserted to match
+            # numpy's fixed-stride `S{N}` dtype).
+            arg.fort_declarations = (
+                f'  type(varying_string), dimension(:), allocatable'
+                f' :: {name}_F_\n'
+                f'  character(len=:), allocatable :: {name}_buf_\n'
+                f'  integer(c_size_t) :: {name}_glcI_, {name}_glcJ_\n'
+            )
+            reassign = (
+                f'allocate({name}_F_({name}_count))\n'
+                f'allocate(character(len=int({name}_charLen)) :: {name}_buf_)\n'
+                f'do {name}_glcI_ = 1, {name}_count\n'
+                f'  do {name}_glcJ_ = 1, {name}_charLen\n'
+                f'    {name}_buf_({name}_glcJ_:{name}_glcJ_)'
+                f' = {name}(({name}_glcI_-1)*{name}_charLen + {name}_glcJ_)\n'
+                f'  end do\n'
+                f'  {name}_F_({name}_glcI_) = trim({name}_buf_)\n'
+                f'end do\n'
+            )
+            if is_optional:
+                reassign = (
+                    f'if (present({name})) then\n'
+                    f'   {reassign.replace(chr(10), chr(10) + "   ").rstrip()}\n'
+                    f'end if\n'
+                )
+            arg.fort_reassignment = reassign
+            arg.fort_pass_as      = f'{name}_F_'
+            # ISO_Varying_String supplies both the type and the
+            # `assignment(=)` overload from char to varying_string.
+            arg.fort_modules.setdefault('ISO_Varying_String', {})['varying_string'] = 1
+            arg.fort_modules.setdefault('ISO_Varying_String', {})['assignment(=)']  = 1
+        elif arg.is_array and arg.polymorphic_list_array:
+            # `type(<class>List), dimension(:)`.  bind(c) gets a flat
+            # `type(c_ptr), dimension(*)` buffer plus a parallel
+            # `integer(c_int), dimension(*)` IDs buffer plus a count.
+            # Build a `type(<class>List), dimension(:), allocatable`
+            # local of the right size, then for each element use the
+            # registered class's `<class>GetPtr(ptr,id)` helper to
+            # recover the polymorphic pointer (same dispatch the scalar
+            # `class(<class>Class)` arg path uses) and stash it on the
+            # element's `<class>_` component.
+            stem      = arg.polymorphic_list_class
+            list_type = arg.polymorphic_list_type
+            comp      = arg.polymorphic_list_component
+            arg.fort_declarations = (
+                f'  type({list_type}), dimension(:), allocatable'
+                f' :: {name}_F_\n'
+                f'  integer(c_size_t) :: {name}_glcI_\n'
+            )
+            reassign = (
+                f'allocate({name}_F_({name}_count))\n'
+                f'do {name}_glcI_ = 1, {name}_count\n'
+                f'  {name}_F_({name}_glcI_)%{comp} =>'
+                f' {stem}GetPtr({name}({name}_glcI_), {name}_IDs({name}_glcI_))\n'
+                f'end do\n'
+            )
+            if is_optional:
+                reassign = (
+                    f'if (present({name})) then\n'
+                    f'   {reassign.replace(chr(10), chr(10) + "   ").rstrip()}\n'
+                    f'end if\n'
+                )
+            arg.fort_reassignment   = reassign
+            arg.fort_pass_as        = f'{name}_F_'
+            # Re-use the scalar class-arg path's interface-block emission
+            # (see fortran_declarations in Emitters.py) — the same
+            # `<class>GetPtr` is what we're calling element-by-element.
+            arg.fort_function_class = stem
+            # The list type's home module is needed for the `use ::`
+            # line that imports `<class>List` into the bind(c) wrapper.
+            # Either an explicit override in _SHARED_TYPE_MODULES or a
+            # walk of moduleUses is required; the override is checked
+            # first (same scheme the scalar derived-type branch uses).
+            list_mod = _SHARED_TYPE_MODULES.get(list_type)
+            if not list_mod:
+                for use_block in func_class.get('moduleUses', []):
+                    for mod_name, mod_data in use_block.items():
+                        if (isinstance(mod_data, dict)
+                                and list_type in mod_data.get('only', {})):
+                            list_mod = mod_name
+                            break
+                    if list_mod:
+                        break
+            if implementation and not list_mod:
+                cls = implementation['name']
+                while cls and not list_mod:
+                    for use_block in module_uses_impls.get(cls, []):
+                        for mod_name, mod_data in use_block.items():
+                            if (isinstance(mod_data, dict)
+                                    and list_type in mod_data.get('only', {})):
+                                list_mod = mod_name
+                                break
+                        if list_mod:
+                            break
+                    cls = extensions.get(cls)
+            if list_mod:
+                arg.fort_modules.setdefault(list_mod, {})[list_type] = 1
         elif arg.is_array and arg.intrinsic == 'character':
             # Fixed-length character array.  bind(c) declares it as a
             # flat `character(c_char), dimension(*)` byte buffer (length

--- a/python/LibraryInterfaces/Pipeline.py
+++ b/python/LibraryInterfaces/Pipeline.py
@@ -894,6 +894,22 @@ def build_fortran_reassignments(argument_list, func_class, implementation,
                     cls = extensions.get(cls)
             if list_mod:
                 arg.fort_modules.setdefault(list_mod, {})[list_type] = 1
+            # The bind(c) wrapper also needs `<class>Class` visible in
+            # the host scope so the GetPtr interface block (emitted by
+            # `fortran_declarations` from `fort_function_class`) can
+            # `import` it — without this, gfortran reports "Cannot
+            # IMPORT '<class>class' from host scoping unit ... does not
+            # exist" because the host only sees the List type.  The
+            # Class lives in the registered functionClass's home module
+            # (looked up via `lib_function_classes`), which for the
+            # current set of polymorphic-list-array users happens to be
+            # the same module as the List type, but we don't rely on
+            # that — Galacticus has classes whose List wrapper lives in
+            # a separate module.
+            class_type = stem + 'Class'
+            class_mod  = lib_function_classes.get(stem, {}).get('module')
+            if class_mod:
+                arg.fort_modules.setdefault(class_mod, {})[class_type] = 1
         elif arg.is_array and arg.intrinsic == 'character':
             # Fixed-length character array.  bind(c) declares it as a
             # flat `character(c_char), dimension(*)` byte buffer (length

--- a/python/LibraryInterfaces/Pipeline.py
+++ b/python/LibraryInterfaces/Pipeline.py
@@ -253,18 +253,25 @@ def assign_c_types(argument_list, lib_function_classes):
                 arg.fort_type = 'integer(c_int)'
             elif (type_spec_val.endswith('List')
                   and type_spec_val[:-4] in lib_function_classes
-                  and 'dimension(:)' in arg.attributes):
+                  and 'dimension(:)' in arg.attributes
+                  and type_spec_val in _SHARED_TYPE_MODULES):
                 # `type(<class>List), dimension(:)` — Galacticus's idiom
-                # for "array of class(<class>Class)".  Each element wraps
-                # a `class(<class>Class), pointer` whose component name is
-                # `<class>_` (universal convention; see e.g.
-                # modelParameterList in models.parameters.F90 or
-                # stellarPopulationSpectraPostprocessorList in
-                # stellar_populations.spectra.postprocess.F90).  We ship
-                # parallel buffers of object pointers + class IDs and
-                # rebuild the list inside the bind(c) wrapper using the
-                # registered class's GetPtr helper — same machinery as
-                # the scalar `class(FooClass)` arg path.
+                # for "array of class(<class>Class)".  We only handle
+                # this shape when the List wrapper itself is registered
+                # in `_SHARED_TYPE_MODULES`: that's our promise that
+                # (a) the type is exported from a known module so the
+                # bind(c) host can `use ::` it, and (b) the wrapper has
+                # the canonical thin-pointer layout (one component
+                # named `<class>_`).  Locally-defined `<class>List`
+                # structs that happen to follow the naming convention
+                # but carry extra members — e.g.
+                # `virialDensityContrastList` in
+                # tasks.halo_mass_function.F90, which adds a `label`
+                # field — would otherwise silently drop those extra
+                # members when the wrapper rebuilds the list.  Falling
+                # through to the generic derived-type branch lets
+                # `_unsupported_arg` reject the surrounding constructor,
+                # which is the correct outcome.
                 stem                          = type_spec_val[:-4]
                 arg.ctype                     = 'c_void_p'
                 arg.fort_type                 = 'type(c_ptr)'

--- a/python/LibraryInterfaces/Pipeline.py
+++ b/python/LibraryInterfaces/Pipeline.py
@@ -544,11 +544,21 @@ def build_python_reassignments(argument_list):
                 f"[(s if isinstance(s,(bytes,bytearray)) else str(s).encode('ascii'))"
                 f" for s in {safe}]"
             )
+            # Each element is `ljust`-padded with **spaces** to the
+            # max-length width before being handed to numpy.  numpy's
+            # `S{N}` dtype otherwise NUL-pads short bytes-strings,
+            # which Fortran `trim()` (the unpacking code uses) doesn't
+            # strip — producing varying_string elements with embedded
+            # NUL bytes that fail equality against cleanly-encoded
+            # `varying_string` scalars.  Pre-padding with spaces means
+            # every buffer entry is exactly `_glcLen_` bytes wide AND
+            # correctly trim-able on the Fortran side.
             if arg.is_optional:
                 arg.py_reassignment = (
                     f"    if {safe} is not None:\n"
                     f"        {safe}_glcStrs_ = {encode_block}\n"
                     f"        {safe}_glcLen_ = max((len(b) for b in {safe}_glcStrs_), default=1) or 1\n"
+                    f"        {safe}_glcStrs_ = [b.ljust({safe}_glcLen_, b' ') for b in {safe}_glcStrs_]\n"
                     f"        {safe} = np.ascontiguousarray("
                     f"np.array({safe}_glcStrs_, dtype=f'S{{{safe}_glcLen_}}'))\n"
                 )
@@ -561,6 +571,7 @@ def build_python_reassignments(argument_list):
                 arg.py_reassignment = (
                     f"    {safe}_glcStrs_ = {encode_block}\n"
                     f"    {safe}_glcLen_ = max((len(b) for b in {safe}_glcStrs_), default=1) or 1\n"
+                    f"    {safe}_glcStrs_ = [b.ljust({safe}_glcLen_, b' ') for b in {safe}_glcStrs_]\n"
                     f"    {safe} = np.ascontiguousarray("
                     f"np.array({safe}_glcStrs_, dtype=f'S{{{safe}_glcLen_}}'))\n"
                 )

--- a/python/LibraryInterfaces/tests/test_pipeline.py
+++ b/python/LibraryInterfaces/tests/test_pipeline.py
@@ -725,3 +725,175 @@ def test_fortran_reassignments_char_array_repacks_into_local():
     assert 'elements_F_(elements_glcI_)(elements_glcJ_:elements_glcJ_)' in reassign
     assert 'elements((elements_glcI_-1)*2 + elements_glcJ_)' in reassign
     assert out[0].fort_pass_as == 'elements_F_'
+
+
+# ---------------------------------------------------------------------------
+# 1D varying_string arrays — `type(varying_string), dimension(:)`
+# ---------------------------------------------------------------------------
+
+def test_assign_c_types_vstring_array_inserts_count_and_charlen_companions():
+    """`type(varying_string), dimension(:)` ships as a flat byte buffer
+    plus two c_size_t companions: count (number of elements) and
+    charLen (per-element ASCII byte length, runtime-decided)."""
+    raw = [{'name': 'names', 'intrinsic': 'type', 'type': 'varying_string',
+            'attributes': ['intent(in)', 'dimension(:)']}]
+    out = assign_c_types(raw, lib_function_classes={})
+    assert [a.name for a in out] == ['names', 'names_count', 'names_charLen']
+    assert out[0].is_array             is True
+    assert out[0].varying_string_array is True
+    assert out[0].ctype                == 'c_char'
+    assert out[0].fort_type            == 'character(c_char)'
+    assert out[1].ctype                == 'c_size_t'
+    assert out[2].ctype                == 'c_size_t'
+
+
+def test_python_reassignments_vstring_array_picks_runtime_max_length():
+    """The Python wrapper ASCII-encodes each input element, picks the
+    max length at runtime, and lays the result out as a contiguous
+    `S{N}` numpy buffer.  The count companion reads `.size`, the
+    char-length companion reads `.itemsize` so Fortran sees the
+    runtime-chosen N."""
+    arr = ArgSpec(name='names', intrinsic='type', type_spec='varying_string',
+                  ctype='c_char', is_array=True, varying_string_array=True)
+    cnt = ArgSpec(name='names_count', intrinsic='integer',
+                  type_spec='c_size_t', ctype='c_size_t',
+                  fort_is_present=True, py_is_present=False,
+                  galacticus_is_present=False)
+    cl  = ArgSpec(name='names_charLen', intrinsic='integer',
+                  type_spec='c_size_t', ctype='c_size_t',
+                  fort_is_present=True, py_is_present=False,
+                  galacticus_is_present=False)
+    out = build_python_reassignments([arr, cnt, cl])
+    assert "names_glcStrs_" in out[0].py_reassignment
+    assert "names_glcLen_"  in out[0].py_reassignment
+    assert "dtype=f'S{names_glcLen_}'" in out[0].py_reassignment
+    assert out[0].py_pass_as == "names.ctypes.data_as(POINTER(c_char))"
+    assert out[1].py_pass_as == 'c_size_t(names.size)'
+    assert out[2].py_pass_as == 'c_size_t(names.itemsize)'
+
+
+def test_fortran_reassignments_vstring_array_repacks_into_varying_string_local():
+    """The wrapper allocates a `type(varying_string), dimension(:)`
+    local, builds a per-element scratch character buffer of the
+    runtime-decided length, copies bytes in, then trims and assigns to
+    each varying_string element.  ISO_Varying_String must supply both
+    the type and the assignment(=) overload."""
+    arr = ArgSpec(name='names', intrinsic='type', type_spec='varying_string',
+                  ctype='c_char', fort_type='character(c_char)',
+                  is_array=True, varying_string_array=True)
+    out = build_fortran_reassignments(
+        [arr], func_class={}, implementation=None,
+        extensions={}, module_uses_impls={},
+    )
+    decls    = out[0].fort_declarations
+    reassign = out[0].fort_reassignment
+    assert 'type(varying_string), dimension(:), allocatable :: names_F_' in decls
+    assert 'character(len=:), allocatable :: names_buf_'                  in decls
+    assert 'allocate(names_F_(names_count))'                              in reassign
+    assert 'allocate(character(len=int(names_charLen)) :: names_buf_)'    in reassign
+    assert 'names_F_(names_glcI_) = trim(names_buf_)'                     in reassign
+    assert out[0].fort_pass_as                                            == 'names_F_'
+    assert 'varying_string'  in out[0].fort_modules.get('ISO_Varying_String', {})
+    assert 'assignment(=)'   in out[0].fort_modules.get('ISO_Varying_String', {})
+
+
+# ---------------------------------------------------------------------------
+# 1D polymorphic-list arrays — `type(<class>List), dimension(:)`
+# ---------------------------------------------------------------------------
+
+def test_assign_c_types_list_array_inserts_count_and_id_companions():
+    """`type(modelParameterList), dimension(:)` (the Galacticus idiom for
+    "array of class(modelParameterClass)") expands into a c_void_p
+    pointer buffer + a count companion + a parallel c_int IDs buffer."""
+    raw = [{'name': 'parms', 'intrinsic': 'type',
+            'type': 'modelParameterList',
+            'attributes': ['intent(in)', 'dimension(:)']}]
+    out = assign_c_types(
+        raw, lib_function_classes={'modelParameter': {'module': 'Model_Parameters'}})
+    assert [a.name for a in out] == ['parms', 'parms_count', 'parms_IDs']
+    assert out[0].is_array                   is True
+    assert out[0].polymorphic_list_array     is True
+    assert out[0].polymorphic_list_class     == 'modelParameter'
+    assert out[0].polymorphic_list_type      == 'modelParameterList'
+    assert out[0].polymorphic_list_component == 'modelParameter_'
+    assert out[0].ctype                      == 'c_void_p'
+    assert out[0].fort_type                  == 'type(c_ptr)'
+    assert out[1].ctype                      == 'c_size_t'   # count
+    assert out[2].ctype                      == 'c_int'      # IDs (array)
+    # IDs companion is a deferred-shape array so the bind(c) emitter
+    # rewrites it to dimension(*) (see assign_c_attributes).
+    assert 'dimension(:)' in out[2].attributes
+
+
+def test_assign_c_types_list_array_unregistered_stem_falls_back_to_void_p():
+    """`type(fooList), dimension(:)` where `foo` is not a registered
+    functionClass takes the generic-derived-type path (ctype=c_void_p)
+    rather than the polymorphic-list-array path — _unsupported_arg
+    will reject the surrounding constructor in libraryInterfaces.py."""
+    raw = [{'name': 'xs', 'intrinsic': 'type', 'type': 'fooList',
+            'attributes': ['intent(in)', 'dimension(:)']}]
+    out = assign_c_types(raw, lib_function_classes={})
+    assert out[0].polymorphic_list_array is False
+
+
+def test_python_reassignments_list_array_builds_ptr_and_id_buffers():
+    """The Python wrapper builds parallel ctypes arrays of object
+    pointers + class IDs, one per element, off the `_glcObj` /
+    `_classID` fields the wrapper attaches to every functionClass
+    instance."""
+    arr = ArgSpec(name='parms', intrinsic='type',
+                  type_spec='modelParameterList',
+                  ctype='c_void_p', is_array=True,
+                  polymorphic_list_array=True,
+                  polymorphic_list_class='modelParameter',
+                  polymorphic_list_type='modelParameterList',
+                  polymorphic_list_component='modelParameter_')
+    cnt = ArgSpec(name='parms_count', intrinsic='integer',
+                  type_spec='c_size_t', ctype='c_size_t',
+                  fort_is_present=True, py_is_present=False,
+                  galacticus_is_present=False)
+    ids = ArgSpec(name='parms_IDs', intrinsic='integer',
+                  ctype='c_int', fort_is_present=True,
+                  py_is_present=False, galacticus_is_present=False,
+                  attributes=['intent(in)', 'dimension(:)'])
+    out = build_python_reassignments([arr, cnt, ids])
+    reassign = out[0].py_reassignment
+    assert 'parms_glcN_'    in reassign
+    assert '_glcObj'        in reassign
+    assert '_classID'       in reassign
+    assert '(c_void_p * parms_glcN_)' in reassign
+    assert '(c_int    * parms_glcN_)' in reassign
+    assert out[0].py_pass_as == 'parms_glcPtrs_'
+    assert out[1].py_pass_as == 'c_size_t(parms_glcN_)'
+    assert out[2].py_pass_as == 'parms_glcIDs_'
+
+
+def test_fortran_reassignments_list_array_loops_via_get_ptr():
+    """The Fortran wrapper allocates a `type(<class>List), dimension(:)`
+    local of the right size, then loops over each element and uses the
+    registered class's `<class>GetPtr` helper to recover the polymorphic
+    pointer that the wrapper struct's `<class>_` component should hold.
+    The `_SHARED_TYPE_MODULES` table supplies the wrapper struct's home
+    module for the `use ::` line."""
+    arr = ArgSpec(name='parms', intrinsic='type',
+                  type_spec='modelParameterList',
+                  ctype='c_void_p', fort_type='type(c_ptr)',
+                  is_array=True, polymorphic_list_array=True,
+                  polymorphic_list_class='modelParameter',
+                  polymorphic_list_type='modelParameterList',
+                  polymorphic_list_component='modelParameter_')
+    out = build_fortran_reassignments(
+        [arr], func_class={}, implementation=None,
+        extensions={}, module_uses_impls={},
+    )
+    decls    = out[0].fort_declarations
+    reassign = out[0].fort_reassignment
+    assert 'type(modelParameterList), dimension(:), allocatable :: parms_F_' in decls
+    assert 'integer(c_size_t) :: parms_glcI_'                                in decls
+    assert 'allocate(parms_F_(parms_count))'                                 in reassign
+    assert ('parms_F_(parms_glcI_)%modelParameter_ =>'
+            ' modelParameterGetPtr(parms(parms_glcI_), parms_IDs(parms_glcI_))') in reassign
+    assert out[0].fort_pass_as        == 'parms_F_'
+    assert out[0].fort_function_class == 'modelParameter'
+    # `_SHARED_TYPE_MODULES` supplies modelParameterList's home module.
+    assert 'modelParameterList' in out[0].fort_modules.get('Model_Parameters', {})

--- a/python/LibraryInterfaces/tests/test_pipeline.py
+++ b/python/LibraryInterfaces/tests/test_pipeline.py
@@ -767,6 +767,12 @@ def test_python_reassignments_vstring_array_picks_runtime_max_length():
     assert "names_glcStrs_" in out[0].py_reassignment
     assert "names_glcLen_"  in out[0].py_reassignment
     assert "dtype=f'S{names_glcLen_}'" in out[0].py_reassignment
+    # Each element is space-padded to max-length BEFORE being handed
+    # to numpy: numpy's `S{N}` dtype NUL-pads short bytes-strings,
+    # and Fortran `trim()` doesn't strip NULs, so an element shorter
+    # than the max would otherwise carry embedded NULs into its
+    # varying_string and fail equality with cleanly-encoded scalars.
+    assert "ljust(names_glcLen_, b' ')" in out[0].py_reassignment
     assert out[0].py_pass_as == "names.ctypes.data_as(POINTER(c_char))"
     assert out[1].py_pass_as == 'c_size_t(names.size)'
     assert out[2].py_pass_as == 'c_size_t(names.itemsize)'

--- a/python/LibraryInterfaces/tests/test_pipeline.py
+++ b/python/LibraryInterfaces/tests/test_pipeline.py
@@ -885,6 +885,7 @@ def test_fortran_reassignments_list_array_loops_via_get_ptr():
     out = build_fortran_reassignments(
         [arr], func_class={}, implementation=None,
         extensions={}, module_uses_impls={},
+        lib_function_classes={'modelParameter': {'module': 'Model_Parameters'}},
     )
     decls    = out[0].fort_declarations
     reassign = out[0].fort_reassignment
@@ -896,4 +897,10 @@ def test_fortran_reassignments_list_array_loops_via_get_ptr():
     assert out[0].fort_pass_as        == 'parms_F_'
     assert out[0].fort_function_class == 'modelParameter'
     # `_SHARED_TYPE_MODULES` supplies modelParameterList's home module.
-    assert 'modelParameterList' in out[0].fort_modules.get('Model_Parameters', {})
+    # The Class type ALSO has to be imported into the bind(c) host
+    # scope — otherwise the GetPtr interface block emitted by
+    # `fortran_declarations` (from `fort_function_class`) hits
+    # "Cannot IMPORT 'modelparameterclass' from host scoping unit"
+    # because the host only `use`s the List type, not the Class.
+    assert 'modelParameterList'  in out[0].fort_modules.get('Model_Parameters', {})
+    assert 'modelParameterClass' in out[0].fort_modules.get('Model_Parameters', {})

--- a/python/LibraryInterfaces/tests/test_pipeline.py
+++ b/python/LibraryInterfaces/tests/test_pipeline.py
@@ -836,6 +836,26 @@ def test_assign_c_types_list_array_unregistered_stem_falls_back_to_void_p():
     assert out[0].polymorphic_list_array is False
 
 
+def test_assign_c_types_list_array_unregistered_wrapper_falls_back_to_void_p():
+    """`type(<class>List), dimension(:)` where `<class>` IS a registered
+    functionClass but the wrapper type isn't in `_SHARED_TYPE_MODULES`
+    must NOT take the polymorphic-list-array path — locally-defined
+    wrappers can carry extra members (e.g.
+    `virialDensityContrastList` in tasks.halo_mass_function.F90 has a
+    `label` field alongside the polymorphic pointer) which our
+    rebuild loop would silently drop.  Falling through to the
+    generic-derived-type path means `_unsupported_arg` rejects the
+    surrounding constructor cleanly."""
+    raw = [{'name': 'xs', 'intrinsic': 'type',
+            'type': 'virialDensityContrastList',
+            'attributes': ['intent(in)', 'dimension(:)']}]
+    out = assign_c_types(
+        raw, lib_function_classes={'virialDensityContrast': {'module': 'X'}})
+    assert out[0].polymorphic_list_array is False
+    # Single-element output: no companion args were inserted.
+    assert len(out) == 1
+
+
 def test_python_reassignments_list_array_builds_ptr_and_id_buffers():
     """The Python wrapper builds parallel ctypes arrays of object
     pointers + class IDs, one per element, off the `_glcObj` /

--- a/scripts/build/libraryInterfaces.py
+++ b/scripts/build/libraryInterfaces.py
@@ -335,7 +335,33 @@ def _unsupported_arg(arg, lib_function_classes, *,
                 and attr == 'dimension(:)'
                 and _CHAR_LEN_RX_INTERFACES.match((arg.get('type') or '').strip())
             )
-            if is_supported_dim or is_supported_char_array:
+            # `type(varying_string), dimension(:)`: shipped via a flat
+            # contiguous byte buffer plus count + per-element-length
+            # companions; the wrapper builds a `type(varying_string),
+            # dimension(:)` for the inner call (Pipeline.py's
+            # build_python_reassignments / build_fortran_reassignments).
+            is_supported_vstring_array = (
+                intrinsic == 'type'
+                and (arg.get('type') or '').strip() == 'varying_string'
+                and attr == 'dimension(:)'
+            )
+            # `type(<class>List), dimension(:)`: Galacticus's idiom for
+            # an array of polymorphic pointers — each element is a
+            # wrapper struct whose `<class>_` component holds a
+            # `class(<class>Class), pointer`.  We support these when
+            # `<class>` is a registered functionClass; the wrapper ships
+            # parallel arrays of c_ptr + classID and rebuilds the list
+            # via `<class>GetPtr` element-by-element (same machinery as
+            # the scalar `class(...)` arg path).
+            type_spec = (arg.get('type') or '').strip()
+            is_supported_list_array = (
+                intrinsic == 'type'
+                and attr == 'dimension(:)'
+                and type_spec.endswith('List')
+                and type_spec[:-4] in lib_function_classes
+            )
+            if (is_supported_dim or is_supported_char_array
+                    or is_supported_vstring_array or is_supported_list_array):
                 if 'allocatable' in attrs:
                     return ('1D allocatable array argument'
                             ' (output arrays not yet supported)')

--- a/scripts/build/libraryInterfaces.py
+++ b/scripts/build/libraryInterfaces.py
@@ -354,11 +354,18 @@ def _unsupported_arg(arg, lib_function_classes, *,
             # via `<class>GetPtr` element-by-element (same machinery as
             # the scalar `class(...)` arg path).
             type_spec = (arg.get('type') or '').strip()
+            # The shape is only recognised when the wrapper type is
+            # registered in `_SHARED_TYPE_MODULES` (Pipeline.py's
+            # gatekeeper); see the corresponding branch in
+            # `assign_c_types` for the rationale.  Other locally-defined
+            # `<class>List` structs that happen to share the naming
+            # convention fall through to the generic-rejection path.
             is_supported_list_array = (
                 intrinsic == 'type'
                 and attr == 'dimension(:)'
                 and type_spec.endswith('List')
                 and type_spec[:-4] in lib_function_classes
+                and type_spec in _SHARED_TYPE_MODULES
             )
             if (is_supported_dim or is_supported_char_array
                     or is_supported_vstring_array or is_supported_list_array):

--- a/scripts/build/libraryInterfacesAudit.py
+++ b/scripts/build/libraryInterfacesAudit.py
@@ -51,6 +51,7 @@ sys.path.insert(0, str(REPO_ROOT / 'python'))
 import xml.etree.ElementTree as ET                     # noqa: E402
 
 from Galacticus.Build import SourceTree                # noqa: E402
+from LibraryInterfaces.Pipeline import _SHARED_TYPE_MODULES  # noqa: E402
 
 
 # Match a fixed-size dimension(N) attribute (N a positive integer literal).
@@ -279,11 +280,19 @@ def classify_constructor(args, all_fcs, registered):
             # dependency rather than a hard pipeline blocker, so the
             # closure pass can still pull the class in once the dep
             # is added).
+            # Match the gating in Pipeline.py / libraryInterfaces.py:
+            # the wrapper type itself must be registered in
+            # `_SHARED_TYPE_MODULES`, otherwise it's a locally-defined
+            # struct (likely with extra members beyond the polymorphic
+            # pointer — see `virialDensityContrastList` in
+            # tasks.halo_mass_function.F90) and falls through to the
+            # generic unsupported-arg rejection path.
             is_list_array = (
                 intrinsic == 'type'
                 and dim_attr == 'dimension(:)'
                 and type_spec.endswith('List')
                 and type_spec[:-4] in all_fcs
+                and type_spec in _SHARED_TYPE_MODULES
             )
             if is_list_array:
                 stem = type_spec[:-4]

--- a/scripts/build/libraryInterfacesAudit.py
+++ b/scripts/build/libraryInterfacesAudit.py
@@ -270,6 +270,26 @@ def classify_constructor(args, all_fcs, registered):
             # deferred-shape numeric arrays, are now supported alongside
             # the 1D numeric cases — see the analogous extensions in
             # libraryInterfaces._unsupported_arg.
+            # `type(<class>List), dimension(:)` — supported when the
+            # stripped-`List` stem is a registered functionClass; the
+            # generator ships parallel c_ptr + classID buffers and
+            # rebuilds the wrapper-list via `<class>GetPtr`.  The check
+            # against `registered` matches the scalar class-arg case
+            # below (an unregistered stem gets reported as a missing
+            # dependency rather than a hard pipeline blocker, so the
+            # closure pass can still pull the class in once the dep
+            # is added).
+            is_list_array = (
+                intrinsic == 'type'
+                and dim_attr == 'dimension(:)'
+                and type_spec.endswith('List')
+                and type_spec[:-4] in all_fcs
+            )
+            if is_list_array:
+                stem = type_spec[:-4]
+                if stem not in registered:
+                    missing_deps.add(stem)
+                continue
             is_supported_shape = (
                 (intrinsic in ('double precision', 'integer')
                  and (dim_attr == 'dimension(:)'
@@ -279,6 +299,10 @@ def classify_constructor(args, all_fcs, registered):
                 (intrinsic == 'character'
                  and dim_attr == 'dimension(:)'
                  and _CHAR_LEN_RX.match(type_spec))
+                or
+                (intrinsic == 'type'
+                 and type_spec == 'varying_string'
+                 and dim_attr == 'dimension(:)')
             )
             if not is_supported_shape:
                 pipeline_reasons.append(

--- a/scripts/build/libraryInterfacesAudit.py
+++ b/scripts/build/libraryInterfacesAudit.py
@@ -340,10 +340,17 @@ def aggregate_class(impls, all_fcs, registered):
     empty missing_deps.  MISSING-DEP if no impl is ready but at least one
     impl has empty pipeline_reasons (just unmet deps).  Otherwise
     PIPELINE-BLOCKED.
+
+    The full per-impl classifications are also returned under
+    ``classified`` so the report can surface impl-level drops even when
+    the class as a whole evaluates as ready.  Each entry is a tuple
+    ``(impl_dict, deps_set, reasons_list)`` for one concrete impl;
+    ``deps`` and ``reasons`` are both empty iff the impl is itself ready.
     """
     concrete = [i for i in impls if not i['is_abstract']]
     if not concrete:
-        return {'status': 'no-concrete-impls', 'impls': impls}
+        return {'status': 'no-concrete-impls', 'impls': impls,
+                'classified': []}
 
     classified = []
     for impl in concrete:
@@ -358,8 +365,9 @@ def aggregate_class(impls, all_fcs, registered):
 
     ready = [(i, d, r) for (i, d, r) in classified if not r and not d]
     if ready:
-        return {'status'   : 'ready',
-                'impls'    : impls,
+        return {'status'    : 'ready',
+                'impls'     : impls,
+                'classified': classified,
                 'ready_impl': ready[0][0]['name']}
 
     missing_dep = [(i, d, r) for (i, d, r) in classified if not r and d]
@@ -371,6 +379,7 @@ def aggregate_class(impls, all_fcs, registered):
         rep = min(missing_dep, key=lambda x: (len(x[1]), x[0]['name']))
         return {'status'    : 'missing-dep',
                 'impls'     : impls,
+                'classified': classified,
                 'deps'      : union,
                 'min_deps'  : rep[1],
                 'rep_impl'  : rep[0]['name']}
@@ -380,9 +389,10 @@ def aggregate_class(impls, all_fcs, registered):
     for impl, _, r in classified:
         for s in r:
             reasons.append((impl['name'], s))
-    return {'status' : 'pipeline-blocked',
-            'impls'  : impls,
-            'reasons': reasons}
+    return {'status'    : 'pipeline-blocked',
+            'impls'     : impls,
+            'classified': classified,
+            'reasons'   : reasons}
 
 
 # ---------------------------------------------------------------------------
@@ -456,6 +466,23 @@ def main():
     for fc, info in audit.items():
         by_status[info['status']].append(fc)
 
+    # Impl-level totals — a class can be READY at the class level (some
+    # impl is ready) while still having other impls that the generator
+    # drops; the impl-level numbers make those drops visible alongside
+    # the class-level totals.  `dropped` counts impls (in registered
+    # classes only — drops in unregistered classes don't affect the
+    # built library).
+    impl_total_concrete   = 0
+    impl_ready            = 0
+    impl_dropped_in_built = 0
+    for fc, info in audit.items():
+        for impl, deps, reasons in info.get('classified', []):
+            impl_total_concrete += 1
+            if not deps and not reasons:
+                impl_ready += 1
+            elif fc in registered:
+                impl_dropped_in_built += 1
+
     print(fmt_section("Summary"))
     print(f"  Total functionClasses:    {len(all_fcs)}")
     print(f"  Currently registered:     {len(registered)} "
@@ -467,6 +494,12 @@ def main():
               f"({100*n//len(all_fcs):3d}%)")
     print(f"  (registered classes are also counted in their bucket above —")
     print(f"  they all evaluate as 'ready' so they don't dominate the lists.)")
+    print()
+    print(f"  Total concrete impls:     {impl_total_concrete}")
+    print(f"  Impl-level ready:         {impl_ready} "
+          f"({100*impl_ready//impl_total_concrete}%)")
+    print(f"  Dropped from BUILT lib:   {impl_dropped_in_built} "
+          f"(impls in registered classes the generator skips)")
 
     # READY (excluding already-registered).
     ready_unregistered = sorted(c for c in by_status['ready']
@@ -529,6 +562,43 @@ def main():
         for fc in blocked:
             reason_set = sorted(set(r for _, r in audit[fc]['reasons']))
             print(f"    {fc}".ljust(50) + f"{reason_set[0]}")
+
+    # DROPPED IMPLS — impls of *registered* classes that the generator
+    # nevertheless skips (because their constructor takes a type the
+    # pipeline can't translate, or has unmet missing deps even though
+    # some sibling impl is ready).  These are the impls that show up
+    # as `caution: implementation '<name>' of class '<cls>' has
+    # constructor argument …` warnings during a `make` build, and are
+    # invisible to the class-level READY/MISSING-DEP/PIPELINE-BLOCKED
+    # buckets above — the class itself still surfaces in Python via
+    # its other impls, but the dropped ones simply aren't reachable.
+    dropped = []
+    for fc in sorted(registered):
+        info = audit.get(fc, {})
+        for impl, deps, reasons in info.get('classified', []):
+            if reasons or deps:
+                # Pick the most informative line — pipeline reasons
+                # dominate; otherwise list missing deps.
+                if reasons:
+                    summary = reasons[0]
+                else:
+                    summary = "missing dep(s): " + ', '.join(sorted(deps))
+                dropped.append((fc, impl['name'], summary))
+    print(fmt_section(
+        f"DROPPED IMPLS ({len(dropped)}) — registered classes whose"
+        f" non-ready impls are skipped"))
+    if dropped:
+        # Width chosen so the longest current `<class> :: <impl>` label
+        # fits without truncation; reasons line up in the second column.
+        label_width = max(
+            (len(f"  {fc} :: {impl_name}") for fc, impl_name, _ in dropped),
+            default=0,
+        )
+        for fc, impl_name, summary in dropped:
+            label = f"  {fc} :: {impl_name}"
+            print(f"{label.ljust(label_width)}  {summary}")
+    else:
+        print("  (none — every concrete impl of every registered class is built)")
 
     # NO-CONCRETE-IMPLS — generally these are abstract base classes that
     # only matter as deps; surface them but don't dwell.

--- a/scripts/build/libraryInterfacesDependencies.py
+++ b/scripts/build/libraryInterfacesDependencies.py
@@ -62,8 +62,23 @@ for name in units:
     )
 
 # Rule for libgalacticus_classes.d (concatenates every per-unit .d).
+# The aggregator is also forced to re-run whenever
+# `Makefile_Library_Dependencies` itself is regenerated — because the
+# prereq list of `libgalacticus_classes.d` changes when an impl is
+# removed (e.g. a constructor arg starts failing the predicate and
+# libraryInterfaces.py drops the impl), Make's mtime check otherwise
+# misses the deletion and `libgalacticus_classes.d` keeps its stale
+# concatenation containing the now-unbuildable `<class>__<impl>.o`.
+# That stale entry then survives into the link command, where Make
+# tries to resolve the missing target and errors out with "No rule to
+# make target ...".  Adding `Makefile_Library_Dependencies` as a prereq
+# means a fresh deps file (which it always is whenever this script
+# runs) cascades into a fresh aggregation.
 dep_d_files = ' '.join(f"{build_path}libgalacticus/{n}.d" for n in units)
-rules.append(f"{build_path}libgalacticus_classes.d: {dep_d_files}\n")
+rules.append(
+    f"{build_path}libgalacticus_classes.d: {dep_d_files}"
+    f" {build_path}Makefile_Library_Dependencies\n"
+)
 rules.append(f"\t@rm -f {build_path}libgalacticus_classes.d~\n")
 for name in units:
     rules.append(f"\t@cat {build_path}libgalacticus/{name}.d >> {build_path}libgalacticus_classes.d~\n")

--- a/source/libraryClasses.xml
+++ b/source/libraryClasses.xml
@@ -214,5 +214,7 @@
     <radiativeTransferMatter/>
     <computationalDomain/>
     <distributionFunctionMultivariate/>
+    <posteriorSampleSimulation/>
+    <stellarPopulationSpectraPostprocessorBuilder/>
   </classes>
 </library>

--- a/source/models.likelihoods.SED_fit.F90
+++ b/source/models.likelihoods.SED_fit.F90
@@ -32,7 +32,7 @@
    <description>Used to specify the type of dust model to use in SED fitting likelihoods.</description>
    <encodeFunction>yes</encodeFunction>
    <validator>yes</validator>
-   <visibility>private</visibility>
+   <visibility>public</visibility>
    <entry label="null"           />
    <entry label="charlotFall2000"/>
    <entry label="cardelli1989"   />
@@ -48,7 +48,7 @@
    <description>Used to specify the type of start time to use in SED fitting likelihoods.</description>
    <encodeFunction>yes</encodeFunction>
    <validator>yes</validator>
-   <visibility>private</visibility>
+   <visibility>public</visibility>
    <entry label="time"/>
    <entry label="age" />
   </enumeration>

--- a/testSuite/test-Python-interface.py
+++ b/testSuite/test-Python-interface.py
@@ -401,6 +401,39 @@ with safe_section("outputAnalysisTargetDataStandard"):
     check_eq("outputAnalysisScatterFunction1D exposes targetData_",
              'targetData_' in sig.parameters, True)
 
+# Stellar population spectra postprocessor builder (lookup impl) —
+# exercises BOTH new array-arg paths in a single constructor:
+#   * `type(varying_string), dimension(:) :: names` — Python list of
+#     str is encoded to ASCII at runtime, padded to the longest
+#     element, and shipped as a contiguous S{N} byte buffer plus
+#     count + per-element-length companions; the Fortran wrapper
+#     repacks into `type(varying_string), dimension(:)`.
+#   * `type(stellarPopulationSpectraPostprocessorList), dimension(:)
+#     :: postprocessors` — Galacticus's idiom for an array of
+#     polymorphic pointers; the Python wrapper builds parallel
+#     `(c_void_p * n)` and `(c_int * n)` ctypes arrays from each
+#     instance's `_glcObj` / `_classID`, and the Fortran wrapper
+#     rebuilds the wrapper-list via `stellarPopulationSpectra`
+#     `PostprocessorGetPtr` element-by-element.
+# `build(descriptor=...)` then exercises the class(...) return path on
+# top of all that, so the round-trip lands back in the right Python
+# subclass via _from_classID.
+with safe_section("stellarPopulationSpectraPostprocessorBuilderLookup"):
+    ppIdentity = galacticus.stellarPopulationSpectraPostprocessorIdentity ()
+    ppInoue    = galacticus.stellarPopulationSpectraPostprocessorInoue2014()
+    builder    = galacticus.stellarPopulationSpectraPostprocessorBuilderLookup(
+        names          = ['default', 'igm'         ],
+        postprocessors = [ppIdentity, ppInoue      ],
+    )
+    ppDefault = builder.build(descriptor='default')
+    ppIGM     = builder.build(descriptor='igm'    )
+    check_eq("build('default') resolves to identity subclass",
+             type(ppDefault).__name__,
+             'stellarPopulationSpectraPostprocessorIdentity')
+    check_eq("build('igm') resolves to Inoue2014 subclass",
+             type(ppIGM    ).__name__,
+             'stellarPopulationSpectraPostprocessorInoue2014')
+
 # Final summary and exit code.
 print(f"--- {_failures} failure(s) ---")
 sys.exit(1 if _failures else 0)


### PR DESCRIPTION
## Summary

This PR extends the Python/Fortran interface generator to support two new array argument patterns:

1. **`type(varying_string), dimension(:)`** — Arrays of variable-length strings. The Python wrapper encodes each element to ASCII at runtime, determines the maximum length, pads all elements to that width, and ships a contiguous byte buffer plus count and per-element-length companions. The Fortran wrapper repacks into proper `type(varying_string), dimension(:)`.

2. **`type(<class>List), dimension(:)`** — Galacticus's idiom for arrays of polymorphic pointers (since Fortran disallows direct arrays of polymorphic types). The Python wrapper builds parallel ctypes arrays of object pointers and class IDs; the Fortran wrapper rebuilds the wrapper-list element-by-element using the registered class's `GetPtr` helper.

Both patterns follow the established companion-argument pattern used for numeric and fixed-length character arrays, ensuring consistent handling across the interface layer.

## Type of change

- [x] New feature
- [x] Docs / tooling

## Changes

### Core Pipeline Changes (`Pipeline.py`)

- Added `_make_id_array_companion()` to generate the parallel class-ID buffer for polymorphic-list arrays
- Extended `assign_c_types()` to recognize and handle both new array patterns:
  - `varying_string_array` marker for variable-length string arrays
  - `polymorphic_list_array` marker with metadata (`polymorphic_list_class`, `polymorphic_list_type`, `polymorphic_list_component`)
- Extended `build_python_reassignments()` to generate encoding/padding logic for varying_string arrays and pointer/ID extraction for polymorphic-list arrays
- Extended `build_fortran_reassignments()` to generate unpacking logic that reconstructs the proper Fortran types from the C interface

### Type Definitions (`ArgSpec.py`)

- Added `varying_string_array` boolean marker
- Added `polymorphic_list_array`, `polymorphic_list_class`, `polymorphic_list_type`, and `polymorphic_list_component` fields to track polymorphic-list metadata

### Interface Validation (`libraryInterfaces.py`)

- Updated `_unsupported_arg()` to recognize both new array patterns as supported, gating polymorphic-list arrays on:
  - The stem class being registered in `lib_function_classes`
  - The wrapper type being registered in `_SHARED_TYPE_MODULES` (to prevent silently dropping extra members in locally-defined wrapper structs)

### Audit & Build System

- Updated `libraryInterfacesAudit.py` to track impl-level readiness alongside class-level status, surfacing implementations that are dropped from the built library
- Updated `libraryInterfacesDependencies.py` to force re-aggregation of dependency files when implementations are removed
- Updated `Makefile` to include the dependency file as a prerequisite for proper rebuild tracking

### Tests & Integration

- Added comprehensive unit tests covering:
  - Companion insertion for both array types
  - Python reassignment generation (encoding, padding, pointer extraction)
  - Fortran reassignment generation (unpacking, reconstruction)
  - Edge cases (unregistered stems, unregistered wrapper types)
- Added integration test exercising both new array patterns in a real constructor (`stellarPopulationSpectraPostprocessorBuilderLookup`)
- Updated `libraryClasses.xml` to register new classes using these patterns

## How to test

- Run `testSuite/test-Python-interface.py` to verify the new `stellarPopulationSpectraPostprocessorBuilderLookup` constructor works end-to-end with both array types
- Run `python/LibraryInterfaces/tests/test_pipeline.py` to verify the code generation logic for both patterns
- Existing test suite passes without regression

## Checklist

- [x] I ran relevant tests (unit tests in `test_pipeline.py` and integration test in `test-Python-interface.py`)
- [x] I updated documentation/comments (extensive docstrings in Pipeline.py explaining the new patterns and their C/

https://claude.ai/code/session_01K8v7zwsHAEPc63Ta2fcT9Q