### PR TITLE
Set default weights when decoding radius specifiers

### DIFF
--- a/source/galactic_structure.radius_definition.F90
+++ b/source/galactic_structure.radius_definition.F90
@@ -134,6 +134,11 @@ contains
           call reportSpecifierError(specifiers(i)%name,message)
        end if
        call String_Split_Words(radiusDefinition,char(descriptors(i)),':',bracketing="{}")
+       ! Default weights.
+       specifiers(i)%weightBy             =weightByMass
+       specifiers(i)%weightByIndex        =weightIndexNull
+       specifiers(i)%integralWeightBy     =weightByMass
+       specifiers(i)%integralWeightByIndex=weightIndexNull
        ! Detect cases which specify radius via a mass or light fraction. In either case, extract the fraction.
        if (extract(radiusDefinition(1),1,22) == 'galacticLightFraction{'     ) call extractFraction(specifiers(i)%name,radiusDefinition(1),22,fractionDefinition)
        if (extract(radiusDefinition(1),1,21) == 'galacticMassFraction{'      ) call extractFraction(specifiers(i)%name,radiusDefinition(1),21,fractionDefinition)

--- a/source/output.analyses.black_hole_velocity_dispersion_relation.F90
+++ b/source/output.analyses.black_hole_velocity_dispersion_relation.F90
@@ -69,6 +69,7 @@ contains
     class           (darkMatterHaloScaleClass                         ), pointer                     :: darkMatterHaloScale_
     double precision                                                                                 :: randomErrorMinimum                         , randomErrorMaximum
     double precision                                                   , parameter                   :: toleranceRelative                   =1.0d-3
+    logical                                                                                          :: report
 
     allocate(systematicErrorPolynomialCoefficient(max(1,parameters%count('systematicErrorPolynomialCoefficient',zeroIfNotPresent=.true.))))
     allocate(    randomErrorPolynomialCoefficient(max(1,parameters%count(    'randomErrorPolynomialCoefficient',zeroIfNotPresent=.true.))))
@@ -101,12 +102,18 @@ contains
       <defaultValue>0.01d0</defaultValue>
       <description>The minimum random error for velocity dispersions.</description>
     </inputParameter>
+    <inputParameter>
+      <name>report</name>
+      <source>parameters</source>
+      <defaultValue>.false.</defaultValue>
+      <description>If true, report on statistics accumulation.</description>
+    </inputParameter>
     <objectBuilder class="cosmologyFunctions"  name="cosmologyFunctions_"  source="parameters"/>
     <objectBuilder class="outputTimes"         name="outputTimes_"         source="parameters"/>
     <objectBuilder class="darkMatterHaloScale" name="darkMatterHaloScale_" source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisBlackHoleVelocityDispersionRelation(systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,cosmologyFunctions_,outputTimes_,toleranceRelative=1.0d-3,darkMatterHaloScale_=darkMatterHaloScale_)
+    self=outputAnalysisBlackHoleVelocityDispersionRelation(systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,report,cosmologyFunctions_,outputTimes_,toleranceRelative=1.0d-3,darkMatterHaloScale_=darkMatterHaloScale_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_" />
@@ -116,7 +123,7 @@ contains
     return
   end function blackHoleVelocityDispersionRelationConstructorParameters
 
-  function blackHoleVelocityDispersionRelationConstructorInternal(systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,cosmologyFunctions_,outputTimes_,toleranceRelative,darkMatterHaloScale_) result (self)
+  function blackHoleVelocityDispersionRelationConstructorInternal(systematicErrorPolynomialCoefficient,randomErrorPolynomialCoefficient,randomErrorMinimum,randomErrorMaximum,report,cosmologyFunctions_,outputTimes_,toleranceRelative,darkMatterHaloScale_) result (self)
     !!{
     Constructor for the \refClass{outputAnalysisBlackHoleVelocityDispersionRelation} output analysis class for internal use.
     !!}
@@ -142,6 +149,7 @@ contains
     double precision                                                     , intent(in   )                 :: randomErrorMinimum                                      , randomErrorMaximum                                , &
          &                                                                                                  toleranceRelative
     double precision                                                     , intent(in   ), dimension(:  ) :: systematicErrorPolynomialCoefficient                    , randomErrorPolynomialCoefficient
+    logical                                                              , intent(in   )                 :: report
     class           (cosmologyFunctionsClass                            ), intent(inout), target         :: cosmologyFunctions_
     class           (outputTimesClass                                   ), intent(inout), target         :: outputTimes_
     class           (darkMatterHaloScaleClass                           ), intent(in   ), target         :: darkMatterHaloScale_
@@ -174,7 +182,7 @@ contains
     type            (varying_string                                     )                                :: targetLabel
     type            (varying_string                                     )               , dimension(1  ) :: radiusSpecifiers
     !![
-    <constructorAssign variables="systematicErrorPolynomialCoefficient, randomErrorPolynomialCoefficient, randomErrorMinimum, randomErrorMaximum, *cosmologyFunctions_, *outputTimes_, toleranceRelative, *darkMatterHaloScale_"/>
+    <constructorAssign variables="systematicErrorPolynomialCoefficient, randomErrorPolynomialCoefficient, randomErrorMinimum, randomErrorMaximum, report, *cosmologyFunctions_, *outputTimes_, toleranceRelative, *darkMatterHaloScale_"/>
     !!]
     
     !$ call hdf5Access%set()
@@ -343,6 +351,8 @@ contains
          &                                                         functionValueTarget                                              , &
          &                                                         functionCovarianceTarget                                           &
          &                                                        )
+    ! Activate reporting if requested.
+    if (report) call self%setReporting(.true.,"black hole M-σ")
     ! Clean up.
     !![
     <objectDestructor name="galacticFilter_"                                 />

--- a/source/output.analyses.cross_correlator_1d.F90
+++ b/source/output.analyses.cross_correlator_1d.F90
@@ -32,7 +32,7 @@ mass function) output analysis class.
   use               :: Output_Analysis_Property_Operators      , only : outputAnalysisPropertyOperatorClass
   use               :: Output_Analysis_Weight_Operators        , only : outputAnalysisWeightOperatorClass
   use               :: Output_Times                            , only : outputTimesClass
