### PR TITLE
refactor(build): remove dead code from FunctionClass processor

### DIFF
--- a/python/Galacticus/Build/SourceTree/Process/FunctionClass/__init__.py
+++ b/python/Galacticus/Build/SourceTree/Process/FunctionClass/__init__.py
@@ -28,7 +28,6 @@ from List.ExtraUtils                                         import as_array
 from Sort.Topo                                               import sort as topo_sort
 from XML.Utils                                               import xml_to_dict
 from Galacticus.Build.StateStorables                         import (
-    function_class_entries  as _shared_function_class_entries,
     function_class_names    as _shared_function_class_names,
     function_class_instances as _shared_function_class_instances,
 )
@@ -569,13 +568,6 @@ def _update_if_changed(target, tmp):
 # ---------------------------------------------------------------------------
 # Stubs for the heavy method-builders / body-emitters (D.7.3b, D.7.3c)
 # ---------------------------------------------------------------------------
-
-def _not_implemented(name):
-    raise NotImplementedError(
-        f"process_function_class: {name} is deferred to a later PR "
-        f"(D.7.3b or D.7.3c) of the FunctionClass port"
-    )
-
 
 def _levenshtein(a, b):
     """Iterative Wagner-Fischer edit distance.  Stand-in for Perl


### PR DESCRIPTION
## Summary

Removes two unused symbols from the `functionClass` directive processor (`python/Galacticus/Build/SourceTree/Process/FunctionClass/__init__.py`):

- **`_not_implemented`** — a stub helper that was never called.
- **`_shared_function_class_entries`** — an import alias that was never referenced. The sibling aliases `_shared_function_class_names` and `_shared_function_class_instances` remain in use and are untouched.

## Why they're dead

- No `__all__` in the module, and both names are underscore-prefixed (module-private), so neither is reachable via wildcard import.
- A repo-wide search finds no references other than the definition / import line itself.

## Verification

- Module byte-compiles and imports cleanly.
- All 137 tests in the `SourceTree` test suites and `test_state_storables` pass.
- A full Galacticus compile still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)