### PR TITLE
perf: Hoist loop-invariant trim and size in Atom_Lookup

### DIFF
--- a/source/atomic.data.F90
+++ b/source/atomic.data.F90
@@ -323,12 +323,14 @@ contains
     use :: String_Handling, only : String_Lower_Case
     implicit none
     integer          , intent(in   ), optional :: atomicNumber
-    character(len=* ), intent(in   ), optional :: name         , shortLabel
-    integer                                    :: iAtom
+    character(len=* ), intent(in   ), optional :: name           , shortLabel
+    integer                                    :: iAtom          , atomCount
     character(len=20)                          :: nameLowerCase
+    character(len=:) , allocatable             :: shortLabelTrim , nameTrim
 
     ! Ensure the module is initialized.
     call Atomic_Data_Initialize
+    atomCount=size(atoms)
 
     ! Look up by atomic number if present.
     if (present(atomicNumber)) then
@@ -338,8 +340,9 @@ contains
 
     ! Look up by short label if present.
     if (present(shortLabel)) then
-       do iAtom=1,size(atoms)
-          if (trim(atoms(iAtom)%shortLabel) == trim(shortLabel)) then
+       shortLabelTrim=trim(shortLabel)
+       do iAtom=1,atomCount
+          if (trim(atoms(iAtom)%shortLabel) == shortLabelTrim) then
              Atom_Lookup=iAtom
              return
           end if
@@ -349,8 +352,9 @@ contains
     ! Look up by name if present.
     if (present(name)) then
        nameLowerCase=String_Lower_Case(name)
-       do iAtom=1,size(atoms)
-          if (trim(atoms(iAtom)%name) == trim(nameLowerCase)) then
+       nameTrim=trim(nameLowerCase)
+       do iAtom=1,atomCount
+          if (trim(atoms(iAtom)%name) == nameTrim) then
              Atom_Lookup=iAtom
              return
           end if


### PR DESCRIPTION
## Summary
- In `Atom_Lookup` (`source/atomic.data.F90`), the per-iteration work in the two lookup loops included `trim()` calls on loop-invariant search keys (`shortLabel`, `nameLowerCase`) and repeated `size(atoms)` queries.
- Hoist those invariants out of the loops: compute `atomCount=size(atoms)` once, and stash the trimmed search key in a local `character(len=:), allocatable` before entering the loop.
- No interface, signature, or behavior change — `==` on Fortran character expressions already ignores trailing blanks, so semantics are preserved.

## Why
Each iteration previously re-scanned the search key with `trim()` and allocated a fresh deferred-length temporary. For N atoms this is O(N·L) redundant work where L is the key length. After the change, the per-element trim+compare remains but the key-side trim happens once.

## Test plan
- [ ] `make` builds cleanly with the updated source.
- [ ] Any test exercising `Atom_Lookup` in `testSuite/` still passes (returns the same atom index for the same query).
- [ ] Spot-check: calling `Atom_Lookup` with `shortLabel=` and with `name=` returns the same indices as before for a few known species.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpT9oMHvoKBJ2NmRmGtUD4)_