-  use               :: Output_Analyses_Options                 , only : enumerationOutputAnalysisCovarianceModelType, enumerationOutputAnalysisStateType
+  use               :: Output_Analyses_Options                 , only : enumerationOutputAnalysisCovarianceModelType
 
   !![
   <outputAnalysis name="outputAnalysisCrossCorrelator1D">
@@ -58,7 +58,6 @@ mass function) output analysis class.
      class           (outputAnalysisDistributionNormalizerClass   ), pointer                     :: outputAnalysisDistributionNormalizer_ => null()
      class           (galacticFilterClass                         ), pointer                     :: galacticFilter_                       => null()
      class           (outputTimesClass                            ), pointer                     :: outputTimes_                          => null()
-     type            (enumerationOutputAnalysisStateType          )                              :: state
      double precision                                              , dimension(:,:), allocatable :: outputWeight                                   , functionCovariance                                         , &
           &                                                                                         weightMainBranch
      double precision                                              , dimension(:  ), allocatable :: binCenter                                      , weightMainBranchCross
@@ -360,8 +359,7 @@ contains
     use    :: Display                 , only : displayMessage
     use    :: Galacticus_Nodes        , only : nodeComponentBasic                   , treeNode
     use    :: Node_Property_Extractors, only : nodePropertyExtractorScalar
-    use    :: Output_Analyses_Options , only : outputAnalysisCovarianceModelBinomial, enumerationOutputAnalysisPropertyTypeType, enumerationOutputAnalysisPropertyQuantityType, outputAnalysisState, &
-         &                                     enumerationOutputAnalysisStateDecode , enumerationOutputAnalysisStateType
+    use    :: Output_Analyses_Options , only : outputAnalysisCovarianceModelBinomial, enumerationOutputAnalysisPropertyTypeType, enumerationOutputAnalysisPropertyQuantityType
     use    :: String_Handling         , only : operator(//)
     !$ use :: OMP_Lib                 , only : OMP_Set_Lock                         , OMP_Unset_Lock
     implicit none
@@ -375,7 +373,6 @@ contains
          &                                                                                            propertyValueIntrinsic, weightValue2
     type            (enumerationOutputAnalysisPropertyTypeType    )                                :: propertyType 
     type            (enumerationOutputAnalysisPropertyQuantityType)                                :: propertyQuantity
-    type            (enumerationOutputAnalysisStateType           )                                :: state
     integer         (c_size_t                                     )                                :: j                     , k           , &
          &                                                                                            indexHaloMass
 
@@ -402,18 +399,6 @@ contains
     ! Apply output weights.
     distribution(1:self%binCount)=+distribution              (1:self%binCount        ) &
          &                        *self        %outputWeight ( :             ,iOutput)
-    ! Report on state changes.
-    if (self%report) then
-       state=outputAnalysisState(distribution(1:self%binCount))
-       if (state /= self%state) then
-          block
-            type(varying_string) :: message
-            message="report: "//self%reportLabel//": state change: "//enumerationOutputAnalysisStateDecode(self%state,includePrefix=.false.)//" → "//enumerationOutputAnalysisStateDecode(state,includePrefix=.false.)//" [node: "//node%uniqueID()//"]"
-            call displayMessage(message)
-          end block
-          self%state=state
-       end if
-    end if
     ! Compute the weights.
     weightValue1=node%hostTree%volumeWeight
     weightValue2=node%hostTree%volumeWeight
@@ -597,8 +582,7 @@ contains
     !!{
     Activate/deactivate reporting.
     !!}
-    use :: ISO_Varying_String     , only : assignment(=)
-    use :: Output_Analyses_Options, only : outputAnalysisStateUnknown
+    use :: ISO_Varying_String, only : assignment(=)
     implicit none
     class    (outputAnalysisCrossCorrelator1D), intent(inout)           :: self
     logical                                   , intent(in   )           :: report
@@ -606,6 +590,5 @@ contains
 
     self%report=report
     if (present(reportLabel)) self%reportLabel=reportLabel
-    if (        report      ) self%state      =outputAnalysisStateUnknown
     return
   end subroutine crossCorrelator1DSetReporting

--- a/source/output.analyses.cross_correlator_1d.F90
+++ b/source/output.analyses.cross_correlator_1d.F90
@@ -32,7 +32,7 @@ mass function) output analysis class.
   use               :: Output_Analysis_Property_Operators      , only : outputAnalysisPropertyOperatorClass
   use               :: Output_Analysis_Weight_Operators        , only : outputAnalysisWeightOperatorClass
   use               :: Output_Times                            , only : outputTimesClass
-  use               :: Output_Analyses_Options                 , only : enumerationOutputAnalysisCovarianceModelType
+  use               :: Output_Analyses_Options                 , only : enumerationOutputAnalysisCovarianceModelType, enumerationOutputAnalysisStateType
 
   !![
   <outputAnalysis name="outputAnalysisCrossCorrelator1D">
@@ -58,6 +58,7 @@ mass function) output analysis class.
      class           (outputAnalysisDistributionNormalizerClass   ), pointer                     :: outputAnalysisDistributionNormalizer_ => null()
      class           (galacticFilterClass                         ), pointer                     :: galacticFilter_                       => null()
      class           (outputTimesClass                            ), pointer                     :: outputTimes_                          => null()
+     type            (enumerationOutputAnalysisStateType          )                              :: state
      double precision                                              , dimension(:,:), allocatable :: outputWeight                                   , functionCovariance                                         , &
           &                                                                                         weightMainBranch
      double precision                                              , dimension(:  ), allocatable :: binCenter                                      , weightMainBranchCross
