### PR TITLE
Update workaround notes

### DIFF
--- a/python/Galacticus/Build/SourceTree/Process/FunctionClass/DeepCopy.py
+++ b/python/Galacticus/Build/SourceTree/Process/FunctionClass/DeepCopy.py
@@ -98,7 +98,7 @@ def generate_assignment_allocatable_code(assignment, declaration, name,
     )
     intrinsic = declaration.get('intrinsic')
     if rank > 0 and intrinsic == 'type':
-        # gfortran PR 46897 / 57696 workaround — use explicit element-wise
+        # gfortran PR 57696 workaround — use explicit element-wise
         # assignment rather than a single slice assignment.
         for i in range(1, rank + 1):
             assignment['code'] += (

--- a/source/merger_trees.outputter.standard.F90
+++ b/source/merger_trees.outputter.standard.F90
@@ -1248,10 +1248,13 @@ contains
           self%outputGroupsCount=max(self%outputGroupsCount+standardOutputGroupsIncrement,(indexOutput/standardOutputGroupsIncrement+1)*standardOutputGroupsIncrement)
           allocate(self%outputGroups(self%outputGroupsCount))
           !![
-	  <workaround type="gfortran" PR="46897" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=46897">
-	    <seeAlso type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=57696"/>
+	  <workaround type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=57696">
+	    <seeAlso type="gfortran" PR="124012" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=124012"/>
 	    <description>
-	      Type-bound defined assignment not done because multiple part array references would occur in intermediate expressions.
+             Type-bound defined assignment not done because multiple part array references would occur in intermediate expressions.
+
+             After removing the workaround for PRs 46897/57696, an ICE in `gimplify\_var\_or\_parm\_decl` is triggered (see the
+             `seeAlso` above). So the workaround is left in place for now.
 	    </description>
 	  !!]
           do i=1,size(outputGroupsTemporary)

--- a/source/objects.tables.F90
+++ b/source/objects.tables.F90
@@ -660,9 +660,8 @@ contains
           if (associated(from%interpolators)) then
              allocate(to%interpolators(size(from%interpolators)))
              !![
-	     <workaround type="gfortran" PR="46897" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=46897">
-	       <seeAlso type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=57696"/>
-	       <description>Type-bound defined assignment not done because multiple part array references would occur in intermediate expressions.</description>
+	     <workaround type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=57696">
+	       <description>Defined assignment for components not used when those are ALLOCATABLE</description>
              !!]
              do i=1,size(from%interpolators)
                 if (allocated(to%interpolators(i)%interpolator_)) deallocate(to%interpolators(i)%interpolator_)

--- a/source/stellar_populations.broad_band_luminosities.standard.F90
+++ b/source/stellar_populations.broad_band_luminosities.standard.F90
@@ -348,10 +348,9 @@ contains
              call Move_Alloc(self%luminosityTables,luminosityTablesTemporary)
              allocate(self%luminosityTables(populationID))
              !![
-	     <workaround type="gfortran" PR="46897" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=46897">
-	       <seeAlso type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=57696"/>
+	     <workaround type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=57696">
 	       <description>
-		 Type-bound defined assignment not done because multiple part array references would occur in intermediate expressions.
+		 Defined assignment for components not used when those are ALLOCATABLE.
 	       </description>
 	     !!]
              do iLuminosity=1,size(luminosityTablesTemporary)


### PR DESCRIPTION
## Summary
- Updates the gfortran workaround annotations for type-bound defined-assignment of allocatable derived-type arrays so they reference the relevant upstream bug reports.
- The workarounds were previously tagged against gfortran PR 46897 (with PR 57696 as a "see also"). The primary reference is now PR 57696, which more accurately describes the failure ("defined assignment for co
mponents not used when those are ALLOCATABLE").
- In `merger_trees.outputter.standard.F90`, adds a `seeAlso` for PR 124012 and notes that removing the workaround now triggers an ICE in `gimplify_var_or_parm_decl`, so the workaround is deliberately kept in pl
ace for now.
- Updates the matching comment in `python/.../FunctionClass/DeepCopy.py` to point at PR 57696.
- No functional change to behavior — these are annotation/comment updates plus minor whitespace normalization in the affected `!![ ... !!]` directive blocks.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Docs / tooling
- [ ] Other:

## How to test
- No behavioral change; existing build and test suites should pass unchanged.
- The edited `!![ ... !!]` workaround directives are still well-formed and processed by the source-tree preprocessor (a normal build exercises this).

## Checklist
- [x] I ran relevant tests (or explain why not): documentation/comment-only changes with no functional impact; covered by the standard build.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'
