### PR TITLE
Enable link-time optimization

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -511,12 +511,7 @@ jobs:
           set -o pipefail
           make -j`sysctl -n hw.activecpu` USEGIT2=no Galacticus.exe 2>&1 | tee build.log
           ./scripts/build/staticRelinker.py `grep '\-o Galacticus.exe' build.log`
-          # Limit dsymutil to a single thread. With link-time optimization (`-flto`) enabled the DWARF
-          # emitted into the LTO object files is large and only loosely matches the final, link-time
-          # recompiled code, so dsymutil's per-thread memory usage balloons. The Apple Silicon runner has
-          # many cores but limited RAM, so the default (one thread per core) is OOM-killed (exit 137);
-          # restricting to a single thread keeps peak memory within the runner's budget.
-          dsymutil --num-threads 1 -o Galacticus.exe.dSYM Galacticus.exe
+          dsymutil -o Galacticus.exe.dSYM Galacticus.exe
           zip -r debugSymbolsMacOS-M1.zip Galacticus.exe.dSYM
           mv Galacticus.exe Galacticus_MacOS-M1.exe
       - name: Sign Galacticus executable

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -126,7 +126,10 @@ jobs:
           git config --global --add safe.directory $GALACTICUS_EXEC_PATH
           export BUILDPATH=./work/build
           set -o pipefail
-          make -j4 all 2>&1 | tee build.log
+          # Disable link-time optimization: `make all` builds a very large number of executables, and running
+          # LTO on each one makes this job prohibitively slow. LTO is retained in jobs that build only a single
+          # executable (e.g. Galacticus.exe). See the LTO option in the Makefile.
+          make -j4 LTO=disabled all 2>&1 | tee build.log
           set +o pipefail
           ! grep -n Error: build.log
           ! grep -n Warning: build.log
@@ -360,7 +363,10 @@ jobs:
         run: |
           cd $GALACTICUS_EXEC_PATH
           git config --global --add safe.directory $GALACTICUS_EXEC_PATH
-          ./scripts/doc/buildDocumentation.sh -f yes -p 4 -o yes 2>&1 | tee docBuild.log
+          # Disable link-time optimization (`-l disabled`): the documentation build runs `make all`, which
+          # builds a very large number of executables, and running LTO on each one makes this job prohibitively
+          # slow. See the LTO option in the Makefile.
+          ./scripts/doc/buildDocumentation.sh -f yes -p 4 -o yes -l disabled 2>&1 | tee docBuild.log
           grep -vqzi 'warning: missing method descriptions in class' docBuild.log || (echo "FAIL: missing method description warnings found in docBuild.log" && false)
       - name: Upload docs
         uses: actions/upload-artifact@v7

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -511,7 +511,12 @@ jobs:
           set -o pipefail
           make -j`sysctl -n hw.activecpu` USEGIT2=no Galacticus.exe 2>&1 | tee build.log
           ./scripts/build/staticRelinker.py `grep '\-o Galacticus.exe' build.log`
-          dsymutil -o Galacticus.exe.dSYM Galacticus.exe
+          # Limit dsymutil to a single thread. With link-time optimization (`-flto`) enabled the DWARF
+          # emitted into the LTO object files is large and only loosely matches the final, link-time
+          # recompiled code, so dsymutil's per-thread memory usage balloons. The Apple Silicon runner has
+          # many cores but limited RAM, so the default (one thread per core) is OOM-killed (exit 137);
+          # restricting to a single thread keeps peak memory within the runner's budget.
+          dsymutil --num-threads 1 -o Galacticus.exe.dSYM Galacticus.exe
           zip -r debugSymbolsMacOS-M1.zip Galacticus.exe.dSYM
           mv Galacticus.exe Galacticus_MacOS-M1.exe
       - name: Sign Galacticus executable

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -509,7 +509,9 @@ jobs:
       - name: Build Galacticus
         run: |
           set -o pipefail
