### PR TITLE
fix(criticalOverdensity): mark environmental class as always tree-dependent

### DIFF
--- a/source/structure_formation.critical_overdensity.environmental.F90
+++ b/source/structure_formation.critical_overdensity.environmental.F90
@@ -260,7 +260,12 @@ contains
     !!}
     implicit none
     class(criticalOverdensityEnvironmental), intent(inout) :: self
+    !$GLC attributes unused :: self
 
-    environmentalIsTreeDependent=self%haloEnvironment_%isTreeDependent()
+    ! The value (and gradient) functions always access the base node of the host tree (to compare its mass to the environment
+    ! mass scale), so this critical overdensity is always dependent on the host tree, irrespective of whether the underlying
+    ! halo environment is itself tree dependent. Reporting this correctly ensures that the `node` object is made available to
+    ! the value function (e.g. when tabulating the time of collapse), avoiding a dereference of an undefined `node` pointer.
+    environmentalIsTreeDependent=.true.
     return
   end function environmentalIsTreeDependent


### PR DESCRIPTION
## Problem

A model using the `environmental` critical overdensity together with the `fixed` halo environment segfaults during merger tree building:

```
#3  __galacticus_nodes_MOD_treenodebasicget
#4  __cosmological_density_field_MOD_environmentalvalue
#5  collapsetimeroot
#6  __root_finder_MOD_rootfinderfindrange
#8  __cosmological_density_field_MOD_criticaloverdensitytimeofcollapse
#9  __merger_trees_builders_MOD_cole2000buildbranch
```

## Root cause

`environmentalValue` (and the gradient routines) in `structure_formation.critical_overdensity.environmental.F90` **always** dereference `node%hostTree%nodeBase%basic()` to compare the host tree's base-node mass against the environment mass scale, so the value is genuinely host-tree dependent regardless of the underlying halo environment class.

However, `environmentalIsTreeDependent` simply forwarded `haloEnvironment_%isTreeDependent()`, which returns `.false.` for the `fixed` halo environment (as does `isNodeDependent`). With both reported false:

- In `criticalOverdensityTimeOfCollapse` (`structure_formation.cosmological_density_field.F90`), `nodePresent` and `treePresent` were both `.false.`, so the `self%node => node` assignment was skipped, leaving `self%node` an **undefined pointer** (it has no `=> null()` default).
- `collapseTimeRoot` then passed that pointer into `environmentalValue` during collapse-time tabulation → `treeNodeBasicGet` dereferenced garbage → SIGSEGV.

## Fix

Report tree dependence unconditionally in `environmentalIsTreeDependent`, since the value/gradient functions always read the host tree's base node. This guarantees the framework supplies a valid `node` to the value function.

## Verification

- **Pre-fix** binary on the original model → SIGSEGV (exit 11), exact stack trace above.
- **Post-fix** binary on a low-resolution variant exercising the same path (cole2000 builder + `environmental`/`fixed`, 20 trees, 4 OpenMP threads) → exit 0, clean completion, valid HDF5 output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)