### PR TITLE
feat: add Python parameter-file resolver (XInclude + change files)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,10 +43,10 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install pytest
-        # platformdirs + requests are needed by the galacticus_launcher tests
-        # (the only third-party deps in the python/ pytest suite); both are tiny
-        # pure-Python packages so the job stays fast.
-        run: python -m pip install --upgrade pip pytest platformdirs requests
+        # platformdirs + requests are needed by the galacticus_launcher tests and
+        # lxml by the parameter-resolver tests (the third-party deps in the
+        # python/ pytest suite); all are small wheels so the job stays fast.
+        run: python -m pip install --upgrade pip pytest platformdirs requests lxml
       - name: Run Python regression tests
         run: |
           cd $GITHUB_WORKSPACE

--- a/python/Galacticus/Parameters/resolve.py
+++ b/python/Galacticus/Parameters/resolve.py
@@ -1,0 +1,305 @@
+"""Resolve Galacticus parameter files into a clean, ready-to-run form.
+
+This is the Python re-implementation of the file-level transformations that
+Galacticus applies when it reads a parameter file, so that a fully-resolved file
+can be handed to ``Galacticus.exe`` (see the implementation plan in
+``~/.claude/plans/galacticus-parameter-resolver.md``).
+
+Stage 1 (this module, initial version) implements the two transformations that
+Galacticus bakes eagerly into the DOM and that the
+``--output-processed-parameters`` oracle can certify:
+
+* **XInclude** -- ``<xi:include href=... xpointer="xpointer(parameters/*)"/>`` is
+  replaced by the element children of the referenced document's ``<parameters>``
+  root (Galacticus' own limited XInclude; mirrors ``source/utility/IO/XML.F90``).
+* **Change files** -- the ``<changes>`` operation set
+  (``source/utility/input_parameters.F90``) applied, in command-line order, each
+  ``<change>`` in document order, to the post-XInclude tree.
+
+NOT handled here (by design -- see the plan):
+
+* ``id``/``idRef`` are validated but NEVER dereferenced (they are runtime
+  pointers -> a shared object; dereferencing would create separate copies).
+  Reference validation + conditionals are Stage 2.
+* ``=[...]`` math expressions are left INTACT for Galacticus to evaluate at
+  runtime (deferred).
+
+Processing order matches Galacticus: XInclude -> changes.
+
+Uses ``lxml`` (already a dependency of the ``galacticus`` launcher).
+"""
+
+import copy
+import os
+import re
+
+from lxml import etree
+
+
+_XINCLUDE_NS = 'http://www.w3.org/2001/XInclude'
+_XI_INCLUDE = f'{{{_XINCLUDE_NS}}}include'
+_XI_FALLBACK = f'{{{_XINCLUDE_NS}}}fallback'
+_MAX_INCLUDE_DEPTH = 64
+
+# Galacticus accepts only `xpointer(<root>/*)` (select the element children of the
+# referenced document's root) or no xpointer (the whole root element).
+_XPOINTER_CHILDREN_RE = re.compile(r'^xpointer\(\s*/?(\w+)/\*\s*\)$')
+
+
+class ResolveError(Exception):
+    """A fatal resolution error (mirrors a Galacticus ``Error_Report``)."""
+
+
+# --- load / save ------------------------------------------------------------
+
+def load(path):
+    """Parse a parameter or changes file into an lxml ``ElementTree``.
+
+    Comments and whitespace are preserved so the emitted file stays readable.
+    """
+    parser = etree.XMLParser(remove_blank_text=False, remove_comments=False,
+                             resolve_entities=False)
+    return etree.parse(path, parser)
+
+
+def to_bytes(tree):
+    """Serialize a resolved tree to bytes, with an XML declaration."""
+    root = tree.getroot() if isinstance(tree, etree._ElementTree) else tree
+    return etree.tostring(root, encoding='UTF-8', xml_declaration=True)
+
+
+def _is_element(node):
+    """True for true element nodes (excludes comments and processing instructions)."""
+    return isinstance(node.tag, str)
+
+
+def _element_children(node):
+    """Element children only -- mirrors Fortran ``XML_Get_Child_Elements``."""
+    return [child for child in node if _is_element(child)]
+
+
+# --- path resolution --------------------------------------------------------
+
+def resolve_path(node, path, root):
+    """Return the list of nodes matching ``path`` (Galacticus legacy semantics).
+
+    Galacticus' internal XPath treats a *bare* leading step (not ``.`` / ``..``)
+    as ABSOLUTE from the ``<parameters>`` root, whereas standard XPath is
+    context-relative.  We preserve that for back-compat while letting richer,
+    standard XPath (leading ``/`` or ``//``, predicates, functions, axes -- all
+    provided by lxml) pass through unchanged.  An empty path selects ``node``.
+    """
+    text = path.strip()
+    if text == '':
+        return [node]
+    first_step = text.split('/', 1)[0]
+    if first_step in ('.', '..') or text.startswith('/'):
+        return node.xpath(text)           # relative to node, or absolute document
+    return root.xpath(text)               # legacy bare path: absolute from root
+
+
+def _first(node, path, root):
+    matches = resolve_path(node, path, root)
+    return matches[0] if matches else None
+
+
+# --- XInclude ---------------------------------------------------------------
+
+def _locate_include(href, base_dir):
+    """Locate an xi:include target file, or ``None``.
+
+    Resolves STRICTLY relative to the including file (absolute hrefs verbatim),
+    exactly as Galacticus does (``source/utility/IO/XML.F90``). We deliberately
+    do NOT add the ``GALACTICUS_EXEC_PATH`` leniency that the *validator* uses for
+    template files: the resolver's output must match what Galacticus itself would
+    produce, so an include Galacticus cannot find must fail here too.
+    """
+    if os.path.isabs(href):
+        return href if os.path.exists(href) else None
+    candidate = os.path.normpath(os.path.join(base_dir, href))
+    return candidate if os.path.exists(candidate) else None
+
+
+def _xinclude_fallback_nodes(include_element):
+    fallback = include_element.find(_XI_FALLBACK)
+    return [copy.deepcopy(child) for child in fallback] if fallback is not None else []
+
+
+def _xpointer_select(sub_root, xpointer, href):
+    """Nodes a ``<xi:include>`` contributes, per its xpointer."""
+    if xpointer is None:
+        return [copy.deepcopy(sub_root)]            # whole referenced root
+    match = _XPOINTER_CHILDREN_RE.match(xpointer.strip())
+    if not match:
+        raise ResolveError(f"unsupported xi:include xpointer '{xpointer}' "
+                           f"(href '{href}')")
+    if sub_root.tag != match.group(1):
+        raise ResolveError(
+            f"xi:include xpointer '{xpointer}' does not match referenced root "
+            f"element '{sub_root.tag}' (href '{href}')")
+    return [copy.deepcopy(child) for child in sub_root]
+
+
+def _resolve_include(include_element, base_dir, seen, depth):
+    href = include_element.get('href')
+    if not href:
+        raise ResolveError("xi:include without an href is not supported")
+    target = _locate_include(href, base_dir)
+    if target is None:
+        nodes = _xinclude_fallback_nodes(include_element)
+        if nodes or include_element.find(_XI_FALLBACK) is not None:
+            return nodes
+        raise ResolveError(f"xi:include href '{href}' does not resolve "
+                           f"(relative to {base_dir} or the repository root)")
+    if target in seen:
+        raise ResolveError(f"xi:include cycle detected at '{href}'")
+    sub_root = load(target).getroot()
+    _expand_xincludes(sub_root, os.path.dirname(target), seen | {target}, depth + 1)
+    return _xpointer_select(sub_root, include_element.get('xpointer'), href)
+
+
+def _expand_xincludes(element, base_dir, seen=frozenset(), depth=0):
+    """Recursively replace ``<xi:include>`` descendants of ``element`` in place."""
+    if depth > _MAX_INCLUDE_DEPTH:
+        raise ResolveError("xi:include nesting too deep")
+    for child in list(element):
+        if child.tag == _XI_INCLUDE:
+            nodes = _resolve_include(child, base_dir, seen, depth)
+            index = element.index(child)
+            element.remove(child)
+            for offset, node in enumerate(nodes):
+                element.insert(index + offset, node)
+        elif _is_element(child):
+            _expand_xincludes(child, base_dir, seen, depth)
+
+
+# --- change files -----------------------------------------------------------
+
+def _changes_root(tree):
+    """The first ``<changes>`` element in a change-file tree (Fortran uses
+    ``XML_Get_First_Element_By_Tag_Name(changesDoc,'changes')``)."""
+    root = tree.getroot()
+    if root.tag == 'changes':
+        return root
+    found = next(root.iter('changes'), None)
+    if found is None:
+        raise ResolveError("change file has no <changes> element")
+    return found
+
+
+def _apply_change(root, change):
+    """Apply one ``<change>`` element to the parameter tree ``root``."""
+    change_type = change.get('type')
+    path = change.get('path')
+    if change_type is None:
+        raise ResolveError("`change` element must have the `type` attribute")
+    if path is None:
+        raise ResolveError("`change` element must have the `path` attribute")
+
+    exists = path == '' or bool(resolve_path(root, path, root))
+    if exists:
+        target = root if path == '' else _first(root, path, root)
+        if change_type == 'replaceOrAppend':
+            change_type = 'replace'
+    elif change_type == 'replaceOrAppend':
+        # Path absent: append to the parent (strip the last path step).
+        parent_path = path.rsplit('/', 1)[0] if '/' in path else ''
+        target = root if parent_path == '' else _first(root, parent_path, root)
+        if target is None:
+            raise ResolveError(f"path '{parent_path}' does not exist")
+        change_type = 'append'
+    else:
+        raise ResolveError(f"path '{path}' does not exist")
+
+    if change_type == 'remove':
+        target.getparent().remove(target)
+
+    elif change_type == 'update':
+        if target.get('value') is None:
+            raise ResolveError(
+                "can not update the `value` in a parameter that has no `value`")
+        if change.get('value') is None:
+            raise ResolveError("`change` element must have the `value` attribute")
+        base = target.get('value') if change.get('append') == 'true' else ''
+        target.set('value', base + change.get('value'))
+
+    elif change_type == 'append':
+        for new_node in _element_children(change):
+            target.append(copy.deepcopy(new_node))
+
+    elif change_type in ('insertBefore', 'insertAfter', 'replace'):
+        parent = target.getparent()
+        index = parent.index(target)
+        for offset, new_node in enumerate(_element_children(change)):
+            imported = copy.deepcopy(new_node)
+            if change_type == 'insertAfter':
+                parent.insert(index + 1 + offset, imported)
+            else:
+                parent.insert(index + offset, imported)
+        if change_type == 'replace':
+            parent.remove(target)
+
+    elif change_type == 'replaceWith':
+        target_path = change.get('target')
+        if target_path is None:
+            raise ResolveError(
+                '`change` element with `type="replaceWith"` must have the '
+                '`target` attribute')
+        source = _first(root, target_path, root)
+        if source is None:
+            raise ResolveError(f"target path '{target_path}' does not exist")
+        parent = target.getparent()
+        index = parent.index(target)
+        parent.insert(index, copy.deepcopy(source))
+        parent.remove(target)
+
+    elif change_type == 'encapsulate':
+        parent = target.getparent()
+        index = parent.index(target)
+        wrapper = None
+        for offset, new_node in enumerate(_element_children(change)):
+            imported = copy.deepcopy(new_node)
+            parent.insert(index + offset, imported)
+            if wrapper is None:
+                wrapper = imported
+        if wrapper is None:
+            raise ResolveError("`encapsulate` change provides no wrapping element")
+        parent.remove(target)
+        wrapper.append(target)
+
+    else:
+        raise ResolveError(f"unknown change type `{change_type}`")
+
+
+def apply_changes(root, change_files):
+    """Apply each change file (in order), each ``<change>`` in document order."""
+    for change_file in change_files:
+        change_tree = load(change_file)
+        _expand_xincludes(change_tree.getroot(), os.path.dirname(change_file) or '.')
+        for change in _element_children(_changes_root(change_tree)):
+            if change.tag == 'change':
+                _apply_change(root, change)
+
+
+# --- top-level --------------------------------------------------------------
+
+def resolve_tree(tree, base_dir, change_files=()):
+    """Resolve an lxml parameter ``tree`` in place: XInclude then changes."""
+    root = tree.getroot()
+    _expand_xincludes(root, base_dir or '.')
+    if change_files:
+        apply_changes(root, change_files)
+    return tree
+
+
+def resolve_file(path, change_files=(), output=None):
+    """Resolve ``path`` (+ optional change files); optionally write ``output``.
+
+    Returns the resolved lxml ``ElementTree``.
+    """
+    tree = load(path)
+    resolve_tree(tree, os.path.dirname(os.path.abspath(path)), change_files)
+    if output is not None:
+        with open(output, 'wb') as handle:
+            handle.write(to_bytes(tree))
+    return tree

