### PR TITLE
Refactor N-body halo mass statistics classes

### DIFF
--- a/source/statistics.Nbody.halos.mass_errors.Trenti2010.F90
+++ b/source/statistics.Nbody.halos.mass_errors.Trenti2010.F90
@@ -33,6 +33,7 @@ Implements an N-body dark matter halo mass error class using the model of \cite{
      An N-body halo mass error class using the model of \cite{trenti_how_2010}.
      !!}
      private
+     double precision :: massParticle
   end type nbodyHaloMassErrorTrenti2010
 
   interface nbodyHaloMassErrorTrenti2010
@@ -122,13 +123,13 @@ contains
 
     ! Compute the power-law normalization, sigma_12, that reproduces the Trenti et al. (2010) fractional error formula when
     ! combined with an exponent of -1/3 and zero high-mass error.
-    normalization=+         normalizationTrenti                  &
-         &        *cubeRoot(                                     &
-         &                  +particleNumberReference             &
-         &                  *massParticle                        &
-         &                  /                   massReference    &
+    normalization=+         normalizationTrenti      &
+         &        *cubeRoot(                         &
+         &                  +particleNumberReference &
+         &                  *massParticle            &
+         &                  /massReference           &
          &                 )
-    self%nbodyHaloMassErrorPowerLaw=nbodyHaloMassErrorPowerLaw(                                             &
+    self%nbodyHaloMassErrorPowerLaw=nbodyHaloMassErrorPowerLaw(                                                         &
          &                                                     normalization              =normalization              , &
          &                                                     exponent                   =-1.0d0/3.0d0               , &
          &                                                     fractionalErrorHighMass    =+0.0d0                     , &

--- a/source/statistics.Nbody.halos.mass_errors.Trenti2010.F90
+++ b/source/statistics.Nbody.halos.mass_errors.Trenti2010.F90
@@ -25,23 +25,14 @@ Implements an N-body dark matter halo mass error class using the model of \cite{
 
   !![
   <nbodyHaloMassError name="nbodyHaloMassErrorTrenti2010">
-   <description>An N-body dark matter halo mass error class that models correlated halo mass errors between different halos and epochs using the fitting formula of \cite{trenti_how_2010}. The simulation particle mass and correlation model parameters $C_0$, $\alpha$, and $\beta$ are set via the corresponding input parameters.</description>
+   <description>An N-body dark matter halo mass error class that models correlated halo mass errors between different halos and epochs using the fitting formula of \cite{trenti_how_2010}. The simulation particle mass and correlation model parameters $C_0$, $\alpha$, and $\beta$ are set via the corresponding input parameters. This class is implemented as a specialization of the \refClass{nbodyHaloMassErrorPowerLaw} class, with the parent class parameters set to reproduce the \cite{trenti_how_2010} fractional error formula and to enable the power-law correlation model.</description>
   </nbodyHaloMassError>
   !!]
-  type, extends(nbodyHaloMassErrorClass) :: nbodyHaloMassErrorTrenti2010
+  type, extends(nbodyHaloMassErrorPowerLaw) :: nbodyHaloMassErrorTrenti2010
      !!{
      An N-body halo mass error class using the model of \cite{trenti_how_2010}.
      !!}
      private
-     ! Parameters of the correlation model.
-     class           (cosmologyFunctionsClass), pointer :: cosmologyFunctions_         => null()
-     double precision                                   :: correlationNormalization             , correlationMassExponent, &
-          &                                                correlationRedshiftExponent          , massParticle           , &
-          &                                                normalization
-   contains
-     final     ::                    trenti2010Destructor
-     procedure :: errorFractional => trenti2010ErrorFractional
-     procedure :: correlation     => trenti2010Correlation
   end type nbodyHaloMassErrorTrenti2010
 
   interface nbodyHaloMassErrorTrenti2010
@@ -111,102 +102,41 @@ contains
     a normalization of the fractional error in particle number of 0.15 at $N=1000$ particles. Since this is based on
     comparisons of halos in simulations differing in number of particles by a factor $8$ this actually overestimates the
     normalization by a factor $\sqrt{5/4}$. Therefore, we use a normalization of $0.135$ here.
+
+    The \cite{trenti_how_2010} fractional error model, $\sigma(M) = N_0 / M^{1/3}$ with
+    $N_0 = 0.135 \, (1000 \, m_\mathrm{p})^{1/3}$, is reproduced by the parent
+    \refClass{nbodyHaloMassErrorPowerLaw} class by setting the power-law exponent to $-1/3$, the
+    high-mass error to zero, and the normalization $\sigma_{12} = N_0 / M_\mathrm{ref}^{1/3}$ where
+    $M_\mathrm{ref} = 10^{12} \mathrm{M}_\odot$ is the reference mass used by the parent class.
     !!}
-    use :: Error              , only : Error_Report
     use :: Math_Exponentiation, only : cubeRoot
     implicit none
-    type            (nbodyHaloMassErrorTrenti2010)                                  :: self
-    double precision                              , intent(in   )                   :: massParticle
-    double precision                              , intent(in   ), optional         :: correlationNormalization             , correlationMassExponent, &
-         &                                                                             correlationRedshiftExponent
-    class           (cosmologyFunctionsClass     ), intent(in   ), optional, target :: cosmologyFunctions_
-    double precision                              , parameter                       :: normalization               =+0.135d0
-    double precision                              , parameter                       :: particleNumberReference     =+1.000d3
+    type            (nbodyHaloMassErrorTrenti2010)                        :: self
+    double precision                              , intent(in   )         :: massParticle
+    double precision                              , intent(in   )         :: correlationNormalization             , correlationMassExponent, &
+         &                                                                   correlationRedshiftExponent
+    class           (cosmologyFunctionsClass     ), intent(in   ), target :: cosmologyFunctions_
+    double precision                              , parameter             :: normalizationTrenti         =+0.135d0
+    double precision                              , parameter             :: particleNumberReference     =+1.000d3
+    double precision                                                      :: normalization
 
-    self%massParticle =+massParticle
-    self%normalization=+normalization                     &
-         &             *cubeRoot(                         &
-         &                       +particleNumberReference &
-         &                       *massParticle            &
-         &                      )
-    ! Set correlation properties.
-    if (present(correlationNormalization).or.present(correlationMassExponent).or.present(correlationRedshiftExponent)) then
-       if (.not.(present(correlationNormalization).and.present(correlationMassExponent).and.present(correlationRedshiftExponent))) &
-            & call Error_Report('all parameters of correlation model must be provided'//{introspection:location})
-       if (.not.present(cosmologyFunctions_)) &
-            & call Error_Report('cosmology functions must be provided for correlation model'//{introspection:location})
-       self%correlationNormalization    =  correlationNormalization
-       self%correlationMassExponent     =  correlationMassExponent
-       self%correlationRedshiftExponent =  correlationRedshiftExponent
-       self%cosmologyFunctions_         => cosmologyFunctions_
-       !![
-       <referenceCountIncrement owner="self" isResult="yes" object="cosmologyFunctions_"/>
-       !!]
-    else
-       self%correlationNormalization    =  0.0d0
-       self%correlationMassExponent     =  0.0d0
-       self%correlationRedshiftExponent =  0.0d0
-       self%cosmologyFunctions_         => null()
-    end if
+    ! Compute the power-law normalization, sigma_12, that reproduces the Trenti et al. (2010) fractional error formula when
+    ! combined with an exponent of -1/3 and zero high-mass error.
+    normalization=+         normalizationTrenti                  &
+         &        *cubeRoot(                                     &
+         &                  +particleNumberReference             &
+         &                  *massParticle                        &
+         &                  /                   massReference    &
+         &                 )
+    self%nbodyHaloMassErrorPowerLaw=nbodyHaloMassErrorPowerLaw(                                             &
+         &                                                     normalization              =normalization              , &
+         &                                                     exponent                   =-1.0d0/3.0d0               , &
+         &                                                     fractionalErrorHighMass    =+0.0d0                     , &
+         &                                                     correlationModelTrivial    =.false.                    , &
+         &                                                     correlationNormalization   =correlationNormalization   , &
+         &                                                     correlationMassExponent    =correlationMassExponent    , &
+         &                                                     correlationRedshiftExponent=correlationRedshiftExponent, &
+         &                                                     cosmologyFunctions_        =cosmologyFunctions_          &
+         &                                                    )
     return
   end function nbodyHaloMassErrorTrenti2010ConstructorInternal
-
-  subroutine trenti2010Destructor(self)
-    !!{
-    Destructor for the \refClass{nbodyHaloMassErrorTrenti2010} N-body halo mass error class.
-    !!}
-    implicit none
-    type(nbodyHaloMassErrorTrenti2010), intent(inout) :: self
-
-    if (associated(self%cosmologyFunctions_)) then
-       !![
-       <objectDestructor name="self%cosmologyFunctions_"/>
-       !!]
-    end if
-    return
-  end subroutine trenti2010Destructor
-
-  double precision function trenti2010ErrorFractional(self,node)
-    !!{
-    Return the fractional error on the mass of an N-body halo in the power-law error model.
-    !!}
-    use :: Galacticus_Nodes   , only : nodeComponentBasic, treeNode
-    use :: Math_Exponentiation, only : cubeRoot
-    implicit none
-    class           (nbodyHaloMassErrorTrenti2010), intent(inout) :: self
-    type            (treeNode                    ), intent(inout) :: node
-    class           (nodeComponentBasic          ), pointer       :: basic
-
-    basic                     =>           node %basic        ()
-    trenti2010ErrorFractional =  +         self %normalization    &
-         &                       /cubeRoot(basic%mass         ())
-    return
-  end function trenti2010ErrorFractional
-
-  double precision function trenti2010Correlation(self,node1,node2)
-    !!{
-    Return the correlation of the masses of a pair of N-body halos.
-    !!}
-    use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
-    implicit none
-    class           (nbodyHaloMassErrorTrenti2010), intent(inout) :: self
-    type            (treeNode                    ), intent(inout) :: node1    , node2
-    class           (nodeComponentBasic          ), pointer       :: basic1   , basic2
-    double precision                                              :: massRatio, expansionFactorRatio
-
-    ! Extract mass and expansion factor ratios.
-    basic1               =>                                           node1 %basic()
-    basic2               =>                                           node2 %basic()
-    massRatio            =  +                                         basic2%mass ()  &
-         &                  /                                         basic1%mass ()
-    expansionFactorRatio =  +self%cosmologyFunctions_%expansionFactor(basic2%time ()) &
-         &                  /self%cosmologyFunctions_%expansionFactor(basic1%time ())
-    ! Ensure ratios are below unity, invert otherwise.
-    if (           massRatio > 1.0d0)            massRatio=1.0d0/           massRatio
-    if (expansionFactorRatio > 1.0d0) expansionFactorRatio=1.0d0/expansionFactorRatio
-    ! Evaluate the correlation.
-    trenti2010Correlation=+self%correlationNormalization                                   &
-         &                *                    massRatio**self%correlationMassExponent     &
-         &                *         expansionFactorRatio**self%correlationRedshiftExponent
-    return
-  end function trenti2010Correlation

--- a/source/statistics.Nbody.halos.mass_errors.friends-of-friends.F90
+++ b/source/statistics.Nbody.halos.mass_errors.friends-of-friends.F90
@@ -95,7 +95,7 @@ contains
          &                              +massReference                          &
          &                              /massParticle                           &
          &                             )**exponentLocal
-    self%nbodyHaloMassErrorPowerLaw =  nbodyHaloMassErrorPowerLaw(                                          &
+    self%nbodyHaloMassErrorPowerLaw =  nbodyHaloMassErrorPowerLaw(                                             &
          &                                                        normalization          =normalizationParent, &
          &                                                        exponent               =exponentLocal      , &
          &                                                        fractionalErrorHighMass=errorHighMass      , &

--- a/source/statistics.Nbody.halos.mass_errors.friends-of-friends.F90
+++ b/source/statistics.Nbody.halos.mass_errors.friends-of-friends.F90
@@ -79,17 +79,27 @@ contains
     implicit none
     type            (nbodyHaloMassErrorFriendsOfFriends)                :: self
     double precision                                    , intent(in   ) :: massParticle
-    double precision                                    , parameter     :: exponent         =-0.5d00
-    double precision                                    , parameter     :: normalization    =+1.25d00
-    double precision                                    , parameter     :: errorHighMass    =+0.022d00
+    double precision                                    , parameter     :: exponentLocal      =-0.5d00
+    double precision                                    , parameter     :: normalizationLocal =+1.25d00
+    double precision                                    , parameter     :: errorHighMass      =+0.022d00
+    double precision                                                    :: normalizationParent
     !![
     <constructorAssign variables="massParticle"/>
     !!]
-    
+
     ! Convert from a model defined in terms of particle number (in which the fractional error is 1.2/sqrt(N)) to one defined in
-    ! terms of halo mass as used in our parent class.
-    self%normalizationSquared          =(normalization*(massReference/massParticle)**exponent)**2
-    self%exponent                      =exponent
-    self%fractionalErrorHighMassSquared=errorHighMass                                         **2
+    ! terms of halo mass as used in our parent class. Build the parent class with the trivial correlation model so that the new
+    ! correlation parameters introduced in the parent class are initialized.
+    normalizationParent             = +normalizationLocal                       &
+         &                            *(                                        &
+         &                              +massReference                          &
+         &                              /massParticle                           &
+         &                             )**exponentLocal
+    self%nbodyHaloMassErrorPowerLaw =  nbodyHaloMassErrorPowerLaw(                                          &
+         &                                                        normalization          =normalizationParent, &
+         &                                                        exponent               =exponentLocal      , &
+         &                                                        fractionalErrorHighMass=errorHighMass      , &
+         &                                                        correlationModelTrivial=.true.               &
+         &                                                       )
     return
   end function friendsOfFriendsConstructorInternal

--- a/source/statistics.Nbody.halos.mass_errors.power_law.F90
+++ b/source/statistics.Nbody.halos.mass_errors.power_law.F90
@@ -68,8 +68,8 @@ contains
     type            (nbodyHaloMassErrorPowerLaw)                :: self
     type            (inputParameters           ), intent(inout) :: parameters
     class           (cosmologyFunctionsClass   ), pointer       :: cosmologyFunctions_
-    double precision                                            :: normalization              , fractionalErrorHighMass, &
-         &                                                         exponent                   , correlationNormalization, &
+    double precision                                            :: normalization              , fractionalErrorHighMass    , &
+         &                                                         exponent                   , correlationNormalization   , &
          &                                                         correlationMassExponent    , correlationRedshiftExponent
     logical                                                     :: correlationModelTrivial
 
@@ -186,11 +186,9 @@ contains
     implicit none
     type(nbodyHaloMassErrorPowerLaw), intent(inout) :: self
 
-    if (associated(self%cosmologyFunctions_)) then
-       !![
-       <objectDestructor name="self%cosmologyFunctions_"/>
-       !!]
-    end if
+    !![
+    <objectDestructor name="self%cosmologyFunctions_"/>
+    !!]
     return
   end subroutine powerLawDestructor
 

--- a/source/statistics.Nbody.halos.mass_errors.power_law.F90
+++ b/source/statistics.Nbody.halos.mass_errors.power_law.F90
@@ -22,9 +22,11 @@ Implements an N-body dark matter halo mass error class in which
 errors are a power-law in halo mass.
 !!}
 
+  use :: Cosmology_Functions, only : cosmologyFunctions, cosmologyFunctionsClass
+
   !![
   <nbodyHaloMassError name="nbodyHaloMassErrorPowerLaw">
-   <description>An N-body dark matter halo mass error class in which the fractional mass uncertainty is modeled as a power-law function of halo mass, useful for parameterizing simulation resolution effects. The model is characterized by the normalization parameters $\sigma_{12}$ and $\sigma_\infty$, and the power-law exponent with respect to mass.</description>
+   <description>An N-body dark matter halo mass error class in which the fractional mass uncertainty is modeled as a power-law function of halo mass, useful for parameterizing simulation resolution effects. The model is characterized by the normalization parameters $\sigma_{12}$ and $\sigma_\infty$, and the power-law exponent with respect to mass. Optionally, correlations between mass errors of pairs of halos may be modeled as a power-law in the ratio of halo masses and expansion factors: $C_{12} = C_0 [M_2/M_1]^\alpha [(1+z_2)/(1+z_1)]^\beta$. If this option is disabled (the default), a trivial correlation model is used in which the correlation is unity for halos with identical mass and time, and zero otherwise.</description>
   </nbodyHaloMassError>
   !!]
   type, extends(nbodyHaloMassErrorClass) :: nbodyHaloMassErrorPowerLaw
@@ -32,10 +34,14 @@ errors are a power-law in halo mass.
      An N-body halo mass error class in which errors are a power-law in halo mass.
      !!}
      private
-     double precision :: normalizationSquared          , exponent     , &
-          &              fractionalErrorHighMassSquared, normalization, &
-          &              fractionalErrorHighMass
+     class           (cosmologyFunctionsClass), pointer :: cosmologyFunctions_            => null()
+     double precision                                   :: normalizationSquared                    , exponent                   , &
+          &                                                fractionalErrorHighMassSquared          , normalization              , &
+          &                                                fractionalErrorHighMass                 , correlationNormalization   , &
+          &                                                correlationMassExponent                 , correlationRedshiftExponent
+     logical                                            :: correlationModelTrivial
    contains
+     final     ::                    powerLawDestructor
      procedure :: errorFractional => powerLawErrorFractional
      procedure :: correlation     => powerLawCorrelation
   end type nbodyHaloMassErrorPowerLaw
@@ -61,8 +67,11 @@ contains
     implicit none
     type            (nbodyHaloMassErrorPowerLaw)                :: self
     type            (inputParameters           ), intent(inout) :: parameters
-    double precision                                            :: normalization, fractionalErrorHighMass, &
-         &                                                         exponent
+    class           (cosmologyFunctionsClass   ), pointer       :: cosmologyFunctions_
+    double precision                                            :: normalization              , fractionalErrorHighMass, &
+         &                                                         exponent                   , correlationNormalization, &
+         &                                                         correlationMassExponent    , correlationRedshiftExponent
+    logical                                                     :: correlationModelTrivial
 
     ! Check and read parameters.
     !![
@@ -88,30 +97,102 @@ contains
        where $\sigma_{12}=$\mono{[normalization]}, and $\gamma=$\mono{[exponent]}.
       </description>
     </inputParameter>
+    <inputParameter>
+      <name>correlationModelTrivial</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>If true, the correlation between mass errors of pairs of halos is unity for halos with identical mass and time, and zero otherwise. If false, a power-law correlation model in mass ratio and expansion factor ratio is used instead.</description>
+    </inputParameter>
     !!]
-    self=nbodyHaloMassErrorPowerLaw(normalization,exponent,fractionalErrorHighMass)
+    if (correlationModelTrivial) then
+       self=nbodyHaloMassErrorPowerLaw(normalization,exponent,fractionalErrorHighMass,correlationModelTrivial)
+    else
+       !![
+       <inputParameter>
+         <name>correlationNormalization</name>
+         <source>parameters</source>
+         <defaultValue>0.0d0</defaultValue>
+         <description>Variable $C_0$ in the model for the correlation between halo mass errors: $C_{12} = C_0 [M_2/M_1]^\alpha [(1+z_2)/(1+z_1)]^\beta$.</description>
+       </inputParameter>
+       <inputParameter>
+         <name>correlationMassExponent</name>
+         <source>parameters</source>
+         <defaultValue>0.0d0</defaultValue>
+         <description>Variable $\alpha$ in the model for the correlation between halo mass errors: $C_{12} = C_0 [M_2/M_1]^\alpha [(1+z_2)/(1+z_1)]^\beta$.</description>
+       </inputParameter>
+       <inputParameter>
+         <name>correlationRedshiftExponent</name>
+         <source>parameters</source>
+         <defaultValue>0.0d0</defaultValue>
+         <description>Variable $\beta$ in the model for the correlation between halo mass errors: $C_{12} = C_0 [M_2/M_1]^\alpha [(1+z_2)/(1+z_1)]^\beta$.</description>
+       </inputParameter>
+       <objectBuilder class="cosmologyFunctions" name="cosmologyFunctions_" source="parameters"/>
+       !!]
+       self=nbodyHaloMassErrorPowerLaw(normalization,exponent,fractionalErrorHighMass,correlationModelTrivial,correlationNormalization,correlationMassExponent,correlationRedshiftExponent,cosmologyFunctions_)
+       !![
+       <objectDestructor name="cosmologyFunctions_"/>
+       !!]
+    end if
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function nbodyHaloMassErrorPowerLawConstructorParameters
 
-  function nbodyHaloMassErrorPowerLawConstructorInternal(normalization,exponent,fractionalErrorHighMass) result(self)
+  function nbodyHaloMassErrorPowerLawConstructorInternal(normalization,exponent,fractionalErrorHighMass,correlationModelTrivial,correlationNormalization,correlationMassExponent,correlationRedshiftExponent,cosmologyFunctions_) result(self)
     !!{
     Internal constructor for the \refClass{nbodyHaloMassErrorPowerLaw} N-body halo mass error class.
     !!}
+    use :: Error, only : Error_Report
     implicit none
-    type            (nbodyHaloMassErrorPowerLaw)                :: self
-    double precision                            , intent(in   ) :: normalization          , exponent, &
-         &                                                         fractionalErrorHighMass
+    type            (nbodyHaloMassErrorPowerLaw)                                  :: self
+    double precision                            , intent(in   )                   :: normalization              , exponent                   , &
+         &                                                                           fractionalErrorHighMass
+    logical                                     , intent(in   )                   :: correlationModelTrivial
+    double precision                            , intent(in   ), optional         :: correlationNormalization   , correlationMassExponent    , &
+         &                                                                           correlationRedshiftExponent
+    class           (cosmologyFunctionsClass   ), intent(in   ), optional, target :: cosmologyFunctions_
     !![
-    <constructorAssign variables="normalization, exponent, fractionalErrorHighMass"/>
+    <constructorAssign variables="normalization, exponent, fractionalErrorHighMass, correlationModelTrivial"/>
     !!]
 
     self%normalizationSquared          =normalization          **2
     self%fractionalErrorHighMassSquared=fractionalErrorHighMass**2
+    if (correlationModelTrivial) then
+       self%correlationNormalization    =  0.0d0
+       self%correlationMassExponent     =  0.0d0
+       self%correlationRedshiftExponent =  0.0d0
+       self%cosmologyFunctions_         => null()
+    else
+       if (.not.(present(correlationNormalization).and.present(correlationMassExponent).and.present(correlationRedshiftExponent))) &
+            & call Error_Report('all parameters of correlation model must be provided'//{introspection:location})
+       if (.not.present(cosmologyFunctions_)) &
+            & call Error_Report('cosmology functions must be provided for correlation model'//{introspection:location})
+       self%correlationNormalization    =  correlationNormalization
+       self%correlationMassExponent     =  correlationMassExponent
+       self%correlationRedshiftExponent =  correlationRedshiftExponent
+       self%cosmologyFunctions_         => cosmologyFunctions_
+       !![
+       <referenceCountIncrement owner="self" isResult="yes" object="cosmologyFunctions_"/>
+       !!]
+    end if
     return
   end function nbodyHaloMassErrorPowerLawConstructorInternal
+
+  subroutine powerLawDestructor(self)
+    !!{
+    Destructor for the \refClass{nbodyHaloMassErrorPowerLaw} N-body halo mass error class.
+    !!}
+    implicit none
+    type(nbodyHaloMassErrorPowerLaw), intent(inout) :: self
+
+    if (associated(self%cosmologyFunctions_)) then
+       !![
+       <objectDestructor name="self%cosmologyFunctions_"/>
+       !!]
+    end if
+    return
+  end subroutine powerLawDestructor
 
   double precision function powerLawErrorFractional(self,node)
     !!{
@@ -141,22 +222,36 @@ contains
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
     implicit none
-    class(nbodyHaloMassErrorPowerLaw), intent(inout) :: self
-    type (treeNode                  ), intent(inout) :: node1 , node2
-    class(nodeComponentBasic        ), pointer       :: basic1, basic2
-    !$GLC attributes unused :: self
+    class           (nbodyHaloMassErrorPowerLaw), intent(inout) :: self
+    type            (treeNode                  ), intent(inout) :: node1    , node2
+    class           (nodeComponentBasic        ), pointer       :: basic1   , basic2
+    double precision                                            :: massRatio, expansionFactorRatio
 
     basic1 => node1%basic()
     basic2 => node2%basic()
-    if     (                                &
-         &   basic1%mass() == basic2%mass() &
-         &  .and.                           &
-         &   basic1%time() == basic2%time() &
-         & ) then
-       powerLawCorrelation=1.0d0
+    if (self%correlationModelTrivial) then
+       if     (                                &
+            &   basic1%mass() == basic2%mass() &
+            &  .and.                           &
+            &   basic1%time() == basic2%time() &
+            & ) then
+          powerLawCorrelation=1.0d0
+       else
+          powerLawCorrelation=0.0d0
+       end if
     else
-       powerLawCorrelation=0.0d0
+       ! Extract mass and expansion factor ratios.
+       massRatio            =  +                                         basic2%mass ()  &
+            &                  /                                         basic1%mass ()
+       expansionFactorRatio =  +self%cosmologyFunctions_%expansionFactor(basic2%time ()) &
+            &                  /self%cosmologyFunctions_%expansionFactor(basic1%time ())
+       ! Ensure ratios are below unity, invert otherwise.
+       if (           massRatio > 1.0d0)            massRatio=1.0d0/           massRatio
+       if (expansionFactorRatio > 1.0d0) expansionFactorRatio=1.0d0/expansionFactorRatio
+       ! Evaluate the correlation.
+       powerLawCorrelation  =  +self%correlationNormalization                                   &
+            &                  *                    massRatio**self%correlationMassExponent     &
+            &                  *         expansionFactorRatio**self%correlationRedshiftExponent
     end if
     return
   end function powerLawCorrelation
-


### PR DESCRIPTION
## Summary
- Moved the power-law-in-mass-and-expansion-factor correlation model from `nbodyHaloMassErrorTrenti2010` into its parent class `nbodyHaloMassErrorPowerLaw`, gated by a new `correlationModelTrivial` Boolean parameter (default `.true.`, preserving the existing trivial "1 if identical, 0 otherwise" behavior).
- Reparented `nbodyHaloMassErrorTrenti2010` to extend `nbodyHaloMassErrorPowerLaw`. The Trenti+2010 fractional-error formula is now expressed by setting parent parameters (`exponent = -1/3`, `fractionalErrorHighMass = 0`, and a `massParticle`-derived `normalization`), and the correlation parameters are forwarded to the parent with `correlationModelTrivial = .false.`. The class no longer implements its own `errorFractional` or `correlation` methods.
- Updated `nbodyHaloMassErrorFriendsOfFriends` (the other child of `nbodyHaloMassErrorPowerLaw`) to construct its parent via the public constructor with `correlationModelTrivial = .true.`, so the new parent fields are initialized while behavior is unchanged.

## Type of change
- [x] Other: refactor (no behavior change for existing parameter files)

## How to test
- Build Galacticus and run any existing test that exercises these classes — e.g. `testSuite/parameters/constrainHaloMassFunction.xml` (uses `trenti2010` with non-trivial correlation parameters) and `testSuite/parameters/test-methods.xml` (uses `friendsOfFriends` with the trivial correlation).
- Existing parameter files for `trenti2010` and `friendsOfFriends` should continue to work without changes.
- To exercise the new capability directly on `powerLaw`, add `<correlationModelTrivial value="false"/>` plus `<correlationNormalization/>`, `<correlationMassExponent/>`, `<correlationRedshiftExponent/>` (and a `cosmologyFunctions` block) to a `<nbodyHaloMassError value="powerLaw">` element and verify the resulting correlation matches what `trenti2010` would have produced for the same parameters.

## Checklist
- [ ] I ran relevant tests (or explain why not): _Not run locally — no Fortran toolchain is available in this environment. The refactor is mechanical (no formula changes) and should be validated by CI._
- [x] I updated documentation/comments if needed (descriptions of both classes updated to reflect the new structure).
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'