### PR TITLE
Untap unused aws/tap in macOS CI to silence Homebrew tap-trust warning

### DIFF
--- a/.github/actions/buildMacOS/action.yml
+++ b/.github/actions/buildMacOS/action.yml
@@ -62,6 +62,11 @@ runs:
     - name: Install GCC 16 (gcc/g++/gfortran)
       shell: bash
       run: |
+        # The runner image pre-installs AWS's `aws/tap`, which Galacticus never
+        # uses. Newer Homebrew enforces "tap trust" and warns about it on every
+        # `brew update`. Remove the unused tap to keep CI logs clean. The `|| true`
+        # guards against runner images that don't ship the tap.
+        brew untap aws/tap 2>/dev/null || true
         # Refresh the formula index first: the runner image ships an older
         # `gcc` (e.g. 15.2.0) and a stale tap that reports it as current, so a
         # bare `brew install gcc` is a no-op and no `gcc-16` binary appears.


### PR DESCRIPTION
## Summary
- The macOS build jobs printed a Homebrew `aws/tap` "tap trust" warning on every run. The cause is external to Galacticus: GitHub's macOS runner image pre-installs AWS's official Homebrew tap (`aws/tap`), and newer Homebrew enforces a "tap trust" check that warns about any untrusted third-party tap whenever `brew update` runs.
- Galacticus only touches Homebrew in the "Install GCC 16" step of `.github/actions/buildMacOS/action.yml`, which runs `brew update` (surfacing the warning) and installs `gcc` from the trusted core tap. The warning was cosmetic — nothing the build depends on was ignored — but it cluttered logs, and Homebrew plans to eventually block untrusted taps.
- This PR adds `brew untap aws/tap 2>/dev/null || true` before `brew update`. The unused tap is removed so the warning disappears; `|| true` keeps the step safe on runner images that don't ship the tap. The change is in the shared `buildMacOS` action, so it covers all five macOS jobs.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Docs / tooling
- [ ] Other:

## How to test
- Let CI run the macOS jobs (`Build-Executable-MacOS`, `Build-Executable-MacOS-M1`, `Build-Library-MacOS`, `Build-Tools-MacOS`, `Build-Tools-MacOS-M1`).
- In any macOS job's "Install GCC 16" step logs, confirm the `aws/tap` tap-trust warning block no longer appears.
- Confirm the step still succeeds: `gcc` installs/upgrades and downstream build steps run unchanged.

## Checklist
- [x] I ran relevant tests (or explain why not): CI-only change; validated by the macOS CI jobs themselves. No local test applies.
- [x] I updated documentation/comments if needed: added an explanatory comment in the action.
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FW9TcLzzULRdHfnQArtTn

---
_Generated by [Claude Code](https://claude.ai/code/session_014FW9TcLzzULRdHfnQArtTn)_