### PR TITLE
Optimize binary search by caching array ordering check

### DIFF
--- a/source/numerical.search.F90
+++ b/source/numerical.search.F90
@@ -104,11 +104,13 @@ contains
     {Type¦intrinsic}                        , intent(in   ) :: valueToFind
     integer         (c_size_t)                              :: jLower                 , jMidpoint, &
          &                                                     jUpper
-    logical                                                 :: isInside
+    logical                                                 :: isInside               , isAscending
 
+    ! Determine array ordering once; this is invariant for the call.
+    isAscending=arrayToSearch(size(arrayToSearch,kind=c_size_t)) >= arrayToSearch(1)
     ! Check whether valueToFind is outside range of arrayToSearch().
     isInside=.true.
-    if (arrayToSearch(size(arrayToSearch,kind=c_size_t)) >= arrayToSearch(1)) then ! arrayToSearch() is in ascending order.
+    if (isAscending) then ! arrayToSearch() is in ascending order.
        if      (valueToFind < arrayToSearch(1                                )) then
           isInside=.false.
           searchArray{Type¦label}=                                 0_c_size_t
@@ -131,7 +133,7 @@ contains
        jUpper=size(arrayToSearch,kind=c_size_t)+1
        do while (jUpper-jLower > 1)
           jMidpoint=(jUpper+jLower)/2
-          if ((arrayToSearch(size(arrayToSearch,kind=c_size_t)) >= arrayToSearch(1)) .eqv. (valueToFind >= arrayToSearch(jMidpoint))) then
+          if (isAscending .eqv. (valueToFind >= arrayToSearch(jMidpoint))) then
              jLower=jMidpoint
           else
              jUpper=jMidpoint


### PR DESCRIPTION
## Summary
- Cache the array ordering determination in the `searchArray` function to avoid redundant comparisons during the binary search loop
- Replace two identical ordering checks with a single boolean variable lookup

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## Details
The `searchArray` function was performing the same array ordering check `(arrayToSearch(size(arrayToSearch,kind=c_size_t)) >= arrayToSearch(1))` twice:
1. Once at the beginning to validate the input range
2. Once per iteration in the binary search loop

Since array ordering is invariant throughout the function call, this change computes it once and stores the result in the `isAscending` logical variable. This eliminates redundant array access operations in the hot path of the binary search loop, improving performance for large arrays.

## How to test
- Existing unit tests for `searchArray` should pass without modification
- Performance can be verified by profiling searches on large arrays

## Checklist
- [x] I ran relevant tests (or explain why not): Existing test suite covers this function
- [x] I updated documentation/comments if needed: Added clarifying comment about invariant
- [ ] If this PR is from a fork: I enabled "Allow edits from maintainers"

https://claude.ai/code/session_01QCojqGJchUJMiYAuvN8imr