### PR TITLE
Check compiler availability before building run-time tools

### DIFF
--- a/source/accretion_disks/spectra/Hopkins2007.F90
+++ b/source/accretion_disks/spectra/Hopkins2007.F90
@@ -148,6 +148,7 @@ contains
     use            :: Numerical_Ranges                , only : Make_Range             , rangeTypeLogarithmic
     use            :: String_Handling                 , only : operator(//)
     use            :: System_Command                  , only : System_Command_Do
+    use            :: System_Compilers                , only : languageC              , compilerValidate
     use            :: System_Download                 , only : download
     implicit none
     class           (accretionDiskSpectraHopkins2007), intent(inout)               :: self
@@ -199,6 +200,7 @@ contains
        end if
        ! Compile the AGN SED code.
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")) then
+          call compilerValidate(languageC,'AGN spectrum')
           call System_Command_Do("cd "//char(inputPath(pathTypeDataStatic))//"aux/AGN_Spectrum; gcc agn_spectrum.c -o agn_spectrum.x -lm");
           if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")) call Error_Report('failed to compile agn_spectrum.c'//{introspection:location})
        end if

--- a/source/geometry/mangle.F90
+++ b/source/geometry/mangle.F90
@@ -221,7 +221,8 @@ contains
     use :: String_Handling   , only : stringSubstitute
     use :: System_Download   , only : download
     use :: System_Command    , only : System_Command_Do
-    use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran, languageC
+    use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran, languageC, &
+         &                            compilerValidate
     implicit none
     type   (varying_string), intent(  out)           :: manglePath, mangleVersion
     logical                , intent(in   ), optional :: static
@@ -237,6 +238,8 @@ contains
     manglePath   =inputPath(pathTypeDataDynamic)//"mangle-"//mangleVersion//"/"
     ! Build the mangle code.
     if (.not.File_Exists(manglePath//"bin/harmonize")) then
+       call compilerValidate(languageFortran,'mangle')
+       call compilerValidate(languageC      ,'mangle')
        call Directory_Make(     manglePath                                         )
        call File_Lock     (char(manglePath//"mangle"),fileLock,lockIsShared=.false.)
        ! Unpack the code.

--- a/source/interface/AxionCAMB.F90
+++ b/source/interface/AxionCAMB.F90
@@ -73,7 +73,7 @@ contains
           &                           varying_string
     use :: String_Handling   , only : stringSubstitute
     use :: System_Command    , only : System_Command_Do
-    use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran
+    use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran, compilerValidate
     implicit none
     type   (varying_string), intent(  out)           :: axionCambPath, axionCambVersion
     logical                , intent(in   ), optional :: static
@@ -93,6 +93,7 @@ contains
     call File_Lock(char(lockPath),fileLock,lockIsShared=.false.)
     ! Build the AxionCAMB code.
     if (.not.File_Exists(exePath)) then
+       call compilerValidate(languageFortran,'AxionCAMB')
        if (.not.File_Exists(axionCambPath)) then
           ! Download AxionCAMB if necessary.
           call displayMessage("downloading AxionCAMB code....",verbosityLevelWorking)

--- a/source/interface/CAMB.F90
+++ b/source/interface/CAMB.F90
@@ -71,7 +71,7 @@ contains
     use :: String_Handling   , only : stringSubstitute
     use :: System_Command    , only : System_Command_Do
     use :: System_Download   , only : download
-    use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran
+    use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran, compilerValidate
     implicit none
     type     (varying_string), intent(  out)           :: cambPath       , cambVersion
     logical                  , intent(in   ), optional :: static
@@ -96,6 +96,7 @@ contains
     tarBallForUtils =cambPath//"../forutils_"//char(forutilsVersion)//".tar.gz"
     ! Build the CAMB code.
     if (.not.File_Exists(executable)) then
+       call compilerValidate(languageFortran,'CAMB')
        call Directory_Make(cambPath                                      )
        call File_Lock     (cambPath//"camb",fileLock,lockIsShared=.false.)
        ! Unpack the code.

--- a/source/interface/CLASS.F90
+++ b/source/interface/CLASS.F90
@@ -72,7 +72,7 @@ contains
     use :: String_Handling   , only : stringSubstitute
     use :: System_Command    , only : System_Command_Do
     use :: System_Download   , only : download
-    use :: System_Compilers  , only : compiler         , compilerOptions      , languageC
+    use :: System_Compilers  , only : compiler         , compilerOptions      , languageC   , compilerValidate
     implicit none
     type   (varying_string), intent(  out)           :: classPath, classVersion
     logical                , intent(in   ), optional :: static
@@ -88,6 +88,7 @@ contains
     classPath   =inputPath(pathTypeDataDynamic)//"class_public-"//classVersion//"/"
     ! Build the CLASS code.
     if (.not.File_Exists(classPath//"class")) then
+       call compilerValidate(languageC,'CLASS')
        call Directory_Make(     classPath                                        )
        call File_Lock     (char(classPath//"class"),fileLock,lockIsShared=.false.)
        ! Unpack the code.

--- a/source/interface/Cloudy/_module.F90
+++ b/source/interface/Cloudy/_module.F90
@@ -55,7 +55,7 @@ contains
     use :: String_Handling   , only : stringSubstitute
     use :: System_Command    , only : System_Command_Do
     use :: System_Download   , only : download
-    use :: System_Compilers  , only : compiler         , compilerOptions      , languageCPlusPlus
+    use :: System_Compilers  , only : compiler         , compilerOptions      , languageCPlusPlus, compilerValidate
     implicit none
     type     (varying_string), intent(  out)           :: cloudyPath   , cloudyVersion
     logical                  , intent(in   ), optional :: static
@@ -75,6 +75,7 @@ contains
     cloudyPath   =inputPath(pathTypeDataDynamic)//cloudyVersion
     ! Check for existence of executable - build if necessary.
     if (.not.File_Exists(cloudyPath//"/source/cloudy.exe")) then
+       call compilerValidate(languageCPlusPlus,'Cloudy')
        ! Check for existence of source code - unpack and patch if necessary.
        if (.not.File_Exists(cloudyPath)) then
           ! Check for existence of tarball - download the Cloudy code if necessary.

--- a/source/interface/FSPS.F90
+++ b/source/interface/FSPS.F90
@@ -62,7 +62,7 @@ contains
     use :: String_Handling   , only : operator(//)     , stringSubstitute
     use :: System_Command    , only : System_Command_Do
     use :: System_Download   , only : download
-    use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran
+    use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran   , compilerValidate
     use :: System_Which      , only : which
     implicit none
     type     (varying_string), intent(  out)           :: fspsPath, fspsVersion
@@ -85,6 +85,7 @@ contains
     call File_Lock(char(lockPath),fspsLock)
     ! Build the code if the executable does not exist.
     if (.not.File_Exists(execPath)) then
+       call compilerValidate(languageFortran,'FSPS')
        ! Download the code if not already done.
        if (.not.File_Exists(fspsPath)) then
           tarPath=inputPath(pathTypeDataDynamic)//"FSPS_"//char(fspsVersion)//".tar.gz"

--- a/source/interface/RecFast.F90
+++ b/source/interface/RecFast.F90
@@ -43,7 +43,7 @@ contains
          &                            var_str
     use :: System_Command    , only : System_Command_Do
     use :: System_Download   , only : download
-    use :: System_Compilers  , only : compiler         , languageFortran
+    use :: System_Compilers  , only : compiler         , languageFortran      , compilerValidate
     implicit none
     type     (varying_string), intent(  out)           :: recfastPath, recfastVersion
     logical                  , intent(in   ), optional :: static
@@ -62,6 +62,7 @@ contains
     ! Build the code if the executable does not exist.
     pathExe=recfastPath//"recfast.exe"
     if (.not.File_Exists(pathExe)) then
+       call compilerValidate(languageFortran,'RecFast')
        call Directory_Make(recfastPath                              )
        call File_Lock     (pathExe    ,fileLock,lockIsShared=.false.)
        ! Patch the code if not already patched.

--- a/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
@@ -176,6 +176,7 @@ contains
     use :: ISO_Varying_String  , only : varying_string
     use :: Numerical_Comparison, only : Values_Differ
     use :: System_Command      , only : System_Command_Do
+    use :: System_Compilers    , only : languageC                   , compilerValidate
     use :: System_Download     , only : download
     use :: Table_Labels        , only : extrapolationTypeExtrapolate
     implicit none
@@ -240,6 +241,7 @@ contains
           ! Check for presence of the executable.
           call Directory_Make(inputPath(pathTypeDataDynamic)//"CosmicEmu-master")
           if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/emu.exe")) then
+             call compilerValidate(languageC,'CosmicEmu')
              ! Check for presence of the source code.
              if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.c")) then
                 ! Download the code.

--- a/source/system/compilers.F90
+++ b/source/system/compilers.F90
@@ -27,7 +27,7 @@ module System_Compilers
   !!}
   implicit none
   private
-  public :: compiler, compilerOptions
+  public :: compiler, compilerOptions, compilerValidate
 
   !![
   <enumeration docformat="rst">
@@ -101,6 +101,58 @@ contains
     if (status == 0) compilerOptions=compilerRetrieve(char(compilerEnvironmentVariable),compilerLength)
     return
   end function compilerOptions
+
+  subroutine compilerValidate(language,toolName)
+    !!{RST
+    Verify that the compiler for the given {\normalfont \ttfamily language} is available on the
+    {\normalfont \ttfamily PATH} before attempting to build an external tool from source at run
+    time, aborting with a clear, actionable error if it is not. This turns the otherwise cryptic
+    build failure that results when no compiler is present (e.g. for a binary-only install) into a
+    message telling the user what to install.
+    !!}
+    use :: Error             , only : Error_Report
+    use :: ISO_Varying_String, only : assignment(=), char        , operator(//), operator(==), &
+         &                            var_str      , varying_string
+    use :: System_Which      , only : which
+    implicit none
+    type     (enumerationLanguageType), intent(in   )           :: language
+    character(len=*                  ), intent(in   ), optional :: toolName
+    type     (varying_string         )                          :: compilerName       , compilerPath       , &
+         &                                                         label              , environmentVariable, &
+         &                                                         forWhat
+    integer                                                     :: status
+
+    select case (language%ID)
+    case (languageFortran  %ID)
+       label              =var_str('Fortran'    )
+       environmentVariable=var_str('FCCOMPILER' )
+    case (languageC        %ID)
+       label              =var_str('C'          )
+       environmentVariable=var_str('CCOMPILER'  )
+    case (languageCPlusPlus%ID)
+       label              =var_str('C++'        )
+       environmentVariable=var_str('CPPCOMPILER')
+    case default
+       call Error_Report('unknown language'//{introspection:location})
+    end select
+    compilerName=compiler(language)
+    compilerPath=which(char(compilerName),status)
+    if (status /= 0 .or. compilerPath == var_str('')) then
+       if (present(toolName)) then
+          forWhat=var_str(' to build the ')//toolName//var_str(' tool')
+       else
+          forWhat=var_str('')
+       end if
+       call Error_Report(                                                                                       &
+            &            var_str('no ')//label//' compiler available'//forWhat//': the compiler '//"'"//        &
+            &            compilerName//"'"//' was not found on the PATH. Galacticus compiles some external '//  &
+            &            'tools from source at run time; install a '//label//' compiler, or set the '//         &
+            &            environmentVariable//' environment variable to one, then re-run.'//                    &
+            &            {introspection:location}                                                               &
+            &           )
+    end if
+    return
+  end subroutine compilerValidate
 
   function compilerRetrieve(compilerEnvironmentVariable,compilerLength)
     !!{RST

--- a/source/system/compilers.F90
+++ b/source/system/compilers.F90
@@ -111,7 +111,7 @@ contains
     message telling the user what to install.
     !!}
     use :: Error             , only : Error_Report
-    use :: ISO_Varying_String, only : assignment(=), char        , operator(//), operator(==), &
+    use :: ISO_Varying_String, only : assignment(=), char        , len         , operator(//), &
          &                            var_str      , varying_string
     use :: System_Which      , only : which
     implicit none
@@ -137,7 +137,7 @@ contains
     end select
     compilerName=compiler(language)
     compilerPath=which(char(compilerName),status)
-    if (status /= 0 .or. compilerPath == var_str('')) then
+    if (status /= 0 .or. len(compilerPath) == 0) then
        if (present(toolName)) then
           forWhat=var_str(' to build the ')//toolName//var_str(' tool')
        else


### PR DESCRIPTION
## Summary

Galacticus compiles several external tools from source **at run time** when a pre-built copy isn't present: CAMB, CLASS, FSPS, RecFast, AxionCAMB, Cloudy, mangle, CosmicEmu, and the Hopkins2007 AGN spectrum code. If no suitable compiler is on the `PATH`, the build previously failed with a cryptic error from `make`/`gcc`. This is most likely to bite users of a binary-only install (e.g. via `pip install galacticus`), who have the pre-built tools but no compiler — and would hit it only for the tools that aren't shipped pre-built (CosmicEmu, AGN spectrum).

This adds an up-front, actionable check.

## Changes

- **`source/system/compilers.F90`** — new `compilerValidate(language[, toolName])` in `System_Compilers`. It resolves the compiler with the existing `compiler(language)` and uses the existing `which` utility (`source/system/which.F90`) to check it is on the `PATH`. If not, it aborts via `Error_Report` with a clear message naming the language, the tool being built, and the environment variable to set (`FCCOMPILER` / `CCOMPILER` / `CPPCOMPILER`), e.g.:

  > no C compiler available to build the CosmicEmu tool: the compiler 'gcc' was not found on the PATH. Galacticus compiles some external tools from source at run time; install a C compiler, or set the CCOMPILER environment variable to one, then re-run.

- **9 run-time build sites** call `compilerValidate` immediately inside the "executable missing" branch, so the check fires only when a build is actually attempted (a pre-built tool is untouched): `source/interface/{CAMB,CLASS,FSPS,RecFast,AxionCAMB}.F90`, `source/interface/Cloudy/_module.F90`, `source/geometry/mangle.F90` (validates both Fortran and C, which it needs), `source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90`, and `source/accretion_disks/spectra/Hopkins2007.F90`.

For a normal source build the compiler is present, so the check is a no-op.

## Notes
- Independent of the `pip`-install PR (#1197); branches off `master`.
- Reuses existing utilities only (`compiler`, `which`, `Error_Report`) — no new dependencies.
- Verified the build-site sweep is complete (no other run-time `make`/`gcc`/`configure` sites). Compilation is exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EYfCRwK2cinTYBSfLokGS)_