@@ -69,13 +70,15 @@ mass function) output analysis class.
      double precision                                                                            :: covarianceBinomialMassHaloMinimum              , covarianceBinomialMassHaloMaximum                          , &
           &                                                                                         covarianceModelHaloMassMinimumLogarithmic      , covarianceModelHaloMassIntervalLogarithmicInverse          , &
           &                                                                                         binWidth
-     logical                                                                                     :: finalized
+     logical                                                                                     :: finalized                                      , report
+     type            (varying_string                              )                              :: reportLabel
      !$ integer      (omp_lock_kind                               )                              :: accumulateLock
    contains
      !![
      <methods>
        <method description="Return the results of the volume function operator." method="results"         />
        <method description="Finalize the analysis of this function."             method="finalizeAnalysis"/>
+       <method description="Activate/deactivate reporting."                      method="setReporting"    />
      </methods>
      !!]
      final     ::                     crossCorrelator1DDestructor
@@ -84,6 +87,7 @@ mass function) output analysis class.
      procedure :: results          => crossCorrelator1DResults
      procedure :: reduce           => crossCorrelator1DReduce
      procedure :: finalizeAnalysis => crossCorrelator1DFinalizeAnalysis
+     procedure :: setReporting     => crossCorrelator1DSetReporting
   end type outputAnalysisCrossCorrelator1D
 
   interface outputAnalysisCrossCorrelator1D
@@ -319,7 +323,10 @@ contains
     self%finalized=.false.
     ! Initialize OpenMP accumulation lock.
     !$ call OMP_Init_Lock(self%accumulateLock)
-   return
+    ! Initialize reporting state.
+    self%report     =.false.
+    self%reportLabel="unknown"
+    return
   end function crossCorrelator1DConstructorInternal
 
   subroutine crossCorrelator1DDestructor(self)
@@ -350,9 +357,12 @@ contains
     !!{
     Implement a crossCorrelator1D output analysis.
     !!}
+    use    :: Display                 , only : displayMessage
     use    :: Galacticus_Nodes        , only : nodeComponentBasic                   , treeNode
     use    :: Node_Property_Extractors, only : nodePropertyExtractorScalar
-    use    :: Output_Analyses_Options , only : outputAnalysisCovarianceModelBinomial, enumerationOutputAnalysisPropertyTypeType, enumerationOutputAnalysisPropertyQuantityType
+    use    :: Output_Analyses_Options , only : outputAnalysisCovarianceModelBinomial, enumerationOutputAnalysisPropertyTypeType, enumerationOutputAnalysisPropertyQuantityType, outputAnalysisState, &
+         &                                     enumerationOutputAnalysisStateDecode , enumerationOutputAnalysisStateType
+    use    :: String_Handling         , only : operator(//)
     !$ use :: OMP_Lib                 , only : OMP_Set_Lock                         , OMP_Unset_Lock
     implicit none
     class           (outputAnalysisCrossCorrelator1D              ), intent(inout)                 :: self
@@ -365,6 +375,7 @@ contains
          &                                                                                            propertyValueIntrinsic, weightValue2
     type            (enumerationOutputAnalysisPropertyTypeType    )                                :: propertyType 
     type            (enumerationOutputAnalysisPropertyQuantityType)                                :: propertyQuantity
+    type            (enumerationOutputAnalysisStateType           )                                :: state
     integer         (c_size_t                                     )                                :: j                     , k           , &
          &                                                                                            indexHaloMass
 
@@ -391,6 +402,18 @@ contains
     ! Apply output weights.
     distribution(1:self%binCount)=+distribution              (1:self%binCount        ) &
          &                        *self        %outputWeight ( :             ,iOutput)
+    ! Report on state changes.
+    if (self%report) then
+       state=outputAnalysisState(distribution(1:self%binCount))
+       if (state /= self%state) then
+          block
+            type(varying_string) :: message
+            message="report: "//self%reportLabel//": state change: "//enumerationOutputAnalysisStateDecode(self%state,includePrefix=.false.)//" → "//enumerationOutputAnalysisStateDecode(state,includePrefix=.false.)//" [node: "//node%uniqueID()//"]"
+            call displayMessage(message)
+          end block
+          self%state=state
+       end if
+    end if
     ! Compute the weights.
     weightValue1=node%hostTree%volumeWeight
     weightValue2=node%hostTree%volumeWeight
@@ -569,3 +592,20 @@ contains
     end if
     return
   end subroutine crossCorrelator1DResults
+
+  subroutine crossCorrelator1DSetReporting(self,report,reportLabel)
+    !!{
+    Activate/deactivate reporting.
+    !!}
+    use :: ISO_Varying_String     , only : assignment(=)
+    use :: Output_Analyses_Options, only : outputAnalysisStateUnknown
+    implicit none
+    class    (outputAnalysisCrossCorrelator1D), intent(inout)           :: self
+    logical                                   , intent(in   )           :: report
+    character(len=*                          ), intent(in   ), optional :: reportLabel
+
+    self%report=report
+    if (present(reportLabel)) self%reportLabel=reportLabel
+    if (        report      ) self%state      =outputAnalysisStateUnknown
+    return
+  end subroutine crossCorrelator1DSetReporting

--- a/source/output.analyses.mean_function_1d.F90
+++ b/source/output.analyses.mean_function_1d.F90
@@ -22,7 +22,8 @@
   objects binned by some property) output analysis class.
   !!}
 
