### PR TITLE
fix(fdm): free prior massDistributionHeated_ before reallocating in solitonNFWHeated

### DIFF
--- a/source/dark_matter_profiles_DMO.soliton_NFW_heated.F90
+++ b/source/dark_matter_profiles_DMO.soliton_NFW_heated.F90
@@ -576,7 +576,13 @@ contains
          &          )
     ! If weighting is not by mass, return a null profile.
     if (weightBy_ /= weightByMass) return
-    ! Create the mass distribution.
+    ! Create the mass distribution. Any previously-built distribution is destroyed first to avoid leaking it: this profile
+    ! object is reused across nodes (and across calculation resets), and `computeProperties` is re-entered each time the
+    ! memoized properties are invalidated, so without this the prior `massDistributionHeated_` (and the NFW and heating
+    ! distributions it owns) would be orphaned with a non-zero reference count.
+    !![
+    <objectDestructor name="self%massDistributionHeated_"/>
+    !!]
     allocate(self%massDistributionHeated_)
     massDistributionDecorated => self%darkMatterProfileDMO_    %get(node,weightBy,weightIndex)
     massDistributionHeating_  => self%darkMatterProfileHeating_%get(node                     )


### PR DESCRIPTION
## Summary

Fixes a continuous memory leak in the fuzzy dark matter `solitonNFWHeated` dark matter profile (`darkMatterProfileDMOSolitonNFWHeated`), reported as very high memory usage when running FDM models.

The class caches a `massDistributionSphericalHeated` object on `self%massDistributionHeated_`, rebuilt in `solitonNFWHeatedComputeProperties` whenever the memoized profile properties are invalidated — which happens per node and on every calculation reset (the reset event fires on essentially every evolution step). The rebuild did `allocate(self%massDistributionHeated_)` over the already-associated owning pointer **without releasing the previous target**, orphaning it with a non-zero reference count.

Each orphaned instance also held the sole references to the decorated NFW distribution, the heating distribution, and any lazily-built mass/potential interpolation tables, so a whole object chain leaked per rebuild. With `nonAnalyticSolver="numerical"` (as in the FDM model) those numerical tables are populated, making each leaked unit non-trivial. The net effect is memory that grows continuously throughout a run.

## Fix

Destroy the prior instance with `objectDestructor` immediately before reallocating:

```fortran
!![
<objectDestructor name="self%massDistributionHeated_"/>
!!]
allocate(self%massDistributionHeated_)
```

- `objectDestructor` performs its own `associated()` check, so the first call (member still `=> null()`) is a no-op — no extra guard needed.
- The destroy lives inside the gated `computeProperties` path, so the **rebuild-only-on-reset memoization optimization is preserved**. Between resets, `get` continues to reuse the cached `self%massDistributionHeated_` (it reads it on every call), so the fast path is unaffected.
- The member is intentionally kept on `self` rather than converted to a local: `get` consumes it on every (memoized) call, so a pure-local refactor would force rebuilding the heated wrapper each call and defeat the optimization.

The sibling non-heated class `darkMatterProfileDMOSolitonNFW` does not share this bug — it caches only scalars and builds its distributions locally in `get`, so no change is needed there.

## Verification

Suggested: run an FDM model with memory tracking (or watch RSS over wall-clock) to confirm memory usage is now flat. Pre-commit Fortran static analysis and review hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)