### PR TITLE
docs: link "How Galacticus Works" mermaid nodes to specific physics entries

### DIFF
--- a/docs/manuals/physics/overview/black-holes.rst
+++ b/docs/manuals/physics/overview/black-holes.rst
@@ -13,5 +13,5 @@ Below is a flowchart indicating the physical components and processes that typic
        SMBH
        CGM -- accretion --> SMBH
        Spheroid -- accretion --> SMBH
-       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>energy input</a>| Spheroid -- outflow --> CGM
-       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>energy input</a>| CGM -- outflow --> IGM
+       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#nodeOperatorBlackHolesWinds' style='text-decoration: none'>energy input</a>| Spheroid -- outflow --> CGM
+       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#blackHoleCGMHeating' style='text-decoration: none'>energy input</a>| CGM -- outflow --> IGM

--- a/docs/manuals/physics/overview/cgm-cooling.rst
+++ b/docs/manuals/physics/overview/cgm-cooling.rst
@@ -7,16 +7,16 @@ Below is a flowchart indicating the ingredients of Galacticus CGM cooling model.
 
    flowchart LR
       Galaxy
-      Cold[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Cold Mode Inflow</a>]
-      Lambda[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Cooling Function</a>]
-      Radius[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Cooling Radius</a>]
-      Rate[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Cooling Rate</a>]
-      Time[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Cooling Time</a>]
-      RadiusFreefall[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Freefall Radius</a>]
-      Available[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Time Available Cooling]
-      AvailableFreefall[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Time Available Freefall]
-      Infall[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Infall Radius</a>]
-      Angular[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Angular Momentum Content</a>]
+      Cold[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coldModeInfallRate' style='text-decoration: none'>Cold Mode Inflow</a>]
+      Lambda[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingFunction' style='text-decoration: none'>Cooling Function</a>]
+      Radius[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingRadius' style='text-decoration: none'>Cooling Radius</a>]
+      Rate[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingRate' style='text-decoration: none'>Cooling Rate</a>]
+      Time[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingTime' style='text-decoration: none'>Cooling Time</a>]
+      RadiusFreefall[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#freefallRadius' style='text-decoration: none'>Freefall Radius</a>]
+      Available[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingTimeAvailable' style='text-decoration: none'>Time Available Cooling]
+      AvailableFreefall[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#freefallTimeAvailable' style='text-decoration: none'>Time Available Freefall]
+      Infall[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingInfallRadius' style='text-decoration: none'>Infall Radius</a>]
+      Angular[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingSpecificAngularMomentum' style='text-decoration: none'>Angular Momentum Content</a>]
       Lambda --> Time
       Time --> Radius
       Available --> Radius

--- a/docs/manuals/physics/overview/cgm.rst
+++ b/docs/manuals/physics/overview/cgm.rst
@@ -10,8 +10,8 @@ Below is a flowchart indicating the physical components and processes that typic
        CGM
    	Outflowed
    	Galaxy
-   	IGM -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>accretion</a>| CGM
-   	Outflowed -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>reincorportation</a>| CGM
+   	IGM -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#accretionHalo' style='text-decoration: none'>accretion</a>| CGM
+   	Outflowed -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#hotHaloOutflowReincorporation' style='text-decoration: none'>reincorportation</a>| CGM
    	CGM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/CGM-Cooling-Physics' style='text-decoration: none'>cooling</a>| Galaxy
    	Galaxy -- outflow --> Outflowed
    	Galaxy -- outflow --> IGM

--- a/docs/manuals/physics/overview/galactic-structure.rst
+++ b/docs/manuals/physics/overview/galactic-structure.rst
@@ -6,10 +6,10 @@ Below is a flowchart indicating the ingredients of Galacticus galactic structure
 .. mermaid::
 
    flowchart LR
-      Galaxy[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Galaxy structure</a>]
-      DMO[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Dark matter-only profile</a>]
-      DM[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Dark matter profile</a>]
-      Solver[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Structure solver</a>]
+      Galaxy[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#galacticStructureSolver' style='text-decoration: none'>Galaxy structure</a>]
+      DMO[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#darkMatterProfileDMO' style='text-decoration: none'>Dark matter-only profile</a>]
+      DM[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#darkMatterProfile' style='text-decoration: none'>Dark matter profile</a>]
+      Solver[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#galacticStructureSolver' style='text-decoration: none'>Structure solver</a>]
       DMO --> DM
       DM --> Solver
       Solver --> Galaxy

--- a/docs/manuals/physics/overview/galaxy.rst
+++ b/docs/manuals/physics/overview/galaxy.rst
@@ -23,9 +23,9 @@ Below is a flowchart indicating the physical components and processes that typic
        end
        CGM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/CGM-Cooling-Physics' style='text-decoration: none'>cooling</a>| DiskISM
        DiskISM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/Star-Formation-Physics' style='text-decoration: none'>star formation</a>| DiskStars
-       DiskStars -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>recycling</a>| DiskISM
+       DiskStars -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#stellarPopulationProperties' style='text-decoration: none'>recycling</a>| DiskISM
        SpheroidISM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/Star-Formation-Physics' style='text-decoration: none'>star formation</a>| SpheroidStars
-       SpheroidStars -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>recycling</a>| SpheroidISM
-       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>instability</a>| Spheroid
+       SpheroidStars -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#stellarPopulationProperties' style='text-decoration: none'>recycling</a>| SpheroidISM
+       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#galacticDynamicsBarInstability' style='text-decoration: none'>instability</a>| Spheroid
        DiskISM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/Outflow-Physics' style='text-decoration: none'>outflow</a>| Environment
        SpheroidISM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/Outflow-Physics' style='text-decoration: none'>outflow</a>| Environment

--- a/docs/manuals/physics/overview/index.rst
+++ b/docs/manuals/physics/overview/index.rst
@@ -35,22 +35,22 @@ Consider the following, highly simplified, description of how the process of sta
 Components
 ----------
 
-The variables highlighted in red represent physical quantities - in this case the masses of stars and ISM in the galaxy. These are provided by a "`component <https://galacticus.readthedocs.io/en/latest/physics/index.html>`_" (e.g. a galactic disk) in Galacticus.
+The variables highlighted in red represent physical quantities - in this case the masses of stars and ISM in the galaxy. These are provided by a "`component <https://galacticus.readthedocs.io/en/latest/physics/components.html>`_" (e.g. a galactic disk) in Galacticus.
 
 Operators
 ---------
 
-The operators highlighted in magenta represent a physical process - in this case the process of star formation, which moves mass from the ISM to the stars. Physical processes in Galacticus are implemented by the `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/index.html>`_.
+The operators highlighted in magenta represent a physical process - in this case the process of star formation, which moves mass from the ISM to the stars. Physical processes in Galacticus are implemented by the `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#nodeOperator>`_.
 
 Functions
 ---------
 
-The function highlighted in blue represents the actual physics of that process - in this case it describes the rate of star formation. Such functions in Galacticus are provided by numerous different `functionClass <https://galacticus.readthedocs.io/en/latest/manuals/developer-guide/index.html>`_ objects - e.g. `starFormationRateDisksClass <https://galacticus.readthedocs.io/en/latest/physics/index.html>`_ in the case of star formation rates in galaxy disks.
+The function highlighted in blue represents the actual physics of that process - in this case it describes the rate of star formation. Such functions in Galacticus are provided by numerous different `functionClass <https://galacticus.readthedocs.io/en/latest/manuals/developer-guide/index.html>`_ objects - e.g. `starFormationRateDisksClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationRateDisks>`_ in the case of star formation rates in galaxy disks.
 
 Engine
 ------
 
-Galacticus' evolver engine works by applying a set of `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/index.html>`_ objects to each node in a merger tree in turn - gradually evolving the components in that node forward in time in accordance with the physical processes described by those `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/index.html>`_ objects. The engine consists of the `mergerTreeEvolverClass <https://galacticus.readthedocs.io/en/latest/physics/index.html>`_ and `mergerTreeNodeEvolverClass <https://galacticus.readthedocs.io/en/latest/physics/index.html>`_ classes.
+Galacticus' evolver engine works by applying a set of `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#nodeOperator>`_ objects to each node in a merger tree in turn - gradually evolving the components in that node forward in time in accordance with the physical processes described by those `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#nodeOperator>`_ objects. The engine consists of the `mergerTreeEvolverClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeEvolver>`_ and `mergerTreeNodeEvolverClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeNodeEvolver>`_ classes.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/manuals/physics/overview/merger-tree-building.rst
+++ b/docs/manuals/physics/overview/merger-tree-building.rst
@@ -6,15 +6,15 @@ Below is a flowchart indicating the ingredients of Galacticus merger tree buildi
 .. mermaid::
 
    flowchart LR
-      Builder[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Builder</a>]
-      Masses[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Mass Distribution</a>]
-      Branching[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Branching Distribution</a>]
-      Excursion[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Excursion Set Solver</a>]
-      Controller[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Controller</a>]
-      Variance["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>δ<sub>c</sub>(t)</a>"]
-      Critical["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>σ(M)</a>"]
-      Cosmology[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Cosmology</a>]
-      Resolution[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Resolution</a>]
+      Builder[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeBuilder' style='text-decoration: none'>Builder</a>]
+      Masses[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeBuildMassDistribution' style='text-decoration: none'>Mass Distribution</a>]
+      Branching[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeBranchingProbability' style='text-decoration: none'>Branching Distribution</a>]
+      Excursion[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#excursionSetFirstCrossing' style='text-decoration: none'>Excursion Set Solver</a>]
+      Controller[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeBuildController' style='text-decoration: none'>Controller</a>]
+      Variance["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#cosmologicalMassVariance' style='text-decoration: none'>σ(M)</a>"]
+      Critical["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#criticalOverdensity' style='text-decoration: none'>δ<sub>c</sub>(t)</a>"]
+      Cosmology[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#cosmologyParameters' style='text-decoration: none'>Cosmology</a>]
+      Resolution[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeMassResolution' style='text-decoration: none'>Resolution</a>]
       Cosmology --> Builder
       Masses --> Builder
       Controller --> Builder

--- a/docs/manuals/physics/overview/outflows.rst
+++ b/docs/manuals/physics/overview/outflows.rst
@@ -9,5 +9,5 @@ Below is a flowchart indicating the ingredients of Galacticus outflows model. (G
       ISM
       CGM
       IGM
-      ISM -->|"<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>outflow (ejective)</a>"| CGM
-      ISM -->|"<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>outflow (expulsive)</a>"| IGM
+      ISM -->|"<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#stellarFeedbackOutflows' style='text-decoration: none'>outflow (ejective)</a>"| CGM
+      ISM -->|"<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#stellarFeedbackOutflows' style='text-decoration: none'>outflow (expulsive)</a>"| IGM

--- a/docs/manuals/physics/overview/star-formation.rst
+++ b/docs/manuals/physics/overview/star-formation.rst
@@ -6,11 +6,11 @@ Below is a flowchart indicating the ingredients of Galacticus star formation mod
 .. mermaid::
 
    flowchart LR
-      Disk[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Disk SFR</a>]
-      Spheroid[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Spheroid SFR</a>]
+      Disk[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationRateDisks' style='text-decoration: none'>Disk SFR</a>]
+      Spheroid[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationRateSpheroids' style='text-decoration: none'>Spheroid SFR</a>]
       SFR[["SFR: ψ⭑"]]
-      Timescale[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Timescale</a>]
-      Surface["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>SFR surface density: Σ⭑</a>"]
+      Timescale[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationTimescale' style='text-decoration: none'>Timescale</a>]
+      Surface["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationRateSurfaceDensityDisks' style='text-decoration: none'>SFR surface density: Σ⭑</a>"]
       SFR --> Disk
       SFR --> Spheroid
       Timescale -.-> SFR

--- a/docs/manuals/physics/overview/structure-formation.rst
+++ b/docs/manuals/physics/overview/structure-formation.rst
@@ -6,15 +6,15 @@ Below is a flowchart indicating the ingredients of Galacticus structure formatio
 .. mermaid::
 
    flowchart LR
-       Cosmology[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Cosmology</a>]
-       Power[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Power spectrum</a>]
-       Transfer[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Transfer function</a>]
-       Window[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Window function</a>]
-       Linear[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Linear growth</a>]
-       Variance["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>δ<sub>c</sub>(t)</a>"]
-       Critical["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>σ(M)</a>"]
-       Environment["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Environment</a>"]
-       HMF[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Halo mass function</a>]
+       Cosmology[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#cosmologyParameters' style='text-decoration: none'>Cosmology</a>]
+       Power[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#powerSpectrumPrimordial' style='text-decoration: none'>Power spectrum</a>]
+       Transfer[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#transferFunction' style='text-decoration: none'>Transfer function</a>]
+       Window[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#powerSpectrumWindowFunction' style='text-decoration: none'>Window function</a>]
+       Linear[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#linearGrowth' style='text-decoration: none'>Linear growth</a>]
+       Variance["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#cosmologicalMassVariance' style='text-decoration: none'>σ(M)</a>"]
+       Critical["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#criticalOverdensity' style='text-decoration: none'>δ<sub>c</sub>(t)</a>"]
+       Environment["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#haloEnvironment' style='text-decoration: none'>Environment</a>"]
+       HMF[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#haloMassFunction' style='text-decoration: none'>Halo mass function</a>]
        Cosmology --> Linear
        Cosmology --> Transfer
        Power --> Transfer

--- a/docs/manuals/physics/overview/subhalo-evolution.rst
+++ b/docs/manuals/physics/overview/subhalo-evolution.rst
@@ -7,11 +7,11 @@ Below is a flowchart indicating the ingredients of Galacticus subhalo evolution 
 
    flowchart LR
       Subhalo
-      Host[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Host potential</a>]
-      Friction[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Dynamical friction</a>]
-      Heat[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Tidal heating</a>]
-      Strip[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>Tidal stripping</a>]
-      Host -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>orbit</a>| Subhalo
-      Friction -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>orbit decay</a>| Subhalo
-      Heat -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>expansion</a>| Subhalo
-      Strip -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html' style='text-decoration: none'>mass loss</a>| Subhalo
+      Host[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#massDistribution' style='text-decoration: none'>Host potential</a>]
+      Friction[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteDynamicalFriction' style='text-decoration: none'>Dynamical friction</a>]
+      Heat[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteTidalHeatingRate' style='text-decoration: none'>Tidal heating</a>]
+      Strip[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteTidalStripping' style='text-decoration: none'>Tidal stripping</a>]
+      Host -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#virialOrbit' style='text-decoration: none'>orbit</a>| Subhalo
+      Friction -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteDynamicalFriction' style='text-decoration: none'>orbit decay</a>| Subhalo
+      Heat -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#darkMatterProfileHeating' style='text-decoration: none'>expansion</a>| Subhalo
+      Strip -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteTidalStripping' style='text-decoration: none'>mass loss</a>| Subhalo


### PR DESCRIPTION
## Summary

Following the migration of the wiki "How Galacticus Works" content into the local docs, the mermaid diagram nodes in the physics overview section all linked to the generic physics index (`physics/index.html`). This updates each node to point at the specific functionClass anchor for the concept it represents.

## Changes

- **All mermaid diagram nodes** across the overview pages (structure formation, merger tree building, galaxy, CGM, CGM cooling, star formation, galactic structure, outflows, black holes, subhalo evolution) now link to their specific physics-documentation anchor (e.g. `#coolingFunction`, `#transferFunction`, `#satelliteDynamicalFriction`).
- **Prose class references** in `index.rst` (`nodeOperatorClass`, `starFormationRateDisksClass`, `mergerTreeEvolverClass`, `mergerTreeNodeEvolverClass`) now link to their anchors.
- **"component" reference** now points at the Node Components page (`physics/components.html`) rather than the generic index.
- **Symbol/ID fix**: in the structure-formation and merger-tree-building diagrams, the `Variance` node now displays σ(M) and `Critical` displays δ_c(t), matching their node IDs and anchors (the displayed symbols were previously swapped).

## Notes on ambiguous mappings

A handful of nodes did not map to an obvious single anchor; these were resolved in consultation:

- **Cosmology** → `#cosmologyParameters`
- **Galaxy structure** → `#galacticStructureSolver`
- **mass loss** (subhalo) → `#satelliteTidalStripping`
- **energy input** (Disk→Spheroid, black holes) → `#nodeOperatorBlackHolesWinds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)