### PR TITLE
feat: generate parameter-file XSD schema for editor validation

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -61,6 +61,13 @@ jobs:
             --catalog parameters.catalog.json \
             --exceptions testSuite/parameterValidationExceptions.json \
             testSuite/parameters parameters parameters.xml
+      - name: Check parameter-file schema is up to date
+        run: |
+          cd $GITHUB_WORKSPACE
+          export GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE
+          python3 scripts/build/parameterSchema.py `pwd` schema/parameters.xsd
+          git diff --exit-code -- schema/parameters.xsd \
+            || { echo "schema/parameters.xsd is out of date; run 'make parameters-schema' and commit."; exit 1; }
       - run: echo "This job's status is ${{ job.status }}."
   # Build and deploy
   ## Linux

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ __pycache__
 *.egg-info
 .pytest_cache
 .DS_Store
-.vscode
+.vscode/*
+!.vscode/settings.json
 .ipynb_checkpoints

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "//": "Associate Galacticus parameter files with the generated XSD so that VS Code's XML extension (redhat.vscode-xml) provides real-time validation and autocompletion. See docs/manuals/user-guide/advanced.rst ('Editor validation and autocompletion').",
+  "xml.fileAssociations": [
+    {
+      "pattern": "**/parameters/**/*.xml",
+      "systemId": "${workspaceFolder}/schema/parameters.xsd"
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -812,6 +812,13 @@ $(BUILDPATH)/parameters.catalog.json: ./scripts/build/parameterCatalog.py ./pyth
 
 parameters-catalog: $(BUILDPATH)/parameters.catalog.json
 
+# Editor-assistance schema for parameter files, generated from the catalog and
+# committed (so editors can reference it). Regenerate with `make parameters-schema`
+# after changing functionClass implementations or enumerations; CI checks it is
+# up to date.
+parameters-schema:
+	./scripts/build/parameterSchema.py `pwd` schema/parameters.xsd
+
 # Rules for XSpec code.
 aux/XSpec/%.o: ./aux/XSpec/%.f Makefile
 	$(FCCOMPILER) -c $< -o aux/XSpec/$*.o $(FCFLAGS)

--- a/docs/manuals/developer-guide/continuous-integration.rst
+++ b/docs/manuals/developer-guide/continuous-integration.rst
@@ -83,6 +83,46 @@ of the reusable ``testCode.yml`` and ``testModel.yml`` workflows and compares
 outputs against references (``hdf5Diff.yml``). This pipeline is heavier and takes
 considerably longer than the pull-request checks.
 
+.. _git-hooks:
+
+Git hooks
+---------
+
+Galacticus shares a set of `git hooks <https://github.com/galacticusorg/gitHooks>`_
+across its repositories. Installing them is optional but recommended: they catch
+many of the same problems as the CI checks above, but *before* a commit is made.
+The hooks include:
+
+* **pre-commit** — a dispatcher (``pre-commit``) that runs every executable in
+  ``pre-commit.d/`` in order. The main check script (``00-galacticus``) performs
+  Fortran static analysis, validates ``.bib``, XML, YAML and Python files,
+  spell-checks documentation, compiles embedded XML directives, flags leftover
+  debugging statements, and verifies that the generated parameter-file schema
+  (``schema/parameters.xsd``) is up to date with the sources — regenerating it
+  only when a staged change could affect it (a Fortran source, the schema
+  generator, the catalog builder, or the schema itself). A second script
+  (``01-claude-review``) optionally reviews the staged diff.
+* **commit-msg** / **prepare-commit-msg** — enforce and pre-fill
+  `Conventional Commits <https://www.conventionalcommits.org>`_ messages.
+* **pre-push** — asks for confirmation before pushing directly to
+  ``master``/``main``.
+
+To install them, clone the ``gitHooks`` repository and symlink it in place of
+your clone's ``.git/hooks`` directory (the ``pre-commit`` dispatcher expects to
+find ``pre-commit.d/`` under ``.git/hooks``):
+
+.. code-block:: bash
+
+   git clone https://github.com/galacticusorg/gitHooks.git /path/to/gitHooks
+   cd /path/to/your/galacticus
+   rm -rf .git/hooks
+   ln -s /path/to/gitHooks .git/hooks
+
+The hooks degrade gracefully when optional tools (for example ``hunspell``,
+``yamllint``, ``lxml``, or ``claude``) are not installed; see the
+`gitHooks README <https://github.com/galacticusorg/gitHooks/blob/main/README.md>`_
+for the full list of checks and configuration options.
+
 Before opening a pull request
 -----------------------------
 

--- a/docs/manuals/user-guide/advanced.rst
+++ b/docs/manuals/user-guide/advanced.rst
@@ -172,6 +172,35 @@ The validator can additionally perform deeper, catalog-aware checks—verifying 
 
 A directory may be given in place of a file, in which case all ``*.xml`` files under it are validated and a summary is printed. This same tool is run in continuous integration to validate the bundled parameter files.
 