--- a/python/Galacticus/Parameters/tests/test_resolve.py
+++ b/python/Galacticus/Parameters/tests/test_resolve.py
@@ -1,0 +1,227 @@
+"""Tests for Galacticus.Parameters.resolve (parameter-file resolver, Stage 1)."""
+
+import os
+
+import pytest
+
+from lxml import etree
+
+from Galacticus.Parameters import resolve
+from Galacticus.Parameters.resolve import ResolveError
+
+
+def _tree(xml):
+    return etree.ElementTree(etree.fromstring(xml.encode()))
+
+
+def _root(xml):
+    return etree.fromstring(xml.encode())
+
+
+def _tags(element):
+    return [child.tag for child in element if isinstance(child.tag, str)]
+
+
+# --- path resolution (Stage 0) ---------------------------------------------
+
+def test_resolve_path_legacy_bare_is_absolute_from_root():
+    root = _root('<parameters><a><b value="1"/></a><c><b value="2"/></c></parameters>')
+    a = root[0]
+    # A bare path is absolute-from-root even when evaluated from a nested node.
+    matches = resolve.resolve_path(a, 'c/b', root)
+    assert [m.get('value') for m in matches] == ['2']
+
+
+def test_resolve_path_relative_and_self_and_parent():
+    root = _root('<parameters><a><b value="1"/></a></parameters>')
+    a = root[0]
+    assert resolve.resolve_path(a, '.', root) == [a]
+    assert resolve.resolve_path(a, './b', root)[0].get('value') == '1'
+    assert resolve.resolve_path(a[0], '..', root) == [a]
+
+
+def test_resolve_path_predicate_and_empty():
+    root = _root('<parameters><n value="x"/><n value="y"/></parameters>')
+    assert resolve.resolve_path(root, '', root) == [root]
+    assert resolve.resolve_path(root, "n[@value='y']", root)[0].get('value') == 'y'
+
+
+# --- XInclude (Stage 1) -----------------------------------------------------
+
+def _write(tmp_path, name, xml):
+    path = tmp_path / name
+    path.write_text(xml)
+    return str(path)
+
+
+def test_xinclude_children_of_parameters_root(tmp_path):
+    _write(tmp_path, 'cosmology.xml',
+           '<parameters><Hubble value="70"/><Omega value="0.3"/></parameters>')
+    main = _write(
+        tmp_path, 'main.xml',
+        '<parameters xmlns:xi="http://www.w3.org/2001/XInclude">'
+        '<first value="1"/>'
+        '<xi:include href="cosmology.xml" xpointer="xpointer(parameters/*)"/>'
+        '<last value="9"/></parameters>')
+    root = resolve.resolve_file(main).getroot()
+    # Included children are spliced in place, preserving order.
+    assert _tags(root) == ['first', 'Hubble', 'Omega', 'last']
+
+
+def test_xinclude_nested(tmp_path):
+    _write(tmp_path, 'inner.xml', '<parameters><deep value="1"/></parameters>')
+    _write(tmp_path, 'outer.xml',
+           '<parameters xmlns:xi="http://www.w3.org/2001/XInclude">'
+           '<mid value="2"/>'
+           '<xi:include href="inner.xml" xpointer="xpointer(parameters/*)"/>'
+           '</parameters>')
+    main = _write(tmp_path, 'main.xml',
+                  '<parameters xmlns:xi="http://www.w3.org/2001/XInclude">'
+                  '<xi:include href="outer.xml" xpointer="xpointer(parameters/*)"/>'
+                  '</parameters>')
+    root = resolve.resolve_file(main).getroot()
+    assert _tags(root) == ['mid', 'deep']
+
+
+def test_xinclude_missing_href_raises(tmp_path):
+    main = _write(tmp_path, 'main.xml',
+                  '<parameters xmlns:xi="http://www.w3.org/2001/XInclude">'
+                  '<xi:include href="nope.xml" xpointer="xpointer(parameters/*)"/>'
+                  '</parameters>')
+    with pytest.raises(ResolveError, match="does not resolve"):
+        resolve.resolve_file(main)
+
+
+def test_xinclude_fallback_used_when_missing(tmp_path):
+    main = _write(tmp_path, 'main.xml',
+                  '<parameters xmlns:xi="http://www.w3.org/2001/XInclude">'
+                  '<xi:include href="nope.xml">'
+                  '<xi:fallback><backup value="1"/></xi:fallback>'
+                  '</xi:include></parameters>')
+    root = resolve.resolve_file(main).getroot()
+    assert _tags(root) == ['backup']
+
+
+# --- changes (Stage 1): one test per operation ------------------------------
+
+def _apply(base_xml, changes_xml, tmp_path):
+    """Apply an inline <changes> document to an inline <parameters> document."""
+    change_file = _write(tmp_path, 'changes.xml', changes_xml)
+    tree = _tree(base_xml)
+    resolve.apply_changes(tree.getroot(), [change_file])
+    return tree.getroot()
+
+
+def test_change_remove(tmp_path):
+    root = _apply('<parameters><a value="1"/><b value="2"/></parameters>',
+                  '<changes><change type="remove" path="a"/></changes>', tmp_path)
+    assert _tags(root) == ['b']
+
+
+def test_change_update(tmp_path):
+    root = _apply('<parameters><a value="1"/></parameters>',
+                  '<changes><change type="update" path="a" value="9"/></changes>',
+                  tmp_path)
+    assert root[0].get('value') == '9'
+
+
+def test_change_update_append(tmp_path):
+    root = _apply('<parameters><a value="1 2"/></parameters>',
+                  '<changes><change type="update" path="a" value=" 3" '
+                  'append="true"/></changes>', tmp_path)
+    assert root[0].get('value') == '1 2 3'
+
+
+def test_change_update_no_value_on_target_raises(tmp_path):
+    with pytest.raises(ResolveError, match="no `value`"):
+        _apply('<parameters><a><child value="1"/></a></parameters>',
+               '<changes><change type="update" path="a" value="9"/></changes>',
+               tmp_path)
+
+
+def test_change_append(tmp_path):
+    root = _apply('<parameters><a><x value="1"/></a></parameters>',
+                  '<changes><change type="append" path="a">'
+                  '<y value="2"/></change></changes>', tmp_path)
+    assert _tags(root[0]) == ['x', 'y']
+
+
+def test_change_insert_before_and_after(tmp_path):
+    root = _apply('<parameters><a value="1"/><b value="2"/></parameters>',
+                  '<changes>'
+                  '<change type="insertBefore" path="b"><before value="0"/></change>'
+                  '<change type="insertAfter" path="b"><after value="3"/></change>'
+                  '</changes>', tmp_path)
+    assert _tags(root) == ['a', 'before', 'b', 'after']
+
+
+def test_change_replace(tmp_path):
+    root = _apply('<parameters><a value="1"/></parameters>',
+                  '<changes><change type="replace" path="a">'
+                  '<b value="2"/><c value="3"/></change></changes>', tmp_path)
+    assert _tags(root) == ['b', 'c']
+
+
+def test_change_replace_or_append_existing_replaces(tmp_path):
+    root = _apply('<parameters><a value="1"/></parameters>',
+                  '<changes><change type="replaceOrAppend" path="a">'
+                  '<a value="2"/></change></changes>', tmp_path)
+    assert _tags(root) == ['a'] and root[0].get('value') == '2'
+
+
+def test_change_replace_or_append_missing_appends_to_parent(tmp_path):
+    root = _apply('<parameters><a><x value="1"/></a></parameters>',
+                  '<changes><change type="replaceOrAppend" path="a/y">'
+                  '<y value="2"/></change></changes>', tmp_path)
+    assert _tags(root[0]) == ['x', 'y']
+
+
+def test_change_replace_with(tmp_path):
+    root = _apply(
+        '<parameters><src value="keep"><deep value="d"/></src>'
+        '<dst value="drop"/></parameters>',
+        '<changes><change type="replaceWith" path="dst" target="src"/></changes>',
+        tmp_path)
+    # dst is replaced by a deep clone of src.
+    assert _tags(root) == ['src', 'src']
+    assert root[1].get('value') == 'keep' and _tags(root[1]) == ['deep']
+
+
+def test_change_encapsulate(tmp_path):
+    root = _apply('<parameters><t value="inner"/></parameters>',
+                  '<changes><change type="encapsulate" path="t">'
+                  '<wrapper value="outer"/></change></changes>', tmp_path)
+    assert _tags(root) == ['wrapper']
+    wrapper = root[0]
+    assert wrapper.get('value') == 'outer' and _tags(wrapper) == ['t']
+    assert wrapper[0].get('value') == 'inner'
+
+
+def test_change_predicate_path(tmp_path):
+    root = _apply(
+        '<parameters><op value="a"/><op value="b"><inner value="1"/></op></parameters>',
+        '<changes><change type="update" path="op[@value=\'b\']/inner" '
+        'value="9"/></changes>', tmp_path)
+    assert root[1][0].get('value') == '9'
+
+
+def test_change_unknown_type_raises(tmp_path):
+    with pytest.raises(ResolveError, match="unknown change type"):
+        _apply('<parameters><a value="1"/></parameters>',
+               '<changes><change type="bogus" path="a"/></changes>', tmp_path)
+
+
+def test_change_missing_path_raises(tmp_path):
+    with pytest.raises(ResolveError, match="does not exist"):
+        _apply('<parameters><a value="1"/></parameters>',
+               '<changes><change type="remove" path="nope"/></changes>', tmp_path)
+
+
+def test_changes_applied_in_order(tmp_path):
+    # Second change sees the first change's effect (append then update).
+    root = _apply('<parameters><a><x value="1"/></a></parameters>',
+                  '<changes>'
+                  '<change type="append" path="a"><y value="2"/></change>'
+                  '<change type="update" path="a/y" value="3"/>'
+                  '</changes>', tmp_path)
+    assert root[0][1].tag == 'y' and root[0][1].get('value') == '3'

