### PR TITLE
Allow multiple fallback URLs in the downloader

### DIFF
--- a/source/interface.RecFast.F90
+++ b/source/interface.RecFast.F90
@@ -70,18 +70,16 @@ contains
           ! Download the code if not already downloaded.
           pathFor=recfastPath//"recfast.for"
           if (.not.File_Exists(pathFor)) then
-             call displayMessage("downloading RecFast code....",verbosityLevelWorking)
-             call download(                                                                                                                        &
-                  &                   [                                                                                                            &
-                  &                    var_str("https://www.astro.ubc.ca/people/scott/recfast.for"                                              ), &
-                  &                    var_str("https://web.archive.org/web/20250818121544im_/https://www.astro.ubc.ca/people/scott/recfast.for")  &
-                  &                   ]                                                                                                          , &
-                  &                   pathFor                                                                                                    , &
-                  &        retries  = 5                                                                                                          , &
-                  &        retryWait=60                                                                                                            &
-                  &       )
-             if (.not.File_Exists(pathFor)) &
+             block
+               type(varying_string), dimension(2) :: urls
+
+               call displayMessage("downloading RecFast code....",verbosityLevelWorking)
+               urls(1)=var_str("https://www.astro.ubc.ca/people/scott/recfast.for"                                              )
+               urls(2)=var_str("https://web.archive.org/web/20250818121544im_/https://www.astro.ubc.ca/people/scott/recfast.for")
+               call download(urls,pathFor,retries=5,retryWait=10)
+               if (.not.File_Exists(pathFor)) &
                   & call Error_Report("failed to download RecFast code"//{introspection:location})
+             end block
           end if
           call displayMessage("patching RecFast code....",verbosityLevelWorking)
           command="cp "//inputPath(pathTypeDataStatic)//"patches/RecFast/recfast.for.patch "//recfastPath//"; cd "//recfastPath//"; patch < recfast.for.patch"

--- a/source/interface.RecFast.F90
+++ b/source/interface.RecFast.F90
@@ -39,7 +39,8 @@ contains
           &                           lockDescriptor
     use :: Error             , only : Error_Report
     use :: Input_Paths       , only : inputPath        , pathTypeDataDynamic  , pathTypeDataStatic
-    use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)      , varying_string
+    use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)      , varying_string, &
+         &                            var_str
     use :: System_Command    , only : System_Command_Do
     use :: System_Download   , only : download
     use :: System_Compilers  , only : compiler         , languageFortran
@@ -70,7 +71,15 @@ contains
           pathFor=recfastPath//"recfast.for"
           if (.not.File_Exists(pathFor)) then
              call displayMessage("downloading RecFast code....",verbosityLevelWorking)
