### PR TITLE
Enrich parameter reference docs from the parameter catalog

### DIFF
--- a/python/Galacticus/Parameters/catalog.py
+++ b/python/Galacticus/Parameters/catalog.py
@@ -178,6 +178,20 @@ def discover_enumerations(source_files):
     return enumerations
 
 
+# A string default is written in Fortran as `var_str('value')`; the value a user
+# actually enters in a parameter file is just the inner string.
+_VAR_STR_RE = re.compile(r"""^var_str\s*\(\s*(['"])(.*)\1\s*\)$""", re.IGNORECASE)
+
+
+def _normalize_default(value):
+    """Render a default value as a user would enter it: unwrap `var_str('x')`
+    to `x`.  Leaves numeric/boolean literals and expressions unchanged."""
+    if value is None:
+        return None
+    match = _VAR_STR_RE.match(value.strip())
+    return match.group(2) if match else value
+
+
 def _constraint_bound(raw):
     """Parse a `<minimum>`/`<maximum>` directive value into ``{value, inclusive}``.
 
@@ -298,7 +312,7 @@ def _harvest_parameters(scope_node, declaration_lookup, source_elements,
                 'provenance':    inferred['provenance'],
                 'enumeration':   enumeration_links.get(variable),
                 'constraints':   _capture_constraints(directive),
-                'default':       _scalar(directive.get('defaultValue')),
+                'default':       _normalize_default(_scalar(directive.get('defaultValue'))),
                 'cardinality':   _scalar(directive.get('cardinality')),
                 'description':   _scalar(directive.get('description')),
             })

--- a/python/Galacticus/Parameters/query.py
+++ b/python/Galacticus/Parameters/query.py
@@ -1,0 +1,53 @@
+"""Consumer-facing queries over the parameter catalog.
+
+Helpers that resolve an implementation's full parameter set (its own parameters
+plus those inherited from ancestor implementations) and attach enumeration
+allowed-values, for use by documentation, schema, and configuration generators.
+The catalog stores each implementation's *own* parameters and a `parent` link;
+inheritance is resolved here (mirroring the validator).
+
+Andrew Benson (2026)
+"""
+
+__all__ = ['inheritance_chain', 'enumeration_values', 'resolved_parameters']
+
+
+def inheritance_chain(catalog, impl_type):
+    """Return `impl_type` followed by each ancestor implementation it extends,
+    stopping when the parent is not a known implementation (the base class)."""
+    implementations = catalog.get('implementations', {})
+    chain, seen, current = [], set(), impl_type
+    while current in implementations and current not in seen:
+        seen.add(current)
+        chain.append(current)
+        current = implementations[current].get('parent')
+    return chain
+
+
+def enumeration_values(catalog, enumeration):
+    """Return the allowed labels for an enumeration, or None."""
+    if not enumeration:
+        return None
+    return catalog.get('enumerations', {}).get(enumeration)
+
+
+def resolved_parameters(catalog, impl_type):
+    """Return the ordered, de-duplicated parameter list for an implementation:
+    its own parameters first, then inherited ones.  Each entry is a copy of the
+    catalog parameter with two added keys: ``inheritedFrom`` (the ancestor
+    implementation type, or None if declared directly) and ``allowedValues``
+    (the enumeration's labels, or None)."""
+    implementations = catalog.get('implementations', {})
+    resolved, seen = [], set()
+    for type_name in inheritance_chain(catalog, impl_type):
+        for parameter in implementations[type_name].get('parameters', []):
+            name = parameter.get('name')
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            entry = dict(parameter)
+            entry['inheritedFrom'] = None if type_name == impl_type else type_name
+            entry['allowedValues'] = enumeration_values(
+                catalog, parameter.get('enumeration'))
+            resolved.append(entry)
+    return resolved

--- a/python/Galacticus/Parameters/tests/test_catalog.py
+++ b/python/Galacticus/Parameters/tests/test_catalog.py
@@ -18,6 +18,7 @@ import pytest
 from Galacticus.Parameters.catalog import (
     derive_label, _resolve_source_elements, harvest_file,
     discover_enumerations, _enumeration_links, _capture_constraints,
+    _normalize_default,
 )
 from Galacticus.Build.SourceTree import parse_file
 
@@ -164,6 +165,18 @@ def test_harvest_links_enumeration(tmp_path):
     entries = harvest_file(str(impl), {"myClass"}, str(source_root))
     params = {p['name']: p for p in entries[0]['parameters']}
     assert params['densityType']['enumeration'] == 'fixedDensityType'
+
+
+def test_normalize_default():
+    assert _normalize_default("var_str('critical')") == 'critical'
+    assert _normalize_default('var_str("none")') == 'none'
+    assert _normalize_default("var_str( 'x' )") == 'x'
+    # Non-var_str defaults pass through unchanged.
+    assert _normalize_default('9.97d0') == '9.97d0'
+    assert _normalize_default('.true.') == '.true.'
+    assert _normalize_default("inputPath(pathTypeDataStatic)//'f.hdf5'") \
+        == "inputPath(pathTypeDataStatic)//'f.hdf5'"
+    assert _normalize_default(None) is None
 
 
 def test_capture_constraints():

--- a/python/Galacticus/Parameters/tests/test_query.py
+++ b/python/Galacticus/Parameters/tests/test_query.py
@@ -1,0 +1,48 @@
+"""Tests for `Galacticus.Parameters.query` (inheritance resolution for consumers)."""
+
+from Galacticus.Parameters.query import (
+    inheritance_chain, enumeration_values, resolved_parameters,
+)
+
+CATALOG = {
+    'enumerations': {'densityKind': ['critical', 'mean']},
+    'implementations': {
+        'baseSimple': {
+            'parent': 'baseClass',
+            'parameters': [
+                {'name': 'alpha', 'type': 'real'},
+                {'name': 'mode', 'type': 'string', 'enumeration': 'densityKind'},
+            ],
+        },
+        'baseChild': {            # extends baseSimple; redeclares alpha
+            'parent': 'baseSimple',
+            'parameters': [
+                {'name': 'beta', 'type': 'integer'},
+                {'name': 'alpha', 'type': 'real'},
+            ],
+        },
+    },
+}
+
+
+def test_inheritance_chain():
+    assert inheritance_chain(CATALOG, 'baseChild') == ['baseChild', 'baseSimple']
+    assert inheritance_chain(CATALOG, 'baseSimple') == ['baseSimple']
+    assert inheritance_chain(CATALOG, 'missing') == []
+
+
+def test_enumeration_values():
+    assert enumeration_values(CATALOG, 'densityKind') == ['critical', 'mean']
+    assert enumeration_values(CATALOG, None) is None
+    assert enumeration_values(CATALOG, 'nope') is None
+
+
+def test_resolved_parameters_inheritance_dedup_and_enum():
+    params = resolved_parameters(CATALOG, 'baseChild')
+    assert [p['name'] for p in params] == ['beta', 'alpha', 'mode']  # own first, dedup
+    by_name = {p['name']: p for p in params}
+    assert by_name['beta']['inheritedFrom'] is None
+    assert by_name['alpha']['inheritedFrom'] is None        # child's redeclaration wins
+    assert by_name['mode']['inheritedFrom'] == 'baseSimple'  # inherited
+    assert by_name['mode']['allowedValues'] == ['critical', 'mean']
+    assert by_name['alpha']['allowedValues'] is None

--- a/scripts/doc/extractDocsRST.py
+++ b/scripts/doc/extractDocsRST.py
@@ -32,12 +32,34 @@ import sys
 import textwrap
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Make the in-tree Galacticus Python packages importable.  The doc build sets
+# PYTHONPATH=python; add it explicitly so the extractor also runs stand-alone.
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir, os.pardir, 'python'))
 from latexToRST import (                                       # noqa: E402
     parse_glossary, glossary_display_map, latex_to_rst,
 )
 from extractContributors import (                              # noqa: E402
     collect_contributor_names, render_contributors_rst,
 )
