### PR TITLE
Fix Python path resolution on macOS CI runner

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1787,6 +1787,9 @@ jobs:
           echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "PYTHONPATH=$GITHUB_WORKSPACE/galacticus/python" >> $GITHUB_ENV
           echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
+          # Prepend /opt/local/bin so the MacPorts-installed `python3` (with numpy) is
+          # picked up ahead of the runner's pre-installed Python, which lacks numpy.
+          echo "PATH=/opt/local/bin:$PATH" >> $GITHUB_ENV
       - name: Install Python
         run: |
           sudo port install python312 py312-numpy


### PR DESCRIPTION
## Summary
- Prepend `/opt/local/bin` to the `PATH` environment variable on macOS CI to ensure the MacPorts-installed Python 3.12 with numpy is used instead of the runner's pre-installed Python, which lacks numpy.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- The macOS CI workflow will use the correct Python installation with numpy available, allowing downstream Python-dependent jobs to execute successfully.

## Checklist
- [x] I ran relevant tests (or explain why not): CI workflow will validate the fix
- [x] I updated documentation/comments if needed: Added inline comment explaining the PATH modification
- [ ] If this PR is from a fork: I enabled "Allow edits from maintainers"

https://claude.ai/code/session_01FT4DamJngy4wchxKdg7zCj