### PR TITLE
fix(build): add '+' prefix to executable link recipes so LTO uses make's jobserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,9 +332,9 @@ $(BUILDPATH)/hdf5FCInterop.dat  : $(BUILDPATH)/hdf5FCInterop.exe $(BUILDPATH)/hd
 	$(BUILDPATH)/hdf5FCInteropC.exe >> $(BUILDPATH)/hdf5FCInterop.dat
 $(BUILDPATH)/hdf5FCInterop.exe  : source/system/hdf5FCInterop.F90
 	@mkdir -p $(BUILDPATH)/moduleBuild
-	$(FCCOMPILER) source/system/hdf5FCInterop.F90 -o $(BUILDPATH)/hdf5FCInterop.exe $(FCFLAGS)
+	+$(FCCOMPILER) source/system/hdf5FCInterop.F90 -o $(BUILDPATH)/hdf5FCInterop.exe $(FCFLAGS)
 $(BUILDPATH)/hdf5FCInteropC.exe : source/system/hdf5FCInteropC.c
-	$(CCOMPILER) source/system/hdf5FCInteropC.c -o $(BUILDPATH)/hdf5FCInteropC.exe $(CFLAGS)
+	+$(CCOMPILER) source/system/hdf5FCInteropC.c -o $(BUILDPATH)/hdf5FCInteropC.exe $(CFLAGS)
 
 # Configuration of proc filesystem.
 -include $(BUILDPATH)/Makefile_Config_Proc
@@ -701,7 +701,7 @@ libgalacticus.so: $(BUILDPATH)/libgalacticus.o $(BUILDPATH)/libgalacticus_classe
 # GNU Fortran emits stack-based trampolines). Newer kernels/loaders refuse to `dlopen()` such a library,
 # causing the Python interface to fail with "cannot enable executable stack as shared object requires:
 # Invalid argument". This flag is applied only to the library link, leaving executable builds unchanged.
-	$(FCCOMPILER) -shared $(LINKNOEXECSTACK) `sort -u $(BUILDPATH)/libgalacticus.d $(BUILDPATH)/libgalacticus_classes.d` $(BUILDPATH)/libgalacticus.parameters.o $(BUILDPATH)/libgalacticus.md5s.o -o libgalacticus.so $(FCFLAGS) $(FCFLAGS_LINK) `scripts/build/libraryDependencies.py libgalacticus.o $(FCFLAGS)`
+	+$(FCCOMPILER) -shared $(LINKNOEXECSTACK) `sort -u $(BUILDPATH)/libgalacticus.d $(BUILDPATH)/libgalacticus_classes.d` $(BUILDPATH)/libgalacticus.parameters.o $(BUILDPATH)/libgalacticus.md5s.o -o libgalacticus.so $(FCFLAGS) $(FCFLAGS_LINK) `scripts/build/libraryDependencies.py libgalacticus.o $(FCFLAGS)`
 endif
 
 # Ensure that we don't delete object files which make considers to be intermediate

--- a/scripts/build/findExecutables.py
+++ b/scripts/build/findExecutables.py
@@ -100,7 +100,7 @@ with open(os.path.join(build_path, "Makefile_All_Execs"), 'w') as out:
 \tfi; \\
 \t./scripts/build/sourceDigests.py `pwd` {obj_root}.exe $$useLocks
 \t$(CCOMPILER) -c {work_dir}{obj_root}.md5s.c -o {work_dir}{obj_root}.md5s.o $(CFLAGS)
-\t$(FCCOMPILER) `cat {work_dir}{obj_root}.d` {work_dir}{obj_root}.parameters.o {work_dir}{obj_root}.md5s.o -o {exe_root}.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `./scripts/build/libraryDependencies.py {obj_root}.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
+\t+$(FCCOMPILER) `cat {work_dir}{obj_root}.d` {work_dir}{obj_root}.parameters.o {work_dir}{obj_root}.md5s.o -o {exe_root}.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `./scripts/build/libraryDependencies.py {obj_root}.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
 
 """
         out.write(rule)


### PR DESCRIPTION
## Summary

Building with LTO enabled (e.g. `make -j32 Galacticus.exe`) printed:

```
lto-wrapper: warning: jobserver is not available: '--jobserver-auth=' is not present in 'MAKEFLAGS'
lto-wrapper: note: see the '-flto' option documentation for more information
```

and fell back to serial LTRANS recompilation, defeating the point of `-flto=jobserver`.

## Root cause

GNU Make only shares its jobserver with a recipe line that is flagged *recursive* — i.e. prefixed with `+` (or containing `$(MAKE)`). Without it, `lto-wrapper` can't find the jobserver and warns.

The per-executable build rules are generated by `scripts/build/findExecutables.py` into `Makefile_All_Execs` as **explicit** rules. An explicit rule overrides the `%.exe` pattern rule (which already carries the `+`), so for every generated executable — `Galacticus.exe` and all tests/benchmarks — the link ran *without* the jobserver. The hand-written links for the `hdf5FCInterop` helpers and `libgalacticus.so` were likewise missing the `+`.

## Changes

- `scripts/build/findExecutables.py`: add `+` to the emitted link line (covers `Galacticus.exe` and ~150 test/benchmark executables).
- `Makefile`: add `+` to the `hdf5FCInterop.exe`, `hdf5FCInteropC.exe`, and `libgalacticus.so` link recipes.

## Verification

With the fix, `make -j20 Galacticus.exe` links cleanly with no `lto-wrapper` warning, and LTRANS parallelism is governed by the `-jN` token pool as the comment block in `Makefile` intends. Confirmed on GNU Make 4.3 + gfortran 16.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)