### PR TITLE
chore: raise minimum Python to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.0"
 description = "Python infrastructure for the Galacticus semi-analytic galaxy formation model."
 readme = "README.md"
 license = {file = "COPYING"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Andrew Benson"},
 ]
@@ -95,7 +95,7 @@ exclude  = ["*.tests", "*.tests.*", "tests", "tests.*"]
 # discussion in the audit for the rationale.
 # ----------------------------------------------------------------------
 [tool.mypy]
-python_version           = "3.9"
+python_version           = "3.10"
 ignore_missing_imports   = true
 disallow_untyped_defs    = false
 warn_unused_ignores      = true


### PR DESCRIPTION
## What

Raise the `requires-python` floor in `pyproject.toml` from `>=3.9` to `>=3.10`, and update the matching `[tool.mypy]` `python_version` to `3.10`.

## Why

Dependabot posts a warning on its open PRs that it will stop supporting Python 3.9. The trigger is the `requires-python = ">=3.9"` declaration, which Dependabot uses to pick the interpreter it resolves pip updates against. Python 3.9 reached **end-of-life in October 2025**.

## Safety

All three CI workflows (`cicd.yml`, `prChecks.yml`, `linkCheck.yml`) already run on `python-version: '3.x'` (latest Python 3), so 3.9 was never actually exercised — the floor was aspirational. Nothing else in the repo pins 3.9.

This lands on the default branch; it does not need to be applied to the existing Dependabot PRs, which clear once future Dependabot runs see the new floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)