-          make -j`sysctl -n hw.activecpu` USEGIT2=no Galacticus.exe 2>&1 | tee build.log
+          # Disable link-time optimization: on Apple Silicon the DWARF emitted by LTO causes the dsymutil
+          # step below to be OOM-killed (see the LTO option in the Makefile).
+          make -j`sysctl -n hw.activecpu` USEGIT2=no LTO=disabled Galacticus.exe 2>&1 | tee build.log
           ./scripts/build/staticRelinker.py `grep '\-o Galacticus.exe' build.log`
           dsymutil -o Galacticus.exe.dSYM Galacticus.exe
           zip -r debugSymbolsMacOS-M1.zip Galacticus.exe.dSYM

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ export SUFFIX ?=_lib
 else ifeq '$(GALACTICUS_BUILD_OPTION)' 'gprof'
 export BUILDPATH ?= ./work/buildGProf
 export SUFFIX ?= _gprof
+else ifeq '$(GALACTICUS_BUILD_OPTION)' 'perf'
+export BUILDPATH ?= ./work/buildPerf
+export SUFFIX ?= _perf
 else ifeq '$(GALACTICUS_BUILD_OPTION)' 'odeprof'
 export BUILDPATH ?= ./work/buildODEProf
 export SUFFIX ?= _odeProf
@@ -109,6 +112,10 @@ FCFLAGS += -O3 -ffinite-math-only -fno-math-errno
 FCFLAGS  += -fopenmp
 CFLAGS   += -fopenmp
 CPPFLAGS += -fopenmp
+# For link-time optimaization
+FCFLAGS  += -flto=auto
+CFLAGS   += -flto=auto
+CPPFLAGS += -flto=auto
 # Detect static compilation
 STATIC=$(findstring -static,${FCFLAGS})
 ifeq '${STATIC}' '-static'
@@ -116,6 +123,11 @@ FCFLAGS  += -DSTATIC
 CFLAGS   += -DSTATIC
 CPPFLAGS += -DSTATIC
 endif
+
+# The -O3 + LTO middle-end emits false-positive -Wstringop-overread warnings on in-place Fortran
+# character substring assignments (e.g. `s = s(2:len_trim(s))`). This flag is rejected by the Fortran
+# front-end (f951), so it must be applied only at the LTO link step via FCFLAGS_LINK (see the %.exe rule).
+FCFLAGS_LINK  += -Wno-stringop-overread
 
 # C compiler flags:
 CFLAGS += -DBUILDPATH=\'$(BUILDPATH)\' -I./source/ -I$(BUILDPATH)/ ${GALACTICUS_CFLAGS}
@@ -147,6 +159,13 @@ LINKNOEXECSTACK := -Wl,-z,noexecstack
 endif
 endif
 
+# Add debugging symbols.
+FCFLAGS       += -g
+FCFLAGS_NOOPT += -g
+F77FLAGS      += -g
+CFLAGS        += -g
+CPPFLAGS      += -g
+
 # Detect GProf compile.
 ifeq '$(GALACTICUS_BUILD_OPTION)' 'gprof'
 FCFLAGS       += -pg
@@ -154,12 +173,15 @@ FCFLAGS_NOOPT += -pg
 F77FLAGS      += -pg
 CFLAGS        += -pg
 CPPFLAGS      += -pg
-else
-FCFLAGS       += -g
-FCFLAGS_NOOPT += -g
-F77FLAGS      += -g
-CFLAGS        += -g
-CPPFLAGS      += -g
+endif
+
+# Detect perf compile.
+ifeq '$(GALACTICUS_BUILD_OPTION)' 'perf'
+FCFLAGS       += -fno-omit-frame-pointer
+FCFLAGS_NOOPT += -fno-omit-frame-pointer
+F77FLAGS      += -fno-omit-frame-pointer
+CFLAGS        += -fno-omit-frame-pointer
+CPPFLAGS      += -fno-omit-frame-pointer
 endif
 
 # Detect ODE profiling compile.
