### PR TITLE
ci: skip macOS code-signing when signing certificate is unavailable

### DIFF
--- a/.github/actions/codeSignMacOS/action.yml
+++ b/.github/actions/codeSignMacOS/action.yml
@@ -21,7 +21,15 @@ runs:
   steps:
     - name: Sign Galacticus executable
       shell: bash
+      env:
+        MACOS_CERTIFICATE: ${{ inputs.macos_certificate }}
       run: |
+        # The signing secrets are unavailable for workflows triggered by Dependabot or fork pull
+        # requests. In that case skip code-signing gracefully rather than failing the job.
+        if [ -z "${MACOS_CERTIFICATE}" ]; then
+          echo "macOS signing certificate is unavailable (e.g. a Dependabot or fork pull request) -- skipping code-signing."
+          exit 0
+        fi
         ORIGINAL_DEFAULT_KEYCHAIN=$(security default-keychain | sed 's/^ *"//; s/"$//')
         trap 'security default-keychain -s "$ORIGINAL_DEFAULT_KEYCHAIN"; security delete-keychain build.keychain' EXIT
         security create-keychain -p "${{ inputs.macos_keychain_password }}" build.keychain


### PR DESCRIPTION
## Problem

Mac OS jobs (`Build-Executable-MacOS`, `Build-Tools-MacOS`, `Build-Tools-MacOS-M1`) fail on Dependabot PRs (e.g. #1142) at the code-signing step with:

```
security: SecKeychainItemImport: One or more parameters passed to a function were not valid.
```

This is **not** caused by the dependency being bumped. Workflows triggered by **Dependabot** (and fork) pull requests do not have access to the repository's Actions secrets, so `secrets.MACOS_CERTIFICATE` and the related signing secrets resolve to empty strings. The rendered command in the logs confirms it:

```bash
echo "" | base64 --decode > certificate.p12        # empty file
security import certificate.p12 -k build.keychain -P "" ...   # fails here
--sign "" Galacticus_MacOS.exe
```

`security import` rejects the zero-byte `certificate.p12` and the job exits 1. Linux jobs are unaffected because they never touch the signing secrets.

## Fix

Guard the signing step in `.github/actions/codeSignMacOS/action.yml`: when the certificate secret is empty, log a clear message and exit 0 instead of failing.

- **Normal pushes / maintainer PRs** — secret is populated, guard is skipped, signing runs exactly as before.
- **Dependabot / fork PRs** — signing is skipped gracefully; the build still produces the (unsigned) executable and downstream steps proceed, so the job goes green.

The certificate being empty implies the other signing secrets are empty too (they are withheld together), so guarding on the certificate alone is sufficient. This single action file backs all four Mac signing call sites in `cicd.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)