### PR TITLE
Add output group type indicator to merger tree outputs#1132

### DIFF
--- a/doc/Advanced.tex
+++ b/doc/Advanced.tex
@@ -290,6 +290,7 @@ galacticus.hdf5
  |    |    x-> ...                            Group              [optional]
  |    |    x-> mergerTree<treeCount>          Group              [optional]
  |    |    |
+ |    |    +-> outputType                     Attribute {1}
  |    |    +-> outputExpansionFactor          Attribute {1}
  |    |    +-> outputTime                     Attribute {1}
  |    |
@@ -382,6 +383,7 @@ The \mono{Version} group contains a record of the \glc\ version used for this mo
 
 The \mono{Outputs} group contains one or more sub-groups corresponding to the output times requested from \glc. Each sub-group contains the following information:
 \begin{description}
+ \item[\mono{outputTiype} \emph{(attribute)}] The type of the output---common types are \mono{snapshot} (for outputs containing halos/galaxies at a single snapshot in time) and \mono{lightcone} (for outputs containing halos/galaxies on an observer's past lightcone);
  \item[\mono{outputTime} \emph{(attribute)}] The cosmic time (in Gyr) at this output;
  \item[\mono{outputExpansionFactor} \emph{(attribute)}] The expansion factor at this output;
  \item[\mono{nodeData}] A group of node properties as described below.

--- a/source/merger_trees.evolve.timesteps.lightcone_crossing.F90
+++ b/source/merger_trees.evolve.timesteps.lightcone_crossing.F90
@@ -207,6 +207,7 @@ contains
     use :: Display                            , only : displayMessage
     use :: Error                              , only : Error_Report
     use :: Merger_Trees_Evolve_Deadlock_Status, only : deadlockStatusIsNotDeadlocked
+    use :: Merger_Tree_Outputters             , only : outputGroupTypeLightcone
     use :: Galacticus_Nodes                   , only : nodeComponentBasic
     implicit none
     class           (*                            ), intent(inout)               :: self
@@ -223,7 +224,7 @@ contains
        basic         => node %basic                    (                    )     
        timesCrossing =  basic%floatRank1MetaPropertyGet(self%timesCrossingID)
        if (basic%time() /= timesCrossing(1)) return
-       call self%mergerTreeOutputter_%outputNode(node,1_c_size_t)
+       call self%mergerTreeOutputter_%outputNode(node,1_c_size_t,outputGroupTypeLightcone)
        if (any(node%index() == self%nodeIndicesReport)) then
           write (label,'(i12,1x,"/",1x,e12.6)') node%index(),timesCrossing(1)
           call displayMessage('Lightcone crossing timestep {process} for node/time: '//trim(adjustl(label)))

--- a/source/merger_trees.outputter.F90
+++ b/source/merger_trees.outputter.F90
@@ -30,6 +30,19 @@ module Merger_Tree_Outputters
   private
 
   !![
+  <enumeration>
+   <name>outputGroupType</name>
+   <description>Enumeration of the types of output groups.</description>
+   <decodeFunction>yes</decodeFunction>
+   <visibility>public</visibility>
+   <entry label="tree"     />
+   <entry label="node"     />
+   <entry label="snapshot" />
+   <entry label="lightcone"/>
+  </enumeration>
+  !!]
+
+  !![
   <functionClass>
    <name>mergerTreeOutputter</name>
    <descriptiveName>Merger Tree Outputters</descriptiveName>
@@ -41,22 +54,24 @@ module Merger_Tree_Outputters
     properties as defined by the active \refClass{nodePropertyExtractorClass} instances.</description>
    <default>standard</default>
    <method name="outputTree" >
-    <description>Serialize all galaxy and halo properties from the given \mono{tree} to the output dataset corresponding to output index \mono{indexOutput} at cosmic time \mono{time}.</description>
+    <description>Serialize all galaxy and halo properties from the given \mono{tree} to the output dataset corresponding to output index \mono{indexOutput} at cosmic time \mono{time}. Optionally provide an \mono{outputType} describing the type of output.</description>
     <type>void</type>
     <pass>yes</pass>
-    <argument>type            (mergerTree), intent(inout), target :: tree       </argument>
-    <argument>integer         (c_size_t  ), intent(in   )         :: indexOutput</argument>
-    <argument>double precision            , intent(in   )         :: time       </argument>
+    <argument>type            (mergerTree                    ), intent(inout), target   :: tree       </argument>
+    <argument>integer         (c_size_t                      ), intent(in   )           :: indexOutput</argument>
+    <argument>double precision                                , intent(in   )           :: time       </argument>
+    <argument>type            (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType </argument>
    </method>
    <method name="outputNode" >
     <description>Serialize galaxy and halo properties of the given individual \mono{node} to the output dataset corresponding to output index \mono{indexOutput}.</description>
     <type>void</type>
     <pass>yes</pass>
-    <argument>type   (treeNode), intent(inout) :: node       </argument>
-    <argument>integer(c_size_t), intent(in   ) :: indexOutput</argument>
+    <argument>type   (treeNode                      ), intent(inout)           :: node       </argument>
+    <argument>integer(c_size_t                      ), intent(in   )           :: indexOutput</argument>
+    <argument>type   (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType </argument>
    </method>
    <method name="finalize" >
-    <description>Finalize the output of merger trees, flushing any buffered data to persistent storage and performing any post-processing required after all trees have been serialized.</description>
+    <description>Finalize the output of merger trees, flushing any buffered data to persistent storage and performing any post-processing required after all trees have been serialized. Optionally provide an \mono{outputType} describing the type of output.</description>
     <type>void</type>
     <pass>yes</pass>
     <code>

--- a/source/merger_trees.outputter.analyzer.F90
+++ b/source/merger_trees.outputter.analyzer.F90
@@ -100,7 +100,7 @@ contains
     return
   end subroutine analyzerDestructor
 
-  subroutine analyzerOutputTree(self,tree,indexOutput,time)
+  subroutine analyzerOutputTree(self,tree,indexOutput,time,outputType)
     !!{
     Write properties of nodes in \mono{tree} to the \glc\ output file.
     !!}
@@ -108,14 +108,16 @@ contains
     use :: Galacticus_Nodes   , only : mergerTree              , nodeComponentBasic, treeNode
     use :: Merger_Tree_Walkers, only : mergerTreeWalkerAllNodes
     implicit none
-    class           (mergerTreeOutputterAnalyzer), intent(inout)          :: self
-    type            (mergerTree                 ), intent(inout), target  :: tree
-    integer         (c_size_t                   ), intent(in   )          :: indexOutput
-    double precision                             , intent(in   )          :: time
-    type            (treeNode                   )               , pointer :: node
-    class           (nodeComponentBasic         )               , pointer :: basic
-    type            (mergerTree                 )               , pointer :: treeCurrent
-    type            (mergerTreeWalkerAllNodes   )                         :: treeWalker
+    class           (mergerTreeOutputterAnalyzer   ), intent(inout)           :: self
+    type            (mergerTree                    ), intent(inout), target   :: tree
+    integer         (c_size_t                      ), intent(in   )           :: indexOutput
+    double precision                                , intent(in   )           :: time
+    type            (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    type            (treeNode                      )               , pointer  :: node
+    class           (nodeComponentBasic            )               , pointer  :: basic
+    type            (mergerTree                    )               , pointer  :: treeCurrent
+    type            (mergerTreeWalkerAllNodes      )                          :: treeWalker
+    !$GLC attributes unused :: outputType
 
     ! Iterate over trees.
     treeCurrent => tree
@@ -138,16 +140,17 @@ contains
     return
   end subroutine analyzerOutputTree
 
-  subroutine analyzerOutputNode(self,node,indexOutput)
+  subroutine analyzerOutputNode(self,node,indexOutput,outputType)
     !!{
     Perform no output.
     !!}
     use :: Error, only : Error_Report
     implicit none
-    class  (mergerTreeOutputterAnalyzer), intent(inout) :: self
-    type   (treeNode                   ), intent(inout) :: node
-    integer(c_size_t                   ), intent(in   ) :: indexOutput
-    !$GLC attributes unused :: self, node, indexOutput
+    class  (mergerTreeOutputterAnalyzer   ), intent(inout)           :: self
+    type   (treeNode                      ), intent(inout)           :: node
+    integer(c_size_t                      ), intent(in   )           :: indexOutput
+    type   (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    !$GLC attributes unused :: self, node, indexOutput, outputType
 
     call Error_Report('output of single nodes is not supported'//{introspection:location})
     return

--- a/source/merger_trees.outputter.full_state.F90
+++ b/source/merger_trees.outputter.full_state.F90
@@ -90,19 +90,20 @@ contains
     return
   end function fullStateConstructorInternal
   
-  subroutine fullStateOutputTree(self,tree,indexOutput,time)
+  subroutine fullStateOutputTree(self,tree,indexOutput,time,outputType)
     !!{
     Write properties of nodes in \mono{tree} to the \glc\ output file.
     !!}
     use :: File_Utilities          , only : File_Lock           , File_Unlock, lockDescriptor
     use :: Merger_Tree_Construction, only : mergerTreeStateStore
     implicit none
-    class           (mergerTreeOutputterFullState), intent(inout)         :: self
-    type            (mergerTree                  ), intent(inout), target :: tree
-    integer         (c_size_t                    ), intent(in   )         :: indexOutput
-    double precision                              , intent(in   )         :: time
-    type            (lockDescriptor              )                        :: fileLock
-    !$GLC attributes unused :: time
+    class           (mergerTreeOutputterFullState  ), intent(inout)           :: self
+    type            (mergerTree                    ), intent(inout), target   :: tree
+    integer         (c_size_t                      ), intent(in   )           :: indexOutput
+    double precision                                , intent(in   )           :: time
+    type            (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    type            (lockDescriptor                )                          :: fileLock
+    !$GLC attributes unused :: time, outputType
     
     call File_Lock(char(self%fileName),fileLock,lockIsShared=.false.)
     call mergerTreeStateStore(tree,char(self%fileName),indexOutput=indexOutput,snapshot=.false.,append=.true.)
@@ -110,16 +111,17 @@ contains
     return
   end subroutine fullStateOutputTree
 
-  subroutine fullStateOutputNode(self,node,indexOutput)
+  subroutine fullStateOutputNode(self,node,indexOutput,outputType)
     !!{
     Perform no output.
     !!}
     use :: Error, only : Error_Report
     implicit none
-    class  (mergerTreeOutputterFullState), intent(inout) :: self
-    type   (treeNode                    ), intent(inout) :: node
-    integer(c_size_t                    ), intent(in   ) :: indexOutput
-    !$GLC attributes unused :: self, node, indexOutput
+    class  (mergerTreeOutputterFullState  ), intent(inout)           :: self
+    type   (treeNode                      ), intent(inout)           :: node
+    integer(c_size_t                      ), intent(in   )           :: indexOutput
+    type   (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    !$GLC attributes unused :: self, node, indexOutput, outputType
 
     call Error_Report('output of single nodes is not supported'//{introspection:location})
     return

--- a/source/merger_trees.outputter.halo_Fourier_profiles.F90
+++ b/source/merger_trees.outputter.halo_Fourier_profiles.F90
@@ -173,7 +173,7 @@ contains
     return
   end subroutine haloFourierProfilesDestructor
   
-  subroutine haloFourierProfilesOutputTree(self,tree,indexOutput,time)
+  subroutine haloFourierProfilesOutputTree(self,tree,indexOutput,time,outputType)
     !!{
     Write properties of nodes in \mono{tree} to the \glc\ output file.
     !!}
@@ -191,6 +191,7 @@ contains
     type            (mergerTree                            ), intent(inout), target       :: tree
     integer         (c_size_t                              ), intent(in   )               :: indexOutput
     double precision                                        , intent(in   )               :: time
+    type            (enumerationOutputGroupTypeType        ), intent(in   ), optional     :: outputType
     type            (treeNode                              )               , pointer      :: node
     class           (nodeComponentBasic                    )               , pointer      :: basic
     class           (massDistributionClass                 )               , pointer      :: massDistribution_
@@ -201,7 +202,7 @@ contains
     integer         (c_size_t                              )                              :: treeIndexPrevious
     double precision                                                                      :: expansionFactor  , radiusVirial
     integer                                                                               :: i
-    !$GLC attributes unused :: time
+    !$GLC attributes unused :: time, outputType
     
     allocate(fourierProfile(self%wavenumberCount))
     !$ call hdf5Access%set  ()
@@ -241,16 +242,17 @@ contains
     return
   end subroutine haloFourierProfilesOutputTree
 
-  subroutine haloFourierProfilesOutputNode(self,node,indexOutput)
+  subroutine haloFourierProfilesOutputNode(self,node,indexOutput, outputType)
     !!{
     Perform no output.
     !!}
     use :: Error, only : Error_Report
     implicit none
-    class  (mergerTreeOutputterHaloFourierProfiles), intent(inout) :: self
-    type   (treeNode                              ), intent(inout) :: node
-    integer(c_size_t                              ), intent(in   ) :: indexOutput
-    !$GLC attributes unused :: self, node, indexOutput
+    class  (mergerTreeOutputterHaloFourierProfiles), intent(inout)           :: self
+    type   (treeNode                              ), intent(inout)           :: node
+    integer(c_size_t                              ), intent(in   )           :: indexOutput
+    type   (enumerationOutputGroupTypeType        ), intent(in   ), optional :: outputType
+    !$GLC attributes unused :: self, node, indexOutput, outputType
 
     call Error_Report('output of single nodes is not supported'//{introspection:location})
     return

--- a/source/merger_trees.outputter.multi.F90
+++ b/source/merger_trees.outputter.multi.F90
@@ -129,38 +129,40 @@ contains
     return
   end subroutine multiDestructor
 
-  subroutine multiOutputTree(self,tree,indexOutput,time)
+  subroutine multiOutputTree(self,tree,indexOutput,time,outputType)
     !!{
     Output from all outputters.
     !!}
     implicit none
-    class           (mergerTreeOutputterMulti), intent(inout)         :: self
-    type            (mergerTree              ), intent(inout), target :: tree
-    integer         (c_size_t                ), intent(in   )         :: indexOutput
-    double precision                          , intent(in   )         :: time
-    type            (multiOutputterList      ), pointer               :: outputter_
+    class           (mergerTreeOutputterMulti      ), intent(inout)           :: self
+    type            (mergerTree                    ), intent(inout), target   :: tree
+    integer         (c_size_t                      ), intent(in   )           :: indexOutput
+    double precision                                , intent(in   )           :: time
+    type            (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    type            (multiOutputterList            ), pointer                 :: outputter_
 
     outputter_ => self%outputters
     do while (associated(outputter_))
-       call outputter_%outputter_%outputTree(tree,indexOutput,time)
+       call outputter_%outputter_%outputTree(tree,indexOutput,time,outputType)
        outputter_ => outputter_%next
     end do
     return
   end subroutine multiOutputTree
 
-  subroutine multiOutputNode(self,node,indexOutput)
+  subroutine multiOutputNode(self,node,indexOutput,outputType)
     !!{
     Output from all outputters.
     !!}
     implicit none
-    class  (mergerTreeOutputterMulti), intent(inout) :: self
-    type   (treeNode                ), intent(inout) :: node
-    integer(c_size_t                ), intent(in   ) :: indexOutput
-    type   (multiOutputterList      ), pointer       :: outputter_
+    class  (mergerTreeOutputterMulti      ), intent(inout)           :: self
+    type   (treeNode                      ), intent(inout)           :: node
+    integer(c_size_t                      ), intent(in   )           :: indexOutput
+    type   (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    type   (multiOutputterList            ), pointer                 :: outputter_
 
     outputter_ => self%outputters
     do while (associated(outputter_))
-       call outputter_%outputter_%outputNode(node,indexOutput)
+       call outputter_%outputter_%outputNode(node,indexOutput,outputType)
        outputter_ => outputter_%next
     end do
     return

--- a/source/merger_trees.outputter.null.F90
+++ b/source/merger_trees.outputter.null.F90
@@ -61,29 +61,31 @@ contains
     return
   end function nullConstructorParameters
 
-  subroutine nullOutputTree(self,tree,indexOutput,time)
+  subroutine nullOutputTree(self,tree,indexOutput,time,outputType)
     !!{
     Perform no output.
     !!}
     implicit none
-    class           (mergerTreeOutputterNull), intent(inout)         :: self
-    type            (mergerTree             ), intent(inout), target :: tree
-    integer         (c_size_t               ), intent(in   )         :: indexOutput
-    double precision                         , intent(in   )         :: time
-    !$GLC attributes unused :: self, tree, indexOutput, time
+    class           (mergerTreeOutputterNull       ), intent(inout)           :: self
+    type            (mergerTree                    ), intent(inout), target   :: tree
+    integer         (c_size_t                      ), intent(in   )           :: indexOutput
+    double precision                                , intent(in   )           :: time
+    type            (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    !$GLC attributes unused :: self, tree, indexOutput, time, outputType
 
     return
   end subroutine nullOutputTree
 
-  subroutine nullOutputNode(self,node,indexOutput)
+  subroutine nullOutputNode(self,node,indexOutput,outputType)
     !!{
     Perform no output.
     !!}
     implicit none
-    class           (mergerTreeOutputterNull), intent(inout) :: self
-    type            (treeNode               ), intent(inout) :: node
-    integer         (c_size_t               ), intent(in   ) :: indexOutput
-    !$GLC attributes unused :: self, node, indexOutput
+    class  (mergerTreeOutputterNull       ), intent(inout)           :: self
+    type   (treeNode                      ), intent(inout)           :: node
+    integer(c_size_t                      ), intent(in   )           :: indexOutput
+    type   (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    !$GLC attributes unused :: self, node, indexOutput, outputType
 
     return
   end subroutine nullOutputNode

--- a/source/merger_trees.outputter.standard.F90
+++ b/source/merger_trees.outputter.standard.F90
@@ -33,9 +33,10 @@
      !!{
      Type used for output group information.
      !!}
-     logical             :: doubleAttributesWritten, integerAttributesWritten, &
-          &                 opened
-     type   (hdf5Object) :: hdf5Group              , nodeDataGroup
+     logical                                 :: doubleAttributesWritten, integerAttributesWritten, &
+          &                                     opened
+     type   (hdf5Object                    ) :: hdf5Group              , nodeDataGroup
+     type   (enumerationOutputGroupTypeType) :: type_
    contains
      !![
      <methods>
@@ -225,7 +226,7 @@ contains
     return
   end subroutine standardDestructor
 
-  subroutine standardOutputTree(self,tree,indexOutput,time)
+  subroutine standardOutputTree(self,tree,indexOutput,time,outputType)
     !!{
     Write properties of nodes in \mono{tree} to the \glc\ output file.
     !!}
@@ -236,20 +237,24 @@ contains
     use, intrinsic :: ISO_C_Binding      , only : c_size_t
     use            :: Merger_Tree_Walkers, only : mergerTreeWalkerAllNodes
     implicit none
-    class           (mergerTreeOutputterStandard), intent(inout)          :: self
-    type            (mergerTree                 ), intent(inout), target  :: tree
-    integer         (c_size_t                   ), intent(in   )          :: indexOutput
-    double precision                             , intent(in   )          :: time
-    type            (treeNode                   )               , pointer :: node
-    integer         (kind=hsize_t               ), dimension(1)           :: referenceLength , referenceStart
-    class           (nodeComponentBasic         )               , pointer :: basic
-    type            (mergerTree                 )               , pointer :: currentTree
-    type            (mergerTreeWalkerAllNodes   )                         :: treeWalker
-    integer                                                               :: iProperty
-    type            (hdf5Object                 )                         :: toDataset
-
+    class           (mergerTreeOutputterStandard   ), intent(inout)           :: self
+    type            (mergerTree                    ), intent(inout), target   :: tree
+    integer         (c_size_t                      ), intent(in   )           :: indexOutput
+    double precision                                , intent(in   )           :: time
+    type            (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    type            (treeNode                      )               , pointer  :: node
+    integer         (kind=hsize_t                  ), dimension(1)            :: referenceLength , referenceStart
+    class           (nodeComponentBasic            )               , pointer  :: basic
+    type            (mergerTree                    )               , pointer  :: currentTree
+    type            (mergerTreeWalkerAllNodes      )                          :: treeWalker
+    integer                                                                   :: iProperty
+    type            (hdf5Object                    )                          :: toDataset
+    !![
+    <optionalArgument name="outputType" defaultsTo="outputGroupTypeTree"/>
+    !!]
+    
     ! Create an output group.
-    call self%outputGroupCreate(indexOutput,time)
+    call self%outputGroupCreate(indexOutput,time,outputType_)
     ! Iterate over trees.
     currentTree => tree
     do while (associated(currentTree))
@@ -333,20 +338,24 @@ contains
     return
   end subroutine standardOutputTree
 
-  subroutine standardOutputNode(self,node,indexOutput)
+  subroutine standardOutputNode(self,node,indexOutput,outputType)
     !!{
     Output a single node.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic
     implicit none
-    class  (mergerTreeOutputterStandard), intent(inout) :: self
-    type   (treeNode                   ), intent(inout) :: node
-    integer(c_size_t                   ), intent(in   ) :: indexOutput
-    class  (nodeComponentBasic         ), pointer       :: basic
-    
+    class  (mergerTreeOutputterStandard   ), intent(inout)           :: self
+    type   (treeNode                      ), intent(inout)           :: node
+    integer(c_size_t                      ), intent(in   )           :: indexOutput
+    type   (enumerationOutputGroupTypeType), intent(in   ), optional :: outputType
+    class  (nodeComponentBasic            ), pointer                 :: basic
+    !![
+    <optionalArgument name="outputType" defaultsTo="outputGroupTypeNode"/>
+    !!]
+
     ! Create an output group.
     basic => node%basic()
-    call self%outputGroupCreate(indexOutput,basic%time())
+    call self%outputGroupCreate(indexOutput,basic%time(),outputType_)
     ! Initialize output buffers.
     ! Count up the number of properties to be output.
     call self%propertiesCount       (basic%time(),node)
@@ -1212,7 +1221,7 @@ contains
     return
   end subroutine standardPropertyNamesEstablish
 
-  subroutine standardOutputGroupCreate(self,indexOutput,time)
+  subroutine standardOutputGroupCreate(self,indexOutput,time,outputType)
     !!{
     Create a group in which to store this output.
     !!}
@@ -1222,13 +1231,14 @@ contains
     use            :: Numerical_Constants_Astronomical, only : gigaYear    , megaParsec
     use            :: String_Handling                 , only : operator(//)
     implicit none
-    class           (mergerTreeOutputterStandard), intent(inout)               :: self
-    integer         (c_size_t                   ), intent(in   )               :: indexOutput
-    double precision                             , intent(in   )               :: time
-    type            (outputGroup                ), allocatable  , dimension(:) :: outputGroupsTemporary
-    type            (varying_string             )                              :: description          , groupName
-    double precision                                                           :: expansionFactor      , distanceComoving
-    integer                                                                    :: i
+    class           (mergerTreeOutputterStandard   ), intent(inout)               :: self
+    integer         (c_size_t                      ), intent(in   )               :: indexOutput
+    double precision                                , intent(in   )               :: time
+    type            (enumerationOutputGroupTypeType), intent(in   ), optional     :: outputType
+    type            (outputGroup                   ), allocatable  , dimension(:) :: outputGroupsTemporary
+    type            (varying_string                )                              :: description          , groupName
+    double precision                                                              :: expansionFactor      , distanceComoving
+    integer                                                                       :: i
     
     !$ call hdf5Access%set()
     ! Ensure group ID space is large enough.
@@ -1283,6 +1293,8 @@ contains
        self%outputGroups(indexOutput)%opened                  =.true.
        self%outputGroups(indexOutput)%integerAttributesWritten=.false.
        self%outputGroups(indexOutput)%doubleAttributesWritten =.false.
+       ! Record the "type" of output for this group.
+       call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(enumerationOutputGroupTypeDecode(outputType,includePrefix=.false.),'outputType')
        ! Add the time to this group.
        expansionFactor    =+self%cosmologyFunctions_%expansionFactor (time)
        if (expansionFactor > 1.0d0) then

--- a/source/star_formation.histories.fixed_ages.F90
+++ b/source/star_formation.histories.fixed_ages.F90
@@ -749,7 +749,7 @@ contains
        times_=timesCrossing(1)+starFormationHistory%time
        times=pack(times_,times_ > 0.0d0)
     else
-       ! Truncation is now allowed - return all times.
+       ! Truncation is not allowed - return all times.
        allocate(times(self%countAges+1))
        times=timesCrossing(1)+starFormationHistory%time
     end if

--- a/source/tasks.evolve_forests.F90
+++ b/source/tasks.evolve_forests.F90
@@ -445,6 +445,7 @@ contains
     use               :: Memory_Reporting        , only : reportMemoryUsage
     use               :: Merger_Tree_Construction, only : mergerTreeStateFromFile
     use               :: Merger_Tree_Walkers     , only : mergerTreeWalkerAllNodes
+    use               :: Merger_Tree_Outputters  , only : outputGroupTypeSnapshot
     use               :: Node_Components         , only : Node_Components_Thread_Initialize, Node_Components_Thread_Uninitialize
     use               :: Node_Events_Inter_Tree  , only : Inter_Tree_Event_Post_Evolve
     !$ use            :: OMP_Lib                 , only : OMP_Destroy_Lock                 , OMP_Get_Thread_Num                 , OMP_Init_Lock  , omp_lock_kind
@@ -805,7 +806,7 @@ contains
                 message="Output tree data at t="//trim(label)//" Gyr"
                 call displayMessage(message)
                 if (associated(tree)) then
-                   call mergerTreeOutputter_%outputTree(tree,iOutput,evolveToTime)
+                   call mergerTreeOutputter_%outputTree(tree,iOutput,evolveToTime,outputGroupTypeSnapshot)
                    ! Perform any extra output and post-output processing on nodes.
                    treeWalkerAll=mergerTreeWalkerAllNodes(tree,spanForest=.true.)
                    do while (treeWalkerAll%next(node))


### PR DESCRIPTION
## Summary
- Thread an optional outputType enumeration (tree, node, snapshot, lightcone) through the merger tree outputter interface and record it as an "outputType" HDF5 attribute on each output group. This lets downstream consumers of the output file distinguish how a given output group was produced.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- 

## Checklist
- [x] I ran relevant tests (or explain why not):
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled ?Allow edits from maintainers?