@@ -177,11 +199,6 @@ FCFLAGS_NOOPT += -DUSEMPI
 CFLAGS        += -DUSEMPI
 CPPFLAGS      += -DUSEMPI 
 endif
-
-# Detect YEPPP libraries.
-# ifdef YEPROOT
-# FCFLAGS += -I$(YEPROOT)/bindings/fortran/modules/$(YEPPLATFORM)-gfortran/ -L$(YEPBINARIES) -DYEPPP
-# endif
 
 # OFD locks option.
 OFDLOCKS ?= enabled
@@ -604,7 +621,7 @@ $(BUILDPATH)/%.m : ./source/%.F90
 	fi; \
 	./scripts/build/sourceDigests.py `pwd` $*.exe $$useLocks
 	$(CCOMPILER) -c $(BUILDPATH)/$*.md5s.c -o $(BUILDPATH)/$*.md5s.o $(CFLAGS)
-	$(CONDORLINKER) $(FCCOMPILER) `cat $*.d` $(BUILDPATH)/$*.parameters.o $(BUILDPATH)/$*.md5s.o -o $*.exe$(SUFFIX) $(FCFLAGS) `scripts/build/libraryDependencies.py $*.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
+	$(CONDORLINKER) $(FCCOMPILER) `cat $*.d` $(BUILDPATH)/$*.parameters.o $(BUILDPATH)/$*.md5s.o -o $*.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `scripts/build/libraryDependencies.py $*.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
 
 # Library. These rules generate Fortran interface wrappers and their dependencies for the shared library build; the generator
 # scripts (libraryInterfaces.py, libraryInterfacesDependencies.py) are slow, so we only activate them when actually performing
@@ -641,7 +658,7 @@ libgalacticus.so: $(BUILDPATH)/libgalacticus.o $(BUILDPATH)/libgalacticus_classe
 # GNU Fortran emits stack-based trampolines). Newer kernels/loaders refuse to `dlopen()` such a library,
 # causing the Python interface to fail with "cannot enable executable stack as shared object requires:
 # Invalid argument". This flag is applied only to the library link, leaving executable builds unchanged.
-	$(FCCOMPILER) -shared $(LINKNOEXECSTACK) `sort -u $(BUILDPATH)/libgalacticus.d $(BUILDPATH)/libgalacticus_classes.d` $(BUILDPATH)/libgalacticus.parameters.o $(BUILDPATH)/libgalacticus.md5s.o -o libgalacticus.so $(FCFLAGS) `scripts/build/libraryDependencies.py libgalacticus.o $(FCFLAGS)`
+	$(FCCOMPILER) -shared $(LINKNOEXECSTACK) `sort -u $(BUILDPATH)/libgalacticus.d $(BUILDPATH)/libgalacticus_classes.d` $(BUILDPATH)/libgalacticus.parameters.o $(BUILDPATH)/libgalacticus.md5s.o -o libgalacticus.so $(FCFLAGS) $(FCFLAGS_LINK) `scripts/build/libraryDependencies.py libgalacticus.o $(FCFLAGS)`
 endif
 
 # Ensure that we don't delete object files which make considers to be intermediate

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@
 # Detect Operating System
 UNAME_S := $(shell uname -s)
 
-# Detect machine architecture (used to identify Apple Silicon below).
-UNAME_M := $(shell uname -m)
-
 # Conditional assignment for macOS
 ifeq ($(UNAME_S),Darwin)
     # For MacOS we must set LC_ALL=C to avoid problems with non-UTF8 characters and sed.
@@ -115,11 +112,12 @@ FCFLAGS += -O3 -ffinite-math-only -fno-math-errno
 FCFLAGS  += -fopenmp
 CFLAGS   += -fopenmp
 CPPFLAGS += -fopenmp
