### PR TITLE
perf(build): parallelise source-tree scan scripts to overlap NFS latency

### DIFF
--- a/python/Galacticus/Build/ParallelScan.py
+++ b/python/Galacticus/Build/ParallelScan.py
@@ -1,0 +1,108 @@
+"""Run an independent per-source-file scan concurrently across a process pool.
+
+Several build scripts walk the `source/` tree and parse every file. The per-file
+cost is dominated by blocking file I/O (open/read over NFS); on a loaded node
+each open stalls in close-to-open metadata revalidation, so doing them one at a
+time serialises thousands of millisecond waits. Scanning the files concurrently
+overlaps those waits (and the parsing CPU work).
+
+A *fork*-based process pool is used so workers are fully isolated -- callers need
+make no assumptions about the thread-safety of the parser -- and the read-only
+inputs a worker needs are inherited via copy-on-write rather than pickled per
+task. Results are returned in the SAME order as the input tasks, so callers that
+depend on deterministic ordering (e.g. Makefile emission) are unaffected.
+
+Andrew Benson (2026).
+"""
+
+import concurrent.futures
+import multiprocessing
+import os
+import re
+import sys
+
+# Worker count when run standalone (no `make`, no explicit override). Capped at
+# the task count by `resolve_jobs`. Oversubscribing cores is intentional: the
+# work is I/O-latency bound, so workers blocked on NFS still overlap waits.
+_DEFAULT_STANDALONE = 16
+
+_MAKEFLAGS_J_RE = re.compile(r'(?:^|\s)-j(\d*)')
+
+
+def _cpu_count():
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return os.cpu_count() or 1
+
+
+def resolve_jobs(n_tasks):
+    """Decide how many workers to use.
+
+    Precedence:
+      * `GALACTICUS_BUILD_JOBS` (explicit override; 0/"unlimited" -> cpu count);
+      * the `-j` value `make` passed down via `MAKEFLAGS` (so the build's own
+        `-jN` flows through -- bare `-j` means unlimited -> cpu count, and a
+        `make` invocation with no `-j` is serial -> 1);
+      * when not run under `make` at all, `_DEFAULT_STANDALONE`.
+    The result is clamped to `[1, n_tasks]`.
+    """
+    override = os.environ.get('GALACTICUS_BUILD_JOBS')
+    if override is not None and override.strip() != '':
+        try:
+            jobs = int(override)
+        except ValueError:
+            jobs = 0
+    else:
+        makeflags = os.environ.get('MAKEFLAGS')
+        if makeflags is None:
+            jobs = _DEFAULT_STANDALONE          # standalone (no make)
+        else:
+            m = _MAKEFLAGS_J_RE.search(makeflags)
+            if m is None:
+                jobs = 1                         # under make, no -j -> serial
+            elif m.group(1) == '':
+                jobs = 0                         # bare -j -> unlimited
+            else:
+                jobs = int(m.group(1))           # make -jN -> N
+
+    if jobs <= 0:
+        jobs = _cpu_count()
+    return max(1, min(jobs, n_tasks))
+
+
+def scan(tasks, worker, script_name, jobs=None):
+    """Apply `worker(task)` to every task, returning results in task order.
+
+    `worker` must be a module-level (picklable) callable. `script_name` is used
+    only to make failures legible. Falls back to a serial loop when one worker
+    is requested or there is a single task. On a worker failure the underlying
+    error is surfaced with a hint to re-run serially for a full traceback,
+    rather than a raw pool traceback.
+    """
+    tasks = list(tasks)
+    if not tasks:
+        return []
+    if jobs is None:
+        jobs = resolve_jobs(len(tasks))
+    if jobs <= 1:
+        return [worker(task) for task in tasks]
+
+    results = [None] * len(tasks)
+    ctx = multiprocessing.get_context('fork')
+    try:
+        with concurrent.futures.ProcessPoolExecutor(
+                max_workers=jobs, mp_context=ctx) as pool:
+            futures = {pool.submit(worker, task): i
+                       for i, task in enumerate(tasks)}
+            for future in concurrent.futures.as_completed(futures):
+                results[futures[future]] = future.result()
+    except concurrent.futures.process.BrokenProcessPool as exc:
+        sys.exit(f"{script_name}: a parallel worker was killed before it could "
+                 f"return (out of memory, or a crash in the parser). Re-run "
+                 f"with GALACTICUS_BUILD_JOBS=1 to reproduce serially.")
+    except BaseException as exc:  # noqa: B036  (re-raised cleanly below)
+        sys.exit(f"{script_name}: a parallel worker failed: {exc}\n"
+                 f"Re-run with GALACTICUS_BUILD_JOBS=1 for a full serial "
+                 f"traceback.")
+    return results

--- a/scripts/build/codeDirectivesParse.py
+++ b/scripts/build/codeDirectivesParse.py
@@ -24,6 +24,7 @@ import sys
 
 from Galacticus.Build.FileChanges               import update as file_changes_update
 from Galacticus.Build.Directives      import extract_directives
+from Galacticus.Build.ParallelScan    import scan as parallel_scan
 from XML.Utils                        import dict_to_xml_string
 
 
@@ -126,6 +127,156 @@ def _add_implicit_directives(directive, per_file_entry, file_name, file_path):
 
 
 # ---------------------------------------------------------------------------
