### PR TITLE
docs: fix physics links to use per-class pages, not index anchors

### DIFF
--- a/docs/manuals/physics/overview/black-holes.rst
+++ b/docs/manuals/physics/overview/black-holes.rst
@@ -13,5 +13,5 @@ Below is a flowchart indicating the physical components and processes that typic
        SMBH
        CGM -- accretion --> SMBH
        Spheroid -- accretion --> SMBH
-       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#nodeOperatorBlackHolesWinds' style='text-decoration: none'>energy input</a>| Spheroid -- outflow --> CGM
-       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#blackHoleCGMHeating' style='text-decoration: none'>energy input</a>| CGM -- outflow --> IGM
+       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/nodeOperator.html#nodeOperatorBlackHolesWinds' style='text-decoration: none'>energy input</a>| Spheroid -- outflow --> CGM
+       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/blackHoleCGMHeating.html' style='text-decoration: none'>energy input</a>| CGM -- outflow --> IGM

--- a/docs/manuals/physics/overview/cgm-cooling.rst
+++ b/docs/manuals/physics/overview/cgm-cooling.rst
@@ -7,16 +7,16 @@ Below is a flowchart indicating the ingredients of Galacticus CGM cooling model.
 
    flowchart LR
       Galaxy
-      Cold[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coldModeInfallRate' style='text-decoration: none'>Cold Mode Inflow</a>]
-      Lambda[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingFunction' style='text-decoration: none'>Cooling Function</a>]
-      Radius[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingRadius' style='text-decoration: none'>Cooling Radius</a>]
-      Rate[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingRate' style='text-decoration: none'>Cooling Rate</a>]
-      Time[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingTime' style='text-decoration: none'>Cooling Time</a>]
-      RadiusFreefall[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#freefallRadius' style='text-decoration: none'>Freefall Radius</a>]
-      Available[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingTimeAvailable' style='text-decoration: none'>Time Available Cooling]
-      AvailableFreefall[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#freefallTimeAvailable' style='text-decoration: none'>Time Available Freefall]
-      Infall[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingInfallRadius' style='text-decoration: none'>Infall Radius</a>]
-      Angular[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#coolingSpecificAngularMomentum' style='text-decoration: none'>Angular Momentum Content</a>]
+      Cold[<a href='https://galacticus.readthedocs.io/en/latest/physics/coldModeInfallRate.html' style='text-decoration: none'>Cold Mode Inflow</a>]
+      Lambda[<a href='https://galacticus.readthedocs.io/en/latest/physics/coolingFunction.html' style='text-decoration: none'>Cooling Function</a>]
+      Radius[<a href='https://galacticus.readthedocs.io/en/latest/physics/coolingRadius.html' style='text-decoration: none'>Cooling Radius</a>]
+      Rate[<a href='https://galacticus.readthedocs.io/en/latest/physics/coolingRate.html' style='text-decoration: none'>Cooling Rate</a>]
+      Time[<a href='https://galacticus.readthedocs.io/en/latest/physics/coolingTime.html' style='text-decoration: none'>Cooling Time</a>]
+      RadiusFreefall[<a href='https://galacticus.readthedocs.io/en/latest/physics/freefallRadius.html' style='text-decoration: none'>Freefall Radius</a>]
+      Available[<a href='https://galacticus.readthedocs.io/en/latest/physics/coolingTimeAvailable.html' style='text-decoration: none'>Time Available Cooling]
+      AvailableFreefall[<a href='https://galacticus.readthedocs.io/en/latest/physics/freefallTimeAvailable.html' style='text-decoration: none'>Time Available Freefall]
+      Infall[<a href='https://galacticus.readthedocs.io/en/latest/physics/coolingInfallRadius.html' style='text-decoration: none'>Infall Radius</a>]
+      Angular[<a href='https://galacticus.readthedocs.io/en/latest/physics/coolingSpecificAngularMomentum.html' style='text-decoration: none'>Angular Momentum Content</a>]
       Lambda --> Time
       Time --> Radius
       Available --> Radius

--- a/docs/manuals/physics/overview/cgm.rst
+++ b/docs/manuals/physics/overview/cgm.rst
@@ -10,8 +10,8 @@ Below is a flowchart indicating the physical components and processes that typic
        CGM
    	Outflowed
    	Galaxy
-   	IGM -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#accretionHalo' style='text-decoration: none'>accretion</a>| CGM
-   	Outflowed -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#hotHaloOutflowReincorporation' style='text-decoration: none'>reincorportation</a>| CGM
+   	IGM -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/accretionHalo.html' style='text-decoration: none'>accretion</a>| CGM
+   	Outflowed -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/hotHaloOutflowReincorporation.html' style='text-decoration: none'>reincorportation</a>| CGM
    	CGM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/CGM-Cooling-Physics' style='text-decoration: none'>cooling</a>| Galaxy
    	Galaxy -- outflow --> Outflowed
    	Galaxy -- outflow --> IGM

--- a/docs/manuals/physics/overview/galactic-structure.rst
+++ b/docs/manuals/physics/overview/galactic-structure.rst
@@ -6,10 +6,10 @@ Below is a flowchart indicating the ingredients of Galacticus galactic structure
 .. mermaid::
 
    flowchart LR
-      Galaxy[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#galacticStructureSolver' style='text-decoration: none'>Galaxy structure</a>]
-      DMO[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#darkMatterProfileDMO' style='text-decoration: none'>Dark matter-only profile</a>]
-      DM[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#darkMatterProfile' style='text-decoration: none'>Dark matter profile</a>]
-      Solver[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#galacticStructureSolver' style='text-decoration: none'>Structure solver</a>]
+      Galaxy[<a href='https://galacticus.readthedocs.io/en/latest/physics/galacticStructureSolver.html' style='text-decoration: none'>Galaxy structure</a>]
+      DMO[<a href='https://galacticus.readthedocs.io/en/latest/physics/darkMatterProfileDMO.html' style='text-decoration: none'>Dark matter-only profile</a>]
+      DM[<a href='https://galacticus.readthedocs.io/en/latest/physics/darkMatterProfile.html' style='text-decoration: none'>Dark matter profile</a>]
+      Solver[<a href='https://galacticus.readthedocs.io/en/latest/physics/galacticStructureSolver.html' style='text-decoration: none'>Structure solver</a>]
       DMO --> DM
       DM --> Solver
       Solver --> Galaxy

--- a/docs/manuals/physics/overview/galaxy.rst
+++ b/docs/manuals/physics/overview/galaxy.rst
@@ -23,9 +23,9 @@ Below is a flowchart indicating the physical components and processes that typic
        end
        CGM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/CGM-Cooling-Physics' style='text-decoration: none'>cooling</a>| DiskISM
        DiskISM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/Star-Formation-Physics' style='text-decoration: none'>star formation</a>| DiskStars
-       DiskStars -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#stellarPopulationProperties' style='text-decoration: none'>recycling</a>| DiskISM
+       DiskStars -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/stellarPopulationProperties.html' style='text-decoration: none'>recycling</a>| DiskISM
        SpheroidISM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/Star-Formation-Physics' style='text-decoration: none'>star formation</a>| SpheroidStars
-       SpheroidStars -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#stellarPopulationProperties' style='text-decoration: none'>recycling</a>| SpheroidISM
-       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#galacticDynamicsBarInstability' style='text-decoration: none'>instability</a>| Spheroid
+       SpheroidStars -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/stellarPopulationProperties.html' style='text-decoration: none'>recycling</a>| SpheroidISM
+       Disk -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/galacticDynamicsBarInstability.html' style='text-decoration: none'>instability</a>| Spheroid
        DiskISM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/Outflow-Physics' style='text-decoration: none'>outflow</a>| Environment
        SpheroidISM -->|<a href='https://github.com/galacticusorg/galacticus/wiki/Outflow-Physics' style='text-decoration: none'>outflow</a>| Environment

--- a/docs/manuals/physics/overview/index.rst
+++ b/docs/manuals/physics/overview/index.rst
@@ -40,17 +40,17 @@ The variables highlighted in red represent physical quantities - in this case th
 Operators
 ---------
 
-The operators highlighted in magenta represent a physical process - in this case the process of star formation, which moves mass from the ISM to the stars. Physical processes in Galacticus are implemented by the `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#nodeOperator>`_.
+The operators highlighted in magenta represent a physical process - in this case the process of star formation, which moves mass from the ISM to the stars. Physical processes in Galacticus are implemented by the `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/nodeOperator.html>`_.
 
 Functions
 ---------
 
-The function highlighted in blue represents the actual physics of that process - in this case it describes the rate of star formation. Such functions in Galacticus are provided by numerous different `functionClass <https://galacticus.readthedocs.io/en/latest/manuals/developer-guide/index.html>`_ objects - e.g. `starFormationRateDisksClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationRateDisks>`_ in the case of star formation rates in galaxy disks.
+The function highlighted in blue represents the actual physics of that process - in this case it describes the rate of star formation. Such functions in Galacticus are provided by numerous different `functionClass <https://galacticus.readthedocs.io/en/latest/manuals/developer-guide/index.html>`_ objects - e.g. `starFormationRateDisksClass <https://galacticus.readthedocs.io/en/latest/physics/starFormationRateDisks.html>`_ in the case of star formation rates in galaxy disks.
 
 Engine
 ------
 
-Galacticus' evolver engine works by applying a set of `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#nodeOperator>`_ objects to each node in a merger tree in turn - gradually evolving the components in that node forward in time in accordance with the physical processes described by those `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#nodeOperator>`_ objects. The engine consists of the `mergerTreeEvolverClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeEvolver>`_ and `mergerTreeNodeEvolverClass <https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeNodeEvolver>`_ classes.
+Galacticus' evolver engine works by applying a set of `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/nodeOperator.html>`_ objects to each node in a merger tree in turn - gradually evolving the components in that node forward in time in accordance with the physical processes described by those `nodeOperatorClass <https://galacticus.readthedocs.io/en/latest/physics/nodeOperator.html>`_ objects. The engine consists of the `mergerTreeEvolverClass <https://galacticus.readthedocs.io/en/latest/physics/mergerTreeEvolver.html>`_ and `mergerTreeNodeEvolverClass <https://galacticus.readthedocs.io/en/latest/physics/mergerTreeNodeEvolver.html>`_ classes.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/manuals/physics/overview/merger-tree-building.rst
+++ b/docs/manuals/physics/overview/merger-tree-building.rst
@@ -6,15 +6,15 @@ Below is a flowchart indicating the ingredients of Galacticus merger tree buildi
 .. mermaid::
 
    flowchart LR
-      Builder[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeBuilder' style='text-decoration: none'>Builder</a>]
-      Masses[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeBuildMassDistribution' style='text-decoration: none'>Mass Distribution</a>]
-      Branching[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeBranchingProbability' style='text-decoration: none'>Branching Distribution</a>]
-      Excursion[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#excursionSetFirstCrossing' style='text-decoration: none'>Excursion Set Solver</a>]
-      Controller[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeBuildController' style='text-decoration: none'>Controller</a>]
-      Variance["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#cosmologicalMassVariance' style='text-decoration: none'>σ(M)</a>"]
-      Critical["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#criticalOverdensity' style='text-decoration: none'>δ<sub>c</sub>(t)</a>"]
-      Cosmology[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#cosmologyParameters' style='text-decoration: none'>Cosmology</a>]
-      Resolution[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#mergerTreeMassResolution' style='text-decoration: none'>Resolution</a>]
+      Builder[<a href='https://galacticus.readthedocs.io/en/latest/physics/mergerTreeBuilder.html' style='text-decoration: none'>Builder</a>]
+      Masses[<a href='https://galacticus.readthedocs.io/en/latest/physics/mergerTreeBuildMassDistribution.html' style='text-decoration: none'>Mass Distribution</a>]
+      Branching[<a href='https://galacticus.readthedocs.io/en/latest/physics/mergerTreeBranchingProbability.html' style='text-decoration: none'>Branching Distribution</a>]
+      Excursion[<a href='https://galacticus.readthedocs.io/en/latest/physics/excursionSetFirstCrossing.html' style='text-decoration: none'>Excursion Set Solver</a>]
+      Controller[<a href='https://galacticus.readthedocs.io/en/latest/physics/mergerTreeBuildController.html' style='text-decoration: none'>Controller</a>]
+      Variance["<a href='https://galacticus.readthedocs.io/en/latest/physics/cosmologicalMassVariance.html' style='text-decoration: none'>σ(M)</a>"]
+      Critical["<a href='https://galacticus.readthedocs.io/en/latest/physics/criticalOverdensity.html' style='text-decoration: none'>δ<sub>c</sub>(t)</a>"]
+      Cosmology[<a href='https://galacticus.readthedocs.io/en/latest/physics/cosmologyParameters.html' style='text-decoration: none'>Cosmology</a>]
+      Resolution[<a href='https://galacticus.readthedocs.io/en/latest/physics/mergerTreeMassResolution.html' style='text-decoration: none'>Resolution</a>]
       Cosmology --> Builder
       Masses --> Builder
       Controller --> Builder

--- a/docs/manuals/physics/overview/outflows.rst
+++ b/docs/manuals/physics/overview/outflows.rst
@@ -9,5 +9,5 @@ Below is a flowchart indicating the ingredients of Galacticus outflows model. (G
       ISM
       CGM
       IGM
-      ISM -->|"<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#stellarFeedbackOutflows' style='text-decoration: none'>outflow (ejective)</a>"| CGM
-      ISM -->|"<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#stellarFeedbackOutflows' style='text-decoration: none'>outflow (expulsive)</a>"| IGM
+      ISM -->|"<a href='https://galacticus.readthedocs.io/en/latest/physics/stellarFeedbackOutflows.html' style='text-decoration: none'>outflow (ejective)</a>"| CGM
+      ISM -->|"<a href='https://galacticus.readthedocs.io/en/latest/physics/stellarFeedbackOutflows.html' style='text-decoration: none'>outflow (expulsive)</a>"| IGM

--- a/docs/manuals/physics/overview/star-formation.rst
+++ b/docs/manuals/physics/overview/star-formation.rst
@@ -6,11 +6,11 @@ Below is a flowchart indicating the ingredients of Galacticus star formation mod
 .. mermaid::
 
    flowchart LR
-      Disk[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationRateDisks' style='text-decoration: none'>Disk SFR</a>]
-      Spheroid[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationRateSpheroids' style='text-decoration: none'>Spheroid SFR</a>]
+      Disk[<a href='https://galacticus.readthedocs.io/en/latest/physics/starFormationRateDisks.html' style='text-decoration: none'>Disk SFR</a>]
+      Spheroid[<a href='https://galacticus.readthedocs.io/en/latest/physics/starFormationRateSpheroids.html' style='text-decoration: none'>Spheroid SFR</a>]
       SFR[["SFR: ψ⭑"]]
-      Timescale[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationTimescale' style='text-decoration: none'>Timescale</a>]
-      Surface["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#starFormationRateSurfaceDensityDisks' style='text-decoration: none'>SFR surface density: Σ⭑</a>"]
+      Timescale[<a href='https://galacticus.readthedocs.io/en/latest/physics/starFormationTimescale.html' style='text-decoration: none'>Timescale</a>]
+      Surface["<a href='https://galacticus.readthedocs.io/en/latest/physics/starFormationRateSurfaceDensityDisks.html' style='text-decoration: none'>SFR surface density: Σ⭑</a>"]
       SFR --> Disk
       SFR --> Spheroid
       Timescale -.-> SFR

--- a/docs/manuals/physics/overview/structure-formation.rst
+++ b/docs/manuals/physics/overview/structure-formation.rst
@@ -6,15 +6,15 @@ Below is a flowchart indicating the ingredients of Galacticus structure formatio
 .. mermaid::
 
    flowchart LR
-       Cosmology[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#cosmologyParameters' style='text-decoration: none'>Cosmology</a>]
-       Power[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#powerSpectrumPrimordial' style='text-decoration: none'>Power spectrum</a>]
-       Transfer[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#transferFunction' style='text-decoration: none'>Transfer function</a>]
-       Window[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#powerSpectrumWindowFunction' style='text-decoration: none'>Window function</a>]
-       Linear[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#linearGrowth' style='text-decoration: none'>Linear growth</a>]
-       Variance["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#cosmologicalMassVariance' style='text-decoration: none'>σ(M)</a>"]
-       Critical["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#criticalOverdensity' style='text-decoration: none'>δ<sub>c</sub>(t)</a>"]
-       Environment["<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#haloEnvironment' style='text-decoration: none'>Environment</a>"]
-       HMF[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#haloMassFunction' style='text-decoration: none'>Halo mass function</a>]
+       Cosmology[<a href='https://galacticus.readthedocs.io/en/latest/physics/cosmologyParameters.html' style='text-decoration: none'>Cosmology</a>]
+       Power[<a href='https://galacticus.readthedocs.io/en/latest/physics/powerSpectrumPrimordial.html' style='text-decoration: none'>Power spectrum</a>]
+       Transfer[<a href='https://galacticus.readthedocs.io/en/latest/physics/transferFunction.html' style='text-decoration: none'>Transfer function</a>]
+       Window[<a href='https://galacticus.readthedocs.io/en/latest/physics/powerSpectrumWindowFunction.html' style='text-decoration: none'>Window function</a>]
+       Linear[<a href='https://galacticus.readthedocs.io/en/latest/physics/linearGrowth.html' style='text-decoration: none'>Linear growth</a>]
+       Variance["<a href='https://galacticus.readthedocs.io/en/latest/physics/cosmologicalMassVariance.html' style='text-decoration: none'>σ(M)</a>"]
+       Critical["<a href='https://galacticus.readthedocs.io/en/latest/physics/criticalOverdensity.html' style='text-decoration: none'>δ<sub>c</sub>(t)</a>"]
+       Environment["<a href='https://galacticus.readthedocs.io/en/latest/physics/haloEnvironment.html' style='text-decoration: none'>Environment</a>"]
+       HMF[<a href='https://galacticus.readthedocs.io/en/latest/physics/haloMassFunction.html' style='text-decoration: none'>Halo mass function</a>]
        Cosmology --> Linear
        Cosmology --> Transfer
        Power --> Transfer

--- a/docs/manuals/physics/overview/subhalo-evolution.rst
+++ b/docs/manuals/physics/overview/subhalo-evolution.rst
@@ -7,11 +7,11 @@ Below is a flowchart indicating the ingredients of Galacticus subhalo evolution 
 
    flowchart LR
       Subhalo
-      Host[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#massDistribution' style='text-decoration: none'>Host potential</a>]
-      Friction[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteDynamicalFriction' style='text-decoration: none'>Dynamical friction</a>]
-      Heat[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteTidalHeatingRate' style='text-decoration: none'>Tidal heating</a>]
-      Strip[<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteTidalStripping' style='text-decoration: none'>Tidal stripping</a>]
-      Host -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#virialOrbit' style='text-decoration: none'>orbit</a>| Subhalo
-      Friction -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteDynamicalFriction' style='text-decoration: none'>orbit decay</a>| Subhalo
-      Heat -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#darkMatterProfileHeating' style='text-decoration: none'>expansion</a>| Subhalo
-      Strip -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/index.html#satelliteTidalStripping' style='text-decoration: none'>mass loss</a>| Subhalo
+      Host[<a href='https://galacticus.readthedocs.io/en/latest/physics/massDistribution.html' style='text-decoration: none'>Host potential</a>]
+      Friction[<a href='https://galacticus.readthedocs.io/en/latest/physics/satelliteDynamicalFriction.html' style='text-decoration: none'>Dynamical friction</a>]
+      Heat[<a href='https://galacticus.readthedocs.io/en/latest/physics/satelliteTidalHeatingRate.html' style='text-decoration: none'>Tidal heating</a>]
+      Strip[<a href='https://galacticus.readthedocs.io/en/latest/physics/satelliteTidalStripping.html' style='text-decoration: none'>Tidal stripping</a>]
+      Host -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/virialOrbit.html' style='text-decoration: none'>orbit</a>| Subhalo
+      Friction -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/satelliteDynamicalFriction.html' style='text-decoration: none'>orbit decay</a>| Subhalo
+      Heat -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/darkMatterProfileHeating.html' style='text-decoration: none'>expansion</a>| Subhalo
+      Strip -->|<a href='https://galacticus.readthedocs.io/en/latest/physics/satelliteTidalStripping.html' style='text-decoration: none'>mass loss</a>| Subhalo


### PR DESCRIPTION
## Summary

Follow-up fix to #1189. That PR linked the "How Galacticus Works" mermaid nodes to fragment anchors on the physics **index** page (`physics/index.html#className`). The index is only a table-of-contents page, so those anchors do not resolve.

Each physics class actually has its own page, so this links directly to `physics/<className>.html` instead.

## Changes

- All mermaid node links and prose class references now point to `physics/<className>.html`.
- The black-hole-winds node is an *implementation* (subsection) of the node operator class, so it links to `physics/nodeOperator.html#nodeOperatorBlackHolesWinds`.

Verified representative target pages resolve (e.g. `linearGrowth.html`, `cosmologyParameters.html`, `coolingSpecificAngularMomentum.html`, `mergerTreeBuildMassDistribution.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)