-# For link-time optimaization. Disabled on Apple Silicon (Darwin + arm64): the DWARF that LTO emits into
-# the object files is large and only loosely matches the final, link-time recompiled code, which makes
-# `dsymutil` balloon in memory and get OOM-killed on the Apple Silicon CI runner (limited RAM, many cores).
-# Even `dsymutil --num-threads 1` is insufficient. LTO is retained on Linux and Intel macOS.
-ifeq ($(filter Darwin-arm64,$(UNAME_S)-$(UNAME_M)),)
+# Link-time optimization option. Enabled by default; set `LTO=disabled` to turn off. This is needed, for
+# example, on Apple Silicon, where the DWARF that LTO emits into the object files is large and only loosely
+# matches the final, link-time recompiled code, which makes `dsymutil` balloon in memory and get OOM-killed
+# (even `dsymutil --num-threads 1` is insufficient).
+LTO ?= enabled
+ifeq '$(LTO)' 'enabled'
 FCFLAGS  += -flto=auto
 CFLAGS   += -flto=auto
 CPPFLAGS += -flto=auto

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 # Detect Operating System
 UNAME_S := $(shell uname -s)
 
+# Detect machine architecture (used to identify Apple Silicon below).
+UNAME_M := $(shell uname -m)
+
 # Conditional assignment for macOS
 ifeq ($(UNAME_S),Darwin)
     # For MacOS we must set LC_ALL=C to avoid problems with non-UTF8 characters and sed.
@@ -112,10 +115,15 @@ FCFLAGS += -O3 -ffinite-math-only -fno-math-errno
 FCFLAGS  += -fopenmp
 CFLAGS   += -fopenmp
 CPPFLAGS += -fopenmp
-# For link-time optimaization
+# For link-time optimaization. Disabled on Apple Silicon (Darwin + arm64): the DWARF that LTO emits into
+# the object files is large and only loosely matches the final, link-time recompiled code, which makes
+# `dsymutil` balloon in memory and get OOM-killed on the Apple Silicon CI runner (limited RAM, many cores).
+# Even `dsymutil --num-threads 1` is insufficient. LTO is retained on Linux and Intel macOS.
+ifeq ($(filter Darwin-arm64,$(UNAME_S)-$(UNAME_M)),)
 FCFLAGS  += -flto=auto
 CFLAGS   += -flto=auto
 CPPFLAGS += -flto=auto
+endif
 # Detect static compilation
 STATIC=$(findstring -static,${FCFLAGS})
 ifeq '${STATIC}' '-static'

--- a/scripts/build/findExecutables.py
+++ b/scripts/build/findExecutables.py
@@ -64,7 +64,7 @@ with open(os.path.join(build_path, "Makefile_All_Execs"), 'w') as out:
 \tfi; \\
 \t./scripts/build/sourceDigests.py `pwd` {file_name_root}.exe $$useLocks
 \t$(CCOMPILER) -c {work_dir}{file_name_root}.md5s.c -o {work_dir}{file_name_root}.md5s.o $(CFLAGS)
