### PR TITLE
Launcher: resolve bundled parameter paths and show download progress

### DIFF
--- a/docs/manuals/user-guide/installation/pip.rst
+++ b/docs/manuals/user-guide/installation/pip.rst
@@ -30,11 +30,18 @@ Running a model
 
    galacticus run parameters/quickTest.xml
 
-On first use you will see the launcher fetch the executable, datasets, and tools;
-subsequent runs reuse the cached copies. ``galacticus run`` validates the
-parameter file before dispatching it; pass ``--no-validate`` to skip that, and
-any other arguments (e.g. ``--dry-run``) are passed straight through to the
-executable. ``galacticus <file>`` is shorthand for ``galacticus run <file>``.
+On first use you will see the launcher fetch the executable, datasets, and tools,
+with a progress bar for each download; subsequent runs reuse the cached copies.
+``galacticus run`` validates the parameter file before dispatching it; pass
+``--no-validate`` to skip that, and any other arguments (e.g. ``--dry-run``) are
+passed straight through to the executable. ``galacticus <file>`` is shorthand for
+``galacticus run <file>``.
+
+The bundled example parameter files (such as ``parameters/quickTest.xml``)
+resolve against the install, so the command above works from any directory --
+you do not need to ``cd`` into the install tree. A relative path that exists
+in your current directory always takes precedence, so your own parameter files
+are found first.
 
 The model writes its output (by default ``galacticus.hdf5``) to the current
 directory, exactly as the executable does when run directly. See

--- a/python/galacticus_launcher/cli.py
+++ b/python/galacticus_launcher/cli.py
@@ -133,6 +133,7 @@ def _cmd_install(install, *, force):
 
 
 def _cmd_validate(install, parameter_file, structural):
+    parameter_file = _resolve_parameter_file(install, parameter_file)
     result = _validate.validate(parameter_file, install, structural=structural)
     _report_findings(result)
     if result.ok:
@@ -143,11 +144,12 @@ def _cmd_validate(install, parameter_file, structural):
 
 
 def _cmd_run(install, args):
+    parameter_file = _resolve_parameter_file(install, args.parameter_file)
     if not args.no_validate:
-        result = _validate.validate(args.parameter_file, install)
+        result = _validate.validate(parameter_file, install)
         _report_findings(result)
         if not result.ok:
-            print(f"galacticus: refusing to run; {args.parameter_file} failed "
+            print(f"galacticus: refusing to run; {parameter_file} failed "
                   "validation (use --no-validate to override).", file=sys.stderr)
             return 1
     if install.data_path is None:
@@ -155,7 +157,7 @@ def _cmd_run(install, args):
               "Set GALACTICUS_DATA_PATH.", file=sys.stderr)
     env = install.environ()
     extra = [a for a in (args.extra or []) if a != "--"]
-    command = [str(install.binary), str(args.parameter_file), *extra]
+    command = [str(install.binary), parameter_file, *extra]
     sys.stdout.flush()
     os.execve(str(install.binary), command, env)  # replaces this process
 
@@ -238,6 +240,33 @@ def _cmd_clean(args):
 
 
 # --- helpers ---------------------------------------------------------------
+
+def _resolve_parameter_file(install, parameter_file):
+    """Return the parameter file to hand to the binary, as a string.
+
+    Galacticus reads relative paths in a parameter file (and the parameter file
+    argument itself) relative to the *current working directory*, but the bundled
+    example parameter files (``parameters/quickTest.xml`` etc.) live under the
+    install's ``GALACTICUS_EXEC_PATH``, not the user's CWD.  So ``galacticus run
+    parameters/quickTest.xml`` would fail for a pip user unless they happened to
+    be standing in the exec dir.
+
+    Resolution: a path that exists relative to the CWD (or an absolute path) is
+    used as-is, so the user's own files always win.  Otherwise, if the path
+    exists under the install's exec dir, the absolute path there is used, letting
+    the bundled examples run from any directory.  A path that matches neither is
+    passed through unchanged so the binary emits its own "file not found" error.
+    Output is still written relative to the CWD, as before.
+    """
+    given = Path(parameter_file)
+    if given.exists():
+        return str(given)
+    if install.exec_path is not None and not given.is_absolute():
+        bundled = Path(install.exec_path) / parameter_file
+        if bundled.is_file():
+            return str(bundled)
+    return parameter_file
+
 
 def _report_findings(result):
     for finding in result.findings:

--- a/python/galacticus_launcher/download.py
+++ b/python/galacticus_launcher/download.py
@@ -17,6 +17,7 @@ Four components make up a runnable install:
 
 import os
 import shutil
+import sys
 import tarfile
 import tempfile
 import time
