### PR TITLE
Add dark matter profile DMO to Naoz-Barkana accretion class

### DIFF
--- a/source/accretion.halo.Naoz_Barkana_2007.F90
+++ b/source/accretion.halo.Naoz_Barkana_2007.F90
@@ -25,6 +25,7 @@
   !!}
   
   use :: Intergalactic_Medium_Filtering_Masses, only : intergalacticMediumFilteringMass, intergalacticMediumFilteringMassClass
+  use :: Dark_Matter_Profiles_DMO             , only : darkMatterProfileDMOClass
   use :: Virial_Density_Contrast              , only : virialDensityContrastClass
 
   !![
@@ -74,6 +75,7 @@
      integer         (kind=kind_int8                       )          :: lastUniqueID
      class           (intergalacticMediumFilteringMassClass), pointer :: intergalacticMediumFilteringMass_ => null()
      class           (virialDensityContrastClass           ), pointer :: virialDensityContrast_            => null()
+     class           (darkMatterProfileDMOClass            ), pointer :: darkMatterProfileDMO_             => null()
    contains
      !![
      <methods>
@@ -124,7 +126,7 @@ contains
     implicit none
     type(accretionHaloNaozBarkana2007)                :: self
     type(inputParameters             ), intent(inout) :: parameters
- 
+
     self%accretionHaloSimple=accretionHaloSimple(parameters)
     !![
     <inputParameter>
@@ -143,13 +145,14 @@ contains
     </inputParameter>
     <objectBuilder class="intergalacticMediumFilteringMass" name="self%intergalacticMediumFilteringMass_" source="parameters"/>
     <objectBuilder class="virialDensityContrast"            name="self%virialDensityContrast_"            source="parameters"/>
+    <objectBuilder class="darkMatterProfileDMO"             name="self%darkMatterProfileDMO_"             source="parameters"/>
     <inputParametersValidate source="parameters"/>
     !!]
     call self%initialize()
     return
   end function naozBarkana2007ConstructorParameters
 
-  function naozBarkana2007ConstructorInternal(timeReionization,velocitySuppressionReionization,accretionNegativeAllowed,accretionNewGrowthOnly,rateAdjust,massMinimum,cosmologyParameters_,cosmologyFunctions_,darkMatterHaloScale_,accretionHaloTotal_,chemicalState_,intergalacticMediumState_,intergalacticMediumFilteringMass_,virialDensityContrast_) result(self)
+  function naozBarkana2007ConstructorInternal(timeReionization,velocitySuppressionReionization,accretionNegativeAllowed,accretionNewGrowthOnly,rateAdjust,massMinimum,cosmologyParameters_,cosmologyFunctions_,darkMatterHaloScale_,accretionHaloTotal_,chemicalState_,intergalacticMediumState_,intergalacticMediumFilteringMass_,virialDensityContrast_,darkMatterProfileDMO_) result(self)
     !!{
     Internal constructor for the \refClass{accretionHaloNaozBarkana2007} halo accretion class.
     !!}
@@ -168,8 +171,9 @@ contains
     class           (intergalacticMediumStateClass        ), intent(in   ), target :: intergalacticMediumState_
     class           (intergalacticMediumFilteringMassClass), intent(in   ), target :: intergalacticMediumFilteringMass_
     class           (virialDensityContrastClass           ), intent(in   ), target :: virialDensityContrast_
+    class           (darkMatterProfileDMOClass            ), intent(in   ), target :: darkMatterProfileDMO_
     !![
-    <constructorAssign variables="rateAdjust, massMinimum, *intergalacticMediumFilteringMass_, *virialDensityContrast_"/>
+    <constructorAssign variables="rateAdjust, massMinimum, *intergalacticMediumFilteringMass_, *virialDensityContrast_, *darkMatterProfileDMO_"/>
     !!]
 
     self%accretionHaloSimple=accretionHaloSimple(timeReionization,velocitySuppressionReionization,accretionNegativeAllowed,accretionNewGrowthOnly,cosmologyParameters_,cosmologyFunctions_,darkMatterHaloScale_,accretionHaloTotal_,chemicalState_,intergalacticMediumState_)
@@ -215,6 +219,7 @@ contains
     !![
     <objectDestructor name="self%intergalacticMediumFilteringMass_"/>
     <objectDestructor name="self%virialDensityContrast_"           />
+    <objectDestructor name="self%darkMatterProfileDMO_"            />
     !!]
     return
   end subroutine naozBarkana2007Destructor
@@ -293,6 +298,7 @@ contains
             &                                                                                                             densityContrastVirial   , &
             &                                                                                cosmologyParameters_  =self %cosmologyParameters_    , &
             &                                                                                cosmologyFunctions_   =self %cosmologyFunctions_     , &
+            &                                                                                darkMatterProfileDMO_ =self %darkMatterProfileDMO_   , &
             &                                                                                virialDensityContrast_=self %virialDensityContrast_    &
             &                                                                               )
        self%filteredFractionStored   =  self%filteredFractionCompute(massHalo,massFiltering)
@@ -330,6 +336,7 @@ contains
             &                                                                                             densityContrastVirial   , &
             &                                                                cosmologyParameters_  =self %cosmologyParameters_    , &
             &                                                                cosmologyFunctions_   =self %cosmologyFunctions_     , &
+            &                                                                darkMatterProfileDMO_ =self %darkMatterProfileDMO_   , &
             &                                                                virialDensityContrast_=self %virialDensityContrast_    &
             &                                                               )
        if (.not.self%filteredFractionComputed) then


### PR DESCRIPTION
## Summary
- Pass a `darkMatterProfileDMO` object through the Naoz-Barkana 2007 halo accretion class so it can be supplied to the filtering mass calculations.

- This is needed as the class converts between halo mass definitions, and for some non-CDM models it is possible that there is no solution (e.g. if the dark matter halo has a finite central density).

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- 

## Checklist
- [ ] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'