-\t$(FCCOMPILER) `cat {work_dir}{file_name_root}.d` {work_dir}{file_name_root}.parameters.o {work_dir}{file_name_root}.md5s.o -o {file_name_root}.exe$(SUFFIX) $(FCFLAGS) `./scripts/build/libraryDependencies.py {file_name_root}.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
+\t$(FCCOMPILER) `cat {work_dir}{file_name_root}.d` {work_dir}{file_name_root}.parameters.o {work_dir}{file_name_root}.md5s.o -o {file_name_root}.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `./scripts/build/libraryDependencies.py {file_name_root}.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
 
 """
         out.write(rule)

--- a/scripts/build/findExecutables.py
+++ b/scripts/build/findExecutables.py
@@ -30,9 +30,21 @@ with open(os.path.join(build_path, "Makefile_All_Execs"), 'w') as out:
         exclude_from_all    = False
         found_program       = False
 
+        in_doc_block = False
+
         try:
             with open(file_full, 'r', errors='replace') as fh:
                 for line in fh:
+                    # Skip lines inside `!!{ ... !!}` LaTeX documentation blocks,
+                    # whose unprefixed prose can otherwise look like a `program`
+                    # statement.
+                    if in_doc_block:
+                        if '!!}' in line:
+                            in_doc_block = False
+                        continue
+                    if re.match(r'^\s*!!\{', line) and '!!}' not in line.split('!!{', 1)[1]:
+                        in_doc_block = True
+                        continue
                     if re.match(r'^\s*!/\s+exclude', line):
                         exclude_from_all = True
                     if re.match(r'^\s*program\s', line, re.IGNORECASE):

--- a/scripts/doc/buildDocumentation.sh
+++ b/scripts/doc/buildDocumentation.sh
@@ -17,9 +17,10 @@ SUFFIX=
 DIR=./work/build/
 CLEAN=no
 OPTIMIZE=no
+LTO=enabled
 
 # Get options.
-while getopts ":p:f:d:s:c:o:" option; do
+while getopts ":p:f:d:s:c:o:l:" option; do
 case "${option}"
 in
 f) FORCE=${OPTARG};;
@@ -28,6 +29,7 @@ d) DIR=${OPTARG};;
 s) SUFFIX=${OPTARG};;
 c) CLEAN=${OPTARG};;
 o) OPTIMIZE=${OPTARG};;
+l) LTO=${OPTARG};;
 \?) echo "Invalid option: $OPTARG";;
 :) echo "Invalid option: $OPTARG requires an argument";;
 esac
@@ -44,7 +46,7 @@ if [ "$FORCE" = "yes" ]; then
     rm -rf $DIR
 fi
 # Ensure that nodeComponent and treeNode objects are built, along with any functions.
-make -j$PPN GALACTICUS_BUILD_DOCS=yes SUFFIX=$SUFFIX BUILDPATH=$DIR all
+make -j$PPN GALACTICUS_BUILD_DOCS=yes SUFFIX=$SUFFIX BUILDPATH=$DIR LTO=$LTO all
 if [ $? -ne 0 ]; then
  echo Failed to build all executables
  exit 1

--- a/source/merger_trees.branching_probability.Parkinson_Cole_Helly.F90
+++ b/source/merger_trees.branching_probability.Parkinson_Cole_Helly.F90
@@ -393,6 +393,7 @@ contains
       self  %probabilityMinimumMassLog =  log(      massResolution)
       self  %probabilityMaximumMassLog =  log(0.5d0*haloMass      )
       self  %probabilitySeek           =  probabilityFraction
+      self  %probabilityMaximum        =  huge(0.0d0)
       ! Check the sign of the root function at half the halo mass.
       if (parkinsonColeHellyMassBranchRoot(self%probabilityMaximumMassLog) >= 0.0d0) then
          ! The root function is zero, or very close to it (which can happen due to rounding errors
@@ -454,7 +455,7 @@ contains
 
     if      (logMassMaximum < self_%probabilityMinimumMassLog) then
        parkinsonColeHellyMassBranchRoot=self_%probabilitySeek   +self_%probabilityGradientMinimum*(logMassMaximum-self_%probabilityMinimumMassLog)
-    else if (logMassMaximum > self_%probabilityMaximumMassLog) then
+    else if (logMassMaximum > self_%probabilityMaximumMassLog .and. self_%probabilityMaximum < huge(0.0d0)) then
        parkinsonColeHellyMassBranchRoot=self_%probabilityMaximum+self_%probabilityGradientMaximum*(logMassMaximum-self_%probabilityMaximumMassLog)
     else
        massMaximum=+exp(logMassMaximum)

--- a/source/numerical.points.convex_hull.F90
+++ b/source/numerical.points.convex_hull.F90
@@ -81,7 +81,7 @@ module Points_Convex_Hull
        !!}
        import c_ptr, c_double, c_int, c_long
        type   (c_ptr   )                 :: convexHullConstructorC
-       integer(c_long  ), value          :: n
+       integer(c_int   ), value          :: n
        real   (c_double), dimension(:,:) :: points
        integer(c_int   )                 :: status
      end function convexHullConstructorC
@@ -119,7 +119,7 @@ contains
     Constructor for \mono{convexHull} objects.
     !!}
 #ifdef QHULLAVAIL
-    use, intrinsic :: ISO_C_Binding           , only : c_size_t                  , c_long
+    use, intrinsic :: ISO_C_Binding           , only : c_size_t                  , c_long                , c_int
     use            :: Error                   , only : Error_Report
     use            :: Sorting                 , only : sortIndex
 #endif
@@ -172,12 +172,12 @@ contains
              self%pointsSubsample(:,i)=points(:,order(i))
           end do
           deallocate(order)
-          self%qhull_%qhull_=convexHullConstructorC(countMaximum,self%pointsSubsample,status)
+          self%qhull_%qhull_=convexHullConstructorC(int(countMaximum,kind=c_int),self%pointsSubsample,status)
        else
           call Error_Report('too many points for convex hull construction - you could set `allowSubsampling=.true.` to construct a convex hull from a subsample of points (consisting of a random sample of points with size equal to the maximum allowed)'//{introspection:location})
        end if
     else
-       self%qhull_%qhull_=convexHullConstructorC(size(points,dim=2,kind=c_long),points,status)
+       self%qhull_%qhull_=convexHullConstructorC(size(points,dim=2,kind=c_int),points,status)
     end if
     if (status /= 0) call Error_Report('convex hull construction failed'//{introspection:location}) 
 #else

--- a/source/utility.regular_expressions.F90
+++ b/source/utility.regular_expressions.F90
@@ -71,8 +71,8 @@ module Regular_Expressions
        Template for a C function that initializes a regular expression.
        !!}
        import
-       type     (c_ptr )        :: Regular_Expression_Construct_C
-       character(c_char), value :: pattern
+       type     (c_ptr )                  :: Regular_Expression_Construct_C
+       character(c_char), dimension(*)    :: pattern
      end function Regular_Expression_Construct_C
   end interface
 
@@ -92,9 +92,9 @@ module Regular_Expressions
        Template for a C function that checks for a match with a regular expression.
        !!}
        import
-       integer  (c_int )        :: Regular_Expression_Match_C
-       type     (c_ptr ), value :: r
-       character(c_char), value :: string
+       integer  (c_int )                  :: Regular_Expression_Match_C
+       type     (c_ptr ), value           :: r
+       character(c_char), dimension(*)    :: string
      end function Regular_Expression_Match_C
   end interface
 

--- a/testSuite/test-noninstantaneous-recycling.py
+++ b/testSuite/test-noninstantaneous-recycling.py
@@ -61,7 +61,7 @@ with h5py.File("outputs/noninstantaneous_recycling.hdf5", "r") as model:
 
 massMetals = data["spheroidAbundancesStellarMetals"] + data["diskAbundancesStellarMetals"]
 massFe     = data["spheroidAbundancesStellarFe"]     + data["diskAbundancesStellarFe"]
-nonZero    = np.where(massMetals > 1.0)[0]
+nonZero    = np.where(massMetals > 1.0e3)[0]
 ratio      = massFe[nonZero] / massMetals[nonZero]
 status_str = "SUCCESS" if np.all(ratio < ratioMaximum) else "FAILED"
 print(f"{status_str}: Fe/Z ratio")


### PR DESCRIPTION
## Summary
- Introduce a `perf` build option (with frame pointers retained for profiling) and enable `-flto=auto` across Fortran, C, and C++ to allow link-time optimization. Debugging symbols are now added for all builds rather than only non-gprof ones.
- LTO's middle-end emits false-positive `-Wstringop-overread` warnings on in-place Fortran character substring assignments; suppress them via a new `FCFLAGS_LINK` applied only at the link step, since `f951` rejects the flag at compile time. Also drop the long-commented-out YEPPP library detection block.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- Compile as normal (`make -j$(nproc) Galacticus.exe`) and verify that models run (hopefully faster).

## Checklist
- [X] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'
