### PR TITLE
Fix PyPI rejection of dev builds (drop local version segment)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,7 +102,12 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          # A repeated dry run from the same commit produces the same dev
+          # version; skip rather than fail if it was already uploaded.
+          skip-existing: true
       - name: Publish to PyPI
+        # No skip-existing here: a duplicate version on a real release should
+        # fail loudly (it signals a tagging mistake).
         if: ${{ github.event_name == 'push' }}
         uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,14 +73,19 @@ Issues        = "https://github.com/galacticusorg/galacticus/issues"
 # ----------------------------------------------------------------------
 # Versioning: setuptools_scm derives the version from git tags so PyPI
 # releases are immutable and reproducible.  A clean `vX.Y.Z` tag yields
-# version `X.Y.Z`; untagged/dev checkouts get a `0.0.0.devN+g<hash>`
-# version, which the launcher treats as "track bleeding-edge".  The
-# fallback keeps builds working in a tarball with no .git present.
+# version `X.Y.Z`; untagged/dev checkouts get a `0.0.0.devN` version,
+# which the launcher treats as "track bleeding-edge".  The fallback keeps
+# builds working in a tarball with no .git present.
+#
+# `local_scheme = "no-local-version"` omits the `+g<hash>` local segment.
+# PyPI/TestPyPI reject any local version identifier (a `+...` suffix), so
+# this is required for dev builds to be uploadable (e.g. the TestPyPI dry
+# run); a clean tagged release has no local segment either way.
 # ----------------------------------------------------------------------
 [tool.setuptools_scm]
 fallback_version = "0.0.0"
 version_scheme   = "no-guess-dev"
-local_scheme     = "node-and-date"
+local_scheme     = "no-local-version"
 
 # The repository carries non-version tags (e.g. `publication/doi/10.1103/...`).
 # Require version tags to start with `v`, so the `git describe --match` glob


### PR DESCRIPTION
## Summary

The TestPyPI dry run failed when building from an untagged `master` commit:

```
400 The use of local versions in '0.0.0.post1.dev17182+ge7f7404a6' is not allowed.
```

PyPI and TestPyPI reject any **local version identifier** (the `+...` suffix). `setuptools_scm`'s `local_scheme = "node-and-date"` appends `+g<hash>.d<date>` to dev/untagged builds, so those builds can't be uploaded.

## Changes

- **`pyproject.toml`:** switch `local_scheme` to `no-local-version`, so dev/untagged builds are `0.0.0.devN` (no `+g<hash>`) and therefore uploadable. A clean `vX.Y.Z` tagged release has no local segment either way, so **real releases are unaffected**; the launcher still treats any non-`X.Y.Z` version as `bleeding-edge`.
- **`.github/workflows/publish.yml`:** add `skip-existing: true` to the **TestPyPI** publish step so a repeated dry run from the same commit (same dev version) skips rather than fails with "file already exists". The real PyPI step intentionally omits this, so a duplicate version on a tagged release still fails loudly (which would signal a tagging mistake).

## Verification

With the change, `python -m setuptools_scm` on an untagged checkout now yields e.g. `0.0.0.post1.dev597` — a valid PEP 440 version with no local segment, which TestPyPI/PyPI accept. After this merges, re-run the **Publish** workflow (`workflow_dispatch`, `testpypi = true`) to complete the dry run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EYfCRwK2cinTYBSfLokGS)_