### PR TITLE
fix: parse preprocessor-guarded module uses and unblock -DOMPPROFILE builds (#1030)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,25 +398,31 @@ ifeq '${STATIC}' '-static'
 $(BUILDPATH)/Makefile_Config_Git2:
 	@mkdir -p $(BUILDPATH)
 	echo "FCFLAGS  += -DGIT2UNAVAIL" >  $(BUILDPATH)/Makefile_Config_Git2
-	echo "CFLAGS   += -DGIT2UNAVAIL" >  $(BUILDPATH)/Makefile_Config_Git2
+	echo "CFLAGS   += -DGIT2UNAVAIL" >> $(BUILDPATH)/Makefile_Config_Git2
 	echo "CPPFLAGS += -DGIT2UNAVAIL" >> $(BUILDPATH)/Makefile_Config_Git2
 else ifeq '${USEGIT2}' 'no'
 $(BUILDPATH)/Makefile_Config_Git2:
 	@mkdir -p $(BUILDPATH)
 	echo "FCFLAGS  += -DGIT2UNAVAIL" >  $(BUILDPATH)/Makefile_Config_Git2
-	echo "CFLAGS   += -DGIT2UNAVAIL" >  $(BUILDPATH)/Makefile_Config_Git2
+	echo "CFLAGS   += -DGIT2UNAVAIL" >> $(BUILDPATH)/Makefile_Config_Git2
 	echo "CPPFLAGS += -DGIT2UNAVAIL" >> $(BUILDPATH)/Makefile_Config_Git2
 else
 $(BUILDPATH)/Makefile_Config_Git2: source/libgit2_config.c
 	@mkdir -p $(BUILDPATH)
-	$(CCOMPILER) -c source/libgit2_config.c -o $(BUILDPATH)/libgit2_config.o $(CFLAGS) > /dev/null 2>&1 ; \
+# Probe only against the system/user libgit2 headers (via GALACTICUS_CFLAGS),
+# *not* the full CFLAGS. The latter adds `-I$(BUILDPATH)/`, which can contain a
+# zero-byte `git2.h` stub left by an earlier GIT2UNAVAIL build (created by the
+# generic `%.h` rule for the preprocessed-out include in git2.c). That stub
+# would shadow the real header and make the probe spuriously fail, trapping the
+# build in GIT2UNAVAIL even when a working libgit2 is installed.
+	$(CCOMPILER) -c source/libgit2_config.c -o $(BUILDPATH)/libgit2_config.o $(GALACTICUS_CFLAGS) > /dev/null 2>&1 ; \
 	if [ $$? -eq 0 ] ; then \
 	 echo "FCFLAGS  += -DGIT2AVAIL"   >  $(BUILDPATH)/Makefile_Config_Git2 ; \
 	 echo "CFLAGS   += -DGIT2AVAIL"   >> $(BUILDPATH)/Makefile_Config_Git2 ; \
 	 echo "CPPFLAGS += -DGIT2AVAIL"   >> $(BUILDPATH)/Makefile_Config_Git2 ; \
 	else \
 	 echo "FCFLAGS  += -DGIT2UNAVAIL" >  $(BUILDPATH)/Makefile_Config_Git2 ; \
-	 echo "CFLAGS   += -DGIT2UNAVAIL" >  $(BUILDPATH)/Makefile_Config_Git2 ; \
+	 echo "CFLAGS   += -DGIT2UNAVAIL" >> $(BUILDPATH)/Makefile_Config_Git2 ; \
 	 echo "CPPFLAGS += -DGIT2UNAVAIL" >> $(BUILDPATH)/Makefile_Config_Git2 ; \
 	fi
 endif

--- a/python/Galacticus/Build/SourceTree/Parse/ModuleUses.py
+++ b/python/Galacticus/Build/SourceTree/Parse/ModuleUses.py
@@ -12,11 +12,38 @@ import copy
 
 from Galacticus.Build.FortranUtils import get_fortran_line
 
+# NB: the `(?![a-zA-Z0-9_])` after `use` is essential — without it, an
+# assignment to a variable whose name merely *starts* with "use" (e.g.
+# `useCache=lastCache`) parses as `use Cache, only : =lastCache`, fabricating
+# a bogus module-use node in the middle of a procedure body (issue #1030).
+# The lookahead requires a non-identifier character (whitespace, `,`, or `::`)
+# to follow `use`, mirroring the Perl original's mandatory separator while
+# also accepting the `use::module` spelling the Perl regex wrongly rejected.
 _MODULE_USE_RE = re.compile(
-    r'^\s*(!\$)?\s*use\s*(,\s*(intrinsic))?\s*(::)?\s*([a-zA-Z0-9_]+)'
+    r'^\s*(!\$)?\s*use(?![a-zA-Z0-9_])\s*(,\s*(intrinsic))?\s*(::)?\s*([a-zA-Z0-9_]+)'
     r'\s*(,\s*only\s*:)?\s*([a-zA-Z0-9_()/=*\-+.,\s]+)?\s*$',
     re.IGNORECASE,
 )
+
+
+def _as_entry_list(value):
+    """Normalize a `moduleUse[module]` value to a list of entry dicts.
+
+    Parsed `moduleUse` nodes store a *list* of entries per module — one per
+    distinct preprocessor condition set — so that the same module `use`d
+    under different `#ifdef` guards within one unit is preserved and each
+    occurrence re-emitted under its own guard (issue #1030).  Callers of
+    `add_uses` may still pass a bare entry dict for the common unconditional
+    case; treat that as a single-element list.
+    """
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _condition_key(entry):
+    """A hashable identity for an entry's preprocessor condition set."""
+    return tuple((c['name'], c['invert']) for c in entry.get('conditions', []))
 
 
 def parse_module_uses(tree):
@@ -125,21 +152,32 @@ def parse_module_uses(tree):
                 mod_name     = m.group(5)
                 only_text    = m.group(7)
 
-                if mod_name not in module_uses:
+                # Entries are keyed by module name *and* preprocessor
+                # condition set: the same module may be `use`d under
+                # different `#ifdef` guards within one unit, and each such
+                # occurrence must be preserved and re-emitted under its own
+                # guard (issue #1030).
+                conditions = copy.deepcopy(pp_stack) if pp_stack else []
+                cond_key   = tuple((c['name'], c['invert']) for c in conditions)
+
+                entries = module_uses.setdefault(mod_name, [])
+                if not entries:
+                    # First occurrence of this module name fixes its order.
                     if is_intrinsic:
                         module_order.insert(0, mod_name)
                     else:
                         module_order.append(mod_name)
 
-                entry = module_uses.setdefault(mod_name, {
-                    'openMP':    is_openmp,
-                    'intrinsic': is_intrinsic,
-                })
-                entry['openMP']    = is_openmp
-                entry['intrinsic'] = is_intrinsic
-
-                if pp_stack:
-                    entry['conditions'] = copy.deepcopy(pp_stack)
+                entry = next(
+                    (e for e in entries if _condition_key(e) == cond_key), None)
+                if entry is None:
+                    entry = {'openMP': is_openmp, 'intrinsic': is_intrinsic}
+                    if conditions:
+                        entry['conditions'] = conditions
+                    entries.append(entry)
+                else:
+                    entry['openMP']    = is_openmp
+                    entry['intrinsic'] = is_intrinsic
 
                 if only_text and 'all' not in entry:
                     only_text = only_text.strip()
@@ -221,29 +259,33 @@ def update_uses(uses_node):
     module_use  = uses_node.get('moduleUse', {})
     module_order = uses_node.get('moduleOrder', list(module_use.keys()))
 
-    openmp_any   = any(v.get('openMP')    for v in module_use.values())
-    intrinsic_any = any(v.get('intrinsic') for v in module_use.values())
+    openmp_any = any(
+        e.get('openMP')
+        for v in module_use.values() for e in _as_entry_list(v))
+    intrinsic_any = any(
+        e.get('intrinsic')
+        for v in module_use.values() for e in _as_entry_list(v))
 
     name_len_max = max((len(n) for n in module_use), default=0)
 
     # Compute 4-column max widths for 'only' symbols.
     col_max = [0, 0, 0, 0]
-    for mod_name in module_use:
-        only = module_use[mod_name].get('only', {})
-        if only:
-            for i, sym in enumerate(sorted(only.keys())):
-                j = i % 4
-                if len(sym) > col_max[j]:
-                    col_max[j] = len(sym)
+    for v in module_use.values():
+        for entry in _as_entry_list(v):
+            only = entry.get('only', {})
+            if only:
+                for i, sym in enumerate(sorted(only.keys())):
+                    j = i % 4
+                    if len(sym) > col_max[j]:
+                        col_max[j] = len(sym)
 
-    content = ""
-    for mod_name in module_order:
-        entry = module_use.get(mod_name, {})
+    def _emit_entry(mod_name, entry):
+        text = ""
 
         # Emit preprocessor conditions.
         for cond in entry.get('conditions', []):
             directive = "#ifndef" if cond['invert'] else "#ifdef"
-            content += directive + " " + cond['name'] + "\n"
+            text += directive + " " + cond['name'] + "\n"
 
         use_line = indent
 
@@ -286,11 +328,17 @@ def update_uses(uses_node):
                         use_line += cont_prefix + "&" + " " * (offset_len - len(cont_prefix) - 1)
 
         use_line += "\n"
-        content += use_line
+        text += use_line
 
         # Close preprocessor conditions.
         for _ in entry.get('conditions', []):
-            content += "#endif\n"
+            text += "#endif\n"
+        return text
+
+    content = ""
+    for mod_name in module_order:
+        for entry in _as_entry_list(module_use.get(mod_name, [])):
+            content += _emit_entry(mod_name, entry)
 
     if uses_node.get('firstChild') is None:
         uses_node['firstChild'] = {
@@ -361,36 +409,40 @@ def add_uses(node, module_uses_node):
     new_module_order = module_uses_node.get('moduleOrder', sorted(new_module_use.keys()))
 
     for mod_name in new_module_order:
-        new_entry = new_module_use[mod_name]
+        for new_entry in _as_entry_list(new_module_use[mod_name]):
+            cond_key = _condition_key(new_entry)
+            entries  = uses_node['moduleUse'].setdefault(mod_name, [])
 
-        if mod_name not in uses_node['moduleOrder']:
-            if new_entry.get('intrinsic'):
-                uses_node['moduleOrder'].insert(0, mod_name)
-            else:
-                uses_node['moduleOrder'].append(mod_name)
+            if mod_name not in uses_node['moduleOrder']:
+                if new_entry.get('intrinsic'):
+                    uses_node['moduleOrder'].insert(0, mod_name)
+                else:
+                    uses_node['moduleOrder'].append(mod_name)
 
-        existing = uses_node['moduleUse'].setdefault(mod_name, {})
-        existing['openMP']    = new_entry.get('openMP', False)
-        existing['intrinsic'] = new_entry.get('intrinsic', False)
-        if 'conditions' in new_entry:
-            existing['conditions'] = copy.deepcopy(new_entry['conditions'])
-        else:
-            # The caller wants to use this module unconditionally — if the
-            # existing entry was wrapped in `#ifdef …`, drop the conditions
-            # so the wrapper is removed.  Otherwise the merged `use` ends up
-            # only imported in builds where the original (e.g. MPI-only)
-            # condition holds, and the new caller's symbol is undefined in
-            # other builds.  This mirrors the intuitive read of "merge in
-            # an unconditional use of mod_name".
-            existing.pop('conditions', None)
+            # Merge into the entry with the *same* condition set.  An
+            # unconditional `use` thus joins (or creates) the unconditional
+            # entry and leaves any `#ifdef`-guarded entry of the same module
+            # intact — and vice versa.  This is what fixes the condition
+            # conflation of issue #1030: with a single per-module entry, a
+            # later occurrence's guard used to overwrite (or be merged
+            # under) the earlier one's, moving symbols into the wrong block.
+            existing = next(
+                (e for e in entries if _condition_key(e) == cond_key), None)
+            if existing is None:
+                existing = {}
+                if 'conditions' in new_entry:
+                    existing['conditions'] = copy.deepcopy(new_entry['conditions'])
+                entries.append(existing)
+            existing['openMP']    = new_entry.get('openMP', False)
+            existing['intrinsic'] = new_entry.get('intrinsic', False)
 
-        if 'all' not in existing:
-            if new_entry.get('all'):
-                existing['all'] = True
-                existing.pop('only', None)
-            else:
-                only = existing.setdefault('only', {})
-                for sym in new_entry.get('only', {}):
-                    only[sym] = True
+            if 'all' not in existing:
+                if new_entry.get('all'):
+                    existing['all'] = True
+                    existing.pop('only', None)
+                else:
+                    only = existing.setdefault('only', {})
+                    for sym in new_entry.get('only', {}):
+                        only[sym] = True
 
     update_uses(uses_node)

--- a/python/Galacticus/Build/SourceTree/Process/EventHooks.py
+++ b/python/Galacticus/Build/SourceTree/Process/EventHooks.py
@@ -711,13 +711,8 @@ _WAIT_TIMES_TAIL = """    ! Open output group.
     call waitTimeGroup%writeDataset(eventHookNames         ,"eventHookNames"         ,"Names of event hooks"                                                              )
     call waitTimeGroup%writeDataset(eventHookReadWaitTimes ,"eventHookReadWaitTimes" ,"Total time spent waiting to read-lock event hooks" ,datasetReturned=waitTimeDataset)
     call waitTimeDataset%writeAttribute(unitType(1.0d0,"seconds","s"),"units")
-    call waitTimeDataset%close()
     call waitTimeGroup%writeDataset(eventHookWriteWaitTimes,"eventHookWriteWaitTimes","Total time spent waiting to write-lock event hooks",datasetReturned=waitTimeDataset)
     call waitTimeDataset%writeAttribute(unitType(1.0d0,"seconds","s"),"units")
-    call waitTimeDataset%close()
-    ! Close output groups.
-    call waitTimeGroup%close()
-    call metaDataGroup%close()
     !$ call hdf5Access%unset()
 #endif
    return

--- a/python/Galacticus/Build/SourceTree/Process/FunctionClass/__init__.py
+++ b/python/Galacticus/Build/SourceTree/Process/FunctionClass/__init__.py
@@ -43,7 +43,7 @@ from Galacticus.Build.SourceTree.Process                     import (
 from Galacticus.Build.SourceTree.Parse.Declarations          import (
     parse_declaration, build_declarations, declaration_exists, get_declaration,
 )
-from Galacticus.Build.SourceTree.Parse.ModuleUses            import add_uses
+from Galacticus.Build.SourceTree.Parse.ModuleUses            import add_uses, _as_entry_list
 from Galacticus.Build.SourceTree.Parse.Visibilities          import update_visibilities
 from Galacticus.Build.SourceTree.Process.FunctionClass.Utils import (
     class_dependencies,
@@ -3292,16 +3292,22 @@ def _generate_class_submodules(directive, classes_ordered, non_abstract_classes,
         for mu_node in module_use_nodes:
             uses = mu_node.get('moduleUse') or {}
             for module_name in sorted(uses.keys()):
-                entry = uses[module_name]
-                if entry.get('all'):
-                    continue
-                only = entry.get('only', {}) or {}
-                kept = {
-                    sym: flag for sym, flag in only.items()
-                    if sym.lower() in module_symbols
-                }
-                entry['only'] = kept
-                if not kept:
+                kept_entries = []
+                for entry in _as_entry_list(uses[module_name]):
+                    if entry.get('all'):
+                        kept_entries.append(entry)
+                        continue
+                    only = entry.get('only', {}) or {}
+                    kept = {
+                        sym: flag for sym, flag in only.items()
+                        if sym.lower() in module_symbols
+                    }
+                    if kept:
+                        entry['only'] = kept
+                        kept_entries.append(entry)
+                if kept_entries:
+                    uses[module_name] = kept_entries
+                else:
                     del uses[module_name]
             if uses:
                 add_uses(parent, {

--- a/python/Galacticus/Build/SourceTree/tests/test_module_uses.py
+++ b/python/Galacticus/Build/SourceTree/tests/test_module_uses.py
@@ -1,6 +1,6 @@
 """Regression tests for `Galacticus.Build.SourceTree.Parse.ModuleUses`.
 
-Two bug classes:
+Bug classes covered:
 
   1. `_flush_code` used to absorb `raw_pp_buf` whenever flushing a code
      buffer.  That broke the case where a `#ifdef USEMPI` line sat
@@ -10,14 +10,23 @@ Two bug classes:
      (one of which was unmatched and produced "unterminated #ifdef" at
      compile time).
 
-  2. `add_uses` merged a new unconditional `use` onto an existing
-     conditional entry while preserving the existing entry's `conditions`
-     list.  This meant code that simply asked to `use mpiSelf` ended up
-     only importing it under `#ifdef USEMPI`, and was undefined in serial
-     builds.
+  2. Issue #1030 — preprocessor condition conflation.  A module was keyed
+     by name alone, so when the same module was `use`d twice in one unit
+     under different `#ifdef` guards (or under a guard *and* unconditionally),
+     the second occurrence's condition set overwrote — or absorbed the
+     symbols of — the first, moving imports into the wrong preprocessor
+     block.  Entries are now keyed by name *and* condition set: a module
+     maps to a list of entries, one per distinct guard, each re-emitted
+     under its own `#ifdef … #endif`.
+
+  3. Issue #1030 — the use-statement regex matched assignments to variables
+     whose name starts with "use" (e.g. `useCache=lastCache`), fabricating
+     a spurious module-use node mid-procedure-body.
 """
 
-from Galacticus.Build.SourceTree                  import parse_code, serialize
+import re
+
+from Galacticus.Build.SourceTree                  import parse_code, serialize, walk_tree
 from Galacticus.Build.SourceTree.Parse.ModuleUses import parse_module_uses, add_uses
 
 
@@ -29,6 +38,10 @@ def _parse_with_module_uses(source):
     return parse_code(source, name='<test>', instrument=False)
 
 
+def _module_use_node(tree):
+    return next(n for n in walk_tree(tree) if n.get('type') == 'moduleUse')
+
+
 def test_pp_guarded_use_does_not_duplicate_when_rebuilt():
     """When `update_uses` rebuilds the moduleUse content (which `add_uses`
     triggers), the `#ifdef USEMPI` wrapper must come from exactly ONE
@@ -38,7 +51,6 @@ def test_pp_guarded_use_does_not_duplicate_when_rebuilt():
     `#ifdef` ended up duplicated between the code node and the rebuild,
     yielding "unterminated #ifdef" at compile time."""
     from Galacticus.Build.SourceTree.Parse.ModuleUses import update_uses
-    from Galacticus.Build.SourceTree                  import walk_tree
 
     source = (
         "module foo\n"
@@ -50,22 +62,24 @@ def test_pp_guarded_use_does_not_duplicate_when_rebuilt():
     )
     tree = _parse_with_module_uses(source)
 
-    module_use_node = next(
-        n for n in walk_tree(tree) if n.get('type') == 'moduleUse')
-    update_uses(module_use_node)
+    update_uses(_module_use_node(tree))
 
     out = serialize(tree)
     assert out.count('#ifdef USEMPI') == 1, out
     assert out.count('#endif')        == 1, out
     # The `use mpi` survives.
-    import re as _re
-    assert _re.search(r'\buse\b\s*(::)?\s*mpi\b', out), out
+    assert re.search(r'\buse\b\s*(::)?\s*mpi\b', out), out
 
 
-def test_unconditional_add_uses_drops_existing_conditions():
-    """If the tree already imports `mpi` under `#ifdef USEMPI`, an unconditional
-    `add_uses(...)` for `mpi` must drop the wrapper — otherwise `mpiSelf` is
-    only available in MPI builds."""
+def test_unconditional_add_uses_coexists_with_conditional():
+    """If the tree already imports `mpi` under `#ifdef USEMPI`, an
+    unconditional `add_uses(...)` for `mpi` must make `mpi` available in
+    *every* build — otherwise `mpiSelf` is undefined in serial builds.
+
+    Under the issue #1030 fix this no longer means deleting the existing
+    `#ifdef USEMPI` entry; instead a separate, unconditional entry is added
+    alongside it.  The guarded entry is harmless (a whole-module `use mpi`
+    is idempotent), and crucially the module is now imported unconditionally."""
     source = (
         "module foo\n"
         "#ifdef USEMPI\n"
@@ -75,16 +89,14 @@ def test_unconditional_add_uses_drops_existing_conditions():
         "end module foo\n"
     )
     tree = _parse_with_module_uses(source)
+    module_use_node = _module_use_node(tree)
 
-    # Find the moduleUse node.
-    from Galacticus.Build.SourceTree import walk_tree
-    module_use_node = next(
-        n for n in walk_tree(tree) if n.get('type') == 'moduleUse')
+    # Sanity: the existing entry is keyed under the USEMPI condition.
+    entries = module_use_node['moduleUse']['mpi']
+    assert isinstance(entries, list)
+    assert entries[0].get('conditions') == [{'name': 'USEMPI', 'invert': False}]
 
-    # Sanity: the existing entry has a `conditions` list.
-    assert 'conditions' in module_use_node['moduleUse']['mpi']
-
-    # Now add an unconditional `use mpi`.  The new node carries no
+    # Now add an unconditional `use mpi`.  The new entry carries no
     # `conditions`, mirroring the call sites that simply want the module
     # imported in every build.
     add_uses(module_use_node['parent'], {
@@ -92,13 +104,15 @@ def test_unconditional_add_uses_drops_existing_conditions():
         'moduleOrder': ['mpi'],
     })
 
+    # An unconditional entry now exists in the structure.
+    assert any('conditions' not in e
+               for e in module_use_node['moduleUse']['mpi'])
+
     out = serialize(tree)
-    # The conditional wrapper is gone.
-    assert '#ifdef USEMPI' not in out
-    assert '#endif'        not in out
-    # `use mpi` survives in some emit form (`use mpi` or `use :: mpi`).
-    import re as _re
-    assert _re.search(r'\buse\b\s*(::)?\s*mpi\b', out), out
+    # With every `#ifdef USEMPI … #endif` block stripped, `mpi` is still
+    # imported — i.e. it is available unconditionally.
+    unguarded = re.sub(r'#ifdef USEMPI.*?#endif', '', out, flags=re.S)
+    assert re.search(r'\buse\b\s*(::)?\s*mpi\b', unguarded), out
 
 
 def test_pp_guarded_use_attaches_conditions_to_entry():
@@ -112,9 +126,115 @@ def test_pp_guarded_use_attaches_conditions_to_entry():
     )
     tree = _parse_with_module_uses(source)
 
-    from Galacticus.Build.SourceTree import walk_tree
-    module_use_node = next(
-        n for n in walk_tree(tree) if n.get('type') == 'moduleUse')
+    entries = _module_use_node(tree)['moduleUse']['mpi']
+    assert entries[0].get('conditions') == [{'name': 'USEMPI', 'invert': False}]
 
-    entry = module_use_node['moduleUse']['mpi']
-    assert entry.get('conditions') == [{'name': 'USEMPI', 'invert': False}]
+
+def test_dual_condition_module_kept_in_separate_blocks():
+    """Issue #1030, conditional-first case (the `output.version.F90` pattern):
+    a module used both inside an `#else` branch *and* unconditionally must
+    keep each occurrence under its own guard.  An `add_uses` (as the OpenMP
+    profiler does) triggers a rebuild, which is where the conflation used to
+    surface."""
+    source = (
+        "subroutine demo\n"
+        "#ifdef GIT2AVAIL\n"
+        "    use, intrinsic :: ISO_C_Binding, only : c_null_char\n"
+        "#else\n"
+        "    use :: Input_Paths, only : pathTypeDataDynamic\n"
+        "#endif\n"
+        "    use :: Input_Paths, only : inputPath, pathTypeDataStatic\n"
+        "    implicit none\n"
+        "end subroutine demo\n"
+    )
+    tree = _parse_with_module_uses(source)
+    subroutine = next(n for n in walk_tree(tree) if n.get('type') == 'subroutine')
+    add_uses(subroutine, {
+        'moduleUse':   {'OMP_Lib': {'intrinsic': False, 'all': True}},
+        'moduleOrder': ['OMP_Lib'],
+    })
+
+    out = serialize(tree)
+
+    # `pathTypeDataStatic` and `inputPath` are imported unconditionally; only
+    # `pathTypeDataDynamic` belongs under `#ifndef GIT2AVAIL` (`#else`).
+    unguarded = re.sub(r'#if[n]?def \w+.*?#endif', '', out, flags=re.S)
+    assert 'pathTypeDataStatic' in unguarded, out
+    assert 'inputPath'          in unguarded, out
+    assert 'pathTypeDataDynamic' not in unguarded, out
+
+    # Input_Paths appears under two distinct condition sets.
+    entries = _module_use_node(tree)['moduleUse']['Input_Paths']
+    keys = sorted(tuple(sorted((c['name'], c['invert']) for c in e.get('conditions', [])))
+                  for e in entries)
+    assert keys == [(), (('GIT2AVAIL', True),)], entries
+
+
+def test_unconditional_first_conditional_later_not_conflated():
+    """Issue #1030, unconditional-first case (the `utility.input_parameters.F90`
+    pattern): `use Error, only : Error_Report` unconditionally, then
+    `use Error, only : Warn` under `#else`.  `Error_Report` must stay
+    unconditional — it used to be dragged under the later `#ifndef` guard."""
+    source = (
+        "subroutine demo2\n"
+        "    use :: Error, only : Error_Report\n"
+        "#ifdef GIT2AVAIL\n"
+        "    use :: Input_Paths, only : pathTypeExec\n"
+        "#else\n"
+        "    use :: Error, only : Warn\n"
+        "#endif\n"
+        "    implicit none\n"
+        "end subroutine demo2\n"
+    )
+    tree = _parse_with_module_uses(source)
+    subroutine = next(n for n in walk_tree(tree) if n.get('type') == 'subroutine')
+    add_uses(subroutine, {
+        'moduleUse':   {'OMP_Lib': {'intrinsic': False, 'all': True}},
+        'moduleOrder': ['OMP_Lib'],
+    })
+
+    out = serialize(tree)
+    unguarded = re.sub(r'#if[n]?def \w+.*?#endif', '', out, flags=re.S)
+    assert 'Error_Report' in unguarded, out      # available in every build
+    assert 'Warn' not in unguarded, out          # only under #ifndef GIT2AVAIL
+
+
+def test_assignment_to_use_prefixed_var_not_parsed_as_use():
+    """Issue #1030: an assignment to a variable named `use…` is code, not a
+    `use` statement.  Triggering a rebuild via `add_uses` must not destroy
+    the assignment or fabricate a `Cache` module."""
+    source = (
+        "subroutine demo3\n"
+        "    use :: Error, only : Error_Report\n"
+        "    implicit none\n"
+        "    integer :: useCache, lastCache\n"
+        "    useCache  =lastCache\n"
+        "    return\n"
+        "end subroutine demo3\n"
+    )
+    tree = _parse_with_module_uses(source)
+    subroutine = next(n for n in walk_tree(tree) if n.get('type') == 'subroutine')
+    add_uses(subroutine, {
+        'moduleUse':   {'OMP_Lib': {'intrinsic': False, 'all': True}},
+        'moduleOrder': ['OMP_Lib'],
+    })
+
+    out = serialize(tree)
+    assert 'useCache  =lastCache' in out, out
+    # No spurious module parsed out of the assignment.
+    for node in walk_tree(tree):
+        if node.get('type') == 'moduleUse':
+            assert 'Cache' not in node['moduleUse'], node['moduleUse']
+
+
+def test_use_double_colon_no_space_accepted():
+    """The boundary fix must still accept the `use::module` spelling (which
+    the Perl regex wrongly rejected)."""
+    source = (
+        "module foo\n"
+        "  use::iso_fortran_env\n"
+        "  implicit none\n"
+        "end module foo\n"
+    )
+    tree = _parse_with_module_uses(source)
+    assert 'iso_fortran_env' in _module_use_node(tree)['moduleUse']

--- a/python/LibraryInterfaces/Pipeline.py
+++ b/python/LibraryInterfaces/Pipeline.py
@@ -78,6 +78,22 @@ _SHARED_TYPE_MODULES = {
 }
 
 
+def _module_for_symbol(use_blocks, symbol):
+    """Return the name of the module whose `use ..., only :` list includes
+    `symbol`, or None.
+
+    A parsed moduleUse node maps each module to a *list* of entries (one per
+    preprocessor condition set); a bare dict is tolerated for safety.
+    """
+    for use_block in use_blocks or []:
+        for mod_name, mod_data in use_block.items():
+            entries = mod_data if isinstance(mod_data, list) else [mod_data]
+            for entry in entries:
+                if isinstance(entry, dict) and symbol in entry.get('only', {}):
+                    return mod_name
+    return None
+
+
 # Match a fixed-size dimension attribute of any rank.  Each comma-
 # separated dim is either `N` (default lower bound 1) or `L:U` (explicit
 # lower bound).  Used to distinguish a fixed-size array — whose shape is
@@ -1130,25 +1146,13 @@ def build_fortran_reassignments(argument_list, func_class, implementation,
             # first (same scheme the scalar derived-type branch uses).
             list_mod = _SHARED_TYPE_MODULES.get(list_type)
             if not list_mod:
-                for use_block in func_class.get('moduleUses', []):
-                    for mod_name, mod_data in use_block.items():
-                        if (isinstance(mod_data, dict)
-                                and list_type in mod_data.get('only', {})):
-                            list_mod = mod_name
-                            break
-                    if list_mod:
-                        break
+                list_mod = _module_for_symbol(
+                    func_class.get('moduleUses', []), list_type)
             if implementation and not list_mod:
                 cls = implementation['name']
                 while cls and not list_mod:
-                    for use_block in module_uses_impls.get(cls, []):
-                        for mod_name, mod_data in use_block.items():
-                            if (isinstance(mod_data, dict)
-                                    and list_type in mod_data.get('only', {})):
-                                list_mod = mod_name
-                                break
-                        if list_mod:
-                            break
+                    list_mod = _module_for_symbol(
+                        module_uses_impls.get(cls, []), list_type)
                     cls = extensions.get(cls)
             if list_mod:
                 arg.fort_modules.setdefault(list_mod, {})[list_type] = 1
@@ -1284,25 +1288,13 @@ def build_fortran_reassignments(argument_list, func_class, implementation,
                 if implementation:
                     cls = implementation['name']
                     while cls and not import_module:
-                        for use_block in module_uses_impls.get(cls, []):
-                            for mod_name, mod_data in use_block.items():
-                                if (isinstance(mod_data, dict)
-                                        and type_spec_val in mod_data.get('only', {})):
-                                    import_module = mod_name
-                                    break
-                            if import_module:
-                                break
+                        import_module = _module_for_symbol(
+                            module_uses_impls.get(cls, []), type_spec_val)
                         cls = extensions.get(cls)
                 # 2. fall back to the functionClass file's own module uses.
                 if not import_module:
-                    for use_block in func_class.get('moduleUses', []):
-                        for mod_name, mod_data in use_block.items():
-                            if (isinstance(mod_data, dict)
-                                    and type_spec_val in mod_data.get('only', {})):
-                                import_module = mod_name
-                                break
-                        if import_module:
-                            break
+                    import_module = _module_for_symbol(
+                        func_class.get('moduleUses', []), type_spec_val)
                 # 3. last resort: the functionClass's own module.
                 if not import_module:
                     import_module = func_class.get('module')

--- a/scripts/build/enumerateOpenMPCriticalSections.py
+++ b/scripts/build/enumerateOpenMPCriticalSections.py
@@ -74,12 +74,18 @@ with open(count_tmp, 'w') as fh:
 _update_file(os.path.join(build_path, "openMPCriticalSections.count.inc"), count_tmp)
 
 # --- openMPCriticalSections.enumerate.inc ---
+# A fixed-length `character` array is used (rather than `varying_string`) to
+# mirror the event-hook wait-time code in EventHooks.py: a local automatic
+# `varying_string` array segfaults gfortran when it is finalized on return
+# from OpenMP_Critical_Wait_Times (it is written to the output file and never
+# otherwise needs the dynamic length).
 enum_tmp = os.path.join(build_path, "openMPCriticalSections.enumerate.inc.tmp")
 sorted_names = sorted(critical_section_names)
+name_length_max = max((len(name) for name in sorted_names), default=1)
 with open(enum_tmp, 'w') as fh:
-    fh.write("type(varying_string), dimension(criticalSectionCount) :: criticalSectionNames\n")
-    fh.write("criticalSectionNames=[ &\n")
-    joined = "'), &\n & var_str('".join(sorted_names)
-    fh.write(f" & var_str('{joined}') &\n")
+    fh.write(f"character(len={name_length_max}), dimension(criticalSectionCount) :: criticalSectionNames\n")
+    fh.write(f"criticalSectionNames=[character(len={name_length_max}) :: &\n")
+    joined = "', &\n & '".join(sorted_names)
+    fh.write(f" & '{joined}' &\n")
     fh.write(" & ]\n")
 _update_file(os.path.join(build_path, "openMPCriticalSections.enumerate.inc"), enum_tmp)

--- a/scripts/build/libraryInterfaces.py
+++ b/scripts/build/libraryInterfaces.py
@@ -315,9 +315,13 @@ def _find_enum_module(enum_type, func_class):
         return explicit
     for use_block in func_class.get('moduleUses', []):
         for mod_name, mod_data in use_block.items():
-            if (isinstance(mod_data, dict)
-                    and enum_type in mod_data.get('only', {})):
-                return mod_name
+            # A parsed moduleUse node maps each module to a *list* of entries
+            # (one per preprocessor condition set); tolerate a bare dict too.
+            entries = mod_data if isinstance(mod_data, list) else [mod_data]
+            for entry in entries:
+                if (isinstance(entry, dict)
+                        and enum_type in entry.get('only', {})):
+                    return mod_name
     return func_class.get('module')
 
 

--- a/source/libgit2_config.c
+++ b/source/libgit2_config.c
@@ -19,5 +19,26 @@
 
 #include <git2.h>
 
+// Reference every libgit2 function that git2.c actually calls. Taking the
+// address of an undeclared identifier is a hard compile error in C, so this
+// probe only succeeds when the installed git2.h is new enough to declare all
+// of them. That makes the Makefile select GIT2AVAIL only when git2.c will in
+// fact compile, and otherwise fall back cleanly to GIT2UNAVAIL (using the
+// `git` command line) instead of hard-failing later in git2.c -- which is what
+// happened when an older libgit2 lacked git_graph_descendant_of.
+// Keep this list in sync with the git_* calls in git2.c.
+void *libgit2RequiredSymbols[] = {
+  (void *) &git_repository_open_ext,
+  (void *) &git_repository_head,
+  (void *) &git_reference_type,
+  (void *) &git_reference_target,
+  (void *) &git_oid_tostr,
+  (void *) &git_reference_free,
+  (void *) &git_repository_free,
+  (void *) &git_oid_fromstr,
+  (void *) &git_oid_equal,
+  (void *) &git_graph_descendant_of
+};
+
 int main() {
 }

--- a/source/utility.OpenMP.F90
+++ b/source/utility.OpenMP.F90
@@ -40,7 +40,6 @@ contains
     use :: Output_HDF5          , only : outputFile
     use :: HDF5_Access          , only : hdf5Access
     use :: IO_HDF5              , only : hdf5Object
-    use :: ISO_Varying_String   , only : varying_string         , var_str
     use :: OpenMP_Utilities_Data, only : criticalSectionWaitTime, criticalSectionCount
     use :: Units_MetaData       , only : unitType
 #endif
@@ -59,10 +58,6 @@ contains
     call waitTimeGroup%writeDataset(criticalSectionNames   ,"criticalSectionNames"    ,"Names of OpenMP critical sections"                                                   )
     call waitTimeGroup%writeDataset(criticalSectionWaitTime,"criticalSectionWaitTimes","Total time spent waiting at OpenMP critical sections",datasetReturned=waitTimeDataset)
     call waitTimeDataset%writeAttribute(unitType(1.0d0,"seconds","s"),"units")
-    call waitTimeDataset%close()
-    ! Close output groups.
-    call waitTimeGroup%close()
-    call metaDataGroup%close()
     !$ call hdf5Access%unset()
 #endif
     return

--- a/testSuite/test-python-utils.py
+++ b/testSuite/test-python-utils.py
@@ -434,9 +434,11 @@ def test_parse_module_uses():
         assert_equal(order[0], 'iso_c_binding', "intrinsic module placed first")
         assert_equal(set(order), {'foo', 'iso_c_binding', 'omp_lib', 'bar'}, "all modules captured")
         mu = uses.get('moduleUse', {})
-        assert_equal(mu['iso_c_binding']['intrinsic'], True, "intrinsic flag set")
-        assert_equal(mu['omp_lib']['openMP'], True, "openMP flag set for !$ use")
-        assert_equal(set(mu['bar'].get('only', {}).keys()), {'baz', 'qux'}, "only symbols captured")
+        # Each module maps to a list of entries (one per preprocessor condition
+        # set); these modules are all unconditional, so a single entry each.
+        assert_equal(mu['iso_c_binding'][0]['intrinsic'], True, "intrinsic flag set")
+        assert_equal(mu['omp_lib'][0]['openMP'], True, "openMP flag set for !$ use")
+        assert_equal(set(mu['bar'][0].get('only', {}).keys()), {'baz', 'qux'}, "only symbols captured")
 
     # Round-trip: serializing the original text should reproduce it.
     assert_equal(serialize(root), text, "moduleUses round-trip preserves source")
@@ -457,7 +459,7 @@ def test_parse_module_uses_preprocessor():
     uses = _find_node(root, 'moduleUse')
     assert_equal(uses is not None, True, "moduleUse node created under preprocessor")
     if uses:
-        conds = uses['moduleUse']['conditional_mod'].get('conditions')
+        conds = uses['moduleUse']['conditional_mod'][0].get('conditions')
         assert_equal(isinstance(conds, list) and len(conds) == 1, True,
                      "conditions list captured")
         if conds:


### PR DESCRIPTION
## Summary

Fixes #1030 (preprocessor directive parsing) and gets `-DOMPPROFILE` builds working end-to-end. Three logically separate fixes, one per commit:

1. **`fix(build): correctly parse preprocessor-guarded module use statements (#1030)`** — the core issue. The module-use parser (a) treated assignments like `useCache=lastCache` as `use` statements (optional separator after `use`), fabricating bogus module-use nodes, and (b) keyed entries by module name alone, conflating a module used under multiple preprocessor conditions into a single `#ifdef` guard. Entries are now keyed by name *and* condition set (a list of entries per module, each re-emitted under its own guard), and the regex requires a real separator after `use`.

2. **`fix(build): make -DOMPPROFILE builds emit OpenMP profiling output`** — with the parser fixed, the profiling-output routines then failed to compile (`%close()` on `hdf5Object`, which has no such member — removed, letting the finalizer close handles as elsewhere in the codebase) and to run (segfault finalizing a local `varying_string` array; the critical-section name enumeration is now a fixed-length `character` array, mirroring the event-hook code).

3. **`fix(build): harden libgit2 detection probe and config generation`** — the probe set `GIT2AVAIL` whenever `<git2.h>` merely existed, so an older libgit2 lacking `git_graph_descendant_of` produced a hard compile error in `git2.c` instead of a clean fallback. The probe now references every libgit2 function `git2.c` uses (undeclared → probe fails → `GIT2UNAVAIL` fallback), compiles against system/user headers only (so a stale build-dir `git2.h` stub can't shadow the real header), and a `>`/`>>` clobber in the `GIT2UNAVAIL` branches is fixed.

## Testing

- Python test suite: **422 passed** (includes the rewritten `test_module_uses.py` covering both conflation directions, the `useCache` case, and `use::module`).
- Full `-DOMPPROFILE` build links cleanly; `parameters/quickTest.xml` runs to completion and writes `metaData/openMP` with `criticalSectionNames` / `criticalSectionWaitTimes` and the event-hook wait times.
- libgit2 probe verified across the matrix: real headers (clean and with a stale stub present) → `GIT2AVAIL`; a fake old header tree missing `git_graph_descendant_of` → clean `GIT2UNAVAIL` fallback; `git2.c` compiles under `GIT2AVAIL` with current headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)