### PR TITLE
feat: parameter resolver — references, conditionals, launcher wiring, catalog generation

### DIFF
--- a/docs/manuals/user-guide/installation/pip.rst
+++ b/docs/manuals/user-guide/installation/pip.rst
@@ -56,8 +56,31 @@ Commands
 ``galacticus update``
    Re-download the install for the current package version.
 
-``galacticus validate <file>``
-   Validate a parameter file without running it.
+``galacticus validate <file> [change files...]``
+   Validate a parameter file without running it. Validation is performed on the
+   *resolved* tree (XInclude, any change files, and ``active=`` conditionals are
+   applied first), so it checks the structure Galacticus will actually build.
+
+``galacticus resolve <file> [change files...] -o <output>``
+   Apply the file-level transformations Galacticus performs when reading a
+   parameter file — XInclude expansion, change-file application, and ``active=``
+   conditional evaluation/pruning — and write a single, clean, self-contained
+   parameter file to ``<output>``. Math expressions (``=[...]``) and ``id``/
+   ``idRef`` anchors are left intact for Galacticus to handle at run time. Pass
+   ``--no-conditionals`` to leave conditionals in place, or ``--validate`` to
+   validate the result. This needs no executable or download.
+
+   This is the recommended way to use the launcher with **MPI**: resolve once,
+   then launch the (unchanged) executable under ``mpirun`` on the resolved file —
+
+   .. code-block:: bash
+
+      galacticus resolve model.xml changes.xml -o resolved.xml
+      mpirun -n 16 Galacticus.exe resolved.xml
+
+   Do **not** run ``mpirun galacticus run …``: that would resolve and launch once
+   per rank. (For a single-process run, ``galacticus run --resolve <file>``
+   resolves to a temporary file and runs that.)
 
 ``galacticus clean``
    Purge the regenerable data cache so it cannot grow without bound. Use

--- a/docs/manuals/user-guide/installation/pip.rst
+++ b/docs/manuals/user-guide/installation/pip.rst
@@ -118,6 +118,12 @@ executable is present, or if ``GALACTICUS_HOME`` points at a build/clone tree
 containing ``Galacticus.exe``, the launcher uses that install and skips all
 downloads. Run ``galacticus info`` to see which install is in effect.
 
+For such a build, catalog-aware validation needs the parameter catalog, which a
+managed install generates automatically but a source build does not. Generate it
+once with ``make parameters-catalog`` (it is written to the build tree where the
+launcher looks for it); without it, ``galacticus validate`` falls back to the
+executable's ``--dry-run``.
+
 .. note::
 
    The launcher fetches assets from the GitHub release matching the installed

--- a/python/Galacticus/Parameters/resolve.py
+++ b/python/Galacticus/Parameters/resolve.py
@@ -16,19 +16,29 @@ Galacticus bakes eagerly into the DOM and that the
   (``source/utility/input_parameters.F90``) applied, in command-line order, each
   ``<change>`` in document order, to the post-XInclude tree.
 
+Stage 2 adds:
+
+* **Reference validation** -- every ``idRef`` must resolve to an element with a
+  matching ``id`` and the SAME tag.  References are VALIDATED but NEVER
+  dereferenced/inlined: Galacticus keeps them as runtime pointers to a single
+  shared object, so inlining would create separate copies and change behaviour.
+* **Conditionals** -- ``active="[path] ==|!= value"`` are evaluated (string
+  comparison, fixed-point over dependency chains, with idRef dereferencing during
+  path resolution, mirroring ``inputParametersEvaluateConditionals``) and
+  inactive subtrees are PRUNED, leaving a clean unconditional tree.
+
 NOT handled here (by design -- see the plan):
 
-* ``id``/``idRef`` are validated but NEVER dereferenced (they are runtime
-  pointers -> a shared object; dereferencing would create separate copies).
-  Reference validation + conditionals are Stage 2.
 * ``=[...]`` math expressions are left INTACT for Galacticus to evaluate at
   runtime (deferred).
 
