### PR TITLE
Remove obsoleted `createFunction` code

### DIFF
--- a/python/Galacticus/Build/Components/Classes/CreateDestroy.py
+++ b/python/Galacticus/Build/Components/Classes/CreateDestroy.py
@@ -134,22 +134,6 @@ def Class_Create_By_Interrupt(build, class_dict):
 
     content = f"{name} => self%{name}(autoCreate=.true.)\n"
 
-    # Iterate through members carrying explicit createFunction overrides.
-    members_with_create = [
-        m for m in (class_dict.get('members') or [])
-        if 'createFunction' in m
-    ]
-    if members_with_create:
-        content += f"select type ({name})\n"
-        for member in members_with_create:
-            create_function = _resolve_create_function(name, member)
-            impl_type = type_name + _ucfirst(member['name'])
-            content += (
-                f"type is ({impl_type})\n"
-                f"   call {create_function}({name},timeEnd)\n"
-            )
-        content += "end select\n"
-
     function = {
         'type':        'void',
         'name':        name + 'CreateByInterrupt',
@@ -179,23 +163,6 @@ def Class_Create_By_Interrupt(build, class_dict):
         'content':     content,
     }
     build.setdefault('functions', []).append(function)
-
-
-def _resolve_create_function(class_name, member):
-    """Return the Fortran symbol to call from a `createIfNeeded`
-    interrupt branch for `member`.  Mirrors the conditional at
-    Classes/CreateDestroy.pm:201-213.
-    """
-    cf = member['createFunction']
-    if isinstance(cf, dict):
-        if cf.get('isDeferred'):
-            return (
-                class_name
-                + _ucfirst(member['name'])
-                + 'CreateFunction'
-            )
-        return cf.get('content', cf)
-    return cf
 
 
 def Class_Add_Meta_Property(build, class_dict):

--- a/python/Galacticus/Build/Components/Implementations/CreateDestroy.py
+++ b/python/Galacticus/Build/Components/Implementations/CreateDestroy.py
@@ -1,5 +1,4 @@
-# Per-implementation lifecycle methods: initialize / destroy / builder /
-# createFunctionSet.
+# Per-implementation lifecycle methods: initialize / destroy / builder.
 # Andrew Benson (ported to Python 2026)
 #
 # Mirrors perl/Galacticus/Build/Components/Implementations/CreateDestroy.pm.
@@ -487,52 +486,6 @@ def Implementation_Builder(build, class_dict, member):
     _bind(build, impl_type, function, 'builder')
 
 
-def Implementation_Deferred_Create_Set(build, class_dict, member):
-    """Generate `<class><Member>CreateFunctionSet` when the member's
-    `createFunction` is deferred.  Mirrors `Implementation_Deferred_Create_Set`.
-    """
-    if not (member.get('createFunction') or {}).get('isDeferred'):
-        return
-
-    name       = class_dict['name']
-    cap_class  = _ucfirst(name)
-    cap_member = _ucfirst(member['name'])
-
-    function = {
-        'type':        'void',
-        'name':        f"{name}{cap_member}CreateFunctionSet",
-        'description': (
-            f"Set the create function for the \\mono{{{member['name']}}} "
-            f"implementation of the \\mono{{{name}}} component class."
-        ),
-        'variables':   [
-            {
-                'intrinsic': 'external',
-                'variables': ['createFunction'],
-            },
-        ],
-        'content': f"{name}{cap_member}CreateFunction => createFunction\n",
-    }
-
-    impl_type = 'nodeComponent' + cap_class + cap_member
-    build.setdefault('types', {}).setdefault(impl_type, {}) \
-                                  .setdefault('boundFunctions', []) \
-                                  .append({
-        'type':       'procedure',
-        'descriptor': function,
-        'name':       'createFunctionSet',
-        'pass':       'nopass',
-    })
-
-    # Module-scope function pointer that the setter assigns.
-    build.setdefault('variables', []).append({
-        'intrinsic':  'procedure',
-        'type':       '',
-        'attributes': ['pointer'],
-        'variables':  [f"{name}{cap_member}CreateFunction"],
-    })
-
-
 def _bind(build, type_name, function, method_name):
     build.setdefault('types', {}).setdefault(type_name, {}) \
                                   .setdefault('boundFunctions', []) \
@@ -557,5 +510,3 @@ register('implementationsCreateDestroy', 'implementationIteratedFunctions',
          Implementation_Builder)
 register('implementationsCreateDestroy', 'implementationIteratedFunctions',
          Implementation_Finalization)
-register('implementationsCreateDestroy', 'implementationIteratedFunctions',
-         Implementation_Deferred_Create_Set)

--- a/python/Galacticus/Build/Components/Implementations/__init__.py
+++ b/python/Galacticus/Build/Components/Implementations/__init__.py
@@ -53,9 +53,6 @@ _IMPLEMENTATION_DEFAULTS = {
             },
         },
     },
-    'createFunction': {
-        'isDeferred': 'booleanFalse',
-    },
     'output':         {
         'instances': 'all',
     },

--- a/schema/componentSchema.xsd
+++ b/schema/componentSchema.xsd
@@ -44,11 +44,6 @@
 	    </xs:all>
 	  </xs:complexType>
 	</xs:element>
