### PR TITLE
Feat merger rate zhang2014

### DIFF
--- a/doc/Galacticus.bib
+++ b/doc/Galacticus.bib
@@ -12391,6 +12391,25 @@
   adsnote	= {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@article{zhang_dark-matter_2014,
+	title = {Dark-matter {Halo} {Assembly} {Bias}: {Environmental} {Dependence} in the {Non}-{Markovian} {Excursion}-set {Theory}},
+	volume = {782},
+	issn = {0004-637X},
+	shorttitle = {Dark-matter {Halo} {Assembly} {Bias}},
+	url = {https://ui.adsabs.harvard.edu/abs/2014ApJ...782...44Z},
+	doi = {10.1088/0004-637X/782/1/44},
+	abstract = {In the standard excursion-set model for the growth of structure, the statistical properties of halos are governed by the halo mass and are independent of the larger-scale environment in which the halos reside. Numerical simulations, however, have found the spatial distributions of halos to depend not only on their mass but also on the details of their assembly history and environment. Here we present a theoretical framework for incorporating this "assembly bias" into the excursion-set model. Our derivations are based on modifications of the path-integral approach of Maggiore \& Riotto that models halo formation as a non-Markovian random-walk process. The perturbed density field is assumed to evolve stochastically with the smoothing scale and exhibits correlated walks in the presence of a density barrier. We write down conditional probabilities for multiple barrier crossings and derive from them analytic expressions for descendant and progenitor halo mass functions and halo merger rates as a function of both halo mass and the linear overdensity δ e of the larger-scale environment of the halo. Our results predict a higher halo merger rate and higher progenitor halo mass function in regions of higher overdensity, consistent with the behavior seen in N-body simulations.},
+	urldate = {2026-05-18},
+	journal = {The Astrophysical Journal},
+	publisher = {IOP},
+	author = {Zhang, Jun and Ma, Chung-Pei and Riotto, Antonio},
+	month = feb,
+	year = {2014},
+	note = {ADS Bibcode: 2014ApJ...782...44Z},
+	keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, cosmology: theory, dark matter, galaxies: clusters: general, galaxies: halos},
+	pages = {44},
+}
+
 @Article{	  zhao_accurate_2009,
   author	= {{Zhao}, D.~H. and {Jing}, Y.~P. and {Mo}, H.~J. and
 		  {B{\"o}rner}, G.},

--- a/source/merger_trees.branching_probability.modifier.Zhang2014.F90
+++ b/source/merger_trees.branching_probability.modifier.Zhang2014.F90
@@ -1,0 +1,244 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a merger tree branching probability rate modifier which uses the model of \cite{zhang_dark-matter_2014} to account
+  for environmental-dependence.
+  !!}
+
+  use :: Cosmology_Functions       , only : cosmologyFunctionsClass
+  use :: Cosmological_Density_Field, only : cosmologicalMassVarianceClass, criticalOverdensityClass, haloEnvironmentClass
+  use :: Kind_Numbers              , only : kind_int8
+  
+  !![
+  <mergerTreeBranchingProbabilityModifier name="mergerTreeBranchingProbabilityModifierZhang2014">
+   <description>
+     Provides a merger tree branching probability rate modifier which uses the model of \cite{zhang_dark-matter_2014} to account
+     for envionmental-dependence of the merger rate. Specifically, the modifier is:
+     \begin{equation}
+     1 + \kappa \beta \alpha - \sqrt{2\pi} \kappa \nu (1-\alpha)^{3/2} + \pi \kappa \left(\nu^2\frac{\delta_\mathrm{d}}{\delta_\mathrm{c}}-1\right) (1-\alpha)^{3/2} \exp\left[\frac{\nu^2}{2}\right] \hbox{erfc}\left[\frac{\nu}{\sqrt{2}}\right]
+     \end{equation}
+     where $\kappa$ characterizes the non-Markovian behavior in the excursion set random walks, and whose value depends on the
+     shape of the window function \citep[e.g., $\kappa \approx 0.44$ for a top-hat function in real space, and $\kappa \approx
+     0.35$ for a Gaussian function][]{zhang_dark-matter_2014}, $\alpha = S_\mathrm{d}/S_\mathrm{p}$ with $S_\mathrm{d}$ being the
+     variance on the scale of the descendant (i.e., parent) halo, and $S_\mathrm{p}$ being the variance on the scale of the
+     progenitor (i.e., child) halo,
+     \begin{equation}
+     \beta = -2 + \frac{(1-\alpha)^{3/2}}{2\alpha}\ln\left(\frac{1+\sqrt{1-\alpha}}{1-\sqrt{1-\alpha}}\right)+\frac{1}{\alpha}+2\alpha,
+     \end{equation}     
+     $\nu = \delta_\mathrm{c}/\sqrt{S_\mathrm{d}}$, $\delta_\mathrm{e}$ is the overdensity on the scale of the environment
+     (evaluated at $z=0$), and $\delta_\mathrm{c}$ is the critical overdensity at the time of the descendant halo.
+
+     Note that this implementation uses the solutions for the limit of large environment scale ($S_\mathrm{e} \rightarrow 0$;
+     equation~30 of \citealt{zhang_dark-matter_2014}). A warning is emitted if $S_\mathrm{e}$ is sufficiently large to break this
+     assumption.
+   </description>
+  </mergerTreeBranchingProbabilityModifier>
+  !!]
+  type, extends(mergerTreeBranchingProbabilityModifierClass) :: mergerTreeBranchingProbabilityModifierZhang2014
+     !!{
+     A merger tree branching probability rate modifier which uses the model of \cite{zhang_dark-matter_2014} to account
+     for environmental-dependence.
+     !!}
+     private
+     class           (cosmologyFunctionsClass      ), pointer :: cosmologyFunctions_       => null()
+     class           (cosmologicalMassVarianceClass), pointer :: cosmologicalMassVariance_ => null()
+     class           (criticalOverdensityClass     ), pointer :: criticalOverdensity_      => null()
+     class           (haloEnvironmentClass         ), pointer :: haloEnvironment_          => null()
+     double precision                                         :: kappa                              , overdensityEnvironment, &
+          &                                                      overdensityCriticalParent          , timeParent
+     integer         (kind_int8                    )          :: uniqueID
+   contains
+     final     ::                 zhang2014Destructor
+     procedure :: rateModifier => zhang2014RateModifier
+  end type mergerTreeBranchingProbabilityModifierZhang2014
+
+  interface mergerTreeBranchingProbabilityModifierZhang2014
+     !!{
+     Constructors for the \refClass{mergerTreeBranchingProbabilityModifierZhang2014} merger tree branching probability rate class.
+     !!}
+     module procedure zhang2014ConstructorParameters
+     module procedure zhang2014ConstructorInternal
+  end interface mergerTreeBranchingProbabilityModifierZhang2014
+
+contains
+
+  function zhang2014ConstructorParameters(parameters) result(self)
+    !!{
+    A constructor for the \mono{zhang2014} merger tree branching probability rate class which builds the
+    object from a parameter set.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (mergerTreeBranchingProbabilityModifierZhang2014)                :: self
+    type            (inputParameters                                ), intent(inout) :: parameters
+    class           (cosmologyFunctionsClass                        ), pointer       :: cosmologyFunctions_
+    class           (cosmologicalMassVarianceClass                  ), pointer       :: cosmologicalMassVariance_
+    class           (criticalOverdensityClass                       ), pointer       :: criticalOverdensity_
+    class           (haloEnvironmentClass                           ), pointer       :: haloEnvironment_
+    double precision                                                                 :: kappa
+
+    !![
+    <inputParameter>
+      <name>kappa</name>
+      <defaultValue>0.44d0</defaultValue>
+      <defaultSource>\citep{zhang_dark-matter_2014}</defaultSource>
+      <description>The parameter characterizing non-Markovian behavior in excursion set random walks \citep[][equation~8]{zhang_dark-matter_2014}.</description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="cosmologyFunctions"       name="cosmologyFunctions_"       source="parameters"/>
+    <objectBuilder class="cosmologicalMassVariance" name="cosmologicalMassVariance_" source="parameters"/>
+    <objectBuilder class="criticalOverdensity"      name="criticalOverdensity_"      source="parameters"/>
+    <objectBuilder class="haloEnvironment"          name="haloEnvironment_"          source="parameters"/>
+    !!]
+    self=mergerTreeBranchingProbabilityModifierZhang2014(kappa,cosmologyFunctions_,cosmologicalMassVariance_,criticalOverdensity_,haloEnvironment_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="cosmologyFunctions_"      />
+    <objectDestructor name="cosmologicalMassVariance_"/>
+    <objectDestructor name="criticalOverdensity_"     />
+    <objectDestructor name="haloEnvironment_"         />
+    !!]
+    return
+  end function zhang2014ConstructorParameters
+
+  function zhang2014ConstructorInternal(kappa,cosmologyFunctions_,cosmologicalMassVariance_,criticalOverdensity_,haloEnvironment_) result(self)
+    !!{
+    Default constructor for the \mono{zhang2014} merger tree branching probability rate class.
+    !!}
+    use :: Error, only : Warn
+    implicit none
+    type            (mergerTreeBranchingProbabilityModifierZhang2014)                        :: self
+    class           (cosmologyFunctionsClass                        ), intent(in   ), target :: cosmologyFunctions_
+    class           (cosmologicalMassVarianceClass                  ), intent(in   ), target :: cosmologicalMassVariance_
+    class           (criticalOverdensityClass                       ), intent(in   ), target :: criticalOverdensity_
+    class           (haloEnvironmentClass                           ), intent(in   ), target :: haloEnvironment_
+    double precision                                                 , intent(in   )         :: kappa
+    double precision                                                 , parameter             :: varianceLarge            =0.1d0
+    double precision                                                                         :: massEnvironment                , timePresent, &
+         &                                                                                      varianceEnvironment
+    character       (len= 5                                         )                        :: labelVariance
+    character       (len=12                                         )                        :: labelMass
+    !![
+    <constructorAssign variables="kappa, *cosmologyFunctions_, *cosmologicalMassVariance_, *criticalOverdensity_, *haloEnvironment_"/>
+    !!]
+
+    ! Initialization memoization state.
+    self%uniqueID=-1_kind_int8
+    ! Validate the environment scale.
+    massEnvironment    =self%haloEnvironment_         %environmentMass(                                                )
+    timePresent        =self%cosmologyFunctions_      %cosmicTime     (                     expansionFactor=1.0d0      )
+    varianceEnvironment=self%cosmologicalMassVariance_%rootVariance   (mass=massEnvironment,time           =timePresent)**2
+    if (varianceEnvironment > varianceLarge) then
+       write (labelVariance,'(f05.2)') varianceEnvironment
+       write (labelMass    ,'(e12.6)') massEnvironment
+       call Warn('this class assume the environment variance Sₑ ≪ 1, but found Sₑ = '//labelVariance//' [Mₑ = '//labelMass//' M☉]')
+    end if
+    return
+  end function zhang2014ConstructorInternal
+
+  subroutine zhang2014Destructor(self)
+    !!{
+    Destructor for the \refClass{mergerTreeBranchingProbabilityModifierZhang2014} class.
+    !!}
+    implicit none
+    type(mergerTreeBranchingProbabilityModifierZhang2014), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%cosmologyFunctions_"      />
+    <objectDestructor name="self%criticalOverdensity_"     />
+    <objectDestructor name="self%cosmologicalMassVariance_"/>
+    <objectDestructor name="self%haloEnvironment_"         />
+    !!]
+    return
+  end subroutine zhang2014Destructor
+
+  double precision function zhang2014RateModifier(self,nodeParent,massParent,sigmaParent,sigmaChild,timeParent) result(modifier)
+    !!{
+    Returns a modifier for merger tree branching rates using the model of \cite{zhang_dark-matter_2014} to account for
+    environmental-dependence.
+    !!}
+    use :: Numerical_Constants_Math, only : Pi
+    use :: Galacticus_Nodes        , only : nodeComponentBasic
+    implicit none
+    class           (mergerTreeBranchingProbabilityModifierZhang2014), intent(inout) :: self
+    type            (treeNode                                       ), intent(inout) :: nodeParent
+    double precision                                                 , intent(in   ) :: sigmaChild , timeParent, &
+         &                                                                              sigmaParent, massParent
+    class           (nodeComponentBasic                             ), pointer       :: basicParent
+    double precision                                                                 :: peakHeight , alpha     , &
+         &                                                                              beta       , wParent
+    
+    ! Evaluate the environmental and critical overdensities.
+    if (nodeParent%uniqueID() /= self%uniqueID .or. timeParent /= self%timeParent) then
+       basicParent => nodeParent%basic()
+       ! Store the w "time" parameter used in merger tree building.
+       wParent=basicParent%time()
+       ! Replace with the actual time.
+       call basicParent%timeSet(timeParent)
+       ! Compute environmental and critical overdensities.
+       self%overdensityEnvironment   =self%haloEnvironment_    %overdensityLinear(                                     nodeParent)
+       self%overdensityCriticalParent=self%criticalOverdensity_%value            (time=timeParent,mass=massParent,node=nodeParent)
+       ! Restore the w time parameter.
+       call basicParent%timeSet(wParent)
+       ! Record memoization state.
+       self%uniqueID  =nodeParent%uniqueID()
+       self%timeParent=timeParent
+    end if
+    ! Evaluate other parameters needed for the rate modifier.
+    peakHeight=+self%overdensityCriticalParent  &
+         &     /sqrt(sigmaParent              )    
+    alpha     =(             &
+         &      +sigmaParent &
+         &      /sigmaChild  &
+         &     )**2    
+    beta      =- 2.0d0                         &
+         &     +(1.0d0-alpha)**1.5d0           &
+         &     / 2.0d0/alpha                   &
+         &     *log(                           &
+         &          +(1.0d0+sqrt(1.0d0-alpha)) &
+         &          /(1.0d0-sqrt(1.0d0-alpha)) &
+         &         )                           &
+         &     +1.0d0/alpha                    &
+         &     +2.0d0*alpha
+    ! Evaluate the rate modifier function.
+    modifier=+1.0d0                            &
+         &   +self%kappa                       &
+         &   *beta                             &
+         &   *alpha                            &
+         &   -sqrt(                            &
+         &         +2.0d0                      &
+         &         *Pi                         &
+         &        )                            &
+         &   *self%kappa                       &
+         &   *peakHeight                       &
+         &   *(1.0d0-alpha)**1.5d0             &
+         &   +Pi                               &
+         &   *self%kappa                       &
+         &   *(                                &
+         &     +     peakHeight**2             &
+         &     *self%overdensityEnvironment    &
+         &     /self%overdensityCriticalParent &
+         &     -1.0d0                          &
+         &    )                                &
+         &   *(1.0d0-alpha)**1.5d0             &
+         &   *exp (peakHeight**2/     2.0d0 )  & 
+         &   *erfc(peakHeight   /sqrt(2.0d0))
+    return
+  end function zhang2014RateModifier

--- a/source/merger_trees.branching_probability.modifier.multi.F90
+++ b/source/merger_trees.branching_probability.modifier.multi.F90
@@ -1,0 +1,151 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{
+  Implements a merger tree branching probability rate modifier which chains multiple other modifiers.
+  !!}
+
+  type, public :: multiModifierList
+     class(mergerTreeBranchingProbabilityModifierClass), pointer :: modifier_ => null()
+     type (multiModifierList                          ), pointer :: next      => null()
+  end type multiModifierList
+
+  !![
+  <mergerTreeBranchingProbabilityModifier name="mergerTreeBranchingProbabilityModifierMulti">
+   <description>
+     Chains multiple other merger tree branch probability modifiers by taking their product.
+   </description>
+   <linkedList type="multiModifierList" variable="modifiers" next="next" object="modifier_" objectType="mergerTreeBranchingProbabilityModifierClass"/>
+  </mergerTreeBranchingProbabilityModifier>
+  !!]
+  type, extends(mergerTreeBranchingProbabilityModifierClass) :: mergerTreeBranchingProbabilityModifierMulti
+     !!{
+     A merger tree branching probability rate modifier which chains multiple other modifiers.
+     !!}
+     private
+     type(multiModifierList), pointer :: modifiers => null()
+   contains
+     final     ::                 multiDestructor
+     procedure :: rateModifier => multiRateModifier
+  end type mergerTreeBranchingProbabilityModifierMulti
+
+  interface mergerTreeBranchingProbabilityModifierMulti
+     !!{
+     Constructors for the \refClass{mergerTreeBranchingProbabilityModifierMulti} merger tree branching probability rate class.
+     !!}
+     module procedure multiConstructorParameters
+     module procedure multiConstructorInternal
+  end interface mergerTreeBranchingProbabilityModifierMulti
+
+contains
+
+  function multiConstructorParameters(parameters) result(self)
+    !!{
+    A constructor for the \mono{multi} merger tree branching probability rate class which builds the
+    object from a parameter set.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type   (mergerTreeBranchingProbabilityModifierMulti)                :: self
+    type   (inputParameters                            ), intent(inout) :: parameters
+    type   (multiModifierList                          ), pointer       :: modifier_
+    integer                                                             :: i
+
+    self     %modifiers => null()
+    modifier_           => null()
+    do i=1,parameters%copiesCount('mergerTreeBranchingProbabilityModifier',zeroIfNotPresent=.true.)
+       if (associated(modifier_)) then
+          allocate(modifier_%next)
+          modifier_ => modifier_%next
+       else
+          allocate(self%modifiers)
+          modifier_ => self%modifiers
+       end if
+       !![
+       <objectBuilder class="mergerTreeBranchingProbabilityModifier" name="modifier_%modifier_" source="parameters" copy="i" />
+       !!]
+    end do
+    !![
+    <inputParametersValidate source="parameters" multiParameters="mergerTreeBranchingProbabilityModifier"/>
+    !!]
+    return
+  end function multiConstructorParameters
+
+  function multiConstructorInternal(modifiers) result(self)
+    !!{
+    Default constructor for the \mono{multi} merger tree branching probability rate class.
+    !!}
+    implicit none
+    type(mergerTreeBranchingProbabilityModifierMulti)                        :: self
+    type(multiModifierList                          ), target, intent(in   ) :: modifiers
+    type(multiModifierList                          ), pointer               :: modifier_
+
+    self     %modifiers => modifiers
+    modifier_           => modifiers
+    do while (associated(modifier_))
+       !![
+       <referenceCountIncrement owner="modifier_" object="modifier_"/>
+       !!]
+       modifier_ => modifier_%next
+    end do
+     return
+  end function multiConstructorInternal
+
+  subroutine multiDestructor(self)
+    !!{
+    Destructor for the \refClass{mergerTreeBranchingProbabilityModifierMulti} class.
+    !!}
+    implicit none
+    type(mergerTreeBranchingProbabilityModifierMulti), intent(inout) :: self
+    type(multiModifierList                          ), pointer       :: modifier_, modifierNext
+
+    if (associated(self%modifiers)) then
+       modifier_ => self%modifiers
+       do while (associated(modifier_))
+          modifierNext => modifier_%next
+          !![
+          <objectDestructor name="modifier_%modifier_"/>
+          !!]
+          deallocate(modifier_)
+          modifier_ => modifierNext
+       end do
+    end if
+    return
+  end subroutine multiDestructor
+
+  double precision function multiRateModifier(self,nodeParent,massParent,sigmaParent,sigmaChild,timeParent) result(modifier)
+    !!{
+    Returns a modifier for merger tree branching rates by taking the product over other modifiers.
+    !!}
+    implicit none
+    class           (mergerTreeBranchingProbabilityModifierMulti), intent(inout) :: self
+    type            (treeNode                                   ), intent(inout) :: nodeParent
+    double precision                                             , intent(in   ) :: sigmaChild , timeParent, &
+         &                                                                          sigmaParent, massParent
+    type            (multiModifierList                          ), pointer       :: modifier_
+
+    modifier  = 1.0d0
+    modifier_ => self%modifiers
+    do while (associated(modifier_))
+       modifier  =  +modifier                                                                                  &
+            &       *modifier_%modifier_%rateModifier(nodeParent,massParent,sigmaParent,sigmaChild,timeParent)
+       modifier_ =>  modifier_%next
+    end do
+     return
+  end function multiRateModifier

--- a/source/structure_formation.excursion_sets.first_crossing_distribution.linear_barrier.F90
+++ b/source/structure_formation.excursion_sets.first_crossing_distribution.linear_barrier.F90
@@ -155,10 +155,10 @@ contains
     use :: Numerical_Constants_Math, only : Pi
     implicit none
     class           (excursionSetFirstCrossingLinearBarrier), intent(inout) :: self
-    double precision                                        , intent(in   ) :: variance                   , varianceProgenitor, &
+    double precision                                        , intent(in   ) :: variance             , varianceProgenitor, &
          &                                                                     time
     type            (treeNode                              ), intent(inout) :: node
-    double precision                                                        :: timeProgenitor             , massProgenitor    , &
+    double precision                                                        :: timeProgenitor       , massProgenitor    , &
          &                                                                     growthFactorEffective
 
     if (variance >= varianceProgenitor) then


### PR DESCRIPTION
## Summary
- Implements the model of [Zhang et al. (2014)](https://ui.adsabs.harvard.edu/abs/2014ApJ...782...44Z) for environment-dependent merger tree branching rates in the large environment scale limit (Sₑ → 0), warning when this assumption is violated.


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- Run a model using the "generalized" merger tree branching rate solver, including this new class as a modifier, e.g.:
```xml
  <mergerTreeBranchingProbability value="gnrlzdPrssSchchtr"/>
  <excursionSetFirstCrossing value="linearBarrier"/>
  <excursionSetBarrier value="criticalOverdensity"/>
  <mergerTreeBranchingProbabilityModifier value="multi">
    <mergerTreeBranchingProbabilityModifier value="parkinson2008">
      <G0 value="+0.57"/>
      <gamma1 value="+0.38"/>
      <gamma2 value="-0.01"/>
    </mergerTreeBranchingProbabilityModifier>
    <mergerTreeBranchingProbabilityModifier value="zhang2014">
      <kappa value="0.44"/>
    </mergerTreeBranchingProbabilityModifier>
  </mergerTreeBranchingProbabilityModifier>
  <haloEnvironment value="fixed">
    <massEnvironment value="1.0e13"/>
    <overdensity     value="-0.2"/>
  </haloEnvironment>
```
and verify that the progenitor mass functions shift as expected as a function of the fixed environmental overdensity - see example results below.

## Checklist
- [x] I ran relevant tests (or explain why not):
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

## Results

Running this for a \$`10^{12}\mathrm{M}_\odot`$ parent at \$`z=0`$, the progenitor mass function at \$`z=1`$ is as follows:
<img width="824" height="584" alt="image" src="https://github.com/user-attachments/assets/996fd989-6c8c-46c7-9705-8790132a674c" />
The "PCH direct" line shows results using the `mergerTreeBranchingProbabilityParkinsonColeHelly` class (our well-tested default). Other lines all use the generalized solver (`mergerTreeBranchingProbabilityGnrlzdPrssSchchtr`). The "no environment" case does not use the Zhang2014 environment model and illustrates that the generalized solver produces results that match those of the usual PCH branching probability class. The others all use Zhang2014, with different values of the environmental overdensity as shown. Note that none of these match the "no environment" case - Zhang2014 assumes correlated random walks, even in a \$`\delta_\mathrm{e}=0`$ environment, so it produces different progenitor mass functions. (A recalibration of the [Parkinson, Cole, & Helly (2008)](https://ui.adsabs.harvard.edu/abs/2008MNRAS.383..557P) modifier would be needed ot bring these into line with N-body results.) The effects of environment can be seen on the progenitor mass function.