-Processing order matches Galacticus: XInclude -> changes.
+Processing order matches Galacticus: XInclude -> changes -> references ->
+conditionals.
 
 Uses ``lxml`` (already a dependency of the ``galacticus`` launcher).
 """
 
+import collections
 import copy
 import os
 import re
@@ -281,24 +291,189 @@ def apply_changes(root, change_files):
                 _apply_change(root, change)
 
 
+# --- references (id / idRef) ------------------------------------------------
+
+def check_references(root):
+    """Return ``[(tag, idRef), ...]`` for every ``idRef`` with no matching,
+    same-tag ``id`` -- the contract Galacticus' ``resolveReferences`` enforces
+    (an unmatched ``idRef`` is a fatal run-time error)."""
+    ids_by_tag = collections.defaultdict(set)
+    for element in root.iter():
+        if _is_element(element) and element.get('id') is not None:
+            ids_by_tag[element.tag].add(element.get('id'))
+    problems = []
+    for element in root.iter():
+        if not _is_element(element):
+            continue
+        id_ref = element.get('idRef')
+        if id_ref is not None and id_ref not in ids_by_tag.get(element.tag, ()):
+            problems.append((element.tag, id_ref))
+    return problems
+
+
+def _dereference(node, root):
+    """Follow ``idRef`` to the same-tag element carrying the matching ``id``."""
+    id_ref = node.get('idRef')
+    if id_ref is None:
+        return node
+    for candidate in root.iter(node.tag):
+        if candidate.get('id') == id_ref:
+            return candidate
+    raise ResolveError(f"unable to find referenced parameter '{id_ref}'")
+
+
+# --- conditionals (active="[path] ==|!= value") -----------------------------
+
+# Temporary attribute used to record evaluated active state during the
+# fixed-point pass; presence == "activeEvaluated", value '1'/'0' == active.
+_ACTIVE_STATE = '__resolver_active'
+
+
+def _parse_condition(condition):
+    """Parse ``[path] == value`` / ``[path] != value`` -> (path, equals, value)."""
+    text = condition.strip()
+    if not (text.startswith('[') and ']' in text and text.index(']') >= 2):
+        raise ResolveError(
+            f"unable to parse parameter name in conditional '{condition}'")
+    close = text.index(']')
+    path = text[1:close]
+    rest = text[close + 1:].lstrip()
+    operator = rest[:2]
+    if operator == '==':
+        equals = True
+    elif operator == '!=':
+        equals = False
+    else:
+        raise ResolveError(f"unable to parse operator in conditional '{condition}'")
+    return path, equals, rest[2:].strip()
+
+
+def _node_value(node):
+    """The parameter's value, read from the ``value`` attribute (mirrors
+    ``inputParameterGet``: a node with no ``value`` attribute is an error)."""
+    value = node.get('value')
+    if value is None:
+        raise ResolveError(
+            f"no parameter value present on <{node.tag}> used in a conditional")
+    return value
+
+
+def _resolve_conditional_target(current, path, root):
+    """Resolve a conditional ``path`` to the node it conditions upon, replicating
+    Galacticus' walker: bare first step is absolute from the root, ``.``/``..``
+    are self/parent, named steps match the first ACTIVE child of that name that
+    carries a value/<value>/idRef; idRef nodes are dereferenced en route."""
+    segments = path.split('/')
+    node = current if segments[0] in ('.', '..') else root
+    for segment in segments:
+        if segment == '.':
+            continue
+        if segment == '..':
+            node = node.getparent()
+            if node is None:
+                raise ResolveError('no parent parameter exists')
+            continue
+        match = None
+        for child in node:
+            if (_is_element(child)
+                    and child.get(_ACTIVE_STATE, '1') == '1'
+                    and child.tag == segment
+                    and (child.get('value') is not None
+                         or child.find('value') is not None
+                         or child.get('idRef') is not None)):
+                match = child
+                break
+        if match is None:
+            raise ResolveError(f"no child parameter '{segment}' exists")
+        node = _dereference(match, root)
+    return node
+
+
+def evaluate_conditionals(root):
+    """Evaluate every ``active`` conditional (fixed-point) then prune inactive
+    subtrees, leaving an unconditional tree."""
+    while True:
+        all_evaluated = True
+        did_evaluate = False
+        for element in root.iter():
+            if not _is_element(element) or element.get(_ACTIVE_STATE) is not None:
+                continue
+            condition = element.get('active')
+            if condition is None:
+                element.set(_ACTIVE_STATE, '1')        # unconditional: always active
+                did_evaluate = True
+                continue
+            path, equals, value_test = _parse_condition(condition)
+            target = _resolve_conditional_target(element, path, root)
+            if target.get(_ACTIVE_STATE) is None:
+                all_evaluated = False                  # dependency not yet known
+                continue
+            matches = _node_value(target).strip() == value_test
+            element.set(_ACTIVE_STATE, '1' if matches == equals else '0')
+            did_evaluate = True
+        if all_evaluated:
+            break
+        if not did_evaluate:
+            raise ResolveError(
+                'failed to evaluate parameter active statuses (cyclic conditional?)')
+    _prune_inactive(root)
+
+
+def _prune_inactive(element):
+    """Remove inactive subtrees; strip the (now-unconditional) ``active`` markers
+    from survivors."""
+    for child in list(element):
+        if not _is_element(child):
+            continue
+        if child.get(_ACTIVE_STATE) == '0':
+            element.remove(child)
+        else:
+            child.attrib.pop(_ACTIVE_STATE, None)
+            child.attrib.pop('active', None)
+            _prune_inactive(child)
+    element.attrib.pop(_ACTIVE_STATE, None)
+
+
 # --- top-level --------------------------------------------------------------
 
-def resolve_tree(tree, base_dir, change_files=()):
-    """Resolve an lxml parameter ``tree`` in place: XInclude then changes."""
+def resolve_tree(tree, base_dir, change_files=(), conditionals=True):
+    """Resolve an lxml parameter ``tree`` in place, in Galacticus' order:
+    XInclude -> changes -> reference validation -> conditionals.
+
+    ``conditionals=False`` skips conditional evaluation/pruning, leaving the tree
+    at the point the ``--output-processed-parameters`` oracle serializes it
+    (XInclude + changes baked in, ``active=`` attributes still present) -- used by
+    the differential test, which can only certify the oracle-faithful scope.
+    """
     root = tree.getroot()
     _expand_xincludes(root, base_dir or '.')
     if change_files:
         apply_changes(root, change_files)
+    problems = check_references(root)
+    if problems:
+        tag, id_ref = problems[0]
+        raise ResolveError(
+            f"idRef '{id_ref}' on <{tag}> has no matching element with id='{id_ref}'")
+    if conditionals:
+        evaluate_conditionals(root)
+        # Conditional pruning must not strand an idRef whose id'd target it removed.
+        problems = check_references(root)
+        if problems:
+            tag, id_ref = problems[0]
+            raise ResolveError(
+                f"conditional pruning left a dangling idRef '{id_ref}' on <{tag}> "
+                "(its id'd target was conditionally removed); not supported")
     return tree
 
 
-def resolve_file(path, change_files=(), output=None):
+def resolve_file(path, change_files=(), output=None, conditionals=True):
     """Resolve ``path`` (+ optional change files); optionally write ``output``.
 
     Returns the resolved lxml ``ElementTree``.
     """
     tree = load(path)
-    resolve_tree(tree, os.path.dirname(os.path.abspath(path)), change_files)
+    resolve_tree(tree, os.path.dirname(os.path.abspath(path)), change_files,
+                 conditionals=conditionals)
     if output is not None:
         with open(output, 'wb') as handle:
             handle.write(to_bytes(tree))

--- a/python/Galacticus/Parameters/tests/test_resolve.py
+++ b/python/Galacticus/Parameters/tests/test_resolve.py
@@ -217,6 +217,132 @@ def test_change_missing_path_raises(tmp_path):
                '<changes><change type="remove" path="nope"/></changes>', tmp_path)
 
 
+def _resolve(xml):
+    tree = _tree(xml)
+    resolve.resolve_tree(tree, base_dir='.')
+    return tree.getroot()
+
+
+# --- references (Stage 2): validate, never dereference -----------------------
+
+def test_check_references_valid():
+    root = _root('<parameters><a value="1" id="k"/><a idRef="k"/></parameters>')
+    assert resolve.check_references(root) == []
+
+
+def test_check_references_dangling():
+    root = _root('<parameters><a idRef="missing"/></parameters>')
+    assert resolve.check_references(root) == [('a', 'missing')]
+
+
+def test_check_references_requires_same_tag():
+    # id 'k' is on <a>, but the idRef is on <b> -> no same-tag match.
+    root = _root('<parameters><a id="k"/><b idRef="k"/></parameters>')
+    assert resolve.check_references(root) == [('b', 'k')]
+
+
+def test_resolve_file_dangling_idref_raises(tmp_path):
+    main = _write(tmp_path, 'main.xml',
+                  '<parameters><a idRef="nope"/></parameters>')
+    with pytest.raises(ResolveError, match="no matching element"):
+        resolve.resolve_file(main)
+
+
+def test_references_are_not_dereferenced():
+    # The resolved tree keeps id/idRef verbatim (runtime pointers, not copies).
+    root = _resolve('<parameters><a value="1" id="k"/><a idRef="k"/></parameters>')
+    assert root[0].get('id') == 'k'
+    assert root[1].get('idRef') == 'k' and root[1].get('value') is None
+
+
+# --- conditionals (Stage 2): evaluate + prune -------------------------------
+
+def test_conditional_equal_kept_not_equal_pruned():
+    root = _root(
+        '<parameters>'
+        '<cosmologicalMassVariance value="filteredPower"><sigma_8 value="0.912"/>'
+        '</cosmologicalMassVariance>'
+        '<active1 value="0.1" active="[cosmologicalMassVariance/sigma_8] != 0.912"/>'
+        '<active1 value="0.2" active="[cosmologicalMassVariance/sigma_8] == 0.912"/>'
+        '</parameters>')
+    resolve.evaluate_conditionals(root)
+    kept = [c for c in root if c.tag == 'active1']
+    assert len(kept) == 1 and kept[0].get('value') == '0.2'
+    assert kept[0].get('active') is None        # marker stripped from survivor
+
+
+def test_conditional_relative_and_parent_path():
+    root = _root('<parameters><wrap><flag value="on"/>'
+                 '<dep value="1" active="[../flag] == on"/></wrap></parameters>')
+    resolve.evaluate_conditionals(root)
+    assert [c.tag for c in root[0]] == ['flag', 'dep']
+
+
+def test_conditional_dereferences_idref_in_path():
+    # Mirrors testsParameters.xml: the path lands on an idRef'd node and follows
+    # it to the real definition to read the value.
+    root = _resolve(
+        '<parameters>'
+        '<cosmologyParameters><cosmologicalMassVariance value="x" id="m">'
+        '<sigma_8 value="0.9"/></cosmologicalMassVariance></cosmologyParameters>'
+        '<cosmologicalMassVariance idRef="m"/>'
+        '<active1 value="a" active="[cosmologicalMassVariance/sigma_8] == 0.9"/>'
+        '</parameters>')
+    assert any(c.tag == 'active1' for c in root)            # kept (0.9 == 0.9)
+    assert any(c.get('idRef') == 'm' for c in root)         # idRef preserved
+
+
+def test_conditional_fixed_point_chain():
+    # `c` depends on `b` which depends on `base`; `c` precedes `b` in document
+    # order, so a single pass cannot resolve it -- requires the fixed point.
+    root = _root('<parameters><base value="go"/>'
+                 '<c value="2" active="[b] == 1"/>'
+                 '<b value="1" active="[base] == go"/></parameters>')
+    resolve.evaluate_conditionals(root)
+    assert {c.tag for c in root} == {'base', 'b', 'c'}      # all active, kept
+
+
+def test_conditional_no_such_child_raises():
+    root = _root('<parameters><x value="1" active="[nope] == 1"/></parameters>')
+    with pytest.raises(ResolveError, match="no child parameter"):
+        resolve.evaluate_conditionals(root)
+
+
+def test_conditional_cyclic_raises():
+    root = _root('<parameters>'
+                 '<a value="1" active="[b] == 1"/>'
+                 '<b value="1" active="[a] == 1"/></parameters>')
+    with pytest.raises(ResolveError, match="cyclic"):
+        resolve.evaluate_conditionals(root)
+
+
+def test_no_resolver_state_leaks_into_output():
+    root = _resolve('<parameters><base value="go"/>'
+                    '<x value="1" active="[base] == go"/></parameters>')
+    assert b'__resolver_active' not in resolve.to_bytes(root)
+
+
+# --- corpus-grounded end-to-end (real test fixture) -------------------------
+
+_REPO = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, os.pardir))
+_TESTS_PARAMS = os.path.join(_REPO, 'testSuite', 'parameters', 'testsParameters.xml')
+
+
+@pytest.mark.skipif(not os.path.exists(_TESTS_PARAMS),
+                    reason="testsParameters.xml not found")
+def test_resolve_real_tests_parameters():
+    root = resolve.resolve_file(_TESTS_PARAMS).getroot()
+    active1 = [c for c in root if c.tag == 'active1']
+    # sigma_8 is 0.912: only the `== 0.912` variant (value 0.2) survives.
+    assert [c.get('value') for c in active1] == ['0.2']
+    # no conditional markers remain anywhere; the idRef anchor is preserved.
+    assert not any(c.get('active') is not None for c in root.iter()
+                   if isinstance(c.tag, str))
+    assert any(c.get('idRef') == 'myCMV' for c in root.iter()
+              if isinstance(c.tag, str))
+
+
 def test_changes_applied_in_order(tmp_path):
     # Second change sees the first change's effect (append then update).
     root = _apply('<parameters><a><x value="1"/></a></parameters>',

--- a/python/galacticus_launcher/cli.py
+++ b/python/galacticus_launcher/cli.py
@@ -3,8 +3,12 @@
 Sub-commands:
 
 * ``install`` / ``update`` -- provision (or refresh) the managed install.
-* ``run <params.xml> [args...]`` -- validate then dispatch to the executable.
-* ``validate <params.xml>`` -- run validation only.
+* ``run <params.xml> [change files...] [args...]`` -- validate then dispatch to
+  the executable (``--resolve`` runs a fully-resolved temporary file instead).
+* ``validate <params.xml> [change files...]`` -- run validation only.
+* ``resolve <params.xml> [change files...] -o <out>`` -- write a resolved
+  (XInclude/changes/conditionals applied) parameter file; the serial pre-step for
+  MPI runs.
 * ``clean`` -- purge the regenerable cache (never the durable install).
 * ``info`` -- report the resolved install, paths, and environment.
 
@@ -21,7 +25,7 @@ import platformdirs
 
 from . import __version__, download, macos, paths, platforms, validate as _validate
 
-_COMMANDS = {"install", "update", "run", "validate", "clean", "info"}
+_COMMANDS = {"install", "update", "run", "validate", "resolve", "clean", "info"}
 
 
 def main(argv=None):
@@ -41,16 +45,35 @@ def main(argv=None):
     sub.add_parser("update", help="re-download the install for the current version")
 
     run_parser = sub.add_parser("run", help="run a parameter file")
-    run_parser.add_argument("parameter_file")
     run_parser.add_argument("--no-validate", action="store_true",
                             help="skip pre-dispatch parameter validation")
+    run_parser.add_argument("--resolve", action="store_true",
+                            help="resolve (XInclude, changes, conditionals) to a "
+                                 "temporary file, then run that")
+    run_parser.add_argument("parameter_file")
     run_parser.add_argument("extra", nargs=argparse.REMAINDER,
-                            help="arguments passed through to Galacticus.exe")
+                            help="change files, then arguments passed through to "
+                                 "Galacticus.exe")
 
     validate_parser = sub.add_parser("validate", help="validate a parameter file")
     validate_parser.add_argument("parameter_file")
+    validate_parser.add_argument("change_files", nargs="*",
+                                 help="change files applied (in order) before validation")
     validate_parser.add_argument("--structural", action="store_true",
                                  help="also run structural checks")
+
+    resolve_parser = sub.add_parser(
+        "resolve", help="resolve a parameter file (XInclude, change files, "
+                        "conditionals) to a single clean file")
+    resolve_parser.add_argument("parameter_file")
+    resolve_parser.add_argument("change_files", nargs="*",
+                                help="change files applied in order")
+    resolve_parser.add_argument("-o", "--output", required=True,
+                                help="write the resolved parameter file here")
+    resolve_parser.add_argument("--no-conditionals", action="store_true",
+                                help="do not evaluate/prune active= conditionals")
+    resolve_parser.add_argument("--validate", action="store_true",
+                                help="also validate the resolved file")
 
     clean_parser = sub.add_parser("clean", help="purge the regenerable cache")
     clean_parser.add_argument("--all", action="store_true",
@@ -91,9 +114,13 @@ def _dispatch(args):
     install = paths.resolve()
     if args.command in ("install", "update"):
         return _cmd_install(install, force=(args.command == "update"))
+    if args.command == "resolve":
+        # Resolution is pure Python; no binary/download is required.
+        return _cmd_resolve(install, args)
     if args.command == "validate":
         _ensure(install)
-        return _cmd_validate(install, args.parameter_file, args.structural)
+        return _cmd_validate(install, args.parameter_file, args.structural,
+                             args.change_files)
     if args.command == "run":
         _ensure(install)
         return _cmd_run(install, args)
@@ -132,9 +159,11 @@ def _cmd_install(install, *, force):
     return 0
 
 
-def _cmd_validate(install, parameter_file, structural):
+def _cmd_validate(install, parameter_file, structural, change_files):
     parameter_file = _resolve_parameter_file(install, parameter_file)
-    result = _validate.validate(parameter_file, install, structural=structural)
+    change_files = [_resolve_parameter_file(install, c) for c in change_files]
+    result = _validate.validate(parameter_file, install, structural=structural,
+                               change_files=change_files)
     _report_findings(result)
     if result.ok:
         print(f"OK ({result.method}): {parameter_file}")
@@ -143,10 +172,53 @@ def _cmd_validate(install, parameter_file, structural):
     return 1
 
 
+def _cmd_resolve(install, args):
+    parameter_file = _resolve_parameter_file(install, args.parameter_file)
+    change_files = [_resolve_parameter_file(install, c) for c in args.change_files]
+    try:
+        _validate.resolve_to_file(parameter_file, install, change_files,
+                                  output=args.output,
+                                  conditionals=not args.no_conditionals)
+    except RuntimeError as error:
+        print(f"galacticus: {error}", file=sys.stderr)
+        return 1
+    print(f"Resolved {parameter_file} -> {args.output}")
+    if args.validate:
+        result = _validate.validate(args.output, install)
+        _report_findings(result)
+        if not result.ok:
+            print(f"INVALID ({result.method}): {args.output}", file=sys.stderr)
+            return 1
+        print(f"OK ({result.method}): {args.output}")
+    return 0
+
+
+def _split_change_files(extra):
+    """Split ``run`` trailing args into (change files, pass-through options).
+
+    Mirrors the Galacticus command line: leading non-option arguments are change
+    files; everything from the first option (or ``--``) on is passed through.
+    """
+    change_files, passthrough, rest = [], [], False
+    for arg in extra:
+        if arg == "--":
+            rest = True
+            continue
+        if not rest and not arg.startswith("-"):
+            change_files.append(arg)
+        else:
+            rest = True
+            passthrough.append(arg)
+    return change_files, passthrough
+
+
 def _cmd_run(install, args):
     parameter_file = _resolve_parameter_file(install, args.parameter_file)
+    change_files, passthrough = _split_change_files(list(args.extra or []))
+    change_files = [_resolve_parameter_file(install, c) for c in change_files]
     if not args.no_validate:
-        result = _validate.validate(parameter_file, install)
+        result = _validate.validate(parameter_file, install,
+                                   change_files=change_files)
         _report_findings(result)
         if not result.ok:
             print(f"galacticus: refusing to run; {parameter_file} failed "
@@ -156,8 +228,22 @@ def _cmd_run(install, args):
         print("galacticus: warning: no datasets path resolved; the run may fail. "
               "Set GALACTICUS_DATA_PATH.", file=sys.stderr)
     env = install.environ()
-    extra = [a for a in (args.extra or []) if a != "--"]
-    command = [str(install.binary), parameter_file, *extra]
+    if args.resolve:
+        import tempfile
+        handle = tempfile.NamedTemporaryFile(suffix=".xml", delete=False)
+        handle.close()
+        try:
+            _validate.resolve_to_file(parameter_file, install, change_files,
+                                      output=handle.name)
+        except RuntimeError as error:
+            os.unlink(handle.name)
+            print(f"galacticus: {error}", file=sys.stderr)
+            return 1
+        # The resolved file already has change files baked in; pass only options.
+        command = [str(install.binary), handle.name, *passthrough]
+    else:
+        # Change files + pass-through options go to the binary, which applies them.
+        command = [str(install.binary), parameter_file, *change_files, *passthrough]
     sys.stdout.flush()
     os.execve(str(install.binary), command, env)  # replaces this process
 

--- a/python/galacticus_launcher/download.py
+++ b/python/galacticus_launcher/download.py
@@ -17,6 +17,7 @@ Four components make up a runnable install:
 
 import os
 import shutil
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -114,7 +115,36 @@ def provision(install, *, force=False, log=print):
         done.append("datasets")
     if _provision_tools(install, force=force, log=log):
         done.append("tools")
+    if _provision_catalog(install, force=force, log=log):
+        done.append("parameter catalog")
     return done
+
+
+def _provision_catalog(install, *, force, log):
+    """Generate the parameter catalog from the just-provisioned source tree.
+
+    The catalog (used by ``galacticus validate``) is NOT a committed/shipped
+    artifact; it is generated on demand here so it always matches the installed
+    source. Best-effort: a failure is logged but does not fail the install
+    (validation then falls back to the executable's ``--dry-run``).
+    """
+    catalog = Path(install.exec_path) / "parameters.catalog.json"
+    generator = Path(install.exec_path) / "scripts" / "build" / "parameterCatalog.py"
+    if not generator.is_file():
+        return False                       # source tree not present
+    if catalog.is_file() and not force:
+        return False
+    log("Generating parameter catalog ...")
+    try:
+        subprocess.run(
+            [sys.executable, str(generator), str(install.exec_path), str(catalog)],
+            check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        log(f"warning: could not generate the parameter catalog ({error}); "
+            "validation will fall back to the executable's --dry-run.")
+        return False
+    return catalog.is_file()
 
 
 def _sentinel(directory, name):

--- a/python/galacticus_launcher/tests/test_validate_resolve.py
+++ b/python/galacticus_launcher/tests/test_validate_resolve.py
@@ -1,0 +1,140 @@
+"""Tests for the launcher's `resolve` subcommand and validate-on-resolved wiring.
+
+These exercise how `galacticus_launcher` drives `Galacticus.Parameters.resolve`
+and `.validate` (Stages 4-5 of the parameter-resolver work). They import the
+in-repo `Galacticus.Parameters` tree via a stub install whose `exec_path` is the
+repository root.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from galacticus_launcher import cli, paths
+from galacticus_launcher import validate as launcher_validate
+
+REPO = Path(__file__).resolve().parents[3]
+
+# Minimal catalog: `accretionHalo` accepts only `simple`/`coldMode`.
+MIN_CATALOG = {
+    "functionClasses": {
+        "accretionHalo": {"default": "simple",
+                          "implementations": ["coldMode", "simple"]},
+    },
+    "implementations": {
+        "accretionHaloSimple": {
+            "functionClass": "accretionHalo", "label": "simple",
+            "parent": "accretionHaloClass",
+            "parameters": [], "objects": [], "directNames": [],
+        },
+    },
+    "enumerations": {},
+}
+
+
+def _install():
+    return paths.Install(
+        source=paths.SOURCE_ENVIRONMENT, tag=None, exec_path=REPO,
+        data_path=None, tools_path=None, dynamic_path=None,
+        binary=None, assets=None)
+
+
+def _write(tmp_path, name, text):
+    path = tmp_path / name
+    path.write_text(text)
+    return path
+
+
+# --- run argument splitting -------------------------------------------------
+
+def test_split_change_files():
+    assert cli._split_change_files(["c1.xml", "c2.xml", "--", "-x"]) \
+        == (["c1.xml", "c2.xml"], ["-x"])
+    assert cli._split_change_files(["c1.xml", "--opt"]) == (["c1.xml"], ["--opt"])
+    assert cli._split_change_files(["--opt", "v"]) == ([], ["--opt", "v"])
+    assert cli._split_change_files([]) == ([], [])
+
+
+# --- resolve subcommand -----------------------------------------------------
+
+def test_resolve_subcommand_expands_xinclude(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "resolve", lambda *a, **k: _install())
+    _write(tmp_path, "frag.xml",
+           '<parameters><accretionHalo value="simple"/></parameters>')
+    main = _write(tmp_path, "main.xml",
+                  '<parameters xmlns:xi="http://www.w3.org/2001/XInclude">'
+                  '<xi:include href="frag.xml" xpointer="xpointer(parameters/*)"/>'
+                  '</parameters>')
+    out = tmp_path / "resolved.xml"
+    assert cli.main(["resolve", str(main), "-o", str(out)]) == 0
+    assert "xi:include" not in out.read_text()
+    assert "accretionHalo" in out.read_text()
+
+
+def test_resolve_subcommand_conditionals(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "resolve", lambda *a, **k: _install())
+    text = ('<parameters>'
+            '<cosmologicalMassVariance value="filteredPower"><sigma_8 value="0.9"/>'
+            '</cosmologicalMassVariance>'
+            '<active1 value="x" active="[cosmologicalMassVariance/sigma_8] != 0.9"/>'
+            '<active1 value="y" active="[cosmologicalMassVariance/sigma_8] == 0.9"/>'
+            '</parameters>')
+    main = _write(tmp_path, "main.xml", text)
+    out = tmp_path / "resolved.xml"
+    assert cli.main(["resolve", str(main), "-o", str(out)]) == 0
+    pruned = out.read_text()
+    assert 'value="y"' in pruned and 'value="x"' not in pruned   # inactive pruned
+    assert "active=" not in pruned                               # marker stripped
+    # --no-conditionals keeps them.
+    out2 = tmp_path / "resolved2.xml"
+    assert cli.main(["resolve", str(main), "-o", str(out2), "--no-conditionals"]) == 0
+    assert out2.read_text().count("active1") == 2
+
+
+def test_resolve_subcommand_error_returns_1(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(paths, "resolve", lambda *a, **k: _install())
+    main = _write(tmp_path, "main.xml",
+                  '<parameters><accretionHalo idRef="missing"/></parameters>')
+    out = tmp_path / "resolved.xml"
+    assert cli.main(["resolve", str(main), "-o", str(out)]) == 1
+    assert "cannot resolve" in capsys.readouterr().err
+
+
+# --- validate on the resolved tree (Stage 4) --------------------------------
+
+def test_validate_checks_xincluded_content(tmp_path, monkeypatch):
+    # A bad selector inside an XIncluded fragment must be caught -- proving
+    # validation runs on the RESOLVED tree, not the raw file.
+    catalog = _write(tmp_path, "catalog.json", json.dumps(MIN_CATALOG))
+    monkeypatch.setenv("GALACTICUS_PARAMETER_CATALOG", str(catalog))
+    _write(tmp_path, "frag.xml",
+           '<parameters><accretionHalo value="bogus"/></parameters>')
+    main = _write(tmp_path, "main.xml",
+                  '<parameters xmlns:xi="http://www.w3.org/2001/XInclude">'
+                  '<xi:include href="frag.xml" xpointer="xpointer(parameters/*)"/>'
+                  '</parameters>')
+    result = launcher_validate.validate(str(main), _install())
+    assert result.method == "catalog"
+    assert not result.ok
+    assert any(f.kind == "selector" for f in result.findings)
+
+
+def test_validate_surfaces_resolve_error(tmp_path, monkeypatch):
+    catalog = _write(tmp_path, "catalog.json", json.dumps(MIN_CATALOG))
+    monkeypatch.setenv("GALACTICUS_PARAMETER_CATALOG", str(catalog))
+    main = _write(tmp_path, "main.xml",
+                  '<parameters><accretionHalo value="simple"/>'
+                  '<accretionHalo idRef="missing"/></parameters>')
+    result = launcher_validate.validate(str(main), _install())
+    assert not result.ok
+    assert any(f.kind == "resolve" for f in result.findings)
+
+
+def test_validate_ok_on_resolved_good_file(tmp_path, monkeypatch):
+    catalog = _write(tmp_path, "catalog.json", json.dumps(MIN_CATALOG))
+    monkeypatch.setenv("GALACTICUS_PARAMETER_CATALOG", str(catalog))
+    main = _write(tmp_path, "main.xml",
+                  '<parameters><accretionHalo value="simple"/></parameters>')
+    result = launcher_validate.validate(str(main), _install())
+    assert result.ok and result.method == "catalog"

--- a/python/galacticus_launcher/tests/test_validate_resolve.py
+++ b/python/galacticus_launcher/tests/test_validate_resolve.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from galacticus_launcher import cli, paths
+from galacticus_launcher import cli, download, paths
 from galacticus_launcher import validate as launcher_validate
 
 REPO = Path(__file__).resolve().parents[3]
@@ -138,3 +138,85 @@ def test_validate_ok_on_resolved_good_file(tmp_path, monkeypatch):
                   '<parameters><accretionHalo value="simple"/></parameters>')
     result = launcher_validate.validate(str(main), _install())
     assert result.ok and result.method == "catalog"
+
+
+# --- catalog generation at provision time (Stage 4 delivery: option B) -------
+
+def _install_at(exec_path):
+    return paths.Install(
+        source=paths.SOURCE_MANAGED, tag="v1.0.0", exec_path=exec_path,
+        data_path=None, tools_path=None, dynamic_path=None, binary=None, assets=None)
+
+
+def _fake_generator(exec_path):
+    gen = exec_path / "scripts" / "build" / "parameterCatalog.py"
+    gen.parent.mkdir(parents=True, exist_ok=True)
+    gen.write_text("# stub generator\n")
+    return gen
+
+
+def test_provision_catalog_generates_when_missing(tmp_path, monkeypatch):
+    _fake_generator(tmp_path)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        Path(cmd[3]).write_text("{}")        # the generator writes the catalog
+    monkeypatch.setattr(download.subprocess, "run", fake_run)
+
+    assert download._provision_catalog(_install_at(tmp_path), force=False,
+                                       log=lambda *a: None) is True
+    assert (tmp_path / "parameters.catalog.json").is_file()
+    assert captured["cmd"][2:] == [str(tmp_path), str(tmp_path / "parameters.catalog.json")]
+
+
+def test_provision_catalog_skips_when_present(tmp_path, monkeypatch):
+    _fake_generator(tmp_path)
+    (tmp_path / "parameters.catalog.json").write_text("{}")
+    ran = []
+    monkeypatch.setattr(download.subprocess, "run", lambda *a, **k: ran.append(a))
+    assert download._provision_catalog(_install_at(tmp_path), force=False,
+                                       log=lambda *a: None) is False
+    assert ran == []                         # not regenerated
+    # ... but force=True regenerates.
+    monkeypatch.setattr(download.subprocess, "run",
+                        lambda cmd, **k: Path(cmd[3]).write_text("{}"))
+    assert download._provision_catalog(_install_at(tmp_path), force=True,
+                                       log=lambda *a: None) is True
+
+
+def test_provision_catalog_without_source_is_noop(tmp_path):
+    assert download._provision_catalog(_install_at(tmp_path), force=False,
+                                       log=lambda *a: None) is False
+
+
+def test_find_catalog_locations(tmp_path, monkeypatch):
+    monkeypatch.delenv("GALACTICUS_PARAMETER_CATALOG", raising=False)
+    install = _install_at(tmp_path)
+    assert launcher_validate.find_catalog(install) is None
+    # Build-dir location (where `make parameters-catalog` writes).
+    build = tmp_path / "work" / "build"
+    build.mkdir(parents=True)
+    (build / "parameters.catalog.json").write_text("{}")
+    assert launcher_validate.find_catalog(install) == build / "parameters.catalog.json"
+    # Exec-path root (managed provision) takes precedence over the build dir.
+    root_catalog = tmp_path / "parameters.catalog.json"
+    root_catalog.write_text("{}")
+    assert launcher_validate.find_catalog(install) == root_catalog
+    # Explicit env override beats both.
+    override = tmp_path / "custom.json"
+    override.write_text("{}")
+    monkeypatch.setenv("GALACTICUS_PARAMETER_CATALOG", str(override))
+    assert launcher_validate.find_catalog(install) == override
+
+
+def test_provision_catalog_failure_is_best_effort(tmp_path, monkeypatch):
+    _fake_generator(tmp_path)
+
+    def boom(*a, **k):
+        raise download.subprocess.CalledProcessError(1, "parameterCatalog.py")
+    monkeypatch.setattr(download.subprocess, "run", boom)
+    messages = []
+    assert download._provision_catalog(_install_at(tmp_path), force=False,
+                                       log=messages.append) is False
+    assert any("could not generate" in m for m in messages)

--- a/python/galacticus_launcher/validate.py
+++ b/python/galacticus_launcher/validate.py
@@ -40,36 +40,97 @@ def find_catalog(install):
     return candidate if candidate.is_file() else None
 
 
-def validate(param_file, install, *, structural=False):
+def _galacticus_python_dir(install):
+    return Path(install.exec_path) / "python"
+
+
+def _ensure_importable(install):
+    """Put the exec-path ``python/`` tree (matching the binary) on ``sys.path``."""
+    python_dir = _galacticus_python_dir(install)
+    if python_dir.is_dir() and str(python_dir) not in sys.path:
+        sys.path.insert(0, str(python_dir))
+
+
+def _import_resolver(install):
+    _ensure_importable(install)
+    from Galacticus.Parameters import resolve
+    return resolve
+
+
+def resolve_to_file(param_file, install, change_files=(), *, output,
+                    conditionals=True):
+    """Resolve ``param_file`` (+ change files) and write ``output``.
+
+    Raises ``RuntimeError`` (which the CLI reports) on a resolution error or if
+    the resolver cannot be imported.
+    """
+    try:
+        resolve = _import_resolver(install)
+    except ImportError as error:
+        raise RuntimeError(f"parameter resolver unavailable: {error}")
+    try:
+        resolve.resolve_file(param_file, list(change_files), output=output,
+                             conditionals=conditionals)
+    except resolve.ResolveError as error:
+        raise RuntimeError(f"cannot resolve {param_file}: {error}")
+
+
+def validate(param_file, install, *, structural=False, change_files=()):
     """Validate `param_file` for `install`; return a :class:`Result`.
 
-    Prefers the catalog-aware Python checker; falls back to the binary's
+    Prefers the catalog-aware Python checker (run on the fully RESOLVED tree --
+    XInclude, change files, and conditionals applied -- so it checks the
+    structure Galacticus will actually build); falls back to the binary's
     ``--dry-run``.  ``ok`` is False only on an error-level finding or a parse /
-    dry-run failure (type-level findings are warnings and do not fail).
+    resolve / dry-run failure (type-level findings are warnings and do not fail).
     """
     catalog_path = find_catalog(install)
     if catalog_path is not None:
-        return _validate_with_catalog(param_file, install, catalog_path, structural)
-    return _validate_with_dry_run(param_file, install)
+        return _validate_with_catalog(param_file, install, catalog_path, structural,
+                                      change_files)
+    return _validate_with_dry_run(param_file, install, change_files)
 
 
-def _validate_with_catalog(param_file, install, catalog_path, structural):
+def _validate_with_catalog(param_file, install, catalog_path, structural, change_files):
     import json
+    import tempfile
 
-    # The checker lives under the exec path's python/ tree; make it importable.
-    python_dir = Path(install.exec_path) / "python"
-    if python_dir.is_dir() and str(python_dir) not in sys.path:
-        sys.path.insert(0, str(python_dir))
+    _ensure_importable(install)
     try:
         from Galacticus.Parameters.validate import validate_file
     except ImportError as error:
         return Result(True, [], "catalog-unavailable", str(error))
 
-    with open(catalog_path) as handle:
-        catalog = json.load(handle)
-    findings_raw, parse_error = validate_file(
-        str(param_file), catalog, structural=structural
-    )
+    # Resolve first so validation sees the structure Galacticus will build. If the
+    # resolver is unavailable (very old install), fall back to the raw file --
+    # validate_file still expands XInclude itself.
+    target = str(param_file)
+    resolved_tmp = None
+    try:
+        resolve = _import_resolver(install)
+    except ImportError:
+        resolve = None
+    if resolve is not None:
+        handle = tempfile.NamedTemporaryFile(suffix=".xml", delete=False)
+        handle.close()
+        try:
+            resolve.resolve_file(param_file, list(change_files), output=handle.name)
+        except resolve.ResolveError as error:
+            os.unlink(handle.name)
+            return Result(False,
+                          [Finding("error", "resolve", str(param_file), str(error))],
+                          "catalog", str(error))
+        target, resolved_tmp = handle.name, handle.name
+
+    try:
+        with open(catalog_path) as handle:
+            catalog = json.load(handle)
+        findings_raw, parse_error = validate_file(
+            target, catalog, structural=structural)
+    finally:
+        if resolved_tmp is not None:
+            os.unlink(resolved_tmp)
+
     if parse_error:
         return Result(False, [Finding("error", "parse", str(param_file), parse_error)],
                       "catalog", parse_error)
@@ -78,11 +139,11 @@ def _validate_with_catalog(param_file, install, catalog_path, structural):
     return Result(ok, findings, "catalog", str(catalog_path))
 
 
-def _validate_with_dry_run(param_file, install):
+def _validate_with_dry_run(param_file, install, change_files=()):
     env = install.environ()
     try:
         completed = subprocess.run(
-            [str(install.binary), str(param_file), "--dry-run"],
+            [str(install.binary), str(param_file), *change_files, "--dry-run"],
             env=env, capture_output=True, text=True,
         )
     except OSError as error:

--- a/python/galacticus_launcher/validate.py
+++ b/python/galacticus_launcher/validate.py
@@ -30,14 +30,21 @@ Result = namedtuple("Result", ["ok", "findings", "method", "detail"])
 def find_catalog(install):
     """Locate a ``parameters.catalog.json``, or None.
 
-    Honors ``GALACTICUS_PARAMETER_CATALOG`` first, then looks beside the
-    executable's exec path.
+    Honors ``GALACTICUS_PARAMETER_CATALOG`` first; then the exec path root (where
+    a managed install generates it at provision time); then the default build
+    output dir ``work/build/`` (where ``make parameters-catalog`` writes it for a
+    build-from-source install). A non-default ``BUILDPATH`` is supported via the
+    env override.
     """
     override = os.environ.get("GALACTICUS_PARAMETER_CATALOG")
     if override and Path(override).is_file():
         return Path(override)
-    candidate = Path(install.exec_path) / "parameters.catalog.json"
-    return candidate if candidate.is_file() else None
+    exec_path = Path(install.exec_path)
+    for candidate in (exec_path / "parameters.catalog.json",
+                      exec_path / "work" / "build" / "parameters.catalog.json"):
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def _galacticus_python_dir(install):

--- a/testSuite/test-parameter-resolver.py
+++ b/testSuite/test-parameter-resolver.py
@@ -91,16 +91,20 @@ def _run_oracle(param_file, change_files, out_path, timeout=40):
 
 
 def _compare(param_file, change_files, label, out_path):
+    # Compare only the oracle-faithful scope (XInclude + changes + reference
+    # validation); the oracle keeps `active=` and does not prune, so conditional
+    # evaluation is excluded here and covered by unit tests instead.
     if not _run_oracle(param_file, change_files, out_path):
         # Oracle errored before serialize; a faithful resolver must agree (error).
         try:
-            resolve.resolve_file(param_file, change_files)
+            resolve.resolve_file(param_file, change_files, conditionals=False)
         except Exception:
             return True, "both error (agreement)"
         return False, "oracle errored but resolver succeeded (too lenient)"
     try:
         oracle = etree.parse(out_path).getroot()
-        mine = resolve.resolve_file(param_file, change_files).getroot()
+        mine = resolve.resolve_file(param_file, change_files,
+                                    conditionals=False).getroot()
     except Exception as exc:                                  # pragma: no cover
         return False, f"comparison setup error: {exc}"
     diff = _first_diff(_norm(oracle), _norm(mine))
@@ -176,6 +180,29 @@ def main():
         if not ok:
             failures += 1
             print(f"  FAILED: {os.path.relpath(path, REPO)} :: {detail}")
+
+    # Conditionals: the oracle keeps `active=` (cannot certify pruning), so verify
+    # end-to-end instead -- fully resolve a real conditional file and confirm
+    # Galacticus accepts the pruned result.
+    tests_params = os.path.join(REPO, "testSuite", "parameters", "testsParameters.xml")
+    if os.path.isfile(tests_params):
+        print("Conditional end-to-end (testsParameters.xml):")
+        resolved = os.path.join(tempfile.gettempdir(), "resolver_resolved.xml")
+        try:
+            root = resolve.resolve_file(tests_params, output=resolved).getroot()
+        except Exception as exc:
+            failures += 1
+            print(f"  FAILED: resolve raised :: {exc}")
+        else:
+            active1 = [c.get("value") for c in root if c.tag == "active1"]
+            if active1 != ["0.2"]:
+                failures += 1
+                print(f"  FAILED: conditional pruning -> active1 {active1}, expected ['0.2']")
+            elif not _run_oracle(resolved, [], out_path):
+                failures += 1
+                print("  FAILED: Galacticus rejected the conditionally-pruned file")
+            else:
+                print("  ok: pruned to active1=0.2 and accepted by Galacticus")
 
     if failures:
         print(f"FAILED: {failures} resolver/oracle divergence(s)")


### PR DESCRIPTION
## Summary

Follow-up to #1207, continuing the Python parameter-file resolver/preprocessor (tracking issue #1208). Three stacked commits:

1. **References + conditionals.** `idRef` is validated against its same-tag `id` (Galacticus fatals on a mismatch) but **never dereferenced** — Galacticus keeps it as a runtime pointer to one shared object, so inlining would create separate copies. `active="[path] ==|!= value"` conditionals are evaluated (string compare, fixed-point over dependency chains, with idRef dereferencing during path resolution, mirroring `inputParametersEvaluateConditionals`) and inactive subtrees are pruned. Resolution order matches Galacticus: **XInclude → changes → references → conditionals**; `=[...]` expressions are left intact (deferred).

2. **Launcher wiring.** New `galacticus resolve <file> [change files...] -o <out>` subcommand (pure Python — no executable/download needed; `--no-conditionals`, `--validate`). `galacticus validate`/`run` now validate the **resolved** tree (XInclude + change files + conditionals applied), accept change files, and surface resolver errors as findings; `galacticus run --resolve` runs a resolved temp file. Documented the **MPI** pattern (resolve once, then `mpirun Galacticus.exe resolved.xml` — never `mpirun galacticus run`). Integrates with the merged `_resolve_parameter_file` bundled-path resolution.

3. **Catalog delivery for validation.** The catalog (`galacticus validate` needs it) is **generated at install/build time**, not committed/shipped: managed installs generate it in `download.provision` from the downloaded source; build-from-source uses the existing `make parameters-catalog`; `find_catalog` checks the override env → exec-path root → `work/build/`.

## Not here (by design)
`=[...]` math expressions stay intact for Galacticus to evaluate (deferred until a fuller object-constructing front end, since they must be re-evaluated per MCMC step).

## Verification
- `python/Galacticus/Parameters/tests/test_resolve.py` (+13 tests for references/conditionals incl. a corpus-grounded `testsParameters.xml` case) and `python/galacticus_launcher/tests/test_validate_resolve.py` (resolve subcommand, validate-on-resolved, catalog provisioning, `find_catalog` precedence).
- `testSuite/test-parameter-resolver.py`: the differential test against the Galacticus oracle (`--output-processed-parameters`) for change ops + XInclude, plus a conditional end-to-end confirming the pruned file is accepted by Galacticus.
- Full `pytest` suite green (584 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
