### PR TITLE
fix(outputAnalysis): avoid parent-class logLikelihood evaluation in volumeFunction1D finalize

### DIFF
--- a/source/output.analyses.progenitor_mass_functions.F90
+++ b/source/output.analyses.progenitor_mass_functions.F90
@@ -71,8 +71,9 @@
      procedure :: newTree          => progenitorMassFunctionNewTree
      procedure :: reduce           => progenitorMassFunctionReduce
      procedure :: finalizeAnalysis => progenitorMassFunctionFinalizeAnalysis
-     procedure :: finalize         => progenitorMassFunctionFinalize
-     procedure :: logLikelihood    => progenitorMassFunctionLogLikelihood
+     procedure :: logLikelihood      => progenitorMassFunctionLogLikelihood
+     procedure :: logLikelihoodWrite => progenitorMassFunctionLogLikelihoodWrite
+     procedure :: metadataWrite      => progenitorMassFunctionMetadataWrite
   end type outputAnalysisProgenitorMassFunction
 
   interface outputAnalysisProgenitorMassFunction
@@ -951,42 +952,40 @@ contains
     return
   end subroutine progenitorMassFunctionFinalizeAnalysis
 
-  subroutine progenitorMassFunctionFinalize(self,groupName)
+  subroutine progenitorMassFunctionLogLikelihoodWrite(self,analysisGroup)
     !!{
-    Implement analysis finalization for progenitor mass functions. We simply normalize the accumulated weight of parent nodes.
+    Write the log-likelihood of the progenitor mass function to the output group. This overrides the
+    \refClass{outputAnalysisVolumeFunction1D} default so that our own {\normalfont \ttfamily logLikelihood} method is used, and
+    the parent-class {\normalfont \ttfamily logLikelihood} method (which requires a covariance matrix that we do not construct)
+    is never evaluated.
     !!}
-    use :: Output_HDF5, only : outputFile
-    use :: HDF5_Access, only : hdf5Access
-    use :: IO_HDF5    , only : hdf5Object
+    use :: IO_HDF5, only : hdf5Object
     implicit none
-    class(outputAnalysisProgenitorMassFunction), intent(inout)           :: self
-    type (varying_string                      ), intent(in   ), optional :: groupName
-    type (hdf5Object                          )               , target   :: analysesGroup, subGroup
-    type (hdf5Object                          )               , pointer  :: inGroup
-    type (hdf5Object                          )                          :: analysisGroup
+    class(outputAnalysisProgenitorMassFunction), intent(inout) :: self
+    type (hdf5Object                          ), intent(inout) :: analysisGroup
 
-    call self                               %finalizeAnalysis(         )
-    call self%outputAnalysisVolumeFunction1D%finalize        (groupName)
-    ! Add attributes giving the range of mass ratios considered. Also re-write the log-likelihood attribute here as it will have
-    ! been written as part of the "outputAnalysisVolumeFunction1D" parent class, but we need to do our own calculation.    
-    !$ call hdf5Access%set()
-    analysesGroup =  outputFile   %openGroup('analyses'     )
-    inGroup       => analysesGroup
-    if (present(groupName)) then
-       subGroup   =  analysesGroup%openGroup(char(groupName))
-       inGroup    => subGroup
-    end if
-    analysisGroup=analysesGroup%openGroup(char(self%label),char(self%comment))
-    call analysisGroup%writeAttribute(self%logLikelihood             (),'logLikelihood'             )
-    call analysisGroup%writeAttribute(self%massRatioLikelihoodMinimum  ,'massRatioLikelihoodMinimum')
-    call analysisGroup%writeAttribute(self%massRatioLikelihoodMaximum  ,'massRatioLikelihoodMaximum')
-    call analysisGroup%writeAttribute(self%massParentMinimum           ,'massParentMinimum'         )
-    call analysisGroup%writeAttribute(self%massParentMaximum           ,'massParentMaximum'         )
-    call analysisGroup%writeAttribute(self%redshiftParent              ,'redshiftParent'            )
-    call analysisGroup%writeAttribute(self%redshiftProgenitor          ,'redshiftProgenitor'        )
-    !$ call hdf5Access%unset()
+    call analysisGroup%writeAttribute(self%logLikelihood(),'logLikelihood')
     return
