### PR TITLE
Add root finder benchmarks and optimize hot-path performance

### DIFF
--- a/source/benchmarks.numerical.root_finder.F90
+++ b/source/benchmarks.numerical.root_finder.F90
@@ -32,8 +32,15 @@ The scenarios are intentionally aligned with code paths in
 \begin{description}
 \item[\mono{*\_bracket}] hits \mono{rootFinderFindRange} (two endpoint
   evaluations).
-\item[\mono{*\_bracket\_values}] hits \mono{rootFinderFindRangeValues} (no
-  endpoint evaluations---wrapper cache should be used for both).
+\item[\mono{*\_bracket\_values}] hits \mono{rootFinderFindRangeValues}: the
+  caller precomputes both endpoint function values (so \mono{find} performs
+  no endpoint evaluations of its own; instead the wrapper's cache serves
+  them on the first two GSL callbacks). The two caller-side \mono{fQuad}
+  evaluations sit inside the timed region, just as they do for the
+  \mono{*\_bracket} scenario (where the same two evaluations happen inside
+  \mono{find}), so the difference between the two scenarios is the cost of
+  wrapper-cache hits versus the cost of evaluating those same endpoints
+  through \mono{rootFinderFindRange}'s procedure-pointer call path.
 \item[\mono{*\_bracket\_valueLow}] hits \mono{rootFinderFindRangeValueLow}
   (one endpoint evaluation).
 \item[\mono{*\_guess}] hits \mono{rootFinderFindGuess} (the degenerate
@@ -168,8 +175,17 @@ contains
     Time \mono{find(rootRange,rootRangeValues)} where both endpoint function
     values are precomputed by the caller. Hits the
     \mono{rootFinderFindRangeValues} entry point and avoids any duplicate
-    evaluation of the user function at the bracket ends. The wrapper's cache
-    of endpoint values should also be used by the first two GSL calls.
+    evaluation of the user function at the bracket ends inside \mono{find}.
+    The wrapper's cache of endpoint values should also be used by the first
+    two GSL calls.
+
+    The two caller-side \mono{fQuad} evaluations are deliberately inside the
+    timed region: they represent the real cost a caller pays to use this
+    entry point. The matching \mono{*\_bracket} scenario pays the same two
+    evaluations inside \mono{rootFinderFindRange}, so the comparison between
+    the two scenarios isolates "wrapper cache hit" vs.\ "wrapper cache miss
+    plus procedure-pointer call to \mono{finderFunction}" rather than
+    introducing or removing user-function calls.
     !!}
     integer                         , intent(in   )                      :: solverType
     character       (len=*         ), intent(in   )                      :: id        , description

--- a/source/benchmarks.numerical.root_finder.F90
+++ b/source/benchmarks.numerical.root_finder.F90
@@ -143,7 +143,7 @@ program Benchmark_Numerical_Root_Finder
        &                                                 gsl_root_fdfsolver_steffenson                               , &
        &                                                 rangeExpandMultiplicative    , rangeExpandAdditive          , &
        &                                                 rangeExpandSignExpectNegative, rangeExpandSignExpectPositive, &
-       &                                                 enumerationRangeExpandType
+       &                                                 enumerationRangeExpandType   , stoppingCriterionDelta
   implicit none
 
   ! Benchmark control.
@@ -412,7 +412,8 @@ contains
          &             rootFunctionBoth      =fQuadBoth        , &
          &             solverType            =solverType       , &
          &             toleranceAbsolute     =0.0d0            , &
-         &             toleranceRelative     =1.0d-7             &
+         &             toleranceRelative     =1.0d-7           , &
+         &             stoppingCriterion     =stoppingCriterionDelta &
          &            )
 
     bmShift=shifts_(0)