@@ -176,17 +177,21 @@ def _provision_tools(install, *, force, log):
 
 
 def _download(url, dest, *, log=print, retries=4):
-    """Stream `url` to `dest` with exponential-backoff retries."""
+    """Stream `url` to `dest` with exponential-backoff retries and progress."""
     last_error = None
     for attempt in range(retries):
         try:
             with requests.get(url, stream=True, timeout=60) as response:
                 response.raise_for_status()
+                total = _content_length(response)
                 tmp = Path(str(dest) + ".part")
+                progress = _Progress(total, log=log)
                 with open(tmp, "wb") as handle:
                     for chunk in response.iter_content(chunk_size=_CHUNK):
                         if chunk:
                             handle.write(chunk)
+                            progress.update(len(chunk))
+                progress.finish()
                 tmp.replace(dest)
             return
         except (requests.RequestException, OSError) as error:  # pragma: no cover - network
@@ -197,6 +202,84 @@ def _download(url, dest, *, log=print, retries=4):
             log(f"  download failed ({error}); retrying in {wait}s ...")
             time.sleep(wait)
     raise RuntimeError(f"failed to download {url}: {last_error}")
+
+
+def _content_length(response):
+    """Total size in bytes from the response headers, or None if not advertised."""
+    value = response.headers.get("Content-Length")
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):  # pragma: no cover - malformed header
+        return None
+
+
+class _Progress:
+    """Render download progress.
+
+    On an interactive terminal a single carriage-return-updated bar is drawn to
+    stderr.  Otherwise (logs, pipes, non-default ``log``) progress is emitted as
+    occasional milestone lines, so it stays readable without a TTY.  Dependency
+    free -- no ``tqdm`` -- to keep the launcher's footprint minimal.
+    """
+
+    _BAR_WIDTH = 30
+    _MILESTONE = 0.10  # log every 10% when not a TTY
+
+    def __init__(self, total, *, log=print):
+        self._total = total if total and total > 0 else None
+        self._log = log
+        self._done = 0
+        self._last_render = 0.0
+        self._next_milestone = self._MILESTONE
+        self._tty = (
+            log is print
+            and hasattr(sys.stderr, "isatty")
+            and sys.stderr.isatty()
+        )
+        self._active = False
+
+    def update(self, count):
+        self._done += count
+        if self._tty:
+            self._render_bar()
+        elif self._total is not None:
+            fraction = self._done / self._total
+            if fraction >= self._next_milestone:
+                while self._next_milestone <= fraction:
+                    self._next_milestone += self._MILESTONE
+                self._log(f"  ... {int(fraction * 100)}% "
+                          f"({_human(self._done)} / {_human(self._total)})")
+
+    def finish(self):
+        if self._tty and self._active:
+            self._render_bar(force=True)
+            sys.stderr.write("\n")
+            sys.stderr.flush()
+
+    def _render_bar(self, *, force=False):
+        now = time.monotonic()
+        if not force and now - self._last_render < 0.1:
+            return
+        self._last_render = now
+        self._active = True
+        if self._total is not None:
+            fraction = min(1.0, self._done / self._total)
+            filled = int(self._BAR_WIDTH * fraction)
+            bar = "#" * filled + "-" * (self._BAR_WIDTH - filled)
+            text = (f"\r  [{bar}] {int(fraction * 100):3d}% "
+                    f"{_human(self._done)} / {_human(self._total)}")
+        else:
+            text = f"\r  {_human(self._done)} downloaded"
+        sys.stderr.write(text)
+        sys.stderr.flush()
+
+
+def _human(num_bytes):
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024.0 or unit == "TiB":
+            return f"{value:.1f} {unit}" if unit != "B" else f"{int(value)} B"
+        value /= 1024.0
 
 
 def _extract(archive, dest, fmt):

--- a/python/galacticus_launcher/tests/test_launcher.py
+++ b/python/galacticus_launcher/tests/test_launcher.py
@@ -225,6 +225,91 @@ def test_purge_tree_all(tmp_path):
     assert list(tmp_path.iterdir()) == []
 
 