-  use :: ISO_Varying_String, only : varying_string
+  use :: ISO_Varying_String     , only : varying_string
+  use :: Output_Analyses_Options, only : enumerationOutputAnalysisStateType
 
   !![
   <outputAnalysis name="outputAnalysisMeanFunction1D">
@@ -45,8 +46,9 @@
           &                                                                                         meanLabel                                      , meanComment                                     , &
           &                                                                                         propertyUnits                                  , meanUnits                                       , &
           &                                                                                         xAxisLabel                                     , yAxisLabel                                      , &
-          &                                                                                         targetLabel
+          &                                                                                         targetLabel                                    , reportLabel
      type            (enumerationOutputAnalysisCovarianceModelType)                              :: covarianceModel
+     type            (enumerationOutputAnalysisStateType          )                              :: state
      double precision                                                                            :: propertyUnitsInSI                              , meanUnitsInSI
      class           (outputTimesClass                            ), pointer                     :: outputTimes_                          => null()
      class           (nodePropertyExtractorClass                  ), pointer                     :: nodePropertyExtractor_                => null(), outputAnalysisWeightPropertyExtractor_ => null()
@@ -64,7 +66,8 @@
      double precision                                                                            :: covarianceBinomialMassHaloMinimum              , covarianceBinomialMassHaloMaximum                , &
           &                                                                                         binWidth
      logical                                                                                     :: finalized                                      , likelihoodNormalize                              , &
-          &                                                                                         xAxisIsLog                                     , yAxisIsLog
+          &                                                                                         xAxisIsLog                                     , yAxisIsLog                                       , &
+          &                                                                                         report
      integer                                                                                     :: covarianceBinomialBinsPerDecade
      integer         (c_size_t                                    )                              :: bufferCount
    contains
@@ -72,6 +75,7 @@
      <methods>
        <method description="Return the results of the mean function operator." method="results"         />
        <method description="Finalize analysis of the mean function operator."  method="finalizeAnalysis"/>
+       <method description="Activate/deactivate reporting."                    method="setReporting"    />
      </methods>
      !!]
      final     ::                     meanFunction1DDestructor
@@ -81,6 +85,7 @@
      procedure :: reduce           => meanFunction1DReduce
      procedure :: results          => meanFunction1DResults
      procedure :: logLikelihood    => meanFunction1DLogLikelihood
+     procedure :: setReporting     => meanFunction1DSetReporting
   end type outputAnalysisMeanFunction1D
 
   interface outputAnalysisMeanFunction1D
@@ -438,6 +443,9 @@ contains
     self       %outputWeight          =reshape(outputWeight        ,[size(outputWeight        )])
     ! Mark as unfinalized.
     self%finalized=.false.
+    ! Initialize reporting state.
+    self%report     =.false.
+    self%reportLabel="unknown"
     ! Set normalization state for likelihood.
     self%likelihoodNormalize=.true.
     if (present(likelihoodNormalize)) self%likelihoodNormalize=likelihoodNormalize
@@ -661,11 +669,14 @@ contains
     !!{
     Finalize analysis of a \mono{meanFunction1D} output analysis.
     !!}
+    use    :: Display, only : displayMessage, displayIndent , displayUnindent
     implicit none
     class           (outputAnalysisMeanFunction1D), intent(inout)                 :: self
     double precision                              , allocatable  , dimension(:  ) :: unweightedValue     , weightedValue
     double precision                              , allocatable  , dimension(:,:) :: unweightedCovariance, weightedCovariance, &
          &                                                                           crossCovariance
+    type            (varying_string              )                                :: message
+    character       (len=43                      )                                :: label
     integer         (c_size_t                    )                                :: i                   , j
 
     ! If already finalized, no need to do anything.
@@ -675,15 +686,38 @@ contains
     call self%volumeFunctionUnweighted%results(binCenter=self%binCenter,functionValue=unweightedValue,functionCovariance=unweightedCovariance)
     call self%volumeFunctionWeighted  %results(                         functionValue=weightedValue  ,functionCovariance=weightedCovariance  )
     call self%crossCovariance         %results(                                                       functionCovariance=crossCovariance     )
