### PR TITLE
perf(surveyGeometryRandomPoints): hoist trig and share unit direction in window-function loop

### DIFF
--- a/source/geometry.surveys.random_points.F90
+++ b/source/geometry.surveys.random_points.F90
@@ -98,11 +98,13 @@ contains
     double precision                            , intent(  out)                                           :: boxLength
     complex         (c_double_complex          ), intent(  out), dimension(gridCount,gridCount,gridCount) :: windowFunction1         , windowFunction2
     double precision                            ,                dimension(3                            ) :: origin                  , position1              , &
-         &                                                                                                   position2
+         &                                                                                                   position2               , direction
     integer                                                                                               :: i
     double precision                                                                                      :: comovingDistanceMaximum1, comovingDistanceMaximum2, &
          &                                                                                                   comovingDistanceMinimum1, comovingDistanceMinimum2, &
-         &                                                                                                   distance1               , distance2
+         &                                                                                                   distance1               , distance2               , &
+         &                                                                                                   sinTheta                , cosTheta                , &
+         &                                                                                                   sinPhi                  , cosPhi
 #ifdef FFTW3AVAIL
     type            (c_ptr                     )                                                          :: plan
 #endif
@@ -157,9 +159,14 @@ contains
             &         comovingDistanceMinimum1                , &
             &         comovingDistanceMinimum2                  &
             &        )
-       ! Convert to Cartesian coordinates.
-       position1=distance1*[sin(self%randomTheta(i))*cos(self%randomPhi(i)),sin(self%randomTheta(i))*sin(self%randomPhi(i)),cos(self%randomTheta(i))]+origin
-       position2=distance2*[sin(self%randomTheta(i))*cos(self%randomPhi(i)),sin(self%randomTheta(i))*sin(self%randomPhi(i)),cos(self%randomTheta(i))]+origin
+       ! Convert to Cartesian coordinates. Both positions lie along the same ray, so build the unit direction vector once.
+       sinTheta =sin(self%randomTheta(i))
+       cosTheta =cos(self%randomTheta(i))
+       sinPhi   =sin(self%randomPhi  (i))
+       cosPhi   =cos(self%randomPhi  (i))
+       direction=[sinTheta*cosPhi,sinTheta*sinPhi,cosTheta]
+       position1=distance1*direction+origin
+       position2=distance2*direction+origin
        ! Apply to the mesh.
        call Meshes_Apply_Point(selectionFunction1,boxLength,position1,pointWeight=cmplx(1.0d0,0.0d0,kind=c_double_complex),cloudType=cloudTypeTriangular)
        call Meshes_Apply_Point(selectionFunction2,boxLength,position2,pointWeight=cmplx(1.0d0,0.0d0,kind=c_double_complex),cloudType=cloudTypeTriangular)


### PR DESCRIPTION
## Summary

In `randomPointsWindowFunctions` (`source/geometry.surveys.random_points.F90`), the per-random-point inner loop built the Cartesian position vector twice — once each for the `mass1` and `mass2` random distances — inlining `sin(theta)`, `cos(theta)`, `sin(phi)`, `cos(phi)` every time. This evaluated `sin(theta)` four times and the other three trig terms twice per iteration, plus six indirect reads of `self%randomTheta(i)` / `self%randomPhi(i)`, even though both positions lie along the same ray and differ only in radial scale.

This PR caches the four trig values into scalar locals, builds the unit direction vector once, and scales it by `distance1` and `distance2`:

- Reduces the inner loop from **10 transcendental calls to 4**.
- Arithmetic is bit-identical for the retained operations — only redundant evaluations are elided, no FP reordering.
- Makes the geometric intent (two points along a shared ray, differing only in radius) explicit in the source.

No interface, semantics, or test changes.

## Test plan

- [ ] CI builds cleanly (the change is local to one subroutine and adds only scalar/3-vector locals).
- [ ] Existing tests covering survey geometries / window functions pass unchanged.
- [ ] (Optional) Spot-check that `windowFunction1` / `windowFunction2` outputs are bit-identical to pre-change for a representative survey configuration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7krLBASviCSCfDsGPWYKW)_