--- a/testSuite/test-parameter-resolver.py
+++ b/testSuite/test-parameter-resolver.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Differential test for the Python parameter-file resolver.
+
+Compares `Galacticus.Parameters.resolve` against the authoritative Galacticus
+oracle (`Galacticus.exe --output-processed-parameters`), which serializes the
+fully-processed DOM. The oracle faithfully reflects the two transformations the
+resolver implements at this stage -- XInclude expansion and change-file
+application -- because Galacticus bakes both into the DOM before any value is
+read (see the plan in ~/.claude/plans/galacticus-parameter-resolver.md).
+
+Run from the `testSuite/` directory (as `test-all.py` does). Prints `FAILED` on
+any divergence; `SKIP` (not a failure) if no built `Galacticus.exe` is found.
+
+Andrew Benson (2026).
+"""
+
+import glob
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO = os.path.abspath(os.environ.get("GALACTICUS_EXEC_PATH", ".."))
+sys.path.insert(0, os.path.join(REPO, "python"))
+from lxml import etree                                        # noqa: E402
+from Galacticus.Parameters import resolve                     # noqa: E402
+
+BINARY = os.path.join(REPO, "Galacticus.exe")
+# Cap the (oracle-backed) XInclude corpus scan so the test stays quick; the cap
+# is logged so partial coverage is never silent.
+XINCLUDE_SAMPLE = int(os.environ.get("RESOLVER_XINCLUDE_SAMPLE", "40"))
+
+
+def _norm(element):
+    """Canonical form ignoring comments, whitespace, and attribute order."""
+    if not isinstance(element.tag, str):
+        return None
+    children = tuple(c for c in (_norm(x) for x in element) if c is not None)
+    return (element.tag, tuple(sorted(element.attrib.items())),
+            (element.text or "").strip(), children)
+
+
+def _first_diff(a, b, path="parameters"):
+    if a is None or b is None:
+        return f"{path}: node presence differs"
+    if a[0] != b[0]:
+        return f"{path}: tag {a[0]} vs {b[0]}"
+    if a[1] != b[1]:
+        return f"{path} <{a[0]}>: attribs {a[1]} vs {b[1]}"
+    if a[2] != b[2]:
+        return f"{path} <{a[0]}>: text {a[2]!r} vs {b[2]!r}"
+    if len(a[3]) != len(b[3]):
+        return (f"{path} <{a[0]}>: child count {len(a[3])} vs {len(b[3])} "
+                f"({[c[0] for c in a[3]]} vs {[c[0] for c in b[3]]})")
+    for ca, cb in zip(a[3], b[3]):
+        deeper = _first_diff(ca, cb, f"{path}/{ca[0]}")
+        if deeper:
+            return deeper
+    return None
+
+
+def _run_oracle(param_file, change_files, out_path, timeout=40):
+    """Run Galacticus.exe to serialize the processed tree; poll-and-kill once the
+    output file is written (it is emitted before the heavy run begins)."""
+    if os.path.exists(out_path):
+        os.remove(out_path)
+    cmd = [BINARY, param_file, *change_files,
+           "--output-processed-parameters", out_path, "--dry-run"]
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    start, last, stable = time.time(), -1, 0
+    try:
+        while time.time() - start < timeout:
+            if proc.poll() is not None:
+                break
+            if os.path.exists(out_path):
+                size = os.path.getsize(out_path)
+                stable = stable + 1 if size > 0 and size == last else 0
+                last = size
+                if stable >= 2:
+                    break
+            time.sleep(0.15)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+    return os.path.exists(out_path) and os.path.getsize(out_path) > 0
+
+
+def _compare(param_file, change_files, label, out_path):
+    if not _run_oracle(param_file, change_files, out_path):
+        # Oracle errored before serialize; a faithful resolver must agree (error).
+        try:
+            resolve.resolve_file(param_file, change_files)
+        except Exception:
+            return True, "both error (agreement)"
+        return False, "oracle errored but resolver succeeded (too lenient)"
+    try:
+        oracle = etree.parse(out_path).getroot()
+        mine = resolve.resolve_file(param_file, change_files).getroot()
+    except Exception as exc:                                  # pragma: no cover
+        return False, f"comparison setup error: {exc}"
+    diff = _first_diff(_norm(oracle), _norm(mine))
+    return diff is None, diff or "ok"
+
+
+# Synthetic base+change pairs exercising every change operation.
+CHANGE_CASES = {
+    "remove": ('<parameters><a value="1"/><b value="2"/></parameters>',
+               '<changes><change type="remove" path="a"/></changes>'),
+    "update": ('<parameters><a value="1"/></parameters>',
+               '<changes><change type="update" path="a" value="9"/></changes>'),
+    "update-append": ('<parameters><a value="1 2"/></parameters>',
+               '<changes><change type="update" path="a" value=" 3" append="true"/></changes>'),
+    "append": ('<parameters><a><x value="1"/></a></parameters>',
+               '<changes><change type="append" path="a"><y value="2"/></change></changes>'),
+    "insertBefore": ('<parameters><a value="1"/><b value="2"/></parameters>',
+               '<changes><change type="insertBefore" path="b"><z value="0"/></change></changes>'),
+    "insertAfter": ('<parameters><a value="1"/><b value="2"/></parameters>',
+               '<changes><change type="insertAfter" path="a"><z value="0"/></change></changes>'),
+    "replace": ('<parameters><a value="1"/></parameters>',
+               '<changes><change type="replace" path="a"><b value="2"/><c value="3"/></change></changes>'),
+    "replaceOrAppend-exists": ('<parameters><a value="1"/></parameters>',
+               '<changes><change type="replaceOrAppend" path="a"><a value="2"/></change></changes>'),
+    "replaceOrAppend-missing": ('<parameters><a><x value="1"/></a></parameters>',
+               '<changes><change type="replaceOrAppend" path="a/y"><y value="2"/></change></changes>'),
+    "replaceWith": ('<parameters><src value="k"><deep value="d"/></src><dst value="x"/></parameters>',
+               '<changes><change type="replaceWith" path="dst" target="src"/></changes>'),
+    "encapsulate": ('<parameters><t value="i"/></parameters>',
+               '<changes><change type="encapsulate" path="t"><w value="o"/></change></changes>'),
+    "predicate": ('<parameters><op value="a"/><op value="b"><inner value="1"/></op></parameters>',
+               """<changes><change type="update" path="op[@value='b']/inner" value="9"/></changes>"""),
+}
+
+
+def main():
+    if not os.path.isfile(BINARY):
+        print(f"SKIP: no built Galacticus.exe at {BINARY}; "
+              "differential resolver test requires the binary.")
+        return 0
+
+    failures = 0
+    out_path = os.path.join(tempfile.gettempdir(), "resolver_oracle.xml")
+
+    print("Change-operation parity vs oracle:")
+    with tempfile.TemporaryDirectory() as work:
+        for name, (base, changes) in CHANGE_CASES.items():
+            base_file = os.path.join(work, "base.xml")
+            change_file = os.path.join(work, "changes.xml")
+            open(base_file, "w").write(base)
+            open(change_file, "w").write(changes)
+            ok, detail = _compare(base_file, [change_file], name, out_path)
+            if ok:
+                print(f"  ok: {name}")
+            else:
+                failures += 1
+                print(f"  FAILED: {name} :: {detail}")
+
+    print(f"XInclude parity vs oracle (first {XINCLUDE_SAMPLE} corpus files):")
+    candidates = []
+    for pattern in ("parameters/**/*.xml", "testSuite/parameters/**/*.xml"):
+        for path in sorted(glob.glob(os.path.join(REPO, pattern), recursive=True)):
+            try:
+                root_tag = etree.parse(path).getroot().tag
+            except Exception:
+                continue
+            if root_tag == "parameters" and b"xi:include" in open(path, "rb").read():
+                candidates.append(path)
+    scanned = candidates[:XINCLUDE_SAMPLE]
+    print(f"  ({len(scanned)} of {len(candidates)} XInclude-using parameter files)")
+    for path in scanned:
+        ok, detail = _compare(path, [], os.path.relpath(path, REPO), out_path)
+        if not ok:
+            failures += 1
+            print(f"  FAILED: {os.path.relpath(path, REPO)} :: {detail}")
+
+    if failures:
+        print(f"FAILED: {failures} resolver/oracle divergence(s)")
+        return 1
+    print("SUCCESS: resolver matches the Galacticus oracle "
+          f"({len(CHANGE_CASES)} change ops, {len(scanned)} XInclude files)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

First stage of the Python parameter-file **resolver/preprocessor** (revised A4 / Pillar B). Adds `Galacticus.Parameters.resolve`, which re-implements on an lxml tree the two file-level transformations Galacticus bakes eagerly into the DOM, so a fully-resolved file can later be handed to `Galacticus.exe`:

- **XInclude** — Galacticus' limited `xpointer(parameters/*)` form, strict file-relative `href` resolution (matching `source/utility/IO/XML.F90`), recursive, with `<xi:fallback>`.
- **Change files** — the full operation set (`remove`, `update`[+`append="true"`], `append`, `insertBefore`, `insertAfter`, `replace`, `replaceOrAppend`, `replaceWith`, `encapsulate`), applied in command-line order, each `<change>` in document order, matching `source/utility/input_parameters.F90`.

A shared path helper gives Galacticus' legacy "bare path is absolute from the `<parameters>` root" semantics while letting **full XPath** (predicates, `//`, axes, functions — via lxml) pass through.

## Deliberately *not* done here (see design notes)

- **`id`/`idRef` are not dereferenced.** They are runtime *pointers* to a single shared object; inlining would make Galacticus build separate copies, changing behaviour. Reference validation + conditionals are a later stage.
- **`=[...]` math expressions are left intact** for Galacticus to evaluate at runtime (deferred until a fuller front end, since they must be re-evaluated per MCMC step).

## Verification

- `python/Galacticus/Parameters/tests/test_resolve.py` — 22 unit tests (path resolution, XInclude, every change operation, ordering, error cases). Runs in the normal `pytest` stage; no binary needed.
- `testSuite/test-parameter-resolver.py` — **differential test against the Galacticus oracle** (`Galacticus.exe --output-processed-parameters`, which serializes the processed DOM before any value is read, so it faithfully reflects XInclude + changes). Every change operation and **every XInclude-using parameter file in the corpus (26/26)** match the binary's output exactly. Skips cleanly if no built binary is present.

This is a pure library + tests addition — no wiring into the `galacticus` launcher yet (that's a later stage), so nothing in existing behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