-	<xs:element name="createFunction"                minOccurs="0" >
-	  <xs:complexType>
-	    <xs:attribute name="isDeferred" type="xs:boolean" use="required" />
-	  </xs:complexType>
-	</xs:element>
 	<xs:element name="properties"                  minOccurs="0" >
 	  <xs:complexType>
 	    <xs:sequence>

--- a/source/objects.nodes.components.hot_halo.standard.F90
+++ b/source/objects.nodes.components.hot_halo.standard.F90
@@ -53,7 +53,6 @@ module Node_Component_Hot_Halo_Standard
    <class>hotHalo</class>
    <name>standard</name>
    <isDefault>true</isDefault>
-   <createFunction isDeferred="true" />
    <properties>
     <property>
       <name>isInitialized</name>
@@ -325,8 +324,6 @@ contains
        call hotHalo%           outflowingMassRateFunction(Node_Component_Hot_Halo_Standard_Outflowing_Mass_Rate      )
        call hotHalo%outflowingAngularMomentumRateFunction(Node_Component_Hot_Halo_Standard_Outflowing_Ang_Mom_Rate   )
        call hotHalo%     outflowingAbundancesRateFunction(Node_Component_Hot_Halo_Standard_Outflowing_Abundances_Rate)
-       ! Bind a creation function.
-       call hotHalo%                    createFunctionSet(Node_Component_Hot_Halo_Standard_Initializor               )
        ! Bind the mass distribution function.
        Node_Component_Hot_Halo_Standard_Mass_Distribution_ => Node_Component_Hot_Halo_Standard_Mass_Distribution
        call hotHalo%             massDistributionFunction(Node_Component_Hot_Halo_Standard_Mass_Distribution_        )

--- a/source/objects.nodes.components.nuclear_star_cluster.standard.F90
+++ b/source/objects.nodes.components.nuclear_star_cluster.standard.F90
@@ -46,7 +46,6 @@ module Node_Component_NSC_Standard
    <class>NSC</class>
    <name>standard</name>
    <isDefault>false</isDefault>
-   <createFunction isDeferred="true" />
    <properties>
     <property>
       <name>isInitialized</name>

--- a/source/objects.nodes.components.satellite.orbiting.F90
+++ b/source/objects.nodes.components.satellite.orbiting.F90
@@ -43,7 +43,6 @@ module Node_Component_Satellite_Orbiting
    <class>satellite</class>
    <name>orbiting</name>
    <isDefault>false</isDefault>
-   <createFunction isDeferred="true" />
    <properties>
     <property>
       <name>position</name>
@@ -150,8 +149,6 @@ contains
        ! Specify the function to use for setting virial orbits.
        call satellite%virialOrbitSetFunction(Node_Component_Satellite_Orbiting_Virial_Orbit_Set)
        call satellite%virialOrbitFunction   (Node_Component_Satellite_Orbiting_Virial_Orbit    )
-       ! Bind a creation function.
-       call satellite%createFunctionSet     (Node_Component_Satellite_Orbiting_Initializor     )
     end if
     return
   end subroutine Node_Component_Satellite_Orbiting_Initialize
@@ -299,20 +296,6 @@ contains
     end select
     return
   end subroutine Node_Component_Satellite_Orbiting_Scale_Set
-
-  subroutine Node_Component_Satellite_Orbiting_Initializor(self,timeEnd)
-    !!{
-    Initializes an orbiting satellite component.
-    !!}
-    use :: Galacticus_Nodes, only : nodeComponentSatelliteOrbiting
-    implicit none
-    type            (nodeComponentSatelliteOrbiting), intent(inout)           :: self
-    double precision                                , intent(in   ), optional :: timeEnd
-    !$GLC attributes unused :: timeEnd
-
-    call Node_Component_Satellite_Orbiting_Create(self%hostNode)
-    return
-  end subroutine Node_Component_Satellite_Orbiting_Initializor
 
   !![
   <nodeMergerTask function="Node_Component_Satellite_Orbiting_Create"/>

--- a/source/objects.nodes.components.spheroid.standard.F90
+++ b/source/objects.nodes.components.spheroid.standard.F90
@@ -45,7 +45,6 @@ module Node_Component_Spheroid_Standard
    <class>spheroid</class>
    <name>standard</name>
    <isDefault>true</isDefault>
-   <createFunction isDeferred="true" />
    <properties>
     <property>
       <name>isInitialized</name>
@@ -215,7 +214,6 @@ contains
        call spheroidStandardComponent%             massGasSinkRateFunction(Node_Component_Spheroid_Standard_Mass_Gas_Sink_Rate         )
        call spheroidStandardComponent%    starFormationHistoryRateFunction(Node_Component_Spheroid_Standard_Star_Formation_History_Rate)
        call spheroidStandardComponent%stellarPropertiesHistoryRateFunction(Node_Component_Spheroid_Standard_Stellar_Prprts_History_Rate)
-       call spheroidStandardComponent%                   createFunctionSet(Node_Component_Spheroid_Standard_Initializor                )
 
        ! Find our parameters.
        subParameters=parameters%subParameters('componentSpheroid')


### PR DESCRIPTION
## Summary
- The components infrastructure used to support a `<create function is deferred="yes"/>` option which allowed a custom function to be defined for creation of a component. This has long been deprecated, but some of the code to generate calls to such functions remained (even though the functions were never actually called), asking with some instances where components set such a function. This PR removes these instances and generator code.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [x] Other:

## How to test
- Build and run test models as usual.

## Checklist
- [x] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
