### PR TITLE
fix: enable age extrapolation for emission-line luminosity interpolation

### DIFF
--- a/source/nodes.property_extractor.luminosity_emission_line.F90
+++ b/source/nodes.property_extractor.luminosity_emission_line.F90
@@ -787,8 +787,8 @@ contains
     ! have entries for zero age populations. In such cases we allow for extrapolation below the smallest age present in the table.
     extrapolationTime      (1)=extrapolationTypeExtrapolate
     extrapolationTime      (2)=extrapolationTypeAbort
-    interpolatorTime          =interpolator(self%ages         )
-    interpolatorMetallicity   =interpolator(self%metallicities)
+    interpolatorTime          =interpolator(self%ages         ,extrapolationType=extrapolationTime)
+    interpolatorMetallicity   =interpolator(self%metallicities                                    )
     !$omp masked
     if (parallelize_) then
        !$omp critical(gfortranInternalIO)


### PR DESCRIPTION
## Summary
- The time interpolator in the emission-line luminosity property extractor was not receiving the `extrapolationTime` array, so the intended extrapolation below the smallest tabulated age was never applied. The argument was accidentally removed during conflict resolution in merge commit `8b6389ab85`. This passes `extrapolationType=extrapolationTime` to the interpolator constructor to restore the intended behavior.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- Run a model whose Cloudy emission-line tables lack zero-age population entries; the extractor should now extrapolate below the smallest tabulated age rather than aborting.

## Checklist
- [ ] I ran relevant tests (or explain why not):
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'