### PR TITLE
perf(massDistributions): fast-path whole-composite subsets and pool member-list nodes

### DIFF
--- a/python/Galacticus/Build/Components/TreeNodes/Utils.py
+++ b/python/Galacticus/Build/Components/TreeNodes/Utils.py
@@ -200,7 +200,8 @@ def Tree_Node_Mass_Distribution(build):
             ("Mass_Distributions        , only : massDistributionClass"
              "       , massDistributionComposite, massDistributionList"
              "   , massDistributionZero, kinematicsDistributionClass"
-             ", kinematicsDistributionIsothermal"),
+             ", kinematicsDistributionIsothermal"
+             ", massDistributionListAcquire, massDistributionListRelease"),
             ("Galactic_Structure_Options, only : enumerationComponentTypeType"
              ", enumerationMassTypeType  , enumerationWeightByType"
              ", componentTypeAll    , componentTypeDarkMatterOnly"
@@ -303,13 +304,13 @@ def Tree_Node_Mass_Distribution(build):
             f"%massDistribution(componentType__,massType__,weightBy_,weightIndex_)\n"
             "       if (associated(massDistributionComponent)) then\n"
             "          if (associated(massDistributionList_)) then\n"
-            "            allocate(next_    %next)\n"
-            "            allocate(nextCopy_%next)\n"
+            "            next_    %next => massDistributionListAcquire()\n"
+            "            nextCopy_%next => massDistributionListAcquire()\n"
             "            next_     => next_    %next\n"
             "            nextCopy_ => nextCopy_%next\n"
             "          else\n"
-            "            allocate(massDistributionList_    )\n"
-            "            allocate(massDistributionListCopy_)\n"
+            "            massDistributionList_     => massDistributionListAcquire()\n"
+            "            massDistributionListCopy_ => massDistributionListAcquire()\n"
             "            next_     => massDistributionList_\n"
             "            nextCopy_ => massDistributionListCopy_\n"
             "          end if\n"
@@ -459,7 +460,7 @@ _MASS_DISTRIBUTION_TAIL = """   allocate(massDistributionComposite :: massDistri
     <objectDestructor name="next_%massDistribution_" nullify="no"/>
     !!]
     nextCopy_ => next_%next
-    deallocate(next_)
+    call massDistributionListRelease(next_)
     next_ => nextCopy_
    end do
    nullify(massDistributionList_)

--- a/source/mass_distributions/_class.F90
+++ b/source/mass_distributions/_class.F90
@@ -34,7 +34,7 @@ module Mass_Distributions
   use :: Tensors                   , only : tensorRank2Dimension3Symmetric
   use :: Numerical_Interpolation   , only : interpolator
   private
-  public  :: massDistributionMatches_
+  public  :: massDistributionMatches_, massDistributionListAcquire, massDistributionListRelease
   
   !![
   <functionClass docformat="rst">
@@ -1026,9 +1026,73 @@ module Mass_Distributions
   integer            , parameter                 :: massSolversIncrement=10
   integer                                        :: massSolversCount    = 0
   !$omp threadprivate(massSolvers,massSolversCount)
-  
+
+  ! Linked-list node type for composite mass distributions. Defined here (rather than in
+  ! composite.F90) so that the node free-list below and its acquire/release helpers - shared by the
+  ! composite class, the disk/spheroid component getters, and the treeNodeMassDistribution builder -
+  ! can be declared and used. Placed after massDistributionClass (defined above) and before the
+  ! composite class type (which references it).
+  type, public :: massDistributionList
+     class(massDistributionClass), pointer :: massDistribution_ => null()
+     type (massDistributionList ), pointer :: next              => null()
+  end type massDistributionList
+
+  ! Thread-private free-list of recycled massDistributionList nodes, shared by all producers of
+  ! composite member lists (the composite class, the disk/spheroid component getters, and the
+  ! per-node treeNodeMassDistribution builder). Building these lists and tearing them down would
+  ! otherwise allocate/deallocate one node per member per call - a dominant source of allocation
+  ! churn in baryonic models. Recycling the node containers (not the objects they reference) removes
+  ! that churn. Per-thread, so no locking and no cross-thread node migration. BOUNDED: releases beyond
+  ! the maximum are deallocated (releases - every composite teardown - vastly outnumber acquires, so
+  ! an uncapped list would grow without bound).
+  integer                      , parameter :: massDistributionListFreeMaximum =  1024
+  type   (massDistributionList), pointer   :: massDistributionListFree        => null()
+  integer                                  :: massDistributionListFreeCount   =     0
+  !$omp threadprivate(massDistributionListFree,massDistributionListFreeCount)
+
 contains
-  
+
+  function massDistributionListAcquire() result(node)
+    !!{RST
+    Return a ``massDistributionList`` node, reusing one from the thread-private free-list if
+    available, otherwise allocating a new one. The returned node has both pointers nullified.
+    !!}
+    implicit none
+    type(massDistributionList), pointer :: node
+
+    if (associated(massDistributionListFree)) then
+       node                          => massDistributionListFree
+       massDistributionListFree      => node%next
+       massDistributionListFreeCount =  massDistributionListFreeCount-1
+       node%next                     => null()
+       node%massDistribution_        => null()
+    else
+       allocate(node)
+    end if
+    return
+  end function massDistributionListAcquire
+
+  subroutine massDistributionListRelease(node)
+    !!{RST
+    Return a ``massDistributionList`` node to the thread-private free-list for re-use, nullifying
+    the caller's pointer. The caller must already have released (e.g.\ via an ``objectDestructor``)
+    any object referenced by ``node%massDistribution_``.
+    !!}
+    implicit none
+    type(massDistributionList), pointer, intent(inout) :: node
+
+    node%massDistribution_ => null()
+    if (massDistributionListFreeCount < massDistributionListFreeMaximum) then
+       node%next                     => massDistributionListFree
+       massDistributionListFree      => node
+       massDistributionListFreeCount =  massDistributionListFreeCount+1
+       node                          => null()
+    else
+       deallocate(node)
+    end if
+    return
+  end subroutine massDistributionListRelease
+
   subroutine kinematicsDistributionDestructor(self)
     !!{RST
     Destroy a kinematics distribution.

--- a/source/mass_distributions/composite.F90
+++ b/source/mass_distributions/composite.F90
@@ -30,11 +30,8 @@
   </massDistribution>
   !!]
 
-  type, public :: massDistributionList
-     class(massDistributionClass), pointer :: massDistribution_ => null()
-     type (massDistributionList ), pointer :: next              => null()
-  end type massDistributionList
-
+  ! Note: the massDistributionList node type is defined in the parent module (_class.F90), alongside
+  ! the shared node free-list, so it can be used by the disk/spheroid getters and treeNode builder.
 
   type, public, extends(massDistributionClass) :: massDistributionComposite
      !!{RST
@@ -92,6 +89,10 @@
      module procedure compositeConstructorParameters
      module procedure compositeConstructorInternal
   end interface massDistributionComposite
+
+  ! The massDistributionList node free-list and its massDistributionListAcquire/Release helpers live
+  ! in the parent module (_class.F90) so they can be shared with the disk/spheroid getters and the
+  ! treeNodeMassDistribution builder; they are used below in compositeSubset and compositeDestructor.
 
 contains
 
@@ -161,7 +162,7 @@ contains
           !![
           <objectDestructor name="massDistribution_%massDistribution_"/>
           !!]
-          deallocate(massDistribution_)
+          call massDistributionListRelease(massDistribution_)
           massDistribution_ => massDistributionNext
        end do
     end if
@@ -381,7 +382,8 @@ contains
     type (massDistributionList        ), pointer                 :: subsetHead         , subsetNext    , &
          &                                                          compositesHead     , compositesNext, &
          &                                                          massDistribution_
-    integer                                                      :: countComponents
+    integer                                                      :: countComponents    , countMembers
+    logical                                                      :: allWhole
     !![
     <optionalArgument name="componentType" defaultsTo="componentTypeAll"/>
     <optionalArgument name="massType"      defaultsTo="massTypeAll"     />
@@ -394,50 +396,72 @@ contains
        compositesHead    => null()
        massDistribution_ => self%massDistributions
        countComponents   =  0
+       countMembers      =  0
+       allWhole          =  .true.
        do while (associated(massDistribution_))
+          countMembers=countMembers+1
           select type (massDistribution__ => massDistribution_ %massDistribution_)
           class is (massDistributionComposite)
              massDistribution___ => massDistribution__%subset(componentType_,massType_)
              if (associated(massDistribution___)) then
+                ! A composite member is included "whole" only if its subset returned the member
+                ! itself; a partial sub-composite means the result differs from "self".
+                if (.not.associated(massDistribution___,massDistribution_%massDistribution_)) allWhole=.false.
                 countComponents=countComponents+1
                 if (associated(subsetHead)) then
-                   allocate(subsetNext%next)
-                   subsetNext => subsetNext%next
+                   subsetNext%next => massDistributionListAcquire()
+                   subsetNext      => subsetNext%next
                 else
-                   allocate(subsetHead     )
-                   subsetNext => subsetHead
+                   subsetHead      => massDistributionListAcquire()
+                   subsetNext      => subsetHead
                 end if
                 subsetNext%massDistribution_ => massDistribution___
                 if (associated(compositesHead)) then
-                   allocate(compositesNext%next)
-                   compositesNext => compositesNext%next
+                   compositesNext%next => massDistributionListAcquire()
+                   compositesNext      => compositesNext%next
                 else
-                   allocate(compositesHead     )
-                   compositesNext => compositesHead
+                   compositesHead      => massDistributionListAcquire()
+                   compositesNext      => compositesHead
                 end if
                 compositesNext%massDistribution_ => massDistribution___
+             else
+                ! A composite member matched nothing, so the subset cannot equal "self".
+                allWhole=.false.
              end if
           class default
              if (massDistribution__%matches(componentType,massType)) then
                 countComponents=countComponents+1
                 if (associated(subsetHead)) then
-                   allocate(subsetNext%next)
+                   subsetNext%next => massDistributionListAcquire()
                    subsetNext => subsetNext%next
                 else
-                   allocate(subsetHead     )
+                   subsetHead => massDistributionListAcquire()
                    subsetNext => subsetHead
                 end if
                 subsetNext%massDistribution_ => massDistribution__
+             else
+                ! A member did not match, so the subset cannot equal "self".
+                allWhole=.false.
              end if
           end select
           massDistribution_ => massDistribution_%next
        end do
        if (associated(subsetHead)) then
-          if (countComponents == 1) then
+          if (countComponents == countMembers .and. countMembers > 1 .and. allWhole) then
+             ! Every member matched and was included whole, so the subset is identical to "self":
+             ! return "self" directly and recycle the temporary list we built, instead of
+             ! constructing a duplicate composite.
+             do while (associated(subsetHead))
+                subsetNext => subsetHead%next
+                call massDistributionListRelease(subsetHead)
+                subsetHead => subsetNext
+             end do
+             call compositeSelfAcquire(self,subset)
+          else if (countComponents == 1) then
              !![
 	     <referenceAcquire target="subset" source="subsetHead%massDistribution_"/>
 	     !!]
-             deallocate(subsetHead)
+             call massDistributionListRelease(subsetHead)
           else
              allocate(massDistributionComposite :: subset)
              select type(subset)
@@ -453,12 +477,27 @@ contains
           !![
 	  <objectDestructor name="compositesHead%massDistribution_" nullify="no"/>
 	  !!]
-          deallocate(compositesHead)
+          call massDistributionListRelease(compositesHead)
           compositesHead => compositesNext
        end do
     end if
     return
   end function compositeSubset
+
+  subroutine compositeSelfAcquire(self,self_)
+    !!{RST
+    Return a counted reference to self (used by :galacticus-class:`compositeSubset` when the
+    requested subset is identical to the whole composite). A submodule-local equivalent of the
+    module-level selfAcquire, declared here so it is linkable from this submodule.
+    !!}
+    implicit none
+    class(massDistributionComposite), intent(inout), target  :: self
+    class(massDistributionClass    ),                pointer :: self_
+
+    self_ => self
+    call self_%referenceCountIncrement()
+    return
+  end subroutine compositeSelfAcquire
 
   double precision function compositeMassTotal(self)
     !!{RST

--- a/source/objects/nodes/components/disk/standard/bound_functions.Inc
+++ b/source/objects/nodes/components/disk/standard/bound_functions.Inc
@@ -26,7 +26,7 @@ function Node_Component_Disk_Standard_Mass_Distribution(self,componentType,massT
   Return the mass distribution for the standard disk component.
   !!}
   use :: Mass_Distributions               , only : massDistributionClass      , massDistributionCylindricalScaler, massDistributionComposite   , massDistributionList   , &
-       &                                           massDistributionCylindrical, massDistributionMatches_
+       &                                           massDistributionCylindrical, massDistributionMatches_         , massDistributionListAcquire
   use :: Node_Component_Disk_Standard_Data, only : massDistributionStellar_   , massDistributionGas_             , kinematicDistribution_      , scalerStellarPool      , &
        &                                           scalerGasPool
   use :: Galactic_Structure_Options       , only : componentTypeDisk          , massTypeStellar                  , massTypeGaseous             , enumerationWeightByType, &
@@ -129,8 +129,8 @@ function Node_Component_Disk_Standard_Mass_Distribution(self,componentType,massT
      if      (includeStars .and. includeGas) then
         ! Wrap the dimensionless mass distribution inside scaler classes to allow us to re-scale it to any disk system, and then composite those.
         allocate(massDistributionTotal          )
-        allocate(massDistributionComponents     )
-        allocate(massDistributionComponents%next)
+        massDistributionComponents                        => massDistributionListAcquire()
+        massDistributionComponents%next                   => massDistributionListAcquire()
         massDistributionComponents     %massDistribution_ => massDistributionStellar
         massDistributionComponents%next%massDistribution_ => massDistributionGas
         !![

--- a/source/objects/nodes/components/spheroid/standard/bound_functions.Inc
+++ b/source/objects/nodes/components/spheroid/standard/bound_functions.Inc
@@ -26,7 +26,7 @@ function Node_Component_Spheroid_Standard_Mass_Distribution(self,componentType,m
   Return the mass distribution for the standard spheroid component.
   !!}
   use :: Mass_Distributions                   , only : massDistributionClass    , massDistributionSphericalScaler, massDistributionComposite   , massDistributionList   , &
-        &                                              massDistributionSpherical, massDistributionMatches_
+        &                                              massDistributionSpherical, massDistributionMatches_       , massDistributionListAcquire
   use :: Node_Component_Spheroid_Standard_Data, only : massDistributionStellar_ , massDistributionGas_           , kinematicDistribution_      , scalerStellarPool      , &
        &                                               scalerGasPool
   use :: Galactic_Structure_Options           , only : componentTypeSpheroid    , massTypeStellar                , massTypeGaseous             , enumerationWeightByType, &
@@ -129,8 +129,8 @@ function Node_Component_Spheroid_Standard_Mass_Distribution(self,componentType,m
      if      (includeStars .and. includeGas) then
         ! Wrap the dimensionless mass distribution inside scaler classes to allow us to re-scale it to any spheroid system, and then composite those.
         allocate(massDistributionTotal          )
-        allocate(massDistributionComponents     )
-        allocate(massDistributionComponents%next)
+        massDistributionComponents                        => massDistributionListAcquire()
+        massDistributionComponents%next                   => massDistributionListAcquire()
         massDistributionComponents     %massDistribution_ => massDistributionStellar
         massDistributionComponents%next%massDistribution_ => massDistributionGas
         !![

--- a/source/tests/mass_distributions.F90
+++ b/source/tests/mass_distributions.F90
@@ -41,12 +41,14 @@ program Test_Mass_Distributions
        &                                    massDistributionSIDMParametricProfile, massDistributionBlackHole
   use :: Numerical_Constants_Math  , only : Pi                                   , e
   use :: Tensors                   , only : assignment(=)
-  use :: Unit_Tests                , only : Assert                               , Unit_Tests_Begin_Group             , Unit_Tests_End_Group                   , Unit_Tests_Finish
+  use :: Unit_Tests                , only : Assert                               , Unit_Tests_Begin_Group             , Unit_Tests_End_Group                   , Unit_Tests_Finish                           , &
+       &                                    compareEquals                        , compareNotEqual
   implicit none
-  class           (massDistributionClass                  )                                    , allocatable :: massDistribution_                                                                                                       , massDistributionRotated                   , &
-       &                                                                                                        massDistributionDisk                                                                                                    , massDistributionSpheroid                  , &
+  class           (massDistributionClass                  )                                    , allocatable :: massDistribution_                                                                                                       , massDistributionRotated   , &
+       &                                                                                                        massDistributionDisk                                                                                                    , massDistributionSpheroid  , &
        &                                                                                                        massDistributionDMO
-  class           (massDistributionClass                  )                                    , pointer     :: massDistributionDisk_                                                                                                   , massDistributionSpheroid_ 
+  class           (massDistributionClass                  )                                    , pointer     :: massDistributionDisk_                                                                                                   , massDistributionSpheroid_ , &
+       &                                                                                                        massDistributionAll_                                                                                                    , massDistributionDiskAgain_
   class           (kinematicsDistributionClass            )                                    , pointer     :: kinematicsDistribution_
   type            (massDistributionList                   )                                    , pointer     :: massDistributions
   integer                                                  , parameter                                       :: sidmParametricTableCount              =7
@@ -83,7 +85,7 @@ program Test_Mass_Distributions
        &                                                                                                        positionReference
   type            (coordinateCartesian                    )                                                  :: positionCartesian
   type            (enumerationMassDistributionSymmetryType)                                                  :: symmetry_
-  integer                                                                                                    :: i
+  integer                                                                                                    :: i                                                                                                                       , referenceCountDiscard
   double precision                                                                                           :: radiusInProjection                                                                                                      , radius                                           , &
        &                                                                                                        rotationCurveGradientAnalytic                                                                                           , rotationCurveGradientNumerical                   , &
        &                                                                                                        massFraction                                                                                                            , time
@@ -629,6 +631,63 @@ program Test_Mass_Distributions
   call Assert("Density at (x,y,z)=(1,0,0) kpc",massDistribution_%density(positionCartesian),1.47756308872d18                      ,relTol=1.0d-6)
   nullify   (massDistributions)
   deallocate(massDistribution_)
+  call Unit_Tests_End_Group()
+
+  ! Composite subset: all-match fast path & list-node free-list re-use.
+  ! Exercises the optimizations in compositeSubset: (1) when every member matches the requested
+  ! filter the whole composite is returned directly ("self") instead of rebuilding a duplicate, and
+  ! (2) the thread-private massDistributionList free-list recycles member-list nodes. The composite
+  ! is rebuilt and destroyed on each iteration so the free-list acquire/release path is exercised
+  ! across object lifetimes; densities must stay correct and stable. Reference values match the
+  ! "Composite profile" test above (same component parameters).
+  call Unit_Tests_Begin_Group("Composite subset (fast path & node re-use)")
+  do i=1,4
+     allocate(                                   massDistributions                       )
+     allocate(                                   massDistributions%next                  )
+     allocate(massDistributionHernquist       :: massDistributions     %massDistribution_)
+     allocate(massDistributionExponentialDisk :: massDistributions%next%massDistribution_)
+     select type (massDistribution_ => massDistributions     %massDistribution_)
+     type is (massDistributionHernquist      )
+        massDistribution_=massDistributionHernquist      (mass=9.0d09,scaleLength=0.7d-3                   ,componentType=componentTypeSpheroid)
+     end select
+     select type (massDistribution_ => massDistributions%next%massDistribution_)
+     type is (massDistributionExponentialDisk)
+        massDistribution_=massDistributionExponentialDisk(mass=5.7d10,scaleRadius=2.9d-3,scaleHeight=0.3d-3,componentType=componentTypeDisk    )
+     end select
+     allocate(massDistributionComposite :: massDistribution_)
+     select type (massDistribution_)
+     type is (massDistributionComposite)
+        massDistribution_=massDistributionComposite(massDistributions)
+     end select
+     positionCartesian=[1.0d-3,0.0d0,0.0d0]
+     ! All-match subset (default componentTypeAll, massTypeAll): every member matches, so the fast
+     ! path returns a distribution equivalent to the full composite.
+     massDistributionAll_       => massDistribution_%subset(                                   )
+     ! Partial subsets must return only the matching component (i.e. NOT the whole composite).
+     massDistributionDisk_      => massDistribution_%subset(componentType=componentTypeDisk    )
+     massDistributionSpheroid_  => massDistribution_%subset(componentType=componentTypeSpheroid)
+     ! Re-subsetting the same composite must give an identical result (free-list re-use path).
+     massDistributionDiskAgain_ => massDistribution_%subset(componentType=componentTypeDisk    )
+     call Assert("all-match subset = full composite"            ,loc(massDistributionAll_      ),loc(massDistribution_    ),compare=compareEquals  )
+     call Assert("disk subset      ≠ full composite"            ,loc(massDistributionDisk_     ),loc(massDistribution_    ),compare=compareNotEqual)
+     call Assert("spheroid subset  ≠ full composite"            ,loc(massDistributionSpheroid_ ),loc(massDistribution_    ),compare=compareNotEqual)
+     call Assert("disk re-subset   = disk subset"               ,loc(massDistributionDiskAgain_),loc(massDistributionDisk_),compare=compareEquals  )
+     call Assert("all-match subset density = full composite"    ,massDistributionAll_      %density(positionCartesian),1.47756308872d18,relTol=1.0d-6)
+     call Assert("disk subset density      = disk component"    ,massDistributionDisk_     %density(positionCartesian),1.27347675828d18,relTol=1.0d-6)
+     call Assert("spheroid subset density  = spheroid component",massDistributionSpheroid_ %density(positionCartesian),2.04086330446d17,relTol=1.0d-6)
+     call Assert("re-subset disk density consistent"            ,massDistributionDiskAgain_%density(positionCartesian),1.27347675828d18,relTol=1.0d-6)
+     ! Release references. The all-match result is "self" (the composite), so balance its reference
+     ! count without destroying it; the partial subsets are counted references to members.
+     referenceCountDiscard=massDistributionAll_%referenceCountDecrement()
+     !![
+     <objectDestructor name="massDistributionDisk_"     />
+     <objectDestructor name="massDistributionSpheroid_" />
+     <objectDestructor name="massDistributionDiskAgain_"/>
+     !!]
+     nullify   (massDistributionAll_)
+     nullify   (massDistributions   )
+     deallocate(massDistribution_   )
+  end do
   call Unit_Tests_End_Group()
 
   ! Patej & Loeb (2015) profile.


### PR DESCRIPTION
## Summary

Reduces the composite-mass-distribution allocation churn that dominates the `milkyWay` model's per-node memory traffic, via two changes in `compositeSubset`/`Mass_Distributions`:

1. **All-match fast path in `compositeSubset`.** When every member of a composite matches the requested `(componentType, massType)` filter (and each composite member is returned whole), return the composite itself via a counted reference instead of building an identical duplicate composite. This eliminates the recursive re-subsetting of the nested disk/spheroid (stars+gas) component composites — previously ~55% of all subset allocations.

2. **Bounded, thread-private free-list for `massDistributionList` nodes.** The node type, free-list, and `massDistributionListAcquire`/`Release` helpers live in the `Mass_Distributions` parent module and are shared by the composite class, the disk/spheroid component getters, and the generated `treeNodeMassDistribution` builder, so member-list node allocate/free pairs recycle instead of churning `malloc`/`free`. The list is capped (releases — one per composite teardown — vastly outnumber acquires, so an uncapped list would grow without bound).

## Results — `validate_milkyWay`, 24 trees, 8 threads

| Metric | Baseline | This PR | Δ |
|---|---:|---:|---:|
| Cumulative allocations | 44.85e9 | 36.47e9 | **−18.7%** |
| Cumulative bytes | 2.33 TB | 1.009 TB | **−56.8%** |
| Peak RSS | 10.5 GB | 10.05 GB | flat |
| Wall time¹ | 200.2 s | 193.6 s | **−3.3%** |
| Instructions¹ | 2.950 T | 2.830 T | **−4.1%** |

¹ Single-thread, deterministic A/B (the 8-thread model is chaotic, so wall is dominated by run-to-run trajectory noise; single-thread isolates the work removed). `compositeSubset` and `treeNodeMassDistribution` drop out of the top allocation sites entirely.

The bulk of the wall/bytes win is the fast path (avoided composite deep-copies); the node free-list is mostly an allocation-count reduction (16-byte nodes).

## Validation

- **Unit test:** new "Composite subset (fast path & node re-use)" group in `tests.mass_distributions.F90`, with `loc()`-based identity checks (all-match subset *is* the composite; partial subsets *are* the matching members; re-subset returns the same object) plus density checks, over repeated build/destroy cycles. Whole suite passes (0 failures).
- **Reproducibility:** `test-reproducibility.py` (`cooling`, `closedBox`, `leakyBox`, `adiabaticContraction`) — these exercise the disk/spheroid getters and the treeNode builder — all assertions pass, results unchanged.

## Notes

The residual top allocation sites are now composite/kinematics *object* finalizers and the deep-copy assignment — i.e. pooling of the composite/scaler *objects* themselves (component-local "Site 1" composites and the top-level treeNode composite). That is a separate, larger effort and is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
