### PR TITLE
Fix race condition in OMP lock owner thread assignment

### DIFF
--- a/source/utility.locks.F90
+++ b/source/utility.locks.F90
@@ -232,11 +232,16 @@ contains
     !!}
     !$ use :: OMP_Lib, only : OMP_Get_Thread_Num, OMP_Set_Lock
     implicit none
-    class(ompLock), intent(inout) :: self
+    class  (ompLock), intent(inout) :: self
+    integer                         :: ownerThread
 
+    ! Determine the ID of the current thread using a local variable. The shared `self%ownerThread` must be updated in a single
+    ! assignment: writing a default of `0` and then overriding it via the OpenMP-conditional line would briefly expose an owner
+    ! ID of `0` to other threads, which a concurrent `ownedByThread()` call from thread 0 would mistake for ownership.
+    ownerThread=0
+    !$ ownerThread=OMP_Get_Thread_Num()
     !$ call OMP_Set_Lock(self%lock)
-    self%ownerThread=0
-    !$ self%ownerThread=OMP_Get_Thread_Num()
+    self%ownerThread=ownerThread
     return
   end subroutine ompLockSet
 
@@ -246,13 +251,16 @@ contains
     !!}
     !$ use :: OMP_Lib, only : OMP_Get_Thread_Num, OMP_Test_Lock
     implicit none
-    class(ompLock), intent(inout) :: self
+    class  (ompLock), intent(inout) :: self
+    integer                         :: ownerThread
 
     success=.true.
     !$ success=OMP_Test_Lock(self%lock)
     if (.not.success) return
-    self%ownerThread=0
-    !$ self%ownerThread=OMP_Get_Thread_Num()
+    ! Set the owner thread ID via a local variable so that `self%ownerThread` is updated in a single assignment (see `ompLockSet`).
+    ownerThread=0
+    !$ ownerThread=OMP_Get_Thread_Num()
+    self%ownerThread=ownerThread
     return
   end function ompLockSetNonBlocking
 

--- a/source/utility.locks.F90
+++ b/source/utility.locks.F90
@@ -238,7 +238,7 @@ contains
     ! Determine the ID of the current thread using a local variable. The shared `self%ownerThread` must be updated in a single
     ! assignment: writing a default of `0` and then overriding it via the OpenMP-conditional line would briefly expose an owner
     ! ID of `0` to other threads, which a concurrent `ownedByThread()` call from thread 0 would mistake for ownership.
-    ownerThread=0
+    ownerThread   =0
     !$ ownerThread=OMP_Get_Thread_Num()
     !$ call OMP_Set_Lock(self%lock)
     self%ownerThread=ownerThread
@@ -258,7 +258,7 @@ contains
     !$ success=OMP_Test_Lock(self%lock)
     if (.not.success) return
     ! Set the owner thread ID via a local variable so that `self%ownerThread` is updated in a single assignment (see `ompLockSet`).
-    ownerThread=0
+    ownerThread   =0
     !$ ownerThread=OMP_Get_Thread_Num()
     self%ownerThread=ownerThread
     return


### PR DESCRIPTION
## Summary
- Fix a race condition in `ompLockSet()` and `ompLockSetNonBlocking()` where the owner thread ID could be briefly exposed as `0` to concurrent threads, causing incorrect ownership detection.

## Type of change
- [x] Bug fix

## Details
The original code assigned `self%ownerThread` in two separate statements:
1. First setting it to `0` unconditionally
2. Then conditionally overwriting it with the actual thread ID via OpenMP directives

This created a window where other threads could observe `self%ownerThread=0` even though the lock was held by a non-zero thread ID. A concurrent call to `ownedByThread()` from thread 0 would incorrectly interpret this as ownership.

The fix uses a local variable `ownerThread` to compute the correct value first, then performs a single atomic assignment to `self%ownerThread`. This ensures the shared state is never exposed in an inconsistent intermediate state.

Applied the same fix to both `ompLockSet()` and `ompLockSetNonBlocking()` for consistency.

## How to test
- Existing unit tests for OMP lock functionality should pass
- The fix is particularly relevant for multi-threaded scenarios where thread 0 frequently acquires locks concurrently with other threads

## Checklist
- [x] I ran relevant tests (existing OMP lock tests pass)
- [x] I updated documentation/comments if needed (added explanatory comments)

https://claude.ai/code/session_01GGtsyk3zRnGTjJ8LnvVNzV