--- a/source/benchmarks.numerical.root_finder.F90
+++ b/source/benchmarks.numerical.root_finder.F90
@@ -1,0 +1,439 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Module providing root-callback functions and shared state for the rootFinder
+benchmark program. Kept separate from the program unit so the callbacks can be
+passed as procedure(...) actual arguments to \refClass{rootFinder} without
+running into Fortran restrictions on procedure pointers to internal procedures.
+!!}
+
+module Benchmark_Root_Finder_Functions
+  !!{
+  Callbacks and shared state for the \refClass{rootFinder} benchmark.
+
+  The functions read a single module-level shift, \mono{bmShift}, which is
+  rewritten by the benchmark driver before every call. This perturbs the
+  problem (so the optimizer cannot constant-fold the solver chain) and keeps
+  the cache state of \mono{rootFinder}'s wrapper realistic from one call to
+  the next.
+  !!}
+  implicit none
+  private
+  public :: bmShift, fQuad, fQuadDerivative, fQuadBoth, fFar
+
+  ! Module-level shift consumed by every callback. Updated by the benchmark
+  ! driver immediately before each find() invocation.
+  double precision, save :: bmShift=0.0d0
+
+contains
+
+  double precision function fQuad(x)
+    !!{
+    Quadratic with a single root in the interval $[0,3]$.
+
+    $f(x) = (x - (\mathrm{bmShift}+1))(x + 5)$ has roots at $x=\mathrm{bmShift}+1$
+    and $x=-5$. With $\mathrm{bmShift} \in [-0.4,0.4]$ the in-bracket root sits
+    in $[0.6,1.4]$.
+    !!}
+    double precision, intent(in   ) :: x
+
+    fQuad=(x-(bmShift+1.0d0))*(x+5.0d0)
+    return
+  end function fQuad
+
+  double precision function fQuadDerivative(x)
+    !!{
+    Derivative of \mono{fQuad}.
+    !!}
+    double precision, intent(in   ) :: x
+
+    fQuadDerivative=2.0d0*x+5.0d0-(bmShift+1.0d0)
+    return
+  end function fQuadDerivative
+
+  subroutine fQuadBoth(x,f,df)
+    !!{
+    Combined value and derivative of \mono{fQuad}.
+    !!}
+    double precision, intent(in   ) :: x
+    double precision, intent(  out) :: f, df
+
+    f =(x-(bmShift+1.0d0))*(x+5.0d0)
+    df=2.0d0*x+5.0d0-(bmShift+1.0d0)
+    return
+  end subroutine fQuadBoth
+
+  double precision function fFar(x)
+    !!{
+    Linear function with its root far above a typical initial guess.
+
+    $f(x) = x - (\mathrm{bmShift}+10)$. With $\mathrm{bmShift} \in [-0.4,0.4]$
+    the root lies in $[9.6,10.4]$. Used in expansion benchmarks where the
+    initial bracket/guess is intentionally below the root so the bracket
+    expansion loop is exercised.
+    !!}
+    double precision, intent(in   ) :: x
+
+    fFar=x-(bmShift+10.0d0)
+    return
+  end function fFar
+
+end module Benchmark_Root_Finder_Functions
+
+
+!!{
+Contains a program to benchmark the \refClass{rootFinder} class.
+
+Each scenario constructs a rootFinder configured for a particular solver type
+and entry point. A precomputed deterministic array of per-call shifts perturbs
+the underlying function on every call so the optimizer cannot constant-fold
+the solver chain and the wrapper's endpoint-value cache sees realistic
+turnover. An inner loop of many find() calls per timed trial amortizes
+\mono{System\_Clock} resolution.
+
+The scenarios are intentionally aligned with code paths in
+\mono{numerical.root\_finder.F90} that we plan to optimize:
+\begin{description}
+\item[\mono{*\_bracket}] hits \mono{rootFinderFindRange} (two endpoint
+  evaluations).
+\item[\mono{*\_bracket\_values}] hits \mono{rootFinderFindRangeValues} (no
+  endpoint evaluations — wrapper cache should be used for both).
+\item[\mono{*\_bracket\_valueLow}] hits \mono{rootFinderFindRangeValueLow}
+  (one endpoint evaluation).
+\item[\mono{*\_guess}] hits \mono{rootFinderFindGuess} (the degenerate
+  bracket case where two redundant endpoint evaluations happen) plus the
+  bracket-expansion \mono{do while} loop.
+\item[\mono{newton}, \mono{steffenson}] exercise the derivative-based
+  callbacks (no wrapper cache).
+\end{description}
+
+A running checksum of the returned roots is accumulated across every call
+and printed at the end so the compiler cannot dead-code-eliminate the work.
+!!}
+
+program Benchmark_Numerical_Root_Finder
+  use, intrinsic :: ISO_Fortran_Env             , only : output_unit
+  use            :: Benchmark_Utilities         , only : Benchmark_Report             , Benchmark_Seed_RNG           , &
+       &                                                 Benchmark_Sink_Add           , Benchmark_Sink_Print
+  use            :: Benchmark_Root_Finder_Functions, only : bmShift                   , fQuad                        , &
+       &                                                    fQuadDerivative           , fQuadBoth                    , &
+       &                                                    fFar
+  use            :: Display                     , only : displayVerbositySet          , verbosityLevelStandard
+  use            :: Kind_Numbers                , only : kind_int8
+  use            :: Root_Finder                 , only : rootFinder                                                  , &
+       &                                                 gsl_root_fsolver_brent       , gsl_root_fsolver_bisection   , &
+       &                                                 gsl_root_fsolver_falsepos    , gsl_root_fdfsolver_newton    , &
+       &                                                 gsl_root_fdfsolver_steffenson                               , &
+       &                                                 rangeExpandMultiplicative    , rangeExpandAdditive          , &
+       &                                                 rangeExpandSignExpectNegative, rangeExpandSignExpectPositive, &
+       &                                                 enumerationRangeExpandType
+  implicit none
+
+  ! Benchmark control.
+  integer        , parameter :: trialCount   =  100      ! Outer trials over which we report mean and standard error.
+  integer        , parameter :: warmupTrials =    2      ! Trials dropped to absorb cache / branch-predictor / lazy-init warmup.
+  integer        , parameter :: innerCount   = 1000      ! find() calls per trial — heavier than a single interp() so we use fewer.
+  integer        , parameter :: shiftCount   = 4096      ! Size of the precomputed shift array (power of 2 for cheap masking).
+  integer        , parameter :: shiftMask    = shiftCount-1
+
+  double precision, dimension(0:shiftCount-1) :: shifts_
+
+  call displayVerbositySet(verbosityLevelStandard)
+
+  write (output_unit,'(a,i0,a,i0,a,i0,a)') '# Benchmark configuration: trialCount=',trialCount, &
+       &                                   ' innerCount=',innerCount,' warmupTrials=',warmupTrials,' (dropped)'
+
+  call buildShifts()
+
+  ! Bracketed entry points — root well inside the bracket, no expansion.
+  call benchmarkBracket        (gsl_root_fsolver_brent    ,id="rootFinder_brent_bracket"           ,description="Brent solver, bracket given"                            )
+  call benchmarkBracketValues  (gsl_root_fsolver_brent    ,id="rootFinder_brent_bracket_values"    ,description="Brent solver, bracket + both f-values given"           )
+  call benchmarkBracketValueLow(gsl_root_fsolver_brent    ,id="rootFinder_brent_bracket_valueLow"  ,description="Brent solver, bracket + f(lower) given"                 )
+  call benchmarkBracket        (gsl_root_fsolver_bisection,id="rootFinder_bisection_bracket"       ,description="Bisection solver, bracket given"                        )
+  call benchmarkBracket        (gsl_root_fsolver_falsepos ,id="rootFinder_falsepos_bracket"        ,description="False-position solver, bracket given"                   )
+
+  ! Guess entry point with bracket expansion (root well outside the initial guess).
+  call benchmarkGuessExpand    (rangeExpandMultiplicative ,id="rootFinder_brent_guess_multExpand"  ,description="Brent solver, single guess + multiplicative expansion"  )
+  call benchmarkGuessExpand    (rangeExpandAdditive       ,id="rootFinder_brent_guess_addExpand"   ,description="Brent solver, single guess + additive expansion"        )
+
+  ! Derivative-based solvers (no wrapper cache; exercises gsl_root_fdfsolver path).
+  call benchmarkDerivative     (gsl_root_fdfsolver_newton    ,id="rootFinder_newton_guess"         ,description="Newton solver, single guess"                            )
+  call benchmarkDerivative     (gsl_root_fdfsolver_steffenson,id="rootFinder_steffenson_guess"     ,description="Steffenson solver, single guess"                        )
+
+  ! Make the accumulated checksum externally observable so the optimizer
+  ! cannot elide the benchmark.
+  call Benchmark_Sink_Print()
+
+contains
+
+  subroutine buildShifts()
+    !!{
+    Build a deterministic array of per-call shifts in $[-0.4,0.4]$ used to
+    perturb the root location on every call.
+    !!}
+    integer :: i
+
+    call Benchmark_Seed_RNG()
+    call random_number(shifts_)
+    do i=0,shiftCount-1
+       shifts_(i)=0.8d0*shifts_(i)-0.4d0
+    end do
+    return
+  end subroutine buildShifts
+
+  subroutine benchmarkBracket(solverType,id,description)
+    !!{
+    Time \mono{find(rootRange)} on a bracket that already contains the root.
+    Each call evaluates the user function at both bracket endpoints
+    (\mono{rootFinderFindRange}) and then iterates the GSL solver to
+    convergence.
+    !!}
+    integer                         , intent(in   )                      :: solverType
+    character       (len=*         ), intent(in   )                      :: id        , description
+    type            (rootFinder    )                                     :: finder_
+    integer         (kind=kind_int8)                                     :: countStart, countEnd
+    integer         (kind=kind_int8)             , dimension(trialCount) :: trialTime
+    integer                                                              :: trial     , i
+    double precision                                                     :: acc       , root
+    double precision                             , dimension(2)          :: bracket
+
+    finder_=rootFinder(                                  &
+         &             rootFunction     =fQuad         , &
+         &             solverType       =solverType    , &
+         &             toleranceAbsolute=0.0d0         , &
+         &             toleranceRelative=1.0d-7         &
+         &            )
+    bracket=[0.0d0,3.0d0]
+
+    ! Warm: trigger lazy GSL allocation / first-touch caches.
+    bmShift=shifts_(0)
+    root   =finder_%find(rootRange=bracket)
+    call Benchmark_Sink_Add(root)
+
+    do trial=1,trialCount
+       acc=0.0d0
+       call System_Clock(countStart)
+       do i=0,innerCount-1
+          bmShift=shifts_(iand(i,shiftMask))
+          root   =finder_%find(rootRange=bracket)
+          acc    =acc+root
+       end do
+       call System_Clock(countEnd)
+       trialTime(trial)=countEnd-countStart
+       call Benchmark_Sink_Add(acc)
+    end do
+    call Benchmark_Report('numericalRootFinder',id,description,trialTime, &
+         &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
+    return
+  end subroutine benchmarkBracket
+
+  subroutine benchmarkBracketValues(solverType,id,description)
+    !!{
+    Time \mono{find(rootRange,rootRangeValues)} where both endpoint function
+    values are precomputed by the caller. Hits the
+    \mono{rootFinderFindRangeValues} entry point and avoids any duplicate
+    evaluation of the user function at the bracket ends. The wrapper's cache
+    of endpoint values should also be used by the first two GSL calls.
+    !!}
+    integer                         , intent(in   )                      :: solverType
+    character       (len=*         ), intent(in   )                      :: id        , description
+    type            (rootFinder    )                                     :: finder_
+    integer         (kind=kind_int8)                                     :: countStart, countEnd
+    integer         (kind=kind_int8)             , dimension(trialCount) :: trialTime
+    integer                                                              :: trial     , i
+    double precision                                                     :: acc       , root
+    double precision                             , dimension(2)          :: bracket   , bracketValues
+
+    finder_=rootFinder(                                  &
+         &             rootFunction     =fQuad         , &
+         &             solverType       =solverType    , &
+         &             toleranceAbsolute=0.0d0         , &
+         &             toleranceRelative=1.0d-7         &
+         &            )
+    bracket=[0.0d0,3.0d0]
+
+    bmShift         =shifts_(0)
+    bracketValues(1)=fQuad(bracket(1))
+    bracketValues(2)=fQuad(bracket(2))
+    root            =finder_%find(rootRange=bracket,rootRangeValues=bracketValues)
+    call Benchmark_Sink_Add(root)
+
+    do trial=1,trialCount
+       acc=0.0d0
+       call System_Clock(countStart)
+       do i=0,innerCount-1
+          bmShift         =shifts_(iand(i,shiftMask))
+          bracketValues(1)=fQuad(bracket(1))
+          bracketValues(2)=fQuad(bracket(2))
+          root            =finder_%find(rootRange=bracket,rootRangeValues=bracketValues)
+          acc             =acc+root
+       end do
+       call System_Clock(countEnd)
+       trialTime(trial)=countEnd-countStart
+       call Benchmark_Sink_Add(acc)
+    end do
+    call Benchmark_Report('numericalRootFinder',id,description,trialTime, &
+         &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
+    return
+  end subroutine benchmarkBracketValues
+
+  subroutine benchmarkBracketValueLow(solverType,id,description)
+    !!{
+    Time \mono{findWithFLower(rootRange,fLower)}. Hits
+    \mono{rootFinderFindRangeValueLow}, which evaluates the user function at
+    only the upper bracket endpoint.
+    !!}
+    integer                         , intent(in   )                      :: solverType
+    character       (len=*         ), intent(in   )                      :: id        , description
+    type            (rootFinder    )                                     :: finder_
+    integer         (kind=kind_int8)                                     :: countStart, countEnd
+    integer         (kind=kind_int8)             , dimension(trialCount) :: trialTime
+    integer                                                              :: trial     , i
+    double precision                                                     :: acc       , root  , &
+         &                                                                  fLower
+    double precision                             , dimension(2)          :: bracket
+
+    finder_=rootFinder(                                  &
+         &             rootFunction     =fQuad         , &
+         &             solverType       =solverType    , &
+         &             toleranceAbsolute=0.0d0         , &
+         &             toleranceRelative=1.0d-7         &
+         &            )
+    bracket=[0.0d0,3.0d0]
+
+    bmShift=shifts_(0)
+    fLower =fQuad(bracket(1))
+    root   =finder_%findWithFLower(rootRange=bracket,rootRangeValueLow=fLower)
+    call Benchmark_Sink_Add(root)
+
+    do trial=1,trialCount
+       acc=0.0d0
+       call System_Clock(countStart)
+       do i=0,innerCount-1
+          bmShift=shifts_(iand(i,shiftMask))
+          fLower =fQuad(bracket(1))
+          root   =finder_%findWithFLower(rootRange=bracket,rootRangeValueLow=fLower)
+          acc    =acc+root
+       end do
+       call System_Clock(countEnd)
+       trialTime(trial)=countEnd-countStart
+       call Benchmark_Sink_Add(acc)
+    end do
+    call Benchmark_Report('numericalRootFinder',id,description,trialTime, &
+         &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
+    return
+  end subroutine benchmarkBracketValueLow
+
+  subroutine benchmarkGuessExpand(expandType,id,description)
+    !!{
+    Time \mono{find(rootGuess)} on a function whose root sits well above the
+    initial guess, forcing the bracket-expansion loop in
+    \mono{rootFinderFind} to run. With \mono{rangeExpandMultiplicative} and
+    \mono{rangeExpandUpward}=2 the upper bracket doubles from 0.5 until it
+    crosses the root near 10 ($\sim$5 expansion steps). With
+    \mono{rangeExpandAdditive} and \mono{rangeExpandUpward}=2 the upper
+    bracket grows by 2 each step.
+    !!}
+    type            (enumerationRangeExpandType), intent(in   )            :: expandType
+    character       (len=*                     ), intent(in   )            :: id        , description
+    type            (rootFinder                )                           :: finder_
+    integer         (kind=kind_int8            )                           :: countStart, countEnd
+    integer         (kind=kind_int8            ), dimension(trialCount)    :: trialTime
+    integer                                                                :: trial     , i
+    double precision                                                       :: acc       , root
+
+    finder_=rootFinder(                                                          &
+         &             rootFunction                 =fFar                      , &
+         &             solverType                   =gsl_root_fsolver_brent    , &
+         &             toleranceAbsolute            =0.0d0                     , &
+         &             toleranceRelative            =1.0d-7                    , &
+         &             rangeExpandType              =expandType                , &
+         &             rangeExpandUpward            =2.0d0                     , &
+         &             rangeExpandDownward          =1.0d0                     , &
+         &             rangeExpandUpwardSignExpect  =rangeExpandSignExpectPositive, &
+         &             rangeExpandDownwardSignExpect=rangeExpandSignExpectNegative  &
+         &            )
+
+    bmShift=shifts_(0)
+    root   =finder_%find(rootGuess=0.5d0)
+    call Benchmark_Sink_Add(root)
+
+    do trial=1,trialCount
+       acc=0.0d0
+       call System_Clock(countStart)
+       do i=0,innerCount-1
+          bmShift=shifts_(iand(i,shiftMask))
+          root   =finder_%find(rootGuess=0.5d0)
+          acc    =acc+root
+       end do
+       call System_Clock(countEnd)
+       trialTime(trial)=countEnd-countStart
+       call Benchmark_Sink_Add(acc)
+    end do
+    call Benchmark_Report('numericalRootFinder',id,description,trialTime, &
+         &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
+    return
+  end subroutine benchmarkGuessExpand
+
+  subroutine benchmarkDerivative(solverType,id,description)
+    !!{
+    Time \mono{find(rootGuess)} with a derivative-based GSL solver. Both
+    the value-only and value+derivative callbacks are exercised; the
+    wrapper does \emph{not} cache endpoint values in this path.
+    !!}
+    integer                         , intent(in   )                      :: solverType
+    character       (len=*         ), intent(in   )                      :: id        , description
+    type            (rootFinder    )                                     :: finder_
+    integer         (kind=kind_int8)                                     :: countStart, countEnd
+    integer         (kind=kind_int8)             , dimension(trialCount) :: trialTime
+    integer                                                              :: trial     , i
+    double precision                                                     :: acc       , root
+
+    finder_=rootFinder(                                          &
+         &             rootFunction          =fQuad            , &
+         &             rootFunctionDerivative=fQuadDerivative  , &
+         &             rootFunctionBoth      =fQuadBoth        , &
+         &             solverType            =solverType       , &
+         &             toleranceAbsolute     =0.0d0            , &
+         &             toleranceRelative     =1.0d-7             &
+         &            )
+
+    bmShift=shifts_(0)
+    root   =finder_%find(rootGuess=2.0d0)
+    call Benchmark_Sink_Add(root)
+
+    do trial=1,trialCount
+       acc=0.0d0
+       call System_Clock(countStart)
+       do i=0,innerCount-1
+          bmShift=shifts_(iand(i,shiftMask))
+          root   =finder_%find(rootGuess=2.0d0)
+          acc    =acc+root
+       end do
+       call System_Clock(countEnd)
+       trialTime(trial)=countEnd-countStart
+       call Benchmark_Sink_Add(acc)
+    end do
+    call Benchmark_Report('numericalRootFinder',id,description,trialTime, &
+         &                warmupTrials=warmupTrials,innerCount=innerCount,unitsLabel='ns/call')
+    return
+  end subroutine benchmarkDerivative
+
+end program Benchmark_Numerical_Root_Finder

--- a/source/benchmarks.numerical.root_finder.F90
+++ b/source/benchmarks.numerical.root_finder.F90
@@ -18,103 +18,22 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Module providing root-callback functions and shared state for the rootFinder
-benchmark program. Kept separate from the program unit so the callbacks can be
-passed as procedure(...) actual arguments to \refClass{rootFinder} without
-running into Fortran restrictions on procedure pointers to internal procedures.
-!!}
-
-module Benchmark_Root_Finder_Functions
-  !!{
-  Callbacks and shared state for the \refClass{rootFinder} benchmark.
-
-  The functions read a single module-level shift, \mono{bmShift}, which is
-  rewritten by the benchmark driver before every call. This perturbs the
-  problem (so the optimizer cannot constant-fold the solver chain) and keeps
-  the cache state of \mono{rootFinder}'s wrapper realistic from one call to
-  the next.
-  !!}
-  implicit none
-  private
-  public :: bmShift, fQuad, fQuadDerivative, fQuadBoth, fFar
-
-  ! Module-level shift consumed by every callback. Updated by the benchmark
-  ! driver immediately before each find() invocation.
-  double precision, save :: bmShift=0.0d0
-
-contains
-
-  double precision function fQuad(x)
-    !!{
-    Quadratic with a single root in the interval $[0,3]$.
-
-    $f(x) = (x - (\mathrm{bmShift}+1))(x + 5)$ has roots at $x=\mathrm{bmShift}+1$
-    and $x=-5$. With $\mathrm{bmShift} \in [-0.4,0.4]$ the in-bracket root sits
-    in $[0.6,1.4]$.
-    !!}
-    double precision, intent(in   ) :: x
-
-    fQuad=(x-(bmShift+1.0d0))*(x+5.0d0)
-    return
-  end function fQuad
-
-  double precision function fQuadDerivative(x)
-    !!{
-    Derivative of \mono{fQuad}.
-    !!}
-    double precision, intent(in   ) :: x
-
-    fQuadDerivative=2.0d0*x+5.0d0-(bmShift+1.0d0)
-    return
-  end function fQuadDerivative
-
-  subroutine fQuadBoth(x,f,df)
-    !!{
-    Combined value and derivative of \mono{fQuad}.
-    !!}
-    double precision, intent(in   ) :: x
-    double precision, intent(  out) :: f, df
-
-    f =(x-(bmShift+1.0d0))*(x+5.0d0)
-    df=2.0d0*x+5.0d0-(bmShift+1.0d0)
-    return
-  end subroutine fQuadBoth
-
-  double precision function fFar(x)
-    !!{
-    Linear function with its root far above a typical initial guess.
-
-    $f(x) = x - (\mathrm{bmShift}+10)$. With $\mathrm{bmShift} \in [-0.4,0.4]$
-    the root lies in $[9.6,10.4]$. Used in expansion benchmarks where the
-    initial bracket/guess is intentionally below the root so the bracket
-    expansion loop is exercised.
-    !!}
-    double precision, intent(in   ) :: x
-
-    fFar=x-(bmShift+10.0d0)
-    return
-  end function fFar
-
-end module Benchmark_Root_Finder_Functions
-
-
-!!{
 Contains a program to benchmark the \refClass{rootFinder} class.
 
-Each scenario constructs a rootFinder configured for a particular solver type
+Each scenario constructs a \mono{rootFinder} configured for a particular solver type
 and entry point. A precomputed deterministic array of per-call shifts perturbs
 the underlying function on every call so the optimizer cannot constant-fold
 the solver chain and the wrapper's endpoint-value cache sees realistic
-turnover. An inner loop of many find() calls per timed trial amortizes
+turnover. An inner loop of many \mono{find()} calls per timed trial amortizes
 \mono{System\_Clock} resolution.
 
 The scenarios are intentionally aligned with code paths in
-\mono{numerical.root\_finder.F90} that we plan to optimize:
+\mono{numerical.root\_finder.F90}:
 \begin{description}
 \item[\mono{*\_bracket}] hits \mono{rootFinderFindRange} (two endpoint
   evaluations).
 \item[\mono{*\_bracket\_values}] hits \mono{rootFinderFindRangeValues} (no
-  endpoint evaluations — wrapper cache should be used for both).
+  endpoint evaluations---wrapper cache should be used for both).
 \item[\mono{*\_bracket\_valueLow}] hits \mono{rootFinderFindRangeValueLow}
   (one endpoint evaluation).
 \item[\mono{*\_guess}] hits \mono{rootFinderFindGuess} (the degenerate
@@ -129,29 +48,29 @@ and printed at the end so the compiler cannot dead-code-eliminate the work.
 !!}
 
 program Benchmark_Numerical_Root_Finder
-  use, intrinsic :: ISO_Fortran_Env             , only : output_unit
-  use            :: Benchmark_Utilities         , only : Benchmark_Report             , Benchmark_Seed_RNG           , &
-       &                                                 Benchmark_Sink_Add           , Benchmark_Sink_Print
-  use            :: Benchmark_Root_Finder_Functions, only : bmShift                   , fQuad                        , &
-       &                                                    fQuadDerivative           , fQuadBoth                    , &
+  use, intrinsic :: ISO_Fortran_Env                , only : output_unit
+  use            :: Benchmark_Utilities            , only : Benchmark_Report             , Benchmark_Seed_RNG           , &
+       &                                                    Benchmark_Sink_Add           , Benchmark_Sink_Print
+  use            :: Benchmark_Root_Finder_Functions, only : bmShift                      , fQuad                        , &
+       &                                                    fQuadDerivative              , fQuadBoth                    , &
        &                                                    fFar
-  use            :: Display                     , only : displayVerbositySet          , verbosityLevelStandard
-  use            :: Kind_Numbers                , only : kind_int8
-  use            :: Root_Finder                 , only : rootFinder                                                  , &
-       &                                                 gsl_root_fsolver_brent       , gsl_root_fsolver_bisection   , &
-       &                                                 gsl_root_fsolver_falsepos    , gsl_root_fdfsolver_newton    , &
-       &                                                 gsl_root_fdfsolver_steffenson                               , &
-       &                                                 rangeExpandMultiplicative    , rangeExpandAdditive          , &
-       &                                                 rangeExpandSignExpectNegative, rangeExpandSignExpectPositive, &
-       &                                                 enumerationRangeExpandType   , stoppingCriterionDelta
+  use            :: Display                        , only : displayVerbositySet          , verbosityLevelStandard
+  use            :: Kind_Numbers                   , only : kind_int8
+  use            :: Root_Finder                    , only : rootFinder                                                  , &
+       &                                                    gsl_root_fsolver_brent       , gsl_root_fsolver_bisection   , &
+       &                                                    gsl_root_fsolver_falsepos    , gsl_root_fdfsolver_newton    , &
+       &                                                    gsl_root_fdfsolver_steffenson                               , &
+       &                                                    rangeExpandMultiplicative    , rangeExpandAdditive          , &
+       &                                                    rangeExpandSignExpectNegative, rangeExpandSignExpectPositive, &
+       &                                                    enumerationRangeExpandType   , stoppingCriterionDelta
   implicit none
 
   ! Benchmark control.
-  integer        , parameter :: trialCount   =  100      ! Outer trials over which we report mean and standard error.
-  integer        , parameter :: warmupTrials =    2      ! Trials dropped to absorb cache / branch-predictor / lazy-init warmup.
-  integer        , parameter :: innerCount   = 1000      ! find() calls per trial — heavier than a single interp() so we use fewer.
-  integer        , parameter :: shiftCount   = 4096      ! Size of the precomputed shift array (power of 2 for cheap masking).
-  integer        , parameter :: shiftMask    = shiftCount-1
+  integer         , parameter                 :: trialCount   =  100      ! Outer trials over which we report mean and standard error.
+  integer         , parameter                 :: warmupTrials =    2      ! Trials dropped to absorb cache / branch-predictor / lazy-init warmup.
+  integer         , parameter                 :: innerCount   = 1000      ! find() calls per trial — heavier than a single interp() so we use fewer.
+  integer         , parameter                 :: shiftCount   = 4096      ! Size of the precomputed shift array (power of 2 for cheap masking).
+  integer         , parameter                 :: shiftMask    = shiftCount-1
 
   double precision, dimension(0:shiftCount-1) :: shifts_
 
@@ -163,19 +82,19 @@ program Benchmark_Numerical_Root_Finder
   call buildShifts()
 
   ! Bracketed entry points — root well inside the bracket, no expansion.
-  call benchmarkBracket        (gsl_root_fsolver_brent    ,id="rootFinder_brent_bracket"           ,description="Brent solver, bracket given"                            )
-  call benchmarkBracketValues  (gsl_root_fsolver_brent    ,id="rootFinder_brent_bracket_values"    ,description="Brent solver, bracket + both f-values given"           )
-  call benchmarkBracketValueLow(gsl_root_fsolver_brent    ,id="rootFinder_brent_bracket_valueLow"  ,description="Brent solver, bracket + f(lower) given"                 )
-  call benchmarkBracket        (gsl_root_fsolver_bisection,id="rootFinder_bisection_bracket"       ,description="Bisection solver, bracket given"                        )
-  call benchmarkBracket        (gsl_root_fsolver_falsepos ,id="rootFinder_falsepos_bracket"        ,description="False-position solver, bracket given"                   )
+  call benchmarkBracket        (gsl_root_fsolver_brent       ,id="rootFinder_brent_bracket"         ,description="Brent solver, bracket given"                          )
+  call benchmarkBracketValues  (gsl_root_fsolver_brent       ,id="rootFinder_brent_bracket_values"  ,description="Brent solver, bracket + both f-values given"          )
+  call benchmarkBracketValueLow(gsl_root_fsolver_brent       ,id="rootFinder_brent_bracket_valueLow",description="Brent solver, bracket + f(lower) given"               )
+  call benchmarkBracket        (gsl_root_fsolver_bisection   ,id="rootFinder_bisection_bracket"     ,description="Bisection solver, bracket given"                      )
+  call benchmarkBracket        (gsl_root_fsolver_falsepos    ,id="rootFinder_falsepos_bracket"      ,description="False-position solver, bracket given"                 )
 
   ! Guess entry point with bracket expansion (root well outside the initial guess).
-  call benchmarkGuessExpand    (rangeExpandMultiplicative ,id="rootFinder_brent_guess_multExpand"  ,description="Brent solver, single guess + multiplicative expansion"  )
-  call benchmarkGuessExpand    (rangeExpandAdditive       ,id="rootFinder_brent_guess_addExpand"   ,description="Brent solver, single guess + additive expansion"        )
+  call benchmarkGuessExpand    (rangeExpandMultiplicative    ,id="rootFinder_brent_guess_multExpand",description="Brent solver, single guess + multiplicative expansion")
+  call benchmarkGuessExpand    (rangeExpandAdditive          ,id="rootFinder_brent_guess_addExpand" ,description="Brent solver, single guess + additive expansion"      )
 
   ! Derivative-based solvers (no wrapper cache; exercises gsl_root_fdfsolver path).
-  call benchmarkDerivative     (gsl_root_fdfsolver_newton    ,id="rootFinder_newton_guess"         ,description="Newton solver, single guess"                            )
-  call benchmarkDerivative     (gsl_root_fdfsolver_steffenson,id="rootFinder_steffenson_guess"     ,description="Steffenson solver, single guess"                        )
+  call benchmarkDerivative     (gsl_root_fdfsolver_newton    ,id="rootFinder_newton_guess"          ,description="Newton solver, single guess"                          )
+  call benchmarkDerivative     (gsl_root_fdfsolver_steffenson,id="rootFinder_steffenson_guess"      ,description="Steffenson solver, single guess"                      )
 
   ! Make the accumulated checksum externally observable so the optimizer
   ! cannot elide the benchmark.
@@ -214,11 +133,11 @@ contains
     double precision                                                     :: acc       , root
     double precision                             , dimension(2)          :: bracket
 
-    finder_=rootFinder(                                  &
-         &             rootFunction     =fQuad         , &
-         &             solverType       =solverType    , &
-         &             toleranceAbsolute=0.0d0         , &
-         &             toleranceRelative=1.0d-7         &
+    finder_=rootFinder(                              &
+         &             rootFunction     =fQuad     , &
+         &             solverType       =solverType, &
+         &             toleranceAbsolute=0.0d0     , &
+         &             toleranceRelative=1.0d-7      &
          &            )
     bracket=[0.0d0,3.0d0]
 
@@ -261,11 +180,11 @@ contains
     double precision                                                     :: acc       , root
     double precision                             , dimension(2)          :: bracket   , bracketValues
 
-    finder_=rootFinder(                                  &
-         &             rootFunction     =fQuad         , &
-         &             solverType       =solverType    , &
-         &             toleranceAbsolute=0.0d0         , &
-         &             toleranceRelative=1.0d-7         &
+    finder_=rootFinder(                              &
+         &             rootFunction     =fQuad     , &
+         &             solverType       =solverType, &
+         &             toleranceAbsolute=0.0d0     , &
+         &             toleranceRelative=1.0d-7      &
          &            )
     bracket=[0.0d0,3.0d0]
 
@@ -306,15 +225,15 @@ contains
     integer         (kind=kind_int8)                                     :: countStart, countEnd
     integer         (kind=kind_int8)             , dimension(trialCount) :: trialTime
     integer                                                              :: trial     , i
-    double precision                                                     :: acc       , root  , &
+    double precision                                                     :: acc       , root       , &
          &                                                                  fLower
     double precision                             , dimension(2)          :: bracket
 
-    finder_=rootFinder(                                  &
-         &             rootFunction     =fQuad         , &
-         &             solverType       =solverType    , &
-         &             toleranceAbsolute=0.0d0         , &
-         &             toleranceRelative=1.0d-7         &
+    finder_=rootFinder(                              &
+         &             rootFunction     =fQuad     , &
+         &             solverType       =solverType, &
+         &             toleranceAbsolute=0.0d0     , &
+         &             toleranceRelative=1.0d-7      &
          &            )
     bracket=[0.0d0,3.0d0]
 
@@ -351,22 +270,22 @@ contains
     \mono{rangeExpandAdditive} and \mono{rangeExpandUpward}=2 the upper
     bracket grows by 2 each step.
     !!}
-    type            (enumerationRangeExpandType), intent(in   )            :: expandType
-    character       (len=*                     ), intent(in   )            :: id        , description
-    type            (rootFinder                )                           :: finder_
-    integer         (kind=kind_int8            )                           :: countStart, countEnd
-    integer         (kind=kind_int8            ), dimension(trialCount)    :: trialTime
-    integer                                                                :: trial     , i
-    double precision                                                       :: acc       , root
+    type            (enumerationRangeExpandType), intent(in   )         :: expandType
+    character       (len=*                     ), intent(in   )         :: id        , description
+    type            (rootFinder                )                        :: finder_
+    integer         (kind=kind_int8            )                        :: countStart, countEnd
+    integer         (kind=kind_int8            ), dimension(trialCount) :: trialTime
+    integer                                                             :: trial     , i
+    double precision                                                    :: acc       , root
 
-    finder_=rootFinder(                                                          &
-         &             rootFunction                 =fFar                      , &
-         &             solverType                   =gsl_root_fsolver_brent    , &
-         &             toleranceAbsolute            =0.0d0                     , &
-         &             toleranceRelative            =1.0d-7                    , &
-         &             rangeExpandType              =expandType                , &
-         &             rangeExpandUpward            =2.0d0                     , &
-         &             rangeExpandDownward          =1.0d0                     , &
+    finder_=rootFinder(                                                             &
+         &             rootFunction                 =fFar                         , &
+         &             solverType                   =gsl_root_fsolver_brent       , &
+         &             toleranceAbsolute            =0.0d0                        , &
+         &             toleranceRelative            =1.0d-7                       , &
+         &             rangeExpandType              =expandType                   , &
+         &             rangeExpandUpward            =2.0d0                        , &
+         &             rangeExpandDownward          =1.0d0                        , &
          &             rangeExpandUpwardSignExpect  =rangeExpandSignExpectPositive, &
          &             rangeExpandDownwardSignExpect=rangeExpandSignExpectNegative  &
          &            )
@@ -406,14 +325,14 @@ contains
     integer                                                              :: trial     , i
     double precision                                                     :: acc       , root
 
-    finder_=rootFinder(                                          &
-         &             rootFunction          =fQuad            , &
-         &             rootFunctionDerivative=fQuadDerivative  , &
-         &             rootFunctionBoth      =fQuadBoth        , &
-         &             solverType            =solverType       , &
-         &             toleranceAbsolute     =0.0d0            , &
-         &             toleranceRelative     =1.0d-7           , &
-         &             stoppingCriterion     =stoppingCriterionDelta &
+    finder_=rootFinder(                                               &
+         &             rootFunction          =fQuad                 , &
+         &             rootFunctionDerivative=fQuadDerivative       , &
+         &             rootFunctionBoth      =fQuadBoth             , &
+         &             solverType            =solverType            , &
+         &             toleranceAbsolute     =0.0d0                 , &
+         &             toleranceRelative     =1.0d-7                , &
+         &             stoppingCriterion     =stoppingCriterionDelta  &
          &            )
 
     bmShift=shifts_(0)

--- a/source/benchmarks.numerical.root_finder.functions.F90
+++ b/source/benchmarks.numerical.root_finder.functions.F90
@@ -1,0 +1,99 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{
+Module providing root-callback functions and shared state for the \mono{rootFinder}
+benchmark program. Kept separate from the program unit so the callbacks can be
+passed as \mono{procedure(...)} actual arguments to \refClass{rootFinder} without
+running into Fortran restrictions on procedure pointers to internal procedures.
+!!}
+
+module Benchmark_Root_Finder_Functions
+  !!{
+  Callbacks and shared state for the \refClass{rootFinder} benchmark.
+
+  The functions read a single module-level shift, \mono{bmShift}, which is
+  rewritten by the benchmark driver before every call. This perturbs the
+  problem (so the optimizer cannot constant-fold the solver chain) and keeps
+  the cache state of \mono{rootFinder}'s wrapper realistic from one call to
+  the next.
+  !!}
+  implicit none
+  private
+  public :: bmShift, fQuad, fQuadDerivative, fQuadBoth, &
+       &    fFar
+
+  ! Module-level shift consumed by every callback. Updated by the benchmark
+  ! driver immediately before each find() invocation.
+  double precision, save :: bmShift=0.0d0
+
+contains
+
+  double precision function fQuad(x)
+    !!{
+    Quadratic with a single root in the interval $[0,3]$.
+
+    $f(x) = (x - (\mathrm{bmShift}+1))(x + 5)$ has roots at $x=\mathrm{bmShift}+1$
+    and $x=-5$. With $\mathrm{bmShift} \in [-0.4,0.4]$ the in-bracket root sits
+    in $[0.6,1.4]$.
+    !!}
+    double precision, intent(in   ) :: x
+
+    fQuad=(x-(bmShift+1.0d0))*(x+5.0d0)
+    return
+  end function fQuad
+
+  double precision function fQuadDerivative(x)
+    !!{
+    Derivative of \mono{fQuad}.
+    !!}
+    double precision, intent(in   ) :: x
+
+    fQuadDerivative=2.0d0*x+5.0d0-(bmShift+1.0d0)
+    return
+  end function fQuadDerivative
+
+  subroutine fQuadBoth(x,f,df)
+    !!{
+    Combined value and derivative of \mono{fQuad}.
+    !!}
+    double precision, intent(in   ) :: x
+    double precision, intent(  out) :: f, df
+
+    f =(x-(bmShift+1.0d0))*(x+5.0d0)
+    df=2.0d0*x+5.0d0-(bmShift+1.0d0)
+    return
+  end subroutine fQuadBoth
+
+  double precision function fFar(x)
+    !!{
+    Linear function with its root far above a typical initial guess.
+
+    $f(x) = x - (\mathrm{bmShift}+10)$. With $\mathrm{bmShift} \in [-0.4,0.4]$
+    the root lies in $[9.6,10.4]$. Used in expansion benchmarks where the
+    initial bracket/guess is intentionally below the root so the bracket
+    expansion loop is exercised.
+    !!}
+    double precision, intent(in   ) :: x
+
+    fFar=x-(bmShift+10.0d0)
+    return
+  end function fFar
+
+end module Benchmark_Root_Finder_Functions

--- a/source/numerical.root_finder.F90
+++ b/source/numerical.root_finder.F90
@@ -207,6 +207,15 @@ module Root_Finder
   ! List of currently active root finders. 'currentFinder' is a hot-path
   ! pointer into 'currentFinders' at the active depth; the GSL wrappers
   ! follow it on every callback instead of indexing the array each time.
+  !
+  ! Lifetime invariant for 'currentFinder': it is (re)bound on entry to
+  ! 'rootFinderFind' AFTER any growth of 'currentFinders' for this frame
+  ! has happened, and rebound by 'popCurrentFinder' from
+  ! 'currentFinders(currentFinderIndex)' on every exit (normal or early)
+  ! so that, after a recursive call that grew the array, the caller's
+  ! pointer is refreshed against the new array before control returns.
+  ! No other code path resizes 'currentFinders', so the pointer cannot
+  ! dangle for a frame that is currently using it.
   integer                                                     :: currentFinderIndex =  0
   type   (rootFinderList), allocatable, dimension(:), target  :: currentFinders
   type   (rootFinderList)                           , pointer :: currentFinder      => null()
@@ -623,6 +632,12 @@ contains
        allocate(currentFinders(findersIncrement))
     end if
     currentFinders(currentFinderIndex)%finder => self
+    ! Bind 'currentFinder' to the (now stable) array slot. Any growth of
+    ! 'currentFinders' for this frame has already happened in the block
+    ! above; no later code path in 'rootFinderFind' resizes the array, so
+    ! this pointer remains valid for the lifetime of this frame except
+    ! across recursive calls — where 'popCurrentFinder' re-derives it
+    ! from the (possibly grown) array before control returns here.
     currentFinder                             => currentFinders(currentFinderIndex)
     ! Initialize the root finder variables if necessary.
     if (self%useDerivative) then
@@ -1059,6 +1074,13 @@ contains
       Decrement the active-finder stack pointer and restore the
       module-level \mono{currentFinder} pointer to the parent's slot
       (or nullify it when the stack is empty).
+
+      The pointer is re-derived from \mono{currentFinders(currentFinderIndex)},
+      not restored from a saved value, so if the array was grown by the
+      child frame this routine is exiting from, the parent's
+      \mono{currentFinder} is rebound against the new array before
+      control returns to the parent. This is what keeps the pointer
+      from dangling across recursive root-finding calls.
       !!}
       implicit none
 

--- a/source/numerical.root_finder.F90
+++ b/source/numerical.root_finder.F90
@@ -597,7 +597,8 @@ contains
     integer                                                                       :: iteration             , statusActual
     double precision                                                              :: xHigh                 , xLow                , xRoot               , &
          &                                                                           xRootPrevious         , fLow                , fHigh               , &
-         &                                                                           fDownwardLimit        , fUpwardLimit
+         &                                                                           fDownwardLimit        , fUpwardLimit                              , &
+         &                                                                           signExpectDown        , signExpectUp
     type            (varying_string      ), save                                  :: message
     !$omp threadprivate(message)
     character       (len= 30             )                                        :: label
@@ -784,24 +785,29 @@ contains
           fHigh=rootRangeValues(2)
        end if
        if (report_) call displayIndent("expanding range")
+       ! Encode the sign expectations as ±1/0 multipliers so the per-iteration test below collapses
+       ! to a single multiply + compare. "Negative" → -1, "positive" → +1, "none" → 0 (which makes
+       ! the product never exceed zero, matching the original .false. result for that case).
+       select case (self%rangeExpandDownwardSignExpect%ID)
+       case (rangeExpandSignExpectNegative%ID)
+          signExpectDown=-1.0d0
+       case (rangeExpandSignExpectPositive%ID)
+          signExpectDown=+1.0d0
+       case default
+          signExpectDown= 0.0d0
+       end select
+       select case (self%rangeExpandUpwardSignExpect%ID)
+       case (rangeExpandSignExpectNegative%ID)
+          signExpectUp  =-1.0d0
+       case (rangeExpandSignExpectPositive%ID)
+          signExpectUp  =+1.0d0
+       case default
+          signExpectUp  = 0.0d0
+       end select
        do while (sign(1.0d0,fLow)*sign(1.0d0,fHigh) > 0.0d0 .and. fLow /= 0.0d0 .and. fHigh /= 0.0d0)
-          rangeChanged=.false.
-          select case (self%rangeExpandDownwardSignExpect%ID)
-          case (rangeExpandSignExpectNegative%ID)
-             rangeLowerAsExpected=(fLow  < 0.0d0)
-          case (rangeExpandSignExpectPositive%ID)
-             rangeLowerAsExpected=(fLow  > 0.0d0)
-          case default
-             rangeLowerAsExpected=.false.
-          end select
-          select case (self%rangeExpandUpwardSignExpect  %ID)
-          case (rangeExpandSignExpectNegative%ID)
-             rangeUpperAsExpected=(fHigh < 0.0d0)
-          case (rangeExpandSignExpectPositive%ID)
-             rangeUpperAsExpected=(fHigh > 0.0d0)
-          case default
-             rangeUpperAsExpected=.false.
-          end select
+          rangeChanged        =.false.
+          rangeLowerAsExpected=(signExpectDown*fLow  > 0.0d0)
+          rangeUpperAsExpected=(signExpectUp  *fHigh > 0.0d0)
           if (report_) call reportState(includeExpectations=.true.)
           select case (self%rangeExpandType%ID)
           case (rangeExpandAdditive      %ID)

--- a/source/numerical.root_finder.F90
+++ b/source/numerical.root_finder.F90
@@ -208,7 +208,7 @@ module Root_Finder
   ! pointer into 'currentFinders' at the active depth; the GSL wrappers
   ! follow it on every callback instead of indexing the array each time.
   integer                                            :: currentFinderIndex=0
-  type   (rootFinderList), allocatable, dimension(:) :: currentFinders
+  type   (rootFinderList), allocatable, dimension(:), target :: currentFinders
   type   (rootFinderList), pointer                   :: currentFinder     =>null()
   !$omp threadprivate(currentFinders,currentFinderIndex,currentFinder)
 

--- a/source/numerical.root_finder.F90
+++ b/source/numerical.root_finder.F90
@@ -204,10 +204,13 @@ module Root_Finder
           &                                   fLowInitial             , fHighInitial
   end type rootFinderList
 
-  ! List of currently active root finders.
+  ! List of currently active root finders. 'currentFinder' is a hot-path
+  ! pointer into 'currentFinders' at the active depth; the GSL wrappers
+  ! follow it on every callback instead of indexing the array each time.
   integer                                            :: currentFinderIndex=0
   type   (rootFinderList), allocatable, dimension(:) :: currentFinders
-  !$omp threadprivate(currentFinders,currentFinderIndex)
+  type   (rootFinderList), pointer                   :: currentFinder     =>null()
+  !$omp threadprivate(currentFinders,currentFinderIndex,currentFinder)
 
   interface
      function gsl_root_fsolver_alloc(T) bind(c,name='gsl_root_fsolver_alloc')
@@ -620,6 +623,7 @@ contains
        allocate(currentFinders(findersIncrement))
     end if
     currentFinders(currentFinderIndex)%finder => self
+    currentFinder                             => currentFinders(currentFinderIndex)
     ! Initialize the root finder variables if necessary.
     if (self%useDerivative) then
        if (.not.self%functionInitialized.or.self%resetRequired) then
@@ -718,7 +722,7 @@ contains
        if (.not.rangeLowerAsExpected) then
           if (present(status)) then
              status            =errorStatusOutOfRange
-             currentFinderIndex=currentFinderIndex-1
+             call popCurrentFinder()
              rootFinderFind    =self%rangeDownwardLimit
              return
           else
@@ -749,7 +753,7 @@ contains
        if (.not.rangeUpperAsExpected) then
           if (present(status)) then
              status            =errorStatusOutOfRange
-             currentFinderIndex=currentFinderIndex-1
+             call popCurrentFinder()
              rootFinderFind    =self%rangeUpwardLimit
              return
           else
@@ -774,8 +778,8 @@ contains
        xRoot       =0.5d0*(xLow+xHigh)
        statusActual=GSL_Root_fdfSolver_Set(self%solver%gsl,self%gslFunction%gsl,xRoot)
     else
-       currentFinders(currentFinderIndex)%lowInitialUsed =.true.
-       currentFinders(currentFinderIndex)%highInitialUsed=.true.
+       currentFinder%lowInitialUsed =.true.
+       currentFinder%highInitialUsed=.true.
        fLow=rootRangeValues(1)
        if (xHigh == xLow) then
           ! If a root guess was used, the initial xHigh will equal xLow, so we can avoid re-evaluating the function here.
@@ -927,7 +931,7 @@ contains
              end if
              if (present(status)) then
                 status=errorStatusOutOfRange
-                currentFinderIndex=currentFinderIndex-1
+                call popCurrentFinder()
                 return
              else
                 fLow =self%finderFunction(xLow )
@@ -966,12 +970,12 @@ contains
        if (report_) call reportState(includeExpectations=.false.)
        if (report_) call displayUnindent("done")
        ! Store the values of the function at the lower and upper extremes of the range.
-       currentFinders(currentFinderIndex)%xLowInitial    =xLow
-       currentFinders(currentFinderIndex)%xHighInitial   =xHigh
-       currentFinders(currentFinderIndex)%fLowInitial    =fLow
-       currentFinders(currentFinderIndex)%fHighInitial   =fHigh
-       currentFinders(currentFinderIndex)%lowInitialUsed =.false.
-       currentFinders(currentFinderIndex)%highInitialUsed=.false.
+       currentFinder%xLowInitial    =xLow
+       currentFinder%xHighInitial   =xHigh
+       currentFinder%fLowInitial    =fLow
+       currentFinder%fHighInitial   =fHigh
+       currentFinder%lowInitialUsed =.false.
+       currentFinder%highInitialUsed=.false.
        ! Set the initial range for the solver.
        statusActual=GSL_Root_fSolver_Set(self%solver%gsl,self%gslFunction%gsl,xLow,xHigh)
     end if
@@ -1043,12 +1047,29 @@ contains
     ! Reset error handler.
     if (present(status)) call GSL_Error_Handler_Abort_On()
     ! Restore state.
-    currentFinderIndex=currentFinderIndex-1
+    call popCurrentFinder()
     ! Finish reporting.
     if (report_) call displayUnindent("done")
     return
 
   contains
+
+    subroutine popCurrentFinder()
+      !!{
+      Decrement the active-finder stack pointer and restore the
+      module-level \mono{currentFinder} pointer to the parent's slot
+      (or nullify it when the stack is empty).
+      !!}
+      implicit none
+
+      currentFinderIndex=currentFinderIndex-1
+      if (currentFinderIndex > 0) then
+         currentFinder => currentFinders(currentFinderIndex)
+      else
+         currentFinder => null()
+      end if
+      return
+    end subroutine popCurrentFinder
 
     subroutine reportState(includeExpectations)
       !!{
@@ -1265,15 +1286,15 @@ contains
     real(c_double)                       :: rootFunctionWrapper
 
     ! Attempt to use previously computed solutions if possible.
-    if      (.not.currentFinders(currentFinderIndex)%lowInitialUsed  .and. x == currentFinders(currentFinderIndex)%xLowInitial ) then
-       rootFunctionWrapper=currentFinders(currentFinderIndex)%fLowInitial
-       currentFinders(currentFinderIndex)%lowInitialUsed =.true.
-    else if (.not.currentFinders(currentFinderIndex)%highInitialUsed .and. x == currentFinders(currentFinderIndex)%xHighInitial) then
-       rootFunctionWrapper=currentFinders(currentFinderIndex)%fHighInitial
-       currentFinders(currentFinderIndex)%highInitialUsed=.true.
+    if      (.not.currentFinder%lowInitialUsed  .and. x == currentFinder%xLowInitial ) then
+       rootFunctionWrapper=currentFinder%fLowInitial
+       currentFinder%lowInitialUsed =.true.
+    else if (.not.currentFinder%highInitialUsed .and. x == currentFinder%xHighInitial) then
+       rootFunctionWrapper=currentFinder%fHighInitial
+       currentFinder%highInitialUsed=.true.
     else
        ! No previously computed solution available - evaluate the function.
-       rootFunctionWrapper=currentFinders(currentFinderIndex)%finder%finderFunction(x)
+       rootFunctionWrapper=currentFinder%finder%finderFunction(x)
     end if
     return
   end function rootFunctionWrapper
@@ -1286,7 +1307,7 @@ contains
     real(c_double)                       :: rootFunctionDerivativeWrapper
     real(c_double), intent(in   ), value :: x
 
-    rootFunctionDerivativeWrapper=currentFinders(currentFinderIndex)%finder%finderFunctionDerivative(x)
+    rootFunctionDerivativeWrapper=currentFinder%finder%finderFunctionDerivative(x)
     return
   end function rootFunctionDerivativeWrapper
 
@@ -1300,7 +1321,7 @@ contains
     type(c_ptr   ), intent(in   ), value :: parameters
     !$GLC attributes unused :: parameters
 
-    call currentFinders(currentFinderIndex)%finder%finderFunctionBoth(x,f,df)
+    call currentFinder%finder%finderFunctionBoth(x,f,df)
     return
   end subroutine rootFunctionBothWrapper
 

--- a/source/numerical.root_finder.F90
+++ b/source/numerical.root_finder.F90
@@ -597,8 +597,7 @@ contains
     integer                                                                       :: iteration             , statusActual
     double precision                                                              :: xHigh                 , xLow                , xRoot               , &
          &                                                                           xRootPrevious         , fLow                , fHigh               , &
-         &                                                                           fDownwardLimit        , fUpwardLimit                              , &
-         &                                                                           signExpectDown        , signExpectUp
+         &                                                                           fDownwardLimit        , fUpwardLimit
     type            (varying_string      ), save                                  :: message
     !$omp threadprivate(message)
     character       (len= 30             )                                        :: label
@@ -785,29 +784,24 @@ contains
           fHigh=rootRangeValues(2)
        end if
        if (report_) call displayIndent("expanding range")
-       ! Encode the sign expectations as ±1/0 multipliers so the per-iteration test below collapses
-       ! to a single multiply + compare. "Negative" → -1, "positive" → +1, "none" → 0 (which makes
-       ! the product never exceed zero, matching the original .false. result for that case).
-       select case (self%rangeExpandDownwardSignExpect%ID)
-       case (rangeExpandSignExpectNegative%ID)
-          signExpectDown=-1.0d0
-       case (rangeExpandSignExpectPositive%ID)
-          signExpectDown=+1.0d0
-       case default
-          signExpectDown= 0.0d0
-       end select
-       select case (self%rangeExpandUpwardSignExpect%ID)
-       case (rangeExpandSignExpectNegative%ID)
-          signExpectUp  =-1.0d0
-       case (rangeExpandSignExpectPositive%ID)
-          signExpectUp  =+1.0d0
-       case default
-          signExpectUp  = 0.0d0
-       end select
        do while (sign(1.0d0,fLow)*sign(1.0d0,fHigh) > 0.0d0 .and. fLow /= 0.0d0 .and. fHigh /= 0.0d0)
-          rangeChanged        =.false.
-          rangeLowerAsExpected=(signExpectDown*fLow  > 0.0d0)
-          rangeUpperAsExpected=(signExpectUp  *fHigh > 0.0d0)
+          rangeChanged=.false.
+          select case (self%rangeExpandDownwardSignExpect%ID)
+          case (rangeExpandSignExpectNegative%ID)
+             rangeLowerAsExpected=(fLow  < 0.0d0)
+          case (rangeExpandSignExpectPositive%ID)
+             rangeLowerAsExpected=(fLow  > 0.0d0)
+          case default
+             rangeLowerAsExpected=.false.
+          end select
+          select case (self%rangeExpandUpwardSignExpect  %ID)
+          case (rangeExpandSignExpectNegative%ID)
+             rangeUpperAsExpected=(fHigh < 0.0d0)
+          case (rangeExpandSignExpectPositive%ID)
+             rangeUpperAsExpected=(fHigh > 0.0d0)
+          case default
+             rangeUpperAsExpected=.false.
+          end select
           if (report_) call reportState(includeExpectations=.true.)
           select case (self%rangeExpandType%ID)
           case (rangeExpandAdditive      %ID)

--- a/source/numerical.root_finder.F90
+++ b/source/numerical.root_finder.F90
@@ -207,9 +207,9 @@ module Root_Finder
   ! List of currently active root finders. 'currentFinder' is a hot-path
   ! pointer into 'currentFinders' at the active depth; the GSL wrappers
   ! follow it on every callback instead of indexing the array each time.
-  integer                                            :: currentFinderIndex=0
-  type   (rootFinderList), allocatable, dimension(:), target :: currentFinders
-  type   (rootFinderList), pointer                   :: currentFinder     =>null()
+  integer                                                     :: currentFinderIndex =  0
+  type   (rootFinderList), allocatable, dimension(:), target  :: currentFinders
+  type   (rootFinderList)                           , pointer :: currentFinder      => null()
   !$omp threadprivate(currentFinders,currentFinderIndex,currentFinder)
 
   interface
@@ -721,9 +721,9 @@ contains
        end select
        if (.not.rangeLowerAsExpected) then
           if (present(status)) then
-             status            =errorStatusOutOfRange
+             status        =errorStatusOutOfRange
              call popCurrentFinder()
-             rootFinderFind    =self%rangeDownwardLimit
+             rootFinderFind=self%rangeDownwardLimit
              return
           else
              message='root function has incorrect sign at downward limit'
@@ -752,9 +752,9 @@ contains
        end select
        if (.not.rangeUpperAsExpected) then
           if (present(status)) then
-             status            =errorStatusOutOfRange
+             status        =errorStatusOutOfRange
              call popCurrentFinder()
-             rootFinderFind    =self%rangeUpwardLimit
+             rootFinderFind=self%rangeUpwardLimit
              return
           else
              message='root function has incorrect sign at upward limit'

--- a/source/numerical.root_finder.F90
+++ b/source/numerical.root_finder.F90
@@ -496,7 +496,13 @@ contains
        rootRangeValues=-huge(0.0d0)
     else
        rootRangeValues(1)=self%finderFunction(rootRange(1))
-       rootRangeValues(2)=self%finderFunction(rootRange(2))
+       if (rootRange(2) == rootRange(1)) then
+          ! Degenerate bracket (typical when dispatched from rootFinderFindGuess) — avoid the
+          ! redundant evaluation of the user function at the same point.
+          rootRangeValues(2)=rootRangeValues(1)
+       else
+          rootRangeValues(2)=self%finderFunction(rootRange(2))
+       end if
     end if
     rootFinderFindRange=self%find(rootRange,rootRangeValues,report,status)
     return

--- a/source/numerical.root_finder.F90
+++ b/source/numerical.root_finder.F90
@@ -796,7 +796,7 @@ contains
           case default
              rangeUpperAsExpected=.false.
           end select
-          call reportState(includeExpectations=.true.)
+          if (report_) call reportState(includeExpectations=.true.)
           select case (self%rangeExpandType%ID)
           case (rangeExpandAdditive      %ID)
              if     (                                  &
@@ -957,7 +957,7 @@ contains
              end if
           end if
        end do
-       call reportState(includeExpectations=.false.)
+       if (report_) call reportState(includeExpectations=.false.)
        if (report_) call displayUnindent("done")
        ! Store the values of the function at the lower and upper extremes of the range.
        currentFinders(currentFinderIndex)%xLowInitial    =xLow
@@ -1046,12 +1046,12 @@ contains
 
     subroutine reportState(includeExpectations)
       !!{
-      Report on the state of the root finder.
+      Report on the state of the root finder. Callers must guard with
+      \mono{if (report\_)} — the routine itself no longer tests \mono{report\_}.
       !!}
       implicit none
       logical, intent(in   ) :: includeExpectations
-      
-      if (.not.report_) return
+
       write (label,'(e12.6,a2,e12.6)') xLow,", ",fLow
       message="xLow , fLow  = "//trim(label)
       if (includeExpectations .and. self%rangeExpandDownwardSignExpect /= rangeExpandSignExpectNone) then


### PR DESCRIPTION
## Summary
- Add comprehensive benchmark suite for the `rootFinder` class covering multiple solver types and entry points
- Optimize hot-path performance in `rootFinderFind` by caching the active finder pointer to avoid repeated array indexing in GSL callbacks
- Avoid redundant function evaluations in degenerate bracket cases
- Add guard conditions to prevent unnecessary reporting operations

## Type of change
- [x] New feature (benchmarks)
- [x] Performance optimization

## Details

### New Benchmarks
Added two new benchmark modules:
- `benchmarks.numerical.root_finder.F90`: Main benchmark program with scenarios for:
  - Bracketed entry points (Brent, Bisection, False-position solvers)
  - Bracket with precomputed values (tests wrapper cache efficiency)
  - Bracket with lower value only
  - Guess-based entry points with bracket expansion (multiplicative and additive)
  - Derivative-based solvers (Newton, Steffenson)
  
- `benchmarks.numerical.root_finder.functions.F90`: Callback functions and shared state for benchmarks

Each scenario uses deterministic perturbations to prevent constant-folding optimizations and realistic cache behavior.

### Performance Optimizations
1. **Hot-path pointer caching**: Added `currentFinder` module-level pointer that directly references the active finder in the `currentFinders` array. GSL callbacks now dereference this pointer instead of indexing the array on every call, reducing memory traffic on the critical path.

2. **Degenerate bracket optimization**: In `rootFinderFindRange`, detect when `rootRange(2) == rootRange(1)` (typical when dispatched from `rootFinderFindGuess`) and avoid redundant function evaluation at the same point.

3. **Conditional reporting**: Guard `reportState` calls with `if (report_)` checks to avoid unnecessary string formatting and I/O operations when reporting is disabled.

4. **Stack management**: Introduced `popCurrentFinder()` subroutine to properly manage the finder stack and maintain the `currentFinder` pointer invariant.

## How to test
- Run the new benchmark program: `./Benchmark_Numerical_Root_Finder`
- Verify benchmark output shows reasonable timing distributions across solver types
- Existing root finder tests should continue to pass (no functional changes to solver logic)

## Checklist
- [x] I ran relevant tests (benchmarks execute and produce output)
- [x] I updated documentation/comments (added detailed comments explaining benchmark scenarios and optimizations)
- [x] Performance optimizations maintain functional correctness (no changes to solver algorithms)

https://claude.ai/code/session_0162uyRzDFPXxdPvEgvZphQD