+from Galacticus.Parameters.query import resolved_parameters    # noqa: E402
+
+
+def _build_catalog(source_dir):
+    """Build the parameter catalog for richer parameter docs (type, allowed
+    values, ranges, inherited parameters).  Returns None and warns on any
+    failure, so the documentation build never depends on it."""
+    os.environ.setdefault(
+        'GALACTICUS_EXEC_PATH',
+        os.path.dirname(os.path.abspath(source_dir)) or '.')
+    try:
+        from Galacticus.Parameters.catalog import build_catalog
+        return build_catalog(source_dir)
+    except Exception as exc:                                    # noqa: BLE001
+        print(f'NOTE: parameter catalog unavailable ({exc}); parameter docs '
+              f'will not include type/range/enumeration enrichment.',
+              file=sys.stderr)
+        return None
 
 # ``!![ … !!]`` directive block.
 _BLOCK_RE = re.compile(r'^[ \t]*!!\[(.*?)^[ \t]*!!\]', re.DOTALL | re.MULTILINE)
@@ -347,21 +369,75 @@ def scan_source(source_dir: str):
 # Rendering
 # ---------------------------------------------------------------------------
 
+def _range_label(constraints: dict | None) -> str | None:
+    """Render a `{minimum,maximum}` constraint as an inequality string."""
+    if not constraints:
+        return None
+    parts = []
+    minimum = constraints.get('minimum')
+    maximum = constraints.get('maximum')
+    if minimum:
+        parts.append(f'{"≥" if minimum.get("inclusive") else ">"} {minimum["value"]}')
+    if maximum:
+        parts.append(f'{"≤" if maximum.get("inclusive") else "<"} {maximum["value"]}')
+    return ', '.join(parts) or None
+
+
+def _parameter_facets(p: dict) -> list[str]:
+    """Catalog-derived annotations for a parameter: type, allowed values, range,
+    and default — shown as a parenthetical after the parameter name."""
+    facets = []
+    ptype = p.get('type')
+    if ptype and ptype != 'unknown':
+        facets.append(ptype)
+    allowed = p.get('allowedValues')
+    if allowed:
+        facets.append('one of ' + ', '.join(f'``{v}``' for v in allowed))
+    rng = _range_label(p.get('constraints'))
+    if rng:
+        facets.append(rng)
+    default = p.get('default')
+    if default is not None and str(default).strip() != '':
+        facets.append(f'default ``{str(default).strip()}``')
+    return facets
+
+
 def render_parameter(p: dict, glsmap: dict) -> str:
     name = p.get('name', '')
     desc = _desc_to_rst(p.get('description'), glsmap)
     # Parameter descriptions are short; collapse to a single logical line.
     desc = re.sub(r'\s*\n\s*', ' ', desc).strip()
