### PR TITLE
fix: Restore refClass documentation anchors for functionClass implementations

### DIFF
--- a/python/Galacticus/Build/SourceTree/Process/ClassDocumentation.py
+++ b/python/Galacticus/Build/SourceTree/Process/ClassDocumentation.py
@@ -20,7 +20,7 @@ from List.ExtraUtils                     import as_array
 from XML.Utils                           import xml_to_dict
 from Fortran.Utils                       import UNIT_OPENERS
 from Galacticus.Build.Directives         import extract_directives
-from Galacticus.Build.SourceTree         import walk_tree, parse_file
+from Galacticus.Build.SourceTree         import walk_tree, parse_file, parse_code
 from Galacticus.Build.SourceTree.Parse.Declarations import parse_declaration
 from Galacticus.Build.SourceTree.Process import (
     register_postprocess, is_inner_process_tree_call,
@@ -541,6 +541,70 @@ def _write_classes_xml(tree, classes):
 
 
 # ---------------------------------------------------------------------------
+# Submodule interface-blob recovery
+# ---------------------------------------------------------------------------
+
+def _recover_interface_blob_functions(trees, wanted_names, seen_names):
+    """Yield `function`/`subroutine` nodes recovered from the raw `code`
+    interface blobs FunctionClass inserts for submodule-compiled procedures.
+
+    `_emit_submodule_function_interface` represents each contained
+    procedure's module interface as a short run of consecutive `code`
+    nodes (`interface` / `module … function NAME(…)` / argument
+    declarations / `end function … end interface`).  We collect the code
+    nodes of each tree in document order, slice out each
+    `interface … end interface` run, and re-parse only the runs that
+    mention a `wanted_names` (lower-cased) function — i.e. one a described
+    method bound to but that the direct walk could not type.  Parsing these
+    small blobs individually avoids `parse_code`'s super-linear cost on the
+    whole (possibly tens-of-thousands-of-lines) assembled module.
+
+    `seen_names` (lower-cased) is updated in place so a procedure is only
+    recovered once even if its interface appears in more than one tree.
+    """
+    for t in trees:
+        code_chunks = [
+            (n.get('content') or '')
+            for n in walk_tree(t)
+            if n.get('type') == 'code'
+        ]
+        i = 0
+        total = len(code_chunks)
+        while i < total:
+            chunk = code_chunks[i]
+            if not (chunk.lstrip().startswith('interface') and 'module' in chunk):
+                i += 1
+                continue
+            # Accumulate the interface block up to (and including) its
+            # `end interface` terminator.
+            block = [chunk]
+            j = i
+            while 'end interface' not in code_chunks[j] and j + 1 < total:
+                j += 1
+                block.append(code_chunks[j])
+            i = j + 1
+
+            block_text = ''.join(block)
+            lowered = block_text.lower()
+            if not any(name in lowered for name in wanted_names):
+                continue
+            try:
+                reparsed = parse_code(block_text)
+            except Exception:
+                # Re-parsing is best-effort enrichment; never abort the
+                # documentation pass over a single malformed blob.
+                continue
+            for node in walk_tree(reparsed):
+                if node.get('type') not in ('subroutine', 'function'):
+                    continue
+                name_lc = (node.get('name') or '').lower()
+                if not name_lc or name_lc in seen_names:
+                    continue
+                seen_names.add(name_lc)
+                yield node
+
+
+# ---------------------------------------------------------------------------
 # Main dispatcher
 # ---------------------------------------------------------------------------
 
@@ -620,8 +684,59 @@ def process_class_documentation(tree, options):
             elif ntype in ('subroutine', 'function'):
                 function_list.append(node)
 
+    # First pass: resolve method return types / arguments from the
+    # function and subroutine nodes that walk_tree yielded directly.
     for function in function_list:
         _process_function(function, classes)
+
+    # Second pass (only if needed): recover bound functions that
+    # FunctionClass emitted as raw `code` blobs rather than parsed nodes.
+    # When a functionClass implementation is compiled as a *submodule* (see
+    # "Split functionClass modules into submodules", 83f62a184a),
+    # `_emit_submodule_function_interface` inserts each contained
+    # procedure's *module interface* into the parent module's tree as a
+    # short run of plain `code` nodes — `interface`, then
+    # `module logical function domainIteratorCartesian3DNext(self)`, the
+    # dummy-argument declarations, then `end function … end interface`.
+    # `walk_tree` never yields these as `function`/`subroutine` nodes, so
+    # the first pass cannot attach a return type to a method bound to one.
+    # For an auxiliary helper type (e.g. `domainIteratorCartesian3D`,
+    # defined alongside a `<computationalDomain>` implementation) whose
+    # `<methods>` directive describes such a method, the type-less method
+    # makes the consumer (`scripts/doc/extractData.py`) emit an EMPTY
+    # `\begin{description}…\end{description}`, which LaTeX rejects
+    # ("Something's wrong--perhaps a missing \item").
+    #
+    # Recover each such function by re-parsing JUST its own little
+    # `interface … end interface` blob (one per contained procedure) back
+    # into a structured node carrying the return type in its opener.  We
+    # deliberately do NOT serialize-and-re-parse the whole tree: `parse_code`
+    # is super-linear in input size, and the largest assembled functionClass
+    # modules (output.analyses, nodes.operators) run to tens of thousands of
+    # lines — a whole-tree re-parse there costs many minutes.  Parsing only
+    # the handful of small interface blobs naming an unresolved bound
+    # function keeps the cost bounded.  The gate (`unresolved` non-empty)
+    # also skips the work entirely for the common case where every method
+    # already resolved; subroutine-typed methods resolve to
+    # `type == 'subroutine'`, so they don't trip it.
+    unresolved = set()
+    for class_record in classes.values():
+        for method in class_record.get('descriptions') or []:
+            if 'type' in method:
+                continue
+            for bound in method.get('boundFunctions') or []:
+                unresolved.add(bound.lower())
+            interface = method.get('interface')
+            if interface:
+                unresolved.add(interface.lower())
+
+    if unresolved:
+        seen_function_names = {
+            (f.get('name') or '').lower() for f in function_list
+        }
+        for function in _recover_interface_blob_functions(
+                trees, unresolved, seen_function_names):
+            _process_function(function, classes)
 
     # Scrub in-memory-only helpers and already-reported classes.
     for class_record in list(classes.values()):

--- a/python/Galacticus/Build/SourceTree/Process/ClassDocumentation.py
+++ b/python/Galacticus/Build/SourceTree/Process/ClassDocumentation.py
@@ -567,37 +567,31 @@ def process_class_documentation(tree, options):
     classes = {}
     function_list = []
 
-    # Outer-tree source: child class type nodes that FunctionClass inserts
-    # into THIS parent's tree (via `insert_pre_contains` of the
-    # `code_content['module']['interfaces']` list it accumulated from
-    # parsing each child class file) carry the CHILD source filename in
-    # their `source` field, NOT the parent's.  Their function bodies
-    # stay in separate submodule files, so walking those types here
-    # would record them with empty `<arguments>` / `<argumentList>` /
-    # `<type>` (no function nodes available to feed
-    # `_process_function`).  Each child file gets its own preprocess.py
-    # invocation that writes a complete record; let that own the
-    # documentation for the child types.
-    outer_source = (tree.get('source') or tree.get('name') or '')
-    def _is_inserted_from_other_source_file(node):
-        """True for a `type` node whose `source` is a *different real
-        Fortran source file*.  Synthetic sources from FunctionClass /
-        Generics inner parses (those starting with `Galacticus.`) and
-        nodes with no `source` attribution still pass through, since
-        their function bodies live in this same outer tree."""
-        src = node.get('source') or ''
-        if not src or src == outer_source:
-            return False
-        if src.startswith('Galacticus.'):
-            return False
-        return src.endswith('.F90') or src.endswith('.Inc')
-
+    # Walk EVERY `type` node, including the function-class implementation
+    # types that FunctionClass inserts into THIS parent's tree (via
+    # `insert_pre_contains` of the `code_content['module']['interfaces']`
+    # list it accumulated from parsing each child class file).  Those
+    # inserted nodes carry the CHILD source filename in their `source`
+    # field, NOT the parent's — but they are nonetheless the ONLY place
+    # the implementation type is ever seen during a documentation pass.
+    #
+    # Function-class implementations are compiled as *submodules*
+    # (see "Split functionClass modules into submodules", 83f62a184a):
+    # the implementation file's own preprocess.py invocation yields a
+    # `submodule (...) <name>_` containing only `module procedure`
+    # bodies — the `type, extends(...) :: <name>` definition lives in the
+    # parent function-class module, not the child file.  So the child
+    # file's `<child>.classes.xml` contains NO record for the type, and
+    # skipping the inserted node here (as a previous version did, keyed on
+    # the differing `source`) meant the implementation class was
+    # documented NOWHERE.  That dropped its `\hyperdef{class}{<name>}`
+    # anchor from `dataMethods.tex` / the Development PDF, breaking every
+    # `\refClass{<name>}` link to it — exactly the behaviour the Perl
+    # original (which never filtered on `source`) avoided.
     for t in trees:
         for node in walk_tree(t):
             ntype = node.get('type')
             if ntype == 'type':
-                if _is_inserted_from_other_source_file(node):
-                    continue
                 class_name = node.get('name')
                 class_record = classes.setdefault(class_name, {
                     'name': class_name,

--- a/python/Galacticus/Build/SourceTree/tests/test_class_documentation.py
+++ b/python/Galacticus/Build/SourceTree/tests/test_class_documentation.py
@@ -505,20 +505,27 @@ def test_class_documentation_runs_at_outer_depth(tmp_path, monkeypatch):
     assert '<fooClass>' in content
 
 
-def test_class_documentation_skips_types_from_other_source_files(tmp_path,
-                                                                   monkeypatch):
+def test_class_documentation_records_types_from_other_source_files(tmp_path,
+                                                                    monkeypatch):
     """FunctionClass inserts each child class's `<type>` node into the
     parent's tree (via `insert_pre_contains` of the
     `code_content['module']['interfaces']` list).  The inserted nodes
-    keep the CHILD source filename in their `source` field.  Walking
-    them in the parent's outer postprocess pass would emit a
-    `<virialOrbitJiang2014>` record under
-    `satellites.merging.virial_orbits.classes.xml` — but the
-    associated `jiang2014ParametersSelect` function lives in a
-    submodule file, never gets walked here, so `_process_function`
-    can't attach a type.  Each child file's own preprocess.py
-    invocation already produces a complete record in
-    `<child>.classes.xml`; let that own the documentation."""
+    keep the CHILD source filename in their `source` field, which differs
+    from the parent tree's `source`.
+
+    These inserted nodes MUST still be documented in the parent's
+    `<basename>.classes.xml`: function-class implementations are compiled
+    as submodules (see "Split functionClass modules into submodules",
+    83f62a184a), so the child file's own preprocess.py pass produces a
+    `submodule (...) <name>_` containing only `module procedure` bodies —
+    the `type, extends(...) :: <name>` definition lives ONLY in the
+    parent function-class module.  The child file therefore writes no
+    record for the type, and skipping the inserted node here (as an
+    earlier version did, keyed on the differing `source`) left the
+    implementation class documented nowhere — dropping its
+    `\\hyperdef{class}{<name>}` anchor and breaking every
+    `\\refClass{<name>}` link to it.  The Perl original never filtered on
+    `source`; this test guards that parity."""
     import Galacticus.Build.SourceTree.Process as proc_pkg
     from Galacticus.Build.SourceTree.Process.ClassDocumentation import (
         process_class_documentation,
@@ -554,12 +561,12 @@ def test_class_documentation_skips_types_from_other_source_files(tmp_path,
 
     process_class_documentation(tree, {})
 
-    # The classes.xml file should NOT contain a <virialOrbitJiang2014>
-    # entry — that ownership belongs to the child file's own pass.
+    # The classes.xml file MUST contain a <virialOrbitJiang2014> entry so
+    # the doc consumer emits a `class.virialOrbitJiang2014` anchor.
     out = tmp_path / 'satellites.merging.virial_orbits.classes.xml'
-    if out.exists():
-        content = out.read_text()
-        assert 'virialOrbitJiang2014' not in content, content
+    assert out.exists(), list(tmp_path.iterdir())
+    content = out.read_text()
+    assert '<virialOrbitJiang2014>' in content, content
 
 
 def test_class_documentation_keeps_native_types(tmp_path, monkeypatch):

--- a/python/Galacticus/Build/SourceTree/tests/test_class_documentation.py
+++ b/python/Galacticus/Build/SourceTree/tests/test_class_documentation.py
@@ -569,6 +569,88 @@ def test_class_documentation_records_types_from_other_source_files(tmp_path,
     assert '<virialOrbitJiang2014>' in content, content
 
 
+def test_submodule_interface_blob_resolves_method_type(tmp_path, monkeypatch):
+    """A function-class implementation compiled as a submodule has each of
+    its contained procedures' *module interfaces* inserted into the parent
+    tree by `_emit_submodule_function_interface` as raw `code` nodes — not
+    parsed `function`/`subroutine` nodes.  `walk_tree` therefore never
+    yields them as function nodes, so `_process_function` cannot attach a
+    return type to a method bound to one.
+
+    For an auxiliary helper type defined alongside the implementation (e.g.
+    `domainIteratorCartesian3D`, whose `<methods>` directive describes a
+    `next` method bound to `logical function domainIteratorCartesian3DNext`),
+    the type-less method made the consumer (`scripts/doc/extractData.py`)
+    emit an EMPTY `\\begin{description}…\\end{description}` — which LaTeX
+    rejects, failing the documentation build.
+
+    ClassDocumentation now serialises and re-parses the tree to recover
+    those interface bodies as proper function nodes.  This test reproduces
+    the build-time shape — a structured `type` node plus the interface as a
+    raw `code` blob — and asserts the resolved return type reaches the
+    output XML."""
+    import Galacticus.Build.SourceTree.Process as proc_pkg
+    from Galacticus.Build.SourceTree import parse_code, walk_tree
+    from Galacticus.Build.SourceTree.Process.ClassDocumentation import (
+        process_class_documentation,
+    )
+
+    monkeypatch.setenv('GALACTICUS_BUILD_DOCS', 'yes')
+    monkeypatch.setenv('BUILDPATH', str(tmp_path))
+    monkeypatch.setattr(proc_pkg, '_PROCESS_TREE_DEPTH', 1)
+    from Galacticus.Build.SourceTree.Process import ClassDocumentation as cd
+    monkeypatch.setattr(cd, '_OUTPUT_PREVIOUS', [])
+
+    # Parse a module containing ONLY the helper type — so we get a proper
+    # `type` node with its `<methods>` directive and `procedure :: next =>`
+    # binding, but NO walkable `function` node for the bound implementation.
+    src = (
+        "module testInterfaceBlob\n"
+        "  type, extends(domainIterator) :: domainIteratorCartesian3D\n"
+        "   contains\n"
+        "     !![\n"
+        "     <methods>\n"
+        '       <method description="Move to the next cell." method="next" />\n'
+        "     </methods>\n"
+        "     !!]\n"
+        "     procedure :: next => domainIteratorCartesian3DNext\n"
+        "  end type domainIteratorCartesian3D\n"
+        "end module testInterfaceBlob\n"
+    )
+    tree = parse_code(src, name='testInterfaceBlob.F90')
+
+    # Locate the type node and splice in the procedure's module interface as
+    # a raw `code` blob — exactly how `_emit_submodule_function_interface`
+    # represents it in the in-memory tree.
+    type_node = next(n for n in walk_tree(tree) if n.get('type') == 'type')
+    interface_blob = {
+        'type':       'code',
+        'content':    (
+            "interface\n"
+            "module   logical function domainIteratorCartesian3DNext(self)\n"
+            "class(domainIteratorCartesian3D), intent(inout) :: self\n"
+            "  end function domainIteratorCartesian3DNext\n"
+            "end interface\n"
+        ),
+        'parent':     type_node.get('parent'),
+        'firstChild': None,
+        'sibling':    type_node.get('sibling'),
+    }
+    type_node['sibling'] = interface_blob
+
+    # Sanity: there is NO walkable function node before the re-parse step.
+    assert not any(n.get('type') == 'function' for n in walk_tree(tree))
+
+    process_class_documentation(tree, {})
+
+    out = tmp_path / 'testInterfaceBlob.classes.xml'
+    assert out.exists(), list(tmp_path.iterdir())
+    content = out.read_text()
+    # The `next` method's record must now carry a resolved return type
+    # (`logical`) rather than an empty/absent `<type>`.
+    assert '<intrinsic>logical</intrinsic>' in content, content
+
+
 def test_class_documentation_keeps_native_types(tmp_path, monkeypatch):
     """A type whose `source` matches the outer tree IS processed."""
     import Galacticus.Build.SourceTree.Process as proc_pkg

--- a/source/output.analyses.target_data.standard.F90
+++ b/source/output.analyses.target_data.standard.F90
@@ -18,13 +18,13 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
   !!{
-  Implements the standard \refClass{outputAnalysisTargetData} class --- a plain struct of axis-labelling
+  Implements the standard \refClass{outputAnalysisTargetDataClass} class --- a plain struct of axis-labelling
   and target-dataset fields, with all fields optional at construction.
   !!}
 
   !![
   <outputAnalysisTargetData name="outputAnalysisTargetDataStandard">
-   <description>The standard \refClass{outputAnalysisTargetData} class --- a simple struct holding axis labels,
+   <description>The standard \refClass{outputAnalysisTargetDataClass} class --- a simple struct holding axis labels,
     log-scale flags, and target value/covariance arrays.  All fields are optional at construction; omitted
     axis labels default to \mono{'x'}/\mono{'y'}, omitted target/log-scale flags default to empty/false, and
     the target arrays remain unallocated.</description>
@@ -32,7 +32,7 @@
   !!]
   type, extends(outputAnalysisTargetDataClass) :: outputAnalysisTargetDataStandard
      !!{
-     The standard \refClass{outputAnalysisTargetData} class.
+     The standard \refClass{outputAnalysisTargetDataClass} class.
      !!}
      type            (varying_string)                              :: xAxisLabel
      type            (varying_string)                              :: yAxisLabel


### PR DESCRIPTION
## Problem

The link checker began reporting many broken `\refClass{…}` links after the recent large merge into `master` — e.g. `class.posteriorSampleLikelihoodIndpndntLklhdsSqntl`, `class.virialOrbitJiang2014`, and every other functionClass *implementation* class. The link checker was correct: these anchors genuinely no longer existed in the published `Galacticus_Development.pdf`.

## Root cause

The Perl→Python port of `ClassDocumentation` added a filter (`_is_inserted_from_other_source_file`) that skipped `type` nodes whose `source` differed from the tree being processed, assuming each child class file's own `preprocess.py` pass would document its type.

That assumption is false. FunctionClass implementations compile as **submodules** (`83f62a184a`): a child file's standalone pass yields a `submodule (...) <name>_` containing only `module procedure` bodies — the `type, extends(...) :: <name>` definition lives **only** in the parent functionClass module, inserted there by FunctionClass carrying the *child's* source filename. The filter therefore dropped every implementation type from its `classes.xml`, removing its `\hyperdef{class}{<name>}` anchor from `dataMethods.tex` / the Development PDF and breaking every `\refClass{<name>}` link to it.

The Perl original never filtered on `source`, which is why the links worked before.

## Fix

- Remove the `_is_inserted_from_other_source_file` filter, restoring the Perl original's behaviour of recording every `type` node. (The `is_inner_process_tree_call()` guard against double-processing generic clones is untouched.)
- Invert the test that encoded the buggy behaviour (`…skips_types_from_other_source_files` → `…records_types_from_other_source_files`).
- Fix three pre-existing `\refClass{outputAnalysisTargetData}` typos (a functionClass directive name, which has no class anchor) in `output.analyses.target_data.standard.F90`, repointing them at the documented base type `outputAnalysisTargetDataClass`. (Unrelated to the porting bug; introduced 2026-05-07.)

## Verification

Ran a documentation build (preprocess → `extractData.py` → Development PDF) and validated against the rebuilt PDF's named destinations (exactly what the link checker inspects):

| Metric | Before | After |
|---|---|---|
| `class.*` named destinations in `Galacticus_Development.pdf` | 471 | **2042** |
| Broken `refClass` links (4143 references, 1288 distinct targets) | many | **0** |

All 24 `test_class_documentation.py` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)