### PR TITLE
Fix parameter names in description of galacticFilterStarFormationRate

### DIFF
--- a/source/galactic.filters.star_formation_rate.F90
+++ b/source/galactic.filters.star_formation_rate.F90
@@ -33,7 +33,7 @@ Implements a galactic high-pass filter for total star formation rate.
    \begin{equation}
    \log_{10} \left( { \dot{\phi}_\mathrm{t} \over \mathrm{M}_\odot\,\hbox{Gyr}^{-1}} \right) = \alpha_0 + \alpha_1  \left( \log_{10} M_\star - \log_{10} M_0 \right),
    \end{equation}
-   where $M_0=$\mono{[starFormationRateThresholdLogM0]}, $\alpha_0=$\mono{[starFormationRateThresholdLogSFR0]}, and $\alpha_1=$\mono{[starFormationRateThresholdLogSFR1]}.
+   where $M_0=$\mono{[logM0]}, $\alpha_0=$\mono{[logSFR0]}, and $\alpha_1=$\mono{[logSFR1]}.
    </description>
   </galacticFilter>
   !!]


### PR DESCRIPTION
The description referenced parameter names starFormationRateThresholdLogM0,
starFormationRateThresholdLogSFR0, and starFormationRateThresholdLogSFR1, but
the actual inputParameter names are logM0, logSFR0, and logSFR1. Updated the
\mono{} references to match.