-    default = p.get('default')
     head = f'``[{name}]``'
-    if default not in (None, ''):
-        head += f' (default ``{str(default).strip()}``)'
+    facets = _parameter_facets(p)
+    if facets:
+        head += ' (' + '; '.join(facets) + ')'
+    if p.get('inheritedFrom'):
+        desc = (desc + ' ' if desc else '') + f'*(inherited from* ``{p["inheritedFrom"]}``\\ *)*'
     return f'* {head} — {desc}' if desc else f'* {head}'
+
+
+def _implementation_parameters(impl: dict, params_by_file: dict,
+                               catalog: dict | None) -> list[dict]:
+    """Parameters to document for an implementation.
+
+    With a catalog, use its per-implementation resolved set (own + inherited,
+    annotated with type / allowed values / range), preferring the raw
+    source-extracted description for the implementation's own parameters.
+    Without a catalog, fall back to the file-based extraction (no enrichment)."""
+    file_params = params_by_file.get(impl.get('file', ''), [])
+    if catalog is None or impl.get('name') not in catalog.get('implementations', {}):
+        return file_params
+    raw_description = {p['name']: p.get('description') for p in file_params}
+    resolved = resolved_parameters(catalog, impl['name'])
+    for parameter in resolved:
+        if raw_description.get(parameter['name']) is not None:
+            parameter['description'] = raw_description[parameter['name']]
+    return resolved
 
 
 def render_family(fam: str, families: dict, implementations: dict,
                   params_by_file: dict, methods_by_file: dict,
-                  glsmap: dict) -> str:
+                  glsmap: dict, catalog: dict | None = None) -> str:
     directive = families[fam]
     descriptive = directive.get('descriptiveName', fam)
     out = [f'.. _physics-{fam}:\n', _heading(descriptive, '=')]