-  end subroutine progenitorMassFunctionFinalize
+  end subroutine progenitorMassFunctionLogLikelihoodWrite
+
+  subroutine progenitorMassFunctionMetadataWrite(self,analysisGroup)
+    !!{
+    Write progenitor-mass-function-specific metadata to the analysis output group, namely the ranges of mass ratio and parent
+    mass considered, together with the parent and progenitor redshifts.
+    !!}
+    use :: IO_HDF5, only : hdf5Object
+    implicit none
+    class(outputAnalysisProgenitorMassFunction), intent(inout) :: self
+    type (hdf5Object                          ), intent(inout) :: analysisGroup
+
+    call analysisGroup%writeAttribute(self%massRatioLikelihoodMinimum,'massRatioLikelihoodMinimum')
+    call analysisGroup%writeAttribute(self%massRatioLikelihoodMaximum,'massRatioLikelihoodMaximum')
+    call analysisGroup%writeAttribute(self%massParentMinimum         ,'massParentMinimum'         )
+    call analysisGroup%writeAttribute(self%massParentMaximum         ,'massParentMaximum'         )
+    call analysisGroup%writeAttribute(self%redshiftParent            ,'redshiftParent'            )
+    call analysisGroup%writeAttribute(self%redshiftProgenitor        ,'redshiftProgenitor'        )
+    return
+  end subroutine progenitorMassFunctionMetadataWrite
 
   double precision function progenitorMassFunctionLogLikelihood(self)
     !!{

--- a/source/output.analyses.volume_function_1d.F90
+++ b/source/output.analyses.volume_function_1d.F90
@@ -136,9 +136,11 @@ mass function) output analysis class.
    contains
      !![
      <methods>
-       <method description="Return the results of the volume function operator." method="results"         />
-       <method description="Finalize the analysis of this function."             method="finalizeAnalysis"/>
-       <method description="Activate/deactivate reporting."                      method="setReporting"    />
+       <method description="Return the results of the volume function operator." method="results"           />
+       <method description="Finalize the analysis of this function."             method="finalizeAnalysis"  />
+       <method description="Activate/deactivate reporting."                      method="setReporting"      />
+       <method description="Write the log-likelihood of this analysis to the output group. Child classes that compute their own log-likelihood should override this to avoid evaluating the parent-class {\normalfont \ttfamily logLikelihood} method." method="logLikelihoodWrite"/>
+       <method description="Write class-specific metadata to the analysis output group. The default implementation does nothing; child classes may override it to add further attributes or datasets." method="metadataWrite"/>
      </methods>
      !!]
      final     ::                     volumeFunction1DDestructor
@@ -149,6 +151,8 @@ mass function) output analysis class.
      procedure :: logLikelihood    => volumeFunction1DLogLikelihood
      procedure :: finalizeAnalysis => volumeFunction1DFinalizeAnalysis
      procedure :: setReporting     => volumeFunction1DSetReporting
+     procedure :: logLikelihoodWrite => volumeFunction1DLogLikelihoodWrite
+     procedure :: metadataWrite      => volumeFunction1DMetadataWrite
   end type outputAnalysisVolumeFunction1D
 
   interface outputAnalysisVolumeFunction1D
