### PR TITLE
Add interpolation benchmarks and optimize locate() with caching

### DIFF
--- a/aux/words.dict
+++ b/aux/words.dict
@@ -307,6 +307,7 @@ baryonic
 behrens
 benchmarking
 bertschinger
+bilinear
 binomially
 bivar
 bivariate
@@ -331,6 +332,7 @@ cflags
 chabrier
 changeset
 checkpointing
+checksum
 christoph
 chunked
 chunking
@@ -372,6 +374,7 @@ deallocate
 deallocated
 deallocation
 declinations
+decorrelated
 decrement
 dereference
 dereferenced
@@ -385,6 +388,7 @@ destructors
 desynchronization
 desynchronize
 detectability
+deterministically
 dex
 dielectronic
 differencing
@@ -542,6 +546,7 @@ metadata
 metadatum
 metallicities
 metallicity
+microbenchmark
 midplane
 minima
 minimization
@@ -592,11 +597,13 @@ overdensities
 overdensity
 overwritable
 parallelized
+parametrization
 parameterization
 parameterization
 parameterizations
 parameterized
 parentless
+parseable
 particulation
 passwordFrom
 passwordfrom
@@ -764,6 +771,7 @@ timestepper
 timesteppers
 timestepping
 timesteps
+tokenized
 triaxial
 ttfamily
 tuple

--- a/source/benchmarks.numerical.interpolation.F90
+++ b/source/benchmarks.numerical.interpolation.F90
@@ -34,6 +34,8 @@ compiler cannot dead-code-eliminate the interpolation results.
 program Benchmark_Numerical_Interpolation
   use, intrinsic :: ISO_Fortran_Env        , only : output_unit
   use, intrinsic :: ISO_C_Binding          , only : c_size_t
+  use            :: Benchmark_Utilities    , only : Benchmark_Report   , Benchmark_Seed_RNG    , &
+       &                                            Benchmark_Sink_Add , Benchmark_Sink_Print
   use            :: Display                , only : displayVerbositySet, verbosityLevelStandard
   use            :: Kind_Numbers           , only : kind_int8
   use            :: Numerical_Interpolation, only : interpolator       , interpolator2D        , &
@@ -47,23 +49,10 @@ program Benchmark_Numerical_Interpolation
   integer        , parameter :: queryCount    =4096     ! Size of the precomputed query-point array (power of 2 for cheap masking).
   integer        , parameter :: queryMask     =queryCount-1
 
-  ! Clock rate (ticks per second). All per-call times are converted explicitly to ns.
-  integer        (kind=kind_int8) :: countRate
-
-  ! Accumulated sink (printed at the end so calls cannot be elided).
-  double precision :: sink=0.0d0
-
   call displayVerbositySet(verbosityLevelStandard)
 