@@ -418,7 +494,7 @@ def render_family(fam: str, families: dict, implementations: dict,
                 out.append(f'* ``{meth["name"]}`` — {mdesc}' if mdesc
                            else f'* ``{meth["name"]}``')
             out.append('')
-        params = params_by_file.get(impl.get('file', ''), [])
+        params = _implementation_parameters(impl, params_by_file, catalog)
         if params:
             out.append('**Parameters**\n')
             for p in params:
@@ -643,12 +719,16 @@ def main() -> int:
     (families, implementations, params_by_file, methods_by_file, enumerations,
      modules, workarounds) = scan_source(source_dir)
 
+    # Build the parameter catalog to enrich parameter docs (type, allowed values,
+    # ranges, inherited parameters); degrades gracefully to None.
+    catalog = _build_catalog(source_dir)
+
     physics_dir = os.path.join(out_dir, 'physics')
     os.makedirs(physics_dir, exist_ok=True)
 
     for fam in implementations:
         page = render_family(fam, families, implementations,
-                             params_by_file, methods_by_file, glsmap)
+                             params_by_file, methods_by_file, glsmap, catalog)
         with open(os.path.join(physics_dir, f'{fam}.rst'), 'w',
                   encoding='utf-8') as fh:
             fh.write(page)


### PR DESCRIPTION
## Summary

Enriches the auto-generated parameter reference (the **Physics** pages built by `scripts/doc/extractDocsRST.py`) using the parameter catalog from #1191. Each implementation's parameter list now shows, per parameter:

- **inferred type**, **allowed enumeration values**, and **range constraints**;
- **inherited parameters** — previously omitted entirely, because the extractor only listed parameters declared in the same source file. A subclass implementation now documents the parameters it inherits from its parent, tagged *(inherited from …)*.

String defaults are rendered as a user would actually enter them in a parameter file (`var_str('critical')` → `critical`).

## Examples
- `virialDensityContrastFixed`: `[densityType] (string; one of critical, mean; default critical)`
- `distributionFunctionDiscrete1DBinomial`: `[probabilitySuccess] (real; ≥ 0.0, ≤ 1.0)`
- `accretionHaloColdMode`: now lists the `accretionHaloSimple` parameters it inherits.

## Changes
- `python/Galacticus/Parameters/query.py` — reusable resolver (`inheritance_chain`, `enumeration_values`, `resolved_parameters`) for an implementation's full (own + inherited) parameter set. This is also the foundation for the upcoming user-facing schema and typed-config layers.
- `scripts/doc/extractDocsRST.py` — builds the catalog on demand (degrades gracefully to the previous behaviour if unavailable) and annotates each parameter; omits empty defaults.
- `python/Galacticus/Parameters/catalog.py` — normalizes `var_str('…')` defaults to the bare string.

The catalog is generated on demand during the doc build (no committed JSON), keeping the build reproducible and the repo clean.

## Verification
- 489 Python unit tests pass (incl. new `test_query.py`); the doc-extractor's own tests pass.
- Full Sphinx build: 198 physics pages, **0 warnings**.
- Fallback verified: with no catalog, output is identical to before (no regression).
- The parameter-validation gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
