### PR TITLE
Make Galacticus installable via pip

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,7 +41,10 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install pytest
-        run: python -m pip install --upgrade pip pytest
+        # platformdirs + requests are needed by the galacticus_launcher tests
+        # (the only third-party deps in the python/ pytest suite); both are tiny
+        # pure-Python packages so the job stays fast.
+        run: python -m pip install --upgrade pip pytest platformdirs requests
       - name: Run Python regression tests
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
-      - name: Mirror bleeding-edge assets onto the version tag
+      - name: Mirror bleeding-edge assets and pin datasets onto the version tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
@@ -139,9 +139,25 @@ jobs:
               --pattern "${asset}" --dir release-assets || \
               echo "WARNING: ${asset} not found on bleeding-edge; skipping."
           done
-          # Create the release if it does not yet exist, then (re)upload assets.
+          # Pin the datasets version: record the current datasets master HEAD
+          # commit so this release always installs against the same data. The
+          # launcher reads the `datasets.ref` asset; the value is also written
+          # into the release notes for users installing manually (not via pip).
+          datasets_sha=$(git ls-remote https://github.com/galacticusorg/datasets.git HEAD | cut -f1)
+          echo "datasets pinned to ${datasets_sha}"
+          printf '%s\n' "${datasets_sha}" > release-assets/datasets.ref
+          # Create the release (with generated notes) if it does not yet exist.
           gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1 || \
             gh release create "${TAG}" --repo "${GITHUB_REPOSITORY}" \
               --title "${TAG}" --generate-notes
+          # Append the datasets pin to the release notes (idempotent: only once).
+          body=$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json body -q .body)
+          if ! printf '%s' "${body}" | grep -q "galacticusorg/datasets@"; then
+            {
+              printf '%s\n\n' "${body}"
+              printf '**Run-time datasets:** this release was built against `galacticusorg/datasets@%s`. If you install manually (not via `pip install galacticus`), check out the datasets repository at this commit for matching data.\n' "${datasets_sha}"
+            } > release-notes.md
+            gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --notes-file release-notes.md
+          fi
           gh release upload "${TAG}" release-assets/* \
             --repo "${GITHUB_REPOSITORY}" --clobber

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,115 @@
+name: 'Publish'
+
+# Cut a versioned release of Galacticus:
+#   * build the `galacticus` Python distribution (sdist + wheel) and publish it
+#     to PyPI via Trusted Publishing (OIDC -- no stored token); and
+#   * create a versioned GitHub Release carrying the same pre-built binary and
+#     tools assets that the CI/CD `Deploy` job publishes to `bleeding-edge`, so
+#     that the launcher can fetch reproducible artefacts pinned to the version.
+#
+# Trigger by pushing a semantic-version tag, e.g.:
+#   git tag v1.2.3 && git push origin v1.2.3
+#
+# One-time setup required before the first run:
+#   * Configure a PyPI (and, for the dry run, TestPyPI) Trusted Publisher for
+#     this repository + workflow (`publish.yml`) and environment (`pypi`).
+#     See https://docs.pypi.org/trusted-publishers/ .
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      testpypi:
+        description: 'Publish to TestPyPI instead of PyPI (dry run)'
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  Build-Distribution:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v7
+        with:
+          # setuptools_scm derives the version from tags, so we need full history.
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-distribution
+          path: dist/
+
+  Publish-PyPI:
+    needs: Build-Distribution
+    runs-on: ubuntu-latest
+    # Trusted Publishing requires an environment and the id-token permission.
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-distribution
+          path: dist/
+      - name: Publish to TestPyPI
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.testpypi }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+      - name: Publish to PyPI
+        if: ${{ github.event_name == 'push' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  Release-Assets:
+    # Mirror the current `bleeding-edge` binary/tools assets onto the versioned
+    # tag so the launcher can fetch artefacts pinned to this release. Runs only
+    # for real tag pushes (not the TestPyPI dry run).
+    if: ${{ github.event_name == 'push' }}
+    needs: Build-Distribution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v7
+      - name: Mirror bleeding-edge assets onto the version tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          assets=(
+            Galacticus.exe
+            Galacticus_MacOS.exe
+            Galacticus_MacOS-M1.exe
+            tools.tar.bz2
+            toolsMacOS.zip
+            toolsMacOSM1.zip
+          )
+          mkdir -p release-assets
+          for asset in "${assets[@]}"; do
+            echo "Downloading ${asset} from bleeding-edge ..."
+            gh release download bleeding-edge --repo "${GITHUB_REPOSITORY}" \
+              --pattern "${asset}" --dir release-assets || \
+              echo "WARNING: ${asset} not found on bleeding-edge; skipping."
+          done
+          # Create the release if it does not yet exist, then (re)upload assets.
+          gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1 || \
+            gh release create "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+              --title "${TAG}" --generate-notes
+          gh release upload "${TAG}" release-assets/* \
+            --repo "${GITHUB_REPOSITORY}" --clobber

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,40 @@ jobs:
           name: python-distribution
           path: dist/
 
+  Verify-Release:
+    # Guard against tagging before CI/CD has refreshed `bleeding-edge`: the
+    # versioned release mirrors the assets currently on `bleeding-edge`, so the
+    # `bleeding-edge` tag must point at the very commit being released. Fail fast
+    # otherwise, blocking BOTH the PyPI publish and the asset mirror. A no-op for
+    # the TestPyPI dry run (workflow_dispatch), so it can never skip its needers.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Verify bleeding-edge matches the tagged commit
+        if: ${{ github.event_name == 'push' }}
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git fetch origin 'refs/tags/bleeding-edge:refs/tags/bleeding-edge' --force
+          bleeding=$(git rev-list -n1 bleeding-edge)
+          tagged=$(git rev-list -n1 "${TAG}")
+          echo "bleeding-edge -> ${bleeding}"
+          echo "${TAG} -> ${tagged}"
+          if [ "${bleeding}" != "${tagged}" ]; then
+            echo "::error::bleeding-edge (${bleeding}) does not point at ${TAG} (${tagged}). Wait for the master CI/CD run for this commit to finish and refresh bleeding-edge before tagging, then re-tag."
+            exit 1
+          fi
+      - name: Dry-run note
+        if: ${{ github.event_name != 'push' }}
+        run: echo "workflow_dispatch dry run - skipping bleeding-edge verification."
+
   Publish-PyPI:
-    needs: Build-Distribution
+    needs: [Build-Distribution, Verify-Release]
     runs-on: ubuntu-latest
     # Trusted Publishing requires an environment and the id-token permission.
     environment: pypi
@@ -79,7 +111,7 @@ jobs:
     # tag so the launcher can fetch artefacts pinned to this release. Runs only
     # for real tag pushes (not the TestPyPI dry run).
     if: ${{ github.event_name == 'push' }}
-    needs: Build-Distribution
+    needs: [Build-Distribution, Verify-Release]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Have questions? Ask them in the [discussion forum](https://github.com/galacticus
 
 ## Quickstart
 
+> **Just want to run models?** If you don't need to modify the code, the easiest way to get started is to install the pre-built launcher from PyPI — no compiler or manual setup required:
+>
+> ```bash
+> pip install galacticus
+> galacticus run parameters/quickTest.xml
+> ```
+>
+> The first run downloads the right binary, datasets, and tools for your platform (Linux x86-64, macOS Intel, or macOS Apple Silicon) and configures the environment for you. See the [pip installation guide](https://galacticus.readthedocs.io/en/latest/manuals/user-guide/installation/pip.html). The rest of this section covers building from source, which you need only if you want to modify or extend Galacticus.
+
 This section walks you through building and running a minimal Galacticus model for the first time.
 
 ### Prerequisites

--- a/docs/manuals/developer-guide/versions-and-releases.rst
+++ b/docs/manuals/developer-guide/versions-and-releases.rst
@@ -22,7 +22,7 @@ The "API" for Galacticus consists of:
    #. The main output HDF5 file;
    #. Any auxiliary files that are output.
 
-Changes to the format or syntax of any of these files are considered to incompatible API changes. Note that additions to the formats that don't break backward compatibility (e.g. adding a new class with new parameters) *are* backwards compatible and so do not require a major version increment.
+Changes to the format or syntax of any of these files are considered to be incompatible API changes. Note that additions to the formats that don't break backward compatibility (e.g. adding a new class with new parameters) *are* backwards compatible and so do not require a major version increment.
 
 Versions are implemented through GitHub's "`release <https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/about-releases>`_" mechanism, and so are based on ``git`` "`tags <https://git-scm.com/book/en/v2/Git-Basics-Tagging>`_". Associated with each release are a statically-linked binary executable and documentation. Additionally a Docker image is built for each version, which can be retrieved using ``docker pull galacticusorg/galacticus:X.Y.Z``.
 

--- a/docs/manuals/developer-guide/versions-and-releases.rst
+++ b/docs/manuals/developer-guide/versions-and-releases.rst
@@ -107,9 +107,13 @@ therefore lightweight:
    GitHub release, mirroring the current ``bleeding-edge`` binary and tools
    assets onto it (see `Publishing the Python Package to PyPI`_ below). This is
    what makes ``pip install galacticus`` resolve to the new version.
-#. Create the corresponding
-   `datasets <https://github.com/galacticusorg/datasets>`_ release so that
-   matching versions of the code and data are available.
+The publish workflow also pins the run-time data: it records the current
+``datasets`` ``master`` commit as a ``datasets.ref`` asset on the release and
+notes that commit in the release body, so every install of that version (whether
+via ``pip`` or by hand) uses the same data. Cutting a matching tagged
+`datasets <https://github.com/galacticusorg/datasets>`_ release is therefore
+optional — useful for a human-readable version, but the recorded commit is the
+source of truth.
 
 .. note::
 

--- a/docs/manuals/developer-guide/versions-and-releases.rst
+++ b/docs/manuals/developer-guide/versions-and-releases.rst
@@ -28,6 +28,29 @@ Versions are implemented through GitHub's "`release <https://docs.github.com/en/
 
 The Galacticus ``datasets`` repo has corresponding versions - it's recommended to using matching versions of the `galacticus <https://github.com/galacticusorg/galacticus>`_ and `datasets <https://github.com/galacticusorg/galacticus>`_ repos.
 
+When to Create a Release
+------------------------
+
+Day-to-day development is delivered continuously through the rolling
+``bleeding-edge`` release (updated by CI on every push to ``master``), so a
+tagged release is a deliberate, stable checkpoint rather than something cut for
+every change. Create one when:
+
+#. a backward-compatible **bug fix** is ready that users should be able to pin to
+   — increment the patch version ``Z``;
+#. new **backward-compatible functionality** has landed (e.g. a new class,
+   parameter, or output) — increment the minor version ``Y`` and reset ``Z`` to
+   ``0``; or
+#. an **incompatible API change** has been made to the parameter-file syntax,
+   input data formats, or output HDF5 format (see the API definition above) —
+   increment the major version ``X`` and reset ``Y`` and ``Z`` to ``0``.
+
+A practical cadence is to tag a minor release periodically once a useful batch of
+features has accumulated and the test suite is green, and to tag a patch release
+promptly when a fix matters to users. Always tag from a ``master`` commit whose
+CI is passing, so the binaries on ``bleeding-edge`` (which the versioned release
+mirrors) correspond to the tagged code.
+
 Determining the Exact Version Used
 ----------------------------------
 
@@ -77,6 +100,8 @@ Release Steps
 
    #. `datasets <https://github.com/galacticusorg/datasets>`_ release in GitHub;
    #. `galacticusDockerBuildEnv <https://github.com/galacticusorg/galacticusDockerBuildEnv>`_
+
+#. Publish the ``galacticus`` Python package to PyPI (see `Publishing the Python Package to PyPI`_ below). This is what makes ``pip install galacticus`` resolve to the new version.
 
 #. Add archives of external dependencies to the GitHub release. Currently these are:
 
@@ -145,3 +170,44 @@ Compilation instructions for MacOS are given `here <https://github.com/galacticu
       zip -r galacticusExecutablesMacOS.zip galacticus/Galacticus.exe datasets/dynamic/fsps-3.2 datasets/dynamic/class_public-3.0.2 datasets/dynamic/CAMB-1.3.2 datasets/dynamic/RecFast datasets/dynamic/c17.02
 
 #. Add ``galacticusExecutablesMacOS.zip`` to the GitHub release.
+
+Publishing the Python Package to PyPI
+-------------------------------------
+
+``pip install galacticus`` installs the launcher described in
+:doc:`../user-guide/installation/pip`, which downloads the pre-built executable,
+datasets, and tools on first use. Publishing a new version to
+`PyPI <https://pypi.org/project/galacticus/>`_ is automated by the
+``.github/workflows/publish.yml`` workflow and is triggered simply by pushing a
+semantic-version tag:
+
+.. code-block:: bash
+
+   git tag v1.2.3
+   git push origin v1.2.3
+
+On a version tag the workflow:
+
+#. builds the source distribution and wheel — the version is derived from the
+   git tag by `setuptools_scm <https://setuptools-scm.readthedocs.io/>`_, so the
+   ``X.Y.Z`` you tag is exactly the version on PyPI;
+#. publishes them to PyPI using `Trusted Publishing
+   <https://docs.pypi.org/trusted-publishers/>`_ (OIDC), so no API token is
+   stored in the repository; and
+#. mirrors the current ``bleeding-edge`` binary and tools assets onto the
+   versioned GitHub release, so the launcher fetches artefacts pinned to that
+   version.
+
+Because the launcher resolves the GitHub release tag from the installed package
+version, the binary assets **must** be present on the ``vX.Y.Z`` release; the
+workflow handles this automatically, but if you create a release by hand, attach
+the binary and tools assets too.
+
+One-time setup
+~~~~~~~~~~~~~~
+
+Before the first publish, register a PyPI (and TestPyPI) *Trusted Publisher* for
+this repository, with the workflow filename ``publish.yml`` and environment
+``pypi``. To dry-run the pipeline without touching the real index, run the
+``Publish`` workflow manually (``workflow_dispatch``) with the ``testpypi`` input
+set to ``true``; this builds and uploads to TestPyPI only.

--- a/docs/manuals/developer-guide/versions-and-releases.rst
+++ b/docs/manuals/developer-guide/versions-and-releases.rst
@@ -87,89 +87,46 @@ The ``fb96dd63391b52e801e8c1059e6ece2ca433efd6`` in the above is the Git revisio
 Release Steps
 -------------
 
-#. Both MPI and non-MPI builds must compile cleanly without errors or warnings;
-#. Create releases on GitHub:
+The binary executables (Linux and macOS), the run-time tools, and the Docker
+image are all built and published automatically by the CI/CD pipeline
+(``.github/workflows/cicd.yml``) on every push to ``master``, which keeps the
+rolling ``bleeding-edge`` release up to date. Cutting a versioned release is
+therefore lightweight:
 
-   #. `galacticus <https://github.com/galacticusorg/galacticus>`_, with assets:
+#. Ensure all CI checks are green on the ``master`` commit you intend to tag.
+   This includes that both the MPI and non-MPI builds compile cleanly without
+   errors or warnings, and — importantly — that the CI/CD run for that commit has
+   finished and uploaded the binaries and tools to ``bleeding-edge``.
+#. Tag that commit with a semantic-version tag and push it::
 
-      #. Statically-linked binary, ``galacticus.exe``.
+      git tag vX.Y.Z
+      git push origin vX.Y.Z
 
-      .. note::
+   The ``Publish`` workflow (``.github/workflows/publish.yml``) then builds and
+   publishes the ``galacticus`` Python package to PyPI and creates the versioned
+   GitHub release, mirroring the current ``bleeding-edge`` binary and tools
+   assets onto it (see `Publishing the Python Package to PyPI`_ below). This is
+   what makes ``pip install galacticus`` resolve to the new version.
+#. Create the corresponding
+   `datasets <https://github.com/galacticusorg/datasets>`_ release so that
+   matching versions of the code and data are available.
 
-         The LaTeX/PDF manuals have been retired. Documentation is now published automatically on `ReadTheDocs <https://galacticus.readthedocs.io/>`_, so there are no documentation PDFs to build or attach as release assets.
+.. note::
 
-   #. `datasets <https://github.com/galacticusorg/datasets>`_ release in GitHub;
-   #. `galacticusDockerBuildEnv <https://github.com/galacticusorg/galacticusDockerBuildEnv>`_
+   Because the versioned release **mirrors the assets currently on**
+   ``bleeding-edge``, only tag a commit once that commit's CI/CD run has finished
+   and refreshed ``bleeding-edge`` — otherwise the versioned release would pick up
+   stale binaries. The publish workflow guards against this by checking that the
+   ``bleeding-edge`` tag points at the tagged commit, and fails fast if not.
 
-#. Publish the ``galacticus`` Python package to PyPI (see `Publishing the Python Package to PyPI`_ below). This is what makes ``pip install galacticus`` resolve to the new version.
+.. note::
 
-#. Add archives of external dependencies to the GitHub release. Currently these are:
-
-   #. `CAMB <https://github.com/cmbant/CAMB>`_
-
-      #. plus `forutils <https://github.com/cmbant/forutils>`_
-
-   #. `RecFast <https://www.astro.ubc.ca/people/scott/recfast.html>`_
-   #. `FSPS <https://github.com/cconroy20/fsps>`_
-   #. `Cloudy <https://gitlab.nublado.org/cloudy/cloudy/-/wikis/home>`_
-   #. `FFTLog <http://jila.colorado.edu/~ajsh/FFTLog/fftlog.tgz>`_
-   #. `FoX <https://github.com/andreww/fox>`_
-   #. `ANN <http://www.cs.umd.edu/~mount/ANN>`_
-   #. `libmatheval <https://github.com/galacticusorg/libmatheval>`_
-   #. `FFTW3 <https://www.fftw.org/>`_
-   #. `HDF5 <https://www.hdfgroup.org/solutions/hdf5/>`_
-   #. `gfortran <https://gfortran.meteodat.ch/>`_
-   #. `GSL <https://www.gnu.org/software/gsl/>`_
-   #. `Guile <https://www.gnu.org/software/guile/>`_
-
-Docker images can be built locally following the instructions `here <https://github.com/galacticusorg/galacticus/wiki/Building-Docker-Images>`_.
-
-Docker images can be exported as follows:
-
-.. code-block:: bash
-
-   sudo docker pull ghcr.io/galacticusorg/buildenv:latest
-   sudo docker run --name buildenvV1.0.0 galacticusorg/buildenv
-   sudo docker export --output="/home/abensonca/Scratch/galacticusorg_buildenv_v1.0.0.tar" buildenvV1.0.0
-   sudo docker stop buildenvV1.0.0
-   sudo bzip2 galacticusorg_buildenv_v1.0.0.tar
-
-MacOS Binaries
-~~~~~~~~~~~~~~
-
-Compilation instructions for MacOS are given `here <https://github.com/galacticusorg/galacticus/wiki/Installation-from-source-on-MacOS>`_. To create statically-linked binaries on MacOS proceed as follows:
-
-#. Compile Galacticus as usual.
-#. Run ``./Galacticus.exe parameters/buildTools.xml`` to build all run-time tools (RecFast, FSPS, CAMB, Class, Cloudy).
-#. Since MacOS does not really support static-linking we need to do some manual re-linking to making statically linked binaries. To make this easier a script ``./scripts/build/staticRelinker.py`` is provided. Static executables can be created using the following commands:
-
-   .. code-block:: bash
-
-      cd ~/galacticus
-      ~/galacticus/scripts/build/staticRelinker.py gfortran-16 `cat ./work/build/Galacticus.d` ./work/build/Galacticus.parameters.o ./work/build/Galacticus.md5s.o -o Galacticus.exe -ffree-line-length-none -frecursive -DBUILDPATH=\'./work/build\' -J./work/build/moduleBuild/ -I./work/build/ -fintrinsic-modules-path /usr/local/include -L/usr/local/lib -L/opt/local/lib -fintrinsic-modules-path /usr/local/finclude -fintrinsic-modules-path /usr/local/include/gfortran -fintrinsic-modules-path /usr/local/include -fintrinsic-modules-path /usr/lib/gfortran/modules -fintrinsic-modules-path /usr/include/gfortran -fintrinsic-modules-path /usr/include -fintrinsic-modules-path /usr/finclude -fintrinsic-modules-path /usr/lib64/gfortran/modules -fintrinsic-modules-path /usr/lib64/openmpi/lib -pthread -Wall -fbacktrace -ffpe-trap=invalid,zero,overflow -fdump-core -O3 -ffinite-math-only -fno-math-errno -fopenmp -g -DOFDUNAVAIL -DFFTW3AVAIL -DANNAVAIL -DMATHEVALAVAIL `./scripts/build/libraryDependencies.py Galacticus.exe -ffree-line-length-none -frecursive -DBUILDPATH=\'./work/build\' -J./work/build/moduleBuild/ -I./work/build/ -fintrinsic-modules-path /usr/local/include -L/usr/local/lib -L/opt/local/lib -fintrinsic-modules-path /usr/local/finclude -fintrinsic-modules-path /usr/local/include/gfortran -fintrinsic-modules-path /usr/local/include -fintrinsic-modules-path /usr/lib/gfortran/modules -fintrinsic-modules-path /usr/include/gfortran -fintrinsic-modules-path /usr/include -fintrinsic-modules-path /usr/finclude -fintrinsic-modules-path /usr/lib64/gfortran/modules -fintrinsic-modules-path /usr/lib64/openmpi/lib -pthread -Wall -fbacktrace -ffpe-trap=invalid,zero,overflow -fdump-core -O3 -ffinite-math-only -fno-math-errno -fopenmp -g -DOFDUNAVAIL -DFFTW3AVAIL -DANNAVAIL -DMATHEVALAVAIL`
-
-      cd ~/datasets/dynamic/RecFast
-      ~/galacticus/scripts/build/staticRelinker.py gfortran-16 recfast.for -o recfast.exe -O3 -ffixed-form -ffixed-line-length-none
-
-      cd ~/datasets/dynamic/CAMB-1.3.2/fortran
-      ~/galacticus/scripts/build/staticRelinker.py gfortran-16 -cpp -Ofast -fopenmp -fintrinsic-modules-path /usr/local/include -L/usr/local/lib -L/opt/local/lib -JRelease -IRelease/ -I"Users/ajb/datasets/dynamic/CAMB-1.3.2/fortran/../forutils/Release/" Release/inidriver.o Release/libcamb.a  -L"/Users/ajb/datasets/dynamic/CAMB-1.3.2/fortran/../forutils/Release/" -lforutils -o camb
-
-      cd ~/datasets/dynamic/class_public-3.0.2
-      ~/galacticus/scripts/build/staticRelinker.py gcc-16 -O3 -fopenmp -g -fPIC -o class build/growTable.o build/dei_rkck.o build/sparse.o build/evolver_rkck.o build/evolver_ndf15.o build/arrays.o build/parser.o build/quadrature.o build/hyperspherical.o build/common.o build/trigonometric_integrals.o build/input.o build/background.o build/thermodynamics.o build/perturbations.o build/primordial.o build/fourier.o build/transfer.o build/harmonic.o build/lensing.o build/distortions.o build/wrap_recfast.o build/injection.o build/noninjection.o build/hyrectools.o build/helium.o build/hydrogen.o build/history.o build/wrap_hyrec.o build/energy_injection.o build/output.o build/class.o -lm
-
-      cd ~/datasets/dynamic/fsps-3.2/src
-      ~/galacticus/scripts/build/staticRelinker.py gfortran-16 -O3 -cpp -fPIC -mcmodel=medium  -o autosps.exe autosps.o sps_vars.o sps_utils.o compsp.o csp_gen.o galacticus_IMF.o ssp_gen.o getmags.o locate.o funcint.o sps_setup.o pz_convol.o get_tuniv.o intsfwght.o imf.o imf_weight.o add_dust.o getspec.o sbf.o add_bs.o mod_hb.o add_remnants.o getindx.o smoothspec.o mod_gb.o add_nebular.o write_isochrone.o sfhstat.o linterp.o tsum.o add_agb_dust.o linterparr.o ztinterp.o vacairconv.o igm_absorb.o get_lumdist.o attn_curve.o sfh_weight.o sfhlimit.o sfhinfo.o setup_tabular_sfh.o agn_dust.o
-
-      cd ~/datasets/dynamic/c23.01/source
-      ~/galacticus/scripts/build/staticRelinker.py g++-16 -O3 -ftrapping-math -fnop-math-errno -ftree-vectorize -Wall -g -o cloudy.exe maincl.o -L. -lcloudy
-
-#. Package the executables (and data):
-
-   .. code-block:: bash
-
-      zip -r galacticusExecutablesMacOS.zip galacticus/Galacticus.exe datasets/dynamic/fsps-3.2 datasets/dynamic/class_public-3.0.2 datasets/dynamic/CAMB-1.3.2 datasets/dynamic/RecFast datasets/dynamic/c17.02
-
-#. Add ``galacticusExecutablesMacOS.zip`` to the GitHub release.
+   The LaTeX/PDF manuals have been retired; documentation is published
+   automatically on `ReadTheDocs <https://galacticus.readthedocs.io/>`_. The
+   statically-linked Linux and macOS binaries, the run-time tool archives, the
+   Docker image, and the archives of external build dependencies are all produced
+   and uploaded automatically by CI (or maintained out of band), so none of them
+   need to be assembled or relinked by hand as part of a release.
 
 Publishing the Python Package to PyPI
 -------------------------------------

--- a/docs/manuals/user-guide/installation/binary.rst
+++ b/docs/manuals/user-guide/installation/binary.rst
@@ -43,6 +43,10 @@ To do this:
 
    Galacticus needs to write some data files to disk at run time. Usually these are written to ``$GALACTICUS_DATA_PATH/dynamic/``. If you do not have write permission to that location, you should set the environment variable ``GALACTICUS_DYNAMIC_DATA_PATH`` to a path where dynamically-generated files can be written.
 
+.. note::
+
+   The run-time tools (CAMB, CLASS, Cloudy, FSPS, RecFast, AxionCAMB, and mangle) are, by default, stored under the dynamic data path alongside regenerable data. You can relocate them by setting the environment variable ``GALACTICUS_TOOLS_PATH`` to a separate directory. This is useful if you want to keep the (immutable) pre-built tools apart from regenerable cache data — for example so that the cache can be cleared without removing the tools, or to share a read-only tools directory between installs. When unset, ``GALACTICUS_TOOLS_PATH`` defaults to the dynamic data path, so existing setups are unaffected.
+
 You can then run a quick test model using:
 
 .. code-block:: bash

--- a/docs/manuals/user-guide/installation/index.rst
+++ b/docs/manuals/user-guide/installation/index.rst
@@ -4,8 +4,13 @@ Installation
 Galacticus is designed to run on Linux, with experimental support for macOS.
 There are several ways to install it, listed here from easiest to most involved:
 
-* **Pre-compiled binary** — the quickest way to get running; no compilation
-  required. Available for :doc:`Linux <binary>` and :doc:`macOS <binary-macos>`.
+* **pip** — the quickest way to get running for end users. ``pip install
+  galacticus`` installs a launcher that downloads the right pre-built binary,
+  datasets, and tools on first use and sets the environment up for you; see
+  :doc:`pip`.
+* **Pre-compiled binary** — download and configure the binary yourself; no
+  compilation required. Available for :doc:`Linux <binary>` and
+  :doc:`macOS <binary-macos>`.
 * **Container** — a ready-to-use Docker image with Galacticus already installed;
   see :doc:`container`.
 * **From source** — needed if you want to modify or extend the code. Step-by-step
@@ -56,6 +61,7 @@ Python
    :maxdepth: 1
    :caption: Installation routes
 
+   pip
    binary
    binary-macos
    container

--- a/docs/manuals/user-guide/installation/pip.rst
+++ b/docs/manuals/user-guide/installation/pip.rst
@@ -16,6 +16,13 @@ macOS (Apple Silicon). On other platforms — including native Windows — there
 no pre-built binary; build :doc:`from source <source-linux>` instead (on Windows,
 use WSL 2 and the Linux build).
 
+.. note::
+
+   The pre-built macOS binaries are compiled on a recent macOS and will only run
+   on that version or newer. The launcher checks this before running: if your
+   macOS is too old it stops with a clear message (rather than a cryptic
+   ``dyld`` error) telling you to upgrade macOS or build from source.
+
 Running a model
 ---------------
 

--- a/docs/manuals/user-guide/installation/pip.rst
+++ b/docs/manuals/user-guide/installation/pip.rst
@@ -85,5 +85,8 @@ downloads. Run ``galacticus info`` to see which install is in effect.
 
    The launcher fetches assets from the GitHub release matching the installed
    package version (development installs track the rolling ``bleeding-edge``
-   release). ``GALACTICUS_RELEASE_TAG`` and ``GALACTICUS_DATASETS_REF`` override
-   the release tag and datasets ref respectively.
+   release). For a versioned release the run-time datasets are pinned to a
+   specific ``datasets`` commit, recorded on the release, so a given package
+   version always installs the same data. ``GALACTICUS_RELEASE_TAG`` and
+   ``GALACTICUS_DATASETS_REF`` override the release tag and datasets ref
+   respectively.

--- a/docs/manuals/user-guide/installation/pip.rst
+++ b/docs/manuals/user-guide/installation/pip.rst
@@ -1,0 +1,89 @@
+Installing with ``pip``
+=======================
+
+The quickest way to get a working Galacticus for running models is to install
+the ``galacticus`` package from `PyPI <https://pypi.org/project/galacticus/>`_::
+
+   pip install galacticus
+
+This installs a small launcher (the ``galacticus`` command). The first time you
+run a model, the launcher downloads the pre-built executable, the run-time
+``datasets``, and the pre-built ``tools`` for your platform, and sets the
+required environment variables for you — so there is nothing else to configure.
+
+Pre-built binaries are available for Linux (x86-64), macOS (Intel x86-64), and
+macOS (Apple Silicon). On other platforms — including native Windows — there is
+no pre-built binary; build :doc:`from source <source-linux>` instead (on Windows,
+use WSL 2 and the Linux build).
+
+Running a model
+---------------
+
+.. code-block:: bash
+
+   galacticus run parameters/quickTest.xml
+
+On first use you will see the launcher fetch the executable, datasets, and tools;
+subsequent runs reuse the cached copies. ``galacticus run`` validates the
+parameter file before dispatching it; pass ``--no-validate`` to skip that, and
+any other arguments (e.g. ``--dry-run``) are passed straight through to the
+executable. ``galacticus <file>`` is shorthand for ``galacticus run <file>``.
+
+The model writes its output (by default ``galacticus.hdf5``) to the current
+directory, exactly as the executable does when run directly. See
+:doc:`../running` for what to do with the output.
+
+Commands
+--------
+
+``galacticus install``
+   Download (or complete) the install without running a model.
+
+``galacticus update``
+   Re-download the install for the current package version.
+
+``galacticus validate <file>``
+   Validate a parameter file without running it.
+
+``galacticus clean``
+   Purge the regenerable data cache so it cannot grow without bound. Use
+   ``--older-than N`` to remove only files older than ``N`` days, ``--all`` to
+   empty the cache, ``--dry-run`` to report how much would be freed without
+   deleting, and ``--prune-installs`` to also remove superseded per-version
+   installs. ``clean`` never removes the executable, datasets, or tools.
+
+``galacticus info``
+   Show the resolved install, the environment variables it sets, and the current
+   cache size.
+
+Where things are stored
+-----------------------
+
+The launcher keeps two separate locations (resolved via
+`platformdirs <https://pypi.org/project/platformdirs/>`_):
+
+* a **durable data directory** (``user_data_dir``) for the executable, datasets,
+  and pre-built tools — managed by ``install``/``update``; and
+* a **cache directory** (``user_cache_dir``) for regenerable data such as
+  transfer functions and stellar-population spectra — safe to delete, and the
+  only thing ``galacticus clean`` ever touches.
+
+Tools are deliberately kept in the durable directory (via
+``GALACTICUS_TOOLS_PATH``): a binary-only install has no compilers, so losing the
+pre-built tools to a cache purge would leave Galacticus unable to rebuild them.
+
+Using an existing build
+-----------------------
+
+The launcher also works as a front-end to a Galacticus you built yourself. If
+``GALACTICUS_EXEC_PATH`` and ``GALACTICUS_DATA_PATH`` are already set and the
+executable is present, or if ``GALACTICUS_HOME`` points at a build/clone tree
+containing ``Galacticus.exe``, the launcher uses that install and skips all
+downloads. Run ``galacticus info`` to see which install is in effect.
+
+.. note::
+
+   The launcher fetches assets from the GitHub release matching the installed
+   package version (development installs track the rolling ``bleeding-edge``
+   release). ``GALACTICUS_RELEASE_TAG`` and ``GALACTICUS_DATASETS_REF`` override
+   the release tag and datasets ref respectively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,13 @@
 [build-system]
-requires = ["setuptools>=82.0.1", "wheel"]
+requires = ["setuptools>=82.0.1", "wheel", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "galacticus"
-version = "0.0.0"
-description = "Python infrastructure for the Galacticus semi-analytic galaxy formation model."
+# Version is derived from git tags by setuptools_scm (see [tool.setuptools_scm]
+# below). Tag a release `vX.Y.Z` to publish 0.0.0+... dev builds otherwise.
+dynamic = ["version"]
+description = "Install and run the Galacticus semi-analytic galaxy formation model."
 readme = "README.md"
 license = {file = "COPYING"}
 requires-python = ">=3.10"
@@ -35,6 +37,7 @@ dependencies = [
     "PyYAML",
     "GitPython",
     "termcolor",
+    "platformdirs",
 ]
 
 [project.optional-dependencies]
@@ -58,10 +61,26 @@ lint = [
     "pyflakes",
 ]
 
+[project.scripts]
+# End-user launcher: `galacticus run model.xml`, `galacticus install`, etc.
+galacticus = "galacticus_launcher.cli:main"
+
 [project.urls]
 Homepage      = "https://github.com/galacticusorg/galacticus"
 Documentation = "https://github.com/galacticusorg/galacticus/wiki"
 Issues        = "https://github.com/galacticusorg/galacticus/issues"
+
+# ----------------------------------------------------------------------
+# Versioning: setuptools_scm derives the version from git tags so PyPI
+# releases are immutable and reproducible.  A clean `vX.Y.Z` tag yields
+# version `X.Y.Z`; untagged/dev checkouts get a `0.0.0.devN+g<hash>`
+# version, which the launcher treats as "track bleeding-edge".  The
+# fallback keeps builds working in a tarball with no .git present.
+# ----------------------------------------------------------------------
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+version_scheme   = "no-guess-dev"
+local_scheme     = "node-and-date"
 
 # ----------------------------------------------------------------------
 # setuptools layout: source lives under python/ rather than alongside

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,16 @@ fallback_version = "0.0.0"
 version_scheme   = "no-guess-dev"
 local_scheme     = "node-and-date"
 
+# The repository carries non-version tags (e.g. `publication/doi/10.1103/...`).
+# Require version tags to start with `v`, so the `git describe --match` glob
+# becomes `v*[0-9]*` and the DOI tags are ignored -- otherwise the default match
+# (`*[0-9]*`) selects a DOI tag and the build fails with "Can't parse version
+# from tag". `strict = false` keeps `vX`/`vX.Y`/`vX.Y.Z` all valid and silences
+# the future-default warning.
+[tool.setuptools_scm.tag]
+prefix = "v"
+strict = false
+
 # ----------------------------------------------------------------------
 # setuptools layout: source lives under python/ rather than alongside
 # pyproject.toml at the repo root, so we tell setuptools to treat python/

--- a/python/galacticus_launcher/__init__.py
+++ b/python/galacticus_launcher/__init__.py
@@ -1,0 +1,26 @@
+"""End-user launcher for Galacticus.
+
+Galacticus is a Fortran/C++ code, but its pre-built static binaries plus the
+``datasets`` repository and run-time ``tools`` are all published as GitHub
+release assets.  This package turns ``pip install galacticus`` into a working
+model run: it downloads the right artefacts for the host platform into a
+per-user location, sets the environment variables the binary reads
+(``GALACTICUS_EXEC_PATH``, ``GALACTICUS_DATA_PATH``, ``GALACTICUS_TOOLS_PATH``,
+``GALACTICUS_DYNAMIC_DATA_PATH``), and dispatches parameter files to the
+executable.
+
+The ``galacticus`` console script (see :mod:`galacticus_launcher.cli`) is the
+entry point.  The launcher also works as a thin dispatch front-end on top of a
+non-pip install (a git clone built from source): when a usable build is already
+present in the environment, downloads are skipped entirely (see
+:mod:`galacticus_launcher.paths`).
+"""
+
+from importlib import metadata as _metadata
+
+try:
+    __version__ = _metadata.version("galacticus")
+except _metadata.PackageNotFoundError:  # pragma: no cover - source checkouts
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/python/galacticus_launcher/cli.py
+++ b/python/galacticus_launcher/cli.py
@@ -54,11 +54,14 @@ def main(argv=None):
 
     clean_parser = sub.add_parser("clean", help="purge the regenerable cache")
     clean_parser.add_argument("--all", action="store_true",
-                              help="remove the entire dynamic cache")
+                              help="remove the entire dynamic data cache")
     clean_parser.add_argument("--older-than", type=float, metavar="N",
                               help="only remove cache files older than N days")
     clean_parser.add_argument("--prune-installs", action="store_true",
                               help="also remove superseded per-version install dirs")
+    clean_parser.add_argument("--force", action="store_true",
+                              help="clean even when pre-built tools share the "
+                                   "dynamic path (deletes them too)")
     clean_parser.add_argument("--dry-run", action="store_true",
                               help="report what would be freed; delete nothing")
 
@@ -159,39 +162,68 @@ def _cmd_info():
         print(f"release tag    : {install.tag}")
     print(f"executable     : {install.binary}"
           f"{'' if install.binary and Path(install.binary).is_file() else '  (not present)'}")
-    env = install.environ()
-    for name in ("GALACTICUS_EXEC_PATH", "GALACTICUS_DATA_PATH",
-                 "GALACTICUS_TOOLS_PATH", "GALACTICUS_DYNAMIC_DATA_PATH"):
-        print(f"{name:<28} = {env.get(name, '(unset)')}")
-    cache_base = Path(platformdirs.user_cache_dir(paths.APP_NAME))
-    print(f"cache size     : {_human(_tree_size(cache_base))} ({cache_base})")
+    # Show the paths the binary will actually use. For a managed install these
+    # are imposed by the launcher; for env/home they reflect the resolved
+    # effective locations (dynamic defaults to <data>/dynamic when unset).
+    rows = [
+        ("GALACTICUS_EXEC_PATH", install.exec_path),
+        ("GALACTICUS_DATA_PATH", install.data_path),
+        ("GALACTICUS_TOOLS_PATH", install.tools_path),
+        ("GALACTICUS_DYNAMIC_DATA_PATH", install.dynamic_path),
+    ]
+    for name, value in rows:
+        suffix = ""
+        if name == "GALACTICUS_TOOLS_PATH" and install.tools_path is None:
+            value = "(unset; tools share the dynamic path)"
+        elif name == "GALACTICUS_DYNAMIC_DATA_PATH" and not install.managed \
+                and os.environ.get("GALACTICUS_DYNAMIC_DATA_PATH") is None:
+            suffix = "  (default <data>/dynamic)"
+        print(f"{name:<28} = {value if value is not None else '(unset)'}{suffix}")
+    if install.dynamic_path is not None:
+        size = _tree_size(install.dynamic_path)
+        note = "" if install.tools_separated else "  (includes pre-built tools)"
+        print(f"dynamic data   : {_human(size)} ({install.dynamic_path}){note}")
     return 0
 
 
 def _cmd_clean(args):
-    cache_base = Path(platformdirs.user_cache_dir(paths.APP_NAME))
+    install = paths.resolve()
+    target = install.dynamic_path
+    if target is None or not Path(target).exists():
+        print("Nothing to clean (no dynamic data path resolved).")
+        return 0
+    # Guard: when tools are NOT on a separate path they live under the dynamic
+    # path, and purging it would delete pre-built tools a binary-only install
+    # cannot rebuild. Refuse unless the user explicitly forces it.
+    if not install.tools_separated and not args.force:
+        size = _tree_size(target)
+        print(
+            f"galacticus: {target} ({_human(size)}) holds regenerable data AND "
+            "pre-built tools (no separate GALACTICUS_TOOLS_PATH is set).\n"
+            "Refusing to clean to avoid deleting tools that a binary-only install "
+            "cannot rebuild. Set GALACTICUS_TOOLS_PATH to a separate location to "
+            "keep tools out of the cache, or pass --force to clean everything here.",
+            file=sys.stderr,
+        )
+        return 1
+
     cutoff = None
     if args.older_than is not None:
         cutoff = time.time() - args.older_than * 86400.0
-
-    freed, removed = _purge_tree(cache_base, cutoff=cutoff, dry_run=args.dry_run)
+    freed, removed = _purge_tree(Path(target), cutoff=cutoff, dry_run=args.dry_run)
     verb = "Would free" if args.dry_run else "Freed"
-    print(f"{verb} {_human(freed)} from cache ({removed} item(s)).")
+    print(f"{verb} {_human(freed)} from {target} ({removed} item(s)).")
 
-    if args.prune_installs:
-        current = paths.resolve()
+    if args.prune_installs and install.managed:
         data_base = Path(platformdirs.user_data_dir(paths.APP_NAME))
-        keep = current.tag if current.managed else None
-        pruned = 0
+        keep = install.tag
         for child in (data_base.iterdir() if data_base.is_dir() else []):
             if child.is_dir() and child.name != keep:
                 size = _tree_size(child)
                 print(f"{verb} {_human(size)} from install {child.name}.")
                 if not args.dry_run:
                     _rmtree(child)
-                pruned += 1
-        if keep:
-            print(f"Kept current install: {keep}")
+        print(f"Kept current install: {keep}")
     return 0
 
 

--- a/python/galacticus_launcher/cli.py
+++ b/python/galacticus_launcher/cli.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import platformdirs
 
-from . import __version__, download, paths, platforms, validate as _validate
+from . import __version__, download, macos, paths, platforms, validate as _validate
 
 _COMMANDS = {"install", "update", "run", "validate", "clean", "info"}
 
@@ -110,6 +110,12 @@ def _ensure(install):
             f"{install.exec_path}. Build it, or unset GALACTICUS_EXEC_PATH/"
             "GALACTICUS_HOME to use a managed download."
         )
+    # On macOS, refuse a downloaded binary that requires a newer macOS than this
+    # host (it would otherwise fail at exec with a cryptic dyld error).
+    if install.binary is not None and Path(install.binary).is_file():
+        reason = macos.incompatible_reason(install.binary)
+        if reason:
+            raise RuntimeError(reason)
 
 
 def _cmd_install(install, *, force):
@@ -162,6 +168,10 @@ def _cmd_info():
         print(f"release tag    : {install.tag}")
     print(f"executable     : {install.binary}"
           f"{'' if install.binary and Path(install.binary).is_file() else '  (not present)'}")
+    if install.binary is not None and Path(install.binary).is_file():
+        minimum = macos.parse_minimum_macos(install.binary)
+        if minimum is not None:  # only macOS (Mach-O) binaries report this
+            print(f"min macOS      : {minimum[0]}.{minimum[1]}")
     # Show the paths the binary will actually use. For a managed install these
     # are imposed by the launcher; for env/home they reflect the resolved
     # effective locations (dynamic defaults to <data>/dynamic when unset).

--- a/python/galacticus_launcher/cli.py
+++ b/python/galacticus_launcher/cli.py
@@ -1,0 +1,281 @@
+"""``galacticus`` command-line entry point.
+
+Sub-commands:
+
+* ``install`` / ``update`` -- provision (or refresh) the managed install.
+* ``run <params.xml> [args...]`` -- validate then dispatch to the executable.
+* ``validate <params.xml>`` -- run validation only.
+* ``clean`` -- purge the regenerable cache (never the durable install).
+* ``info`` -- report the resolved install, paths, and environment.
+
+``galacticus <params.xml>`` is accepted as shorthand for ``galacticus run``.
+"""
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+import platformdirs
+
+from . import __version__, download, paths, platforms, validate as _validate
+
+_COMMANDS = {"install", "update", "run", "validate", "clean", "info"}
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # Shorthand: `galacticus params.xml` -> `galacticus run params.xml`.
+    if argv and argv[0] not in _COMMANDS and not argv[0].startswith("-"):
+        argv = ["run"] + argv
+
+    parser = argparse.ArgumentParser(
+        prog="galacticus",
+        description="Install and run the Galacticus galaxy-formation model.",
+    )
+    parser.add_argument("--version", action="version", version=f"galacticus {__version__}")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("install", help="download the binary, datasets, and tools")
+    sub.add_parser("update", help="re-download the install for the current version")
+
+    run_parser = sub.add_parser("run", help="run a parameter file")
+    run_parser.add_argument("parameter_file")
+    run_parser.add_argument("--no-validate", action="store_true",
+                            help="skip pre-dispatch parameter validation")
+    run_parser.add_argument("extra", nargs=argparse.REMAINDER,
+                            help="arguments passed through to Galacticus.exe")
+
+    validate_parser = sub.add_parser("validate", help="validate a parameter file")
+    validate_parser.add_argument("parameter_file")
+    validate_parser.add_argument("--structural", action="store_true",
+                                 help="also run structural checks")
+
+    clean_parser = sub.add_parser("clean", help="purge the regenerable cache")
+    clean_parser.add_argument("--all", action="store_true",
+                              help="remove the entire dynamic cache")
+    clean_parser.add_argument("--older-than", type=float, metavar="N",
+                              help="only remove cache files older than N days")
+    clean_parser.add_argument("--prune-installs", action="store_true",
+                              help="also remove superseded per-version install dirs")
+    clean_parser.add_argument("--dry-run", action="store_true",
+                              help="report what would be freed; delete nothing")
+
+    sub.add_parser("info", help="show the resolved install and environment")
+
+    args = parser.parse_args(argv)
+    if not args.command:
+        parser.print_help()
+        return 0
+
+    try:
+        return _dispatch(args)
+    except platforms.UnsupportedPlatform as error:
+        print(f"galacticus: {error}", file=sys.stderr)
+        return 2
+    except (RuntimeError, ValueError) as error:
+        print(f"galacticus: {error}", file=sys.stderr)
+        return 1
+
+
+def _dispatch(args):
+    if args.command == "clean":
+        return _cmd_clean(args)
+    if args.command == "info":
+        return _cmd_info()
+
+    install = paths.resolve()
+    if args.command in ("install", "update"):
+        return _cmd_install(install, force=(args.command == "update"))
+    if args.command == "validate":
+        _ensure(install)
+        return _cmd_validate(install, args.parameter_file, args.structural)
+    if args.command == "run":
+        _ensure(install)
+        return _cmd_run(install, args)
+    raise ValueError(f"unknown command {args.command!r}")  # pragma: no cover
+
+
+def _ensure(install):
+    """Make sure `install` is runnable, provisioning a managed one on demand."""
+    if install.managed:
+        download.provision(install)
+    elif install.binary is None or not Path(install.binary).is_file():
+        raise RuntimeError(
+            f"no Galacticus executable found for the {install.source} install at "
+            f"{install.exec_path}. Build it, or unset GALACTICUS_EXEC_PATH/"
+            "GALACTICUS_HOME to use a managed download."
+        )
+
+
+def _cmd_install(install, *, force):
+    if not install.managed:
+        print(f"Using existing {install.source} install at {install.exec_path}; "
+              "nothing to download.")
+        return 0
+    done = download.provision(install, force=force)
+    if done:
+        print("Provisioned: " + ", ".join(done))
+    else:
+        print("Install already up to date.")
+    print(f"Install location: {install.exec_path.parent}")
+    return 0
+
+
+def _cmd_validate(install, parameter_file, structural):
+    result = _validate.validate(parameter_file, install, structural=structural)
+    _report_findings(result)
+    if result.ok:
+        print(f"OK ({result.method}): {parameter_file}")
+        return 0
+    print(f"INVALID ({result.method}): {parameter_file}", file=sys.stderr)
+    return 1
+
+
+def _cmd_run(install, args):
+    if not args.no_validate:
+        result = _validate.validate(args.parameter_file, install)
+        _report_findings(result)
+        if not result.ok:
+            print(f"galacticus: refusing to run; {args.parameter_file} failed "
+                  "validation (use --no-validate to override).", file=sys.stderr)
+            return 1
+    if install.data_path is None:
+        print("galacticus: warning: no datasets path resolved; the run may fail. "
+              "Set GALACTICUS_DATA_PATH.", file=sys.stderr)
+    env = install.environ()
+    extra = [a for a in (args.extra or []) if a != "--"]
+    command = [str(install.binary), str(args.parameter_file), *extra]
+    sys.stdout.flush()
+    os.execve(str(install.binary), command, env)  # replaces this process
+
+
+def _cmd_info():
+    install = paths.resolve()
+    print(f"galacticus launcher {__version__}")
+    print(f"install source : {install.source}")
+    if install.tag:
+        print(f"release tag    : {install.tag}")
+    print(f"executable     : {install.binary}"
+          f"{'' if install.binary and Path(install.binary).is_file() else '  (not present)'}")
+    env = install.environ()
+    for name in ("GALACTICUS_EXEC_PATH", "GALACTICUS_DATA_PATH",
+                 "GALACTICUS_TOOLS_PATH", "GALACTICUS_DYNAMIC_DATA_PATH"):
+        print(f"{name:<28} = {env.get(name, '(unset)')}")
+    cache_base = Path(platformdirs.user_cache_dir(paths.APP_NAME))
+    print(f"cache size     : {_human(_tree_size(cache_base))} ({cache_base})")
+    return 0
+
+
+def _cmd_clean(args):
+    cache_base = Path(platformdirs.user_cache_dir(paths.APP_NAME))
+    cutoff = None
+    if args.older_than is not None:
+        cutoff = time.time() - args.older_than * 86400.0
+
+    freed, removed = _purge_tree(cache_base, cutoff=cutoff, dry_run=args.dry_run)
+    verb = "Would free" if args.dry_run else "Freed"
+    print(f"{verb} {_human(freed)} from cache ({removed} item(s)).")
+
+    if args.prune_installs:
+        current = paths.resolve()
+        data_base = Path(platformdirs.user_data_dir(paths.APP_NAME))
+        keep = current.tag if current.managed else None
+        pruned = 0
+        for child in (data_base.iterdir() if data_base.is_dir() else []):
+            if child.is_dir() and child.name != keep:
+                size = _tree_size(child)
+                print(f"{verb} {_human(size)} from install {child.name}.")
+                if not args.dry_run:
+                    _rmtree(child)
+                pruned += 1
+        if keep:
+            print(f"Kept current install: {keep}")
+    return 0
+
+
+# --- helpers ---------------------------------------------------------------
+
+def _report_findings(result):
+    for finding in result.findings:
+        print(f"  [{finding.level}/{finding.kind}] {finding.path}: {finding.message}")
+
+
+def _purge_tree(base, *, cutoff, dry_run):
+    """Delete files under `base` (older than `cutoff` if given). Returns
+    ``(bytes_freed, items_removed)``.  Never deletes `base` itself."""
+    if not base.is_dir():
+        return 0, 0
+    freed = 0
+    removed = 0
+    if cutoff is None:
+        for child in base.iterdir():
+            size = _tree_size(child)
+            freed += size
+            removed += 1
+            if not dry_run:
+                _rmtree(child) if child.is_dir() else child.unlink()
+        return freed, removed
+    # Age-based: walk files, remove those older than cutoff, then empty dirs.
+    for dirpath, _dirnames, filenames in os.walk(base):
+        for name in filenames:
+            file_path = Path(dirpath) / name
+            try:
+                stat = file_path.stat()
+            except OSError:
+                continue
+            if stat.st_mtime < cutoff:
+                freed += stat.st_size
+                removed += 1
+                if not dry_run:
+                    try:
+                        file_path.unlink()
+                    except OSError:
+                        pass
+    if not dry_run:
+        _remove_empty_dirs(base)
+    return freed, removed
+
+
+def _remove_empty_dirs(base):
+    for dirpath, dirnames, filenames in os.walk(base, topdown=False):
+        if Path(dirpath) == base:
+            continue
+        if not dirnames and not filenames:
+            try:
+                Path(dirpath).rmdir()
+            except OSError:
+                pass
+
+
+def _rmtree(path):
+    import shutil
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _tree_size(path):
+    if not Path(path).exists():
+        return 0
+    if Path(path).is_file():
+        return Path(path).stat().st_size
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(path):
+        for name in filenames:
+            try:
+                total += (Path(dirpath) / name).stat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def _human(num_bytes):
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024.0 or unit == "TiB":
+            return f"{value:.1f} {unit}" if unit != "B" else f"{int(value)} B"
+        value /= 1024.0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/python/galacticus_launcher/download.py
+++ b/python/galacticus_launcher/download.py
@@ -28,11 +28,13 @@ import requests
 REPO = "galacticusorg/galacticus"
 DATASETS_REPO = "galacticusorg/datasets"
 
-# Tool executables whose execute bit must be restored after unpacking a zip
-# (macOS tools ship as .zip; tar archives already preserve permissions).
+# Tool executables in the pre-built tools archive whose execute bit must be
+# restored after unpacking a zip (macOS tools ship as .zip; tar archives already
+# preserve permissions). This list matches the binaries the CI `Build-Tools`
+# jobs pack into tools.tar.bz2 / toolsMacOS*.zip; tools built at run time and
+# NOT shipped (CosmicEmu's emu.exe, AGN_Spectrum) are intentionally absent.
 _TOOL_EXECUTABLE_NAMES = frozenset({
-    "camb", "class", "recfast.exe", "cloudy.exe", "autosps.exe",
-    "harmonize", "ransack", "emu.exe",
+    "camb", "class", "recfast.exe", "cloudy.exe", "autosps.exe", "harmonize",
 })
 
 _CHUNK = 1 << 20  # 1 MiB

--- a/python/galacticus_launcher/download.py
+++ b/python/galacticus_launcher/download.py
@@ -51,10 +51,44 @@ def source_url(tag):
     return f"https://github.com/{REPO}/archive/refs/tags/{tag}.zip"
 
 
-def datasets_url():
-    """URL of the datasets archive (``GALACTICUS_DATASETS_REF`` selects a ref)."""
-    ref = os.environ.get("GALACTICUS_DATASETS_REF", "master")
-    return f"https://github.com/{DATASETS_REPO}/archive/refs/heads/{ref}.zip"
+def datasets_url(ref="master"):
+    """URL of the datasets archive at `ref` (a branch, tag, or commit SHA).
+
+    GitHub's ``archive/<ref>.zip`` endpoint resolves all three, so a pinned
+    commit SHA yields exactly that snapshot.
+    """
+    return f"https://github.com/{DATASETS_REPO}/archive/{ref}.zip"
+
+
+def resolve_datasets_ref(tag, *, log=print):
+    """Resolve which datasets ref to fetch for a release `tag`.
+
+    ``GALACTICUS_DATASETS_REF`` overrides everything. Otherwise a versioned
+    release pins datasets to the commit recorded in its ``datasets.ref`` asset
+    (written by the publish workflow), so a given package version always fetches
+    the same data. Dev/bleeding-edge installs, or a release with no pin, track
+    datasets ``master``.
+    """
+    override = os.environ.get("GALACTICUS_DATASETS_REF")
+    if override:
+        return override
+    if tag and tag != "bleeding-edge":
+        pinned = _read_remote_text(asset_url(tag, "datasets.ref"))
+        if pinned:
+            return pinned.strip().split()[0]
+        log(f"  no datasets pin on release {tag}; using datasets master.")
+    return "master"
+
+
+def _read_remote_text(url):
+    """Return the text body of `url`, or None if it is absent / unreachable."""
+    try:
+        response = requests.get(url, timeout=30)
+        if response.status_code == 200:
+            return response.text
+    except requests.RequestException:  # pragma: no cover - network
+        pass
+    return None
 
 
 def provision(install, *, force=False, log=print):
@@ -107,12 +141,13 @@ def _provision_datasets(install, *, force, log):
     sentinel = _sentinel(install.data_path, "datasets")
     if sentinel.exists() and not force:
         return False
-    log("Fetching datasets ...")
+    ref = resolve_datasets_ref(install.tag, log=log)
+    log(f"Fetching datasets ({ref}) ...")
     with tempfile.TemporaryDirectory() as work:
         archive = Path(work) / "datasets.zip"
-        _download(datasets_url(), archive, log=log)
+        _download(datasets_url(ref), archive, log=log)
         _extract_strip_top(archive, install.data_path)
-    sentinel.write_text(os.environ.get("GALACTICUS_DATASETS_REF", "master"))
+    sentinel.write_text(ref)
     return True
 
 

--- a/python/galacticus_launcher/download.py
+++ b/python/galacticus_launcher/download.py
@@ -1,0 +1,202 @@
+"""Fetch and unpack Galacticus release artefacts into a managed install.
+
+Provisioning is idempotent: each component drops a sentinel file once complete,
+and a present sentinel means the component is skipped.  Only managed installs
+are ever provisioned -- a local build/clone is used in place, untouched.
+
+Four components make up a runnable install:
+
+* **exec**     -- the repository source archive (whole tree), giving
+  ``GALACTICUS_EXEC_PATH`` its ``parameters/``, ``aux/`` and ``scripts/``,
+  plus the platform executable copied in as ``Galacticus.exe``.
+* **datasets** -- the ``galacticusorg/datasets`` archive (static data root).
+* **tools**    -- the pre-built run-time tools archive.  Its entries are
+  prefixed ``dynamic/`` (the location the un-relocated binary expects); we strip
+  that prefix so the contents land directly under ``GALACTICUS_TOOLS_PATH``.
+"""
+
+import os
+import shutil
+import tarfile
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+import requests
+
+REPO = "galacticusorg/galacticus"
+DATASETS_REPO = "galacticusorg/datasets"
+
+# Tool executables whose execute bit must be restored after unpacking a zip
+# (macOS tools ship as .zip; tar archives already preserve permissions).
+_TOOL_EXECUTABLE_NAMES = frozenset({
+    "camb", "class", "recfast.exe", "cloudy.exe", "autosps.exe",
+    "harmonize", "ransack", "emu.exe",
+})
+
+_CHUNK = 1 << 20  # 1 MiB
+
+
+def asset_url(tag, asset):
+    return f"https://github.com/{REPO}/releases/download/{tag}/{asset}"
+
+
+def source_url(tag):
+    """URL of the Galacticus source archive matching `tag`."""
+    if tag == "bleeding-edge":
+        return f"https://github.com/{REPO}/archive/refs/heads/master.zip"
+    return f"https://github.com/{REPO}/archive/refs/tags/{tag}.zip"
+
+
+def datasets_url():
+    """URL of the datasets archive (``GALACTICUS_DATASETS_REF`` selects a ref)."""
+    ref = os.environ.get("GALACTICUS_DATASETS_REF", "master")
+    return f"https://github.com/{DATASETS_REPO}/archive/refs/heads/{ref}.zip"
+
+
+def provision(install, *, force=False, log=print):
+    """Download and unpack any missing components of a managed `install`.
+
+    Returns the list of component names that were (re)provisioned.  Raises if
+    `install` is not managed.
+    """
+    if not install.managed:
+        raise ValueError("only managed installs can be provisioned")
+    if install.assets is None:  # pragma: no cover - managed always has assets
+        raise ValueError("managed install is missing platform assets")
+
+    done = []
+    for path in (install.exec_path, install.data_path, install.tools_path,
+                 install.dynamic_path):
+        path.mkdir(parents=True, exist_ok=True)
+
+    if _provision_exec(install, force=force, log=log):
+        done.append("exec")
+    if _provision_datasets(install, force=force, log=log):
+        done.append("datasets")
+    if _provision_tools(install, force=force, log=log):
+        done.append("tools")
+    return done
+
+
+def _sentinel(directory, name):
+    return Path(directory) / f".galacticus-{name}"
+
+
+def _provision_exec(install, *, force, log):
+    sentinel = _sentinel(install.exec_path, "exec")
+    if sentinel.exists() and not force:
+        return False
+    log(f"Fetching Galacticus source ({install.tag}) ...")
+    with tempfile.TemporaryDirectory() as work:
+        archive = Path(work) / "source.zip"
+        _download(source_url(install.tag), archive, log=log)
+        _extract_strip_top(archive, install.exec_path)
+    log(f"Fetching executable {install.assets.binary} ...")
+    binary = install.exec_path / "Galacticus.exe"
+    _download(asset_url(install.tag, install.assets.binary), binary, log=log)
+    binary.chmod(0o755)
+    sentinel.write_text(install.tag)
+    return True
+
+
+def _provision_datasets(install, *, force, log):
+    sentinel = _sentinel(install.data_path, "datasets")
+    if sentinel.exists() and not force:
+        return False
+    log("Fetching datasets ...")
+    with tempfile.TemporaryDirectory() as work:
+        archive = Path(work) / "datasets.zip"
+        _download(datasets_url(), archive, log=log)
+        _extract_strip_top(archive, install.data_path)
+    sentinel.write_text(os.environ.get("GALACTICUS_DATASETS_REF", "master"))
+    return True
+
+
+def _provision_tools(install, *, force, log):
+    sentinel = _sentinel(install.tools_path, "tools")
+    if sentinel.exists() and not force:
+        return False
+    log(f"Fetching tools {install.assets.tools} ...")
+    with tempfile.TemporaryDirectory() as work:
+        archive = Path(work) / install.assets.tools
+        _download(asset_url(install.tag, install.assets.tools), archive, log=log)
+        staging = Path(work) / "unpacked"
+        _extract(archive, staging, install.assets.tools_format)
+        # Tools archives are rooted at "dynamic/"; lift that subtree up so the
+        # contents sit directly under GALACTICUS_TOOLS_PATH.
+        root = staging / "dynamic"
+        source = root if root.is_dir() else staging
+        for child in source.iterdir():
+            destination = install.tools_path / child.name
+            if destination.exists():
+                shutil.rmtree(destination) if destination.is_dir() else destination.unlink()
+            shutil.move(str(child), str(destination))
+    _restore_executable_bits(install.tools_path)
+    sentinel.write_text(install.tag)
+    return True
+
+
+def _download(url, dest, *, log=print, retries=4):
+    """Stream `url` to `dest` with exponential-backoff retries."""
+    last_error = None
+    for attempt in range(retries):
+        try:
+            with requests.get(url, stream=True, timeout=60) as response:
+                response.raise_for_status()
+                tmp = Path(str(dest) + ".part")
+                with open(tmp, "wb") as handle:
+                    for chunk in response.iter_content(chunk_size=_CHUNK):
+                        if chunk:
+                            handle.write(chunk)
+                tmp.replace(dest)
+            return
+        except (requests.RequestException, OSError) as error:  # pragma: no cover - network
+            last_error = error
+            if attempt == retries - 1:
+                break
+            wait = 2 ** (attempt + 1)
+            log(f"  download failed ({error}); retrying in {wait}s ...")
+            time.sleep(wait)
+    raise RuntimeError(f"failed to download {url}: {last_error}")
+
+
+def _extract(archive, dest, fmt):
+    """Unpack `archive` (`fmt` in {'zip','tar.bz2','tar.gz'}) into `dest`."""
+    dest.mkdir(parents=True, exist_ok=True)
+    if fmt == "zip":
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(dest)
+    else:
+        mode = "r:bz2" if fmt == "tar.bz2" else "r:gz"
+        with tarfile.open(archive, mode) as tf:
+            tf.extractall(dest)
+
+
+def _extract_strip_top(archive, dest):
+    """Extract a GitHub source/datasets zip, stripping its single top-level
+    directory (``galacticus-master/`` / ``datasets-master/``) so contents land
+    directly in `dest`."""
+    dest.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as work:
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(work)
+        entries = [child for child in Path(work).iterdir()]
+        top = entries[0] if len(entries) == 1 and entries[0].is_dir() else Path(work)
+        for child in top.iterdir():
+            destination = dest / child.name
+            if destination.exists():
+                shutil.rmtree(destination) if destination.is_dir() else destination.unlink()
+            shutil.move(str(child), str(destination))
+
+
+def _restore_executable_bits(tools_path):
+    for dirpath, _dirnames, filenames in os.walk(tools_path):
+        for name in filenames:
+            if name in _TOOL_EXECUTABLE_NAMES or name.endswith(".exe"):
+                file_path = Path(dirpath) / name
+                try:
+                    file_path.chmod(file_path.stat().st_mode | 0o111)
+                except OSError:  # pragma: no cover - best effort
+                    pass

--- a/python/galacticus_launcher/macos.py
+++ b/python/galacticus_launcher/macos.py
@@ -1,0 +1,132 @@
+"""macOS binary compatibility check.
+
+The pre-built macOS binaries are built on a recent macOS (currently macOS 15)
+with no lowered deployment target, so the Mach-O minimum-OS load command pins the
+oldest macOS they will run on. Running one on an older host fails with a cryptic
+``dyld`` error, so before dispatching we read that minimum directly from the
+binary (pure Python -- no Xcode tools) and refuse with a clear message when the
+host macOS is older.
+
+Only the Mach-O header and load commands are read (a few KiB near the start), not
+the whole multi-hundred-MB binary.
+"""
+
+import platform
+import struct
+
+# Mach-O magics (thin) and fat/universal magics (always big-endian on disk).
+_MH_MAGIC_64 = 0xFEEDFACF
+_MH_MAGIC_32 = 0xFEEDFACE
+_FAT_MAGIC = 0xCAFEBABE
+_FAT_MAGIC_64 = 0xCAFEBABF
+
+# Load commands carrying a minimum-OS, and the macOS platform id.
+_LC_VERSION_MIN_MACOSX = 0x24
+_LC_BUILD_VERSION = 0x32
+_PLATFORM_MACOS = 1
+
+_DOCS = ("https://galacticus.readthedocs.io/en/latest/manuals/user-guide/"
+         "installation/source-macos.html")
+
+
+def _decode_version(value):
+    """Decode an X.Y.Z nibble-packed Mach-O version into ``(major, minor)``."""
+    return (value >> 16, (value >> 8) & 0xFF)
+
+
+def _u32(fh, offset, endian="<"):
+    fh.seek(offset)
+    data = fh.read(4)
+    if len(data) < 4:
+        raise struct.error("short read")
+    return struct.unpack(endian + "I", data)[0]
+
+
+def parse_minimum_macos(path):
+    """Return the binary's minimum macOS as ``(major, minor)``, or None if it is
+    not a Mach-O / has no version load command / cannot be read."""
+    try:
+        with open(path, "rb") as fh:
+            magic_be = _u32(fh, 0, ">")
+            if magic_be in (_FAT_MAGIC, _FAT_MAGIC_64):
+                return _parse_fat(fh, magic_be)
+            return _parse_thin(fh, 0)
+    except (OSError, struct.error):
+        return None
+
+
+def _parse_fat(fh, magic):
+    """Scan the slices of a universal binary; return the first slice's minimum."""
+    nfat = _u32(fh, 4, ">")
+    wide = magic == _FAT_MAGIC_64
+    entry_size = 32 if wide else 20  # fat_arch_64 vs fat_arch
+    for i in range(nfat):
+        base = 8 + i * entry_size
+        # offset field follows cputype(4) + cpusubtype(4).
+        if wide:
+            fh.seek(base + 8)
+            offset = struct.unpack(">Q", fh.read(8))[0]
+        else:
+            offset = _u32(fh, base + 8, ">")
+        result = _parse_thin(fh, offset)
+        if result is not None:
+            return result
+    return None
+
+
+def _parse_thin(fh, base):
+    raw = _u32(fh, base, "<")
+    if raw in (_MH_MAGIC_64, _MH_MAGIC_32):
+        endian, magic = "<", raw
+    else:
+        magic = _u32(fh, base, ">")
+        if magic not in (_MH_MAGIC_64, _MH_MAGIC_32):
+            return None
+        endian = ">"
+    is64 = magic == _MH_MAGIC_64
+    ncmds = _u32(fh, base + 16, endian)          # field 4 of the mach_header
+    offset = base + (32 if is64 else 28)         # header size (64- vs 32-bit)
+    for _ in range(ncmds):
+        cmd = _u32(fh, offset, endian)
+        cmdsize = _u32(fh, offset + 4, endian)
+        if cmdsize == 0:
+            break
+        if cmd == _LC_BUILD_VERSION:
+            if _u32(fh, offset + 8, endian) == _PLATFORM_MACOS:   # platform
+                return _decode_version(_u32(fh, offset + 12, endian))  # minos
+        elif cmd == _LC_VERSION_MIN_MACOSX:
+            return _decode_version(_u32(fh, offset + 8, endian))  # version
+        offset += cmdsize
+    return None
+
+
+def host_version():
+    """Return the host macOS version as ``(major, minor)``, or None."""
+    release = platform.mac_ver()[0]
+    if not release:
+        return None
+    parts = release.split(".")
+    try:
+        return (int(parts[0]), int(parts[1]) if len(parts) > 1 else 0)
+    except ValueError:
+        return None
+
+
+def incompatible_reason(binary_path):
+    """Return a human-readable message if the host macOS is older than
+    `binary_path`'s minimum, else None.
+
+    A no-op (None) on non-macOS hosts and whenever the minimum or host version
+    cannot be determined -- the guard only fires on a definite mismatch.
+    """
+    if platform.system() != "Darwin":
+        return None
+    minimum = parse_minimum_macos(binary_path)
+    host = host_version()
+    if minimum is None or host is None or host >= minimum:
+        return None
+    return (
+        f"this pre-built Galacticus binary requires macOS {minimum[0]}.{minimum[1]} "
+        f"or newer, but this host is macOS {host[0]}.{host[1]}. Upgrade macOS, or "
+        f"build Galacticus from source: {_DOCS}"
+    )

--- a/python/galacticus_launcher/paths.py
+++ b/python/galacticus_launcher/paths.py
@@ -1,0 +1,172 @@
+"""Resolve where Galacticus and its data live, and the env it runs under.
+
+Two storage roots are used for a managed (pip) install, chosen so that
+refreshing the install and purging the cache are independent operations:
+
+* **data root** (``platformdirs.user_data_dir``) -- durable, managed by
+  ``galacticus install``/``update``: the executable, the source tree (for
+  ``parameters/`` + ``aux/`` + ``scripts/``), the ``datasets`` repository, and
+  the pre-built run-time ``tools``.  Laid out per release tag so multiple
+  versions can coexist: ``<data>/<tag>/{exec,datasets,tools}``.
+* **cache root** (``platformdirs.user_cache_dir``) -- regenerable compute cache
+  (transfer functions, SSP spectra, cooling tables, ...): ``<cache>/<tag>``.
+  Safe to delete; ``galacticus clean`` only ever touches this.
+
+Tools deliberately live under the *data* root (not the cache): a binary-only
+pip user has no compilers, so if the pre-built tools were lost to a cache purge
+Galacticus would try -- and fail -- to build CAMB/Cloudy/etc. from source.
+``GALACTICUS_TOOLS_PATH`` keeps them out of the purgeable cache.
+
+Resolution order (the first that matches wins), which lets the same launcher
+drive a non-pip, build-from-source install with downloads skipped:
+
+1. ``GALACTICUS_HOME`` -- a Galacticus build/clone tree containing
+   ``Galacticus.exe``; data taken from ``GALACTICUS_DATA_PATH`` if set, else
+   from a sibling ``datasets`` directory, else the managed data root.
+2. ``GALACTICUS_EXEC_PATH`` + ``GALACTICUS_DATA_PATH`` already set in the
+   environment with the executable present -- use them as-is.
+3. The managed download cache (default for pip users).
+"""
+
+import os
+from collections import namedtuple
+from pathlib import Path
+
+import platformdirs
+
+from . import platforms
+
+APP_NAME = "galacticus"
+
+# Source of the resolved install, for reporting by `galacticus info`.
+SOURCE_ENVIRONMENT = "environment"   # GALACTICUS_EXEC_PATH/DATA_PATH preset
+SOURCE_HOME = "home"                 # GALACTICUS_HOME build/clone tree
+SOURCE_MANAGED = "managed"           # downloaded into platformdirs cache
+
+
+class Install(namedtuple(
+    "Install",
+    ["source", "tag", "exec_path", "data_path", "tools_path",
+     "dynamic_path", "binary", "assets"],
+)):
+    """A resolved Galacticus install and the environment it runs under.
+
+    Paths are :class:`pathlib.Path`.  ``assets`` is the
+    :class:`~galacticus_launcher.platforms.PlatformAssets` for the host, or
+    ``None`` for a local (non-managed) install where assets are never fetched.
+    ``managed`` is True only when the launcher owns the install and may
+    download into it.
+    """
+
+    @property
+    def managed(self):
+        return self.source == SOURCE_MANAGED
+
+    def environ(self, base=None):
+        """Return a copy of `base` (default ``os.environ``) with the Galacticus
+        path variables set to this install's locations."""
+        env = dict(os.environ if base is None else base)
+        env["GALACTICUS_EXEC_PATH"] = str(self.exec_path)
+        if self.data_path is not None:
+            env["GALACTICUS_DATA_PATH"] = str(self.data_path)
+        if self.tools_path is not None:
+            env["GALACTICUS_TOOLS_PATH"] = str(self.tools_path)
+        if self.dynamic_path is not None:
+            env["GALACTICUS_DYNAMIC_DATA_PATH"] = str(self.dynamic_path)
+        return env
+
+
+def release_tag(version=None):
+    """Resolve the GitHub release tag to fetch assets from.
+
+    ``GALACTICUS_RELEASE_TAG`` overrides everything.  Otherwise a clean
+    ``X.Y.Z`` package version (other than the ``0.0.0`` development placeholder)
+    maps to the ``vX.Y.Z`` release; anything else -- dev/local checkouts -- maps
+    to the rolling ``bleeding-edge`` release.
+    """
+    override = os.environ.get("GALACTICUS_RELEASE_TAG")
+    if override:
+        return override
+    if version is None:
+        from . import __version__ as version
+    parts = version.split(".")
+    is_final = (
+        version != "0.0.0"
+        and len(parts) == 3
+        and all(part.isdigit() for part in parts)
+    )
+    return f"v{version}" if is_final else "bleeding-edge"
+
+
+def data_root(tag):
+    return Path(platformdirs.user_data_dir(APP_NAME)) / tag
+
+
+def cache_root(tag):
+    return Path(platformdirs.user_cache_dir(APP_NAME)) / tag
+
+
+def _has_binary(directory):
+    binary = Path(directory) / platforms.LOCAL_BINARY_NAME
+    return binary if binary.is_file() else None
+
+
+def resolve(version=None):
+    """Resolve the active install per the documented order above.
+
+    Never performs I/O beyond ``stat`` checks; for a managed install it returns
+    the *intended* layout whether or not the artefacts have been downloaded yet
+    (callers provision via :mod:`galacticus_launcher.download`).
+    """
+    # 1. GALACTICUS_HOME -- an explicit build/clone tree.
+    home = os.environ.get("GALACTICUS_HOME")
+    if home:
+        home = Path(home)
+        binary = _has_binary(home) or (home / platforms.LOCAL_BINARY_NAME)
+        data = os.environ.get("GALACTICUS_DATA_PATH")
+        if data:
+            data = Path(data)
+        elif (home.parent / "datasets" / "static").is_dir():
+            data = home.parent / "datasets"
+        else:
+            data = None
+        return Install(
+            source=SOURCE_HOME, tag=None, exec_path=home, data_path=data,
+            tools_path=_env_path("GALACTICUS_TOOLS_PATH"),
+            dynamic_path=_env_path("GALACTICUS_DYNAMIC_DATA_PATH"),
+            binary=binary, assets=None,
+        )
+
+    # 2. Environment already configured for an existing (source) install.
+    exec_env = os.environ.get("GALACTICUS_EXEC_PATH")
+    data_env = os.environ.get("GALACTICUS_DATA_PATH")
+    if exec_env and data_env:
+        binary = _has_binary(exec_env)
+        if binary is not None:
+            return Install(
+                source=SOURCE_ENVIRONMENT, tag=None, exec_path=Path(exec_env),
+                data_path=Path(data_env),
+                tools_path=_env_path("GALACTICUS_TOOLS_PATH"),
+                dynamic_path=_env_path("GALACTICUS_DYNAMIC_DATA_PATH"),
+                binary=binary, assets=None,
+            )
+
+    # 3. Managed download install.
+    assets = platforms.detect()
+    tag = release_tag(version)
+    data = data_root(tag)
+    cache = cache_root(tag)
+    return Install(
+        source=SOURCE_MANAGED, tag=tag,
+        exec_path=data / "exec",
+        data_path=data / "datasets",
+        tools_path=data / "tools",
+        dynamic_path=cache / "dynamic",
+        binary=data / "exec" / platforms.LOCAL_BINARY_NAME,
+        assets=assets,
+    )
+
+
+def _env_path(name):
+    value = os.environ.get(name)
+    return Path(value) if value else None

--- a/python/galacticus_launcher/paths.py
+++ b/python/galacticus_launcher/paths.py
@@ -62,16 +62,38 @@ class Install(namedtuple(
     def managed(self):
         return self.source == SOURCE_MANAGED
 
+    @property
+    def tools_separated(self):
+        """True if the pre-built tools live on a path distinct from the dynamic
+        (regenerable) data path, so the dynamic path can be purged safely.
+
+        Always true for a managed install (tools under the data root). For an
+        environment/home install it is true only when ``GALACTICUS_TOOLS_PATH``
+        was set to something other than the dynamic path; otherwise tools are
+        colocated under the dynamic path (the binary's default) and purging the
+        dynamic path would also delete them.
+        """
+        if self.managed:
+            return True
+        return self.tools_path is not None and self.tools_path != self.dynamic_path
+
     def environ(self, base=None):
         """Return a copy of `base` (default ``os.environ``) with the Galacticus
-        path variables set to this install's locations."""
+        path variables set to this install's locations.
+
+        A managed install imposes the full layout (exec/data/tools/dynamic). An
+        environment/home install only fixes exec/data and otherwise passes the
+        user's environment through unchanged, so ``GALACTICUS_TOOLS_PATH`` /
+        ``GALACTICUS_DYNAMIC_DATA_PATH`` stay exactly as the user set them (or
+        unset -> the binary's own defaults) and ``run`` behaves identically to
+        invoking the binary directly.
+        """
         env = dict(os.environ if base is None else base)
         env["GALACTICUS_EXEC_PATH"] = str(self.exec_path)
         if self.data_path is not None:
             env["GALACTICUS_DATA_PATH"] = str(self.data_path)
-        if self.tools_path is not None:
+        if self.managed:
             env["GALACTICUS_TOOLS_PATH"] = str(self.tools_path)
-        if self.dynamic_path is not None:
             env["GALACTICUS_DYNAMIC_DATA_PATH"] = str(self.dynamic_path)
         return env
 
@@ -133,7 +155,7 @@ def resolve(version=None):
         return Install(
             source=SOURCE_HOME, tag=None, exec_path=home, data_path=data,
             tools_path=_env_path("GALACTICUS_TOOLS_PATH"),
-            dynamic_path=_env_path("GALACTICUS_DYNAMIC_DATA_PATH"),
+            dynamic_path=_effective_dynamic(data),
             binary=binary, assets=None,
         )
 
@@ -147,7 +169,7 @@ def resolve(version=None):
                 source=SOURCE_ENVIRONMENT, tag=None, exec_path=Path(exec_env),
                 data_path=Path(data_env),
                 tools_path=_env_path("GALACTICUS_TOOLS_PATH"),
-                dynamic_path=_env_path("GALACTICUS_DYNAMIC_DATA_PATH"),
+                dynamic_path=_effective_dynamic(Path(data_env)),
                 binary=binary, assets=None,
             )
 
@@ -170,3 +192,14 @@ def resolve(version=None):
 def _env_path(name):
     value = os.environ.get(name)
     return Path(value) if value else None
+
+
+def _effective_dynamic(data_path):
+    """The dynamic (regenerable) data path the binary will actually use:
+    ``GALACTICUS_DYNAMIC_DATA_PATH`` if set, else ``<data_path>/dynamic`` (the
+    binary's default), else None. Used so ``info``/``clean`` reflect where the
+    regenerable data really lives for an environment/home install."""
+    explicit = _env_path("GALACTICUS_DYNAMIC_DATA_PATH")
+    if explicit is not None:
+        return explicit
+    return (data_path / "dynamic") if data_path is not None else None

--- a/python/galacticus_launcher/platforms.py
+++ b/python/galacticus_launcher/platforms.py
@@ -1,0 +1,63 @@
+"""Map the host platform to the Galacticus release assets it needs.
+
+The CI ``Deploy`` job publishes one executable and one tools archive per
+platform to a GitHub release.  The names are fixed strings (there is no
+platform suffix scheme to parse), so we map ``(system, machine)`` to them
+explicitly.  Anything we do not recognise raises :class:`UnsupportedPlatform`
+with an actionable message rather than guessing.
+"""
+
+import platform
+from collections import namedtuple
+
+# Describes the release assets for one platform.
+#   binary       -- name of the executable asset (e.g. "Galacticus.exe").
+#   tools        -- name of the run-time tools archive asset.
+#   tools_format -- "tar.bz2" or "zip"; how to unpack `tools`.
+#   key          -- short human label for the platform (used in messages).
+PlatformAssets = namedtuple(
+    "PlatformAssets", ["binary", "tools", "tools_format", "key"]
+)
+
+
+class UnsupportedPlatform(RuntimeError):
+    """Raised when no pre-built binary exists for the host platform."""
+
+
+# Local source builds always produce an executable called "Galacticus.exe"
+# regardless of platform; only the *released* asset names differ.
+LOCAL_BINARY_NAME = "Galacticus.exe"
+
+
+def detect(system=None, machine=None):
+    """Return the :class:`PlatformAssets` for the host (or the given override).
+
+    `system`/`machine` default to :func:`platform.system` /
+    :func:`platform.machine` and are accepted as arguments so the mapping can
+    be unit-tested without monkey-patching.
+    """
+    system = (system if system is not None else platform.system()).strip()
+    machine = (machine if machine is not None else platform.machine()).strip().lower()
+
+    if system == "Linux":
+        if machine in ("x86_64", "amd64"):
+            return PlatformAssets("Galacticus.exe", "tools.tar.bz2", "tar.bz2", "Linux x86-64")
+        raise UnsupportedPlatform(
+            f"Galacticus provides no pre-built Linux binary for machine '{machine}'. "
+            "Build from source: https://galacticus.readthedocs.io/en/latest/"
+            "manuals/user-guide/installation/source-linux.html"
+        )
+    if system == "Darwin":
+        if machine in ("x86_64", "amd64"):
+            return PlatformAssets("Galacticus_MacOS.exe", "toolsMacOS.zip", "zip", "macOS x86-64")
+        if machine in ("arm64", "aarch64"):
+            return PlatformAssets("Galacticus_MacOS-M1.exe", "toolsMacOSM1.zip", "zip", "macOS Apple Silicon")
+        raise UnsupportedPlatform(
+            f"Galacticus provides no pre-built macOS binary for machine '{machine}'."
+        )
+    raise UnsupportedPlatform(
+        f"Galacticus provides no pre-built binary for system '{system}'. "
+        "On Windows, use WSL 2 and install the Linux build. Otherwise build "
+        "from source: https://galacticus.readthedocs.io/en/latest/manuals/"
+        "user-guide/installation/index.html"
+    )

--- a/python/galacticus_launcher/tests/test_launcher.py
+++ b/python/galacticus_launcher/tests/test_launcher.py
@@ -1,0 +1,172 @@
+"""Unit tests for the Galacticus launcher.
+
+Network-free: every test exercises the pure logic (platform mapping, install
+resolution, version->tag resolution, and the cache-clean selection logic).
+"""
+
+import os
+
+import pytest
+
+from galacticus_launcher import platforms, paths, cli, download
+
+
+# --- platform mapping ------------------------------------------------------
+
+@pytest.mark.parametrize("system,machine,binary,fmt", [
+    ("Linux", "x86_64", "Galacticus.exe", "tar.bz2"),
+    ("Linux", "AMD64", "Galacticus.exe", "tar.bz2"),
+    ("Darwin", "x86_64", "Galacticus_MacOS.exe", "zip"),
+    ("Darwin", "arm64", "Galacticus_MacOS-M1.exe", "zip"),
+    ("Darwin", "aarch64", "Galacticus_MacOS-M1.exe", "zip"),
+])
+def test_detect_supported(system, machine, binary, fmt):
+    assets = platforms.detect(system, machine)
+    assert assets.binary == binary
+    assert assets.tools_format == fmt
+
+
+@pytest.mark.parametrize("system,machine", [
+    ("Linux", "ppc64le"),
+    ("Darwin", "i386"),
+    ("Windows", "AMD64"),
+    ("SunOS", "sparc"),
+])
+def test_detect_unsupported(system, machine):
+    with pytest.raises(platforms.UnsupportedPlatform):
+        platforms.detect(system, machine)
+
+
+# --- version -> release tag ------------------------------------------------
+
+@pytest.mark.parametrize("version,expected", [
+    ("1.2.3", "v1.2.3"),
+    ("0.0.0", "bleeding-edge"),          # development placeholder
+    ("1.2.3.dev4+g999", "bleeding-edge"),
+    ("0.1.dev575+g58c2.d20260626", "bleeding-edge"),
+    ("1.2", "bleeding-edge"),            # not X.Y.Z
+])
+def test_release_tag(monkeypatch, version, expected):
+    monkeypatch.delenv("GALACTICUS_RELEASE_TAG", raising=False)
+    assert paths.release_tag(version) == expected
+
+
+def test_release_tag_override(monkeypatch):
+    monkeypatch.setenv("GALACTICUS_RELEASE_TAG", "v9.9.9")
+    assert paths.release_tag("1.2.3") == "v9.9.9"
+
+
+# --- install resolution ----------------------------------------------------
+
+def _clear_galacticus_env(monkeypatch):
+    for name in ("GALACTICUS_HOME", "GALACTICUS_EXEC_PATH", "GALACTICUS_DATA_PATH",
+                 "GALACTICUS_TOOLS_PATH", "GALACTICUS_DYNAMIC_DATA_PATH",
+                 "GALACTICUS_RELEASE_TAG"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_resolve_managed(monkeypatch):
+    _clear_galacticus_env(monkeypatch)
+    monkeypatch.setattr(platforms, "detect",
+                        lambda: platforms.PlatformAssets("Galacticus.exe", "tools.tar.bz2", "tar.bz2", "test"))
+    install = paths.resolve("1.2.3")
+    assert install.source == paths.SOURCE_MANAGED
+    assert install.managed
+    assert install.tag == "v1.2.3"
+    # Tools live under the durable data root; dynamic under the cache root.
+    assert install.tools_path.parent == install.exec_path.parent
+    assert "cache" not in str(install.tools_path).lower() or install.tools_path != install.dynamic_path
+    assert install.dynamic_path != install.tools_path
+    env = install.environ()
+    assert env["GALACTICUS_TOOLS_PATH"] == str(install.tools_path)
+    assert env["GALACTICUS_DYNAMIC_DATA_PATH"] == str(install.dynamic_path)
+
+
+def test_resolve_environment(monkeypatch, tmp_path):
+    _clear_galacticus_env(monkeypatch)
+    exec_dir = tmp_path / "build"
+    exec_dir.mkdir()
+    (exec_dir / "Galacticus.exe").write_text("#!/bin/true\n")
+    data_dir = tmp_path / "datasets"
+    data_dir.mkdir()
+    monkeypatch.setenv("GALACTICUS_EXEC_PATH", str(exec_dir))
+    monkeypatch.setenv("GALACTICUS_DATA_PATH", str(data_dir))
+    install = paths.resolve()
+    assert install.source == paths.SOURCE_ENVIRONMENT
+    assert not install.managed
+    assert install.binary == exec_dir / "Galacticus.exe"
+
+
+def test_resolve_environment_without_binary_falls_through(monkeypatch, tmp_path):
+    _clear_galacticus_env(monkeypatch)
+    monkeypatch.setattr(platforms, "detect",
+                        lambda: platforms.PlatformAssets("Galacticus.exe", "tools.tar.bz2", "tar.bz2", "test"))
+    monkeypatch.setenv("GALACTICUS_EXEC_PATH", str(tmp_path / "nope"))
+    monkeypatch.setenv("GALACTICUS_DATA_PATH", str(tmp_path / "datasets"))
+    install = paths.resolve("1.2.3")
+    assert install.source == paths.SOURCE_MANAGED  # no binary -> managed
+
+
+def test_resolve_home(monkeypatch, tmp_path):
+    _clear_galacticus_env(monkeypatch)
+    home = tmp_path / "galacticus"
+    home.mkdir()
+    (home / "Galacticus.exe").write_text("#!/bin/true\n")
+    (tmp_path / "datasets" / "static").mkdir(parents=True)
+    monkeypatch.setenv("GALACTICUS_HOME", str(home))
+    install = paths.resolve()
+    assert install.source == paths.SOURCE_HOME
+    assert install.exec_path == home
+    # Datasets discovered from the sibling directory.
+    assert install.data_path == tmp_path / "datasets"
+
+
+# --- url builders ----------------------------------------------------------
+
+def test_source_url():
+    assert download.source_url("bleeding-edge").endswith("/heads/master.zip")
+    assert download.source_url("v1.2.3").endswith("/tags/v1.2.3.zip")
+
+
+def test_asset_url():
+    url = download.asset_url("v1.2.3", "tools.tar.bz2")
+    assert url == ("https://github.com/galacticusorg/galacticus/releases/"
+                   "download/v1.2.3/tools.tar.bz2")
+
+
+# --- cache cleaning --------------------------------------------------------
+
+def test_purge_tree_older_than(tmp_path):
+    old = tmp_path / "old.dat"
+    new = tmp_path / "new.dat"
+    old.write_bytes(b"x" * 100)
+    new.write_bytes(b"y" * 50)
+    # Age `old` to 10 days; keep `new` fresh.
+    ten_days = 10 * 86400
+    now = os.path.getmtime(new)
+    os.utime(old, (now - ten_days, now - ten_days))
+    # Cutoff = 5 days ago: only `old` qualifies.
+    cutoff = now - 5 * 86400
+    freed, removed = cli._purge_tree(tmp_path, cutoff=cutoff, dry_run=True)
+    assert removed == 1 and freed == 100
+    assert old.exists()  # dry-run deletes nothing
+    freed, removed = cli._purge_tree(tmp_path, cutoff=cutoff, dry_run=False)
+    assert removed == 1 and freed == 100
+    assert not old.exists() and new.exists()
+
+
+def test_purge_tree_all(tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "a.dat").write_bytes(b"a" * 10)
+    (tmp_path / "b.dat").write_bytes(b"b" * 20)
+    freed, removed = cli._purge_tree(tmp_path, cutoff=None, dry_run=False)
+    assert freed == 30
+    assert removed == 2  # one dir + one file at top level
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_human_readable():
+    assert cli._human(0) == "0 B"
+    assert cli._human(1023) == "1023 B"
+    assert cli._human(1024).endswith("KiB")
+    assert cli._human(1024 ** 3).endswith("GiB")

--- a/python/galacticus_launcher/tests/test_launcher.py
+++ b/python/galacticus_launcher/tests/test_launcher.py
@@ -158,6 +158,34 @@ def test_asset_url():
                    "download/v1.2.3/tools.tar.bz2")
 
 
+def test_datasets_url():
+    assert download.datasets_url().endswith("/datasets/archive/master.zip")
+    assert download.datasets_url("deadbeef").endswith("/datasets/archive/deadbeef.zip")
+
+
+def test_resolve_datasets_ref_env_override(monkeypatch):
+    monkeypatch.setenv("GALACTICUS_DATASETS_REF", "my-branch")
+    assert download.resolve_datasets_ref("v1.2.3") == "my-branch"
+
+
+def test_resolve_datasets_ref_bleeding(monkeypatch):
+    monkeypatch.delenv("GALACTICUS_DATASETS_REF", raising=False)
+    # bleeding-edge tracks master and never hits the network for a pin.
+    assert download.resolve_datasets_ref("bleeding-edge") == "master"
+
+
+def test_resolve_datasets_ref_pinned(monkeypatch):
+    monkeypatch.delenv("GALACTICUS_DATASETS_REF", raising=False)
+    monkeypatch.setattr(download, "_read_remote_text", lambda url: "abc123def\n")
+    assert download.resolve_datasets_ref("v1.2.3") == "abc123def"
+
+
+def test_resolve_datasets_ref_unpinned_falls_back(monkeypatch):
+    monkeypatch.delenv("GALACTICUS_DATASETS_REF", raising=False)
+    monkeypatch.setattr(download, "_read_remote_text", lambda url: None)
+    assert download.resolve_datasets_ref("v1.2.3") == "master"
+
+
 # --- cache cleaning --------------------------------------------------------
 
 def test_purge_tree_older_than(tmp_path):

--- a/python/galacticus_launcher/tests/test_launcher.py
+++ b/python/galacticus_launcher/tests/test_launcher.py
@@ -75,8 +75,8 @@ def test_resolve_managed(monkeypatch):
     assert install.tag == "v1.2.3"
     # Tools live under the durable data root; dynamic under the cache root.
     assert install.tools_path.parent == install.exec_path.parent
-    assert "cache" not in str(install.tools_path).lower() or install.tools_path != install.dynamic_path
     assert install.dynamic_path != install.tools_path
+    assert install.tools_separated  # managed always separates tools from cache
     env = install.environ()
     assert env["GALACTICUS_TOOLS_PATH"] == str(install.tools_path)
     assert env["GALACTICUS_DYNAMIC_DATA_PATH"] == str(install.dynamic_path)
@@ -95,6 +95,30 @@ def test_resolve_environment(monkeypatch, tmp_path):
     assert install.source == paths.SOURCE_ENVIRONMENT
     assert not install.managed
     assert install.binary == exec_dir / "Galacticus.exe"
+    # Dynamic data path defaults to <data>/dynamic when unset, so info/clean
+    # reflect where the binary actually writes regenerable data.
+    assert install.dynamic_path == data_dir / "dynamic"
+    # Tools are not separated (no GALACTICUS_TOOLS_PATH), so they share dynamic.
+    assert install.tools_path is None
+    assert not install.tools_separated
+    # environ() must NOT impose tools/dynamic in environment mode.
+    env = install.environ({"PATH": "/usr/bin"})
+    assert "GALACTICUS_TOOLS_PATH" not in env
+    assert "GALACTICUS_DYNAMIC_DATA_PATH" not in env
+
+
+def test_resolve_environment_separated_tools(monkeypatch, tmp_path):
+    _clear_galacticus_env(monkeypatch)
+    exec_dir = tmp_path / "build"
+    exec_dir.mkdir()
+    (exec_dir / "Galacticus.exe").write_text("#!/bin/true\n")
+    (tmp_path / "datasets").mkdir()
+    tools_dir = tmp_path / "tools"
+    monkeypatch.setenv("GALACTICUS_EXEC_PATH", str(exec_dir))
+    monkeypatch.setenv("GALACTICUS_DATA_PATH", str(tmp_path / "datasets"))
+    monkeypatch.setenv("GALACTICUS_TOOLS_PATH", str(tools_dir))
+    install = paths.resolve()
+    assert install.tools_separated  # explicit tools path differs from dynamic
 
 
 def test_resolve_environment_without_binary_falls_through(monkeypatch, tmp_path):

--- a/python/galacticus_launcher/tests/test_launcher.py
+++ b/python/galacticus_launcher/tests/test_launcher.py
@@ -14,7 +14,9 @@ import pytest
 pytest.importorskip("platformdirs")
 pytest.importorskip("requests")
 
-from galacticus_launcher import platforms, paths, cli, download
+import struct
+
+from galacticus_launcher import platforms, paths, cli, download, macos
 
 
 # --- platform mapping ------------------------------------------------------
@@ -228,3 +230,72 @@ def test_human_readable():
     assert cli._human(1023) == "1023 B"
     assert cli._human(1024).endswith("KiB")
     assert cli._human(1024 ** 3).endswith("GiB")
+
+
+# --- macOS compatibility guard --------------------------------------------
+
+def _macho64(load_command):
+    """A minimal little-endian 64-bit Mach-O carrying one load command."""
+    header = struct.pack(
+        "<IiiIIIII",
+        0xFEEDFACF,    # magic (MH_MAGIC_64)
+        0x01000007,    # cputype (x86_64)
+        0x3,           # cpusubtype
+        0x2,           # filetype (MH_EXECUTE)
+        1,             # ncmds
+        len(load_command),  # sizeofcmds
+        0, 0,          # flags, reserved
+    )
+    return header + load_command
+
+
+def _lc_build_version(major, minor):
+    minos = (major << 16) | (minor << 8)
+    # cmd, cmdsize, platform(=macOS), minos, sdk, ntools
+    return struct.pack("<IIIIII", 0x32, 24, 1, minos, minos, 0)
+
+
+def _lc_version_min(major, minor):
+    version = (major << 16) | (minor << 8)
+    # cmd, cmdsize, version, sdk
+    return struct.pack("<IIII", 0x24, 16, version, version)
+
+
+def test_parse_minimum_macos_build_version(tmp_path):
+    binary = tmp_path / "Galacticus_MacOS.exe"
+    binary.write_bytes(_macho64(_lc_build_version(14, 0)))
+    assert macos.parse_minimum_macos(binary) == (14, 0)
+
+
+def test_parse_minimum_macos_version_min(tmp_path):
+    binary = tmp_path / "Galacticus_MacOS.exe"
+    binary.write_bytes(_macho64(_lc_version_min(13, 3)))
+    assert macos.parse_minimum_macos(binary) == (13, 3)
+
+
+def test_parse_minimum_macos_not_macho(tmp_path):
+    plain = tmp_path / "Galacticus.exe"
+    plain.write_bytes(b"\x7fELF" + b"\x00" * 60)  # an ELF, not a Mach-O
+    assert macos.parse_minimum_macos(plain) is None
+
+
+def test_incompatible_reason_blocks_older_host(tmp_path, monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(macos, "parse_minimum_macos", lambda path: (15, 0))
+    monkeypatch.setattr(macos, "host_version", lambda: (13, 5))
+    reason = macos.incompatible_reason(tmp_path / "bin")
+    assert reason is not None and "15.0" in reason and "13.5" in reason
+
+
+def test_incompatible_reason_allows_newer_host(tmp_path, monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(macos, "parse_minimum_macos", lambda path: (15, 0))
+    monkeypatch.setattr(macos, "host_version", lambda: (15, 2))
+    assert macos.incompatible_reason(tmp_path / "bin") is None
+
+
+def test_incompatible_reason_noop_off_macos(tmp_path, monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Linux")
+    # Even if a minimum could be read, a non-macOS host is never blocked.
+    monkeypatch.setattr(macos, "parse_minimum_macos", lambda path: (99, 0))
+    assert macos.incompatible_reason(tmp_path / "bin") is None

--- a/python/galacticus_launcher/tests/test_launcher.py
+++ b/python/galacticus_launcher/tests/test_launcher.py
@@ -8,6 +8,12 @@ import os
 
 import pytest
 
+# The launcher's only third-party deps. Skip the whole module (rather than
+# erroring at collection) where they are absent -- e.g. a minimal CI job that
+# installs pytest but not the package's runtime dependencies.
+pytest.importorskip("platformdirs")
+pytest.importorskip("requests")
+
 from galacticus_launcher import platforms, paths, cli, download
 
 

--- a/python/galacticus_launcher/validate.py
+++ b/python/galacticus_launcher/validate.py
@@ -1,0 +1,95 @@
+"""Parameter-file validation hook, invoked before dispatch.
+
+This is intentionally a thin, swappable layer.  Today it reuses what already
+exists in the tree:
+
+* the catalog-aware Python checker
+  :func:`Galacticus.Parameters.validate.validate_file`, when a
+  ``parameters.catalog.json`` can be found; and
+* otherwise the executable's own ``--dry-run`` mode, which parses and
+  structurally validates the parameter file without running a model.
+
+The public surface is a single :func:`validate` call returning a
+:class:`Result`, so a richer middle-layer validator can replace the
+implementation without any change to :mod:`galacticus_launcher.cli`.
+"""
+
+import os
+import subprocess
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+# A finding mirrors Galacticus.Parameters.validate.Finding so callers can treat
+# both code paths uniformly.
+Finding = namedtuple("Finding", ["level", "kind", "path", "message"])
+
+Result = namedtuple("Result", ["ok", "findings", "method", "detail"])
+
+
+def find_catalog(install):
+    """Locate a ``parameters.catalog.json``, or None.
+
+    Honors ``GALACTICUS_PARAMETER_CATALOG`` first, then looks beside the
+    executable's exec path.
+    """
+    override = os.environ.get("GALACTICUS_PARAMETER_CATALOG")
+    if override and Path(override).is_file():
+        return Path(override)
+    candidate = Path(install.exec_path) / "parameters.catalog.json"
+    return candidate if candidate.is_file() else None
+
+
+def validate(param_file, install, *, structural=False):
+    """Validate `param_file` for `install`; return a :class:`Result`.
+
+    Prefers the catalog-aware Python checker; falls back to the binary's
+    ``--dry-run``.  ``ok`` is False only on an error-level finding or a parse /
+    dry-run failure (type-level findings are warnings and do not fail).
+    """
+    catalog_path = find_catalog(install)
+    if catalog_path is not None:
+        return _validate_with_catalog(param_file, install, catalog_path, structural)
+    return _validate_with_dry_run(param_file, install)
+
+
+def _validate_with_catalog(param_file, install, catalog_path, structural):
+    import json
+
+    # The checker lives under the exec path's python/ tree; make it importable.
+    python_dir = Path(install.exec_path) / "python"
+    if python_dir.is_dir() and str(python_dir) not in sys.path:
+        sys.path.insert(0, str(python_dir))
+    try:
+        from Galacticus.Parameters.validate import validate_file
+    except ImportError as error:
+        return Result(True, [], "catalog-unavailable", str(error))
+
+    with open(catalog_path) as handle:
+        catalog = json.load(handle)
+    findings_raw, parse_error = validate_file(
+        str(param_file), catalog, structural=structural
+    )
+    if parse_error:
+        return Result(False, [Finding("error", "parse", str(param_file), parse_error)],
+                      "catalog", parse_error)
+    findings = [Finding(f.level, f.kind, f.path, f.message) for f in findings_raw]
+    ok = not any(f.level == "error" for f in findings)
+    return Result(ok, findings, "catalog", str(catalog_path))
+
+
+def _validate_with_dry_run(param_file, install):
+    env = install.environ()
+    try:
+        completed = subprocess.run(
+            [str(install.binary), str(param_file), "--dry-run"],
+            env=env, capture_output=True, text=True,
+        )
+    except OSError as error:
+        return Result(False, [Finding("error", "exec", str(param_file), str(error))],
+                      "dry-run", str(error))
+    if completed.returncode == 0:
+        return Result(True, [], "dry-run", "ok")
+    detail = (completed.stderr or completed.stdout or "").strip()
+    return Result(False, [Finding("error", "dry-run", str(param_file), detail)],
+                  "dry-run", detail)

--- a/source/geometry/mangle.F90
+++ b/source/geometry/mangle.F90
@@ -216,7 +216,7 @@ contains
     use :: File_Utilities    , only : Directory_Make   , File_Exists          , File_Lock      , File_Unlock  , &
           &                           lockDescriptor
     use :: Error             , only : Error_Report
-    use :: Input_Paths       , only : inputPath        , pathTypeDataDynamic
+    use :: Input_Paths       , only : inputPath        , pathTypeTools
     use :: ISO_Varying_String, only : operator(//)     , varying_string       , char           , assignment(=)
     use :: String_Handling   , only : stringSubstitute
     use :: System_Download   , only : download
@@ -234,7 +234,7 @@ contains
 
     ! Get the version to use.
     mangleVersion=dependencyVersion("mangle")
-    manglePath   =inputPath(pathTypeDataDynamic)//"mangle-"//mangleVersion//"/"
+    manglePath   =inputPath(pathTypeTools)//"mangle-"//mangleVersion//"/"
     ! Build the mangle code.
     if (.not.File_Exists(manglePath//"bin/harmonize")) then
        call Directory_Make(     manglePath                                         )
@@ -248,7 +248,7 @@ contains
              if (status /= 0 .or. .not.File_Exists(manglePath//".tar.gz")) call Error_Report("unable to download mangle"//{introspection:location})
           end if
           call displayMessage("unpacking mangle code....",verbosityLevelWorking)
-          call System_Command_Do("tar -x -v -z -C "//inputPath(pathTypeDataDynamic)//" -f "//manglePath//".tar.gz",status)
+          call System_Command_Do("tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//manglePath//".tar.gz",status)
           if (status /= 0 .or. .not.File_Exists(manglePath//"src/Makefile.in")) call Error_Report('failed to unpack mangle code'//{introspection:location})
        end if
        staticOptions=""

--- a/source/input/paths.F90
+++ b/source/input/paths.F90
@@ -40,6 +40,7 @@ module Input_Paths
    <entry label="exec"       />
    <entry label="dataStatic" />
    <entry label="dataDynamic"/>
+   <entry label="tools"      />
   </enumeration>
   !!]
 
@@ -80,6 +81,17 @@ contains
           call Get_Environment_Variable("GALACTICUS_DYNAMIC_DATA_PATH",length=pathLength,status=pathStatus)
           if (pathStatus == 0)                                                                     &
                & call pathsRetrieve(pathTypeDataDynamic,"GALACTICUS_DYNAMIC_DATA_PATH",pathLength)
+          ! Pre-built external tools (CAMB, CLASS, Cloudy, FSPS, RecFast,
+          ! AxionCAMB, mangle) default to living under the dynamic data path, but
+          ! can be relocated independently via the GALACTICUS_TOOLS_PATH
+          ! environment variable. This allows a managed (e.g. pip) install to keep
+          ! immutable, pre-built tool binaries separate from the regenerable
+          ! dynamic data cache, so that the cache can be purged without losing the
+          ! tools (which a binary-only install cannot rebuild).
+          paths(pathTypeTools%ID)=paths(pathTypeDataDynamic%ID)
+          call Get_Environment_Variable("GALACTICUS_TOOLS_PATH",length=pathLength,status=pathStatus)
+          if (pathStatus == 0)                                                                     &
+               & call pathsRetrieve(pathTypeTools,"GALACTICUS_TOOLS_PATH",pathLength)
           pathsRetrieved=.true.
        end if
        !$omp end critical (Input_Path_Initialize)

--- a/source/interface/AxionCAMB.F90
+++ b/source/interface/AxionCAMB.F90
@@ -68,7 +68,7 @@ contains
          &                            Directory_Make
     use :: Display           , only : displayMessage   , verbosityLevelWorking
     use :: Error             , only : Error_Report
-    use :: Input_Paths       , only : inputPath        , pathTypeDataDynamic
+    use :: Input_Paths       , only : inputPath        , pathTypeTools
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//), replace       , &
           &                           varying_string
     use :: String_Handling   , only : stringSubstitute
@@ -86,8 +86,8 @@ contains
     !!]
 
     ! Set path and version
-    axionCambPath   =inputPath(pathTypeDataDynamic)//"AxionCAMB/"
-    lockPath        =inputPath(pathTypeDataDynamic)//"axion_camb"
+    axionCambPath   =inputPath(pathTypeTools)//"AxionCAMB/"
+    lockPath        =inputPath(pathTypeTools)//"axion_camb"
     exePath         =axionCambPath//"camb"
     axionCambVersion="?"
     call File_Lock(char(lockPath),fileLock,lockIsShared=.false.)

--- a/source/interface/CAMB.F90
+++ b/source/interface/CAMB.F90
@@ -65,7 +65,7 @@ contains
     use :: File_Utilities    , only : Directory_Make   , File_Exists          , File_Lock      , File_Unlock, &
           &                           lockDescriptor
     use :: Error             , only : Error_Report
-    use :: Input_Paths       , only : inputPath        , pathTypeDataDynamic
+    use :: Input_Paths       , only : inputPath        , pathTypeTools
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)   , replace    , &
           &                           varying_string
     use :: String_Handling   , only : stringSubstitute
@@ -88,11 +88,11 @@ contains
     ! Set path and version
     cambVersion     =dependencyVersion("camb"    )
     forutilsVersion =dependencyVersion("forutils")
-    cambPath        =inputPath(pathTypeDataDynamic)//"CAMB-"//cambVersion//"/fortran/"
+    cambPath        =inputPath(pathTypeTools)//"CAMB-"//cambVersion//"/fortran/"
     executable      =cambPath//"camb"
     makeFile        =cambPath//"Makefile"
     makeFileForUtils=cambPath//"../forutils/Makefile"
-    tarBall         =inputPath(pathTypeDataDynamic)//"CAMB_"//char(cambVersion)//".tar.gz"
+    tarBall         =inputPath(pathTypeTools)//"CAMB_"//char(cambVersion)//".tar.gz"
     tarBallForUtils =cambPath//"../forutils_"//char(forutilsVersion)//".tar.gz"
     ! Build the CAMB code.
     if (.not.File_Exists(executable)) then
@@ -108,7 +108,7 @@ contains
              if (status /= 0 .or. .not.File_Exists(tarBall)) call Error_Report("unable to download CAMB"//{introspection:location})
           end if
           call displayMessage("unpacking CAMB code....",verbosityLevelWorking)
-          command="tar -x -v -z -C "//inputPath(pathTypeDataDynamic)//" -f "//inputPath(pathTypeDataDynamic)//"CAMB_"//cambVersion//".tar.gz"
+          command="tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz"
           call System_Command_Do(command,status);
           if (status /= 0 .or. .not.File_Exists(cambPath)) call Error_Report('failed to unpack CAMB code'//{introspection:location})
           ! Download the "forutils" package if necessary.

--- a/source/interface/CLASS.F90
+++ b/source/interface/CLASS.F90
@@ -66,7 +66,7 @@ contains
     use :: File_Utilities    , only : Directory_Make   , File_Exists          , File_Lock   , File_Unlock, &
           &                           lockDescriptor
     use :: Error             , only : Error_Report
-    use :: Input_Paths       , only : inputPath        , pathTypeDataDynamic
+    use :: Input_Paths       , only : inputPath        , pathTypeTools
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//), replace    , &
           &                           varying_string
     use :: String_Handling   , only : stringSubstitute
@@ -85,7 +85,7 @@ contains
 
     ! Set path and version
     classVersion=dependencyVersion("class")
-    classPath   =inputPath(pathTypeDataDynamic)//"class_public-"//classVersion//"/"
+    classPath   =inputPath(pathTypeTools)//"class_public-"//classVersion//"/"
     ! Build the CLASS code.
     if (.not.File_Exists(classPath//"class")) then
        call Directory_Make(     classPath                                        )
@@ -93,13 +93,13 @@ contains
        ! Unpack the code.
        if (.not.File_Exists(classPath//"Makefile")) then
           ! Download CLASS if necessary.
-          if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"class_public-"//char(classVersion)//".tar.gz")) then
+          if (.not.File_Exists(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")) then
              call displayMessage("downloading CLASS code....",verbosityLevelWorking)
-             call download("https://github.com/lesgourg/class_public/archive/refs/tags/v"//char(classVersion)//".tar.gz",char(inputPath(pathTypeDataDynamic))//"class_public-"//char(classVersion)//".tar.gz",status=status,retries=5,retryWait=60)
-             if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeDataDynamic)//"class_public-"//char(classVersion)//".tar.gz")) call Error_Report("unable to download CLASS"//{introspection:location})
+             call download("https://github.com/lesgourg/class_public/archive/refs/tags/v"//char(classVersion)//".tar.gz",char(inputPath(pathTypeTools))//"class_public-"//char(classVersion)//".tar.gz",status=status,retries=5,retryWait=60)
+             if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")) call Error_Report("unable to download CLASS"//{introspection:location})
           end if
           call displayMessage("unpacking CLASS code....",verbosityLevelWorking)
-          call System_Command_Do("tar -x -v -z -C "//inputPath(pathTypeDataDynamic)//" -f "//inputPath(pathTypeDataDynamic)//"class_public-"//char(classVersion)//".tar.gz",status)
+          call System_Command_Do("tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz",status)
           if (status /= 0 .or. .not.File_Exists(classPath)) call Error_Report('failed to unpack CLASS code'//{introspection:location})        
        end if
        call displayMessage("compiling CLASS code",verbosityLevelWorking)

--- a/source/interface/Cloudy/_module.F90
+++ b/source/interface/Cloudy/_module.F90
@@ -50,7 +50,7 @@ contains
     use :: Display           , only : displayMessage   , verbosityLevelWorking
     use :: File_Utilities    , only : File_Exists
     use :: Error             , only : Error_Report
-    use :: Input_Paths       , only : inputPath        , pathTypeDataDynamic
+    use :: Input_Paths       , only : inputPath        , pathTypeTools
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)     , varying_string
     use :: String_Handling   , only : stringSubstitute
     use :: System_Command    , only : System_Command_Do
@@ -72,7 +72,7 @@ contains
     cloudyVersion     ="c"//dependencyVersion("cloudy"                 )
     cloudyVersionMajor=     dependencyVersion("cloudy",majorOnly=.true.)
     ! Specify Cloudy path.
-    cloudyPath   =inputPath(pathTypeDataDynamic)//cloudyVersion
+    cloudyPath   =inputPath(pathTypeTools)//cloudyVersion
     ! Check for existence of executable - build if necessary.
     if (.not.File_Exists(cloudyPath//"/source/cloudy.exe")) then
        ! Check for existence of source code - unpack and patch if necessary.
@@ -89,7 +89,7 @@ contains
           end if
           ! Unpack and patch the code.
           call displayMessage("unpacking and patching Cloudy code....",verbosityLevelWorking)
-          call System_Command_Do("tar -x -v -z -C "//inputPath(pathTypeDataDynamic)//" -f "//cloudyPath//".tar.gz",status)
+          call System_Command_Do("tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//cloudyPath//".tar.gz",status)
           if (status /= 0 .or. .not.File_Exists(cloudyPath)) call Error_Report("failed to unpack Cloudy code"//{introspection:location})
           call System_Command_Do('sed -i~ -E s/"^#\!\/bin\/sh"/"#\!\/usr\/bin\/env bash"/ '//cloudyPath//'/source/configure.sh',status)
           if (status /= 0                                  ) call Error_Report("failed to patch Cloudy code"//{introspection:location})

--- a/source/interface/FSPS.F90
+++ b/source/interface/FSPS.F90
@@ -57,7 +57,7 @@ contains
     use :: Display           , only : displayMessage   , verbosityLevelWorking
     use :: File_Utilities    , only : File_Exists      , File_Lock            , File_Remove       , File_Unlock
     use :: Error             , only : Error_Report
-    use :: Input_Paths       , only : inputPath        , pathTypeDataDynamic  , pathTypeDataStatic
+    use :: Input_Paths       , only : inputPath        , pathTypeTools        , pathTypeDataStatic
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)      , varying_string
     use :: String_Handling   , only : operator(//)     , stringSubstitute
     use :: System_Command    , only : System_Command_Do
@@ -79,15 +79,15 @@ contains
 
     ! Specify source code path.
     call Interface_FSPS_Version(fspsVersion)
-    fspsPath=inputPath(pathTypeDataDynamic)//"fsps-"//fspsVersion
-    lockPath=inputPath(pathTypeDataDynamic)//"fsps" //fspsVersion
+    fspsPath=inputPath(pathTypeTools)//"fsps-"//fspsVersion
+    lockPath=inputPath(pathTypeTools)//"fsps" //fspsVersion
     execPath=fspsPath//"/src/autosps.exe"
     call File_Lock(char(lockPath),fspsLock)
     ! Build the code if the executable does not exist.
     if (.not.File_Exists(execPath)) then
        ! Download the code if not already done.
        if (.not.File_Exists(fspsPath)) then
-          tarPath=inputPath(pathTypeDataDynamic)//"FSPS_"//char(fspsVersion)//".tar.gz"
+          tarPath=inputPath(pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz"
           if (.not.File_Exists(tarPath)) then
              call displayMessage("downloading FSPS source code....",verbosityLevelWorking)
              url="https://github.com/cconroy20/fsps/archive/refs/tags/v"//fspsVersion//".tar.gz"
@@ -95,7 +95,7 @@ contains
              if (.not.File_Exists(tarPath) .or. status /= 0) call Error_Report("failed to download FSPS"//{introspection:location})
           end if
           call displayMessage("unpacking FSPS code....",verbosityLevelWorking)
-          command="tar -x -v -z -C "//inputPath(pathTypeDataDynamic)//" -f "//inputPath(pathTypeDataDynamic)//"FSPS_"//char(fspsVersion)//".tar.gz"
+          command="tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//inputPath(pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz"
           call System_Command_Do(command,status)          
           if (status /= 0 .or. .not.File_Exists(fspsPath)) call Error_Report('failed to unpack FSPS code'//{introspection:location})
        end if

--- a/source/interface/RecFast.F90
+++ b/source/interface/RecFast.F90
@@ -38,7 +38,7 @@ contains
     use :: File_Utilities    , only : Directory_Make   , File_Exists          , File_Lock         , File_Unlock   , &
           &                           lockDescriptor
     use :: Error             , only : Error_Report
-    use :: Input_Paths       , only : inputPath        , pathTypeDataDynamic  , pathTypeDataStatic
+    use :: Input_Paths       , only : inputPath        , pathTypeTools        , pathTypeDataStatic
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)      , varying_string, &
          &                            var_str
     use :: System_Command    , only : System_Command_Do
@@ -58,7 +58,7 @@ contains
     !!]
 
     ! Set path.
-    recfastPath=inputPath(pathTypeDataDynamic)//"RecFast/"
+    recfastPath=inputPath(pathTypeTools)//"RecFast/"
     ! Build the code if the executable does not exist.
     pathExe=recfastPath//"recfast.exe"
     if (.not.File_Exists(pathExe)) then

--- a/source/tasks/report.F90
+++ b/source/tasks/report.F90
@@ -61,19 +61,26 @@ contains
     !!{RST
     Builds the tabulation.
     !!}
-    use :: Display          , only : displayIndent      , displayMessage, displayUnindent
+    use :: Display          , only : displayIndent      , displayMessage     , displayUnindent
     use :: Output_Build     , only : Output_Build_String
     use :: Error            , only : errorStatusSuccess
     use :: Output_Versioning, only : Version_String
+    use :: Input_Paths      , only : inputPath          , pathTypeExec       , pathTypeDataStatic, &
+         &                           pathTypeDataDynamic, pathTypeTools
+    use :: ISO_Varying_String, only : char
     implicit none
     class  (taskReport), intent(inout), target   :: self
     integer            , intent(  out), optional :: status
     !$GLC attributes unused :: self
 
-    call displayIndent  ('Begin task: report'                         )
-    call displayMessage ('This is Galacticus: '//Version_String     ())
-    call displayMessage ('Built with: '        //Output_Build_String())
-    call displayUnindent('Done task: report'                          )
+    call displayIndent  ('Begin task: report'                                              )
+    call displayMessage ('This is Galacticus: '//Version_String     ()                     )
+    call displayMessage ('Built with: '        //Output_Build_String()                     )
+    call displayMessage ('Executable path:    '//char(inputPath(pathTypeExec       ))      )
+    call displayMessage ('Static data path:   '//char(inputPath(pathTypeDataStatic ))      )
+    call displayMessage ('Dynamic data path:  '//char(inputPath(pathTypeDataDynamic))      )
+    call displayMessage ('Tools path:         '//char(inputPath(pathTypeTools      ))      )
+    call displayUnindent('Done task: report'                                               )
     if (present(status)) status=errorStatusSuccess
     return
   end subroutine reportPerform


### PR DESCRIPTION
## Summary

Adds a one-line `pip install galacticus` path for end users. Galacticus is a Fortran/C++ code, so rather than compiling at install time, a thin pure-Python **launcher** downloads the pre-built static binary, datasets, and run-time tools (already published as GitHub release assets) on first use, sets the required environment variables, and dispatches parameter files to the executable.

```bash
pip install galacticus
galacticus run parameters/quickTest.xml
```

## What's included

**New `galacticus_launcher` package** (`python/galacticus_launcher/`) exposing a `galacticus` console script:
- `platforms.py` — map the host to the right release assets (Linux x86-64, macOS Intel, macOS Apple Silicon).
- `paths.py` — resolve the active install: an existing environment (`GALACTICUS_EXEC_PATH`/`GALACTICUS_DATA_PATH`) → a `GALACTICUS_HOME` build/clone → a managed download. Uses a durable data root for the binary/datasets/tools and a separate, purgeable cache root for regenerable data.
- `download.py` — fetch and unpack assets idempotently; pin datasets per release.
- `validate.py` — pre-dispatch parameter validation behind a swappable interface (reuses `Galacticus.Parameters.validate` / the binary's `--dry-run`).
- `cli.py` — `install` / `update` / `run` / `validate` / `clean` / `info`, plus `galacticus <file>` shorthand.

**New `GALACTICUS_TOOLS_PATH` environment variable** (`source/input/paths.F90` + the seven tool interface modules). Lets pre-built tools live separately from the regenerable dynamic-data cache, **defaulting to the dynamic path** so existing installs are unaffected. This keeps `galacticus clean` from ever deleting tools a binary-only install has no compiler to rebuild. The `report` task now also prints the resolved exec/data/dynamic/tools paths.

**Versioned PyPI publishing** — versions are derived from git tags via `setuptools_scm` (restricted to `v*` tags so the repo's `publication/doi/...` tags are ignored). A new `.github/workflows/publish.yml` builds and publishes the package to PyPI via Trusted Publishing on a `vX.Y.Z` tag, mirrors the current `bleeding-edge` binary/tools assets onto the versioned release, and pins the datasets commit (recorded as a `datasets.ref` asset and in the release notes). A `Verify-Release` job fails fast unless `bleeding-edge` points at the tagged commit, so a release can never pick up stale binaries.

**Docs** — new pip installation guide (wired into the installation index and README quickstart); `GALACTICUS_TOOLS_PATH` documented in the binary guide; developer guide updated with how/when to cut a versioned release and the PyPI publishing procedure, and trimmed of now-automated manual steps.

## Verification
- 30 launcher unit tests pass (platform mapping, install resolution, version→tag, datasets-ref resolution, cache-clean selection); `pyflakes` clean.
- `python -m build` produces a clean sdist + wheel; the `galacticus` console script resolves in a fresh venv.
- `publish.yml` validated as YAML; the asset-mirror/notes step passes `bash -n`.
- The `setuptools_scm` tag restriction verified end-to-end against a `publication/doi/...` tag.

## Notes / follow-ups
- After merge: register a PyPI + TestPyPI Trusted Publisher (pending publisher) for project `galacticus`, workflow `publish.yml`, environment `pypi`; create the GitHub `pypi` environment; do a TestPyPI dry run via `workflow_dispatch`; then push the first `vX.Y.Z`. (Verify the `galacticus` name is available/owned on PyPI.)
- Deferred (out of scope): exposing the `libgalacticus.so` ctypes API via pip; an upfront "no compiler" error for the run-time-built tools (CosmicEmu, AGN_Spectrum), which currently report a generic build-failure message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EYfCRwK2cinTYBSfLokGS)_