### PR TITLE
ci: back off make parallelism on Build-Library-Linux to avoid OOM

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -284,7 +284,22 @@ jobs:
         run: |
           cd $GALACTICUS_EXEC_PATH
           git config --global --add safe.directory $GALACTICUS_EXEC_PATH
-          make -j4 GALACTICUS_BUILD_OPTION=lib libgalacticus.so
+          # Build with parallel make, backing off the level of parallelism on failure. The library build can
+          # exhaust the runner's memory when too many large source files compile concurrently. Since make is
+          # incremental, each retry resumes from the objects already built rather than starting over, so this
+          # keeps the fast path for the common case while reducing memory pressure if a parallel build fails.
+          for j in 4 3 2 1; do
+            echo "Attempting build with -j$j"
+            if make -j$j GALACTICUS_BUILD_OPTION=lib libgalacticus.so; then
+              echo "Build succeeded with -j$j"
+              break
+            fi
+            if [ "$j" -eq 1 ]; then
+              echo "Build failed even with -j1"
+              exit 1
+            fi
+            echo "Build with -j$j failed; retrying with reduced parallelism"
+          done
       - name: Package the code
         run: |
           cd $GALACTICUS_EXEC_PATH


### PR DESCRIPTION
## Problem

The `Build-Library-Linux` CI job intermittently fails during `make -j4 GALACTICUS_BUILD_OPTION=lib libgalacticus.so`. The library build can exhaust the runner's memory when too many large (auto-generated) source files compile concurrently under `-j4`. For example, run [26970517764](https://github.com/galacticusorg/galacticus/actions/runs/26970517764) shows the `Build the code` step failing after ~42 minutes while every other Linux build job passed.

## Change

Retry the build with decreasing parallelism (`-j4 → -j3 → -j2 → -j1`), breaking on the first success and failing the job only if even `-j1` cannot build.

Because `make` is incremental, each retry resumes from the objects already compiled rather than starting over — so this keeps the fast `-j4` path for the common case while reducing memory pressure if a parallel build runs out of memory. The OOM killer targets `f951` (which produces no `.o` until the later assembler step), so a killed compile leaves no truncated object behind and the incremental restart is clean.

Scoped to `Build-Library-Linux` only; the macOS library build is not affected by this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)