-             call download("https://www.astro.ubc.ca/people/scott/recfast.for",pathFor,retries=5,retryWait=60)
+             call download(                                                                                                                        &
+                  &                   [                                                                                                            &
+                  &                    var_str("https://www.astro.ubc.ca/people/scott/recfast.for"                                              ), &
+                  &                    var_str("https://web.archive.org/web/20250818121544im_/https://www.astro.ubc.ca/people/scott/recfast.for")  &
+                  &                   ]                                                                                                          , &
+                  &                   pathFor                                                                                                    , &
+                  &        retries  = 5                                                                                                          , &
+                  &        retryWait=60                                                                                                            &
+                  &       )
              if (.not.File_Exists(pathFor)) &
                   & call Error_Report("failed to download RecFast code"//{introspection:location})
           end if

--- a/source/system.downloader.F90
+++ b/source/system.downloader.F90
@@ -79,8 +79,10 @@ contains
     type   (varying_string), intent(in   )           :: url    , outputFileName
     integer                , intent(in   ), optional :: retries, retryWait
     integer                , intent(  out), optional :: status
+    type   (varying_string), dimension(1)            :: urls
 
-    call downloadMultiple([url],char(outputFileName),retries,retryWait,status)
+    urls(1)=url
+    call downloadMultiple(urls,char(outputFileName),retries,retryWait,status)
     return
   end subroutine downloadVarStrVarStr
 
@@ -94,8 +96,10 @@ contains
     character(len=*         ), intent(in   )           :: outputFileName
     integer                  , intent(in   ), optional :: retries       , retryWait
     integer                  , intent(  out), optional :: status
+    type   (varying_string), dimension(1)            :: urls
 
-    call downloadMultiple([url],outputFileName,retries,retryWait,status)
+    urls(1)=url
+    call downloadMultiple(urls,outputFileName,retries,retryWait,status)
     return
   end subroutine downloadVarStrChar
 
@@ -103,14 +107,16 @@ contains
     !!{
     Download content from the given {\normalfont url} to the given \mono{outputFileName}.
     !!}
-    use :: ISO_Varying_String, only : char, var_str, varying_string
+    use :: ISO_Varying_String, only : char, var_str, varying_string, assignment(=)
     implicit none
     character(len=*         ), intent(in   )           :: url
     type     (varying_string), intent(in   )           :: outputFileName
     integer                  , intent(in   ), optional :: retries       , retryWait
     integer                  , intent(  out), optional :: status
+    type     (varying_string), dimension(1)            :: urls
 
-    call downloadMultiple([var_str(url)],char(outputFileName),retries,retryWait,status)
+    urls(1)=url
+    call downloadMultiple(urls,char(outputFileName),retries,retryWait,status)
     return
   end subroutine downloadCharVarStr
 
@@ -118,13 +124,15 @@ contains
     !!{
     Download content from the given {\normalfont url} to the given \mono{outputFileName}.
     !!}
-    use :: ISO_Varying_String, only : var_str
+    use :: ISO_Varying_String, only : varying_string, assignment(=)
     implicit none
-    character(len=*), intent(in   )           :: url    , outputFileName
-    integer         , intent(in   ), optional :: retries, retryWait
-    integer         , intent(  out), optional :: status
+    character(len=*         ), intent(in   )           :: url    , outputFileName
+    integer                  , intent(in   ), optional :: retries, retryWait
+    integer                  , intent(  out), optional :: status
+    type     (varying_string), dimension(1)            :: urls
 
-    call downloadMultiple([var_str(url)],outputFileName,retries,retryWait,status)
+    urls(1)=url
+    call downloadMultiple(urls,outputFileName,retries,retryWait,status)
     return
   end subroutine downloadCharChar
 
@@ -162,14 +170,19 @@ contains
     !!{
     Download content from the first available URL in {\normalfont url} to the given \mono{outputFileName}.
     !!}
-    use :: ISO_Varying_String, only : char, var_str, varying_string
+    use :: ISO_Varying_String, only : char, varying_string, assignment(=)
     implicit none
-    character(len=*         ), intent(in   ), dimension(:) :: url
-    type     (varying_string), intent(in   )               :: outputFileName
-    integer                  , intent(in   ), optional     :: retries       , retryWait
-    integer                  , intent(  out), optional     :: status
+    character(len=*         ), intent(in   ), dimension(:        ) :: url
+    type     (varying_string), intent(in   )                       :: outputFileName
+    integer                  , intent(in   ), optional             :: retries       , retryWait
+    integer                  , intent(  out), optional             :: status
+    type     (varying_string)               , dimension(size(url)) :: urls
+    integer                                                        :: i
 
-    call downloadMultiple(var_str(url),char(outputFileName),retries,retryWait,status)
+    do i=1,size(url)
+       urls(i)=url(i)
+    end do
+    call downloadMultiple(urls,char(outputFileName),retries,retryWait,status)
     return
   end subroutine downloadCharArrayVarStr
 
@@ -177,14 +190,19 @@ contains
     !!{
     Download content from the first available URL in {\normalfont url} to the given \mono{outputFileName}.
     !!}
-    use :: ISO_Varying_String, only : var_str
+    use :: ISO_Varying_String, only : varying_string, assignment(=)
     implicit none
-    character(len=*), intent(in   ), dimension(:) :: url
-    character(len=*), intent(in   )               :: outputFileName
-    integer         , intent(in   ), optional     :: retries       , retryWait
-    integer         , intent(  out), optional     :: status
+    character(len=*       ), intent(in   ), dimension(:        ) :: url
+    character(len=*       ), intent(in   )                       :: outputFileName
+    integer                , intent(in   ), optional             :: retries       , retryWait
+    integer                , intent(  out), optional             :: status
+    type   (varying_string)               , dimension(size(url)) :: urls
+    integer                                                      :: i
 
-    call downloadMultiple(var_str(url),outputFileName,retries,retryWait,status)
+    do i=1,size(url)
+       urls(i)=url(i)
+    end do
+    call downloadMultiple(urls,outputFileName,retries,retryWait,status)
     return
   end subroutine downloadCharArrayChar
 

--- a/source/system.downloader.F90
+++ b/source/system.downloader.F90
@@ -18,12 +18,13 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{
-Contains a module which downloads content from a supplied URL.
+Contains a module which downloads content from a supplied URL (or list of URLs).
 !!}
 
 module System_Download
   !!{
-  Downloads content from a supplied URL.
+  Downloads content from a supplied URL. A scalar URL may be provided, or a 1D array of URLs to be tried in turn---if the
+  download from one URL fails, the next is used as a fallback.
   !!}
   implicit none
   private
@@ -34,12 +35,16 @@ module System_Download
      module procedure downloadVarStrVarStr
      module procedure downloadVarStrChar
      module procedure downloadCharVarStr
+     module procedure downloadCharArrayChar
+     module procedure downloadCharArrayVarStr
+     module procedure downloadVarStrArrayChar
+     module procedure downloadVarStrArrayVarStr
   end interface download
 
   ! Available downloaders.
   logical :: downloadUsingWget  =.false., downloadUsingCurl=.false., &
        &     downloadInitialized=.false.
-  
+
 contains
 
   subroutine downloadInitialize()
@@ -61,10 +66,10 @@ contains
           downloadInitialized=.true.
        end if
        !$omp end critical(downloadInitialize)
-    end if    
+    end if
     return
   end subroutine downloadInitialize
-  
+
   subroutine downloadVarStrVarStr(url,outputFileName,retries,retryWait,status)
     !!{
     Download content from the given {\normalfont url} to the given \mono{outputFileName}.
@@ -75,7 +80,7 @@ contains
     integer                , intent(in   ), optional :: retries, retryWait
     integer                , intent(  out), optional :: status
 
-    call download(char(url),char(outputFileName),retries,retryWait,status)
+    call downloadMultiple([url],char(outputFileName),retries,retryWait,status)
     return
   end subroutine downloadVarStrVarStr
 
@@ -83,14 +88,14 @@ contains
     !!{
     Download content from the given {\normalfont url} to the given \mono{outputFileName}.
     !!}
-    use :: ISO_Varying_String, only : char, varying_string
+    use :: ISO_Varying_String, only : varying_string
     implicit none
     type     (varying_string), intent(in   )           :: url
     character(len=*         ), intent(in   )           :: outputFileName
     integer                  , intent(in   ), optional :: retries       , retryWait
     integer                  , intent(  out), optional :: status
 
-    call download(char(url),outputFileName,retries,retryWait,status)
+    call downloadMultiple([url],outputFileName,retries,retryWait,status)
     return
   end subroutine downloadVarStrChar
 
@@ -98,14 +103,14 @@ contains
     !!{
     Download content from the given {\normalfont url} to the given \mono{outputFileName}.
     !!}
-    use :: ISO_Varying_String, only : char, varying_string
+    use :: ISO_Varying_String, only : char, var_str, varying_string
     implicit none
     character(len=*         ), intent(in   )           :: url
     type     (varying_string), intent(in   )           :: outputFileName
     integer                  , intent(in   ), optional :: retries       , retryWait
     integer                  , intent(  out), optional :: status
 
-    call download(url,char(outputFileName),retries,retryWait,status)
+    call downloadMultiple([var_str(url)],char(outputFileName),retries,retryWait,status)
     return
   end subroutine downloadCharVarStr
 
@@ -113,14 +118,93 @@ contains
     !!{
     Download content from the given {\normalfont url} to the given \mono{outputFileName}.
     !!}
-    use :: Error         , only : Error_Report     , errorStatusFail, errorStatusSuccess
-    use :: System_Command, only : System_Command_Do
-    use :: File_Utilities, only : File_Exists      , File_Remove
+    use :: ISO_Varying_String, only : var_str
     implicit none
     character(len=*), intent(in   )           :: url    , outputFileName
     integer         , intent(in   ), optional :: retries, retryWait
     integer         , intent(  out), optional :: status
-    integer                                   :: status_, tries
+
+    call downloadMultiple([var_str(url)],outputFileName,retries,retryWait,status)
+    return
+  end subroutine downloadCharChar
+
+  subroutine downloadVarStrArrayVarStr(url,outputFileName,retries,retryWait,status)
+    !!{
+    Download content from the first available URL in {\normalfont url} to the given \mono{outputFileName}.
+    !!}
+    use :: ISO_Varying_String, only : char, varying_string
+    implicit none
+    type   (varying_string), intent(in   ), dimension(:) :: url
+    type   (varying_string), intent(in   )               :: outputFileName
+    integer                , intent(in   ), optional     :: retries       , retryWait
+    integer                , intent(  out), optional     :: status
+
+    call downloadMultiple(url,char(outputFileName),retries,retryWait,status)
+    return
+  end subroutine downloadVarStrArrayVarStr
+
+  subroutine downloadVarStrArrayChar(url,outputFileName,retries,retryWait,status)
+    !!{
+    Download content from the first available URL in {\normalfont url} to the given \mono{outputFileName}.
+    !!}
+    use :: ISO_Varying_String, only : varying_string
+    implicit none
+    type     (varying_string), intent(in   ), dimension(:) :: url
+    character(len=*         ), intent(in   )               :: outputFileName
+    integer                  , intent(in   ), optional     :: retries       , retryWait
+    integer                  , intent(  out), optional     :: status
+
+    call downloadMultiple(url,outputFileName,retries,retryWait,status)
+    return
+  end subroutine downloadVarStrArrayChar
+
+  subroutine downloadCharArrayVarStr(url,outputFileName,retries,retryWait,status)
+    !!{
+    Download content from the first available URL in {\normalfont url} to the given \mono{outputFileName}.
+    !!}
+    use :: ISO_Varying_String, only : char, var_str, varying_string
+    implicit none
+    character(len=*         ), intent(in   ), dimension(:) :: url
+    type     (varying_string), intent(in   )               :: outputFileName
+    integer                  , intent(in   ), optional     :: retries       , retryWait
+    integer                  , intent(  out), optional     :: status
+
+    call downloadMultiple(var_str(url),char(outputFileName),retries,retryWait,status)
+    return
+  end subroutine downloadCharArrayVarStr
+
+  subroutine downloadCharArrayChar(url,outputFileName,retries,retryWait,status)
+    !!{
+    Download content from the first available URL in {\normalfont url} to the given \mono{outputFileName}.
+    !!}
+    use :: ISO_Varying_String, only : var_str
+    implicit none
+    character(len=*), intent(in   ), dimension(:) :: url
+    character(len=*), intent(in   )               :: outputFileName
+    integer         , intent(in   ), optional     :: retries       , retryWait
+    integer         , intent(  out), optional     :: status
+
+    call downloadMultiple(var_str(url),outputFileName,retries,retryWait,status)
+    return
+  end subroutine downloadCharArrayChar
+
+  subroutine downloadMultiple(url,outputFileName,retries,retryWait,status)
+    !!{
+    Download content to the given \mono{outputFileName}, trying each URL in {\normalfont url} in turn. If the download from one
+    URL fails (even after any retries), the next URL is used as a fallback. The download is considered successful as soon as any
+    URL succeeds.
+    !!}
+    use :: Error             , only : Error_Report     , errorStatusFail, errorStatusSuccess
+    use :: File_Utilities    , only : File_Exists      , File_Remove
+    use :: ISO_Varying_String, only : varying_string   , char           , operator(//)      , assignment(=)
+    use :: System_Command    , only : System_Command_Do
+    implicit none
+    type     (varying_string), intent(in   ), dimension(:) :: url
+    character(len=*         ), intent(in   )               :: outputFileName
+    integer                  , intent(in   ), optional     :: retries       , retryWait
+    integer                  , intent(  out), optional     :: status
+    integer                                                :: status_       , tries    , i
+    type     (varying_string)                              :: urlList
     !![
     <optionalArgument name="retries"   defaultsTo="0" />
     <optionalArgument name="retryWait" defaultsTo="60"/>
@@ -128,27 +212,38 @@ contains
 
     call downloadInitialize()
     if (present(status)) status=0
-    tries=0
-    do while (tries <= retries_)
-       status_=errorStatusFail
-       if      (downloadUsingWget) then
-          call System_Command_Do('wget --no-check-certificate "'//trim(url)//'" -O '      //trim(outputFileName),status_)
-       else if (downloadUsingCurl) then
-          call System_Command_Do('curl --insecure --location "' //trim(url)//'" --output '//trim(outputFileName),status_)
-       else if (.not.present(status)) then
-          call Error_Report('no downloader available'//{introspection:location})
-       end if
-       if (status_ == 0) then
-          if (present(status)) status=status_
-          return
-       end if
-       tries=tries+1
-       if (File_Exists(outputFileName)) call File_Remove(outputFileName)
-       call sleep(retryWait_)
+    status_=errorStatusFail
+    do i=1,size(url)
+       tries=0
+       do while (tries <= retries_)
+          status_=errorStatusFail
+          if      (downloadUsingWget) then
+             call System_Command_Do('wget --no-check-certificate "'//char(url(i))//'" -O '      //trim(outputFileName),status_)
+          else if (downloadUsingCurl) then
+             call System_Command_Do('curl --insecure --location "' //char(url(i))//'" --output '//trim(outputFileName),status_)
+          else if (.not.present(status)) then
+             call Error_Report('no downloader available'//{introspection:location})
+          end if
+          if (status_ == errorStatusSuccess) then
+             if (present(status)) status=status_
+             return
+          end if
+          tries=tries+1
+          if (File_Exists(outputFileName)) call File_Remove(outputFileName)
+          ! Wait before the next attempt, unless this was the final attempt of the final URL.
+          if (tries <= retries_ .or. i < size(url)) call sleep(retryWait_)
+       end do
     end do
-    if (     present(status)                   )  status=status_
-    if (.not.present(status) .and. status_ /= 0) call Error_Report('failed to download "'//trim(url)//'"'//{introspection:location})
+    if (present(status)) status=status_
+    if (.not.present(status) .and. status_ /= errorStatusSuccess) then
+       urlList=''
+       do i=1,size(url)
+          if (i > 1) urlList=urlList//', '
+          urlList=urlList//char(url(i))
+       end do
+       call Error_Report('failed to download from "'//char(urlList)//'"'//{introspection:location})
+    end if
     return
-  end subroutine downloadCharChar
+  end subroutine downloadMultiple
 
 end module System_Download


### PR DESCRIPTION
## Summary

- The `download()` generic interface now accepts a **1D array of URLs** in addition to a scalar URL. When an array is supplied, each URL is tried in turn — if the download from one URL fails (after any retries), the next is used as a fallback. The download succeeds as soon as any URL works; if all fail, the error/`status` reflects that and lists every URL tried.
- All download logic is funnelled through a single private core routine (`downloadMultiple`); the public procedures are thin wrappers. The generic interface grew from 4 to 8 specifics, covering every combination of URL form (`character` / `varying_string`, scalar / 1D array) and `outputFileName` form (`character` / `varying_string`). Scalar-URL calls are unchanged, so all existing callers are unaffected.
- Applied the new capability to the RecFast download (`interface.RecFast.F90`): a Wayback Machine archived copy of `recfast.for` is now provided as a fallback for when the primary UBC URL is unavailable.
- Minor: the routine no longer sleeps `retryWait` seconds after the final attempt of the last URL, avoiding stacked-up wasted waits when several URLs are exhausted.

## Test plan

- [x] Compiles successfully
- [x] RecFast download exercised with the primary URL currently down — confirmed the fallback URL is used and the download succeeds
- [ ] CI

https://claude.ai/code/session_01N6P4b7FWWv1jS2iAe2nCis

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6P4b7FWWv1jS2iAe2nCis)_