+# --- parameter-file resolution ---------------------------------------------
+
+def _install_with_exec(exec_path):
+    """A minimal Install whose only populated field is `exec_path`."""
+    return paths.Install(
+        source=paths.SOURCE_MANAGED, tag="v1.2.3", exec_path=exec_path,
+        data_path=None, tools_path=None, dynamic_path=None, binary=None, assets=None,
+    )
+
+
+def test_resolve_parameter_file_cwd_wins(tmp_path, monkeypatch):
+    exec_dir = tmp_path / "exec"
+    (exec_dir / "parameters").mkdir(parents=True)
+    (exec_dir / "parameters" / "quickTest.xml").write_text("<exec/>")
+    work = tmp_path / "work"
+    (work / "parameters").mkdir(parents=True)
+    (work / "parameters" / "quickTest.xml").write_text("<cwd/>")
+    monkeypatch.chdir(work)
+    install = _install_with_exec(exec_dir)
+    # A relative path that exists in the CWD resolves there, not the exec dir.
+    resolved = cli._resolve_parameter_file(install, "parameters/quickTest.xml")
+    assert os.path.realpath(resolved) == str(work / "parameters" / "quickTest.xml")
+
+
+def test_resolve_parameter_file_falls_back_to_exec(tmp_path, monkeypatch):
+    exec_dir = tmp_path / "exec"
+    (exec_dir / "parameters").mkdir(parents=True)
+    bundled = exec_dir / "parameters" / "quickTest.xml"
+    bundled.write_text("<exec/>")
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+    install = _install_with_exec(exec_dir)
+    # Not present in CWD -> resolves to the bundled copy under the exec dir.
+    resolved = cli._resolve_parameter_file(install, "parameters/quickTest.xml")
+    assert resolved == str(bundled)
+
+
+def test_resolve_parameter_file_passthrough_when_missing(tmp_path, monkeypatch):
+    exec_dir = tmp_path / "exec"
+    exec_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    install = _install_with_exec(exec_dir)
+    # Neither CWD nor exec dir has it -> passed through unchanged for the
+    # binary to report its own error.
+    resolved = cli._resolve_parameter_file(install, "does/not/exist.xml")
+    assert resolved == "does/not/exist.xml"
+
+
+def test_resolve_parameter_file_absolute_untouched(tmp_path):
+    exec_dir = tmp_path / "exec"
+    exec_dir.mkdir()
+    target = tmp_path / "elsewhere.xml"
+    target.write_text("<x/>")
+    install = _install_with_exec(exec_dir)
+    resolved = cli._resolve_parameter_file(install, str(target))
+    assert resolved == str(target)
+
+
+# --- download progress -----------------------------------------------------
+
+def test_progress_milestones_non_tty(capsys):
+    lines = []
+    progress = download._Progress(1000, log=lines.append)
+    assert not progress._tty  # custom log is never treated as a TTY
+    for _ in range(10):
+        progress.update(100)
+    progress.finish()
+    # Milestone lines report percentage as the download advances.
+    assert any("100%" in line for line in lines)
+    assert any("50%" in line for line in lines)
+
+
+def test_progress_unknown_total_no_crash():
+    lines = []
+    progress = download._Progress(None, log=lines.append)
+    progress.update(500)
+    progress.finish()  # must not raise when the total is unknown
+
+
+def test_download_human_readable():
+    assert download._human(0) == "0 B"
+    assert download._human(1024).endswith("KiB")
+
+
 def test_human_readable():
     assert cli._human(0) == "0 B"
     assert cli._human(1023) == "1023 B"


### PR DESCRIPTION
Two usability fixes for the pip launcher, both reported after a successful `pip install` on Linux.

## Bundled parameter files resolve from any directory

`galacticus run parameters/quickTest.xml` previously failed for a pip user unless they happened to be standing in the install tree, because the bundled example parameter files live under the install's `GALACTICUS_EXEC_PATH`, not the user's current directory. Only giving the full path worked.

The launcher now resolves a relative parameter path:

1. If it exists relative to the current directory (or is absolute) → used as-is, so **the user's own parameter files always take precedence**.
2. Otherwise, if it exists under the install's exec dir → the absolute path there is used, so the **bundled examples run from any directory**.
3. Otherwise → passed through unchanged, so the binary emits its own "file not found" error.

Output is still written relative to the current directory, exactly as before. Applied to both `galacticus run` and `galacticus validate`.

## Download progress bar

The first-run downloads (binary, datasets, tools) can take a while. They now show progress:

- On an interactive terminal, a single carriage-return-updated bar is drawn to stderr (`[######------] 50% 120.0 MiB / 240.0 MiB`).
- When output is not a TTY (logs, pipes), progress is emitted as occasional percentage milestone lines instead.

Dependency-free — no `tqdm` — to keep the launcher's footprint minimal. Falls back gracefully when the server does not advertise `Content-Length`.

## Tests & docs

- New unit tests for the parameter-file resolver (CWD wins, exec-dir fallback, passthrough, absolute untouched) and the progress reporter (milestones, unknown-total no-crash).
- Docs note in the pip installation guide that bundled examples run from any directory and that downloads show progress.

All 43 launcher tests pass; pyflakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EYfCRwK2cinTYBSfLokGS)_