+# Per-file processing (parallelised across files)
+# ---------------------------------------------------------------------------
+#
+# Each source file is scanned independently: it reads the file (and any
+# `include`d files) and produces a single per-file `entry` dict that writes to
+# no shared state. The per-file cost is dominated by blocking file I/O
+# (open/read of the source on NFS), which on a loaded node stretches from
+# microseconds to milliseconds per file; running the scans concurrently overlaps
+# those waits (and the directive-parsing CPU work) instead of paying them one at
+# a time.
+#
+# A fork-based process pool is used rather than threads so the workers are fully
+# isolated -- no assumptions are made about the thread-safety of the parser.
+# Workers inherit the read-only `source_directory`/`build_path` via copy-on-write
+# fork (published to `_WORKER` before the scan), so nothing large is pickled per
+# task; only the small per-file result dicts come back.
+
+_WORKER = {}
+
+
+def _scan_one(task):
+    """Worker: scan one source file (and its include tree) and return
+    `(file_identifier, entry)`. Mirrors the per-file body of the serial scan
+    loop exactly, writing to no shared state.
+    """
+    source_file_name, file_path, file_identifier = task
+    source_directory = _WORKER['source_directory']
+    build_path       = _WORKER['build_path']
+
+    entry = {'files': [file_path]}
+
+    # Walk include files depth-first.
+    pending = [file_path]
+    while pending:
+        current = pending.pop()
+        included = _collect_included_files(current, source_directory)
+        pending.extend(included)
+        entry['files'].extend(included)
+
+        # Extract every directive in the current file.
+        for directive in extract_directives(
+            current, '*', set_root_element_type=True,
+        ):
+            root_type = directive.get('rootElementType')
+            if root_type == 'include':
+                # Include directive: record the source file and the
+                # include file name, drop `content`, and XML-serialize
+                # the remaining attributes for the per-directive file.
+                directive['source'] = current
+                content = directive.get('content', '')
+                if isinstance(content, str):
+                    m = _INCLUDE_BODY_RE.search(content)
+                    if m:
+                        include_leaf = m.group(1)
+                        include_leaf = re.sub(r'\.inc$', '.Inc',
+                                              include_leaf)
+                        directive['fileName'] = os.path.join(
+                            build_path, include_leaf,
+                        )
+                directive.pop('content', None)
+
+                directive_name = (
+                    directive.get('name')
+                    or directive.get('directive')
+                )
+                key = f"{directive_name}.{directive.get('type')}"
+                entry.setdefault('includeDirectives', {})[key] = {
+                    'source':   current,
+                    'fileName': directive.get('fileName'),
+                    'xml':      dict_to_xml_string(root_type, directive),
+                }
+            else:
+                # Non-include directive: remember the source file.
+                non_include = entry.setdefault('nonIncludeDirectives', {})
+                slot = non_include.setdefault(
+                    root_type, {'files': [], 'dependency': []},
+                )
+                slot['files'].append(file_path)
+
+                if root_type == 'functionClass':
+                    preprocessed = re.sub(
+                        r'\.F90$', '.p.F90',
+                        os.path.join(build_path, source_file_name),
+                    )
+                    entry.setdefault(
+                        'functionClasses', {},
+                    )[directive['name']] = preprocessed
+                    _add_implicit_directives(
+                        directive, entry,
+                        preprocessed, preprocessed,
+                    )
+
+    return file_identifier, entry
+
+
+# Literal (compile-time-interned) strings used as dict keys / fixed values when
+# building a per-file `entry` in `_scan_one`. When the serial loop builds entries
+# in-process these literals are a single interned object shared across every
+# entry, so `pickle` writes them once and back-references thereafter. Entries
+# returned from forked workers are unpickled into fresh, de-interned objects, so
+# without help the saved blob would grow (lost back-references) and differ
+# byte-for-byte from the serial blob. `_canonicalize` re-interns exactly these
+# strings (only) so the merged structure pickles identically -- interning more
+# (e.g. every identifier-like string) would wrongly share parser-derived strings
+# that the serial run keeps distinct. Keep this set in sync with the literal
+# keys/values produced by `_scan_one`.
+_ENTRY_LITERALS = {
+    'files', 'includeDirectives', 'source', 'fileName', 'xml',
+    'nonIncludeDirectives', 'dependency', 'functionClasses',
+    'galacticusStateRetrieveTask', 'galacticusStateStoreTask',
+    'functionClassDestroyTask',
+}
+_ENTRY_CANON = {s: s for s in _ENTRY_LITERALS}
+
+
+def _canonicalize(obj):
+    """Return a copy of `obj` with the `_ENTRY_LITERALS` strings replaced by
+    their canonical interned instances (preserving dict insertion order and all
+    other object identities), so a worker-returned entry pickles identically to
+    one the serial loop built in-process. A no-op in the serial path (those
+    strings are already the interned literals), so output is unchanged there.
+    """
+    if isinstance(obj, dict):
+        return {
+            _ENTRY_CANON.get(k, k) if isinstance(k, str) else k:
+                _canonicalize(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_canonicalize(x) for x in obj]
+    if isinstance(obj, str):
+        return _ENTRY_CANON.get(obj, obj)
+    return obj
+
+
+def _scan_files(scan_list, source_directory, build_path):
+    """Scan every file in `scan_list` (a list of
+    `(source_file_name, file_path, file_identifier)` preserving the serial
+    loop's order) and return the results in that SAME order, so the merge into
+    `directives_per_file` -- and therefore the cross-file reduction and emitted
+    Makefile -- is identical to the serial version. The read-only
+    `source_directory`/`build_path` are published to `_WORKER` first so forked
+    workers inherit them via copy-on-write instead of re-pickling per task.
+    """
+    _WORKER['source_directory'] = source_directory
+    _WORKER['build_path']       = build_path
+    return parallel_scan(scan_list, _scan_one, 'codeDirectivesParse.py')
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -169,7 +320,10 @@ def main(argv):
     if any(fid not in file_identifier_set for fid in directives_per_file):
         force_rescan = True
 
-    # Iterate over source files.
+    # Decide which files need a (re)scan, preserving the deterministic sorted
+    # `source_file_names` order so the merge below reproduces the serial
+    # insertion order (and hence the cross-file reduction) exactly.
+    scan_list = []
     for source_file_name in source_file_names:
         file_path       = source_directory + '/' + source_file_name
         file_identifier = file_path.replace('/', '_')
@@ -189,73 +343,16 @@ def main(argv):
         if not (rescan or force_rescan):
             continue
 
-        # Drop stale cache entry and reinitialise.
+        scan_list.append((source_file_name, file_path, file_identifier))
+
+    # Scan the files (concurrently) and merge results in scan-list order so the
+    # output is identical to a serial run: each rescanned file's stale cache
+    # entry is dropped and the freshly-built entry reinserted in the same order
+    # the serial loop would have produced.
+    for file_identifier, entry in _scan_files(
+            scan_list, source_directory, build_path):
         directives_per_file.pop(file_identifier, None)
-        entry = directives_per_file.setdefault(
-            file_identifier,
-            {'files': [file_path]},
-        )
-
-        # Walk include files depth-first.
-        pending = [file_path]
-        while pending:
-            current = pending.pop()
-            included = _collect_included_files(current, source_directory)
-            pending.extend(included)
-            entry['files'].extend(included)
-
-            # Extract every directive in the current file.
-            for directive in extract_directives(
-                current, '*', set_root_element_type=True,
-            ):
-                root_type = directive.get('rootElementType')
-                if root_type == 'include':
-                    # Include directive: record the source file and the
-                    # include file name, drop `content`, and XML-serialize
-                    # the remaining attributes for the per-directive file.
-                    directive['source'] = current
-                    content = directive.get('content', '')
-                    if isinstance(content, str):
-                        m = _INCLUDE_BODY_RE.search(content)
-                        if m:
-                            include_leaf = m.group(1)
-                            include_leaf = re.sub(r'\.inc$', '.Inc',
-                                                  include_leaf)
-                            directive['fileName'] = os.path.join(
-                                build_path, include_leaf,
-                            )
-                    directive.pop('content', None)
-
-                    directive_name = (
-                        directive.get('name')
-                        or directive.get('directive')
-                    )
-                    key = f"{directive_name}.{directive.get('type')}"
-                    entry.setdefault('includeDirectives', {})[key] = {
-                        'source':   current,
-                        'fileName': directive.get('fileName'),
-                        'xml':      dict_to_xml_string(root_type, directive),
-                    }
-                else:
-                    # Non-include directive: remember the source file.
-                    non_include = entry.setdefault('nonIncludeDirectives', {})
-                    slot = non_include.setdefault(
-                        root_type, {'files': [], 'dependency': []},
-                    )
-                    slot['files'].append(file_path)
-
-                    if root_type == 'functionClass':
-                        preprocessed = re.sub(
-                            r'\.F90$', '.p.F90',
-                            os.path.join(build_path, source_file_name),
-                        )
-                        entry.setdefault(
-                            'functionClasses', {},
-                        )[directive['name']] = preprocessed
-                        _add_implicit_directives(
-                            directive, entry,
-                            preprocessed, preprocessed,
-                        )
+        directives_per_file[file_identifier] = _canonicalize(entry)
 
     # -----------------------------------------------------------------------
     # Reduce across files.

--- a/scripts/build/deepCopyActions.py
+++ b/scripts/build/deepCopyActions.py
@@ -21,9 +21,10 @@ import sys
 import xml.etree.ElementTree as ET
 
 
-from Galacticus.Build.SourceTree import parse_file, walk_tree
-from List.ExtraUtils             import as_array
-from XML.Utils                   import dict_to_xml_string, xml_to_dict
+from Galacticus.Build.ParallelScan import scan as parallel_scan
+from Galacticus.Build.SourceTree   import parse_file, walk_tree
+from List.ExtraUtils              import as_array
+from XML.Utils                    import dict_to_xml_string, xml_to_dict
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +101,24 @@ def _inherits_from(classes, class_name, base_class):
     return False
 
 
+def _scan_one(task):
+    """Worker: parse one file and return `(file_identifier, entries)`. Mirrors
+    the per-file body of the serial loop; writes no shared state. The file read
+    + AST parse (the slow, NFS-blocking part) is what runs concurrently.
+    """
+    file_identifier, file_name = task
+    tree = parse_file(file_name)
+    classes, directives = _collect_types_and_directives(tree, 'deepCopyActions')
+    entries = []
+    for node in directives:
+        directive  = node.get('directive') or {}
+        base_class = directive.get('class')
+        for class_name in sorted(classes):
+            if _inherits_from(classes, class_name, base_class):
+                entries.append({'type': class_name, 'class': base_class})
+    return file_identifier, entries
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -119,29 +138,22 @@ def main(argv):
     actions_per_file, cache_mtime = _load_cache(blob_path)
     have_per_file = cache_mtime is not None
 
-    # Iterate over every file that contains a deepCopyActions directive.
+    # Select the files that need a (re)scan, preserving directive-location order.
     files = as_array((directive_locations.get('deepCopyActions') or {}).get('file'))
+    scan_list = []
     for file_name in files:
         file_identifier = _file_identifier(file_name)
         if (have_per_file
                 and file_identifier in actions_per_file
                 and os.stat(file_name).st_mtime < cache_mtime):
             continue
+        scan_list.append((file_identifier, file_name))
+
+    # Parse the files concurrently; merge in scan order, reproducing the serial
+    # pop-then-maybe-set behaviour exactly.
+    for file_identifier, entries in parallel_scan(
+            scan_list, _scan_one, 'deepCopyActions.py'):
         actions_per_file.pop(file_identifier, None)
-
-        tree = parse_file(file_name)
-        classes, directives = _collect_types_and_directives(
-            tree, 'deepCopyActions',
-        )
-
-        # For every directive, record every (derived-type, base-class) pair.
-        entries = []
-        for node in directives:
-            directive  = node.get('directive') or {}
-            base_class = directive.get('class')
-            for class_name in sorted(classes):
-                if _inherits_from(classes, class_name, base_class):
-                    entries.append({'type': class_name, 'class': base_class})
         if entries:
             actions_per_file[file_identifier] = {'deepCopyActions': entries}
 

--- a/scripts/build/enumerateOpenMPCriticalSections.py
+++ b/scripts/build/enumerateOpenMPCriticalSections.py
@@ -5,10 +5,37 @@ import sys
 import xml.etree.ElementTree as ET
 
 from Galacticus.Build.FortranUtils import get_fortran_line
+from Galacticus.Build.ParallelScan import scan as parallel_scan
 
 # Locate all OpenMP critical sections, and build an enumeration of them for use
 # in source code instrumentation.
 # Andrew Benson (ported to Python 2026)
+
+
+def _scan_one(full_path):
+    """Worker: scan one source file and return a dict mapping each OpenMP
+    critical-section name found to its occurrence count within that file.
+
+    Each file is read independently and writes to no shared state, so the scans
+    run concurrently across a fork-based process pool; the per-file cost is
+    dominated by blocking file I/O (open/read over NFS), which overlaps when run
+    in parallel. The small per-file count dicts are then merged in task order.
+    """
+    counts = {}
+    try:
+        with open(full_path, 'r', errors='replace') as fh:
+            while True:
+                raw, processed, _ = get_fortran_line(fh)
+                if not raw:
+                    break
+                m = re.match(r'^\s*!\$omp\s+critical\s*\(([a-z0-9_]+)\)', processed, re.IGNORECASE)
+                if m:
+                    name = m.group(1).lower()
+                    counts[name] = counts.get(name, 0) + 1
+    except OSError:
+        return {}
+    return counts
+
 
 if len(sys.argv) != 2:
     print("Usage: enumerateOpenMPCriticalSections.py <sourceDirectory>", file=sys.stderr)
@@ -27,19 +54,12 @@ for dirpath, dirnames, filenames in os.walk(src_path):
         if re.search(r'\.f(90)?$', file_name, re.IGNORECASE):
             source_file_paths.append(os.path.join(dirpath, file_name))
 
-for full_path in sorted(source_file_paths):
-    try:
-        with open(full_path, 'r', errors='replace') as fh:
-            while True:
-                raw, processed, _ = get_fortran_line(fh)
-                if not raw:
-                    break
-                m = re.match(r'^\s*!\$omp\s+critical\s*\(([a-z0-9_]+)\)', processed, re.IGNORECASE)
-                if m:
-                    name = m.group(1).lower()
-                    critical_section_names[name] = critical_section_names.get(name, 0) + 1
-    except OSError:
-        continue
+# Scan every file (concurrently) and merge results in the original sorted order
+# so the accumulated counts match a serial run exactly.
+tasks = sorted(source_file_paths)
+for counts in parallel_scan(tasks, _scan_one, "enumerateOpenMPCriticalSections.py"):
+    for name, count in counts.items():
+        critical_section_names[name] = critical_section_names.get(name, 0) + count
 
 
 def _update_file(old_path, new_path):

--- a/scripts/build/findExecutables.py
+++ b/scripts/build/findExecutables.py
@@ -3,6 +3,8 @@ import os
 import re
 import sys
 
+from Galacticus.Build.ParallelScan import scan as parallel_scan
+
 # Locate files which contain programs and append to a list of executables.
 # Andrew Benson (ported to Python 2026)
 
@@ -15,7 +17,6 @@ source_directory     = os.path.join(galacticus_directory, "source")
 build_path           = os.environ['BUILDPATH']
 work_dir             = build_path.rstrip('/') + '/'
 
-executable_names = []
 
 def _source_files_recursive(root):
     """Yield every file path under `root`, relative to `root`, walking
@@ -28,64 +29,69 @@ def _source_files_recursive(root):
     return sorted(rel)
 
 
-with open(os.path.join(build_path, "Makefile_All_Execs"), 'w') as out:
-    for file_name in _source_files_recursive(source_directory):
-        # Skip temporary files.
-        if os.path.basename(file_name).startswith('.#'):
-            continue
-        # Skip vendored third-party code: it may carry its own test `program`
-        # units (e.g. Genz's `PROGRAM TSTNRM`) that are not Galacticus
-        # executables.  The flat, pre-hierarchy scan never reached these
-        # subdirectories; preserve that by excluding `external/`.
-        if file_name.split('/', 1)[0] == 'external':
-            continue
-        # Only Fortran source files.
-        if not re.search(r'\.[fF](90)?$', file_name):
-            continue
+# ---------------------------------------------------------------------------
+# Per-file processing (parallelised across files)
+# ---------------------------------------------------------------------------
+#
+# Reading each candidate source file (to detect a `program` statement) is the
+# slow, serial part on NFS: each open blocks on close-to-open metadata
+# revalidation, so doing them one at a time serialises thousands of millisecond
+# waits. Each file is scanned independently and produces only its own result
+# (the Makefile rule text plus the executable name it contributes, if any),
+# writing to no shared state. The read-only `source_directory`/`work_dir` are
+# published as module-level globals BEFORE the scan so forked workers inherit
+# them via copy-on-write rather than re-pickling per task. Results come back in
+# task order, so the emitted Makefile is byte-identical to the serial version.
 
-        file_full           = os.path.join(source_directory, file_name)
-        exclude_from_all    = False
-        found_program       = False
 
-        in_doc_block = False
+def _scan_one(file_name):
+    """Worker: read+parse ONE source file. Returns `None` if the file
+    contributes nothing, otherwise `(rule_text, exe_name_or_None)` where
+    `exe_name_or_None` is the executable name to add to `all_exes` (or `None`
+    when the file is excluded from `all`). Writes to no shared state.
+    """
+    file_full        = os.path.join(source_directory, file_name)
+    exclude_from_all = False
+    found_program    = False
 
-        try:
-            with open(file_full, 'r', errors='replace') as fh:
-                for line in fh:
-                    # Skip lines inside `!!{ ... !!}` LaTeX documentation blocks,
-                    # whose unprefixed prose can otherwise look like a `program`
-                    # statement.
-                    if in_doc_block:
-                        if '!!}' in line:
-                            in_doc_block = False
-                        continue
-                    if re.match(r'^\s*!!\{', line) and '!!}' not in line.split('!!{', 1)[1]:
-                        in_doc_block = True
-                        continue
-                    if re.match(r'^\s*!/\s+exclude', line):
-                        exclude_from_all = True
-                    if re.match(r'^\s*program\s', line, re.IGNORECASE):
-                        found_program = True
-                        break
-        except OSError:
-            continue
+    in_doc_block = False
 
-        if not found_program:
-            continue
+    try:
+        with open(file_full, 'r', errors='replace') as fh:
+            for line in fh:
+                # Skip lines inside `!!{ ... !!}` LaTeX documentation blocks,
+                # whose unprefixed prose can otherwise look like a `program`
+                # statement.
+                if in_doc_block:
+                    if '!!}' in line:
+                        in_doc_block = False
+                    continue
+                if re.match(r'^\s*!!\{', line) and '!!}' not in line.split('!!{', 1)[1]:
+                    in_doc_block = True
+                    continue
+                if re.match(r'^\s*!/\s+exclude', line):
+                    exclude_from_all = True
+                if re.match(r'^\s*program\s', line, re.IGNORECASE):
+                    found_program = True
+                    break
+    except OSError:
+        return None
 
-        # `obj_root` is the path-based stem (relative to source/, e.g.
-        # `tests/nodes`) used for every build artifact, which mirrors the
-        # source hierarchy.  `exe_root` is the historical flat, dot-separated
-        # name (e.g. `tests.nodes`) used for the user-facing executable so that
-        # `make tests.nodes.exe`, CI matrices, and test harnesses keep working
-        # unchanged after the source tree was made hierarchical.
-        obj_root = re.sub(r'\.[fF](90)?t?$', '', file_name)
-        exe_root = obj_root.replace('/', '.')
+    if not found_program:
+        return None
 
-        if not exclude_from_all:
-            executable_names.append(exe_root + '.exe')
+    # `obj_root` is the path-based stem (relative to source/, e.g.
+    # `tests/nodes`) used for every build artifact, which mirrors the
+    # source hierarchy.  `exe_root` is the historical flat, dot-separated
+    # name (e.g. `tests.nodes`) used for the user-facing executable so that
+    # `make tests.nodes.exe`, CI matrices, and test harnesses keep working
+    # unchanged after the source tree was made hierarchical.
+    obj_root = re.sub(r'\.[fF](90)?t?$', '', file_name)
+    exe_root = obj_root.replace('/', '.')
 
-        rule = f"""\
+    exe_name = None if exclude_from_all else exe_root + '.exe'
+
+    rule = f"""\
 {exe_root}.exe: {work_dir}{obj_root}.o {work_dir}{obj_root}.d $(MAKE_DEPS) $(UPDATE_DEPS)
 \t./scripts/build/parameterDependencies.py `pwd` {obj_root}.exe
 \t$(FCCOMPILER) -c {work_dir}{obj_root}.parameters.F90 -o {work_dir}{obj_root}.parameters.o $(FCFLAGS)
@@ -103,6 +109,40 @@ with open(os.path.join(build_path, "Makefile_All_Execs"), 'w') as out:
 \t$(FCCOMPILER) `cat {work_dir}{obj_root}.d` {work_dir}{obj_root}.parameters.o {work_dir}{obj_root}.md5s.o -o {exe_root}.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `./scripts/build/libraryDependencies.py {obj_root}.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
 
 """
+    return rule, exe_name
+
+
+# Build the ordered list of candidate files, applying the cheap filters that
+# never required reading the file (so they impose no I/O cost), then scan the
+# survivors concurrently.
+candidate_files = []
+for file_name in _source_files_recursive(source_directory):
+    # Skip temporary files.
+    if os.path.basename(file_name).startswith('.#'):
+        continue
+    # Skip vendored third-party code: it may carry its own test `program`
+    # units (e.g. Genz's `PROGRAM TSTNRM`) that are not Galacticus
+    # executables.  The flat, pre-hierarchy scan never reached these
+    # subdirectories; preserve that by excluding `external/`.
+    if file_name.split('/', 1)[0] == 'external':
+        continue
+    # Only Fortran source files.
+    if not re.search(r'\.[fF](90)?$', file_name):
+        continue
+    candidate_files.append(file_name)
+
+results = parallel_scan(candidate_files, _scan_one, "findExecutables.py")
+
+# Write the Makefile SEQUENTIALLY, consuming results in order so the output is
+# byte-identical to the serial version.
+executable_names = []
+with open(os.path.join(build_path, "Makefile_All_Execs"), 'w') as out:
+    for result in results:
+        if result is None:
+            continue
+        rule, exe_name = result
+        if exe_name is not None:
+            executable_names.append(exe_name)
         out.write(rule)
 
     if executable_names:

--- a/scripts/build/includeDependencies.py
+++ b/scripts/build/includeDependencies.py
@@ -4,44 +4,18 @@ import re
 import subprocess
 import sys
 
+from Galacticus.Build.ParallelScan import scan as parallel_scan
+
 # Construct Makefile rules for source files which have dependencies on include files.
 # Andrew Benson (ported to Python 2026)
 
-if len(sys.argv) != 2:
-    print("Usage: includeDependencies.py <galacticusDirectory>", file=sys.stderr)
-    sys.exit(1)
+# ---------------------------------------------------------------------------
+# Read-only data shared with forked workers via copy-on-write. These are
+# populated in `main()` BEFORE `parallel_scan` is called, so each forked worker
+# inherits them without anything being pickled per task.
+# ---------------------------------------------------------------------------
+_WORKER = {}
 
-galacticus_directory = sys.argv[1]
-source_directory     = os.path.join(galacticus_directory, "source")
-build_path           = os.environ['BUILDPATH']
-
-# Build a list of pre-existing C include file paths: source dir, system GCC paths,
-# and any paths from GALACTICUS_CFLAGS / GALACTICUS_CPPFLAGS.
-c_include_dirs = [source_directory]
-try:
-    cpp_output = subprocess.run(
-        ["cpp", "-Wp,-v"],
-        input="",
-        capture_output=True,
-        text=True
-    ).stderr
-    for line in cpp_output.splitlines():
-        m = re.match(r'^\s*(/\S+)', line)
-        if m:
-            c_include_dirs.append(m.group(1))
-except Exception:
-    pass
-
-for env_var in ("GALACTICUS_CFLAGS", "GALACTICUS_CPPFLAGS"):
-    val = os.environ.get(env_var, "")
-    for token in val.split():
-        m = re.match(r'^-I(.*)', token)
-        if m:
-            c_include_dirs.append(m.group(1))
-
-# Open output Makefile.
-makefile_path = os.path.join(build_path, "Makefile_Include_Dependencies")
-dependency_file_names = []
 
 def _source_files_recursive(root):
     """Yield every file path under `root`, relative to `root`, walking
@@ -54,7 +28,110 @@ def _source_files_recursive(root):
     return sorted(rel)
 
 
-with open(makefile_path, 'w') as makefile:
+def _c_include_dirs(source_directory):
+    """Build a list of pre-existing C include file paths: source dir, system
+    GCC paths, and any paths from GALACTICUS_CFLAGS / GALACTICUS_CPPFLAGS."""
+    c_include_dirs = [source_directory]
+    try:
+        cpp_output = subprocess.run(
+            ["cpp", "-Wp,-v"],
+            input="",
+            capture_output=True,
+            text=True
+        ).stderr
+        for line in cpp_output.splitlines():
+            m = re.match(r'^\s*(/\S+)', line)
+            if m:
+                c_include_dirs.append(m.group(1))
+    except Exception:
+        pass
+
+    for env_var in ("GALACTICUS_CFLAGS", "GALACTICUS_CPPFLAGS"):
+        val = os.environ.get(env_var, "")
+        for token in val.split():
+            m = re.match(r'^-I(.*)', token)
+            if m:
+                c_include_dirs.append(m.group(1))
+    return c_include_dirs
+
+
+def _scan_one(file_name):
+    """Worker: read and parse one source file, returning its contribution as a
+    `(rule_text, dependency_file_names)` tuple. Writes NOTHING to shared state.
+    Mirrors the per-file body of the original serial loop exactly. The read-only
+    `source_directory`, `build_path` and `c_include_dirs` are inherited from the
+    `_WORKER` globals via copy-on-write fork.
+    """
+    source_directory = _WORKER['source_directory']
+    build_path       = _WORKER['build_path']
+    c_include_dirs   = _WORKER['c_include_dirs']
+
+    file_full = os.path.join(source_directory, file_name)
+    included_files = []
+
+    try:
+        with open(file_full, 'r', errors='replace') as fh:
+            for line in fh:
+                m = re.match(
+                    r'''^\s*#??include\s*[<'"]((.+)\.(inc|h)\d*)['">](\s*!\s*NO_USES)?''',
+                    line
+                )
+                if not m:
+                    continue
+                inc_name  = m.group(1)
+                ext       = m.group(3)
+                no_uses   = m.group(4) is not None
+                if ext == 'inc':
+                    included_files.append({'fileName': inc_name, 'automatic': not no_uses})
+                elif ext == 'h':
+                    # Only include .h files not already present in source or system dirs.
+                    in_source = os.path.exists(os.path.join(source_directory, inc_name))
+                    in_system = any(
+                        os.path.exists(os.path.join(d, inc_name)) for d in c_include_dirs
+                    )
+                    if not in_source and not in_system:
+                        included_files.append({'fileName': inc_name, 'automatic': not no_uses})
+    except OSError:
+        return "", []
+
+    rule_text = ""
+    if included_files:
+        obj_name = re.sub(r'\.[^.]+$', '.o', file_name)
+        deps     = ' '.join(sorted(
+            os.path.join(build_path, f['fileName']) for f in included_files
+        ))
+        rule_text += f"{os.path.join(build_path, obj_name)}: {deps}\n\n"
+        if file_name.endswith('.F90'):
+            pp_name = file_name.replace('.F90', '.p.F90')
+            rule_text += f"{os.path.join(build_path, pp_name)}: {deps}\n\n"
+
+    # Collect auto-generated .inc dependencies for Makefile_Use_Dependencies.
+    dependency_file_names = []
+    for inc in included_files:
+        if inc['fileName'].endswith('.inc') and inc['automatic']:
+            unpp = re.sub(r'\.inc$', '.Inc', inc['fileName'])
+            if os.path.exists(os.path.join(source_directory, unpp)):
+                dependency_file_names.append(unpp)
+            else:
+                dependency_file_names.append(inc['fileName'])
+
+    return rule_text, dependency_file_names
+
+
+def main(argv):
+    if len(argv) != 2:
+        print("Usage: includeDependencies.py <galacticusDirectory>", file=sys.stderr)
+        sys.exit(1)
+
+    galacticus_directory = argv[1]
+    source_directory     = os.path.join(galacticus_directory, "source")
+    build_path           = os.environ['BUILDPATH']
+
+    c_include_dirs = _c_include_dirs(source_directory)
+
+    # Build the ordered list of files to process, preserving the original loop's
+    # order and skip rules (temporary files, non source/include extensions).
+    tasks = []
     for file_name in _source_files_recursive(source_directory):
         # Skip temporary files.
         if os.path.basename(file_name).startswith('.#'):
@@ -62,58 +139,34 @@ with open(makefile_path, 'w') as makefile:
         # Only process Fortran, Fortran include, C, C++, and header files.
         if not re.search(r'\.(f(90)?|inc|c(pp)?|h)$', file_name, re.IGNORECASE):
             continue
+        tasks.append(file_name)
 
-        file_full = os.path.join(source_directory, file_name)
-        included_files = []
+    # Publish read-only data for the forked workers, then scan all files
+    # concurrently. Results come back in the SAME order as `tasks`.
+    _WORKER['source_directory'] = source_directory
+    _WORKER['build_path']       = build_path
+    _WORKER['c_include_dirs']   = c_include_dirs
 
-        try:
-            with open(file_full, 'r', errors='replace') as fh:
-                for line in fh:
-                    m = re.match(
-                        r'''^\s*#??include\s*[<'"]((.+)\.(inc|h)\d*)['">](\s*!\s*NO_USES)?''',
-                        line
-                    )
-                    if not m:
-                        continue
-                    inc_name  = m.group(1)
-                    ext       = m.group(3)
-                    no_uses   = m.group(4) is not None
-                    if ext == 'inc':
-                        included_files.append({'fileName': inc_name, 'automatic': not no_uses})
-                    elif ext == 'h':
-                        # Only include .h files not already present in source or system dirs.
-                        in_source = os.path.exists(os.path.join(source_directory, inc_name))
-                        in_system = any(
-                            os.path.exists(os.path.join(d, inc_name)) for d in c_include_dirs
-                        )
-                        if not in_source and not in_system:
-                            included_files.append({'fileName': inc_name, 'automatic': not no_uses})
-        except OSError:
-            continue
+    results = parallel_scan(tasks, _scan_one, "includeDependencies.py")
 
-        if included_files:
-            obj_name = re.sub(r'\.[^.]+$', '.o', file_name)
-            deps     = ' '.join(sorted(
-                os.path.join(build_path, f['fileName']) for f in included_files
-            ))
-            makefile.write(f"{os.path.join(build_path, obj_name)}: {deps}\n\n")
-            if file_name.endswith('.F90'):
-                pp_name = file_name.replace('.F90', '.p.F90')
-                makefile.write(f"{os.path.join(build_path, pp_name)}: {deps}\n\n")
+    # Write the output Makefile SEQUENTIALLY, consuming results in order so the
+    # per-file rule lines keep their original ordering.
+    makefile_path = os.path.join(build_path, "Makefile_Include_Dependencies")
+    dependency_file_names = []
+    with open(makefile_path, 'w') as makefile:
+        for rule_text, dep_names in results:
+            if rule_text:
+                makefile.write(rule_text)
+            dependency_file_names.extend(dep_names)
 
-        # Collect auto-generated .inc dependencies for Makefile_Use_Dependencies.
-        for inc in included_files:
-            if inc['fileName'].endswith('.inc') and inc['automatic']:
-                unpp = re.sub(r'\.inc$', '.Inc', inc['fileName'])
-                if os.path.exists(os.path.join(source_directory, unpp)):
-                    dependency_file_names.append(unpp)
-                else:
-                    dependency_file_names.append(inc['fileName'])
+        # Dependency line for Makefile_Use_Dependencies.
+        dep_targets = ' '.join(
+            os.path.join(build_path, f) for f in sorted(set(dependency_file_names))
+        )
+        makefile.write(
+            f"\n{os.path.join(build_path, 'Makefile_Use_Dependencies')}: {dep_targets}\n"
+        )
 
-    # Dependency line for Makefile_Use_Dependencies.
-    dep_targets = ' '.join(
-        os.path.join(build_path, f) for f in sorted(set(dependency_file_names))
-    )
-    makefile.write(
-        f"\n{os.path.join(build_path, 'Makefile_Use_Dependencies')}: {dep_targets}\n"
-    )
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/scripts/build/moduleDependencies.py
+++ b/scripts/build/moduleDependencies.py
@@ -26,8 +26,6 @@ Mirrors scripts/build/moduleDependencies.pl.
 Andrew Benson (ported to Python 2026).
 """
 
-import concurrent.futures
-import multiprocessing
 import os
 import pickle
 import re
@@ -35,10 +33,11 @@ import sys
 import xml.etree.ElementTree as ET
 
 
-from Galacticus.Build.Directives import extract_directives
-from Galacticus.Build.SourceTree import parse_file, walk_tree
-from List.ExtraUtils             import as_array
-from XML.Utils                   import xml_to_dict
+from Galacticus.Build.Directives   import extract_directives
+from Galacticus.Build.ParallelScan import scan as parallel_scan
+from Galacticus.Build.SourceTree   import parse_file, walk_tree
+from List.ExtraUtils              import as_array
+from XML.Utils                    import xml_to_dict
 
 
 # ---------------------------------------------------------------------------
@@ -307,42 +306,17 @@ def _scan_one(task):
     return file_identifier, name, desc, entry
 
 
-def _parallel_jobs(n_tasks):
-    """How many workers to use. Overridable with GALACTICUS_MODULE_DEPS_JOBS;
-    defaults to 16. Capped at the number of tasks. Because the work is
-    I/O-latency bound, oversubscribing CPUs is intentional -- workers spend most
-    of their time blocked on NFS, so more workers than cores still overlaps
-    waits. Set to 1 to force the serial path.
-    """
-    try:
-        jobs = int(os.environ.get('GALACTICUS_MODULE_DEPS_JOBS', '16'))
-    except ValueError:
-        jobs = 16
-    return max(1, min(jobs, n_tasks))
-
-
 def _scan_files(scan_list, source_root, locations):
     """Scan every file in `scan_list` (a list of `(file_identifier, name, desc)`
     preserving the serial loop's order) and return the results in that SAME
     order, so downstream `modules_per_file` insertion order -- and therefore the
-    emitted Makefile -- is identical to the serial version.
+    emitted Makefile -- is identical to the serial version. The read-only
+    `source_root`/`locations` are published to `_WORKER` first so forked workers
+    inherit them via copy-on-write instead of re-pickling per task.
     """
-    if not scan_list:
-        return []
     _WORKER['source_root'] = source_root
     _WORKER['locations']   = locations
-    jobs = _parallel_jobs(len(scan_list))
-    if jobs == 1:
-        return [_scan_one(task) for task in scan_list]
-    results = [None] * len(scan_list)
-    ctx = multiprocessing.get_context('fork')
-    with concurrent.futures.ProcessPoolExecutor(
-            max_workers=jobs, mp_context=ctx) as pool:
-        futures = {pool.submit(_scan_one, task): i
-                   for i, task in enumerate(scan_list)}
-        for future in concurrent.futures.as_completed(futures):
-            results[futures[future]] = future.result()
-    return results
+    return parallel_scan(scan_list, _scan_one, 'moduleDependencies.py')
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/build/moduleDependencies.py
+++ b/scripts/build/moduleDependencies.py
@@ -26,6 +26,8 @@ Mirrors scripts/build/moduleDependencies.pl.
 Andrew Benson (ported to Python 2026).
 """
 
+import concurrent.futures
+import multiprocessing
 import os
 import pickle
 import re
@@ -251,6 +253,96 @@ def _scan_file(stack, entry, source_root):
                     in_latex = True
         finally:
             fh.close()
+
+
+# ---------------------------------------------------------------------------
+# Per-file processing (parallelised across files)
+# ---------------------------------------------------------------------------
+#
+# Each source file is scanned independently: it reads the file (and any
+# `include`d files) and produces a single `entry` dict that writes to no shared
+# state. The per-file cost is dominated by blocking file I/O (open/read of the
+# source on NFS), which on a loaded node stretches from microseconds to
+# milliseconds per file; running the scans concurrently overlaps those waits
+# (and the parsing CPU work) instead of paying them one at a time.
+#
+# A fork-based process pool is used rather than threads so the workers are fully
+# isolated -- no assumptions are made about the thread-safety of the parser --
+# and the regex/AST parsing parallelises too. Workers inherit the read-only
+# `locations` map and `source_root` via copy-on-write fork, so nothing large is
+# pickled per task; only the small result dicts come back.
+
+_WORKER = {}
+
+
+def _scan_one(task):
+    """Worker: scan one source file and return its `(file_identifier, name,
+    desc, entry)`. Mirrors the per-file body of the serial scan loop exactly.
+    """
+    file_identifier, name, desc = task
+    source_root = _WORKER['source_root']
+    locations   = _WORKER['locations']
+    file_path   = desc['path'] + '/' + name
+
+    # functionClass -> synthesise submodule records.
+    function_classes = extract_directives(file_path, 'functionClass')
+    submodules_for_file = []
+    for fc in function_classes:
+        for fc_file in as_array((locations.get(fc['name']) or {}).get('file')):
+            submodules_for_file.extend(
+                _find_function_class_submodules(
+                    fc['name'], fc_file, locations, source_root,
+                )
+            )
+
+    entry = {}
+    if submodules_for_file:
+        entry['submodules'] = submodules_for_file
+    entry.setdefault('files', []).append(file_path)
+    entry['sourceFileName']            = name
+    entry['sourceDirectoryDescriptor'] = desc
+    entry.setdefault('modulesProvided', [])
+
+    _scan_file([file_path], entry, source_root)
+    return file_identifier, name, desc, entry
+
+
+def _parallel_jobs(n_tasks):
+    """How many workers to use. Overridable with GALACTICUS_MODULE_DEPS_JOBS;
+    defaults to 16. Capped at the number of tasks. Because the work is
+    I/O-latency bound, oversubscribing CPUs is intentional -- workers spend most
+    of their time blocked on NFS, so more workers than cores still overlaps
+    waits. Set to 1 to force the serial path.
+    """
+    try:
+        jobs = int(os.environ.get('GALACTICUS_MODULE_DEPS_JOBS', '16'))
+    except ValueError:
+        jobs = 16
+    return max(1, min(jobs, n_tasks))
+
+
+def _scan_files(scan_list, source_root, locations):
+    """Scan every file in `scan_list` (a list of `(file_identifier, name, desc)`
+    preserving the serial loop's order) and return the results in that SAME
+    order, so downstream `modules_per_file` insertion order -- and therefore the
+    emitted Makefile -- is identical to the serial version.
+    """
+    if not scan_list:
+        return []
+    _WORKER['source_root'] = source_root
+    _WORKER['locations']   = locations
+    jobs = _parallel_jobs(len(scan_list))
+    if jobs == 1:
+        return [_scan_one(task) for task in scan_list]
+    results = [None] * len(scan_list)
+    ctx = multiprocessing.get_context('fork')
+    with concurrent.futures.ProcessPoolExecutor(
+            max_workers=jobs, mp_context=ctx) as pool:
+        futures = {pool.submit(_scan_one, task): i
+                   for i, task in enumerate(scan_list)}
+        for future in concurrent.futures.as_completed(futures):
+            results[futures[future]] = future.result()
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -510,10 +602,13 @@ def main(argv):
         if any(fid not in unstripped_set for fid in modules_per_file):
             force_rescan = True
 
-    # Per-file scan.
+    # Decide which files need a (re)scan, preserving the deterministic
+    # descriptor-then-sorted-name order so the merge below reproduces the serial
+    # insertion order exactly.
+    scan_list = []
     for desc in descriptors:
         for name in _list_source_files(desc['path']):
-            file_path      = desc['path'] + '/' + name
+            file_path       = desc['path'] + '/' + name
             file_identifier = _file_identifier(file_path)
 
             rescan = True
@@ -527,31 +622,14 @@ def main(argv):
                 rescan = bool(stale)
             if not (rescan or force_rescan):
                 continue
+            scan_list.append((file_identifier, name, desc))
 
-            modules_per_file.pop(file_identifier, None)
-
-            # functionClass -> synthesise submodule records.
-            function_classes = extract_directives(file_path, 'functionClass')
-            submodules_for_file = []
-            for fc in function_classes:
-                for fc_file in as_array(
-                    (locations.get(fc['name']) or {}).get('file'),
-                ):
-                    submodules_for_file.extend(
-                        _find_function_class_submodules(
-                            fc['name'], fc_file, locations, source_root,
-                        )
-                    )
-
-            entry = modules_per_file.setdefault(file_identifier, {})
-            if submodules_for_file:
-                entry['submodules'] = submodules_for_file
-            entry.setdefault('files', []).append(file_path)
-            entry['sourceFileName']           = name
-            entry['sourceDirectoryDescriptor'] = desc
-            entry.setdefault('modulesProvided', [])
-
-            _scan_file([file_path], entry, source_root)
+    # Scan the files (concurrently) and merge results in scan-list order so the
+    # output is identical to a serial run.
+    for file_identifier, name, desc, entry in _scan_files(
+            scan_list, source_root, locations):
+        modules_per_file.pop(file_identifier, None)
+        modules_per_file[file_identifier] = entry
 
     # Build the submodule-by-module map.
     submodules_by_module = _build_submodule_map(modules_per_file)

--- a/scripts/build/stateStorables.py
+++ b/scripts/build/stateStorables.py
@@ -32,6 +32,7 @@ from Galacticus.Build.FileChanges               import update as file_changes_up
 from Galacticus.Build.FortranUtils              import get_fortran_line
 from Fortran.Utils                    import UNIT_OPENERS
 from Galacticus.Build.Directives      import extract_directives
+from Galacticus.Build.ParallelScan    import scan as parallel_scan
 from Galacticus.Build.SourceTree      import parse_file, walk_tree
 from List.ExtraUtils                  import as_array
 from XML.Utils                        import dict_to_xml_string, xml_to_dict
@@ -159,6 +160,59 @@ def _enclosing_module_name(node):
 
 
 # ---------------------------------------------------------------------------
+# Per-file workers (run concurrently; each reads files only, no shared state)
+# ---------------------------------------------------------------------------
+#
+# Each pass's slow part is the per-file open/read/parse over NFS. The workers
+# below do exactly that and return plain data; main() merges the results in the
+# original order, reproducing the serial pop/setdefault sequence (and hence the
+# cache blob) exactly. The final XML is built from fully sorted lists, so it is
+# insensitive to ordering regardless.
+
+def _scan_function_class(task):
+    """Pass 1: module openers + functionClass directive names for one file."""
+    file_identifier, file_name = task
+    modules  = _collect_module_openers(file_name)
+    fc_names = [fc['name'] for fc in extract_directives(file_name, 'functionClass')]
+    return file_identifier, modules, fc_names
+
+
+def _scan_instance(task):
+    """Pass 2: concrete instance names for one (instance-file, functionClass)."""
+    instance_identifier, instance_file, function_class_name = task
+    names = [inst['name']
+             for inst in extract_directives(instance_file, function_class_name)]
+    return instance_identifier, names
+
+
+def _scan_state_storable(task):
+    """Pass 3: derived types matching each stateStorable directive's base."""
+    file_identifier, file_name = task
+    tree = parse_file(file_name)
+    classes, directives = _collect_types_and_directives(tree, 'stateStorable')
+    entries = []
+    for node in directives:
+        directive  = node.get('directive') or {}
+        base_class = directive.get('class')
+        module     = _enclosing_module_name(node)
+        for class_name in sorted(classes):
+            if _inherits_from(classes, class_name, base_class):
+                entries.append({
+                    'type':   class_name,
+                    'class':  base_class,
+                    'module': module,
+                })
+    return file_identifier, entries
+
+
+def _scan_event_static(task):
+    """Pass 4: eventHookStatic directive names for one file."""
+    file_identifier, file_name = task
+    names = [d['name'] for d in extract_directives(file_name, 'eventHookStatic')]
+    return file_identifier, names
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -179,26 +233,45 @@ def main(argv):
 
     # -----------------------------------------------------------------------
     # Pass 1: every functionClass file -- extract modules + directives.
+    # Parsed concurrently, merged in file order (reproducing the serial
+    # pop/setdefault/append sequence exactly).
     # -----------------------------------------------------------------------
     function_class_files = as_array(
         (directive_locations.get('functionClass') or {}).get('file')
     )
+    p1_tasks = [
+        (_file_identifier(f), f) for f in function_class_files
+        if not _fresh(cache_mtime,
+                      _file_identifier(f) in storables_per_file, f)
+    ]
+    p1_results = {
+        fid: (modules, fc_names)
+        for fid, modules, fc_names in parallel_scan(
+            p1_tasks, _scan_function_class, 'stateStorables.py')
+    }
     for file_name in function_class_files:
         file_identifier = _file_identifier(file_name)
-        if not _fresh(cache_mtime,
-                      file_identifier in storables_per_file, file_name):
-            storables_per_file.pop(file_identifier, None)
-            modules = _collect_module_openers(file_name)
-            entry   = storables_per_file.setdefault(file_identifier, {})
-            for fc in extract_directives(file_name, 'functionClass'):
-                descriptor = {'name': fc['name'] + 'Class'}
-                if len(modules) == 1:
-                    descriptor['module'] = modules[0]
-                entry.setdefault('functionClasses', []).append(descriptor)
-                entry.setdefault('functionClassDirectives', []).append(fc['name'])
+        if file_identifier not in p1_results:
+            continue                      # fresh -- keep the cached entry
+        modules, fc_names = p1_results[file_identifier]
+        storables_per_file.pop(file_identifier, None)
+        entry = storables_per_file.setdefault(file_identifier, {})
+        for name in fc_names:
+            descriptor = {'name': name + 'Class'}
+            if len(modules) == 1:
+                descriptor['module'] = modules[0]
+            entry.setdefault('functionClasses', []).append(descriptor)
+            entry.setdefault('functionClassDirectives', []).append(name)
 
-        # Pass 2: for each functionClass declared here, enumerate its
-        # concrete instances -- one per file under the directive's name.
+    # -----------------------------------------------------------------------
+    # Pass 2: for each functionClass, enumerate its concrete instances. Tasks
+    # are built in the original nested order (so the merge's pop/append, which
+    # is order-sensitive when an instance file recurs, matches the serial run);
+    # Pass 1 must be merged first since this reads functionClassDirectives.
+    # -----------------------------------------------------------------------
+    p2_tasks = []
+    for file_name in function_class_files:
+        file_identifier = _file_identifier(file_name)
         directive_names = (
             storables_per_file.get(file_identifier, {})
                               .get('functionClassDirectives') or []
@@ -213,15 +286,15 @@ def main(argv):
                           instance_identifier in storables_per_file,
                           instance_file):
                     continue
-                storables_per_file.pop(instance_identifier, None)
-                instance_entry = storables_per_file.setdefault(
-                    instance_identifier, {},
+                p2_tasks.append(
+                    (instance_identifier, instance_file, function_class_name)
                 )
-                for inst in extract_directives(instance_file,
-                                               function_class_name):
-                    instance_entry.setdefault(
-                        'functionClassInstances', [],
-                    ).append(inst['name'])
+    for instance_identifier, names in parallel_scan(
+            p2_tasks, _scan_instance, 'stateStorables.py'):
+        storables_per_file.pop(instance_identifier, None)
+        instance_entry = storables_per_file.setdefault(instance_identifier, {})
+        for name in names:
+            instance_entry.setdefault('functionClassInstances', []).append(name)
 
     # -----------------------------------------------------------------------
     # Pass 3: every stateStorable file -- walk its AST and record derived
@@ -230,29 +303,14 @@ def main(argv):
     state_storable_files = as_array(
         (directive_locations.get('stateStorable') or {}).get('file')
     )
-    for file_name in state_storable_files:
-        file_identifier = _file_identifier(file_name)
-        if _fresh(cache_mtime,
-                  file_identifier in storables_per_file, file_name):
-            continue
+    p3_tasks = [
+        (_file_identifier(f), f) for f in state_storable_files
+        if not _fresh(cache_mtime,
+                      _file_identifier(f) in storables_per_file, f)
+    ]
+    for file_identifier, entries in parallel_scan(
+            p3_tasks, _scan_state_storable, 'stateStorables.py'):
         storables_per_file.pop(file_identifier, None)
-
-        tree = parse_file(file_name)
-        classes, directives = _collect_types_and_directives(
-            tree, 'stateStorable',
-        )
-        entries = []
-        for node in directives:
-            directive  = node.get('directive') or {}
-            base_class = directive.get('class')
-            module     = _enclosing_module_name(node)
-            for class_name in sorted(classes):
-                if _inherits_from(classes, class_name, base_class):
-                    entries.append({
-                        'type':   class_name,
-                        'class':  base_class,
-                        'module': module,
-                    })
         if entries:
             storables_per_file.setdefault(
                 file_identifier, {},
@@ -264,16 +322,14 @@ def main(argv):
     event_static_files = as_array(
         (directive_locations.get('eventHookStatic') or {}).get('file')
     )
-    for file_name in event_static_files:
-        file_identifier = _file_identifier(file_name)
-        if _fresh(cache_mtime,
-                  file_identifier in storables_per_file, file_name):
-            continue
+    p4_tasks = [
+        (_file_identifier(f), f) for f in event_static_files
+        if not _fresh(cache_mtime,
+                      _file_identifier(f) in storables_per_file, f)
+    ]
+    for file_identifier, names in parallel_scan(
+            p4_tasks, _scan_event_static, 'stateStorables.py'):
         storables_per_file.pop(file_identifier, None)
-        names = [
-            d['name']
-            for d in extract_directives(file_name, 'eventHookStatic')
-        ]
         if names:
             storables_per_file.setdefault(
                 file_identifier, {},

--- a/scripts/build/useDependencies.py
+++ b/scripts/build/useDependencies.py
@@ -21,9 +21,68 @@ import sys
 import xml.etree.ElementTree as ET
 
 
-from Galacticus.Build.Directives import extract_directives
-from List.ExtraUtils             import as_array, hash_list, smart_push
-from XML.Utils                   import xml_to_dict
+from Galacticus.Build.Directives   import extract_directives
+from Galacticus.Build.ParallelScan import scan as parallel_scan
+from List.ExtraUtils              import as_array, hash_list, smart_push
+from XML.Utils                    import xml_to_dict
+
+
+# Directives consulted per source file (module-level so the parallel worker can
+# see it). Order matters only in that it is fixed.
+_DIRECTIVE_NAMES = (
+    'functionClass', 'inputParameter', 'enumeration',
+    'eventHook', 'eventHookStatic', 'eventHookManager',
+    'functionsGlobal', 'objectDestructor',
+)
+
+# Read-only context shared with forked scan workers (inherited via copy-on-write,
+# so it is not pickled per task). Populated in main() before the scan.
+_WORKER = {}
+
+
+def _scan_one(task):
+    """Worker: do the full per-file scan for one source file and return
+    `(file_identifier, entry, event_hook_modules, manager)`.
+
+    Mirrors the body of main()'s per-file loop exactly, but captures the two
+    cross-file side effects -- the ordered `event_hook_modules` pool and the
+    singleton `eventHooksManager` record -- into locals so they can be merged
+    deterministically (in file order) by the caller instead of mutating shared
+    state from a worker.
+    """
+    file_identifier, sf = task
+    file_path = sf['fullPathFileName']
+
+    entry = {
+        'files':                [file_path],
+        'modulesUsed':          [],
+        'dependenciesExplicit': [],
+        'modulesProvided':      {},
+        'submodules':           [],
+        'submodulesProvided':   [],
+        'libraryDependencies':  {},
+    }
+
+    directives = {
+        name: extract_directives(file_path, name)
+        for name in _DIRECTIVE_NAMES
+    }
+
+    file_names_to_process = [file_path]
+    event_hook_modules = []
+    manager = {}   # captures any uses_per_file['eventHooksManager'] write
+
+    _apply_directive_requirements(
+        entry, sf, directives, _WORKER['locations'], _WORKER['state_storables'],
+        _WORKER['work_dir'], file_identifier, event_hook_modules,
+        manager, file_names_to_process,
+    )
+    _scan_source_file(
+        entry, file_names_to_process, sf, directives,
+        _WORKER['locations'], _WORKER['root_source_dir'], _WORKER['work_dir'],
+        _WORKER['preprocessor_set'],
+    )
+    return file_identifier, entry, event_hook_modules, manager
 
 
 # ---------------------------------------------------------------------------
@@ -976,17 +1035,12 @@ def main(argv):
 
     preprocessor_set = frozenset(preprocessor_directives)
     event_hook_modules = []
-    directive_names = (
-        'functionClass', 'inputParameter', 'enumeration',
-        'eventHook', 'eventHookStatic', 'eventHookManager',
-        'functionsGlobal', 'objectDestructor',
-    )
 
-    # Per-file scan.
+    # Decide which files need a (re)scan, preserving `source_files` order so the
+    # merge below reproduces the serial accumulation order exactly.
+    scan_list = []
     for sf in source_files:
-        file_path       = sf['fullPathFileName']
-        file_identifier = _file_identifier(file_path)
-
+        file_identifier = _file_identifier(sf['fullPathFileName'])
         rescan = True
         if have_per_file and file_identifier in uses_per_file:
             tracked = uses_per_file[file_identifier].get('files') or []
@@ -997,35 +1051,25 @@ def main(argv):
             rescan = bool(stale)
         if not (rescan or force_rescan):
             continue
+        scan_list.append((file_identifier, sf))
+
+    # Scan the files concurrently, then merge results in scan-list order. The
+    # per-file `entry`, the ordered `event_hook_modules` pool, and the singleton
+    # `eventHooksManager` record are reconstructed exactly as a serial run would.
+    _WORKER.update({
+        'locations':        locations,
+        'state_storables':  state_storables,
+        'work_dir':         work_dir,
+        'root_source_dir':  root_source_dir,
+        'preprocessor_set': preprocessor_set,
+    })
+    for file_identifier, entry, file_event_hook_modules, manager in parallel_scan(
+            scan_list, _scan_one, 'useDependencies.py'):
         uses_per_file.pop(file_identifier, None)
-
-        entry = uses_per_file.setdefault(file_identifier, {
-            'files':                [file_path],
-            'modulesUsed':          [],
-            'dependenciesExplicit': [],
-            'modulesProvided':      {},
-            'submodules':           [],
-            'submodulesProvided':   [],
-            'libraryDependencies':  {},
-        })
-
-        directives = {
-            name: extract_directives(file_path, name)
-            for name in directive_names
-        }
-
-        file_names_to_process = [file_path]
-
-        _apply_directive_requirements(
-            entry, sf, directives, locations, state_storables,
-            work_dir, file_identifier, event_hook_modules,
-            uses_per_file, file_names_to_process,
-        )
-
-        _scan_source_file(
-            entry, file_names_to_process, sf, directives,
-            locations, root_source_dir, work_dir, preprocessor_set,
-        )
+        uses_per_file[file_identifier] = entry
+        event_hook_modules.extend(file_event_hook_modules)
+        if 'eventHooksManager' in manager:
+            uses_per_file['eventHooksManager'] = manager['eventHooksManager']
 
     _finalise_event_hooks_manager(uses_per_file, event_hook_modules)
 


### PR DESCRIPTION
## Summary

The build's dependency-generation scripts each walk `source/` and open/parse **every** file serially. On NFS-backed nodes under load, each `open()` blocks on close-to-open metadata revalidation, so thousands of tiny per-file round-trips stretch from microseconds to milliseconds and come to dominate wall time (a single dependency step measured ~140 s on a heavily-loaded node vs ~30 s on an idle one, with the process ~70 % of wall time in uninterruptible NFS I/O sleep rather than computing).

This routes the per-file scans through a shared fork-based process pool so those waits — and the parsing CPU work — overlap instead of being paid one at a time.

## What changed

- New helper **`Galacticus.Build.ParallelScan`**: a `fork`-based `ProcessPoolExecutor` driver that returns results in input order, picks its worker count from `GALACTICUS_BUILD_JOBS` → make's `-j` (read from `MAKEFLAGS`) → a default of 16, and reports a worker failure with the underlying error plus a hint to re-run with `GALACTICUS_BUILD_JOBS=1` for a serial traceback.
- Parallelised the per-file scan in: `moduleDependencies.py`, `useDependencies.py`, `codeDirectivesParse.py`, `includeDependencies.py`, `findExecutables.py`, `enumerateOpenMPCriticalSections.py`, `stateStorables.py`, `deepCopyActions.py`.

Workers are fully isolated (fork), so no assumptions are made about parser thread-safety; results are merged back in the original order, and any cross-file aggregation / cache state is reconstructed sequentially so output ordering is preserved.

## Correctness

Each script's output was verified **byte-identical** to the previous serial version (the generated `Makefile_*` / `*.xml`), with **content-identical** cache blobs, across the serial path (`GALACTICUS_BUILD_JOBS=1`), an explicit override, and the `make -j` (`MAKEFLAGS`) path. A full `Galacticus.exe` build was also exercised successfully.

## Performance

- **Swamped NFS node** (load ~370): `moduleDependencies` ~140 s → ~17 s with 8 cpus; **~9.6× even with a single allocated CPU** (pure NFS-wait overlap).
- **Moderately loaded node, warm cache**: ~6.2 s → ~0.8 s (**~7.5×**, driven by multi-core parallelism).

The change helps in both regimes — overlapping NFS waits when the node is contended, and using spare cores when reads are cached.

## Usage notes

- Picks up `make -j` automatically via `MAKEFLAGS`; no Makefile change required.
- Override per-run with `GALACTICUS_BUILD_JOBS=N`; set `GALACTICUS_BUILD_JOBS=1` to force the original serial behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
