### PR TITLE
fix(build): bound LTO parallelism with make job server instead of -flto=auto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,20 @@ CPPFLAGS += -fopenmp
 # (even `dsymutil --num-threads 1` is insufficient).
 LTO ?= enabled
 ifeq '$(LTO)' 'enabled'
-FCFLAGS  += -flto=auto
-CFLAGS   += -flto=auto
-CPPFLAGS += -flto=auto
+# Use `-flto=jobserver` (not `-flto=auto`) so the parallelism of the link-time recompilation (the LTRANS
+# phase) is governed by GNU make's job server rather than by the number of CPUs the compiler detects. This
+# fixes two problems on shared/HPC nodes:
+#   1. `-flto=auto` detects *every* CPU on the node (e.g. 640) regardless of how many were requested via
+#      `make -jN` (e.g. 64), badly oversubscribing a node we only partially own.
+#   2. With `make -jN all`, many executables link simultaneously; with `-flto=auto` each link independently
+#      spawns N LTRANS jobs, so the total process count explodes (N links x N jobs).
+# The job server is a single token pool shared across the whole build, so total LTRANS parallelism is capped
+# at the `-jN` requested, no matter how many executables link at once. This requires a `+` prefix on the link
+# recipe (see the `%.exe` rule) so make exposes the job server to the compiler. With no job server present
+# (e.g. a plain `make Galacticus.exe` with no `-j`), LTO simply runs serially.
+FCFLAGS  += -flto=jobserver
+CFLAGS   += -flto=jobserver
+CPPFLAGS += -flto=jobserver
 endif
 # Detect static compilation
 STATIC=$(findstring -static,${FCFLAGS})
@@ -627,7 +638,7 @@ $(BUILDPATH)/%.m : ./source/%.F90
 	fi; \
 	./scripts/build/sourceDigests.py `pwd` $*.exe $$useLocks
 	$(CCOMPILER) -c $(BUILDPATH)/$*.md5s.c -o $(BUILDPATH)/$*.md5s.o $(CFLAGS)
-	$(CONDORLINKER) $(FCCOMPILER) `cat $*.d` $(BUILDPATH)/$*.parameters.o $(BUILDPATH)/$*.md5s.o -o $*.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `scripts/build/libraryDependencies.py $*.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
+	+$(CONDORLINKER) $(FCCOMPILER) `cat $*.d` $(BUILDPATH)/$*.parameters.o $(BUILDPATH)/$*.md5s.o -o $*.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `scripts/build/libraryDependencies.py $*.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
 
 # Library. These rules generate Fortran interface wrappers and their dependencies for the shared library build; the generator
 # scripts (libraryInterfaces.py, libraryInterfacesDependencies.py) are slow, so we only activate them when actually performing


### PR DESCRIPTION
## Problem

LTO uses `-flto=auto`, which makes each link-time recompilation detect the CPU count itself. On shared/HPC nodes this causes two problems:

1. **Detects every CPU on the node**, not the allocation. Request 64 CPUs (`make -j64`) on a node that physically has 640, and `-flto=auto` fires off up to 640 parallel LTRANS processes — oversubscribing a node we only partially own.
2. **Parallel-link explosion.** With `make -jN all`, many executables link simultaneously and each link *independently* spawns N LTRANS jobs, so the total process count blows up (N links × N jobs) and can grind the node to a halt.

## Fix

Switch `-flto=auto` → `-flto=jobserver` and add a `+` prefix to the `%.exe` link recipe so make exposes its job server to the compiler.

The job server is a single token pool shared across the entire build, so total LTRANS parallelism is capped at the requested `-jN` no matter how many executables link at once — both problems go away. With no job server present (a plain `make Galacticus.exe` with no `-j`), LTO simply runs serially.

The `+` prefix is required for the compiler to see the job server. It's harmless on GNU make 4.4+ (FIFO job server, inherited regardless) and necessary on older make (pipe-based job server), so it's portable across cluster toolchains.

### Behavior change to note

A bare `make Galacticus.exe` with **no** `-j` now runs LTO serially instead of using all CPUs. For parallel LTO on a single target, pass a `-jN` (e.g. `make -j8 Galacticus.exe`). Net mental model: **LTO parallelism = your `-jN`, always.**

## Verification

Full `make -j20 all` with gcc/gfortran 16:

- All **124 executables** built cleanly (including `Galacticus.exe`), `make` exit code 0.
- **Peak concurrent `lto1` (LTRANS) and `f951` processes stayed pinned at exactly 20** (= `-j20`) throughout the link-heavy phase — never exceeded, confirming the job-server cap holds end-to-end.

> Note: matched-version compilers (gfortran and gcc same major) are required for LTO; worth confirming CI/cluster toolchains are aligned, though that's independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)