### PR TITLE
perf: pointer-returning meta-property getter to avoid per-call array copy

### DIFF
--- a/python/Galacticus/Build/Components/Classes/MetaProperties.py
+++ b/python/Galacticus/Build/Components/Classes/MetaProperties.py
@@ -105,6 +105,88 @@ def Class_Meta_Property_Get(build, class_dict):
         })
 
 
+def Class_Meta_Property_Get_Reference(build, class_dict):
+    """Generate one `<class><Label>Rank<N>MetaPropertyGetReference` per
+    rank>=1 meta-property type, returning a POINTER to the stored array
+    (no allocate, no copy).
+
+    Purely additive sibling of `Class_Meta_Property_Get`.  A pointer to a
+    scalar would be pointless, so rank-0 meta-properties are skipped.  The
+    returned pointer is read-only by contract and is valid only while the
+    component and its allocation persist (see the correctness contract in
+    the position-interpolation operator).
+    """
+    name      = class_dict['name']
+    cap       = _ucfirst(name)
+    type_name = 'nodeComponent' + cap
+    active    = name in (build.get('componentClassListActive') or [])
+
+    for mpt in meta_property_types:
+        rank = mpt['rank']
+        if rank == 0:                       # a pointer to a scalar is pointless here
+            continue
+        cap_label = _ucfirst(mpt['label'])
+        rank_attr = ', pointer, dimension(' + ','.join([':'] * rank) + ')'
+
+        if active:
+            content = (
+                f"if (.not.{name}{cap_label}Rank{rank}MetaPropertyCreator(metaPropertyID))"
+                f" call metaPropertyNoCreator('{name}',char({name}{cap_label}"
+                f"Rank{rank}MetaPropertyLabels(metaPropertyID)),'{mpt['label']}',"
+                f"{rank})\n"
+                f"value_=>self%{mpt['label']}Rank{rank}"
+                f"MetaProperties(metaPropertyID)%values\n"
+            )
+        else:
+            content = ''
+
+        return_type_text = (
+            f"{mpt['intrinsic']}"
+            + (f"({mpt['type']})" if 'type' in mpt else "")
+            + f"{rank_attr} => value_"
+        )
+
+        function = {
+            'type':        return_type_text,
+            # The procedure name is abbreviated to `...MetaPropertyRef` (rather
+            # than the full `...MetaPropertyGetReference` used for the public,
+            # caller-facing type-bound name below) so that it stays within the
+            # Fortran 63-character identifier limit: the longest class+label
+            # combination (`darkMatterProfile`+`longInteger`) already reaches
+            # 61 characters with the existing `...MetaPropertyGet` suffix.
+            'name':        f"{type_name}{cap_label}Rank{rank}MetaPropertyRef",
+            'description': (
+                f"Return a pointer to the stored rank-{rank} {mpt['label']} "
+                f"meta-property of a {type_name} component given its ID (no "
+                f"copy; read-only - valid only while the component and its "
+                f"allocation persist)."
+            ),
+            'modules':     ['ISO_Varying_String'],
+            'variables':   [
+                {
+                    'intrinsic':  'class',
+                    'type':       type_name,
+                    'attributes': ['intent(in   )', 'target'],
+                    'variables':  ['self'],
+                },
+                {
+                    'intrinsic':  'integer',
+                    'attributes': ['intent(in   )'],
+                    'variables':  ['metaPropertyID'],
+                },
+            ],
+            'content':     content,
+        }
+
+        build.setdefault('types', {}).setdefault(type_name, {}) \
+                                      .setdefault('boundFunctions', []) \
+                                      .append({
+            'type':       'procedure',
+            'descriptor': function,
+            'name':       f"{mpt['label']}Rank{rank}MetaPropertyGetReference",
+        })
+
+
 def Class_Meta_Property_Set(build, class_dict):
     """Generate one `<class><Label>Rank<N>MetaPropertySet` per
     meta-property type, storing the provided value.
@@ -183,5 +265,6 @@ def _ucfirst(text):
     return text[:1].upper() + text[1:] if text else text
 
 
-register('classMetaProperties', 'classIteratedFunctions', Class_Meta_Property_Get)
-register('classMetaProperties', 'classIteratedFunctions', Class_Meta_Property_Set)
+register('classMetaProperties', 'classIteratedFunctions', Class_Meta_Property_Get          )
+register('classMetaProperties', 'classIteratedFunctions', Class_Meta_Property_Get_Reference)
+register('classMetaProperties', 'classIteratedFunctions', Class_Meta_Property_Set          )

--- a/source/nodes/operators/physics/position/interpolated.F90
+++ b/source/nodes/operators/physics/position/interpolated.F90
@@ -220,23 +220,23 @@ contains
     use :: Numerical_Constants_Astronomical, only : MpcPerKmPerSToGyr
     use :: Display                         , only : displayMessage       , displayIndent     , displayUnindent
     implicit none
-    class           (nodeOperatorPositionInterpolated), intent(inout)                  :: self
-    type            (treeNode                        ), intent(inout)                  :: node
-    double precision                                  , intent(in   )                  :: time
-    class           (nodeComponentPosition           ), pointer                        :: position
-    double precision                                  , dimension(3     )              :: position_          , velocity_
-    double precision                                  , dimension(4,3   )              :: coefficientsCubic
-    double precision                                  , dimension(    20)              :: coefficientsSpiral
-    double precision                                  , dimension(  2, 2)              :: coefficientsAngle  , coefficientsLogRadius
-    double precision                                  , dimension(2,2, 3)              :: vectorInPlaneNormal
-    double precision                                  , dimension(2     )              :: angle              , logRadius
-    double precision                                  , dimension(:     ), allocatable :: coefficients
-    integer         (c_size_t                        )                                 :: countTrace         , iTrace               , &
-         &                                                                                offset
-    integer                                                                            :: i
-    logical                                                                            :: isSpiral           , report
-    double precision                                                                   :: lengthBox
-    character       (len=1024                        )                                 :: label
+    class           (nodeOperatorPositionInterpolated), intent(inout)              :: self
+    type            (treeNode                        ), intent(inout)              :: node
+    double precision                                  , intent(in   )              :: time
+    class           (nodeComponentPosition           ), pointer                    :: position
+    double precision                                  , dimension(3     )          :: position_          , velocity_
+    double precision                                  , dimension(4,3   )          :: coefficientsCubic
+    double precision                                  , dimension(    20)          :: coefficientsSpiral
+    double precision                                  , dimension(  2, 2)          :: coefficientsAngle  , coefficientsLogRadius
+    double precision                                  , dimension(2,2, 3)          :: vectorInPlaneNormal
+    double precision                                  , dimension(2     )          :: angle              , logRadius
+    double precision                                  , dimension(:     ), pointer :: coefficients
+    integer         (c_size_t                        )                             :: countTrace         , iTrace               , &
+         &                                                                            offset
+    integer                                                                        :: i
+    logical                                                                        :: isSpiral           , report
+    double precision                                                               :: lengthBox
+    character       (len=1024                        )                             :: label
     !$GLC attributes initialized :: coefficients
 
     report=any(node%index() == self%nodeIndicesReport)
@@ -245,8 +245,8 @@ contains
        call displayIndent("Position interpolation for node | time: "//trim(adjustl(label)))
     end if
     ! Extract all interpolation coefficients.
-    position     => node    %position                 (                   )
-    coefficients =  position%floatRank1MetaPropertyGet(self%coefficientsID)
+    position     => node    %position                          (                   )
+    coefficients => position%floatRank1MetaPropertyGetReference(self%coefficientsID)
     ! Determine the number of steps in the interpolation.
     countTrace  =size(coefficients)/(2_c_size_t+countCoefficientsCubicPolynomial+countCoefficientsLogarithmicSpiral)
     ! Find the appropriate time.


### PR DESCRIPTION
## Summary

Adds a pointer-returning `...MetaPropertyGetReference` sibling to the by-value `...MetaPropertyGet` for rank≥1 component meta-properties. Instead of allocating a fresh array and copying the stored values on every call, it returns a **pointer** to the stored array. The variant is purely additive (the by-value getter is untouched) and **read-only by contract** — the pointer is valid only while the component and its allocation persist.

The first caller is the lightcone position-interpolation operator (`positionInterpolatedInterpolate`), whose per-node-per-timestep read of the `positionInterpolatedCoefficients` meta-property (a large rank-1 array, `34 × countTrace` doubles) was the single hottest symbol when profiling the lightcone N-body benchmark — ~95% of that symbol's time was the `allocate` + array-copy, not the integer-keyed lookup.

## Implementation notes

- **Generator:** `Class_Meta_Property_Get_Reference` in `python/Galacticus/Build/Components/Classes/MetaProperties.py`, registered alongside the existing get/set. rank-0 is skipped (a pointer to a scalar is pointless). `self` is declared `target` so the pointer association is valid on return (F2008 12.5.2.4).
- **Fortran 63-char identifier limit:** the caller-facing type-bound *method* name is the full `...MetaPropertyGetReference`, but the generated *procedure* name is abbreviated to `...MetaPropertyRef`. The full name on the longest class+label (`nodeComponentDarkMatterProfileLongIntegerRank1...`) would reach 70 chars; the limit is 63. The `=>` binding maps the two.
- **Caller:** `coefficients` is now a `pointer` read via `floatRank1MetaPropertyGetReference`; it is only read, never deallocated (the storage is owned by the meta-property).

## Performance

Profiling the lightcone benchmark with `perf` at 8 threads:

| Symbol | Before | After |
|---|---|---|
| coefficients getter | **10.6%** self-time (hottest symbol) | **0.14%** |
| `__memmove_avx_unaligned_erms` | ~10% | ~4.9% |

## Correctness

Output is **bit-identical** to the by-value path. Because the lightcone model is non-deterministic across OpenMP threads (thread-scheduling-dependent RNG draw order for random halo spins — two runs of the same binary differ in ~85/123 datasets), correctness was verified with a **single-threaded** (`OMP_NUM_THREADS=1`) comparison of the optimized vs. baseline binary: all 123 per-node `/Lightcone` datasets are bit-identical.