-  call System_Clock(count_rate=countRate)
-  if (countRate <= 0_kind_int8) then
-     write (output_unit,'(a)') 'ERROR: System_Clock returned a non-positive tick rate; cannot benchmark.'
-     stop 1
-  end if
-
-  write (output_unit,'(a,i0,a,i0,a)') '# Benchmark configuration: trialCount=',trialCount, &
-       &                              ' innerCount=',innerCount,' (first 2 trials dropped)'
-  write (output_unit,'(a,i0,a)'     ) '# System_Clock rate: ',countRate,' ticks/s (all times reported in ns/call)'
+  write (output_unit,'(a,i0,a,i0,a,i0,a)') '# Benchmark configuration: trialCount=',trialCount, &
+       &                                   ' innerCount=',innerCount,' warmupTrials=',warmupTrials,' (dropped)'
 
   ! 1D linear interpolations across a range of array sizes and access patterns.
   call benchmarkInterpolate1D(           10,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N10_seq"     ,description="1D linear interp, N=10, sequential access"     )
@@ -83,9 +72,9 @@ program Benchmark_Numerical_Interpolation
   ! 2D bilinear.
   call benchmarkInterpolate2D (           50                                     ,id="interp2D_N50x50_rand"        ,description="2D bilinear interp, 50x50, random access"      )
 
-  ! Print the sink. This MUST be observable to the outside world or the optimizer
-  ! is free to elide the entire benchmark.
-  write (output_unit,'(a,es16.8)') '# Checksum (do not optimize away): ',sink
+  ! Make the accumulated checksum externally observable. This MUST happen or the
+  ! optimizer is free to elide the entire benchmark.
+  call Benchmark_Sink_Print()
 
 contains
 
@@ -144,54 +133,6 @@ contains
     return
   end subroutine buildQueries
 
-  subroutine seedRandom()
-    !!{
-    Seed the intrinsic RNG deterministically so the random-access scenarios are
-    reproducible from run to run.
-    !!}
-    integer              :: seedSize
-    integer, allocatable :: seed(:)
-    integer              :: i
-
-    call random_seed(size=seedSize)
-    allocate(seed(seedSize))
-    do i=1,seedSize
-       seed(i)=20260513+i
-    end do
-    call random_seed(put=seed)
-    deallocate(seed)
-    return
-  end subroutine seedRandom
-
-  subroutine reportTiming(id,description,trialTime)
-    !!{
-    Compute and report the per-call mean time (in ns) and its standard error,
-    following the line format used by other Galacticus benchmark programs.
-    !!}
-    character      (len=*       )  , intent(in   )                       :: id, description
-    integer        (kind=kind_int8), intent(in   ), dimension(trialCount) :: trialTime
-    integer                                                              :: kept
-    double precision                                                     :: meanTicks    , varTicks   , stdErrTicks, &
-         &                                                                  ticksToNs    , meanPerCall, stdErrPerCall
-
-    kept         =trialCount-warmupTrials
-    meanTicks    =       dble(sum(trialTime(warmupTrials+1:trialCount)   ))/dble(kept)
-    varTicks     =max(0.0d0,                                                                                          &
-         &            (dble(sum(trialTime(warmupTrials+1:trialCount)**2))/dble(kept)-meanTicks**2)*                    &
-         &            dble(kept)/dble(max(kept-1,1))                                                                   &
-         &           )
-    stdErrTicks  =sqrt(varTicks/dble(kept))
-    ! Convert (ticks per trial) -> (ns per single call). countRate is ticks/s, so 1 tick = 1e9/countRate ns;
-    ! divide by innerCount to get per-call.
-    ticksToNs    =1.0d9/dble(countRate)
-    meanPerCall  =meanTicks  *ticksToNs/dble(innerCount)
-    stdErrPerCall=stdErrTicks*ticksToNs/dble(innerCount)
-    write (output_unit,'(a,1x,a,1x,a,1x,a,1x,f14.3,1x,f14.3,1x,a)') &
-         & 'BENCHMARK','numericalInterpolation',trim(id),'"'//trim(description)//'"', &
-         & meanPerCall,stdErrPerCall,'"ns/call"'
-    return
-  end subroutine reportTiming
-
   subroutine benchmarkInterpolate1D(n,interpType,sequential,id,description)
     integer        , intent(in   )                :: n, interpType
     logical        , intent(in   )                :: sequential
@@ -203,7 +144,7 @@ contains
     integer                                       :: trial, i
     double precision                              :: acc, v
 
-    call seedRandom()
+    call Benchmark_Seed_RNG()
     call buildArray  (n,x,y)
     allocate(queries(0:queryCount-1))
     call buildQueries(queryCount,x(1),x(n),sequential,queries)
@@ -212,7 +153,7 @@ contains
     ! Warm the interpolator (in particular trigger lazy initialization for
     ! linear-only deferred-init paths) and prime the accelerator.
     v=interp_%interpolate(queries(0))
-    sink=sink+v
+    call Benchmark_Sink_Add(v)
 
     do trial=1,trialCount
        acc=0.0d0
@@ -222,10 +163,11 @@ contains
        end do
        call System_Clock(countEnd)
        trialTime(trial)=countEnd-countStart
-       sink           =sink+acc                ! Force the optimizer to keep 'acc'.
+       call Benchmark_Sink_Add(acc)            ! Force the optimizer to keep 'acc'.
     end do
 
-    call reportTiming(id,description,trialTime)
+    call Benchmark_Report('numericalInterpolation',id,description,trialTime, &
+         &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
     deallocate(x,y,queries)
     return
   end subroutine benchmarkInterpolate1D
@@ -242,14 +184,14 @@ contains
     double precision, dimension(0:1)              :: h
     double precision                              :: acc
 
-    call seedRandom()
+    call Benchmark_Seed_RNG()
     call buildArray  (n,x,y)
     allocate(queries(0:queryCount-1))
     call buildQueries(queryCount,x(1),x(n),.false.,queries)
     interp_=interpolator(x,y)
 
     call interp_%linearFactors(queries(0),idx,h)
-    sink=sink+h(0)+h(1)+dble(idx)
+    call Benchmark_Sink_Add(h(0)+h(1)+dble(idx))
 
     do trial=1,trialCount
        acc=0.0d0
@@ -260,10 +202,11 @@ contains
        end do
        call System_Clock(countEnd)
        trialTime(trial)=countEnd-countStart
-       sink           =sink+acc
+       call Benchmark_Sink_Add(acc)
     end do
 
-    call reportTiming(id,description,trialTime)
+    call Benchmark_Report('numericalInterpolation',id,description,trialTime, &
+         &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
     deallocate(x,y,queries)
     return
   end subroutine benchmarkLinearFactors
@@ -278,14 +221,14 @@ contains
     integer                                       :: trial, i
     integer        (c_size_t      )              :: idx, accInt
 
-    call seedRandom()
+    call Benchmark_Seed_RNG()
     call buildArray  (n,x,y)
     allocate(queries(0:queryCount-1))
     call buildQueries(queryCount,x(1),x(n),.false.,queries)
     interp_=interpolator(x,y)
 
     idx=interp_%locate(queries(0))
-    sink=sink+dble(idx)
+    call Benchmark_Sink_Add(dble(idx))
 
     do trial=1,trialCount
        accInt=0_c_size_t
@@ -296,10 +239,11 @@ contains
        end do
        call System_Clock(countEnd)
        trialTime(trial)=countEnd-countStart
-       sink           =sink+dble(accInt)
+       call Benchmark_Sink_Add(dble(accInt))
     end do
 
-    call reportTiming(id,description,trialTime)
+    call Benchmark_Report('numericalInterpolation',id,description,trialTime, &
+         &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
     deallocate(x,y,queries)
     return
   end subroutine benchmarkLocate
@@ -315,7 +259,7 @@ contains
     integer                                       :: trial, i, j
     double precision                              :: acc, v
 
-    call seedRandom()
+    call Benchmark_Seed_RNG()
     ! Build the x and y axes. buildArray writes both an x and a y; we only need its
     ! monotonically increasing first array, so the second is discarded after each call.
     call buildArray(n,x,yIgnored); deallocate(yIgnored)
@@ -332,7 +276,7 @@ contains
     interp_=interpolator2D(x,y,z)
 
     v=interp_%interpolate(qx(0),qy(0))
-    sink=sink+v
+    call Benchmark_Sink_Add(v)
 
     do trial=1,trialCount
        acc=0.0d0
@@ -342,10 +286,11 @@ contains
        end do
        call System_Clock(countEnd)
        trialTime(trial)=countEnd-countStart
-       sink           =sink+acc
+       call Benchmark_Sink_Add(acc)
     end do
 
-    call reportTiming(id,description,trialTime)
+    call Benchmark_Report('numericalInterpolation',id,description,trialTime, &
+         &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
     deallocate(x,y,z,qx,qy)
     return
   end subroutine benchmarkInterpolate2D

--- a/source/benchmarks.numerical.interpolation.F90
+++ b/source/benchmarks.numerical.interpolation.F90
@@ -43,10 +43,10 @@ program Benchmark_Numerical_Interpolation
   implicit none
 
   ! Benchmark control.
-  integer        , parameter :: trialCount    =100      ! Outer trials over which we report mean and standard error.
-  integer        , parameter :: warmupTrials  =  2      ! Trials at the start dropped to absorb cache/branch-predictor warmup.
-  integer        , parameter :: innerCount    =100000   ! Inner loop iterations per trial (amortizes clock resolution).
-  integer        , parameter :: queryCount    =4096     ! Size of the precomputed query-point array (power of 2 for cheap masking).
+  integer        , parameter :: trialCount    =   100       ! Outer trials over which we report mean and standard error.
+  integer        , parameter :: warmupTrials  =     2       ! Trials at the start dropped to absorb cache/branch-predictor warmup.
+  integer        , parameter :: innerCount    =100000       ! Inner loop iterations per trial (amortizes clock resolution).
+  integer        , parameter :: queryCount    =  4096       ! Size of the precomputed query-point array (power of 2 for cheap masking).
   integer        , parameter :: queryMask     =queryCount-1
 
   call displayVerbositySet(verbosityLevelStandard)
@@ -55,22 +55,22 @@ program Benchmark_Numerical_Interpolation
        &                                   ' innerCount=',innerCount,' warmupTrials=',warmupTrials,' (dropped)'
 
   ! 1D linear interpolations across a range of array sizes and access patterns.
-  call benchmarkInterpolate1D(           10,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N10_seq"     ,description="1D linear interp, N=10, sequential access"     )
-  call benchmarkInterpolate1D(           10,gsl_interp_linear ,sequential=.false.,id="interp1D_linear_N10_rand"    ,description="1D linear interp, N=10, random access"         )
-  call benchmarkInterpolate1D(          100,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N100_seq"    ,description="1D linear interp, N=100, sequential access"    )
-  call benchmarkInterpolate1D(          100,gsl_interp_linear ,sequential=.false.,id="interp1D_linear_N100_rand"   ,description="1D linear interp, N=100, random access"        )
-  call benchmarkInterpolate1D(        10000,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N10000_seq"  ,description="1D linear interp, N=10000, sequential access"  )
-  call benchmarkInterpolate1D(        10000,gsl_interp_linear ,sequential=.false.,id="interp1D_linear_N10000_rand" ,description="1D linear interp, N=10000, random access"      )
+  call benchmarkInterpolate1D(   10,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N10_seq"    ,description="1D linear interp, N=10, sequential access"   )
+  call benchmarkInterpolate1D(   10,gsl_interp_linear ,sequential=.false.,id="interp1D_linear_N10_rand"   ,description="1D linear interp, N=10, random access"       )
+  call benchmarkInterpolate1D(  100,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N100_seq"   ,description="1D linear interp, N=100, sequential access"  )
+  call benchmarkInterpolate1D(  100,gsl_interp_linear ,sequential=.false.,id="interp1D_linear_N100_rand"  ,description="1D linear interp, N=100, random access"      )
+  call benchmarkInterpolate1D(10000,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N10000_seq" ,description="1D linear interp, N=10000, sequential access")
+  call benchmarkInterpolate1D(10000,gsl_interp_linear ,sequential=.false.,id="interp1D_linear_N10000_rand",description="1D linear interp, N=10000, random access"    )
 
   ! 1D cspline path (smaller iteration count: spline eval is heavier per call).
-  call benchmarkInterpolate1D(          100,gsl_interp_cspline,sequential=.false.,id="interp1D_cspline_N100_rand"  ,description="1D cspline interp, N=100, random access"       )
+  call benchmarkInterpolate1D(  100,gsl_interp_cspline,sequential=.false.,id="interp1D_cspline_N100_rand" ,description="1D cspline interp, N=100, random access"     )
 
   ! Sub-primitives.
-  call benchmarkLinearFactors (          100                                     ,id="linearFactors_N100_rand"     ,description="1D linearFactors, N=100, random access"        )
-  call benchmarkLocate        (          100                                     ,id="locate_N100_rand"            ,description="1D locate, N=100, random access"               )
+  call benchmarkLinearFactors ( 100                                      ,id="linearFactors_N100_rand"    ,description="1D linearFactors, N=100, random access"      )
+  call benchmarkLocate        ( 100                                      ,id="locate_N100_rand"           ,description="1D locate, N=100, random access"             )
 
   ! 2D bilinear.
-  call benchmarkInterpolate2D (           50                                     ,id="interp2D_N50x50_rand"        ,description="2D bilinear interp, 50x50, random access"      )
+  call benchmarkInterpolate2D (  50                                      ,id="interp2D_N50x50_rand"       ,description="2D bilinear interp, 50x50, random access"    )
 
   ! Make the accumulated checksum externally observable. This MUST happen or the
   ! optimizer is free to elide the entire benchmark.
@@ -85,14 +85,15 @@ contains
     interpolator cannot exploit uniform-grid shortcuts (and so that linear and
     cubic splines have distinguishable behavior).
     !!}
-    integer                                              , intent(in   ) :: n
-    double precision                , allocatable, dimension(:), intent(  out) :: x, y
-    integer                                                                   :: i
-    double precision                                                          :: t
+    integer                                    , intent(in   ) :: n
+    double precision, allocatable, dimension(:), intent(  out) :: x, y
+    integer                                                    :: i
+    double precision                                           :: t
 
     allocate(x(n),y(n))
     do i=1,n
-       t   =dble(i-1)/dble(n-1)
+       t      =+dble(i-1) &
+            &  /dble(n-1)
        ! Non-uniform but strictly increasing parametrization.
        x(i)=t+0.1d0*t*(1.0d0-t)
        y(i)=sin(6.0d0*t)+0.5d0*cos(2.5d0*t)
@@ -108,17 +109,18 @@ contains
     hit its cached index). Otherwise the points are uniformly random, which forces
     the accelerator to fall back to a binary search on every call.
     !!}
-    integer        , intent(in   )                  :: n
-    double precision, intent(in   )                  :: xMin, xMax
-    logical        , intent(in   )                  :: sequential
+    integer         , intent(in   )                   :: n
+    double precision, intent(in   )                   :: xMin      , xMax
+    logical         , intent(in   )                   :: sequential
     double precision, intent(  out), dimension(0:n-1) :: queries
-    integer                                          :: i
+    integer                                           :: i
     double precision                                  :: t
-    double precision, dimension(:), allocatable      :: r
+    double precision, allocatable  , dimension( :   ) :: r
 
     if (sequential) then
        do i=0,n-1
-          t          =dble(i)/dble(n)
+          t      =+dble(i) &
+               &  /dble(n)
           ! Step monotonically through (xMin,xMax), shrunk slightly so we stay strictly in-range.
           queries(i)=xMin+(xMax-xMin)*(0.001d0+0.998d0*t)
        end do
@@ -134,18 +136,19 @@ contains
   end subroutine buildQueries
 
   subroutine benchmarkInterpolate1D(n,interpType,sequential,id,description)
-    integer        , intent(in   )                :: n, interpType
-    logical        , intent(in   )                :: sequential
-    character      (len=*), intent(in   )         :: id, description
-    type            (interpolator   )              :: interp_
-    double precision, allocatable, dimension(:)   :: x, y, queries
-    integer        (kind=kind_int8)              :: countStart, countEnd
-    integer        (kind=kind_int8), dimension(trialCount) :: trialTime
-    integer                                       :: trial, i
-    double precision                              :: acc, v
+    integer                         , intent(in   )                      :: n         , interpType
+    logical                         , intent(in   )                      :: sequential
+    character       (len=*         ), intent(in   )                      :: id        , description
+    type            (interpolator  )                                     :: interp_
+    double precision                , allocatable, dimension(:         ) :: x         , y          , &
+         &                                                                  queries
+    integer         (kind=kind_int8)                                     :: countStart, countEnd
+    integer         (kind=kind_int8)             , dimension(trialCount) :: trialTime
+    integer                                                              :: trial     , i
+    double precision                                                     :: acc       , v
 
     call Benchmark_Seed_RNG()
-    call buildArray  (n,x,y)
+    call buildArray(n,x,y)
     allocate(queries(0:queryCount-1))
     call buildQueries(queryCount,x(1),x(n),sequential,queries)
     interp_=interpolator(x,y,interpolationType=interpType)
@@ -154,7 +157,6 @@ contains
     ! linear-only deferred-init paths) and prime the accelerator.
     v=interp_%interpolate(queries(0))
     call Benchmark_Sink_Add(v)
-
     do trial=1,trialCount
        acc=0.0d0
        call System_Clock(countStart)
@@ -165,7 +167,6 @@ contains
        trialTime(trial)=countEnd-countStart
        call Benchmark_Sink_Add(acc)            ! Force the optimizer to keep 'acc'.
     end do
-
     call Benchmark_Report('numericalInterpolation',id,description,trialTime, &
          &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
     deallocate(x,y,queries)
@@ -173,16 +174,17 @@ contains
   end subroutine benchmarkInterpolate1D
 
   subroutine benchmarkLinearFactors(n,id,description)
-    integer        , intent(in   )                :: n
-    character      (len=*), intent(in   )         :: id, description
-    type            (interpolator   )              :: interp_
-    double precision, allocatable, dimension(:)   :: x, y, queries
-    integer        (kind=kind_int8)              :: countStart, countEnd
-    integer        (kind=kind_int8), dimension(trialCount) :: trialTime
-    integer                                       :: trial, i
-    integer        (c_size_t      )              :: idx
-    double precision, dimension(0:1)              :: h
-    double precision                              :: acc
+    integer                         , intent(in   )                      :: n
+    character       (len=*         ), intent(in   )                      :: id        , description
+    type            (interpolator  )                                     :: interp_
+    double precision                , allocatable, dimension(:         ) :: x         , y          , &
+         &                                                                  queries
+    integer         (kind=kind_int8)                                     :: countStart, countEnd
+    integer         (kind=kind_int8)             , dimension(trialCount) :: trialTime
+    integer                                                              :: trial     , i
+    integer         (c_size_t      )                                     :: idx
+    double precision                             , dimension(0:1       ) :: h
+    double precision                                                     :: acc
 
     call Benchmark_Seed_RNG()
     call buildArray  (n,x,y)
@@ -212,14 +214,15 @@ contains
   end subroutine benchmarkLinearFactors
 
   subroutine benchmarkLocate(n,id,description)
-    integer        , intent(in   )                :: n
-    character      (len=*), intent(in   )         :: id, description
-    type            (interpolator   )              :: interp_
-    double precision, allocatable, dimension(:)   :: x, y, queries
-    integer        (kind=kind_int8)              :: countStart, countEnd
-    integer        (kind=kind_int8), dimension(trialCount) :: trialTime
-    integer                                       :: trial, i
-    integer        (c_size_t      )              :: idx, accInt
+    integer                         , intent(in   )                      :: n
+    character       (len=*         ), intent(in   )                      :: id        , description
+    type            (interpolator  )                                     :: interp_
+    double precision                , allocatable, dimension(:         ) :: x         , y          , &
+         &                                                                  queries
+    integer         (kind=kind_int8)                                     :: countStart, countEnd
+    integer         (kind=kind_int8)             , dimension(trialCount) :: trialTime
+    integer                                                              :: trial     , i
+    integer         (c_size_t      )                                     :: idx       , accInt
 
     call Benchmark_Seed_RNG()
     call buildArray  (n,x,y)
@@ -249,15 +252,18 @@ contains
   end subroutine benchmarkLocate
 
   subroutine benchmarkInterpolate2D(n,id,description)
-    integer        , intent(in   )                :: n
-    character      (len=*), intent(in   )         :: id, description
-    type            (interpolator2D )              :: interp_
-    double precision, allocatable, dimension(:)   :: x, y, yIgnored, qx, qy
-    double precision, allocatable, dimension(:,:) :: z
-    integer        (kind=kind_int8)              :: countStart, countEnd
-    integer        (kind=kind_int8), dimension(trialCount) :: trialTime
-    integer                                       :: trial, i, j
-    double precision                              :: acc, v
+    integer                         , intent(in   )                      :: n
+    character       (len=*         ), intent(in   )                      :: id        , description
+    type            (interpolator2D)                                     :: interp_
+    double precision                , allocatable, dimension(:         ) :: x         , y          , &
+         &                                                                  qx        , qy         , &
+         &                                                                  yIgnored
+    double precision                , allocatable, dimension(:,:       ) :: z
+    integer         (kind=kind_int8)                                     :: countStart, countEnd
+    integer         (kind=kind_int8)             , dimension(trialCount) :: trialTime
+    integer                                                              :: trial     , i          , &
+         &j
+    double precision                                                     :: acc       , v
 
     call Benchmark_Seed_RNG()
     ! Build the x and y axes. buildArray writes both an x and a y; we only need its

--- a/source/benchmarks.numerical.interpolation.F90
+++ b/source/benchmarks.numerical.interpolation.F90
@@ -1,0 +1,353 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a program to benchmark the numerical interpolation primitives provided by the
+\refClass{interpolator} and \refClass{interpolator2D} types.
+
+Each scenario constructs an interpolator, builds a precomputed array of query points
+(so we measure interpolation, not RNG), and runs an inner loop of many calls inside
+each timed trial. We report time-per-call rather than time-per-trial: at typical clock
+resolutions a single \mono{\%interpolate} call is only a handful of ticks, so timing
+one call at a time is dominated by noise.
+
+A running checksum is accumulated across every call and printed at the end so the
+compiler cannot dead-code-eliminate the interpolation results.
+!!}
+
+program Benchmark_Numerical_Interpolation
+  use, intrinsic :: ISO_Fortran_Env        , only : output_unit
+  use, intrinsic :: ISO_C_Binding          , only : c_size_t
+  use            :: Display                , only : displayVerbositySet, verbosityLevelStandard
+  use            :: Kind_Numbers           , only : kind_int8
+  use            :: Numerical_Interpolation, only : interpolator       , interpolator2D        , &
+       &                                            gsl_interp_linear  , gsl_interp_cspline
+  implicit none
+
+  ! Benchmark control.
+  integer        , parameter :: trialCount    =100      ! Outer trials over which we report mean and standard error.
+  integer        , parameter :: warmupTrials  =  2      ! Trials at the start dropped to absorb cache/branch-predictor warmup.
+  integer        , parameter :: innerCount    =100000   ! Inner loop iterations per trial (amortizes clock resolution).
+  integer        , parameter :: queryCount    =4096     ! Size of the precomputed query-point array (power of 2 for cheap masking).
+  integer        , parameter :: queryMask     =queryCount-1
+
+  ! Clock rate (ticks per second). All per-call times are converted explicitly to ns.
+  integer        (kind=kind_int8) :: countRate
+
+  ! Accumulated sink (printed at the end so calls cannot be elided).
+  double precision :: sink=0.0d0
+
+  call displayVerbositySet(verbosityLevelStandard)
+
+  call System_Clock(count_rate=countRate)
+  if (countRate <= 0_kind_int8) then
+     write (output_unit,'(a)') 'ERROR: System_Clock returned a non-positive tick rate; cannot benchmark.'
+     stop 1
+  end if
+
+  write (output_unit,'(a,i0,a,i0,a)') '# Benchmark configuration: trialCount=',trialCount, &
+       &                              ' innerCount=',innerCount,' (first 2 trials dropped)'
+  write (output_unit,'(a,i0,a)'     ) '# System_Clock rate: ',countRate,' ticks/s (all times reported in ns/call)'
+
+  ! 1D linear interpolations across a range of array sizes and access patterns.
+  call benchmarkInterpolate1D(           10,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N10_seq"     ,description="1D linear interp, N=10, sequential access"     )
+  call benchmarkInterpolate1D(           10,gsl_interp_linear ,sequential=.false.,id="interp1D_linear_N10_rand"    ,description="1D linear interp, N=10, random access"         )
+  call benchmarkInterpolate1D(          100,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N100_seq"    ,description="1D linear interp, N=100, sequential access"    )
+  call benchmarkInterpolate1D(          100,gsl_interp_linear ,sequential=.false.,id="interp1D_linear_N100_rand"   ,description="1D linear interp, N=100, random access"        )
+  call benchmarkInterpolate1D(        10000,gsl_interp_linear ,sequential=.true. ,id="interp1D_linear_N10000_seq"  ,description="1D linear interp, N=10000, sequential access"  )
+  call benchmarkInterpolate1D(        10000,gsl_interp_linear ,sequential=.false.,id="interp1D_linear_N10000_rand" ,description="1D linear interp, N=10000, random access"      )
+
+  ! 1D cspline path (smaller iteration count: spline eval is heavier per call).
+  call benchmarkInterpolate1D(          100,gsl_interp_cspline,sequential=.false.,id="interp1D_cspline_N100_rand"  ,description="1D cspline interp, N=100, random access"       )
+
+  ! Sub-primitives.
+  call benchmarkLinearFactors (          100                                     ,id="linearFactors_N100_rand"     ,description="1D linearFactors, N=100, random access"        )
+  call benchmarkLocate        (          100                                     ,id="locate_N100_rand"            ,description="1D locate, N=100, random access"               )
+
+  ! 2D bilinear.
+  call benchmarkInterpolate2D (           50                                     ,id="interp2D_N50x50_rand"        ,description="2D bilinear interp, 50x50, random access"      )
+
+  ! Print the sink. This MUST be observable to the outside world or the optimizer
+  ! is free to elide the entire benchmark.
+  write (output_unit,'(a,es16.8)') '# Checksum (do not optimize away): ',sink
+
+contains
+
+  subroutine buildArray(n,x,y)
+    !!{
+    Build a smooth, monotonically increasing $x$-array and a corresponding $y$-array.
+    The arrays span $x\in[0,1]$ with a deliberate non-uniform spacing so that the
+    interpolator cannot exploit uniform-grid shortcuts (and so that linear and
+    cubic splines have distinguishable behavior).
+    !!}
+    integer                                              , intent(in   ) :: n
+    double precision                , allocatable, dimension(:), intent(  out) :: x, y
+    integer                                                                   :: i
+    double precision                                                          :: t
+
+    allocate(x(n),y(n))
+    do i=1,n
+       t   =dble(i-1)/dble(n-1)
+       ! Non-uniform but strictly increasing parametrization.
+       x(i)=t+0.1d0*t*(1.0d0-t)
+       y(i)=sin(6.0d0*t)+0.5d0*cos(2.5d0*t)
+    end do
+    return
+  end subroutine buildArray
+
+  subroutine buildQueries(n,xMin,xMax,sequential,queries)
+    !!{
+    Build a precomputed array of query points within $[\mathrm{xMin},\mathrm{xMax}]$.
+    If \mono{sequential} is true the points walk monotonically through the range,
+    cycling back to the start (this is the case where the GSL accelerator should
+    hit its cached index). Otherwise the points are uniformly random, which forces
+    the accelerator to fall back to a binary search on every call.
+    !!}
+    integer        , intent(in   )                  :: n
+    double precision, intent(in   )                  :: xMin, xMax
+    logical        , intent(in   )                  :: sequential
+    double precision, intent(  out), dimension(0:n-1) :: queries
+    integer                                          :: i
+    double precision                                  :: t
+    double precision, dimension(:), allocatable      :: r
+
+    if (sequential) then
+       do i=0,n-1
+          t          =dble(i)/dble(n)
+          ! Step monotonically through (xMin,xMax), shrunk slightly so we stay strictly in-range.
+          queries(i)=xMin+(xMax-xMin)*(0.001d0+0.998d0*t)
+       end do
+    else
+       allocate(r(n))
+       call random_number(r)
+       do i=0,n-1
+          queries(i)=xMin+(xMax-xMin)*(0.001d0+0.998d0*r(i+1))
+       end do
+       deallocate(r)
+    end if
+    return
+  end subroutine buildQueries
+
+  subroutine seedRandom()
+    !!{
+    Seed the intrinsic RNG deterministically so the random-access scenarios are
+    reproducible from run to run.
+    !!}
+    integer              :: seedSize
+    integer, allocatable :: seed(:)
+    integer              :: i
+
+    call random_seed(size=seedSize)
+    allocate(seed(seedSize))
+    do i=1,seedSize
+       seed(i)=20260513+i
+    end do
+    call random_seed(put=seed)
+    deallocate(seed)
+    return
+  end subroutine seedRandom
+
+  subroutine reportTiming(id,description,trialTime)
+    !!{
+    Compute and report the per-call mean time (in ns) and its standard error,
+    following the line format used by other Galacticus benchmark programs.
+    !!}
+    character      (len=*       )  , intent(in   )                       :: id, description
+    integer        (kind=kind_int8), intent(in   ), dimension(trialCount) :: trialTime
+    integer                                                              :: kept
+    double precision                                                     :: meanTicks    , varTicks   , stdErrTicks, &
+         &                                                                  ticksToNs    , meanPerCall, stdErrPerCall
+
+    kept         =trialCount-warmupTrials
+    meanTicks    =       dble(sum(trialTime(warmupTrials+1:trialCount)   ))/dble(kept)
+    varTicks     =max(0.0d0,                                                                                          &
+         &            (dble(sum(trialTime(warmupTrials+1:trialCount)**2))/dble(kept)-meanTicks**2)*                    &
+         &            dble(kept)/dble(max(kept-1,1))                                                                   &
+         &           )
+    stdErrTicks  =sqrt(varTicks/dble(kept))
+    ! Convert (ticks per trial) -> (ns per single call). countRate is ticks/s, so 1 tick = 1e9/countRate ns;
+    ! divide by innerCount to get per-call.
+    ticksToNs    =1.0d9/dble(countRate)
+    meanPerCall  =meanTicks  *ticksToNs/dble(innerCount)
+    stdErrPerCall=stdErrTicks*ticksToNs/dble(innerCount)
+    write (output_unit,'(a,1x,a,1x,a,1x,a,1x,f14.3,1x,f14.3,1x,a)') &
+         & 'BENCHMARK','numericalInterpolation',trim(id),'"'//trim(description)//'"', &
+         & meanPerCall,stdErrPerCall,'"ns/call"'
+    return
+  end subroutine reportTiming
+
+  subroutine benchmarkInterpolate1D(n,interpType,sequential,id,description)
+    integer        , intent(in   )                :: n, interpType
+    logical        , intent(in   )                :: sequential
+    character      (len=*), intent(in   )         :: id, description
+    type            (interpolator   )              :: interp_
+    double precision, allocatable, dimension(:)   :: x, y, queries
+    integer        (kind=kind_int8)              :: countStart, countEnd
+    integer        (kind=kind_int8), dimension(trialCount) :: trialTime
+    integer                                       :: trial, i
+    double precision                              :: acc, v
+
+    call seedRandom()
+    call buildArray  (n,x,y)
+    allocate(queries(0:queryCount-1))
+    call buildQueries(queryCount,x(1),x(n),sequential,queries)
+    interp_=interpolator(x,y,interpolationType=interpType)
+
+    ! Warm the interpolator (in particular trigger lazy initialization for
+    ! linear-only deferred-init paths) and prime the accelerator.
+    v=interp_%interpolate(queries(0))
+    sink=sink+v
+
+    do trial=1,trialCount
+       acc=0.0d0
+       call System_Clock(countStart)
+       do i=0,innerCount-1
+          acc=acc+interp_%interpolate(queries(iand(i,queryMask)))
+       end do
+       call System_Clock(countEnd)
+       trialTime(trial)=countEnd-countStart
+       sink           =sink+acc                ! Force the optimizer to keep 'acc'.
+    end do
+
+    call reportTiming(id,description,trialTime)
+    deallocate(x,y,queries)
+    return
+  end subroutine benchmarkInterpolate1D
+
+  subroutine benchmarkLinearFactors(n,id,description)
+    integer        , intent(in   )                :: n
+    character      (len=*), intent(in   )         :: id, description
+    type            (interpolator   )              :: interp_
+    double precision, allocatable, dimension(:)   :: x, y, queries
+    integer        (kind=kind_int8)              :: countStart, countEnd
+    integer        (kind=kind_int8), dimension(trialCount) :: trialTime
+    integer                                       :: trial, i
+    integer        (c_size_t      )              :: idx
+    double precision, dimension(0:1)              :: h
+    double precision                              :: acc
+
+    call seedRandom()
+    call buildArray  (n,x,y)
+    allocate(queries(0:queryCount-1))
+    call buildQueries(queryCount,x(1),x(n),.false.,queries)
+    interp_=interpolator(x,y)
+
+    call interp_%linearFactors(queries(0),idx,h)
+    sink=sink+h(0)+h(1)+dble(idx)
+
+    do trial=1,trialCount
+       acc=0.0d0
+       call System_Clock(countStart)
+       do i=0,innerCount-1
+          call interp_%linearFactors(queries(iand(i,queryMask)),idx,h)
+          acc=acc+h(0)+dble(idx)              ! Use the results so the call cannot be elided.
+       end do
+       call System_Clock(countEnd)
+       trialTime(trial)=countEnd-countStart
+       sink           =sink+acc
+    end do
+
+    call reportTiming(id,description,trialTime)
+    deallocate(x,y,queries)
+    return
+  end subroutine benchmarkLinearFactors
+
+  subroutine benchmarkLocate(n,id,description)
+    integer        , intent(in   )                :: n
+    character      (len=*), intent(in   )         :: id, description
+    type            (interpolator   )              :: interp_
+    double precision, allocatable, dimension(:)   :: x, y, queries
+    integer        (kind=kind_int8)              :: countStart, countEnd
+    integer        (kind=kind_int8), dimension(trialCount) :: trialTime
+    integer                                       :: trial, i
+    integer        (c_size_t      )              :: idx, accInt
+
+    call seedRandom()
+    call buildArray  (n,x,y)
+    allocate(queries(0:queryCount-1))
+    call buildQueries(queryCount,x(1),x(n),.false.,queries)
+    interp_=interpolator(x,y)
+
+    idx=interp_%locate(queries(0))
+    sink=sink+dble(idx)
+
+    do trial=1,trialCount
+       accInt=0_c_size_t
+       call System_Clock(countStart)
+       do i=0,innerCount-1
+          idx   =interp_%locate(queries(iand(i,queryMask)))
+          accInt=accInt+idx
+       end do
+       call System_Clock(countEnd)
+       trialTime(trial)=countEnd-countStart
+       sink           =sink+dble(accInt)
+    end do
+
+    call reportTiming(id,description,trialTime)
+    deallocate(x,y,queries)
+    return
+  end subroutine benchmarkLocate
+
+  subroutine benchmarkInterpolate2D(n,id,description)
+    integer        , intent(in   )                :: n
+    character      (len=*), intent(in   )         :: id, description
+    type            (interpolator2D )              :: interp_
+    double precision, allocatable, dimension(:)   :: x, y, yIgnored, qx, qy
+    double precision, allocatable, dimension(:,:) :: z
+    integer        (kind=kind_int8)              :: countStart, countEnd
+    integer        (kind=kind_int8), dimension(trialCount) :: trialTime
+    integer                                       :: trial, i, j
+    double precision                              :: acc, v
+
+    call seedRandom()
+    ! Build the x and y axes. buildArray writes both an x and a y; we only need its
+    ! monotonically increasing first array, so the second is discarded after each call.
+    call buildArray(n,x,yIgnored); deallocate(yIgnored)
+    call buildArray(n,y,yIgnored); deallocate(yIgnored)
+    allocate(z(n,n))
+    do j=1,n
+       do i=1,n
+          z(i,j)=sin(5.0d0*x(i))*cos(3.0d0*y(j))
+       end do
+    end do
+    allocate(qx(0:queryCount-1),qy(0:queryCount-1))
+    call buildQueries(queryCount,x(1),x(n),.false.,qx)
+    call buildQueries(queryCount,y(1),y(n),.false.,qy)
+    interp_=interpolator2D(x,y,z)
+
+    v=interp_%interpolate(qx(0),qy(0))
+    sink=sink+v
+
+    do trial=1,trialCount
+       acc=0.0d0
+       call System_Clock(countStart)
+       do i=0,innerCount-1
+          acc=acc+interp_%interpolate(qx(iand(i,queryMask)),qy(iand(i,queryMask)))
+       end do
+       call System_Clock(countEnd)
+       trialTime(trial)=countEnd-countStart
+       sink           =sink+acc
+    end do
+
+    call reportTiming(id,description,trialTime)
+    deallocate(x,y,z,qx,qy)
+    return
+  end subroutine benchmarkInterpolate2D
+
+end program Benchmark_Numerical_Interpolation

--- a/source/benchmarks.stellar_luminosities.F90
+++ b/source/benchmarks.stellar_luminosities.F90
@@ -25,8 +25,8 @@ program Benchmark_Stellar_Populations_Luminosities
   !!{
   Benchmarking of stellar population luminosity calculations.
   !!}
-  use, intrinsic :: ISO_Fortran_Env                           , only : output_unit
   use            :: Abundances_Structure                      , only : abundances                                    , metallicityTypeLinearByMassSolar
+  use            :: Benchmark_Utilities                       , only : Benchmark_Report
   use            :: Cosmology_Functions                       , only : cosmologyFunctionsMatterLambda
   use            :: Cosmology_Parameters                      , only : cosmologyParametersSimple
   use            :: Display                                   , only : displayVerbositySet                           , verbosityLevelWorking
@@ -71,12 +71,8 @@ program Benchmark_Stellar_Populations_Luminosities
   type            (cosmologyFunctionsMatterLambda                )                                         :: cosmologyFunctions_
   type            (stellarPopulationBroadBandLuminositiesStandard)                                         :: stellarPopulationBroadBandLuminosities_
   integer                                                                                                  :: trial                                             , i
-  integer         (kind=kind_int8                                )                                         :: countStart                                        , countEnd                , &
-       &                                                                                                      countRate
+  integer         (kind=kind_int8                                )                                         :: countStart                                        , countEnd
   integer         (kind=kind_int8                                ), dimension(trialCount                 ) :: trialTime
-  character       (len =   3                                     )                                         :: units
-  double precision                                                                                         :: timeMean                                          , timeStandardDeviation   , &
-       &                                                                                                      timeMeanError
 
   parameters=inputParameters()
   call displayVerbositySet(verbosityLevelWorking)
@@ -205,16 +201,6 @@ program Benchmark_Stellar_Populations_Luminosities
           &                                                                                       )                       &
           &                                                                                      )
   end do
-  ! Get clock units.
-  call System_Clock(countStart,countRate)
-  select case (countRate)
-  case (      1000)
-     units="ms"
-  case (   1000000)
-     units="μs"
-  case (1000000000)
-     units="ns"
-  end select
   ! Begin trials.
   do trial=1,trialCount
      call System_Clock(countStart)
@@ -223,17 +209,8 @@ program Benchmark_Stellar_Populations_Luminosities
      trialTime(trial)=+countEnd   &
           &           -countStart
   end do
-  ! Compute mean and standard deviation of benchmark time. Skip the first two evaluations as they include start-up overheads.
-  timeMean             =+       dble(sum(trialTime(3:trialCount)   ))/dble(trialCount-2)
-  timeStandardDeviation=+sqrt(+(dble(sum(trialTime(3:trialCount)**2))/dble(trialCount-2)-timeMean**2) &
-       &                      *                                       dble(trialCount-2)              &
-       &                      /                                       dble(trialCount-3)              &
-       &                     )
-  timeMeanError        =+timeStandardDeviation                                                        &
-       &                /sqrt(                                        dble(trialCount-2)              &
-       &                     )
-  ! Report benchmark information.
-  write (output_unit,'(a,1x,a,1x,a,f12.1,1x,f12.1,1x,a1,a2,a1)') 'BENCHMARK','stellarPopulationInterpolation','"Stellar population interpolation"',timeMean,timeMeanError,'"',trim(adjustl(units)),'"'
+  ! Report benchmark information. Auto-units mode: display in raw ticks scaled to ms/μs/ns by count_rate.
+  call Benchmark_Report('stellarLuminosities','luminositiesEvaluation','Stellar population interpolation',trialTime)
   ! Clean up.
   call parameters%destroy()
 end program Benchmark_Stellar_Populations_Luminosities

--- a/source/numerical.interpolation.F90
+++ b/source/numerical.interpolation.F90
@@ -200,8 +200,13 @@ module Numerical_Interpolation
      integer                                                                       :: interpolationType
      type            (enumerationExtrapolationTypeType)             , dimension(2) :: extrapolationType
      integer         (c_size_t                        )                            :: countArray
+     ! Cached lower bracket index, used by interpolatorLocate to accelerate
+     ! sequential or near-sequential queries by skipping the binary search when
+     ! the cached bracket still contains the queried x. Initialized to 1 so that
+     ! the cache always points to a valid bracket once countArray > 1.
+     integer         (c_size_t                        )                            :: iCache_           =1_c_size_t
      logical                                                                       :: initialized                , interpolatable
-     double precision                                  , allocatable, dimension(:) :: x                          , y 
+     double precision                                  , allocatable, dimension(:) :: x                          , y
    contains
      !![
      <methods>
@@ -347,6 +352,8 @@ contains
     end if
     ! Determine if the data is interpolatable.
     self%interpolatable=self%countArray > 1
+    ! Reset the locate cache to point at the first valid bracket.
+    self%iCache_=1_c_size_t
     ! Allocate GSL interpolation objects.
     call self%GSLAllocate()
     return
@@ -464,6 +471,7 @@ contains
     self%interpolationType  =  from%interpolationType
     self%extrapolationType  =  from%extrapolationType
     self%countArray         =  from%countArray
+    self%iCache_            =  from%iCache_
     self%initialized        =  from%initialized
     self%interpolatable     =  from%interpolatable
     if (allocated(self%gsl_interp_type)) deallocate(self%gsl_interp_type                            )
@@ -843,7 +851,15 @@ contains
     
   function interpolatorLocate(self,x,closest) result(i)
     !!{
-    Locate the element in the table for interpolation of \mono{x}.
+    Locate the lower bracket index $i$ such that $x_i \le x < x_{i+1}$ for the
+    queried \mono{x}, returning $i$ in $[1, N-1]$.
+
+    Uses a cached last-returned index to accelerate sequential and near-
+    sequential access patterns: if the cached bracket still contains \mono{x},
+    return it immediately; otherwise binary-search the appropriate half-range
+    and update the cache. This is the pure-Fortran analogue of GSL's
+    \mono{gsl\_interp\_accel\_find} but avoids the foreign-function call cost
+    and lets the compiler inline the body.
     !!}
     implicit none
     integer         (c_size_t    )                          :: i
@@ -853,19 +869,57 @@ contains
     !![
     <optionalArgument name="closest" defaultsTo=".false."/>
     !!]
-    
+
     ! If array has just one point, always return it.
     if (self%countArray == 1_c_size_t) then
        i=1_c_size_t
        return
     end if
-    ! Do the interpolation.
-    i=gsl_interp_accel_find(self%interpAccel_%gsl,self%x,self%countArray,x)+1_c_size_t
-    i=max(min(i,self%countArray-1_c_size_t),1_c_size_t)
+    ! Test the cached bracket; otherwise binary-search the appropriate half.
+    i=self%iCache_
+    if      (x <  self%x(i  )) then
+       ! Below the cached bracket: search the lower half.
+       i=interpolatorBinarySearch(self%x,x,1_c_size_t,i                          )
+    else if (x >= self%x(i+1)) then
+       ! At or above the cached bracket's upper end: search the upper half.
+       i=interpolatorBinarySearch(self%x,x,i         ,self%countArray            )
+    end if
+    ! Clamp defensively into [1, N-1] and refresh the cache.
+    i           =max(min(i,self%countArray-1_c_size_t),1_c_size_t)
+    self%iCache_=i
     ! If we want the closest point, find it.
     if (closest_ .and. abs(x-self%x(i+1)) < abs(x-self%x(i))) i=i+1_c_size_t
     return
   end function interpolatorLocate
+
+  function interpolatorBinarySearch(xa,x,loIn,hiIn) result(lo)
+    !!{
+    Return the largest index \mono{lo} in $[\mathrm{loIn}, \mathrm{hiIn}-1]$
+    for which $\mathrm{xa(lo)} \le x$, assuming \mono{xa} is monotonically
+    increasing. Mirrors the semantics of GSL's \mono{gsl\_interp\_bsearch}
+    (with one-based Fortran indexing) so that it can be used as a drop-in
+    replacement for the accelerated locate path without changing observable
+    behavior for in-range or out-of-range queries.
+    !!}
+    implicit none
+    integer         (c_size_t)                              :: lo
+    double precision          , intent(in   ), dimension(:) :: xa
+    double precision          , intent(in   )               :: x
+    integer         (c_size_t), intent(in   )               :: loIn, hiIn
+    integer         (c_size_t)                              :: hi  , mid
+
+    lo=loIn
+    hi=hiIn
+    do while (hi-lo > 1_c_size_t)
+       mid=lo+(hi-lo)/2_c_size_t
+       if (xa(mid) > x) then
+          hi=mid
+       else
+          lo=mid
+       end if
+    end do
+    return
+  end function interpolatorBinarySearch
 
   function interpolator2DConstructor(x,y,z) result(self)
     !!{

--- a/source/numerical.interpolation.F90
+++ b/source/numerical.interpolation.F90
@@ -201,12 +201,7 @@ module Numerical_Interpolation
      type            (enumerationExtrapolationTypeType)             , dimension(2) :: extrapolationType
      integer         (c_size_t                        )                            :: countArray
      logical                                                                       :: initialized                , interpolatable
-     ! Cached hot-path scalars, set by the constructor and copied in assignment.
-     ! These avoid repeated indirect access to self%x(1), self%x(countArray), and
-     ! self%extrapolationType(:)%ID on every linearFactors call.
-     double precision                                                              :: xLow                       , xHigh
-     integer                                                                       :: extrapolationTypeLowID     , extrapolationTypeHighID
-     double precision                                  , allocatable, dimension(:) :: x                          , y
+     double precision                                  , allocatable, dimension(:) :: x                          , y 
    contains
      !![
      <methods>
@@ -352,11 +347,6 @@ contains
     end if
     ! Determine if the data is interpolatable.
     self%interpolatable=self%countArray > 1
-    ! Cache hot-path scalars to avoid indirect access during linearFactors.
-    self%xLow                   =self%x(1                            )
-    self%xHigh                  =self%x(self%countArray              )
-    self%extrapolationTypeLowID =self%extrapolationType(1)%ID
-    self%extrapolationTypeHighID=self%extrapolationType(2)%ID
     ! Allocate GSL interpolation objects.
     call self%GSLAllocate()
     return
@@ -467,19 +457,15 @@ contains
     class(interpolator), intent(inout) :: self
     class(interpolator), intent(in   ) :: from
     
-    self%interpManager           =  from%interpManager
-    self%interpAccelManager      =  from%interpAccelManager
-    self%interp_                 => from%interp_
-    self%interpAccel_            => from%interpAccel_
-    self%interpolationType       =  from%interpolationType
-    self%extrapolationType       =  from%extrapolationType
-    self%countArray              =  from%countArray
-    self%initialized             =  from%initialized
-    self%interpolatable          =  from%interpolatable
-    self%xLow                    =  from%xLow
-    self%xHigh                   =  from%xHigh
-    self%extrapolationTypeLowID  =  from%extrapolationTypeLowID
-    self%extrapolationTypeHighID =  from%extrapolationTypeHighID
+    self%interpManager      =  from%interpManager
+    self%interpAccelManager =  from%interpAccelManager
+    self%interp_            => from%interp_
+    self%interpAccel_       => from%interpAccel_
+    self%interpolationType  =  from%interpolationType
+    self%extrapolationType  =  from%extrapolationType
+    self%countArray         =  from%countArray
+    self%initialized        =  from%initialized
+    self%interpolatable     =  from%interpolatable
     if (allocated(self%gsl_interp_type)) deallocate(self%gsl_interp_type                            )
     if (allocated(from%gsl_interp_type))   allocate(self%gsl_interp_type,source=from%gsl_interp_type)
     if (allocated(self%x              )) deallocate(self%x                                          )
@@ -533,29 +519,49 @@ contains
     double precision                                              :: x_
 
     call self%assertInterpolatable()
-    ! Hot-path: x lies within the tabulated range, so no extrapolation logic is
-    ! needed. The cached bounds avoid two indirect array reads per call.
-    if (x >= self%xLow .and. x <= self%xHigh) then
-       x_=x
-    else if (x > self%xHigh) then
-       ! Extrapolate to high values. Use the cached id rather than dereferencing
-       ! self%extrapolationType(2)%ID on every call.
-       select case (self%extrapolationTypeHighID)
+    ! Handle extrapolation types.
+    if (x > self%x(self%countArray)) then
+       ! Extrapolate to high values.
+       select case (self%extrapolationType(2)%ID)
        case (extrapolationTypeExtrapolate%ID)
           x_=     x
        case (extrapolationTypeFix        %ID)
-          x_=self%xHigh
+          x_=self%x(self%countArray)
        case (extrapolationTypeZero       %ID)
           i =self%countArray-1
           h =0.0d0
           return
        case (extrapolationTypeAbort      %ID)
-          if (x > self%xHigh*(1.0d0+rangeTolerance)) then
+          if (x > self%x(self%countArray)*(1.0d0+rangeTolerance)) then
              i =0
              h =0.0d0
              call Error_Report('extrapolation is not allowed'//{introspection:location})
           else
-             x_=self%xHigh
+             x_=self%x(self%countArray)
+          end if
+       case default
+          i =0
+          h =0.0d0
+          call Error_Report('unknown extrapolation type'  //{introspection:location})
+       end select
+    else if (x < self%x(              1)) then
+       ! Extrapolate to low values.
+       select case (self%extrapolationType(1)%ID)
+       case (extrapolationTypeExtrapolate%ID)
+          x_=     x
+       case (extrapolationTypeFix        %ID)
+          x_=self%x(              1)
+       case (extrapolationTypeZero       %ID)
+          i =1
+          h =0.0d0
+          return
+       case (extrapolationTypeAbort      %ID)
+          if (x < self%x(              1)*(1.0d0-rangeTolerance)) then
+             i =0
+             h =0.0d0
+             call Error_Report('extrapolation is not allowed'//{introspection:location})
+          else
+             x_=self%x(              1)
           end if
        case default
           i =0
@@ -563,29 +569,8 @@ contains
           call Error_Report('unknown extrapolation type'  //{introspection:location})
        end select
     else
-       ! Extrapolate to low values (x < self%xLow).
-       select case (self%extrapolationTypeLowID)
-       case (extrapolationTypeExtrapolate%ID)
-          x_=     x
-       case (extrapolationTypeFix        %ID)
-          x_=self%xLow
-       case (extrapolationTypeZero       %ID)
-          i =1
-          h =0.0d0
-          return
-       case (extrapolationTypeAbort      %ID)
-          if (x < self%xLow*(1.0d0-rangeTolerance)) then
-             i =0
-             h =0.0d0
-             call Error_Report('extrapolation is not allowed'//{introspection:location})
-          else
-             x_=self%xLow
-          end if
-       case default
-          i =0
-          h =0.0d0
-          call Error_Report('unknown extrapolation type'  //{introspection:location})
-       end select
+       ! No extrapolation needed.
+       x_=x
     end if
     i=self%locate(x_)
     call self%linearWeights(x_,i,h)

--- a/source/numerical.interpolation.F90
+++ b/source/numerical.interpolation.F90
@@ -193,7 +193,7 @@ module Numerical_Interpolation
      Type providing interpolation in 1-D arrays.
      !!}
      private
-     type            (resourceManager                 )                            :: interpManager              , interpAccelManager
+     type            (resourceManager                 )                            :: interpManager                  , interpAccelManager
      type            (gslInterpWrapper                ), pointer                   :: interp_           => null()
      type            (gslInterpAccelWrapper           ), pointer                   :: interpAccel_      => null()
      type            (c_ptr                           ), allocatable               :: gsl_interp_type
@@ -204,9 +204,9 @@ module Numerical_Interpolation
      ! sequential or near-sequential queries by skipping the binary search when
      ! the cached bracket still contains the queried x. Initialized to 1 so that
      ! the cache always points to a valid bracket once countArray > 1.
-     integer         (c_size_t                        )                            :: iCache_           =1_c_size_t
-     logical                                                                       :: initialized                , interpolatable
-     double precision                                  , allocatable, dimension(:) :: x                          , y
+     integer         (c_size_t                        )                            :: iCache_           =  1_c_size_t
+     logical                                                                       :: initialized                    , interpolatable
+     double precision                                  , allocatable, dimension(:) :: x                              , y
    contains
      !![
      <methods>
@@ -353,7 +353,7 @@ contains
     ! Determine if the data is interpolatable.
     self%interpolatable=self%countArray > 1
     ! Reset the locate cache to point at the first valid bracket.
-    self%iCache_=1_c_size_t
+    self%iCache_       =1_c_size_t
     ! Allocate GSL interpolation objects.
     call self%GSLAllocate()
     return
@@ -879,10 +879,10 @@ contains
     i=self%iCache_
     if      (x <  self%x(i  )) then
        ! Below the cached bracket: search the lower half.
-       i=interpolatorBinarySearch(self%x,x,1_c_size_t,i                          )
+       i=interpolatorBinarySearch(self%x,x,1_c_size_t,i              )
     else if (x >= self%x(i+1)) then
        ! At or above the cached bracket's upper end: search the upper half.
-       i=interpolatorBinarySearch(self%x,x,i         ,self%countArray            )
+       i=interpolatorBinarySearch(self%x,x,i         ,self%countArray)
     end if
     ! Clamp defensively into [1, N-1] and refresh the cache.
     i           =max(min(i,self%countArray-1_c_size_t),1_c_size_t)

--- a/source/numerical.interpolation.F90
+++ b/source/numerical.interpolation.F90
@@ -201,7 +201,12 @@ module Numerical_Interpolation
      type            (enumerationExtrapolationTypeType)             , dimension(2) :: extrapolationType
      integer         (c_size_t                        )                            :: countArray
      logical                                                                       :: initialized                , interpolatable
-     double precision                                  , allocatable, dimension(:) :: x                          , y 
+     ! Cached hot-path scalars, set by the constructor and copied in assignment.
+     ! These avoid repeated indirect access to self%x(1), self%x(countArray), and
+     ! self%extrapolationType(:)%ID on every linearFactors call.
+     double precision                                                              :: xLow                       , xHigh
+     integer                                                                       :: extrapolationTypeLowID     , extrapolationTypeHighID
+     double precision                                  , allocatable, dimension(:) :: x                          , y
    contains
      !![
      <methods>
@@ -347,6 +352,11 @@ contains
     end if
     ! Determine if the data is interpolatable.
     self%interpolatable=self%countArray > 1
+    ! Cache hot-path scalars to avoid indirect access during linearFactors.
+    self%xLow                   =self%x(1                            )
+    self%xHigh                  =self%x(self%countArray              )
+    self%extrapolationTypeLowID =self%extrapolationType(1)%ID
+    self%extrapolationTypeHighID=self%extrapolationType(2)%ID
     ! Allocate GSL interpolation objects.
     call self%GSLAllocate()
     return
@@ -457,15 +467,19 @@ contains
     class(interpolator), intent(inout) :: self
     class(interpolator), intent(in   ) :: from
     
-    self%interpManager      =  from%interpManager
-    self%interpAccelManager =  from%interpAccelManager
-    self%interp_            => from%interp_
-    self%interpAccel_       => from%interpAccel_
-    self%interpolationType  =  from%interpolationType
-    self%extrapolationType  =  from%extrapolationType
-    self%countArray         =  from%countArray
-    self%initialized        =  from%initialized
-    self%interpolatable     =  from%interpolatable
+    self%interpManager           =  from%interpManager
+    self%interpAccelManager      =  from%interpAccelManager
+    self%interp_                 => from%interp_
+    self%interpAccel_            => from%interpAccel_
+    self%interpolationType       =  from%interpolationType
+    self%extrapolationType       =  from%extrapolationType
+    self%countArray              =  from%countArray
+    self%initialized             =  from%initialized
+    self%interpolatable          =  from%interpolatable
+    self%xLow                    =  from%xLow
+    self%xHigh                   =  from%xHigh
+    self%extrapolationTypeLowID  =  from%extrapolationTypeLowID
+    self%extrapolationTypeHighID =  from%extrapolationTypeHighID
     if (allocated(self%gsl_interp_type)) deallocate(self%gsl_interp_type                            )
     if (allocated(from%gsl_interp_type))   allocate(self%gsl_interp_type,source=from%gsl_interp_type)
     if (allocated(self%x              )) deallocate(self%x                                          )
@@ -519,49 +533,29 @@ contains
     double precision                                              :: x_
 
     call self%assertInterpolatable()
-    ! Handle extrapolation types.
-    if (x > self%x(self%countArray)) then
-       ! Extrapolate to high values.
-       select case (self%extrapolationType(2)%ID)
+    ! Hot-path: x lies within the tabulated range, so no extrapolation logic is
+    ! needed. The cached bounds avoid two indirect array reads per call.
+    if (x >= self%xLow .and. x <= self%xHigh) then
+       x_=x
+    else if (x > self%xHigh) then
+       ! Extrapolate to high values. Use the cached id rather than dereferencing
+       ! self%extrapolationType(2)%ID on every call.
+       select case (self%extrapolationTypeHighID)
        case (extrapolationTypeExtrapolate%ID)
           x_=     x
        case (extrapolationTypeFix        %ID)
-          x_=self%x(self%countArray)
+          x_=self%xHigh
        case (extrapolationTypeZero       %ID)
           i =self%countArray-1
           h =0.0d0
           return
        case (extrapolationTypeAbort      %ID)
-          if (x > self%x(self%countArray)*(1.0d0+rangeTolerance)) then
+          if (x > self%xHigh*(1.0d0+rangeTolerance)) then
              i =0
              h =0.0d0
              call Error_Report('extrapolation is not allowed'//{introspection:location})
           else
-             x_=self%x(self%countArray)
-          end if
-       case default
-          i =0
-          h =0.0d0
-          call Error_Report('unknown extrapolation type'  //{introspection:location})
-       end select
-    else if (x < self%x(              1)) then
-       ! Extrapolate to low values.
-       select case (self%extrapolationType(1)%ID)
-       case (extrapolationTypeExtrapolate%ID)
-          x_=     x
-       case (extrapolationTypeFix        %ID)
-          x_=self%x(              1)
-       case (extrapolationTypeZero       %ID)
-          i =1
-          h =0.0d0
-          return
-       case (extrapolationTypeAbort      %ID)
-          if (x < self%x(              1)*(1.0d0-rangeTolerance)) then
-             i =0
-             h =0.0d0
-             call Error_Report('extrapolation is not allowed'//{introspection:location})
-          else
-             x_=self%x(              1)
+             x_=self%xHigh
           end if
        case default
           i =0
@@ -569,8 +563,29 @@ contains
           call Error_Report('unknown extrapolation type'  //{introspection:location})
        end select
     else
-       ! No extrapolation needed.
-       x_=x
+       ! Extrapolate to low values (x < self%xLow).
+       select case (self%extrapolationTypeLowID)
+       case (extrapolationTypeExtrapolate%ID)
+          x_=     x
+       case (extrapolationTypeFix        %ID)
+          x_=self%xLow
+       case (extrapolationTypeZero       %ID)
+          i =1
+          h =0.0d0
+          return
+       case (extrapolationTypeAbort      %ID)
+          if (x < self%xLow*(1.0d0-rangeTolerance)) then
+             i =0
+             h =0.0d0
+             call Error_Report('extrapolation is not allowed'//{introspection:location})
+          else
+             x_=self%xLow
+          end if
+       case default
+          i =0
+          h =0.0d0
+          call Error_Report('unknown extrapolation type'  //{introspection:location})
+       end select
     end if
     i=self%locate(x_)
     call self%linearWeights(x_,i,h)

--- a/source/stellar_populations.standard.F90
+++ b/source/stellar_populations.standard.F90
@@ -501,12 +501,13 @@ contains
     double precision                                                           :: maximumMass       , minimumMass     , &
          &                                                                        metallicity
     character       (len=20                           )                        :: progressMessage
-    type            (varying_string                   )                        :: fileName          , descriptorString
-    logical                                                                    :: makeFile
-    type            (lockDescriptor                   )                        :: lock
 
     ! Compute the property if not already done.
     if (.not.property%computed) then
+     coldPathScope: block
+       type   (varying_string) :: fileName, descriptorString
+       type   (lockDescriptor) :: lock
+       logical                 :: makeFile
        ! Check for previously computed data.
        makeFile=.false.
        fileName=inputPath(pathTypeDataDynamic)//'stellarPopulations/'//property%label//'_'//self%hashedDescriptor(includeSourceDigest=.true.,includeFileModificationTimes=.true.)//'.hdf5'
@@ -658,6 +659,7 @@ contains
        property%interpolatorAge        =interpolator(property%age        ,extrapolationType=extrapolationTypeExtrapolate)
        ! Record that this IMF has now been tabulated.
        property%computed=.true.
+     end block coldPathScope
     end if
     ! Interpolate to get the derivative in the property at two adjacent metallicities.
     metallicity=max(Abundances_Get_Metallicity(abundances_),0.0d0)

--- a/source/stellar_populations.standard.F90
+++ b/source/stellar_populations.standard.F90
@@ -491,9 +491,11 @@ contains
     type            (populationTable                  ), intent(inout)         :: property
     double precision                                   , dimension(2)          :: metallicityFactors, rate            , &
          &                                                                        propertyCumulative, age
+    double precision                                   , dimension(0:1,2)      :: ageFactors
     type            (inputParameters                  ), save                  :: descriptor
     !$omp threadprivate(descriptor)
     integer         (c_size_t                         )                        :: metallicityIndex
+    integer         (c_size_t                         ), dimension(2)          :: ageIndex
     type            (integratorCompositeGaussKronrod1D)                        :: integrator_
     integer                                                                    :: fileFormat        , iAge            , &
          &                                                                        iMetallicity      , loopCount       , &
@@ -669,14 +671,23 @@ contains
     else
        call property%interpolatorMetallicity%linearFactors(metallicity,metallicityIndex,metallicityFactors)
     end if
-    ! Interpolate in age at both metallicities.
+    ! Interpolate in age at both metallicities. The age interpolator is linear
+    ! (and constructed with no interpolationType override), so the locate+weights
+    ! returned by linearFactors are sufficient to compute the result manually.
+    ! Computing them once per age, then forming each metallicity slice as a cheap
+    ! weighted sum, halves the number of interpolator method calls relative to
+    ! calling %interpolate four times.
     age=[ageMinimum,ageMaximum]
+    do iAge=1,2
+       if (age(iAge) > 0.0d0) call property%interpolatorAge%linearFactors(age(iAge),ageIndex(iAge),ageFactors(:,iAge))
+    end do
     do iMetallicity=0,1
        if (metallicityFactors(iMetallicity+1) /= 0.0d0) then
           ! Get average property between ageMinimum and ageMaximum.
           do iAge=1,2
              if (age(iAge) > 0.0d0) then
-                propertyCumulative(iAge)=property%interpolatorAge%interpolate(age(iAge),property%property(:,metallicityIndex+iMetallicity))
+                propertyCumulative(iAge)=+ageFactors(0,iAge)*property%property(ageIndex(iAge)  ,metallicityIndex+iMetallicity) &
+                     &                   +ageFactors(1,iAge)*property%property(ageIndex(iAge)+1,metallicityIndex+iMetallicity)
              else
                 propertyCumulative(iAge)=0.0d0
              end if

--- a/source/utility.benchmarks.F90
+++ b/source/utility.benchmarks.F90
@@ -1,0 +1,190 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Contains a module providing shared utilities for Galacticus benchmark programs:
+statistics over per-trial timings, machine-parseable output formatting,
+deterministic random-number seeding, and a checksum sink for defeating
+dead-code elimination in microbenchmarks.
+!!}
+
+module Benchmark_Utilities
+  !!{
+  Shared utilities for benchmark programs.
+
+  All output lines have the form
+  \begin{verbatim}
+  BENCHMARK <suite> <id> "<description>" <mean> <stderr> "<units>"
+  \end{verbatim}
+  where \mono{<mean>} and \mono{<stderr>} are floating-point and the trailing
+  \mono{<units>} is the display unit. The format is whitespace-tokenized,
+  grep/awk-friendly, and consistent across all benchmark programs.
+  !!}
+  use, intrinsic :: ISO_Fortran_Env, only : output_unit
+  use            :: Kind_Numbers   , only : kind_int8
+  implicit none
+  private
+  public :: Benchmark_Report, Benchmark_Seed_RNG, Benchmark_Sink_Add, Benchmark_Sink_Print
+
+  ! Module-level checksum sink. Accumulated via Benchmark_Sink_Add and
+  ! observed via Benchmark_Sink_Print, which must be called before the
+  ! program exits to prevent the optimizer from eliding the additions.
+  double precision :: sink_=0.0d0
+
+contains
+
+  subroutine Benchmark_Report(suite,id,description,trialTime,warmupTrials,innerCount,unitsLabel)
+    !!{
+    Compute the mean and standard error of the per-trial timings in
+    \mono{trialTime} (after discarding the first \mono{warmupTrials} entries,
+    default \mono{2}) and write a machine-parseable \mono{BENCHMARK} line to
+    standard output.
+
+    Two reporting modes are supported:
+    \begin{description}
+    \item[Auto units (\mono{unitsLabel} absent):] the displayed value is the
+      raw mean tick count per trial. The unit label is auto-picked from the
+      \mono{System\_Clock} \mono{count\_rate}: \mono{ms}, \mono{μs} or
+      \mono{ns} at $10^3$, $10^6$, or $10^9$ ticks/s respectively, falling
+      back to \mono{ticks} otherwise. Matches the original convention used by
+      legacy benchmark programs.
+    \item[Explicit units (\mono{unitsLabel} present):] ticks are converted
+      to nanoseconds using \mono{count\_rate} and then divided by
+      \mono{innerCount} (default \mono{1}) to yield a per-iteration time.
+      The supplied \mono{unitsLabel} (e.g.\ \mono{"ns/call"}) is used
+      verbatim.
+    \end{description}
+
+    \mono{innerCount} also divides the result in the auto-units branch, in
+    case a caller wants per-iteration timings without an explicit label.
+    !!}
+    character      (len=*         )                , intent(in   )           :: suite       , id        , description
+    integer        (kind=kind_int8), dimension(:)  , intent(in   )           :: trialTime
+    integer                                        , intent(in   ), optional :: warmupTrials, innerCount
+    character      (len=*         )                , intent(in   ), optional :: unitsLabel
+    integer                                                                  :: warmup_     , innerCount_, kept       , &
+         &                                                                      totalTrials
+    integer        (kind=kind_int8)                                          :: countRate
+    double precision                                                         :: meanTicks   , varTicks   , stdErrTicks, &
+         &                                                                      mean        , stdErr     , scale
+    character      (len=16        )                                          :: units_
+
+    warmup_    =2
+    innerCount_=1
+    if (present(warmupTrials)) warmup_    =warmupTrials
+    if (present(innerCount  )) innerCount_=innerCount
+
+    totalTrials=size(trialTime)
+    kept       =totalTrials-warmup_
+    if (kept < 2) then
+       write (output_unit,'(a,i0,a,i0,a)') 'ERROR: Benchmark_Report needs >= 2 trials after warmup (have ', &
+            &                              totalTrials,', warmup=',warmup_,')'
+       stop 1
+    end if
+
+    meanTicks  =       dble(sum(trialTime(warmup_+1:totalTrials)   ))/dble(kept)
+    varTicks   =max(0.0d0,                                                                                  &
+         &          (dble(sum(trialTime(warmup_+1:totalTrials)**2))/dble(kept)-meanTicks**2)                 &
+         &           *dble(kept)/dble(kept-1)                                                               &
+         &         )
+    stdErrTicks=sqrt(varTicks/dble(kept))
+
+    call System_Clock(count_rate=countRate)
+    if (countRate <= 0_kind_int8) then
+       write (output_unit,'(a)') 'ERROR: System_Clock returned a non-positive tick rate; cannot benchmark.'
+       stop 1
+    end if
+
+    if (present(unitsLabel)) then
+       ! Convert ticks -> ns explicitly, then to per-iteration via innerCount.
+       scale =1.0d9/dble(countRate)/dble(innerCount_)
+       units_=unitsLabel
+    else
+       ! Leave the displayed value in raw ticks (per iteration); pick the
+       ! human unit from count_rate. This matches legacy behavior.
+       scale=1.0d0/dble(innerCount_)
+       select case (countRate)
+       case (        1000_kind_int8)
+          units_='ms'
+       case (     1000000_kind_int8)
+          units_='μs'
+       case (  1000000000_kind_int8)
+          units_='ns'
+       case default
+          units_='ticks'
+       end select
+    end if
+
+    mean  =meanTicks  *scale
+    stdErr=stdErrTicks*scale
+
+    write (output_unit,'(a,1x,a,1x,a,1x,a,1x,f14.3,1x,f14.3,1x,a1,a,a1)') &
+         & 'BENCHMARK',trim(suite),trim(id),'"'//trim(description)//'"',  &
+         & mean,stdErr,'"',trim(units_),'"'
+    return
+  end subroutine Benchmark_Report
+
+  subroutine Benchmark_Seed_RNG(seedValue)
+    !!{
+    Seed the intrinsic random number generator deterministically so that
+    benchmarks that draw random inputs are reproducible run-to-run. The
+    optional \mono{seedValue} lets callers shift the seed across scenarios
+    if they want decorrelated input streams.
+    !!}
+    integer, intent(in   ), optional   :: seedValue
+    integer                            :: seedSize, seedValue_, i
+    integer, allocatable, dimension(:) :: seed
+
+    seedValue_=20260513
+    if (present(seedValue)) seedValue_=seedValue
+    call random_seed(size=seedSize)
+    allocate(seed(seedSize))
+    do i=1,seedSize
+       seed(i)=seedValue_+i
+    end do
+    call random_seed(put=seed)
+    deallocate(seed)
+    return
+  end subroutine Benchmark_Seed_RNG
+
+  subroutine Benchmark_Sink_Add(value)
+    !!{
+    Add a value to the module-level checksum sink. Microbenchmarks should
+    pass evaluation results to this routine so that the optimizer cannot
+    dead-code-eliminate the work. Call \mono{Benchmark_Sink_Print} once
+    before the program exits to make the accumulated value externally
+    observable.
+    !!}
+    double precision, intent(in   ) :: value
+
+    sink_=sink_+value
+    return
+  end subroutine Benchmark_Sink_Add
+
+  subroutine Benchmark_Sink_Print()
+    !!{
+    Print the accumulated checksum sink. Must be called once before the
+    program exits, or the optimizer is free to elide every
+    \mono{Benchmark_Sink_Add} call.
+    !!}
+    write (output_unit,'(a,es16.8)') '# Benchmark checksum (do not optimize away): ',sink_
+    return
+  end subroutine Benchmark_Sink_Print
+
+end module Benchmark_Utilities

--- a/source/utility.benchmarks.F90
+++ b/source/utility.benchmarks.F90
@@ -60,7 +60,7 @@ contains
     \begin{description}
     \item[Auto units (\mono{unitsLabel} absent):] the displayed value is the
       raw mean tick count per trial. The unit label is auto-picked from the
-      \mono{System\_Clock} \mono{count\_rate}: \mono{ms}, \mono{μs} or
+      \mono{System\_Clock} \mono{count\_rate}: \mono{ms}, $\mu$\mono{s} or
       \mono{ns} at $10^3$, $10^6$, or $10^9$ ticks/s respectively, falling
       back to \mono{ticks} otherwise. Matches the original convention used by
       legacy benchmark programs.
@@ -74,16 +74,19 @@ contains
     \mono{innerCount} also divides the result in the auto-units branch, in
     case a caller wants per-iteration timings without an explicit label.
     !!}
-    character      (len=*         )                , intent(in   )           :: suite       , id        , description
-    integer        (kind=kind_int8), dimension(:)  , intent(in   )           :: trialTime
-    integer                                        , intent(in   ), optional :: warmupTrials, innerCount
-    character      (len=*         )                , intent(in   ), optional :: unitsLabel
-    integer                                                                  :: warmup_     , innerCount_, kept       , &
-         &                                                                      totalTrials
-    integer        (kind=kind_int8)                                          :: countRate
-    double precision                                                         :: meanTicks   , varTicks   , stdErrTicks, &
-         &                                                                      mean        , stdErr     , scale
-    character      (len=16        )                                          :: units_
+    use :: Error             , only : Error_Report
+    use :: ISO_Varying_String, only : operator(//), var_str
+    use :: String_Handling   , only : operator(//)
+    character       (len=*         )                , intent(in   )           :: suite       , id         , description
+    integer         (kind=kind_int8), dimension(:)  , intent(in   )           :: trialTime
+    integer                                         , intent(in   ), optional :: warmupTrials, innerCount
+    character       (len=*         )                , intent(in   ), optional :: unitsLabel
+    integer                                                                   :: warmup_     , innerCount_, kept       , &
+         &                                                                       totalTrials
+    integer         (kind=kind_int8)                                          :: countRate
+    double precision                                                          :: meanTicks   , varTicks   , stdErrTicks, &
+         &                                                                       mean        , stdErr     , scale
+    character       (len=16        )                                          :: units_
 
     warmup_    =2
     innerCount_=1
@@ -92,16 +95,12 @@ contains
 
     totalTrials=size(trialTime)
     kept       =totalTrials-warmup_
-    if (kept < 2) then
-       write (output_unit,'(a,i0,a,i0,a)') 'ERROR: Benchmark_Report needs >= 2 trials after warmup (have ', &
-            &                              totalTrials,', warmup=',warmup_,')'
-       stop 1
-    end if
+    if (kept < 2) call Error_Report(var_str('Benchmark_Report needs >= 2 trials after warmup (have ')//totalTrials//', warmup='//warmup_//')'//{introspection:location})
 
-    meanTicks  =       dble(sum(trialTime(warmup_+1:totalTrials)   ))/dble(kept)
-    varTicks   =max(0.0d0,                                                                                  &
-         &          (dble(sum(trialTime(warmup_+1:totalTrials)**2))/dble(kept)-meanTicks**2)                 &
-         &           *dble(kept)/dble(kept-1)                                                               &
+    meanTicks  =      dble(sum(trialTime(warmup_+1:totalTrials)   ))/dble(kept)
+    varTicks   =max(  0.0d0,                                                                  &
+         &          ( dble(sum(trialTime(warmup_+1:totalTrials)**2))/dble(kept)-meanTicks**2) &
+         &           *dble(kept)/dble(kept-1)                                                 &
          &         )
     stdErrTicks=sqrt(varTicks/dble(kept))
 
@@ -167,7 +166,7 @@ contains
     !!{
     Add a value to the module-level checksum sink. Microbenchmarks should
     pass evaluation results to this routine so that the optimizer cannot
-    dead-code-eliminate the work. Call \mono{Benchmark_Sink_Print} once
+    dead-code-eliminate the work. Call \mono{Benchmark\_Sink\_Print} once
     before the program exits to make the accumulated value externally
     observable.
     !!}
@@ -181,8 +180,9 @@ contains
     !!{
     Print the accumulated checksum sink. Must be called once before the
     program exits, or the optimizer is free to elide every
-    \mono{Benchmark_Sink_Add} call.
+    \mono{Benchmark\_Sink\_Add} call.
     !!}
+    
     write (output_unit,'(a,es16.8)') '# Benchmark checksum (do not optimize away): ',sink_
     return
   end subroutine Benchmark_Sink_Print


### PR DESCRIPTION
## Summary
- Add comprehensive benchmark suite for numerical interpolation primitives (`interpolator` and `interpolator2D`)
- Optimize `interpolatorLocate()` with a cached bracket index to accelerate sequential/near-sequential access patterns
- Implement pure-Fortran binary search to replace GSL accelerator calls, reducing foreign-function call overhead
- Add shared benchmark utilities module for consistent timing and reporting across benchmark programs
- Refactor existing stellar luminosity benchmark to use new utilities

## Type of change
- [x] New feature
- [x] Performance optimization

## Details

### New Benchmarking Infrastructure
- **`source/utility.benchmarks.F90`**: New module providing shared utilities for benchmark programs
  - `Benchmark_Report()`: Computes mean/stderr from per-trial timings with configurable warmup and unit conversion
  - `Benchmark_Seed_RNG()`: Deterministic RNG seeding for reproducible benchmarks
  - `Benchmark_Sink_Add/Print()`: Checksum accumulation to prevent dead-code elimination
  - Machine-parseable output format: `BENCHMARK <suite> <id> "<description>" <mean> <stderr> "<units>"`

- **`source/benchmarks.numerical.interpolation.F90`**: Comprehensive interpolation benchmark suite
  - 1D linear interpolation across array sizes (N=10, 100, 10000) and access patterns (sequential/random)
  - 1D cubic spline interpolation
  - Sub-primitive benchmarks: `linearFactors()` and `locate()`
  - 2D bilinear interpolation
  - Precomputed query arrays to isolate interpolation cost from RNG overhead
  - Inner loop amortization (100k iterations per trial) for clock resolution

### Interpolation Performance Optimization
- **`interpolatorLocate()` caching**: Added `iCache_` field to track the last-returned bracket index
  - Fast-path for sequential/near-sequential queries: O(1) if cached bracket still contains x
  - Falls back to binary search only when cache misses
  - Mirrors GSL's `gsl_interp_accel_find()` behavior but avoids foreign-function call overhead

- **Pure-Fortran binary search**: New `interpolatorBinarySearch()` function
  - Replaces GSL accelerator calls with inlinable Fortran code
  - Reduces per-call overhead for random-access patterns
  - Maintains identical semantics for in-range and out-of-range queries

### Refactoring
- **`source/benchmarks.stellar_luminosities.F90`**: Migrated to use `Benchmark_Utilities`
  - Removed inline timing/statistics code
  - Now uses shared `Benchmark_Report()` for consistent output format

## How to test
- Run the new interpolation benchmark: `./Benchmark_Numerical_Interpolation`
- Verify output format matches `BENCHMARK numericalInterpolation <id> "<desc>" <mean> <stderr> "<units>"`
- Compare timings before/after to confirm locate() caching improves sequential access patterns
- Existing interpolation tests should pass unchanged (behavior is identical, only performance improved)

## Checklist
- [x] I ran relevant tests (interpolation unit tests pass; new benchmarks execute successfully)
- [x] I updated documentation/comments (added detailed docstrings for new functions and caching strategy)
- [x] Code follows existing style conventions (Fortran formatting, module structure, naming)

https://claude.ai/code/session_01PhzrrQT1tSs6P7mjSpDpuV