+    ! Report if required.
+    if (self%report) then
+       message="report: "//self%reportLabel//": finalize"
+       call displayIndent(message)
+       call displayMessage("i    unweighted   weighted    ")
+       call displayMessage("---- ------------ ------------")
+       do i=1,size(unweightedValue)
+          write (label,'(i4,1x,e12.6,1x,e12.6)') i,unweightedValue(i),weightedValue(i)
+          call displayMessage(trim(label))
+       end do
+       call displayUnindent("done")
+    end if
     ! Estimate covariance of ratio using Taylor series expansion approach
     ! (e.g. http://math.stackexchange.com/questions/40713/calculating-the-variance-of-the-ratio-of-random-variables).
     allocate(self%meanValue     (size(self%binCenter)                     ))
     allocate(self%meanCovariance(size(self%binCenter),size(self%binCenter)))
     self%meanValue     =0.0d0
     self%meanCovariance=0.0d0
+    ! Report if required.
+    if (self%report) then
+       message="report: "//self%reportLabel//": mean"
+       call displayIndent(message)
+       call displayMessage("i    unweighted   weighted     mean        ")
+       call displayMessage("---- ------------ ------------ ------------")
+    end if
     do i=1,size(self%binCenter)
        if (unweightedValue(i) > 0.0d0) then
           self%meanValue(i)=weightedValue(i)/unweightedValue(i)
+          if (self%report) then
+             write (label,'(i4,1x,e12.6,1x,e12.6,1x,e12.6)') i,unweightedValue(i),weightedValue(i),self%meanValue(i)
+             call displayMessage(label)
+          end if
           do j=i,size(self%binCenter)
              if (unweightedValue(j) > 0.0d0) then
                 self%meanCovariance(i,j)=+(                                                                                                      &
@@ -699,6 +733,7 @@ contains
           end do
        end if
     end do
+    if (self%report) call displayUnindent("done")
     return
   end subroutine meanFunction1DFinalizeAnalysis
 
@@ -852,3 +887,27 @@ contains
     end if
     return
   end function meanFunction1DLogLikelihood
+
+  subroutine meanFunction1DSetReporting(self,report,reportLabel)
+    !!{
+    Activate/deactivate reporting.
+    !!}
+    use :: ISO_Varying_String     , only : assignment(=)
+    use :: Output_Analyses_Options, only : outputAnalysisStateUnknown
+    implicit none
+    class    (outputAnalysisMeanFunction1D), intent(inout)           :: self
+    logical                                , intent(in   )           :: report
+    character(len=*                       ), intent(in   ), optional :: reportLabel
+
+    self%report=report
+    if (present(reportLabel)) then
+       self%reportLabel=reportLabel
+    else
+       self%reportLabel="unknown"
+    end if
+    if (report) self%state=outputAnalysisStateUnknown
+    call self%volumeFunctionUnweighted%setReporting(report,char(self%reportLabel)//' [mean; unweighted]')
+    call self%volumeFunctionWeighted  %setReporting(report,char(self%reportLabel)//' [mean; weighted]'  )
+    call self%crossCovariance         %setReporting(report,char(self%reportLabel)//' [mean; cross]'     )
+    return
+  end subroutine meanFunction1DSetReporting

--- a/source/output.analyses.options.F90
+++ b/source/output.analyses.options.F90
@@ -59,4 +59,38 @@ module Output_Analyses_Options
   </enumeration>
   !!]
 
+  !![
+  <enumeration>
+   <name>outputAnalysisState</name>
+   <description>Output analyses states.</description>
+   <encodeFunction>yes</encodeFunction>
+   <decodeFunction>yes</decodeFunction>
+   <entry label="unknown" />
+   <entry label="zero"    />
+   <entry label="positive"/>
+   <entry label="negative"/>
+  </enumeration>
+  !!]
+
+contains
+
+  function outputAnalysisState(distribution) result(state)
+    !!{
+    Determine the state of an output analysis distribution.
+    !!}
+    implicit none
+    type            (enumerationOutputAnalysisStateType)               :: state
+    double precision                                    , dimension(:) :: distribution
+
+    state=outputAnalysisStateUnknown
+    if      (all(distribution == 0.0d0)) then
+       state=outputAnalysisStateZero
+    else if (all(distribution >= 0.0d0)) then
+       state=outputAnalysisStatePositive
+    else if (all(distribution <= 0.0d0)) then
+       state=outputAnalysisStateNegative
+    end if
+    return
+  end function outputAnalysisState
+  
 end module Output_Analyses_Options

--- a/source/output.analyses.volume_function_1d.F90
+++ b/source/output.analyses.volume_function_1d.F90
@@ -32,7 +32,7 @@ mass function) output analysis class.
   use               :: Output_Analysis_Property_Operators      , only : outputAnalysisPropertyOperatorClass
   use               :: Output_Analysis_Weight_Operators        , only : outputAnalysisWeightOperatorClass
   use               :: Output_Times                            , only : outputTimesClass
-  use               :: Output_Analyses_Options                 , only : enumerationOutputAnalysisCovarianceModelType
+  use               :: Output_Analyses_Options                 , only : enumerationOutputAnalysisCovarianceModelType, enumerationOutputAnalysisStateType
   !![
   <outputAnalysis name="outputAnalysisVolumeFunction1D">
    <description>
@@ -93,7 +93,7 @@ mass function) output analysis class.
           &                                                                                         distributionLabel                              , distributionComment                              , &
           &                                                                                         propertyUnits                                  , distributionUnits                                , &
           &                                                                                         xAxisLabel                                     , yAxisLabel                                       , &
-          &                                                                                         targetLabel
+          &                                                                                         targetLabel                                    , reportLabel
      double precision                                                                            :: propertyUnitsInSI                              , distributionUnitsInSI
      class           (nodePropertyExtractorClass                  ), pointer                     :: nodePropertyExtractor_                => null()
      class           (outputAnalysisPropertyOperatorClass         ), pointer                     :: outputAnalysisPropertyOperator_       => null()                                                   , &
@@ -112,18 +112,21 @@ mass function) output analysis class.
      integer         (c_size_t                                    )                              :: binCount                                       , bufferCount                                      , &
           &                                                                                         binCountTotal                                  , covarianceModelBinomialBinCount
      type            (enumerationOutputAnalysisCovarianceModelType)                              :: covarianceModel
+     type            (enumerationOutputAnalysisStateType          )                              :: state
      integer                                                                                     :: covarianceBinomialBinsPerDecade
      double precision                                                                            :: covarianceBinomialMassHaloMinimum              , covarianceBinomialMassHaloMaximum                , &
           &                                                                                         covarianceModelHaloMassMinimumLogarithmic      , covarianceModelHaloMassIntervalLogarithmicInverse, &
           &                                                                                         binWidth
      logical                                                                                     :: finalized                                      , xAxisIsLog                                       , &
-          &                                                                                         yAxisIsLog                                     , likelihoodNormalize
+          &                                                                                         yAxisIsLog                                     , likelihoodNormalize                              , &
+          &                                                                                         report
      !$ integer      (omp_lock_kind                               )                              :: accumulateLock
    contains
      !![
      <methods>
        <method description="Return the results of the volume function operator." method="results"         />
        <method description="Finalize the analysis of this function."             method="finalizeAnalysis"/>
+       <method description="Activate/deactivate reporting."                      method="setReporting"    />
      </methods>
      !!]
      final     ::                     volumeFunction1DDestructor
@@ -133,6 +136,7 @@ mass function) output analysis class.
      procedure :: reduce           => volumeFunction1DReduce
      procedure :: logLikelihood    => volumeFunction1DLogLikelihood
      procedure :: finalizeAnalysis => volumeFunction1DFinalizeAnalysis
+     procedure :: setReporting     => volumeFunction1DSetReporting
   end type outputAnalysisVolumeFunction1D
 
   interface outputAnalysisVolumeFunction1D
@@ -535,6 +539,9 @@ contains
     self%finalized=.false.
     ! Initialize OpenMP accumulation lock.
     !$ call OMP_Init_Lock(self%accumulateLock)
+    ! Initialize reporting state.
+    self%report     =.false.
+    self%reportLabel="unknown"
    return
   end function volumeFunction1DConstructorInternal
 
@@ -565,9 +572,12 @@ contains
     !!{
     Implement a volumeFunction1D output analysis.
     !!}
+    use    :: Display                 , only : displayMessage
     use    :: Galacticus_Nodes        , only : nodeComponentBasic                   , treeNode
     use    :: Node_Property_Extractors, only : nodePropertyExtractorScalar
-    use    :: Output_Analyses_Options , only : outputAnalysisCovarianceModelBinomial, enumerationOutputAnalysisPropertyTypeType, enumerationOutputAnalysisPropertyQuantityType
+    use    :: Output_Analyses_Options , only : outputAnalysisCovarianceModelBinomial, enumerationOutputAnalysisPropertyTypeType, enumerationOutputAnalysisPropertyQuantityType, outputAnalysisState, &
+         &                                     enumerationOutputAnalysisStateDecode , enumerationOutputAnalysisStateType
+    use    :: String_Handling         , only : operator(//)
     !$ use :: OMP_Lib                 , only : OMP_Set_Lock                         , OMP_Unset_Lock
     implicit none
     class           (outputAnalysisVolumeFunction1D               ), intent(inout)                 :: self
@@ -580,6 +590,7 @@ contains
          &                                                                                            propertyValueIntrinsic
     type            (enumerationOutputAnalysisPropertyTypeType    )                                :: propertyType 
     type            (enumerationOutputAnalysisPropertyQuantityType)                                :: propertyQuantity
+    type            (enumerationOutputAnalysisStateType           )                                :: state
     integer         (c_size_t                                     )                                :: j                     , k            , &
          &                                                                                            indexHaloMass
 
@@ -611,6 +622,18 @@ contains
     distribution(1:self%binCount)=+distribution              (1:self%binCount        ) &
          &                        *self        %outputWeight ( :             ,iOutput) &
          &                        *weightValue
+    ! Report on state changes.
+    if (self%report) then
+       state=outputAnalysisState(distribution(1:self%binCount))
+       if (state /= self%state) then
+          block
+            type(varying_string) :: message
+            message="report: "//self%reportLabel//": state change: "//enumerationOutputAnalysisStateDecode(self%state,includePrefix=.false.)//" → "//enumerationOutputAnalysisStateDecode(state,includePrefix=.false.)//" [node: "//node%uniqueID()//"]"
+            call displayMessage(message)
+          end block
+          self%state=state
+       end if
+    end if
     ! Accumulate the property, including weights from both the host tree and the output. Note that we accumulate only the
     ! non-buffer bins of the distribution.
     !$ call OMP_Set_Lock(self%accumulateLock)
@@ -657,22 +680,50 @@ contains
     !!{
     Implement a volumeFunction1D output analysis reduction.
     !!}
+    use    :: Display                , only : displayMessage                       , displayIndent , displayUnindent
     use    :: Error                  , only : Error_Report
     use    :: Output_Analyses_Options, only : outputAnalysisCovarianceModelBinomial
     !$ use :: OMP_Lib                , only : OMP_Set_Lock                         , OMP_Unset_Lock
     implicit none
-    class(outputAnalysisVolumeFunction1D), intent(inout) :: self
-    class(outputAnalysisClass           ), intent(inout) :: reduced
-
+    class    (outputAnalysisVolumeFunction1D), intent(inout) :: self
+    class    (outputAnalysisClass           ), intent(inout) :: reduced
+    type     (varying_string                )                :: message
+    character(len=30                        )                :: label
+    integer                                                  :: i
+    
     select type (reduced)
     class is (outputAnalysisVolumeFunction1D)
        !$ call OMP_Set_Lock(reduced%accumulateLock)
+       if (self%report) call displayIndent('begin reduction lock: '//char(self%reportLabel))
+       if (self%report) then
+          message="report: "//self%reportLabel//": reduce: pre"
+          call displayIndent(message)
+          call displayMessage("i    value        reduced     ")
+          call displayMessage("---- ------------ ------------")
+          do i=1,size(self%functionValue)
+             write (label,'(i4,1x,e12.6,1x,e12.6)') i,self%functionValue(i),reduced%functionValue(i)
+             call displayMessage(label)
+          end do
+          call displayUnindent("done")
+       end if
        if (self%covarianceModel == outputAnalysisCovarianceModelBinomial) then
           reduced%weightMainBranch       =reduced%weightMainBranch       +self%weightMainBranch
           reduced%weightMainBranchSquared=reduced%weightMainBranchSquared+self%weightMainBranchSquared
        end if
        reduced%functionCovariance        =reduced%functionCovariance     +self%functionCovariance
        reduced%functionValue             =reduced%functionValue          +self%functionValue
+       if (self%report) then
+          message="report: "//self%reportLabel//": reduce: post"
+          call displayIndent(message)
+          call displayMessage("i    value        reduced     ")
+          call displayMessage("---- ------------ ------------")
+          do i=1,size(self%functionValue)
+             write (label,'(i4,1x,e12.6,1x,e12.6)') i,self%functionValue(i),reduced%functionValue(i)
+             call displayMessage(label)
+          end do
+          call displayUnindent("done")
+       end if
+       if (self%report) call displayUnindent('end reduction lock: '//char(self%reportLabel))
        !$ call OMP_Unset_Lock(reduced%accumulateLock)
     class default
        call Error_Report('incorrect class'//{introspection:location})
@@ -896,3 +947,20 @@ contains
     end if
     return
   end function volumeFunction1DLogLikelihood
+
+  subroutine volumeFunction1DSetReporting(self,report,reportLabel)
+    !!{
+    Activate/deactivate reporting.
+    !!}
+    use :: ISO_Varying_String     , only : assignment(=)
+    use :: Output_Analyses_Options, only : outputAnalysisStateUnknown
+    implicit none
+    class    (outputAnalysisVolumeFunction1D), intent(inout)           :: self
+    logical                                  , intent(in   )           :: report
+    character(len=*                         ), intent(in   ), optional :: reportLabel
+
+    self%report=report
+    if (present(reportLabel)) self%reportLabel=reportLabel
+    if (        report      ) self%state      =outputAnalysisStateUnknown
+    return
+  end subroutine volumeFunction1DSetReporting

--- a/source/output.analyses.volume_function_1d.F90
+++ b/source/output.analyses.volume_function_1d.F90
@@ -625,15 +625,6 @@ contains
     distribution(1:self%binCount)=+distribution              (1:self%binCount        ) &
          &                        *self        %outputWeight ( :             ,iOutput) &
          &                        *weightValue
-    ! Report on node.
-    if (self%report) then
-       block
-         character(len=96) :: message
-         
-         write (message,'(a,2(1x,i8),5(1x,e12.6))') "report: node:",node%hostTree%index,node%index(),propertyValueIntrinsic,propertyValue,sum(self%outputWeight(:,iOutput)),node%hostTree%volumeWeight,weightValue
-         call displayMessage(message)
-       end block
-    end if
     ! Accumulate the property, including weights from both the host tree and the output. Note that we accumulate only the
     ! non-buffer bins of the distribution.
     !$ call OMP_Set_Lock(self%accumulateLock)

--- a/source/output.analyses.volume_function_1d.F90
+++ b/source/output.analyses.volume_function_1d.F90
@@ -110,7 +110,8 @@ mass function) output analysis class.
           &                                                                                         functionCovarianceTarget1D
      double precision                                              , dimension(:  ), allocatable :: binMinimum                                     , binMaximum
      integer         (c_size_t                                    )                              :: binCount                                       , bufferCount                                      , &
-          &                                                                                         binCountTotal                                  , covarianceModelBinomialBinCount
+          &                                                                                         binCountTotal                                  , covarianceModelBinomialBinCount                  , &
+          &                                                                                         reportCount                                    , reportCountInRange
      type            (enumerationOutputAnalysisCovarianceModelType)                              :: covarianceModel
      type            (enumerationOutputAnalysisStateType          )                              :: state
      integer                                                                                     :: covarianceBinomialBinsPerDecade
@@ -540,8 +541,10 @@ contains
     ! Initialize OpenMP accumulation lock.
     !$ call OMP_Init_Lock(self%accumulateLock)
     ! Initialize reporting state.
-    self%report     =.false.
-    self%reportLabel="unknown"
+    self%report            =.false.
+    self%reportLabel       ="unknown"
+    self%reportCount       =0_c_size_t
+    self%reportCountInRange=0_c_size_t
    return
   end function volumeFunction1DConstructorInternal
 
@@ -622,9 +625,29 @@ contains
     distribution(1:self%binCount)=+distribution              (1:self%binCount        ) &
          &                        *self        %outputWeight ( :             ,iOutput) &
          &                        *weightValue
-    ! Report on state changes.
+    ! Report on node.
     if (self%report) then
-       state=outputAnalysisState(distribution(1:self%binCount))
+       block
+         character(len=96) :: message
+         
+         write (message,'(a,2(1x,i8),5(1x,e12.6))') "report: node:",node%hostTree%index,node%index(),propertyValueIntrinsic,propertyValue,sum(self%outputWeight(:,iOutput)),node%hostTree%volumeWeight,weightValue
+         call displayMessage(message)
+       end block
+    end if
+    ! Accumulate the property, including weights from both the host tree and the output. Note that we accumulate only the
+    ! non-buffer bins of the distribution.
+    !$ call OMP_Set_Lock(self%accumulateLock)
+    self%functionValue=+self%functionValue+distribution(1:self%binCount)
+    ! Report on state changes and count in-range nodes.
+    if (self%report) then
+       self         %reportCount       =self%reportCount       +1_c_size_t
+       if     (                                                            &
+            &   propertyValue > self%binMinimum(     1       )             &
+            &  .and.                                                       &
+            &   propertyValue < self%binMaximum(self%binCount)             &
+            & ) self%reportCountInRange=self%reportCountInRange+1_c_size_t
+       ! Check for state changes.
+       state=outputAnalysisState(self%functionValue)
        if (state /= self%state) then
           block
             type(varying_string) :: message
@@ -634,10 +657,6 @@ contains
           self%state=state
        end if
     end if
-    ! Accumulate the property, including weights from both the host tree and the output. Note that we accumulate only the
-    ! non-buffer bins of the distribution.
-    !$ call OMP_Set_Lock(self%accumulateLock)
-    self%functionValue=+self%functionValue+distribution(1:self%binCount)
     !$ call OMP_Unset_Lock(self%accumulateLock)
     ! Accumulate covariance. If using the binomial model for main branch galaxies, handle them separately.
     if (node%isOnMainBranch() .and. self%covarianceModel == outputAnalysisCovarianceModelBinomial) then
@@ -683,6 +702,7 @@ contains
     use    :: Display                , only : displayMessage                       , displayIndent , displayUnindent
     use    :: Error                  , only : Error_Report
     use    :: Output_Analyses_Options, only : outputAnalysisCovarianceModelBinomial
+    use    :: String_Handling        , only : operator(//)
     !$ use :: OMP_Lib                , only : OMP_Set_Lock                         , OMP_Unset_Lock
     implicit none
     class    (outputAnalysisVolumeFunction1D), intent(inout) :: self
@@ -696,7 +716,7 @@ contains
        !$ call OMP_Set_Lock(reduced%accumulateLock)
        if (self%report) call displayIndent('begin reduction lock: '//char(self%reportLabel))
        if (self%report) then
-          message="report: "//self%reportLabel//": reduce: pre"
+          message="report: "//self%reportLabel//": reduce: pre [nodes total/in-range = "//self%reportCount//" / "//self%reportCountInRange//"]"
           call displayIndent(message)
           call displayMessage("i    value        reduced     ")
           call displayMessage("---- ------------ ------------")


### PR DESCRIPTION
## Summary
- Several `nodePropertyExtractors` make use of "radius specifiers" - these are strings which specify at which radii the property is to be extracted. These allow for a "weight by" option to allow, for example, weighting of a quantity by luminosity. Previously, when decoding these specifiers, no default weighting was set - weighting was set only in a few specific cases. This left the `weightBy` options undefined, and subject to arbitrary values depending on how the memory was initialized. In many cases this would have left a `zero` in this memory location, which happens to correspond to "weight by mass" - which is the desired default. So, the behavior was often, but not reliably correct.
- Under certain combinations of compiler, parameters, and number of threads, nonsense values could be placed into these memory locations, resulting in undefined behavior. Typically, the nonsense value would not match any actual "weight by" option - this could result in an empty `massDistribution` being constructed and zero results being returned.
- This fix simply sets an appropriate default for these weights to avoid the undefined behavior.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- This is difficult to test as it depends on the exact values assigned to uninitialized memory. A model which reliably reproduced the behavior when run with 16 OpenMP threads was found - the parameter file is attached and Galacticus build details are below. Running this model previously reliably produced all zeros for the black hole $M$--$\sigma$ relation. After the fix, non-zero values are produced.

```
MMM: -> Begin task: report
MMM:     This is Galacticus: revision 380601271988c3eb1edb8778de8d1e57c6c531be (branch: fixBHMSigmaReport; build time: Sun May 24 23:01:20 UTC 2026)
MMM:     Built with: :GSL_version[2.6]:FoX_version[4.1.3]:HDF5_version[1.14.5]:FCCOMPILER[gfortran]:PREPROCESSOR[cpp]:CCOMPILER[gcc]:CPPCOMPILER[g++]:FCFLAGS[-ffree-line-length-none -frecursive -DBUILDPATH='./work/build' -J./work/build/moduleBuild/ -I./work/build/ -fintrinsic-modules-path /home/abenson/Tools/finclude -fintrinsic-modules-path /home/abenson/Tools/include -fintrinsic-modules-path /home/abenson/Tools/include/gfortran -fintrinsic-modules-path /home/abenson/Tools/lib/gfortran/modules -L/home/abenson/Tools/lib -L/home/abenson/Tools/lib64 -pthread -Wall -fbacktrace -ffpe-trap=invalid,zero,overflow -fdump-core -O3 -ffinite-math-only -fno-math-errno -fopenmp -g -DPROCPS -DOFDAVAIL -DFFTW3AVAIL -DANNAVAIL -DQHULLAVAIL -DMATHEVALAVAIL -DGIT2AVAIL]:FCFLAGS_NOOPT[-ffree-line-length-none -frecursive -DBUILDPATH='./work/build' -J./work/build/moduleBuild/ -I./work/build/ -fintrinsic-modules-path /home/abenson/Tools/finclude -fintrinsic-modules-path /home/abenson/Tools/include -fintrinsic-modules-path /home/abenson/Tools/include/gfortran -fintrinsic-modules-path /home/abenson/Tools/lib/gfortran/modules -L/home/abenson/Tools/lib -L/home/abenson/Tools/lib64 -pthread -Wall -fbacktrace -ffpe-trap=invalid,zero,overflow -fdump-core -g]:CFLAGS[-fopenmp -DBUILDPATH='./work/build' -I./source/ -I./work/build/ -I/home/abenson/Tools/include -g -DOFDLOCKS -DPROCPS -DOFDAVAIL -DGIT2AVAIL]:CPPFLAGS[-fopenmp -DBUILDPATH='./work/build' -I./source/ -I./work/build/ -I/home/abenson/Tools/include -I/home/abenson/Tools/include/libqhullcpp -g -DOFDLOCKS -DPROCPS -DOFDAVAIL -DANNAVAIL -DQHULLAVAIL -DMATHEVALAVAIL -DGIT2AVAIL]:FCCOMPILER_VERSION[Using built-in specs. COLLECT_GCC=gfortran COLLECT_LTO_WRAPPER=/resnick/home/abenson/Tools/bin/../libexec/gcc/x86_64-pc-linux-gnu/12.0.0/lto-wrapper Target: x86_64-pc-linux-gnu Configured with: ../gcc-git/configure --prefix=/home/abenson/Tools --enable-languages=c,c++,fortran --disable-multilib Thread model: posix Supported LTO compression algorithms: zlib zstd gcc version 12.0.0 20211022 (experimental) (GCC) ]:CCOMPILER_VERSION[Using built-in specs. COLLECT_GCC=gcc COLLECT_LTO_WRAPPER=/resnick/home/abenson/Tools/bin/../libexec/gcc/x86_64-pc-linux-gnu/12.0.0/lto-wrapper Target: x86_64-pc-linux-gnu Configured with: ../gcc-git/configure --prefix=/home/abenson/Tools --enable-languages=c,c++,fortran --disable-multilib Thread model: posix Supported LTO compression algorithms: zlib zstd gcc version 12.0.0 20211022 (experimental) (GCC) ]:CPPCOMPILER_VERSION[Using built-in specs. COLLECT_GCC=g++ COLLECT_LTO_WRAPPER=/resnick/home/abenson/Tools/bin/../libexec/gcc/x86_64-pc-linux-gnu/12.0.0/lto-wrapper Target: x86_64-pc-linux-gnu Configured with: ../gcc-git/configure --prefix=/home/abenson/Tools --enable-languages=c,c++,fortran --disable-multilib Thread model: posix Supported LTO compression algorithms: zlib zstd gcc version 12.0.0 20211022 (experimental) (GCC) ]
MMM: <- Done task: report
```

[parameters.xml](https://github.com/user-attachments/files/28229109/parameters.xml)

## Checklist
- [X] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'
