### PR TITLE
ci: skip full CI/CD suite for docs-only pull requests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,22 +3,21 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches:
-      - 'master'
-    paths:
+    # Only run the full suite when code (or the suite itself) changes. Docs-only
+    # PRs (e.g. docs/**, docs/requirements.txt bumps) are covered by the docs
+    # validators in prChecks.yml and the ReadTheDocs build, so they skip this.
+    paths: &codePaths
       - 'Makefile'
       - 'source/**'
-      - 'source/Bivar/**'
-      - 'source/ISO_Varying_String/**'
-      - 'source/gslODEInitVal2/**'
-      - 'source/NSWC/**'
-      - 'source/pFq/**'
-      - 'source/gslSpecFuncApprox/**'
-      - 'source/FFTlog/**'
       - 'python/**'
       - 'scripts/build/**'
       - 'schema/**'
+      - 'testSuite/**'
+      - '.github/workflows/cicd.yml'
+  push:
+    branches:
+      - 'master'
+    paths: *codePaths
 concurrency:
   group: cicd-${{ github.ref }}
   cancel-in-progress: true  


### PR DESCRIPTION
## Summary

The `cicd.yml` `pull_request` trigger had no `paths` filter, so **every** PR ran the full build-and-test suite — even when only documentation changed. A recent dependabot PR bumping `furo` in `docs/requirements.txt` triggered a full Galacticus build and all test models, which is wasteful for a change that can only affect docs.

Now that docs build on ReadTheDocs (external to Actions) and the docs validators live in `prChecks.yml`, the heavy suite is unnecessary for docs-only changes.

## Change

Add a `paths` filter to `cicd.yml`'s `pull_request` trigger, mirroring the existing `push` filter via a shared YAML anchor:

- **Docs-only PR** (e.g. `docs/**`, `docs/requirements.txt`) → full suite skipped; `prChecks.yml` docs validators + ReadTheDocs preview still run.
- **Source PR** → full suite runs as before (embedded docstrings stay covered by `prChecks.yml`).
- **Push to `master`** → unchanged.

While here:
- Deduplicated the redundant `source/<subdir>/**` entries (all covered by `source/**`).
- Added `testSuite/**` and `.github/workflows/cicd.yml` so the suite re-runs when tests or the workflow itself change.
- Shared the `push`/`pull_request` filters through one YAML anchor so they can't drift apart.

## Notes

`master`'s ruleset has no required status checks, so path-filtering the `pull_request` trigger cannot deadlock a PR waiting on a check that never runs. The merge queue is intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)