### PR TITLE
fix: skip bibliographyUpdater when an open PR already exists

### DIFF
--- a/.github/workflows/bibliographyUpdater.yml
+++ b/.github/workflows/bibliographyUpdater.yml
@@ -48,8 +48,22 @@ jobs:
           else
             echo "refresh_all=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: "Check for an existing open PR"
+        id: existing
+        if: ${{ ( env.appid != '' ) && ( env.adstoken != '' ) }}
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          branch="${{ steps.mode.outputs.refresh_all == 'true' && 'update/bibliography-refresh' || 'update/bibliography' }}"
+          count=$(gh pr list --repo "${{ github.repository }}" --head "$branch" --state open --json number --jq 'length')
+          if [[ "$count" -gt 0 ]]; then
+            echo "An open PR already exists for '$branch'; skipping to avoid force-push / CI restart."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Update the bibliography
-        if: ${{ env.adstoken != '' }}
+        if: ${{ ( env.adstoken != '' ) && ( steps.existing.outputs.skip != 'true' ) }}
         run: |
           flags=()
           if [[ "${{ steps.mode.outputs.refresh_all }}" == "true" ]]; then
@@ -57,19 +71,19 @@ jobs:
           fi
           PYTHONPATH=$GITHUB_WORKSPACE/python python3 scripts/aux/bibliographyUpdate.py "${flags[@]}" --summary "$RUNNER_TEMP/bibliographyChanges.md" "${{ secrets.NASA_ADS_API_TOKEN }}"
       - name: "Install bibtool"
-        if: ${{ env.adstoken != '' }}
+        if: ${{ ( env.adstoken != '' ) && ( steps.existing.outputs.skip != 'true' ) }}
         run: |
           sudo apt-get update
           sudo apt-get install -y bibtool
       - name: "Tidy the bibliography"
-        if: ${{ env.adstoken != '' }}
+        if: ${{ ( env.adstoken != '' ) && ( steps.existing.outputs.skip != 'true' ) }}
         run: |
           bibtool -r scripts/aux/bibliography.rsc \
                   -i doc/Galacticus.bib \
                   -o doc/Galacticus.bib.tidy
           mv doc/Galacticus.bib.tidy doc/Galacticus.bib
       - name: "Build PR body"
-        if: ${{ ( env.appid != '' ) && ( env.adstoken != '' ) }}
+        if: ${{ ( env.appid != '' ) && ( env.adstoken != '' ) && ( steps.existing.outputs.skip != 'true' ) }}
         id: pr-body
         run: |
           {
@@ -86,7 +100,7 @@ jobs:
             echo '__PR_BODY_EOF__'
           } >> "$GITHUB_OUTPUT"
       - name: Create Pull Request
-        if: ${{ ( env.appid != '' ) && ( env.adstoken != '' ) }}
+        if: ${{ ( env.appid != '' ) && ( env.adstoken != '' ) && ( steps.existing.outputs.skip != 'true' ) }}
         uses: peter-evans/create-pull-request@v8
         with:
           title: "${{ steps.mode.outputs.refresh_all == 'true' && 'fix: Refresh bibliography metadata' || 'fix: Update bibliography records' }}"


### PR DESCRIPTION
## Summary

Prevents `bibliographyUpdater` from force-pushing the update branch — and thereby restarting all CI/CD on an already-open PR — when a prior run's PR is still open.

Previously, `peter-evans/create-pull-request` force-pushes the target branch on every run that finds new changes. If an `update/bibliography` (or `update/bibliography-refresh`) PR was still open, the next scheduled run would rewrite its head and restart the PR's CI/CD.

## Change

- New **"Check for an existing open PR"** step (`id: existing`) computes the target branch from the determined refresh mode (`update/bibliography-refresh` for refresh-all, `update/bibliography` otherwise) and uses `gh pr list --head "$branch" --state open` to set `skip=true` when an open PR exists.
- The five downstream steps (Update / Install bibtool / Tidy / Build PR body / Create Pull Request) are gated on `steps.existing.outputs.skip != 'true'`, so the job no-ops gracefully (green) when a PR is already open.

The check keys on an *open* PR rather than mere branch presence, so a merged-and-deleted branch correctly lets the next run proceed. (The merge also touches `doc/Galacticus.bib`, which fires the existing `push:` trigger to pick up fresh changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)