### PR TITLE
Adds validation of the `power` dataset

### DIFF
--- a/source/structure_formation.power_spectrum.primordial.transferred.file.F90
+++ b/source/structure_formation.power_spectrum.primordial.transferred.file.F90
@@ -108,17 +108,17 @@
           }
           DATASET "redshift" {
              DATATYPE  H5T_IEEE_F64LE
-             DATASPACE  SIMPLE { ( 1000 ) / ( 1000 ) }
+             DATASPACE  SIMPLE { ( 10 ) / ( 10 ) }
           }
           DATASET "power" {
              DATATYPE  H5T_IEEE_F64LE
-             DATASPACE  SIMPLE { ( 1000 ) / ( 1000 ), ( 1000 ) / ( 1000 ) }
+             DATASPACE  SIMPLE { ( 10 ) / ( 10 ), ( 1000 ) / ( 1000 ) }
           }
        }
        }
        \end{verbatim}
-      The `power` dataset should tabulate the transferred power spectrum as a function of $(k,z)$ where $k$ is wavenumber and $z$
-      is redshift.
+      The `power` dataset should tabulate the transferred power spectrum as a function of $(z,k)$ where $z$
+      is redshift and $k$ is wavenumber.
     </description>
     <runTimeFileDependencies paths="fileName"/>
   </powerSpectrumPrimordialTransferred>
@@ -250,7 +250,7 @@ contains
     type            (enumerationExtrapolationTypeType      )                              :: extrapolateWavenumber  , extrapolateRedshift
     integer                                                                               :: versionNumber          , i
     type            (hdf5Object                            )                              :: fileObject             , parametersObject
-    type            (varying_string                        )                              :: limitTypeVar
+    type            (varying_string                        )                              :: limitTypeVar           , message
 
     ! Check that the file exists.
     if (.not.File_Exists(fileName)) call Error_Report("file '"//char(fileName)//"' does not exist"//{introspection:location})
@@ -296,6 +296,12 @@ contains
     ! Close the file.
     call fileObject%close()
     !$ call hdf5Access%unset()
+    ! Validate data.
+    if (any(shape(power) /= [size(wavenumber),size(redshift)])) then
+       message='dimensions of `power` are mismatched with those of `redshift` and `wavenumber` arrays'
+       if (all(shape(power) == [size(redshift),size(wavenumber)])) message=message//' (it appears that the axes of your `power` array may be transposed - they should be [redshift,wavenumber] in the HDF5 dataset)'
+       call Error_Report(message//{introspection:location})
+    end if
     ! Construct the tabulated power spectrum and interpolators. Note that the tabulated power must be in order of increasing time, so sort on redshift and index in reverse.
     order=sortIndex(redshift)
     allocate(self%wavenumberLogarithmic(size(wavenumber)               ))


### PR DESCRIPTION
## Summary
- Checks that the `power` dataset has shape matching that of the combined `redshift` and `wavenumber` datasets, reporting an error if not (and suggesting if transposition of the axes is the likely culprit). Also improves the docstring to make the expected axis ordering more clear.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [x] Other: User input validation

## How to test
- 

## Checklist
- [x] I ran relevant tests (or explain why not):
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