@@ -848,18 +852,55 @@ contains
     call    dataset      %writeAttribute(unitType(self%distributionUnitsInSI   ,description=     char(self%distributionUnits)      ,quantity=     char(self%distributionQuantity)       ,isComoving=self%distributionIsComoving),'units')
     call    analysisGroup%writeDataset  (self%functionCovariance(1:self%binCount,1:self%binCount),char(self%distributionLabel)//"Covariance"     ,char(self%distributionComment)//" [covariance]",datasetReturned=dataset)
     call    dataset      %writeAttribute(unitType(self%distributionUnitsInSI**2,description="["//char(self%distributionUnits)//"]²",quantity="("//char(self%distributionQuantity)//")^2",isComoving=self%distributionIsComoving),'units')
-    ! If available, include the log-likelihood and target dataset.
+    ! Write the log-likelihood. This is delegated to the "logLikelihoodWrite" method so that child classes which compute their
+    ! own log-likelihood can override it, and thereby avoid evaluating the (possibly invalid) parent-class "logLikelihood"
+    ! method.
+    call self%logLikelihoodWrite(analysisGroup)
+    ! If available, include the target dataset.
     if (self%targetData_%hasTarget()) then
-       call analysisGroup%writeAttribute(          self%logLikelihood()                              ,'logLikelihood'                                                                                                    )
        call analysisGroup%writeAttribute(     char(self%targetData_%targetLabel)                     ,'targetLabel'                                                                                                      )
        call analysisGroup%writeDataset  (          self%targetData_%valueTarget                      ,char(self%distributionLabel)//"Target"          ,char(self%distributionComment)                 ,datasetReturned=dataset)
        call dataset      %writeAttribute(unitType(self%distributionUnitsInSI   ,description=     char(self%distributionUnits)      ,quantity=     char(self%distributionQuantity)       ,isComoving=self%distributionIsComoving),'units')
        call analysisGroup%writeDataset  (          self%targetData_%covarianceTarget                 ,char(self%distributionLabel)//"CovarianceTarget",char(self%distributionComment)//" [covariance]",datasetReturned=dataset)
        call dataset      %writeAttribute(unitType(self%distributionUnitsInSI**2,description="["//char(self%distributionUnits)//"]²",quantity="("//char(self%distributionQuantity)//")^2",isComoving=self%distributionIsComoving),'units')
     end if
+    ! Write any class-specific metadata.
+    call self%metadataWrite(analysisGroup)
     !$ call hdf5Access%unset()
     return
   end subroutine volumeFunction1DFinalize
+
+  subroutine volumeFunction1DLogLikelihoodWrite(self,analysisGroup)
+    !!{
+    Write the log-likelihood of this analysis to the output group. This default implementation writes the log-likelihood
+    returned by the \refClass{outputAnalysisVolumeFunction1D} {\normalfont \ttfamily logLikelihood} method whenever a target
+    dataset is available. Child classes that compute their own log-likelihood (and which may not, e.g., initialize the
+    covariance matrix used by the default {\normalfont \ttfamily logLikelihood} method) should override this method so that the
+    parent-class {\normalfont \ttfamily logLikelihood} is never evaluated.
+    !!}
+    use :: IO_HDF5, only : hdf5Object
+    implicit none
+    class(outputAnalysisVolumeFunction1D), intent(inout) :: self
+    type (hdf5Object                    ), intent(inout) :: analysisGroup
+
+    if (self%targetData_%hasTarget()) &
+         & call analysisGroup%writeAttribute(self%logLikelihood(),'logLikelihood')
+    return
+  end subroutine volumeFunction1DLogLikelihoodWrite
+
+  subroutine volumeFunction1DMetadataWrite(self,analysisGroup)
+    !!{
+    Write class-specific metadata to the analysis output group. This default implementation does nothing; child classes may
+    override it to add further attributes or datasets to the analysis group.
+    !!}
+    use :: IO_HDF5, only : hdf5Object
+    implicit none
+    class(outputAnalysisVolumeFunction1D), intent(inout) :: self
+    type (hdf5Object                    ), intent(inout) :: analysisGroup
+    !$GLC attributes unused :: self, analysisGroup
+
+    return
+  end subroutine volumeFunction1DMetadataWrite
 
   subroutine volumeFunction1DFinalizeAnalysis(self)
     !!{


### PR DESCRIPTION
## Problem

Classes that extend `outputAnalysisVolumeFunction1D` and supply their own log-likelihood (e.g. `outputAnalysisProgenitorMassFunction`) call the parent's `finalize` to handle the basic output, then write their own `logLikelihood` attribute. But the parent `finalize` also evaluated and wrote *its own* `logLikelihood`.

Because the parent is invoked via the parent-component name —

```fortran
call self%outputAnalysisVolumeFunction1D%finalize(groupName)
```

— the object is **sliced**: inside the parent `finalize`, `self` is non-polymorphic with dynamic type `outputAnalysisVolumeFunction1D`, so `self%logLikelihood()` dispatches to the *parent's* implementation, not the child's override. That parent implementation can error — e.g. when the child uses a counts-based likelihood and never constructs the covariance matrix the parent's likelihood requires. (Verified empirically that parent-component invocation slices and dispatches to the parent's bound procedure.)

## Fix

Refactor finalization into a template-method pattern:

- The base `volumeFunction1DFinalize` now delegates the log-likelihood attribute to an overridable `logLikelihoodWrite(self, analysisGroup)` method, and calls an overridable `metadataWrite(self, analysisGroup)` hook for class-specific output.
- Both hooks have sensible defaults (`logLikelihoodWrite` writes `self%logLikelihood()` iff a target is present; `metadataWrite` is a no-op), so all existing subclasses are unaffected.
- `outputAnalysisProgenitorMassFunction` **drops its `finalize` override** — this is what allows the hooks to dispatch to the child rather than being sliced back to the base — and instead overrides `logLikelihoodWrite` and `metadataWrite`.

New methods are registered in the parent's `<methods>` block for the documentation build.

### Scope

Only `progenitor_mass_functions` reused the parent `finalize` and therefore hit this bug. The other subclasses that override `finalize` (`subhalo_mass_function`, `mean_function_1d`, `subhalo_radial_distribution`, `Local_Group.stellar_mass_function`) do not call the parent and write structurally different output, so they are intentionally left unchanged.

### Latent bug also fixed

The old progenitor override re-opened the analysis group under the top-level `analyses` group rather than the requested `groupName` subgroup, mis-filing its extra attributes when a `groupName` was supplied. Routing the metadata through the parent's already-open `analysisGroup` fixes this.

## Testing

- Full build of `Galacticus.exe` succeeds.
- A test model runs successfully and produces correct results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)