+Editor validation and autocompletion
+"""""""""""""""""""""""""""""""""""""
+
+For real-time validation and autocompletion while editing parameter files, an XML Schema is provided at ``schema/parameters.xsd``. It is generated from the parameter catalog and constrains each ``functionClass`` selector's ``value`` to the valid implementations, and each enumeration-valued parameter's ``value`` to the allowed labels. (Content is otherwise permissive; for the precise, per-implementation check use ``parameterValidate.py`` above.)
+
+**VS Code (whole repository).** A workspace configuration is shipped with Galacticus in ``.vscode/settings.json`` that associates the schema with every file under a ``parameters/`` directory. After installing the `XML extension <https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml>`_, validation and autocompletion therefore work out of the box when you open the Galacticus repository in VS Code. The shipped association is:
+
+.. code-block:: json
+
+    {
+      "xml.fileAssociations": [
+        { "pattern": "**/parameters/**/*.xml",
+          "systemId": "${workspaceFolder}/schema/parameters.xsd" }
+      ]
+    }
+
+The ``${workspaceFolder}``-anchored path is important: parameter files live at many directory depths, and a bare relative path would be looked for next to each file and not found. If ``${workspaceFolder}`` is not expanded by your version of the extension, use the absolute path to ``schema/parameters.xsd`` in your checkout instead. To cover parameter files kept outside any ``parameters/`` directory, broaden the ``pattern`` (e.g. to ``**/*.xml``).
+
+**A single file (any XSD-aware editor).** Alternatively, reference the schema from the parameter file itself, on its root ``<parameters>`` element:
+
+.. code-block:: xml
+
+    <parameters xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:noNamespaceSchemaLocation="schema/parameters.xsd">
+
+The location in ``xsi:noNamespaceSchemaLocation`` is resolved **relative to the parameter file's own directory** (not the repository root), so a bare ``schema/parameters.xsd`` only works for a file sitting directly above the ``schema/`` directory. For a file deeper in the tree, use a correctly-rooted relative path (e.g. ``../../schema/parameters.xsd`` for a file in ``parameters/tutorials/``) or an absolute path.
+
+The schema is generated from the sources, so it is regenerated (``make parameters-schema``) and verified in continuous integration. The Galacticus :ref:`git hooks <git-hooks>` additionally check it before a commit is made — regenerating it (only when a staged change could affect it) and blocking the commit if ``schema/parameters.xsd`` is out of date.
+
 Generating Parameter Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/parameters.xml
+++ b/parameters.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Default parameters for Galacticus v0.9.4 -->
 <!-- 30-October-2011                          -->
-<parameters>
+ <parameters xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:noNamespaceSchemaLocation="schema/parameters.xsd">
   <formatVersion>2</formatVersion>
   <lastModified revision="975fffd5aadf697707003f16bf9b4caee8ebe97d" time="2025-10-23T18:13:06"/>
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,8 @@
 # existing legacy location at
 # `python/Galacticus/Build/SourceTree/tests/` for SourceTree regressions.
 # `scripts/doc` carries regression tests for the ReadTheDocs doc-extraction
-# tooling (e.g. `scripts/doc/tests/test_extractDocsRST.py`).
-testpaths = python scripts/doc
+# tooling (e.g. `scripts/doc/tests/test_extractDocsRST.py`); `scripts/build`
+# carries tests for build-time generators (e.g. the parameter-file schema).
+testpaths = python scripts/doc scripts/build
 python_files = test_*.py
 python_functions = test_*

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -1,17 +1,5077 @@
 <?xml version="1.0"?>
+<!-- Galacticus parameter-file schema. GENERATED from the parameter
+     catalog by scripts/build/parameterSchema.py (do not edit by hand).
+     For editor assistance only; precise validation is done by
+     scripts/build/parameterValidate.py. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <!-- Schema used to validate Galacticus parameter files -->
 
-  <xs:element name="parameters">
-    <xs:element name="version" type="xs:string" maxOccurs="1" />
-    <xs:element name="parameter">
-      <xs:complexType>
-	<xs:all>
-	  <xs:element name="value"      type="xs:string" minOccurs="1"/>
-	  <xs:element name="name"       type="xs:string" minOccurs="1"/>
-	</xs:all>
-      </xs:complexType>
-    </xs:element>
+  <!-- functionClass selectors: value restricted to valid implementations. -->
+  <xs:element name="accretionDiskSpectra">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="file"/>
+          <xs:enumeration value="hopkins2007"/>
+          <xs:enumeration value="thinDisk"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
   </xs:element>
-  
+  <xs:element name="accretionDisks">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="ADAF"/>
+          <xs:enumeration value="eddingtonLimited"/>
+          <xs:enumeration value="shakuraSunyaev"/>
+          <xs:enumeration value="switched"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="accretionHalo">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="bertschinger"/>
+          <xs:enumeration value="coldMode"/>
+          <xs:enumeration value="isocurvature"/>
+          <xs:enumeration value="naozBarkana2007"/>
+          <xs:enumeration value="simple"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="accretionHaloTotal">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="bertschinger"/>
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="atomicCrossSectionIonizationPhoto">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="verner"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="atomicExcitationRateCollisional">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="scholzWalters1991"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="atomicIonizationPotential">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="verner"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="atomicIonizationRateCollisional">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="verner1996"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="atomicRecombinationRateDielectronic">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="arnaud1985"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="atomicRecombinationRateRadiative">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="computed"/>
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="verner1996"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="atomicRecombinationRateRadiativeCooling">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="computed"/>
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="hummer"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="blackHoleAccretionRate">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="spheroidTracking"/>
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="blackHoleBinaryInitialSeparation">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="spheroidRadiusFraction"/>
+          <xs:enumeration value="tidalRadius"/>
+          <xs:enumeration value="volonteri2003"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="blackHoleBinaryMerger">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="rezzolla2008"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="blackHoleBinaryRecoil">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="campanelli2007"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="blackHoleBinarySeparationGrowthRate">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="standard"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="blackHoleCGMHeating">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="jetPower"/>
+          <xs:enumeration value="quasistatic"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="blackHoleSeeds">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="vergara2023"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="blackHoleWind">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="ciotti2009"/>
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="chemicalReactionRate">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="hydrogenNetwork"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="chemicalState">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="CIEFile"/>
+          <xs:enumeration value="atomicCIECloudy"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="circumgalacticMediumHeating">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="AGNFeedback"/>
+          <xs:enumeration value="summation"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coldModeInfallRate">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="dynamicalTime"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="computationalDomain">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cartesian3D"/>
+          <xs:enumeration value="cylindrical"/>
+          <xs:enumeration value="spherical"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="computationalDomainVolumeIntegrator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cartesian3D"/>
+          <xs:enumeration value="cylindrical"/>
+          <xs:enumeration value="spherical"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="conditionalMassFunction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="behroozi2010"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coolingFunction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="CIEFile"/>
+          <xs:enumeration value="CMBCompton"/>
+          <xs:enumeration value="atomicCIECloudy"/>
+          <xs:enumeration value="molecularHydrogenGalliPalla"/>
+          <xs:enumeration value="summation"/>
+          <xs:enumeration value="velocityCutOff"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coolingInfallRadius">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="coolingFreefall"/>
+          <xs:enumeration value="coolingRadius"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coolingInfallTorque">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fixed"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coolingRadius">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="betaProfile"/>
+          <xs:enumeration value="isothermal"/>
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coolingRate">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cole2000"/>
+          <xs:enumeration value="cutOff"/>
+          <xs:enumeration value="mainBranchOnly"/>
+          <xs:enumeration value="multiplier"/>
+          <xs:enumeration value="noCoolingSatellites"/>
+          <xs:enumeration value="simple"/>
+          <xs:enumeration value="simpleScaling"/>
+          <xs:enumeration value="velocityMaximumScaling"/>
+          <xs:enumeration value="whiteFrenk1991"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coolingSpecificAngularMomentum">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="constantRotation"/>
+          <xs:enumeration value="mean"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coolingTime">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coolingTimeAvailable">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="bensonBower2010"/>
+          <xs:enumeration value="formationTime"/>
+          <xs:enumeration value="whiteFrenk1991"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="correlationFunctionTwoPoint">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="powerSpectrumTransform"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="cosmologicalMassVariance">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="artificialHalos"/>
+          <xs:enumeration value="filteredPower"/>
+          <xs:enumeration value="peakBackgroundSplit"/>
+          <xs:enumeration value="scaled"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="cosmologicalVelocityField">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="filteredPower"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="cosmologyFunctions">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="matterDarkEnergy"/>
+          <xs:enumeration value="matterLambda"/>
+          <xs:enumeration value="staticUniverse"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="cosmologyParameters">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="criticalOverdensity">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+    <xs:attribute name="value" type="xs:string" use="optional"/>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterHaloBias">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="pressSchechter"/>
+          <xs:enumeration value="sheth2001"/>
+          <xs:enumeration value="tinker2005"/>
+          <xs:enumeration value="tinker2010"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterHaloMassAccretionHistory">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="correa2015"/>
+          <xs:enumeration value="diemer2020"/>
+          <xs:enumeration value="hearin2021"/>
+          <xs:enumeration value="hearin2021Stochastic"/>
+          <xs:enumeration value="mergerTreeBranching"/>
+          <xs:enumeration value="wechsler2002"/>
+          <xs:enumeration value="zhao2009"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterHaloMassLossRate">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="vanDenBosch"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterHaloScale">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="virialDensityContrastDefinition"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterParticle">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="CDM"/>
+          <xs:enumeration value="SIDMVelocityDependent"/>
+          <xs:enumeration value="WDMThermal"/>
+          <xs:enumeration value="decayingDarkMatter"/>
+          <xs:enumeration value="fuzzyDarkMatter"/>
+          <xs:enumeration value="selfInteractingDarkMatter"/>
+          <xs:enumeration value="selfInteractingDarkMatterConstant"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterProfile">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="SIDMIsothermal"/>
+          <xs:enumeration value="accelerator"/>
+          <xs:enumeration value="adiabaticGnedin2004"/>
+          <xs:enumeration value="darkMatterOnly"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterProfileConcentration">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="NFW1996"/>
+          <xs:enumeration value="WDM"/>
+          <xs:enumeration value="WDMBose2016"/>
+          <xs:enumeration value="brown2021"/>
+          <xs:enumeration value="bullock2001"/>
+          <xs:enumeration value="correa2015"/>
+          <xs:enumeration value="diemerJoyce2019"/>
+          <xs:enumeration value="diemerKravtsov2014"/>
+          <xs:enumeration value="duttonMaccio2014"/>
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="gao2008"/>
+          <xs:enumeration value="klypin2015"/>
+          <xs:enumeration value="ludlow2016Fit"/>
+          <xs:enumeration value="munozCuartas2011"/>
+          <xs:enumeration value="prada2011"/>
+          <xs:enumeration value="scatterShift"/>
+          <xs:enumeration value="schneider2015"/>
+          <xs:enumeration value="zhao2009"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterProfileDMO">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="NFW"/>
+          <xs:enumeration value="SIDMCoreNFW"/>
+          <xs:enumeration value="SIDMIsothermal"/>
+          <xs:enumeration value="SIDMParametric"/>
+          <xs:enumeration value="accelerator"/>
+          <xs:enumeration value="accretionFlowCorrelationFunction"/>
+          <xs:enumeration value="accretionFlowDiemerKravtsov2014"/>
+          <xs:enumeration value="accretionFlowShi2016"/>
+          <xs:enumeration value="burkert"/>
+          <xs:enumeration value="cuspNFW"/>
+          <xs:enumeration value="decaying"/>
+          <xs:enumeration value="einasto"/>
+          <xs:enumeration value="finiteResolution"/>
+          <xs:enumeration value="finiteResolutionNFW"/>
+          <xs:enumeration value="heated"/>
+          <xs:enumeration value="heatedMonotonic"/>
+          <xs:enumeration value="isothermal"/>
+          <xs:enumeration value="multiple"/>
+          <xs:enumeration value="penarrubia2010"/>
+          <xs:enumeration value="solitonNFW"/>
+          <xs:enumeration value="solitonNFWHeated"/>
+          <xs:enumeration value="truncated"/>
+          <xs:enumeration value="truncatedExponential"/>
+          <xs:enumeration value="zhao1996"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterProfileHeating">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="decayingDarkMatter"/>
+          <xs:enumeration value="impulsiveOutflow"/>
+          <xs:enumeration value="monotonic"/>
+          <xs:enumeration value="monotonicWeak"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="summation"/>
+          <xs:enumeration value="tidal"/>
+          <xs:enumeration value="twoBodyRelaxation"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterProfileScaleRadius">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="binary"/>
+          <xs:enumeration value="concentration"/>
+          <xs:enumeration value="concentrationLimiter"/>
+          <xs:enumeration value="johnson2021"/>
+          <xs:enumeration value="ludlow2014"/>
+          <xs:enumeration value="ludlow2016"/>
+          <xs:enumeration value="ludlow2016Analytic"/>
+          <xs:enumeration value="powerLaw"/>
+          <xs:enumeration value="randomWalk"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="darkMatterProfileShape">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="brown2021"/>
+          <xs:enumeration value="gao2008"/>
+          <xs:enumeration value="klypin2015"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="distributionFunction1D">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="beta"/>
+          <xs:enumeration value="cauchy"/>
+          <xs:enumeration value="gamma"/>
+          <xs:enumeration value="logNormal"/>
+          <xs:enumeration value="logUniform"/>
+          <xs:enumeration value="negativeExponential"/>
+          <xs:enumeration value="nonCentralChiDegree3"/>
+          <xs:enumeration value="normal"/>
+          <xs:enumeration value="peakBackground"/>
+          <xs:enumeration value="studentT"/>
+          <xs:enumeration value="uniform"/>
+          <xs:enumeration value="voight"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="distributionFunctionDiscrete1D">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="binomial"/>
+          <xs:enumeration value="negativeBinomial"/>
+          <xs:enumeration value="poisson"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="distributionFunctionMultivariate">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="normal"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="evolveForestsWorkShare">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="FCFS"/>
+          <xs:enumeration value="cyclic"/>
+          <xs:enumeration value="stride"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="excursionSetBarrier">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="criticalOverdensity"/>
+          <xs:enumeration value="linear"/>
+          <xs:enumeration value="quadratic"/>
+          <xs:enumeration value="remapScale"/>
+          <xs:enumeration value="remapShethMoTormen"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="excursionSetFirstCrossing">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="farahi"/>
+          <xs:enumeration value="farahiMidpoint"/>
+          <xs:enumeration value="farahiMidpointBrownianBridge"/>
+          <xs:enumeration value="linearBarrier"/>
+          <xs:enumeration value="linearBarrierBrownianBridge"/>
+          <xs:enumeration value="zhangHui"/>
+          <xs:enumeration value="zhangHuiHighOrder"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="freefallRadius">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="darkMatterHalo"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="freefallTimeAvailable">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="haloFormation"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="galacticDynamicsBarInstability">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="efstathiou1982"/>
+          <xs:enumeration value="efstathiou1982Tidal"/>
+          <xs:enumeration value="fixedTimescale"/>
+          <xs:enumeration value="stable"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="galacticFilter">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="ISMMass"/>
+          <xs:enumeration value="all"/>
+          <xs:enumeration value="always"/>
+          <xs:enumeration value="any"/>
+          <xs:enumeration value="anyDescendantNode"/>
+          <xs:enumeration value="anySatelliteNode"/>
+          <xs:enumeration value="basicMass"/>
+          <xs:enumeration value="blackHoleMass"/>
+          <xs:enumeration value="branchMostMassive"/>
+          <xs:enumeration value="childNode"/>
+          <xs:enumeration value="constrainedBranch"/>
+          <xs:enumeration value="descendantNode"/>
+          <xs:enumeration value="formationTime"/>
+          <xs:enumeration value="gasFractionISM"/>
+          <xs:enumeration value="haloAlwaysIsolated"/>
+          <xs:enumeration value="haloIsolated"/>
+          <xs:enumeration value="haloMass"/>
+          <xs:enumeration value="haloMassRange"/>
+          <xs:enumeration value="haloNotIsolated"/>
+          <xs:enumeration value="hierarchyDepthMaximum"/>
+          <xs:enumeration value="highPass"/>
+          <xs:enumeration value="hostMassRange"/>
+          <xs:enumeration value="intervalPass"/>
+          <xs:enumeration value="isolatedHostNode"/>
+          <xs:enumeration value="labelled"/>
+          <xs:enumeration value="lightcone"/>
+          <xs:enumeration value="lowPass"/>
+          <xs:enumeration value="mainBranch"/>
+          <xs:enumeration value="mergerRatio"/>
+          <xs:enumeration value="nodeMajorMergerRecent"/>
+          <xs:enumeration value="not"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="outputTimes"/>
+          <xs:enumeration value="parentNode"/>
+          <xs:enumeration value="primaryDescendantNode"/>
+          <xs:enumeration value="radiusEffective"/>
+          <xs:enumeration value="rootNode"/>
+          <xs:enumeration value="spheroidStellarMass"/>
+          <xs:enumeration value="starFormationRate"/>
+          <xs:enumeration value="starFormationRateNonParametric"/>
+          <xs:enumeration value="stellarAbsoluteMagnitudes"/>
+          <xs:enumeration value="stellarApparentMagnitudes"/>
+          <xs:enumeration value="stellarMass"/>
+          <xs:enumeration value="stellarMassMorphology"/>
+          <xs:enumeration value="streamImpact"/>
+          <xs:enumeration value="streamKick"/>
+          <xs:enumeration value="surveyGeometry"/>
+          <xs:enumeration value="treeHosted"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="galacticStructureSolver">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="equilibrium"/>
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="linear"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="gauntFactor">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="sutherland1998"/>
+          <xs:enumeration value="vanHoof2014"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="geometryLightcone">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cylindrical"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="square"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="gravitationalLensing">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="baryonicModifier"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="takahashi2011"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="haloEnvironment">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="logNormal"/>
+          <xs:enumeration value="normal"/>
+          <xs:enumeration value="uniform"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="haloMassFunction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="accelerator"/>
+          <xs:enumeration value="bhattacharya2011"/>
+          <xs:enumeration value="despali2015"/>
+          <xs:enumeration value="detectionEfficiency"/>
+          <xs:enumeration value="environmentAveraged"/>
+          <xs:enumeration value="environmental"/>
+          <xs:enumeration value="errorConvolved"/>
+          <xs:enumeration value="fofBias"/>
+          <xs:enumeration value="multiplier"/>
+          <xs:enumeration value="ondaroMallea2021"/>
+          <xs:enumeration value="pressSchechter"/>
+          <xs:enumeration value="pseudoHalos"/>
+          <xs:enumeration value="reed2007"/>
+          <xs:enumeration value="rodriguezPuebla2016"/>
+          <xs:enumeration value="shethTormen"/>
+          <xs:enumeration value="simpleSystematic"/>
+          <xs:enumeration value="simulationVariance"/>
+          <xs:enumeration value="tinker2008"/>
+          <xs:enumeration value="tinker2008Form"/>
+          <xs:enumeration value="tinker2008Generic"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="haloModelPowerSpectrumModifier">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="triaxiality"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="haloSpinDistribution">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="bett2007"/>
+          <xs:enumeration value="deltaFunction"/>
+          <xs:enumeration value="logNormal"/>
+          <xs:enumeration value="nbodyErrors"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hiiRegionDensityDistribution">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="deltaFunction"/>
+          <xs:enumeration value="logNormal"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hiiRegionEscapeFraction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fixed"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hiiRegionLuminosityFunction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="powerLaw"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hiiRegionMassFunction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="rosolowsky2021"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloColdModeCoreRadii">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="virialFraction"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloColdModeMassDistribution">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="betaProfile"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloMassDistribution">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="betaProfile"/>
+          <xs:enumeration value="enzoHydrostatic"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="patejLoeb2015"/>
+          <xs:enumeration value="ricotti2000"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloMassDistributionCoreRadius">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="growing"/>
+          <xs:enumeration value="virialFraction"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloOutflowReincorporation">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="haloDynamicalTime"/>
+          <xs:enumeration value="henriques2013"/>
+          <xs:enumeration value="velocityMaximumScaling"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloOutflowStripping">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="standard"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloRamPressureForce">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="font2008"/>
+          <xs:enumeration value="orbitalPosition"/>
+          <xs:enumeration value="relativePosition"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloRamPressureStripping">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="font2008"/>
+          <xs:enumeration value="virialRadius"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloRamPressureTimescale">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="haloDynamicalTime"/>
+          <xs:enumeration value="ramPressureAcceleration"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="hotHaloTemperatureProfile">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="enzoHydrostatic"/>
+          <xs:enumeration value="virial"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="initialMassFunction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="BPASS"/>
+          <xs:enumeration value="baugh2005TopHeavy"/>
+          <xs:enumeration value="chabrier2001"/>
+          <xs:enumeration value="kennicutt1983"/>
+          <xs:enumeration value="kroupa2001"/>
+          <xs:enumeration value="millerScalo1979"/>
+          <xs:enumeration value="piecewisePowerLaw"/>
+          <xs:enumeration value="salpeter1955"/>
+          <xs:enumeration value="scalo1986"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="intergalacticMediumFilteringMass">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="gnedin2000"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="intergalacticMediumState">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="file"/>
+          <xs:enumeration value="instantReionization"/>
+          <xs:enumeration value="internal"/>
+          <xs:enumeration value="metallicityAstraeusV"/>
+          <xs:enumeration value="metallicityFixed"/>
+          <xs:enumeration value="metallicityPolynomial"/>
+          <xs:enumeration value="recFast"/>
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="kinematicsDistribution">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="NFW"/>
+          <xs:enumeration value="SIDMIsothermal"/>
+          <xs:enumeration value="burkert"/>
+          <xs:enumeration value="collisionless"/>
+          <xs:enumeration value="collisionlessTabulated"/>
+          <xs:enumeration value="cuspNFW"/>
+          <xs:enumeration value="enzoHydrostatic"/>
+          <xs:enumeration value="finiteResolutionNFW"/>
+          <xs:enumeration value="heated"/>
+          <xs:enumeration value="isothermal"/>
+          <xs:enumeration value="lam2013"/>
+          <xs:enumeration value="local"/>
+          <xs:enumeration value="shi2016"/>
+          <xs:enumeration value="soliton"/>
+          <xs:enumeration value="solitonNFW"/>
+          <xs:enumeration value="solitonNFWHeated"/>
+          <xs:enumeration value="sphericalScaler"/>
+          <xs:enumeration value="truncated"/>
+          <xs:enumeration value="undecorator"/>
+          <xs:enumeration value="zhao1996"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="linearGrowth">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="baryonsDarkMatter"/>
+          <xs:enumeration value="collisionlessMatter"/>
+          <xs:enumeration value="nonClusteringBaryonsDarkMatter"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="massDistribution">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="NFW"/>
+          <xs:enumeration value="SIDMParametricProfile"/>
+          <xs:enumeration value="betaProfile"/>
+          <xs:enumeration value="blackHole"/>
+          <xs:enumeration value="burkert"/>
+          <xs:enumeration value="cloudOverdensities"/>
+          <xs:enumeration value="composite"/>
+          <xs:enumeration value="constantDensityCloud"/>
+          <xs:enumeration value="coredNFW"/>
+          <xs:enumeration value="correlationFunction"/>
+          <xs:enumeration value="cuspNFW"/>
+          <xs:enumeration value="cylindrical"/>
+          <xs:enumeration value="cylindricalScaler"/>
+          <xs:enumeration value="diemerKravtsov2014"/>
+          <xs:enumeration value="einasto"/>
+          <xs:enumeration value="enzoHydrostatic"/>
+          <xs:enumeration value="exponentialDisk"/>
+          <xs:enumeration value="gaussianEllipsoid"/>
+          <xs:enumeration value="gaussianSlab"/>
+          <xs:enumeration value="hernquist"/>
+          <xs:enumeration value="isothermal"/>
+          <xs:enumeration value="miyamotoNagai"/>
+          <xs:enumeration value="patejLoeb2015"/>
+          <xs:enumeration value="sersic"/>
+          <xs:enumeration value="shi2016"/>
+          <xs:enumeration value="soliton"/>
+          <xs:enumeration value="solitonNFW"/>
+          <xs:enumeration value="solitonNFWHeated"/>
+          <xs:enumeration value="spherical"/>
+          <xs:enumeration value="sphericalAccelerator"/>
+          <xs:enumeration value="sphericalAccretionFlow"/>
+          <xs:enumeration value="sphericalAdiabaticGnedin2004"/>
+          <xs:enumeration value="sphericalDecaying"/>
+          <xs:enumeration value="sphericalDecorator"/>
+          <xs:enumeration value="sphericalFiniteResolution"/>
+          <xs:enumeration value="sphericalFiniteResolutionNFW"/>
+          <xs:enumeration value="sphericalHeated"/>
+          <xs:enumeration value="sphericalHeatedMonotonic"/>
+          <xs:enumeration value="sphericalSIDM"/>
+          <xs:enumeration value="sphericalSIDMCoreNFW"/>
+          <xs:enumeration value="sphericalSIDMIsothermal"/>
+          <xs:enumeration value="sphericalSIDMIsothermalBaryons"/>
+          <xs:enumeration value="sphericalScaler"/>
+          <xs:enumeration value="sphericalShellOverdensities"/>
+          <xs:enumeration value="sphericalTabulated"/>
+          <xs:enumeration value="sphericalTruncated"/>
+          <xs:enumeration value="sphericalTruncatedExponential"/>
+          <xs:enumeration value="zero"/>
+          <xs:enumeration value="zhao1996"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="massDistributionHeating">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="decayingDarkMatter"/>
+          <xs:enumeration value="impulsiveOutflow"/>
+          <xs:enumeration value="monotonic"/>
+          <xs:enumeration value="monotonicWeak"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="summation"/>
+          <xs:enumeration value="tidal"/>
+          <xs:enumeration value="twoBodyRelaxation"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="massFunctionIncompleteness">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="complete"/>
+          <xs:enumeration value="surfaceBrightness"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerMassMovements">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="baugh2005"/>
+          <xs:enumeration value="simple"/>
+          <xs:enumeration value="verySimple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerProgenitorProperties">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cole2000"/>
+          <xs:enumeration value="simple"/>
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerRemnantSize">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cole2000"/>
+          <xs:enumeration value="covington2008"/>
+          <xs:enumeration value="null"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeBranchingProbability">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="PCHPlus"/>
+          <xs:enumeration value="fakhouri2010"/>
+          <xs:enumeration value="gnrlzdPrssSchchtr"/>
+          <xs:enumeration value="parkinsonColeHelly"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeBranchingProbabilityModifier">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="PCHPlus"/>
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="multi"/>
+          <xs:enumeration value="parkinson2008"/>
+          <xs:enumeration value="zhang2014"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeBuildController">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="branchless"/>
+          <xs:enumeration value="constrained"/>
+          <xs:enumeration value="filtered"/>
+          <xs:enumeration value="mainBranch"/>
+          <xs:enumeration value="massTimeWindow"/>
+          <xs:enumeration value="multi"/>
+          <xs:enumeration value="outputTimeSnap"/>
+          <xs:enumeration value="singleStep"/>
+          <xs:enumeration value="subsample"/>
+          <xs:enumeration value="uncontrolled"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeBuildMassDistribution">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="gaussian"/>
+          <xs:enumeration value="haloMassFunction"/>
+          <xs:enumeration value="powerLaw"/>
+          <xs:enumeration value="stllrMssFnctn"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeBuildMasses">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fixedMass"/>
+          <xs:enumeration value="read"/>
+          <xs:enumeration value="readHDF5"/>
+          <xs:enumeration value="readXML"/>
+          <xs:enumeration value="replicate"/>
+          <xs:enumeration value="sampledDistribution"/>
+          <xs:enumeration value="sampledDistributionPseudoRandom"/>
+          <xs:enumeration value="sampledDistributionQuasiRandom"/>
+          <xs:enumeration value="sampledDistributionUniform"/>
+          <xs:enumeration value="subset"/>
+          <xs:enumeration value="union"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeBuilder">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cole2000"/>
+          <xs:enumeration value="cole2000Parallel"/>
+          <xs:enumeration value="constrained"/>
+          <xs:enumeration value="excursionSetSimulator"/>
+          <xs:enumeration value="smoothAccretion"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeConstructor">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="build"/>
+          <xs:enumeration value="filter"/>
+          <xs:enumeration value="fullySpecified"/>
+          <xs:enumeration value="read"/>
+          <xs:enumeration value="stateRestored"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeEvolveConcurrency">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="halosSubhalos"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeEvolveProfiler">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="simple"/>
+          <xs:enumeration value="tinySteps"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeEvolveTimestep">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="history"/>
+          <xs:enumeration value="hostTidalMassLoss"/>
+          <xs:enumeration value="lightconeCrossing"/>
+          <xs:enumeration value="multi"/>
+          <xs:enumeration value="recordEvolution"/>
+          <xs:enumeration value="satellite"/>
+          <xs:enumeration value="satelliteDestruction"/>
+          <xs:enumeration value="simple"/>
+          <xs:enumeration value="standard"/>
+          <xs:enumeration value="starFormationHistory"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeEvolver">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="nonEvolving"/>
+          <xs:enumeration value="standard"/>
+          <xs:enumeration value="threaded"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeFilter">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="all"/>
+          <xs:enumeration value="always"/>
+          <xs:enumeration value="any"/>
+          <xs:enumeration value="anyNode"/>
+          <xs:enumeration value="baseNode"/>
+          <xs:enumeration value="treeIndex"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeImporter">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="galacticus"/>
+          <xs:enumeration value="sussing"/>
+          <xs:enumeration value="sussingASCII"/>
+          <xs:enumeration value="sussingHDF5"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeInitializor">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeMassResolution">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="scaled"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeNodeEvolver">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeNodeMerger">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="multiLevelHierarchy"/>
+          <xs:enumeration value="singleLevelHierarchy"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeOperator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="assignOrbits"/>
+          <xs:enumeration value="augment"/>
+          <xs:enumeration value="conditionalMF"/>
+          <xs:enumeration value="consolidateBranches"/>
+          <xs:enumeration value="deforest"/>
+          <xs:enumeration value="dumpToGraphViz"/>
+          <xs:enumeration value="export"/>
+          <xs:enumeration value="informationContent"/>
+          <xs:enumeration value="massAccretionHistory"/>
+          <xs:enumeration value="monotonizeMassGrowth"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="outputRootMasses"/>
+          <xs:enumeration value="outputStructure"/>
+          <xs:enumeration value="particulate"/>
+          <xs:enumeration value="perturbMasses"/>
+          <xs:enumeration value="profiler"/>
+          <xs:enumeration value="pruneBaryons"/>
+          <xs:enumeration value="pruneBranchComplement"/>
+          <xs:enumeration value="pruneBranchTips"/>
+          <xs:enumeration value="pruneByMass"/>
+          <xs:enumeration value="pruneByMassAndTime"/>
+          <xs:enumeration value="pruneByTime"/>
+          <xs:enumeration value="pruneClones"/>
+          <xs:enumeration value="pruneHierarchy"/>
+          <xs:enumeration value="pruneLightcone"/>
+          <xs:enumeration value="pruneLightconeSnapshots"/>
+          <xs:enumeration value="pruneNonEssential"/>
+          <xs:enumeration value="regridTimes"/>
+          <xs:enumeration value="render"/>
+          <xs:enumeration value="scaleWeight"/>
+          <xs:enumeration value="selectWithinRange"/>
+          <xs:enumeration value="sequence"/>
+          <xs:enumeration value="treeProcessingTimer"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeOutputter">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="analyzer"/>
+          <xs:enumeration value="fullState"/>
+          <xs:enumeration value="haloFourierProfiles"/>
+          <xs:enumeration value="multi"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeSeeds">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="incremental"/>
+          <xs:enumeration value="random"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTreeWalker">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="allAndFormationNodes"/>
+          <xs:enumeration value="allNodes"/>
+          <xs:enumeration value="allNodesBranch"/>
+          <xs:enumeration value="isolatedNodes"/>
+          <xs:enumeration value="isolatedNodesBranch"/>
+          <xs:enumeration value="treeConstruction"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="metaTreeProcessingTime">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="file"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="totalEvolveTime"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="modelParameter">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="active"/>
+          <xs:enumeration value="derived"/>
+          <xs:enumeration value="inactive"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="nbodyHaloMassError">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="SOHaloFinder"/>
+          <xs:enumeration value="friendsOfFriends"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="powerLaw"/>
+          <xs:enumeration value="trenti2010"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="nbodyImporter">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="IRATE"/>
+          <xs:enumeration value="gadgetBinary"/>
+          <xs:enumeration value="gadgetHDF5"/>
+          <xs:enumeration value="merge"/>
+          <xs:enumeration value="millenniumCSV"/>
+          <xs:enumeration value="multiple"/>
+          <xs:enumeration value="random"/>
+          <xs:enumeration value="rockstar"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="nbodyOperator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="addAttributes"/>
+          <xs:enumeration value="angularMomentum"/>
+          <xs:enumeration value="concentrationDistributionFunction"/>
+          <xs:enumeration value="convexHull"/>
+          <xs:enumeration value="convexHullOverdensity"/>
+          <xs:enumeration value="convexHullVolume"/>
+          <xs:enumeration value="deleteProperties"/>
+          <xs:enumeration value="distanceFromPoint"/>
+          <xs:enumeration value="energyTensors"/>
+          <xs:enumeration value="environmentalOverdensity"/>
+          <xs:enumeration value="exportIRATE"/>
+          <xs:enumeration value="filterBox"/>
+          <xs:enumeration value="filterConvexHull"/>
+          <xs:enumeration value="filterID"/>
+          <xs:enumeration value="filterProperties"/>
+          <xs:enumeration value="filterUncontaminatedSphere"/>
+          <xs:enumeration value="flagAlwaysIsolated"/>
+          <xs:enumeration value="haloCrossingTime"/>
+          <xs:enumeration value="hostedRootID"/>
+          <xs:enumeration value="identifyFlybysMansfieldKravtsov2020"/>
+          <xs:enumeration value="inertiaTensor"/>
+          <xs:enumeration value="massFunction"/>
+          <xs:enumeration value="massFunctionCorrelation"/>
+          <xs:enumeration value="massTotal"/>
+          <xs:enumeration value="meanPosition"/>
+          <xs:enumeration value="mergerRates"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="pairCounts"/>
+          <xs:enumeration value="pairwiseVelocityStatistics"/>
+          <xs:enumeration value="physicalToComoving"/>
+          <xs:enumeration value="potentialEnergy"/>
+          <xs:enumeration value="progenitorMassFunction"/>
+          <xs:enumeration value="progenitorOrderStatistics"/>
+          <xs:enumeration value="rotationCurve"/>
+          <xs:enumeration value="selectProperties"/>
+          <xs:enumeration value="selfBound"/>
+          <xs:enumeration value="selfBoundBarnesHut"/>
+          <xs:enumeration value="selfFrictionAcceleration"/>
+          <xs:enumeration value="sequence"/>
+          <xs:enumeration value="setBoxSize"/>
+          <xs:enumeration value="shiftProperty"/>
+          <xs:enumeration value="simulationSelector"/>
+          <xs:enumeration value="spinDistributionFunction"/>
+          <xs:enumeration value="subhaloMassFunction"/>
+          <xs:enumeration value="subhaloRadiusFunction"/>
+          <xs:enumeration value="subhaloVelocityMaximumMeanFunction"/>
+          <xs:enumeration value="subsample"/>
+          <xs:enumeration value="timeFormation"/>
+          <xs:enumeration value="timeLastMajorMerger"/>
+          <xs:enumeration value="timeOfFormation"/>
+          <xs:enumeration value="timeSinceFormationFractional"/>
+          <xs:enumeration value="velocityDispersion"/>
+          <xs:enumeration value="virialCrossingOrbitStatistics"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="nodeOperator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="CGMAccretion"/>
+          <xs:enumeration value="CGMChemistry"/>
+          <xs:enumeration value="CGMColdModeInflow"/>
+          <xs:enumeration value="CGMCoolingHeating"/>
+          <xs:enumeration value="CGMOuterRadiusRamPressureStripping"/>
+          <xs:enumeration value="CGMOuterRadiusVirialRadius"/>
+          <xs:enumeration value="CGMOutflowReincorporation"/>
+          <xs:enumeration value="CGMStarvation"/>
+          <xs:enumeration value="DMOInterpolate"/>
+          <xs:enumeration value="DMOUninterpolated"/>
+          <xs:enumeration value="SIDMParametric"/>
+          <xs:enumeration value="agesStellarMassWeighted"/>
+          <xs:enumeration value="assemblyHistoryHeuristics"/>
+          <xs:enumeration value="barInstability"/>
+          <xs:enumeration value="bertschingerMass"/>
+          <xs:enumeration value="blackHolesAccretion"/>
+          <xs:enumeration value="blackHolesRadialMigration"/>
+          <xs:enumeration value="blackHolesSeed"/>
+          <xs:enumeration value="blackHolesTripleInteraction"/>
+          <xs:enumeration value="blackHolesWinds"/>
+          <xs:enumeration value="branchMostMassive"/>
+          <xs:enumeration value="cleanSubsampleStubs"/>
+          <xs:enumeration value="constrainedBranch"/>
+          <xs:enumeration value="coolingEnergyRadiated"/>
+          <xs:enumeration value="cosmicTime"/>
+          <xs:enumeration value="darkMatterProfileInitialize"/>
+          <xs:enumeration value="darkMatterProfilePromptCusps"/>
+          <xs:enumeration value="darkMatterProfileScaleInterpolate"/>
+          <xs:enumeration value="darkMatterProfileScaleSet"/>
+          <xs:enumeration value="darkMatterProfileShapeInterpolate"/>
+          <xs:enumeration value="darkMatterProfileShapeSet"/>
+          <xs:enumeration value="darkMatterProfileSoliton"/>
+          <xs:enumeration value="diskRadiusPowerLaw"/>
+          <xs:enumeration value="diskVerySimpleAnalyticSolver"/>
+          <xs:enumeration value="empiricalCentralDisk"/>
+          <xs:enumeration value="empiricalGalaxyUniverseMachine"/>
+          <xs:enumeration value="empiricalMassiveElliptical"/>
+          <xs:enumeration value="evolutionOutput"/>
+          <xs:enumeration value="excursion"/>
+          <xs:enumeration value="filtered"/>
+          <xs:enumeration value="filteredMainBranch"/>
+          <xs:enumeration value="galaxyGasMajorMergerTime"/>
+          <xs:enumeration value="galaxyMajorMergerTime"/>
+          <xs:enumeration value="galaxyMergerTree"/>
+          <xs:enumeration value="galaxyMergers"/>
+          <xs:enumeration value="haloAngularMomentumInterpolate"/>
+          <xs:enumeration value="haloAngularMomentumRandom"/>
+          <xs:enumeration value="haloAngularMomentumRandomWalk"/>
+          <xs:enumeration value="haloAngularMomentumVitvitska2002"/>
+          <xs:enumeration value="haloAxisRatiosInterpolate"/>
+          <xs:enumeration value="haloAxisRatiosMenkerBenson2022"/>
+          <xs:enumeration value="hierarchy"/>
+          <xs:enumeration value="impulsiveOutflowEnergy"/>
+          <xs:enumeration value="indexBranchTip"/>
+          <xs:enumeration value="indexLastHost"/>
+          <xs:enumeration value="indexShift"/>
+          <xs:enumeration value="label"/>
+          <xs:enumeration value="massAccretionHistory"/>
+          <xs:enumeration value="massBoundMaximum"/>
+          <xs:enumeration value="massCooled"/>
+          <xs:enumeration value="massHostMaximum"/>
+          <xs:enumeration value="massProgenitorMaximum"/>
+          <xs:enumeration value="multi"/>
+          <xs:enumeration value="nodeFormationTimeCole2000"/>
+          <xs:enumeration value="nodeFormationTimeMassFraction"/>
+          <xs:enumeration value="nodeMajorMergerRecentCount"/>
+          <xs:enumeration value="nodeMajorMergerTime"/>
+          <xs:enumeration value="nuclearStarClusterGrowth"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="positionDiscrete"/>
+          <xs:enumeration value="positionInterpolated"/>
+          <xs:enumeration value="positionOrphans"/>
+          <xs:enumeration value="positionToHost"/>
+          <xs:enumeration value="positionTraceDarkMatter"/>
+          <xs:enumeration value="presetNamedShift"/>
+          <xs:enumeration value="radiusVirialLastDefined"/>
+          <xs:enumeration value="ramPressureMassLossDisks"/>
+          <xs:enumeration value="ramPressureMassLossSpheroids"/>
+          <xs:enumeration value="satelliteDecelerationSIDM"/>
+          <xs:enumeration value="satelliteDestructionDensityProfileThreshold"/>
+          <xs:enumeration value="satelliteDestructionMassThreshold"/>
+          <xs:enumeration value="satelliteDynamicalFriction"/>
+          <xs:enumeration value="satelliteEvaporationSIDM"/>
+          <xs:enumeration value="satelliteMassLoss"/>
+          <xs:enumeration value="satelliteMergingRadiusTrigger"/>
+          <xs:enumeration value="satelliteMergingSoliton"/>
+          <xs:enumeration value="satelliteMergingTime"/>
+          <xs:enumeration value="satelliteMinimumDistance"/>
+          <xs:enumeration value="satelliteOrbit"/>
+          <xs:enumeration value="satelliteOrphanize"/>
+          <xs:enumeration value="satelliteSubsampling"/>
+          <xs:enumeration value="satelliteTidalHeating"/>
+          <xs:enumeration value="satelliteTidalMassLoss"/>
+          <xs:enumeration value="spheroidRadiusPowerLaw"/>
+          <xs:enumeration value="starFormationDisks"/>
+          <xs:enumeration value="starFormationNuclearStarClusters"/>
+          <xs:enumeration value="starFormationRateInterOutput"/>
+          <xs:enumeration value="starFormationSpheroids"/>
+          <xs:enumeration value="stellarFeedbackDisks"/>
+          <xs:enumeration value="stellarFeedbackSpheroids"/>
+          <xs:enumeration value="subsubhaloPromotion"/>
+          <xs:enumeration value="tidalHeatingSpheroids"/>
+          <xs:enumeration value="tidalMassLossDisks"/>
+          <xs:enumeration value="tidalMassLossSoliton"/>
+          <xs:enumeration value="tidalMassLossSpheroids"/>
+          <xs:enumeration value="timeFirstInfall"/>
+          <xs:enumeration value="trackOutflowedMass"/>
+          <xs:enumeration value="uniqueIDBranchTip"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="nodePropertyExtractor">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="CGMCoolingFunction"/>
+          <xs:enumeration value="ICMCoolingPowerInBand"/>
+          <xs:enumeration value="ICMOpticalDepthLymanAlpha"/>
+          <xs:enumeration value="ICMSZ"/>
+          <xs:enumeration value="ICMXRayLuminosity"/>
+          <xs:enumeration value="ICMXRayTemperature"/>
+          <xs:enumeration value="SED"/>
+          <xs:enumeration value="SEDAGN"/>
+          <xs:enumeration value="SIDMParametric"/>
+          <xs:enumeration value="adiabaticRatioOrbitalDisk"/>
+          <xs:enumeration value="agesStellarMassWeighted"/>
+          <xs:enumeration value="appendSuffix"/>
+          <xs:enumeration value="array"/>
+          <xs:enumeration value="blackHoleFormationChannel"/>
+          <xs:enumeration value="blackHoleSeedingVergara2023"/>
+          <xs:enumeration value="branchMostMassive"/>
+          <xs:enumeration value="concentration"/>
+          <xs:enumeration value="constrainedStatus"/>
+          <xs:enumeration value="coolingEnergyRadiated"/>
+          <xs:enumeration value="darkMatterProfileRadiusInteractionSIDM"/>
+          <xs:enumeration value="darkMatterProfileScaleRadius"/>
+          <xs:enumeration value="darkMatterProfileShapeParameter"/>
+          <xs:enumeration value="densityContrastVirial"/>
+          <xs:enumeration value="densityContrasts"/>
+          <xs:enumeration value="densityDMOProfile"/>
+          <xs:enumeration value="densityProfile"/>
+          <xs:enumeration value="descendantNode"/>
+          <xs:enumeration value="descendants"/>
+          <xs:enumeration value="excursion"/>
+          <xs:enumeration value="finalDescendant"/>
+          <xs:enumeration value="fluxFromLuminosity"/>
+          <xs:enumeration value="fractionAccretionHotMode"/>
+          <xs:enumeration value="galaxyGasMajorMergerTime"/>
+          <xs:enumeration value="galaxyMajorMergerTime"/>
+          <xs:enumeration value="galaxyMergerTree"/>
+          <xs:enumeration value="galaxyMergerTreeIndices"/>
+          <xs:enumeration value="galaxyMergerTreeMergerIndices"/>
+          <xs:enumeration value="galaxyMergerTreeMergerPhysical"/>
+          <xs:enumeration value="galaxyMergerTreePhysical"/>
+          <xs:enumeration value="galaxyMergers"/>
+          <xs:enumeration value="galaxyMergersIndices"/>
+          <xs:enumeration value="galaxyMergersPhysical"/>
+          <xs:enumeration value="haloBias"/>
+          <xs:enumeration value="haloCollapseEpoch"/>
+          <xs:enumeration value="haloEnvironment"/>
+          <xs:enumeration value="hierarchy"/>
+          <xs:enumeration value="hostNode"/>
+          <xs:enumeration value="indexBranchTip"/>
+          <xs:enumeration value="indexLastHost"/>
+          <xs:enumeration value="indicesHost"/>
+          <xs:enumeration value="indicesTree"/>
+          <xs:enumeration value="integerList"/>
+          <xs:enumeration value="integerScalar"/>
+          <xs:enumeration value="integerTuple"/>
+          <xs:enumeration value="isInLightcone"/>
+          <xs:enumeration value="isPhysicallyPlausible"/>
+          <xs:enumeration value="jetPowerBlackHoles"/>
+          <xs:enumeration value="keplerOrbit"/>
+          <xs:enumeration value="labels"/>
+          <xs:enumeration value="lightcone"/>
+          <xs:enumeration value="list"/>
+          <xs:enumeration value="list2D"/>
+          <xs:enumeration value="lmnstyEmssnLineAGN"/>
+          <xs:enumeration value="lmnstyEmssnLinePanuzzo2003"/>
+          <xs:enumeration value="lmnstyStllrCF2000"/>
+          <xs:enumeration value="luminosityEmissionLine"/>
+          <xs:enumeration value="luminosityStellar"/>
+          <xs:enumeration value="luminosityStellarFromSED"/>
+          <xs:enumeration value="magnitudesAbsolute"/>
+          <xs:enumeration value="magnitudesApparent"/>
+          <xs:enumeration value="mainBranchStatus"/>
+          <xs:enumeration value="massAccretionHistory"/>
+          <xs:enumeration value="massAccretionHistoryHearin2021"/>
+          <xs:enumeration value="massAccretionRateBlackHoles"/>
+          <xs:enumeration value="massBasic"/>
+          <xs:enumeration value="massBertschinger"/>
+          <xs:enumeration value="massBlackHole"/>
+          <xs:enumeration value="massBlackHoles"/>
+          <xs:enumeration value="massBound"/>
+          <xs:enumeration value="massBoundMaximum"/>
+          <xs:enumeration value="massCooled"/>
+          <xs:enumeration value="massHalo"/>
+          <xs:enumeration value="massHost"/>
+          <xs:enumeration value="massHostMaximum"/>
+          <xs:enumeration value="massISM"/>
+          <xs:enumeration value="massProfile"/>
+          <xs:enumeration value="massProgenitorMaximum"/>
+          <xs:enumeration value="massStellar"/>
+          <xs:enumeration value="massStellarMorphology"/>
+          <xs:enumeration value="massStellarSpheroid"/>
+          <xs:enumeration value="mergedSubhaloProperties"/>
+          <xs:enumeration value="metallicityISM"/>
+          <xs:enumeration value="metallicityStellar"/>
+          <xs:enumeration value="mostMassiveProgenitor"/>
+          <xs:enumeration value="multi"/>
+          <xs:enumeration value="nodeFormationTime"/>
+          <xs:enumeration value="nodeIndices"/>
+          <xs:enumeration value="nodeMajorMergerRecentCount"/>
+          <xs:enumeration value="nodeMajorMergerTime"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="outputSelector"/>
+          <xs:enumeration value="peakHeight"/>
+          <xs:enumeration value="positionOrbital"/>
+          <xs:enumeration value="presetNamedIntegers"/>
+          <xs:enumeration value="presetNamedReals"/>
+          <xs:enumeration value="projectedDensity"/>
+          <xs:enumeration value="projectedMass"/>
+          <xs:enumeration value="promptCusps"/>
+          <xs:enumeration value="radiativeEfficiencyBlackHoles"/>
+          <xs:enumeration value="radiiHalfLightProperties"/>
+          <xs:enumeration value="radiusBlackHoles"/>
+          <xs:enumeration value="radiusBoundMass"/>
+          <xs:enumeration value="radiusCooling"/>
+          <xs:enumeration value="radiusEffectiveStellar"/>
+          <xs:enumeration value="radiusEinstein"/>
+          <xs:enumeration value="radiusHalfMassGalactic"/>
+          <xs:enumeration value="radiusHalfMassStellar"/>
+          <xs:enumeration value="radiusOrbital"/>
+          <xs:enumeration value="radiusOrbitalProjected"/>
+          <xs:enumeration value="radiusTidal"/>
+          <xs:enumeration value="radiusVelocityMaximum"/>
+          <xs:enumeration value="radiusVirial"/>
+          <xs:enumeration value="radiusVirialLastDefined"/>
+          <xs:enumeration value="rateCooling"/>
+          <xs:enumeration value="rateInfallColdMode"/>
+          <xs:enumeration value="ratio"/>
+          <xs:enumeration value="redshift"/>
+          <xs:enumeration value="redshiftLastIsolated"/>
+          <xs:enumeration value="rotationCurve"/>
+          <xs:enumeration value="satelliteDynamicalTime"/>
+          <xs:enumeration value="satelliteMinimumDistance"/>
+          <xs:enumeration value="satelliteOrbitalExtrema"/>
+          <xs:enumeration value="satelliteStatus"/>
+          <xs:enumeration value="satelliteVirialOrbit"/>
+          <xs:enumeration value="scalar"/>
+          <xs:enumeration value="scalarizer"/>
+          <xs:enumeration value="soliton"/>
+          <xs:enumeration value="speedOrbital"/>
+          <xs:enumeration value="spin"/>
+          <xs:enumeration value="spinBlackHoles"/>
+          <xs:enumeration value="spinBullock"/>
+          <xs:enumeration value="starFormationHistory"/>
+          <xs:enumeration value="starFormationHistoryMass"/>
+          <xs:enumeration value="starFormationHistoryTimes"/>
+          <xs:enumeration value="starFormationRate"/>
+          <xs:enumeration value="starFormationRateInterOutput"/>
+          <xs:enumeration value="stellarFeedbackOutflowRate"/>
+          <xs:enumeration value="tidalField"/>
+          <xs:enumeration value="tidallyTruncatedNFWFit"/>
+          <xs:enumeration value="time"/>
+          <xs:enumeration value="timeFirstInfall"/>
+          <xs:enumeration value="timescaleBarInstability"/>
+          <xs:enumeration value="trackOutflowedMass"/>
+          <xs:enumeration value="treeWeight"/>
+          <xs:enumeration value="tuple"/>
+          <xs:enumeration value="uniqueIDBranchTip"/>
+          <xs:enumeration value="velocityDispersion"/>
+          <xs:enumeration value="velocityMaximum"/>
+          <xs:enumeration value="velocityOrbital"/>
+          <xs:enumeration value="virialProperties"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="nuclearStarClusterGrowthRates">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="antonini2015"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="operatorUnary">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="inverse"/>
+          <xs:enumeration value="logarithm"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="outputAnalysis">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="HIVsHaloMassRelationPadmanabhan2017"/>
+          <xs:enumeration value="ICMXrayLuminosityTemperature"/>
+          <xs:enumeration value="blackHoleBulgeRelation"/>
+          <xs:enumeration value="blackHoleVelocityDispersionRelation"/>
+          <xs:enumeration value="blackHoleVsHaloMassRelation"/>
+          <xs:enumeration value="colorDistributionSDSS"/>
+          <xs:enumeration value="concentrationDistribution"/>
+          <xs:enumeration value="concentrationDistributionCDMCOCO"/>
+          <xs:enumeration value="concentrationVsHaloMassCDMLudlow2016"/>
+          <xs:enumeration value="correlationFunction"/>
+          <xs:enumeration value="correlationFunctionHearin2013SDSS"/>
+          <xs:enumeration value="crossCorrelator1D"/>
+          <xs:enumeration value="formationTimeDistribution"/>
+          <xs:enumeration value="galaxySizesSDSS"/>
+          <xs:enumeration value="heatedLikelihood"/>
+          <xs:enumeration value="localGroupMassMetallicityRelation"/>
+          <xs:enumeration value="localGroupMassSizeRelation"/>
+          <xs:enumeration value="localGroupMassVelocityDispersionRelation"/>
+          <xs:enumeration value="localGroupOccupationFraction"/>
+          <xs:enumeration value="localGroupStellarMassFunction"/>
+          <xs:enumeration value="localGroupStellarMassHaloMassRelation"/>
+          <xs:enumeration value="luminosityFunction"/>
+          <xs:enumeration value="luminosityFunctionGunawardhana2013SDSS"/>
+          <xs:enumeration value="luminosityFunctionHalpha"/>
+          <xs:enumeration value="luminosityFunctionMonteroDorta2009SDSS"/>
+          <xs:enumeration value="luminosityFunctionSobral2013HiZELS"/>
+          <xs:enumeration value="luminosityFunctionStefanonMarchesini2013"/>
+          <xs:enumeration value="massFunctionHI"/>
+          <xs:enumeration value="massFunctionHIALFALFAMartin2010"/>
+          <xs:enumeration value="massFunctionStellar"/>
+          <xs:enumeration value="massFunctionStellarBaldry2012GAMA"/>
+          <xs:enumeration value="massFunctionStellarBernardi2013SDSS"/>
+          <xs:enumeration value="massFunctionStellarPRIMUS"/>
+          <xs:enumeration value="massFunctionStellarSDSS"/>
+          <xs:enumeration value="massFunctionStellarUKIDSSUDS"/>
+          <xs:enumeration value="massFunctionStellarULTRAVISTA"/>
+          <xs:enumeration value="massFunctionStellarVIPERS"/>
+          <xs:enumeration value="massFunctionStellarZFOURGE"/>
+          <xs:enumeration value="massMetallicityAndrews2013"/>
+          <xs:enumeration value="massMetallicityBlanc2019"/>
+          <xs:enumeration value="massSizeRelationShen2003"/>
+          <xs:enumeration value="meanFunction1D"/>
+          <xs:enumeration value="morphologicalFractionGAMAMoffett2016"/>
+          <xs:enumeration value="multi"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="progenitorMassFunction"/>
+          <xs:enumeration value="quiescentFraction"/>
+          <xs:enumeration value="quiescentFractionWagner2016"/>
+          <xs:enumeration value="satelliteBoundMass"/>
+          <xs:enumeration value="satelliteRadiusVelocityMaximum"/>
+          <xs:enumeration value="satelliteVelocityMaximum"/>
+          <xs:enumeration value="scatterFunction1D"/>
+          <xs:enumeration value="sizeVsStellarMassRelation"/>
+          <xs:enumeration value="spinDistribution"/>
+          <xs:enumeration value="spinDistributionBett2007"/>
+          <xs:enumeration value="starFormationRateFunction"/>
+          <xs:enumeration value="starFormationRateFunctionRobotham2011"/>
+          <xs:enumeration value="starFormingMainSequence"/>
+          <xs:enumeration value="starFormingMainSequenceSchreiber2015"/>
+          <xs:enumeration value="starFormingMainSequenceWagner2016"/>
+          <xs:enumeration value="stellarVsHaloMassRelation"/>
+          <xs:enumeration value="stellarVsHaloMassRelationLeauthaud2012"/>
+          <xs:enumeration value="subhaloMassFunction"/>
+          <xs:enumeration value="subhaloRadialDistribution"/>
+          <xs:enumeration value="subhaloVMaxVsMass"/>
+          <xs:enumeration value="sunyaevZeldovichPlanck2013"/>
+          <xs:enumeration value="tidalTracksVelocityMaximum"/>
+          <xs:enumeration value="volumeFunction1D"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="outputAnalysisDistributionNormalizer">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="binWidth"/>
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="log10ToLog"/>
+          <xs:enumeration value="sequence"/>
+          <xs:enumeration value="unitarity"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="outputAnalysisDistributionOperator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="diskSizeInclntn"/>
+          <xs:enumeration value="grvtnlLnsng"/>
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="massIncompleteness"/>
+          <xs:enumeration value="massRatioNBody"/>
+          <xs:enumeration value="randomError"/>
+          <xs:enumeration value="randomErrorALFLF"/>
+          <xs:enumeration value="randomErrorFixed"/>
+          <xs:enumeration value="randomErrorPlynml"/>
+          <xs:enumeration value="rndmErrNbdyCnc"/>
+          <xs:enumeration value="rndmErrNbodyMass"/>
+          <xs:enumeration value="sequence"/>
+          <xs:enumeration value="spinNBodyErrors"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="outputAnalysisMolecularRatio">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="obreschkow2009"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="outputAnalysisPropertyOperator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="HIMass"/>
+          <xs:enumeration value="antiLog10"/>
+          <xs:enumeration value="boolean"/>
+          <xs:enumeration value="cosmologySZ"/>
+          <xs:enumeration value="csmlgyAnglrDstnc"/>
+          <xs:enumeration value="csmlgyLmnstyDstnc"/>
+          <xs:enumeration value="filterHighPass"/>
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="log10"/>
+          <xs:enumeration value="magnitude"/>
+          <xs:enumeration value="metallicity12LogNH"/>
+          <xs:enumeration value="metallicitySolarRelative"/>
+          <xs:enumeration value="minMax"/>
+          <xs:enumeration value="multiply"/>
+          <xs:enumeration value="normal"/>
+          <xs:enumeration value="sequence"/>
+          <xs:enumeration value="square"/>
+          <xs:enumeration value="systmtcPolynomial"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="outputAnalysisTargetData">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="outputAnalysisWeightOperator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="csmlgyVolume"/>
+          <xs:enumeration value="filterHighPass"/>
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="nbodyMass"/>
+          <xs:enumeration value="normal"/>
+          <xs:enumeration value="property"/>
+          <xs:enumeration value="sequence"/>
+          <xs:enumeration value="subsampling"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="outputTimes">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="list"/>
+          <xs:enumeration value="logarithmicSpacingInCriticalOverdensity"/>
+          <xs:enumeration value="logarithmicSpacingInRedshift"/>
+          <xs:enumeration value="simulationSnapshots"/>
+          <xs:enumeration value="uniformSpacingInRedshift"/>
+          <xs:enumeration value="uniformSpacingInTime"/>
+          <xs:enumeration value="union"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSampleConvergence">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="always"/>
+          <xs:enumeration value="gelmanRubin"/>
+          <xs:enumeration value="likelihoodThreshold"/>
+          <xs:enumeration value="never"/>
+          <xs:enumeration value="stepCount"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSampleDffrntlEvltnProposalSize">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="adaptive"/>
+          <xs:enumeration value="fixed"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSampleDffrntlEvltnPrpslSzTmpExp">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="adaptive"/>
+          <xs:enumeration value="fixed"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSampleDffrntlEvltnRandomJump">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="adaptive"/>
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSampleLikelihood">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="SEDFit"/>
+          <xs:enumeration value="baseParameters"/>
+          <xs:enumeration value="galaxyPopulation"/>
+          <xs:enumeration value="gaussianRegression"/>
+          <xs:enumeration value="haloMassFunction"/>
+          <xs:enumeration value="heated"/>
+          <xs:enumeration value="independentLikelihoods"/>
+          <xs:enumeration value="indpndntLklhdsSqntl"/>
+          <xs:enumeration value="massFunction"/>
+          <xs:enumeration value="mltiVrtNormalStochastic"/>
+          <xs:enumeration value="multivariateNormal"/>
+          <xs:enumeration value="posteriorAsPrior"/>
+          <xs:enumeration value="prjctdCorrelationFunction"/>
+          <xs:enumeration value="spinDistribution"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSampleSimulation">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="annealedDffrntlEvltn"/>
+          <xs:enumeration value="differentialEvolution"/>
+          <xs:enumeration value="grid"/>
+          <xs:enumeration value="initialState"/>
+          <xs:enumeration value="particleSwarm"/>
+          <xs:enumeration value="stochasticDffrntlEvltn"/>
+          <xs:enumeration value="temperedDffrntlEvltn"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSampleState">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="correlation"/>
+          <xs:enumeration value="history"/>
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSampleStateInitialize">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="gaussianSphere"/>
+          <xs:enumeration value="latinHypercube"/>
+          <xs:enumeration value="maximumLikelihood"/>
+          <xs:enumeration value="parameterFile"/>
+          <xs:enumeration value="posteriorMaximumGaussianSphere"/>
+          <xs:enumeration value="priorRandom"/>
+          <xs:enumeration value="resume"/>
+          <xs:enumeration value="switched"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSampleStoppingCriterion">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="correlationLength"/>
+          <xs:enumeration value="never"/>
+          <xs:enumeration value="stepCount"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="posteriorSamples">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="latinHypercube"/>
+          <xs:enumeration value="priorGrid"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="powerSpectrum">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="powerSpectrumNonlinear">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cosmicEmu"/>
+          <xs:enumeration value="linear"/>
+          <xs:enumeration value="peacockDodds1996"/>
+          <xs:enumeration value="smith2003"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="powerSpectrumPrimordial">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cosmologicalCube"/>
+          <xs:enumeration value="piecewisePowerLaw"/>
+          <xs:enumeration value="powerLaw"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="powerSpectrumPrimordialTransferred">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="file"/>
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="powerSpectrumWindowFunction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="ETHOS"/>
+          <xs:enumeration value="ETHOSExtended"/>
+          <xs:enumeration value="hyperbolicTangent"/>
+          <xs:enumeration value="lagrangianChan2017"/>
+          <xs:enumeration value="sharpKSpace"/>
+          <xs:enumeration value="smoothKSpace"/>
+          <xs:enumeration value="topHat"/>
+          <xs:enumeration value="topHatGeneralized"/>
+          <xs:enumeration value="topHatSharpKHybrid"/>
+          <xs:enumeration value="topHatSmoothed"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="radiationField">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="blackBody"/>
+          <xs:enumeration value="cosmicMicrowaveBackground"/>
+          <xs:enumeration value="intergalacticBackground"/>
+          <xs:enumeration value="intergalacticBackgroundFile"/>
+          <xs:enumeration value="intergalacticBackgroundInternal"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="summation"/>
+          <xs:enumeration value="switchOn"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="radiativeTransferConvergence">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="always"/>
+          <xs:enumeration value="hydrogenRecombinationRate"/>
+          <xs:enumeration value="lycEscape"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="radiativeTransferMatter">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="atomic"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="radiativeTransferOutputter">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="continuuaRates"/>
+          <xs:enumeration value="lymanContinuumRate"/>
+          <xs:enumeration value="multi"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="spectrum"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="radiativeTransferPhotonPacket">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="radiativeTransferSource">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="distributed"/>
+          <xs:enumeration value="point"/>
+          <xs:enumeration value="summation"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="radiativeTransferSpectrum">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="accretionDisk"/>
+          <xs:enumeration value="bandPassFilter"/>
+          <xs:enumeration value="blackBody"/>
+          <xs:enumeration value="powerLaw"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="ramPressureStripping">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="simpleCylindrical"/>
+          <xs:enumeration value="simpleSpherical"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="randomNumberGenerator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="GSL"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteDecelerationSIDM">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="kummer2018"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteDynamicalFriction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="chandrasekhar1943"/>
+          <xs:enumeration value="kaur2018"/>
+          <xs:enumeration value="massRatioThreshold"/>
+          <xs:enumeration value="petts2015"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteEvaporationSIDM">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="kummer2018"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteMassBoundInitializor">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="basicMass"/>
+          <xs:enumeration value="densityContrast"/>
+          <xs:enumeration value="maximumRadius"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteMergingTimescales">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="boylanKolchin2008"/>
+          <xs:enumeration value="infinite"/>
+          <xs:enumeration value="jiang2008"/>
+          <xs:enumeration value="laceyCole1993"/>
+          <xs:enumeration value="laceyCole1993Tormen"/>
+          <xs:enumeration value="poulton2021"/>
+          <xs:enumeration value="preset"/>
+          <xs:enumeration value="random"/>
+          <xs:enumeration value="villalobos2013"/>
+          <xs:enumeration value="wetzelWhite2010"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteOrphanDistribution">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="randomIsotropic"/>
+          <xs:enumeration value="traceDarkMatter"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteTidalField">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="sphericalSymmetry"/>
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteTidalHeatingRate">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="gnedin1999"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteTidalStripping">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="zentner2005"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="satelliteTidalStrippingRadius">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="king1962"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="sphericalCollapseSolver">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="baryonsDarkMatterDarkEnergy"/>
+          <xs:enumeration value="cllsnlssMttrCsmlgclCnstnt"/>
+          <xs:enumeration value="cllsnlssMttrDarkEnergy"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="starFormationActiveMass">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="surfaceDensityThreshold"/>
+          <xs:enumeration value="totalISM"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="starFormationHistory">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="adaptive"/>
+          <xs:enumeration value="fixedAges"/>
+          <xs:enumeration value="inSitu"/>
+          <xs:enumeration value="metallicitySplit"/>
+          <xs:enumeration value="null"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="starFormationRateDisks">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="centralsOnly"/>
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="intgrtdSurfaceDensity"/>
+          <xs:enumeration value="timescale"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="starFormationRateNuclearStarClusters">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="krumholz2009"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="starFormationRateSpheroids">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="centralsOnly"/>
+          <xs:enumeration value="timescale"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="starFormationRateSurfaceDensityDisks">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="blitz2006"/>
+          <xs:enumeration value="extendedSchmidt"/>
+          <xs:enumeration value="kennicuttSchmidt"/>
+          <xs:enumeration value="krumholz2009"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="starFormationTimescale">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="baugh2005"/>
+          <xs:enumeration value="dynamicalTime"/>
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="haloScaling"/>
+          <xs:enumeration value="lowerLimited"/>
+          <xs:enumeration value="velocityMaxScaling"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarAstrophysics">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="file"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarFeedback">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="instantCanonical"/>
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarFeedbackOutflows">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="creasey2013"/>
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="haloScaling"/>
+          <xs:enumeration value="haloScalingFormationHalo"/>
+          <xs:enumeration value="massLoadingLimit"/>
+          <xs:enumeration value="powerLaw"/>
+          <xs:enumeration value="powerLawRedshiftScaling"/>
+          <xs:enumeration value="rateLimit"/>
+          <xs:enumeration value="summation"/>
+          <xs:enumeration value="superWind"/>
+          <xs:enumeration value="vlctyMxSclng"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarPopulation">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarPopulationBroadBandLuminosities">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="standard"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarPopulationProperties">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="instantaneous"/>
+          <xs:enumeration value="noninstantaneous"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarPopulationSelector">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="diskSpheroid"/>
+          <xs:enumeration value="fixed"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarPopulationSpectra">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="FSPS"/>
+          <xs:enumeration value="file"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarPopulationSpectraPostprocessor">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="ageWindow"/>
+          <xs:enumeration value="birthCloudsLacey2016"/>
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="inoue2014"/>
+          <xs:enumeration value="lycSuppress"/>
+          <xs:enumeration value="madau1995"/>
+          <xs:enumeration value="meiksin2006"/>
+          <xs:enumeration value="recent"/>
+          <xs:enumeration value="sequence"/>
+          <xs:enumeration value="unescaped"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarPopulationSpectraPostprocessorBuilder">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="lookup"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarSpectraDustAttenuation">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="calzetti2000"/>
+          <xs:enumeration value="cardelli1989"/>
+          <xs:enumeration value="charlotFall2000"/>
+          <xs:enumeration value="gordon2003"/>
+          <xs:enumeration value="prevotBouchet"/>
+          <xs:enumeration value="tabulated"/>
+          <xs:enumeration value="wittGordon2000"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarTracks">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="file"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="stellarWinds">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="leitherer1992"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="supernovaePopulationIII">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="hegerWoosley2002"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="supernovaeTypeIa">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="differentialDTD"/>
+          <xs:enumeration value="fixedYield"/>
+          <xs:enumeration value="massIndependentDTD"/>
+          <xs:enumeration value="nagashima2005"/>
+          <xs:enumeration value="powerLawDTD"/>
+          <xs:enumeration value="powerLawDTDDifferential"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="surveyGeometry">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="baldry2012GAMA"/>
+          <xs:enumeration value="bernardi2013SDSS"/>
+          <xs:enumeration value="caputi2011UKIDSSUDS"/>
+          <xs:enumeration value="combined"/>
+          <xs:enumeration value="davidzon2013VIPERS"/>
+          <xs:enumeration value="fullSky"/>
+          <xs:enumeration value="gunawardhana2013SDSS"/>
+          <xs:enumeration value="hearin2014SDSS"/>
+          <xs:enumeration value="kelvin2014GAMAnear"/>
+          <xs:enumeration value="liWhite2009SDSS"/>
+          <xs:enumeration value="localGroupClassical"/>
+          <xs:enumeration value="localGroupDES"/>
+          <xs:enumeration value="localGroupSDSS"/>
+          <xs:enumeration value="mangle"/>
+          <xs:enumeration value="martin2010ALFALFA"/>
+          <xs:enumeration value="monteroDorta2009SDSS"/>
+          <xs:enumeration value="moustakas2013PRIMUS"/>
+          <xs:enumeration value="muzzin2013ULTRAVISTA"/>
+          <xs:enumeration value="randomPoints"/>
+          <xs:enumeration value="tomczak2014ZFOURGE"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="task">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="AGNSpectraHopkins2008BuildFile"/>
+          <xs:enumeration value="NBodyAnalyze"/>
+          <xs:enumeration value="buildBroadbandLuminosityTabulations"/>
+          <xs:enumeration value="buildSEDTabulations"/>
+          <xs:enumeration value="buildTableCIECloudy"/>
+          <xs:enumeration value="buildToolAxionCAMB"/>
+          <xs:enumeration value="buildToolCAMB"/>
+          <xs:enumeration value="buildToolCLASS"/>
+          <xs:enumeration value="buildToolCloudy"/>
+          <xs:enumeration value="buildToolFSPS"/>
+          <xs:enumeration value="buildToolMangle"/>
+          <xs:enumeration value="buildToolRecFast"/>
+          <xs:enumeration value="catalogProjectedCorrelationFunction"/>
+          <xs:enumeration value="comovingDistances"/>
+          <xs:enumeration value="conditionalMassFunction"/>
+          <xs:enumeration value="evolveForests"/>
+          <xs:enumeration value="excursionSets"/>
+          <xs:enumeration value="haloMassFunction"/>
+          <xs:enumeration value="haloModelGenerate"/>
+          <xs:enumeration value="haloModelProjectedCorrelationFunction"/>
+          <xs:enumeration value="haloSpinDistribution"/>
+          <xs:enumeration value="intergalacticMediumState"/>
+          <xs:enumeration value="localGroupDatabase"/>
+          <xs:enumeration value="massFunctionCovariance"/>
+          <xs:enumeration value="mergerTreeFileBuilder"/>
+          <xs:enumeration value="mergingHaloOrbitDistribution"/>
+          <xs:enumeration value="multi"/>
+          <xs:enumeration value="posteriorSample"/>
+          <xs:enumeration value="postprocessForests"/>
+          <xs:enumeration value="powerSpectra"/>
+          <xs:enumeration value="radiativeTransfer"/>
+          <xs:enumeration value="report"/>
+          <xs:enumeration value="velocityField"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="tidalStripping">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="simple"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="transferFunction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="BBKS"/>
+          <xs:enumeration value="BBKSWDM"/>
+          <xs:enumeration value="CAMB"/>
+          <xs:enumeration value="CLASSCDM"/>
+          <xs:enumeration value="ETHOSDM"/>
+          <xs:enumeration value="accelerator"/>
+          <xs:enumeration value="axionCAMB"/>
+          <xs:enumeration value="bode2001"/>
+          <xs:enumeration value="eisensteinHu1998"/>
+          <xs:enumeration value="eisensteinHu1999"/>
+          <xs:enumeration value="envelope"/>
+          <xs:enumeration value="file"/>
+          <xs:enumeration value="fileFuzzyDarkMatter"/>
+          <xs:enumeration value="fuzzyDMMurgia2017"/>
+          <xs:enumeration value="fuzzyDMPassaglia2022"/>
+          <xs:enumeration value="halfModeSlope"/>
+          <xs:enumeration value="hu2000FDM"/>
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="murgia2017"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="unevolvedSubhaloMassFunction">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="giocoli2008"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="universeOperator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="identity"/>
+          <xs:enumeration value="intergalacticMediumStateEvolve"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="variogram">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="exponential"/>
+          <xs:enumeration value="gaussian"/>
+          <xs:enumeration value="spherical"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="virialDensityContrast">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="bryanNorman1998"/>
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="friendsOfFriends"/>
+          <xs:enumeration value="kitayamaSuto1996"/>
+          <xs:enumeration value="percolation"/>
+          <xs:enumeration value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
+          <xs:enumeration value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+          <xs:enumeration value="sphericalCollapseClsnlssMttrDrkEnrgy"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="virialOrbit">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="benson2005"/>
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="isotropic"/>
+          <xs:enumeration value="jiang2014"/>
+          <xs:enumeration value="li2020"/>
+          <xs:enumeration value="lossCone"/>
+          <xs:enumeration value="massReduced"/>
+          <xs:enumeration value="spinCorrelated"/>
+          <xs:enumeration value="wetzel2010"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+
+  <!-- Enumeration-valued parameters: value restricted to allowed labels. -->
+  <xs:element name="applyTo">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="both"/>
+          <xs:enumeration value="nonRates"/>
+          <xs:enumeration value="rates"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="badValueTest">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="greaterThan"/>
+          <xs:enumeration value="lessThan"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="componentType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="all"/>
+          <xs:enumeration value="blackHole"/>
+          <xs:enumeration value="coldHalo"/>
+          <xs:enumeration value="darkHalo"/>
+          <xs:enumeration value="darkMatterOnly"/>
+          <xs:enumeration value="disk"/>
+          <xs:enumeration value="hotHalo"/>
+          <xs:enumeration value="none"/>
+          <xs:enumeration value="nuclearStarCluster"/>
+          <xs:enumeration value="spheroid"/>
+          <xs:enumeration value="unknown"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="constructionOption">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="allBranches"/>
+          <xs:enumeration value="constrainedAndMainBranchOnly"/>
+          <xs:enumeration value="constrainedBranchOnly"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="coolingFrom">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="currentNode"/>
+          <xs:enumeration value="formationNode"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="covarianceModel">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="binomial"/>
+          <xs:enumeration value="poisson"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="densityContrastRelativeTo">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="critical"/>
+          <xs:enumeration value="mean"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="densityType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="critical"/>
+          <xs:enumeration value="mean"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="destinationGasMinorMerger">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="disk"/>
+          <xs:enumeration value="dominant"/>
+          <xs:enumeration value="spheroid"/>
+          <xs:enumeration value="unmoved"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="destinationStarsMinorMerger">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="disk"/>
+          <xs:enumeration value="dominant"/>
+          <xs:enumeration value="spheroid"/>
+          <xs:enumeration value="unmoved"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="destroyStubs">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="always"/>
+          <xs:enumeration value="never"/>
+          <xs:enumeration value="sideBranchesOnly"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="discriminator">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="boundMass"/>
+          <xs:enumeration value="position"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="distributionType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="bett2007"/>
+          <xs:enumeration value="logNormal"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="dustType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="calzetti2000"/>
+          <xs:enumeration value="cardelli1989"/>
+          <xs:enumeration value="charlotFall2000"/>
+          <xs:enumeration value="gordon2003"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="wittGordon2000"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="efficiencyRadiationType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="thinDisk"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="energyFixedAt">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="turnaround"/>
+          <xs:enumeration value="undefined"/>
+          <xs:enumeration value="virialization"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="energyOption">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="ISCO"/>
+          <xs:enumeration value="pureADAF"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="evolveForestsVerbosity">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="debug"/>
+          <xs:enumeration value="info"/>
+          <xs:enumeration value="silent"/>
+          <xs:enumeration value="standard"/>
+          <xs:enumeration value="warn"/>
+          <xs:enumeration value="working"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="exportFormat">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="galacticus"/>
+          <xs:enumeration value="irate"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="fieldEnhancementOption">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="exponential"/>
+          <xs:enumeration value="linear"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="fitType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="einastoCritical200"/>
+          <xs:enumeration value="nfwCritical200"/>
+          <xs:enumeration value="nfwVirial"/>
+          <xs:enumeration value="userDefined"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="frame">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="observed"/>
+          <xs:enumeration value="rest"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="galaxyType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="quiescent"/>
+          <xs:enumeration value="starForming"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="intervalType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="absolute"/>
+          <xs:enumeration value="dynamical"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="kernelSoftening">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="delta"/>
+          <xs:enumeration value="gadget"/>
+          <xs:enumeration value="plummer"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="lensedProperty">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="luminosity"/>
+          <xs:enumeration value="size"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="massOptions">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="200Crit"/>
+          <xs:enumeration value="200Mean"/>
+          <xs:enumeration value="FoF"/>
+          <xs:enumeration value="default"/>
+          <xs:enumeration value="topHat"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="massType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="all"/>
+          <xs:enumeration value="baryonic"/>
+          <xs:enumeration value="blackHole"/>
+          <xs:enumeration value="dark"/>
+          <xs:enumeration value="galactic"/>
+          <xs:enumeration value="gaseous"/>
+          <xs:enumeration value="stellar"/>
+          <xs:enumeration value="unknown"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="model">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="SMCShellTau3"/>
+          <xs:enumeration value="milkyWayShellTau3"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="nonAnalyticSolver">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fallThrough"/>
+          <xs:enumeration value="numerical"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="odeAlgorithm">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="bdf"/>
+          <xs:enumeration value="bulirschStoer"/>
+          <xs:enumeration value="multistepAdams"/>
+          <xs:enumeration value="rungeKutta"/>
+          <xs:enumeration value="rungeKuttaCashKarp"/>
+          <xs:enumeration value="rungeKuttaFehlberg"/>
+          <xs:enumeration value="rungeKuttaPrinceDormand"/>
+          <xs:enumeration value="rungeKuttaSecondOrder"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="odeAlgorithmNonJacobian">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="bdf"/>
+          <xs:enumeration value="bulirschStoer"/>
+          <xs:enumeration value="multistepAdams"/>
+          <xs:enumeration value="rungeKutta"/>
+          <xs:enumeration value="rungeKuttaCashKarp"/>
+          <xs:enumeration value="rungeKuttaFehlberg"/>
+          <xs:enumeration value="rungeKuttaPrinceDormand"/>
+          <xs:enumeration value="rungeKuttaSecondOrder"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="odeLatentIntegratorType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="gaussKronrod"/>
+          <xs:enumeration value="trapezoidal"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="orderRotation">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="byRank"/>
+          <xs:enumeration value="byRankOnNode"/>
+          <xs:enumeration value="none"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="outputFormat">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="galacticus"/>
+          <xs:enumeration value="irate"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="positionType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="orbital"/>
+          <xs:enumeration value="position"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="radiusFixed">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="turnaround"/>
+          <xs:enumeration value="virial"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="readColumns">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="Ax"/>
+          <xs:enumeration value="Ax500c"/>
+          <xs:enumeration value="Ay"/>
+          <xs:enumeration value="Ay500c"/>
+          <xs:enumeration value="Az"/>
+          <xs:enumeration value="Az500c"/>
+          <xs:enumeration value="Breadth_first_ID"/>
+          <xs:enumeration value="Depth_first_ID"/>
+          <xs:enumeration value="Halfmass_Radius"/>
+          <xs:enumeration value="JX"/>
+          <xs:enumeration value="JY"/>
+          <xs:enumeration value="JZ"/>
+          <xs:enumeration value="Last_mainleaf_depthfirst_ID"/>
+          <xs:enumeration value="Last_progenitor_depthfirst_ID"/>
+          <xs:enumeration value="M200b"/>
+          <xs:enumeration value="M200c"/>
+          <xs:enumeration value="M2500c"/>
+          <xs:enumeration value="M500c"/>
+          <xs:enumeration value="M_pe_Behroozi"/>
+          <xs:enumeration value="M_pe_Diemer"/>
+          <xs:enumeration value="Mmvir_all"/>
+          <xs:enumeration value="Mvir"/>
+          <xs:enumeration value="Next_coprogenitor_depthfirst_ID"/>
+          <xs:enumeration value="Orig_halo_ID"/>
+          <xs:enumeration value="RVmax"/>
+          <xs:enumeration value="Rs_Klypin"/>
+          <xs:enumeration value="Rvir"/>
+          <xs:enumeration value="Snap_num"/>
+          <xs:enumeration value="Spin"/>
+          <xs:enumeration value="Spin_Bullock"/>
+          <xs:enumeration value="TU"/>
+          <xs:enumeration value="Tidal_Force"/>
+          <xs:enumeration value="Tidal_ID"/>
+          <xs:enumeration value="Tree_root_ID"/>
+          <xs:enumeration value="VX"/>
+          <xs:enumeration value="VY"/>
+          <xs:enumeration value="VZ"/>
+          <xs:enumeration value="Vmax"/>
+          <xs:enumeration value="Voff"/>
+          <xs:enumeration value="X"/>
+          <xs:enumeration value="Xoff"/>
+          <xs:enumeration value="Y"/>
+          <xs:enumeration value="Z"/>
+          <xs:enumeration value="b_to_a"/>
+          <xs:enumeration value="b_to_a500c"/>
+          <xs:enumeration value="c_to_a"/>
+          <xs:enumeration value="c_to_a500c"/>
+          <xs:enumeration value="desc_id"/>
+          <xs:enumeration value="desc_pid"/>
+          <xs:enumeration value="desc_scale"/>
+          <xs:enumeration value="id"/>
+          <xs:enumeration value="mmp"/>
+          <xs:enumeration value="num_prog"/>
+          <xs:enumeration value="phantom"/>
+          <xs:enumeration value="pid"/>
+          <xs:enumeration value="rs"/>
+          <xs:enumeration value="sam_Mvir"/>
+          <xs:enumeration value="scale"/>
+          <xs:enumeration value="scale_of_last_MM"/>
+          <xs:enumeration value="upid"/>
+          <xs:enumeration value="vrms"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="relativeTo">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="immediateHost"/>
+          <xs:enumeration value="isolatedHost"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="scaleCutOffModel">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="barkana2001"/>
+          <xs:enumeration value="bode2001"/>
+          <xs:enumeration value="viel05"/>
+          <xs:enumeration value="vogel23SpinHalf"/>
+          <xs:enumeration value="vogel23SpinThreeHalves"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="selection">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="all"/>
+          <xs:enumeration value="hosts"/>
+          <xs:enumeration value="satellites"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="sourceAngularMomentumSpecificMean">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="darkMatter"/>
+          <xs:enumeration value="hotGas"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="sourceNormalizationRotation">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="darkMatter"/>
+          <xs:enumeration value="hotGas"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="startTime">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="age"/>
+          <xs:enumeration value="time"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="subhaloAngularMomentaMethod">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="scale"/>
+          <xs:enumeration value="summation"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="transferFunctionType">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="darkMatter"/>
+          <xs:enumeration value="total"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="type">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="cosmology"/>
+          <xs:enumeration value="generic"/>
+          <xs:enumeration value="groupFinder"/>
+          <xs:enumeration value="provenance"/>
+          <xs:enumeration value="simulation"/>
+          <xs:enumeration value="treeBuilder"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="variogramFitOption">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="maximum"/>
+          <xs:enumeration value="mean"/>
+          <xs:enumeration value="median"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="viscosityOption">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fit"/>
+          <xs:enumeration value="fixed"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+
+  <!-- Root element. Any parameters are permitted; known elements above
+       are validated wherever they appear. -->
+  <xs:element name="parameters">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+
+  <!-- Non-parameter file roots that share parameter directories
+       (merger trees, changes files, parameter grids): declared so that a
+       directory-scoped editor association does not flag them; their content
+       is not validated. -->
+  <xs:element name="changes">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+    <xs:attribute name="value" type="xs:string" use="optional"/>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="mergerTrees">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+    <xs:attribute name="value" type="xs:string" use="optional"/>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="parameterGrid">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+    <xs:attribute name="value" type="xs:string" use="optional"/>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="tree">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+    <xs:attribute name="value" type="xs:string" use="optional"/>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+
 </xs:schema>

--- a/scripts/build/parameterSchema.py
+++ b/scripts/build/parameterSchema.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Generate an XSD for Galacticus parameter FILES from the parameter catalog.
+
+The schema is intended for editor assistance (e.g. the VSCode XML extension):
+it declares each ``functionClass`` selector element with its ``value`` attribute
+restricted to the valid implementation labels, and each *unambiguous*
+enumeration-valued parameter with its ``value`` restricted to the allowed
+labels.  All element content is otherwise lax (``processContents="lax"``), so:
+
+* any nesting is permitted, and unknown elements (global/meta parameters,
+  components, custom parameters) are allowed;
+* known elements (selectors, enum parameters) are validated *wherever* they
+  appear, because lax validation matches them against their global declarations.
+
+This is a pragmatic XSD 1.0 schema (works in any XSD-aware editor).  Precise,
+per-implementation validation (a parameter must be accepted by the *selected*
+implementation) is provided separately by scripts/build/parameterValidate.py.
+
+Usage:
+    parameterSchema.py <sourceDirectory> [<outputFile>]
+
+`<outputFile>` defaults to `<sourceDirectory>/schema/parameters.xsd`.
+
+Andrew Benson (2026).
+"""
+
+import collections
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir, os.pardir, 'python'))
+
+from Galacticus.Parameters.catalog import build_catalog
+
+
+# Root elements of non-parameter files that live in the same directories as
+# parameter files (so an editor association scoped to those directories does not
+# spuriously flag them). Their content is not validated.
+_TOLERATED_ROOTS = ('changes', 'mergerTrees', 'parameterGrid', 'tree')
+
+
+def _escape(text):
+    return (str(text).replace('&', '&amp;').replace('<', '&lt;')
+            .replace('>', '&gt;').replace('"', '&quot;'))
+
+
+def _value_enum_attribute(values):
+    lines = ['    <xs:attribute name="value" use="optional">',
+             '     <xs:simpleType>',
+             '      <xs:restriction base="xs:string">']
+    for value in values:
+        lines.append(f'       <xs:enumeration value="{_escape(value)}"/>')
+    lines += ['      </xs:restriction>',
+              '     </xs:simpleType>',
+              '    </xs:attribute>']
+    return lines
+
+
+def _value_constrained_element(name, values):
+    """A global element whose `value` is restricted to `values`, with lax
+    children and arbitrary other attributes (id, idRef, ignoreWarnings, ...).
+    `mixed` content tolerates the `<name>value</name>` text form."""
+    lines = [f'  <xs:element name="{_escape(name)}">',
+             '   <xs:complexType mixed="true">',
+             '    <xs:sequence>',
+             '     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>',
+             '    </xs:sequence>']
+    lines += ['   ' + ln for ln in _value_enum_attribute(values)]
+    lines += ['    <xs:anyAttribute processContents="lax"/>',
+              '   </xs:complexType>',
+              '  </xs:element>']
+    return lines
+
+
+def _generic_element(name):
+    """A global element with an unconstrained `value` -- used for names that are
+    both a functionClass base and a scalar parameter (so the value may be either
+    an implementation label or an ordinary value)."""
+    return [f'  <xs:element name="{_escape(name)}">',
+            '   <xs:complexType mixed="true">',
+            '    <xs:sequence>',
+            '     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>',
+            '    </xs:sequence>',
+            '    <xs:attribute name="value" type="xs:string" use="optional"/>',
+            '    <xs:anyAttribute processContents="lax"/>',
+            '   </xs:complexType>',
+            '  </xs:element>']
+
+
+def _enum_parameter_elements(catalog):
+    """Return ``{paramName: [allowed values]}`` for parameters that are
+    unambiguously enumeration-valued: every occurrence of the name is linked to
+    the *same* single enumeration, the name is not a functionClass base, and the
+    enumeration's labels are known."""
+    enumerations = catalog.get('enumerations', {})
+    base_names = set(catalog.get('functionClasses', {}))
+    name_enums = collections.defaultdict(set)
+    name_has_free = collections.defaultdict(bool)
+    for impl in catalog.get('implementations', {}).values():
+        for parameter in impl.get('parameters', []):
+            name = parameter.get('name')
+            if not name:
+                continue
+            if parameter.get('enumeration'):
+                name_enums[name].add(parameter['enumeration'])
+            else:
+                name_has_free[name] = True
+    result = {}
+    for name, enums in name_enums.items():
+        if name in base_names or name_has_free.get(name) or len(enums) != 1:
+            continue
+        values = enumerations.get(next(iter(enums)))
+        if values:
+            result[name] = sorted(set(values))
+    return result
+
+
+def build_schema(catalog):
+    function_classes = catalog.get('functionClasses', {})
+    enum_parameters = _enum_parameter_elements(catalog)
+
+    out = ['<?xml version="1.0"?>',
+           '<!-- Galacticus parameter-file schema. GENERATED from the parameter',
+           '     catalog by scripts/build/parameterSchema.py (do not edit by hand).',
+           '     For editor assistance only; precise validation is done by',
+           '     scripts/build/parameterValidate.py. -->',
+           '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">',
+           '']
+
+    # Names that are both a functionClass base and a scalar parameter: their
+    # value may be an implementation label OR an ordinary value, so leave it
+    # unconstrained to avoid false positives.
+    parameter_names = {p.get('name')
+                       for impl in catalog.get('implementations', {}).values()
+                       for p in impl.get('parameters', []) if p.get('name')}
+
+    out.append('  <!-- functionClass selectors: value restricted to valid implementations. -->')
+    for base in sorted(function_classes):
+        # Sort labels so the emitted order is stable regardless of catalog
+        # ordering (keeps regeneration diffs minimal).
+        labels = sorted(function_classes[base].get('implementations', []))
+        if not labels:
+            continue
+        if base in parameter_names:
+            out += _generic_element(base)
+        else:
+            out += _value_constrained_element(base, labels)
+    out.append('')
+
+    out.append('  <!-- Enumeration-valued parameters: value restricted to allowed labels. -->')
+    for name in sorted(enum_parameters):
+        out += _value_constrained_element(name, enum_parameters[name])
+    out.append('')
+
+    out += ['  <!-- Root element. Any parameters are permitted; known elements above',
+            '       are validated wherever they appear. -->',
+            '  <xs:element name="parameters">',
+            '   <xs:complexType mixed="true">',
+            '    <xs:sequence>',
+            '     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>',
+            '    </xs:sequence>',
+            '    <xs:anyAttribute processContents="lax"/>',
+            '   </xs:complexType>',
+            '  </xs:element>',
+            '']
+
+    out.append('  <!-- Non-parameter file roots that share parameter directories')
+    out.append('       (merger trees, changes files, parameter grids): declared so that a')
+    out.append('       directory-scoped editor association does not flag them; their content')
+    out.append('       is not validated. -->')
+    for root_name in _TOLERATED_ROOTS:
+        out += _generic_element(root_name)
+
+    out += ['', '</xs:schema>', '']
+    return '\n'.join(out)
+
+
+def main(argv):
+    if len(argv) not in (2, 3):
+        print("Usage: parameterSchema.py <sourceDirectory> [<outputFile>]",
+              file=sys.stderr)
+        return 1
+    source_directory = argv[1]
+    output_path = argv[2] if len(argv) == 3 else os.path.join(
+        source_directory, 'schema', 'parameters.xsd')
+    os.environ.setdefault('GALACTICUS_EXEC_PATH', source_directory)
+    catalog = build_catalog(os.path.join(source_directory, 'source'))
+    with open(output_path, 'w') as fh:
+        fh.write(build_schema(catalog))
+    n_fc = sum(1 for b in catalog['functionClasses'].values()
+               if b.get('implementations'))
+    print(f"wrote {output_path} ({n_fc} functionClass selectors, "
+          f"{len(_enum_parameter_elements(catalog))} enumeration parameters)",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/scripts/build/tests/test_parameter_schema.py
+++ b/scripts/build/tests/test_parameter_schema.py
@@ -1,0 +1,81 @@
+"""Tests for scripts/build/parameterSchema.py (parameter-file XSD generator)."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir))
+from parameterSchema import build_schema   # noqa: E402
+
+CATALOG = {
+    'functionClasses': {
+        'accretionHalo':        {'implementations': ['coldMode', 'simple']},
+        'criticalOverdensity':  {'implementations': ['fixed']},   # also a parameter -> collision
+    },
+    'enumerations': {'densityKind': ['critical', 'mean']},
+    'implementations': {
+        'accretionHaloSimple': {'parameters': [
+            {'name': 'alpha', 'enumeration': None},
+            {'name': 'densityType', 'enumeration': 'densityKind'},
+        ]},
+        # makes `criticalOverdensity` also a scalar parameter name
+        'haloMassFunctionFixed': {'parameters': [
+            {'name': 'criticalOverdensity', 'enumeration': None},
+        ]},
+    },
+}
+
+
+def test_selector_enum_emitted():
+    xsd = build_schema(CATALOG)
+    assert '<xs:element name="accretionHalo">' in xsd
+    assert '<xs:enumeration value="simple"/>' in xsd
+    assert '<xs:enumeration value="coldMode"/>' in xsd
+
+
+def test_enum_parameter_emitted():
+    xsd = build_schema(CATALOG)
+    assert '<xs:element name="densityType">' in xsd
+    assert '<xs:enumeration value="critical"/>' in xsd
+    assert '<xs:enumeration value="mean"/>' in xsd
+
+
+def test_collision_name_is_unconstrained():
+    """A name that is both a functionClass base and a scalar parameter must not
+    have its value enumerated (its value may be a label or an ordinary value)."""
+    xsd = build_schema(CATALOG)
+    assert '<xs:element name="criticalOverdensity">' in xsd
+    # 'fixed' is criticalOverdensity's only implementation; it must NOT appear as
+    # an enumeration (the element is generic).
+    assert '<xs:enumeration value="fixed"/>' not in xsd
+
+
+def test_tolerated_roots_declared():
+    """Roots of non-parameter files that share parameter directories (changes,
+    merger trees, ...) are declared so a directory-scoped editor association does
+    not flag them."""
+    xsd = build_schema(CATALOG)
+    for root in ('changes', 'mergerTrees', 'parameterGrid', 'tree'):
+        assert f'<xs:element name="{root}">' in xsd
+
+
+def test_schema_compiles_and_validates():
+    etree = pytest.importorskip('lxml.etree')
+    schema = etree.XMLSchema(etree.fromstring(build_schema(CATALOG).encode()))
+    assert schema.validate(etree.fromstring(
+        b'<parameters><accretionHalo value="simple">'
+        b'<densityType value="critical"/></accretionHalo></parameters>'))
+    # bad selector / bad enum value are rejected
+    assert not schema.validate(etree.fromstring(
+        b'<parameters><accretionHalo value="bogus"/></parameters>'))
+    assert not schema.validate(etree.fromstring(
+        b'<parameters><densityType value="bogus"/></parameters>'))
+    # collision name accepts an ordinary (numeric) value
+    assert schema.validate(etree.fromstring(
+        b'<parameters><criticalOverdensity value="1.686"/></parameters>'))
+    # a non-parameter file root (e.g. a `<changes>` file co-located with
+    # parameter files) is tolerated rather than rejected
+    assert schema.validate(etree.fromstring(
+        b'<changes><change type="update"/></changes>'))


### PR DESCRIPTION
## Summary

Adds a generated **XSD 1.0 schema for parameter files** (`schema/parameters.xsd`) for editor validation and autocompletion, plus the tooling, CI gate, and documentation around it.

The schema is generated from the parameter catalog by the new `scripts/build/parameterSchema.py`:

- each `functionClass` selector's `value` is restricted to its valid implementation labels;
- each unambiguously enumeration-valued parameter's `value` is restricted to its allowed labels;
- all other content is left lax, so unknown/global/meta parameters and arbitrary nesting are still permitted.

It is intended for **editor assistance only** (e.g. the VS Code XML extension). Precise, per-implementation validation (does the *selected* implementation accept this parameter?) remains the job of `scripts/build/parameterValidate.py`.

## What's included

- **`scripts/build/parameterSchema.py`** — the generator (deterministic output; selectors/enums sorted so regeneration produces minimal diffs).
- **`schema/parameters.xsd`** — regenerated artifact (replaces the previous invalid stub that editors could not compile).
- **`Makefile`** — `parameters-schema` target.
- **CI sync-check** (`.github/workflows/cicd.yml`) — regenerates the schema and fails if the committed copy is stale.
- **Unit tests** (`scripts/build/tests/test_parameter_schema.py`) — selectors, enums, collision-safety, tolerated non-parameter roots, and an lxml compile/validate round-trip.
- **`.vscode/settings.json`** — a minimal, `${workspaceFolder}`-anchored file association so the VS Code XML extension validates parameter files out of the box (the only un-ignored `.vscode/` file). `parameters.xml` also carries an `xsi:noNamespaceSchemaLocation` as a per-file demo.
- **Documentation** — a user-guide section (editor setup + per-file usage) and a new developer-guide "Git hooks" section documenting the shared [`gitHooks`](https://github.com/galacticusorg/gitHooks) repository and its setup.

The pre-commit half of the freshness check is implemented in the `gitHooks` repository (it regenerates and verifies `schema/parameters.xsd` only when a staged change could affect it).

## Verification

- Generator is deterministic (byte-identical on re-run); the committed schema matches a fresh regeneration against this base.
- The full bundled parameter-file corpus validates against the schema.
- `pytest scripts/build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
