### PR TITLE
refactor: collapse remaining HDF5 type-duplicated functions using generics

### DIFF
--- a/source/tests/IO/HDF5.F90
+++ b/source/tests/IO/HDF5.F90
@@ -32,48 +32,48 @@ program Tests_IO_HDF5
   use :: Units_MetaData    , only : unitType
   use :: Unit_Tests        , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
   implicit none
-  integer                                                                   :: iPass                          , integerValue         , &
-       &                                                                       integerValueReread             , i                    , &
-       &                                                                       j                              , k
+  integer                                                                   :: iPass                            , integerValue                  , &
+       &                                                                       integerValueReread               , i                             , &
+       &                                                                       j                                , k
   logical                                                                   :: appendableOK
-  integer                                                                   :: unitsStatus                    , attributesStatus
+  integer                                                                   :: unitsStatus                      , attributesStatus
   type            (unitType       )                                         :: unitsValue
   integer                                       , dimension(10)             :: integerValueArray
   integer                                       , dimension(10)             :: integerValueArrayRereadStatic
   integer                          , allocatable, dimension( :)             :: integerValueArrayReread
-  integer         (kind=kind_int8 )                                         :: integer8Value                  , integer8ValueReread
+  integer         (kind=kind_int8 )                                         :: integer8Value                    , integer8ValueReread
   integer         (kind=kind_int8 )             , dimension(10)             :: integer8ValueArray
   integer         (kind=kind_int8 )             , dimension(10)             :: integer8ValueArrayRereadStatic
-  integer         (kind=kind_int8 ), allocatable, dimension( :)             :: integer8ValueArrayReread       , integerRangeU32
-  double precision                                                          :: doubleValue                    , doubleValueReread
+  integer         (kind=kind_int8 ), allocatable, dimension( :)             :: integer8ValueArrayReread         , integerRangeU32
+  double precision                                                          :: doubleValue                      , doubleValueReread
   double precision                              , dimension(10)             :: doubleValueArray
   double precision                              , dimension(10)             :: doubleValueArrayRereadStatic
   double precision                 , allocatable, dimension( :)             :: doubleValueArrayReread
-  character       (len=32         )                                         :: characterValue                 , characterValueReread
+  character       (len=32         )                                         :: characterValue                   , characterValueReread
   character       (len=32         )             , dimension(10)             :: characterValueArray
   character       (len=32         )             , dimension(10)             :: characterValueArrayRereadStatic
   character       (len=32         ), allocatable, dimension( :)             :: characterValueArrayReread
-  type            (varying_string )                                         :: varStringValue                 , varStringValueReread
+  type            (varying_string )                                         :: varStringValue                   , varStringValueReread
   type            (varying_string )             , dimension(10)             :: varStringValueArray
   type            (varying_string )             , dimension(10)             :: varStringValueArrayRereadStatic
   type            (varying_string ), allocatable, dimension( :)             :: varStringValueArrayReread
   double precision                              , dimension(10,10)          :: doubleValueArray2d
   double precision                              , dimension(10,10)          :: doubleValueArray2dRereadStatic
-  double precision                 , allocatable, dimension( :, :)          :: doubleValueArray2dReread      , doubleValueArray2dRereadExpect
+  double precision                 , allocatable, dimension( :, :)          :: doubleValueArray2dReread        , doubleValueArray2dRereadExpect
   double precision                              , dimension(10,10,10)       :: doubleValueArray3d
   double precision                              , dimension(10,10,10)       :: doubleValueArray3dRereadStatic
-  double precision                 , allocatable, dimension( :, :, :)       :: doubleValueArray3dReread      , doubleValueArray3dRereadExpect
+  double precision                 , allocatable, dimension( :, :, :)       :: doubleValueArray3dReread        , doubleValueArray3dRereadExpect
   double precision                              , dimension(10,10,10,10)    :: doubleValueArray4d
   double precision                              , dimension(10,10,10,10)    :: doubleValueArray4dRereadStatic
-  double precision                 , allocatable, dimension( :, :, :, :)    :: doubleValueArray4dReread      , doubleValueArray4dRereadExpect
+  double precision                 , allocatable, dimension( :, :, :, :)    :: doubleValueArray4dReread        , doubleValueArray4dRereadExpect
   double precision                              , dimension(10,10,10,10,10) :: doubleValueArray5d
   double precision                              , dimension(10,10,10,10,10) :: doubleValueArray5dRereadStatic
-  double precision                 , allocatable, dimension( :, :, :, :, :) :: doubleValueArray5dReread      , doubleValueArray5dRereadExpect
+  double precision                 , allocatable, dimension( :, :, :, :, :) :: doubleValueArray5dReread        , doubleValueArray5dRereadExpect
   type            (varying_string )             , dimension(27)             :: datasetNamesReference
-  type            (hdf5VarDouble  ), allocatable, dimension( :)             :: varDoubleArray2D              , varDoubleDataset2DArrayReread
-  type            (hdf5VarDouble2D), allocatable, dimension( :)             :: varDoubleArray3D              , varDoubleDataset3DArrayReread
-  type            (hdf5VarInteger8), allocatable, dimension( :)             :: varInteger8Array2D            , varInteger8Dataset2dArrayReread
-  type            (hdf5VarDouble  ), allocatable, dimension( :, :)          :: varDoubleArrayGrid            , varDoubleDatasetGridReread
+  type            (hdf5VarDouble  ), allocatable, dimension( :)             :: varDoubleArray2D                , varDoubleDataset2DArrayReread
+  type            (hdf5VarDouble2D), allocatable, dimension( :)             :: varDoubleArray3D                , varDoubleDataset3DArrayReread
+  type            (hdf5VarInteger8), allocatable, dimension( :)             :: varInteger8Array2D              , varInteger8Dataset2dArrayReread
+  type            (hdf5VarDouble  ), allocatable, dimension( :, :)          :: varDoubleArrayGrid              , varDoubleDatasetGridReread
   integer                                       , dimension(8,6)            :: integerValueArray2d
   integer                                       , dimension(8,6)            :: integerValueArray2dRereadStatic
   integer                          , allocatable, dimension( :, :)          :: integerValueArray2dReread
@@ -86,7 +86,7 @@ program Tests_IO_HDF5
   integer         (kind=kind_int8 )             , dimension(3,4,2,5)        :: integer8ValueArray4d
   double precision                              , dimension(4,4,4,4,4,4)    :: doubleValueArray6d
   double precision                              , dimension(4,4,4,4,4,4)    :: doubleValueArray6dRereadStatic
-  double precision                 , allocatable, dimension( :,:,:,:,:,:)   :: doubleValueArray6dReread      , doubleValueArray6dRereadExpect
+  double precision                 , allocatable, dimension( :,:,:,:,:,:)   :: doubleValueArray6dReread        , doubleValueArray6dRereadExpect
   double precision                              , dimension(3,2)            :: doubleAttribute2d
   real                             , allocatable, dimension( :)             :: tableRealColumn
   integer                          , allocatable, dimension( :)             :: tableIntegerColumn
@@ -333,10 +333,10 @@ program Tests_IO_HDF5
        ! Write zero-sized 1-D array datasets to the file (unchunked, as chunked datasets require chunk sizes of at least 1),
        ! and read them back.
        block
-         double precision, dimension(0)                            :: doubleValueArrayEmpty
-         double precision, allocatable  , dimension(:)             :: doubleValueArrayEmptyReread
-         integer         , dimension(0)                            :: integerValueArrayEmpty
-         integer         , allocatable  , dimension(:)             :: integerValueArrayEmptyReread
+         double precision, dimension(0)                :: doubleValueArrayEmpty
+         double precision, allocatable  , dimension(:) :: doubleValueArrayEmptyReread
+         integer         , dimension(0)                :: integerValueArrayEmpty
+         integer         , allocatable  , dimension(:) :: integerValueArrayEmptyReread
          call fileObject%writeDataset(doubleValueArrayEmpty ,"doubleDatasetEmpty" ,"An empty dataset",chunkSize=-1_hsize_t)
          call fileObject%readDataset ("doubleDatasetEmpty" ,doubleValueArrayEmptyReread )
          call Assert("re-read zero-sized 1-D array double dataset" ,size(doubleValueArrayEmptyReread ),0)
@@ -439,7 +439,7 @@ program Tests_IO_HDF5
           doubleValueArray=[0.0d0,11.0d0,22.0d0,33.0d0,44.0d0,55.0d0,6.0d06,77.0d0,88.0d0,99.0d0]
           call groupObject%writeDataset(doubleValueArray,"doubleDataset1dArrayExtensible","This is an extensible dataset",appendTo=.true.)
           ! Append to the extensible double 1-D array dataset.
-          doubleValueArray=[1.0d0,-.0d02,3.0d0,-4.0d0,5.0d0,-6.0d0,7.0d0,-8.0d0,9.0d0,-10.0d0]
+          doubleValueArray=[1.0d0,-0.0d02,3.0d0,-4.0d0,5.0d0,-6.0d0,7.0d0,-8.0d0,9.0d0,-10.0d0]
           call groupObject%writeDataset(doubleValueArray,"doubleDataset1dArrayExtensible",appendTo=.true.)
        end if
 
@@ -447,7 +447,7 @@ program Tests_IO_HDF5
        doubleValueArray=[0.0d0,11.0d0,22.0d0,33.0d0,44.0d0,55.0d0,6.0d06,77.0d0,88.0d0,99.0d0]
        call groupObject%writeDataset(doubleValueArray,"doubleDataset1dArray","This is an example dataset")
        ! Write a double 1-D array dataset to the group.
-       doubleValueArray=[1.0d0,-.0d02,3.0d0,-4.0d0,5.0d0,-6.0d0,7.0d0,-8.0d0,9.0d0,-10.0d0]
+       doubleValueArray=[1.0d0,-0.0d02,3.0d0,-4.0d0,5.0d0,-6.0d0,7.0d0,-8.0d0,9.0d0,-10.0d0]
        call groupObject%writeDataset(doubleValueArray,"doubleDataset1dArray")
        ! Read a double 1-D array dataset from the group into a static array.
        call groupObject%readDatasetStatic("doubleDataset1dArray",doubleValueArrayRereadStatic)
@@ -922,10 +922,10 @@ program Tests_IO_HDF5
        call groupObject%writeDataset(varDoubleArrayGrid,"varDoubleDatasetGrid")
        ! Read the 2-D array of variable-length double rows back.
        call groupObject%readDataset("varDoubleDatasetGrid",varDoubleDatasetGridReread)
-       call Assert(                                                                                          &
-            &      "re-read 2-D grid varDouble dataset"                                                    , &
+       call Assert(                                                                                           &
+            &      "re-read 2-D grid varDouble dataset"                                                     , &
             &      [((all(varDoubleArrayGrid(i,j)%row == varDoubleDatasetGridReread(i,j)%row),i=1,4),j=1,3)], &
-            &      spread(.true.,1,12)                                                                       &
+            &      spread(.true.,1,12)                                                                        &
             &     )
        deallocate(varDoubleDatasetGridReread)
        deallocate(varDoubleArrayGrid        )
@@ -1053,8 +1053,8 @@ program Tests_IO_HDF5
      call Unit_Tests_Begin_Group("h5py compatibility")
      call System_Command_Do("./testSuite/scripts/generate_h5py.py")
      fileObject=hdf5Object("testSuite/outputs/h5py.hdf5",overWrite=.false.,objectsOverwritable=.false.)
-     call fileObject%readAttribute("stringAttribute"            ,          varStringValueReread                            )
-     call fileObject%readAttribute("stringAttribute"            ,          characterValueReread                            )
+     call fileObject%readAttribute("stringAttribute"            ,          varStringValueReread       )
+     call fileObject%readAttribute("stringAttribute"            ,          characterValueReread       )
      call Assert("read h5py string attribute (character)",characterValueReread,"this is a variable length string")
      call Assert("read h5py string attribute (varying_string)",varStringValueReread,var_str("this is a variable length string"))
      ! Read columns from a table (a compound-type dataset following the H5TB conventions) in the h5py file.

--- a/source/utility/IO/HDF5/_module.F90
+++ b/source/utility/IO/HDF5/_module.F90
@@ -87,6 +87,14 @@ module IO_HDF5
    <instance label="Integer8" intrinsic="integer(kind_int8)" h5Type="H5T_INTEGER8"       h5TypesWrite="H5T_NATIVE_INTEGER_8S" h5TypesRead="H5T_NATIVE_INTEGER_8AS" dataType="hdf5DataTypeInteger8" typeName="long integer" h5TypeImport=""/>
    <instance label="Double"   intrinsic="double precision"   h5Type="H5T_NATIVE_DOUBLE"  h5TypesWrite="H5T_NATIVE_DOUBLES"    h5TypesRead="H5T_NATIVE_DOUBLES"     dataType="hdf5DataTypeDouble"   typeName="double"       h5TypeImport="H5T_NATIVE_DOUBLE, "/>
   </generic>
+  <generic identifier="VlenType">
+   <instance label="VarDouble"   intrinsic="hdf5VarDouble"   h5VlenType="H5T_VLEN_DOUBLE"   dataType="hdf5DataTypeVlenDouble"   typeName="varying-length double"      />
+   <instance label="VarInteger8" intrinsic="hdf5VarInteger8" h5VlenType="H5T_VLEN_INTEGER8" dataType="hdf5DataTypeVlenInteger8" typeName="varying-length long integer"/>
+  </generic>
+  <generic identifier="TableType">
+   <instance label="Real"    intrinsic="real   " typeName="real   "/>
+   <instance label="Integer" intrinsic="integer" typeName="integer"/>
+  </generic>
   !!]
 
   type hdf5Object
@@ -180,17 +188,15 @@ module IO_HDF5
      procedure :: IO_HDF5_Write_Dataset_{Type¦label}
      procedure :: IO_HDF5_Write_Dataset_Character_1D
      procedure :: IO_HDF5_Write_Dataset_VarString_1D
-     procedure :: IO_HDF5_Write_Dataset_VarDouble_1D
+     procedure :: IO_HDF5_Write_Dataset_{VlenType¦label}
      procedure :: IO_HDF5_Write_Dataset_VarVarDouble_1D
      procedure :: IO_HDF5_Write_Dataset_VarDouble_2D
-     procedure :: IO_HDF5_Write_Dataset_VarInteger8_2D
      generic   :: writeDataset        => IO_HDF5_Write_Dataset_{Type¦label}
+     generic   :: writeDataset        => IO_HDF5_Write_Dataset_{VlenType¦label}
      generic   :: writeDataset        => IO_HDF5_Write_Dataset_Character_1D      , &
           &                              IO_HDF5_Write_Dataset_VarString_1D      , &
-          &                              IO_HDF5_Write_Dataset_VarDouble_1D      , &
           &                              IO_HDF5_Write_Dataset_VarVarDouble_1D   , &
-          &                              IO_HDF5_Write_Dataset_VarDouble_2D      , &
-          &                              IO_HDF5_Write_Dataset_VarInteger8_2D
+          &                              IO_HDF5_Write_Dataset_VarDouble_2D
      procedure :: IO_HDF5_Read_Attribute_{Type¦label}_Scalar
      procedure :: IO_HDF5_Read_Attribute_{Type¦label}_1D_Array_Allocatable
      procedure :: IO_HDF5_Read_Attribute_{Type¦label}_1D_Array_Static
@@ -214,27 +220,23 @@ module IO_HDF5
      procedure :: IO_HDF5_Read_Dataset_Character_1D_Array_Static
      procedure :: IO_HDF5_Read_Dataset_VarString_1D_Array_Allocatable
      procedure :: IO_HDF5_Read_Dataset_VarString_1D_Array_Static
-     procedure :: IO_HDF5_Read_Dataset_VarDouble_1D_Array_Allocatable
+     procedure :: IO_HDF5_Read_Dataset_{VlenType¦label}_Array_Allocatable
      procedure :: IO_HDF5_Read_Dataset_VarVarDouble_1D_Array_Allocatable
      procedure :: IO_HDF5_Read_Dataset_VarDouble_2D_Array_Allocatable
-     procedure :: IO_HDF5_Read_Dataset_VarInteger8_2D_Array_Allocatable
      generic   :: readDataset         => IO_HDF5_Read_Dataset_{Type¦label}_Array_Allocatable
+     generic   :: readDataset         => IO_HDF5_Read_Dataset_{VlenType¦label}_Array_Allocatable
      generic   :: readDataset         => IO_HDF5_Read_Dataset_Character_1D_Array_Allocatable   , &
           &                              IO_HDF5_Read_Dataset_VarString_1D_Array_Allocatable   , &
-          &                              IO_HDF5_Read_Dataset_VarDouble_1D_Array_Allocatable   , &
           &                              IO_HDF5_Read_Dataset_VarVarDouble_1D_Array_Allocatable, &
-          &                              IO_HDF5_Read_Dataset_VarDouble_2D_Array_Allocatable   , &
-          &                              IO_HDF5_Read_Dataset_VarInteger8_2D_Array_Allocatable
+          &                              IO_HDF5_Read_Dataset_VarDouble_2D_Array_Allocatable
      generic   :: readDatasetStatic   => IO_HDF5_Read_Dataset_{Type¦label}_Array_Static
      generic   :: readDatasetStatic   => IO_HDF5_Read_Dataset_Character_1D_Array_Static        , &
           &                              IO_HDF5_Read_Dataset_VarString_1D_Array_Static
-     procedure :: IO_HDF5_Read_Table_Real_1D_Array_Allocatable
-     procedure :: IO_HDF5_Read_Table_Integer_1D_Array_Allocatable
+     procedure :: IO_HDF5_Read_Table_{TableType¦label}_1D_Array_Allocatable
      procedure :: IO_HDF5_Read_Table_Integer8_1D_Array_Allocatable
      procedure :: IO_HDF5_Read_Table_Character_1D_Array_Allocatable
-     generic   :: readTable          =>IO_HDF5_Read_Table_Real_1D_Array_Allocatable    , &
-          &                            IO_HDF5_Read_Table_Integer_1D_Array_Allocatable , &
-          &                            IO_HDF5_Read_Table_Integer8_1D_Array_Allocatable, &
+     generic   :: readTable          =>IO_HDF5_Read_Table_{TableType¦label}_1D_Array_Allocatable
+     generic   :: readTable          =>IO_HDF5_Read_Table_Integer8_1D_Array_Allocatable, &
           &                            IO_HDF5_Read_Table_Character_1D_Array_Allocatable
      procedure :: size               =>IO_HDF5_Dataset_Size
      procedure :: rank               =>IO_HDF5_Dataset_Rank
@@ -5670,9 +5672,9 @@ attributeValue=trim(attributeValue)
     return
   end subroutine IO_HDF5_Read_Dataset_VarString_1D_Array_Static_Do_Read
 
-  subroutine IO_HDF5_Read_Dataset_VarDouble_1D_Array_Allocatable(self,datasetName,datasetValue,readBegin,readCount,readSelection)
+  subroutine IO_HDF5_Read_Dataset_{VlenType¦label}_Array_Allocatable(self,datasetName,datasetValue,readBegin,readCount,readSelection)
     !!{RST
-    Open and read a varying-length 1D double dataset in ``self``.
+    Open and read a {VlenType¦typeName} 1-D array dataset in ``self``.
     !!}
     use            :: Error             , only : Error_Report
     use            :: HDF5              , only : H5P_DEFAULT_F       , H5S_ALL_F            , H5S_SELECT_SET_F      , size_t                     , &
@@ -5683,7 +5685,7 @@ attributeValue=trim(attributeValue)
     use, intrinsic :: ISO_C_Binding     , only : c_f_pointer         , c_loc
     use            :: ISO_Varying_String, only : assignment(=)       , operator(//)         , trim
     implicit none
-    type            (hdf5VarDouble    ), allocatable, dimension(:  ), intent(  out)           :: datasetValue
+    type            ({VlenType¦intrinsic}    ), allocatable, dimension(:  ), intent(  out)           :: datasetValue
     class           (hdf5Object       )                             , intent(inout)           :: self
     character       (len=*            )                             , intent(in   ), optional :: datasetName
     integer         (kind=HSIZE_T     )             , dimension(1  ), intent(in   ), optional :: readBegin         , readCount
@@ -5824,8 +5826,8 @@ attributeValue=trim(attributeValue)
        end if
     end if
 
-    ! Check that the object is a 1D double array.
-    call datasetObject%assertDatasetType(H5T_VLEN_DOUBLE,1)
+    ! Check that the type of the dataset matches.
+    call datasetObject%assertDatasetType({VlenType¦h5VlenType},1)
 
     ! Get the dimensions of the array to be read.
     if (isReference) then
@@ -6005,7 +6007,7 @@ attributeValue=trim(attributeValue)
     allocate(datasetValueC(datasetDimensions(1)))
     ! Read the dataset.
     dataBuffer=c_loc(datasetValueC)
-    call h5dread_f(datasetObject%objectID,H5T_VLEN_DOUBLE(1),dataBuffer,errorCode,memorySpaceID,datasetDataspaceID,H5P_DEFAULT_F)
+    call h5dread_f(datasetObject%objectID,{VlenType¦h5VlenType}(1),dataBuffer,errorCode,memorySpaceID,datasetDataspaceID,H5P_DEFAULT_F)
     if (errorCode /= 0) then
        message="unable to read dataset '"//trim(datasetNameActual)//"' in object '"//self%objectName//"'"
        call Error_Report(message//self%locationReport()//{introspection:location})
@@ -6046,7 +6048,7 @@ attributeValue=trim(attributeValue)
        end if
     end if
     return
-  end subroutine IO_HDF5_Read_Dataset_VarDouble_1D_Array_Allocatable
+  end subroutine IO_HDF5_Read_Dataset_{VlenType¦label}_Array_Allocatable
 
   subroutine IO_HDF5_Read_Dataset_VarVarDouble_1D_Array_Allocatable(self,datasetName,datasetValue,readBegin,readCount,readSelection)
     !!{RST
@@ -6812,9 +6814,9 @@ attributeValue=trim(attributeValue)
     return
   end subroutine IO_HDF5_Read_Dataset_VarDouble_2D_Array_Allocatable
 
-  subroutine IO_HDF5_Write_Dataset_VarDouble_1D(self,datasetValue,datasetName,comment,appendTo,chunkSize,compressionLevel,datasetReturned)
+  subroutine IO_HDF5_Write_Dataset_{VlenType¦label}(self,datasetValue,datasetName,comment,appendTo,chunkSize,compressionLevel,datasetReturned)
     !!{RST
-    Open and write a varying-length double 1-D array dataset in ``self``.
+    Open and write a {VlenType¦typeName} 1-D array dataset in ``self``.
     !!}
     use, intrinsic :: ISO_C_Binding     , only : c_loc
     use            :: Error             , only : Error_Report
@@ -6825,7 +6827,7 @@ attributeValue=trim(attributeValue)
     implicit none
     class           (hdf5Object    ), intent(inout)                       :: self
     character       (len=*         ), intent(in   ), optional             :: comment                    , datasetName
-    type            (hdf5VarDouble ), intent(in   ), dimension(:)         :: datasetValue
+    type            ({VlenType¦intrinsic} ), intent(in   ), dimension(:)         :: datasetValue
     logical                         , intent(in   ), optional             :: appendTo
     integer         (hsize_t       ), intent(in   ), optional             :: chunkSize
     integer                         , intent(in   ), optional             :: compressionLevel
@@ -6873,8 +6875,8 @@ attributeValue=trim(attributeValue)
           message="dataset '"//trim(datasetNameActual)//"' is not overwritable"
           call Error_Report(message//self%locationReport()//{introspection:location})
        else
-          ! Check that the object is a 1D vlen double.
-          call self%assertDatasetType(H5T_VLEN_DOUBLE,1)
+          ! Check that the type of the dataset matches.
+          call self%assertDatasetType({VlenType¦h5VlenType},1)
        end if
        select type (self)
        type is (hdf5Object)
@@ -6891,10 +6893,10 @@ attributeValue=trim(attributeValue)
        ! Record if dataset already exists.
        preExisted=self%hasDataset(datasetName)
        ! Open the dataset.
-       datasetObject=IO_HDF5_Open_Dataset(self,datasetName,comment,hdf5DataTypeVlenDouble,datasetDimensions,appendTo&
+       datasetObject=IO_HDF5_Open_Dataset(self,datasetName,comment,{VlenType¦dataType},datasetDimensions,appendTo&
             &=appendTo,chunkSize=chunkSize,compressionLevel=compressionLevel)
-       ! Check that pre-existing object is a 1D double.
-       if (preExisted) call datasetObject%assertDatasetType(H5T_VLEN_DOUBLE,1)
+       ! Check that the type of any pre-existing dataset matches.
+       if (preExisted) call datasetObject%assertDatasetType({VlenType¦h5VlenType},1)
        ! If this dataset if not overwritable, report an error.
        if (preExisted.and..not.(datasetObject%isOverwritable.or.appendToActual)) then
           message="dataset '"//trim(datasetName)//"' is not overwritable"
@@ -6964,7 +6966,7 @@ attributeValue=trim(attributeValue)
        datasetValueC(i)%p     =c_loc(datasetValue(i)%row              )
     end do
     datasetValueC_=c_loc(datasetValueC)
-    call h5dwrite_f(datasetObject%objectID,H5T_VLEN_DOUBLE(1),datasetValueC_,errorCode,newDataspaceID,dataspaceID,H5P_DEFAULT_F)
+    call h5dwrite_f(datasetObject%objectID,{VlenType¦h5VlenType}(1),datasetValueC_,errorCode,newDataspaceID,dataspaceID,H5P_DEFAULT_F)
     if (errorCode /= 0) then
        message="unable to write dataset '"//datasetNameActual//"' in object '"//self%objectName//"'"
        call Error_Report(message//self%locationReport()//{introspection:location})
@@ -6986,7 +6988,7 @@ attributeValue=trim(attributeValue)
     ! Copy the dataset to return if necessary.
     if (present(datasetReturned)) datasetReturned=datasetObject
     return
-  end subroutine IO_HDF5_Write_Dataset_VarDouble_1D
+  end subroutine IO_HDF5_Write_Dataset_{VlenType¦label}
   
   subroutine IO_HDF5_Write_Dataset_VarVarDouble_1D(self,datasetValue,datasetName,comment,appendTo,chunkSize,compressionLevel,datasetReturned)
     !!{RST
@@ -7350,569 +7352,18 @@ attributeValue=trim(attributeValue)
     return
   end subroutine IO_HDF5_Write_Dataset_VarDouble_2D
   
-  subroutine IO_HDF5_Read_Dataset_VarInteger8_2D_Array_Allocatable(self,datasetName,datasetValue,readBegin,readCount,readSelection)
-    !!{RST
-    Open and read a variable-length integer-8 2D array dataset in ``self``.
-    !!}
-    use            :: Error             , only : Error_Report
-    use            :: HDF5              , only : H5P_DEFAULT_F       , H5S_ALL_F            , H5S_SELECT_SET_F      , hdset_reg_ref_t_f          , &
-          &                                      H5T_STD_REF_DSETREG , HID_T                , HSIZE_T               , h5dclose_f                 , &
-          &                                      h5dget_space_f      , h5dread_f            , h5rdereference_f      , h5rget_region_f            , &
-          &                                      h5sclose_f          , h5screate_simple_f   , h5sget_select_bounds_f, h5sget_simple_extent_dims_f, &
-          &                                      h5sselect_elements_f, h5sselect_hyperslab_f, hsize_t               , size_t
-    use, intrinsic :: ISO_C_Binding     , only : c_f_pointer         , c_loc
-    use            :: ISO_Varying_String, only : assignment(=)       , operator(//)         , trim
-    implicit none
-    type            (hdf5VarInteger8  ), allocatable, dimension(:  ), intent(  out)           :: datasetValue
-    class           (hdf5Object       )                             , intent(inout)           :: self
-    character       (len=*            )                             , intent(in   ), optional :: datasetName
-    integer         (kind=HSIZE_T     )             , dimension(1  ), intent(in   ), optional :: readBegin         , readCount
-    integer         (kind=HSIZE_T     )             , dimension(:  ), intent(in   ), optional :: readSelection
-    integer         (kind=HSIZE_T     )             , dimension(1  )                          :: datasetDimensions , datasetMaximumDimensions, &
-         &                                                                                       referenceEnd      , referenceStart
-    integer         (kind=HSIZE_T     ), allocatable, dimension(:,:)                          :: readSelectionMap
-    ! <HDF5> Why is "referencedRegion" saved? Because if it is not then it gets dynamically allocated on the stack, which results
-    ! in an invalid pointer error. According to valgrind, this happens because the wrong deallocation function is used (delete
-    ! instead of delete[] or vice-verse). Presumably this is an HDF5 library error. Saving the variable prevents it from being
-    ! deallocated. This is not an elegant solution, but it works.
-    type            (hdset_reg_ref_t_f), save       , target                                  :: referencedRegion
-    integer                                                                                   :: errorCode
-    integer         (kind=HSIZE_T     )                                                       :: i
-    integer         (kind=HID_T       )                                                       :: datasetDataspaceID, dereferencedObjectID    , &
-         &                                                                                       memorySpaceID     , storedDatasetID
-    logical                                                                                   :: isReference       , readSubsection
-    type            (hdf5Object       )                                                       :: datasetObject
-    type            (varying_string   )                                                       :: datasetNameActual , message
-    type            (c_ptr            )                                                       :: dataBuffer
-    type            (hdf5VlenC        ), allocatable, dimension(:  ), target                  :: datasetValueC
-
-    ! Check that this module is initialized.
-    call IO_HDF_Assert_Is_Initialized
-
-    ! Get the name of the dataset.
-    if (present(datasetName)) then
-       datasetNameActual=datasetName
-    else
-       datasetNameActual=self%objectName
-    end if
-
-    ! Check that the object is already open.
-    if (.not.self%isOpenValue) then
-       message="attempt to read dataset '"//trim(datasetNameActual)//"' in unopen object '"//self%objectName//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-
-    ! Check that the object is already open.
-    if (.not.self%isOpenValue) then
-       message="attempt to read dataset '"//trim(datasetNameActual)//"' in unopen object '"//self%objectName//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-
-    ! If a subsection is to be read, we need both start and count values.
-    if (present(readBegin)) then
-       if (.not.present(readCount)) then
-          message="reading a subsection of dataset '"//trim(datasetNameActual)//"' requires both readBegin and readCount to be specified"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       readSubsection=.true.
-    else
-       if (present(readCount)) then
-          message="reading a subsection of dataset '"//trim(datasetNameActual)//"' requires both readBegin and readCount to be specified"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       readSubsection=.false.
-    end if
-    ! Only one of a subsection and a selection can be present.
-    if (readSubsection.and.present(readSelection)) then
-       message="can not specify both a subsection and selection of dataset '"//trim(datasetNameActual)//"' for reading"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-
-    ! Check if the object is an dataset, or something else.
-    if (self%hdf5ObjectType == hdf5ObjectTypeDataset) then
-       ! Object is the dataset.
-       select type (self)
-       type is (hdf5Object)
-          datasetObject=self
-       end select
-
-       ! No name should be supplied in this case.
-       if (present(datasetName)) then
-          message="dataset name was supplied for dataset object '"//trim(datasetNameActual)//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-    else
-       ! Require that an dataset name was supplied.
-       if (.not.present(datasetName)) then
-          message="dataset name was not supplied for object '"//self%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       ! Check that the dataset exists.
-       if (.not.self%hasDataset(datasetName)) then
-          message="dataset '"//trim(datasetName)//"' does not exist in '"//self%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       ! Open the dataset.
-       datasetObject=self%openDataset(datasetName)
-    end if
-
-    ! Check if the dataset is a reference.
-    storedDatasetID=0
-    if (datasetObject%isReference()) then
-       ! Mark as a reference.
-       isReference=.true.
-       ! It is, so read the reference.
-       dataBuffer=c_loc(referencedRegion)
-       call h5dread_f(datasetObject%objectID,H5T_STD_REF_DSETREG,dataBuffer,errorCode,H5S_ALL_F,H5S_ALL_F,H5P_DEFAULT_F)
-       if (errorCode /= 0) then
-          message="unable to read reference in dataset '"//datasetObject%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       ! Now dereference the pointer.
-       call h5rdereference_f(datasetObject%objectID,referencedRegion,dereferencedObjectID,errorCode)
-       if (errorCode < 0) then
-          message="unable to dereference pointer in dataset '"//datasetObject%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       ! If the dataset object was opened internally, then close it.
-       if (self%hdf5ObjectType /= hdf5ObjectTypeDataset) then
-          call h5dclose_f(datasetObject%objectID,errorCode)
-          if (errorCode < 0) then
-             message="unable to close pointer dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-       else
-          ! Store the ID of this dataset so that we can replace it later.
-          storedDatasetID=datasetObject%objectID
-       end if
-       ! The dataset object ID is now replaced with the referenced region ID.
-       datasetObject%objectID=dereferencedObjectID
-       ! Get the dataspace for this referenced region.
-       call h5rget_region_f(dereferencedObjectID,referencedRegion,datasetDataspaceID,errorCode)
-       if (errorCode /= 0) then
-          message="unable to get dataspace of referenced region in dataset '"//datasetObject%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-    else
-       ! Mark as not reference.
-       isReference=.false.
-       ! Not a reference, so simply get the dataspace.
-       call h5dget_space_f(datasetObject%objectID,datasetDataspaceID,errorCode)
-       if (errorCode /= 0) then
-          message="unable to get dataspace of dataset '"//datasetObject%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-    end if
-
-    ! Check that the object is a variable-length 2D integer-8 array.
-    call datasetObject%assertDatasetType(H5T_VLEN_INTEGER8,1)
-
-    ! Get the dimensions of the array to be read.
-    if (isReference) then
-       ! This is a reference, so get the extent of the referenced region.
-       call h5sget_select_bounds_f(datasetDataspaceID,referenceStart,referenceEnd,errorCode)
-       if (errorCode < 0) then
-          message="unable to get bounds of referenced region for dataset '"//datasetObject%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       ! Compute the dimensions of the referenced region.
-       datasetDimensions=referenceEnd-referenceStart+1
-       ! If only a subsection is to be read, then select the appropriate hyperslab.
-       if (readSubsection) then
-          ! Check that subsection start values are legal.
-          if (any(readBegin < 1 .or. readBegin > datasetDimensions)) then
-             message="requested subsection begins outside of bounds of dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Check that subsection extent is legal.
-          if (any(readCount < 1 .or. readBegin+readCount-1 > datasetDimensions)) then
-             message="requested subsection count is non-positive or outside of bounds of dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Select hyperslab.
-          call h5sselect_hyperslab_f(datasetDataspaceID,H5S_SELECT_SET_F,referenceStart-1+readBegin-1,readCount,errorCode)
-          if (errorCode < 0) then
-             message="could not select filespace hyperslab for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Set the size of the data to read in.
-          datasetDimensions=readCount
-          ! Construct a suitable memory space ID to read this data into.
-          call h5screate_simple_f(1,readCount,memorySpaceID,errorCode)
-          if (errorCode < 0) then
-             message="unable to get create memory dataspace for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Select hyperslab to read to.
-          referenceStart=0
-          call h5sselect_hyperslab_f(memorySpaceID,H5S_SELECT_SET_F,referenceStart,readCount,errorCode)
-          if (errorCode < 0) then
-             message="could not select memory space hyperslab for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-       else if (present(readSelection)) then
-          ! A selection is to be read - create a suitable dataspace selection.
-          ! Check that the selection is valid.
-          if (any(readSelection < 1 .or. readSelection > datasetDimensions(1))) then
-             message="requested selection extends outside of bounds of dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Create a map for selecting elements if necessary.
-          allocate(readSelectionMap(1,size(readSelection)))
-          forall(i=1:size(readSelection))
-             readSelectionMap(:,i)=[readSelection(i)]
-          end forall
-          ! Create selection.
-          call h5sselect_elements_f(datasetDataspaceID,H5S_SELECT_SET_F,1,size(readSelectionMap,dim=2,kind=size_t),readSelectionMap,errorCode)
-          if (errorCode < 0) then
-             message="could not select filespace selection for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          deallocate(readSelectionMap)
-          ! Set the size of the data to read in.
-          datasetDimensions(1)=size(readSelection)
-          ! Construct a suitable memory space ID to read this data into.
-          call h5screate_simple_f(1,int(shape(datasetValue),kind=HSIZE_T),memorySpaceID,errorCode)
-          if (errorCode < 0) then
-             message="unable to get create memory dataspace for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Select hyperslab to read to.
-          referenceStart=0
-          call h5sselect_hyperslab_f(memorySpaceID,H5S_SELECT_SET_F,referenceStart,datasetDimensions,errorCode)
-          if (errorCode < 0) then
-             message="could not select memory space hyperslab for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-       else
-          ! Construct a suitable memory space ID to read this data into.
-          call h5screate_simple_f(1,datasetDimensions,memorySpaceID,errorCode)
-          if (errorCode < 0) then
-             message="unable to get create memory dataspace for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Select hyperslab to read to.
-          referenceStart=0
-          call h5sselect_hyperslab_f(memorySpaceID,H5S_SELECT_SET_F,referenceStart,datasetDimensions,errorCode)
-          if (errorCode < 0) then
-             message="could not select memory space hyperslab for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-       end if
-    else
-       ! Not a reference, so get the extent of the entire dataset.
-       call h5sget_simple_extent_dims_f(datasetDataspaceID,datasetDimensions,datasetMaximumDimensions,errorCode)
-       if (errorCode < 0) then
-          message="unable to get dimensions of dataset '"//datasetObject%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       ! If only a subsection is to be read, then select the appropriate hyperslab.
-       if (readSubsection) then
-          ! Check that subsection start values are legal.
-          if (any(readBegin < 1 .or. readBegin > datasetDimensions)) then
-             message="requested subsection begins outside of bounds of dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Check that subsection extent is legal.
-          if (any(readCount < 1 .or. readBegin+readCount-1 > datasetDimensions)) then
-             message="requested subsection count is non-positive or outside of bounds of dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Select hyperslab.
-          call h5sselect_hyperslab_f(datasetDataspaceID,H5S_SELECT_SET_F,readBegin-1,readCount,errorCode)
-          if (errorCode < 0) then
-             message="could not select filespace hyperslab for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Set the size of the data to read in.
-          datasetDimensions=readCount
-          ! Construct a suitable memory space ID to read this data into.
-          call h5screate_simple_f(1,readCount,memorySpaceID,errorCode)
-          if (errorCode < 0) then
-             message="unable to get create memory dataspace for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Select hyperslab to read to.
-          referenceStart=0
-          call h5sselect_hyperslab_f(memorySpaceID,H5S_SELECT_SET_F,referenceStart,readCount,errorCode)
-          if (errorCode < 0) then
-             message="could not select memory space hyperslab for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-       else if (present(readSelection)) then
-          ! A selection is to be read - create a suitable dataspace selection.
-          ! Check that the selection is valid.
-          if (any(readSelection < 1 .or. readSelection > datasetDimensions(1))) then
-             message="requested selection extends outside of bounds of dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Create a map for selecting elements if necessary.
-          allocate(readSelectionMap(1,size(readSelection)))
-          forall(i=1:size(readSelection))
-             readSelectionMap(:,i)=[readSelection(i)]
-          end forall
-          ! Create selection.
-          call h5sselect_elements_f(datasetDataspaceID,H5S_SELECT_SET_F,1,size(readSelectionMap,dim=2,kind=size_t),readSelectionMap,errorCode)
-          if (errorCode < 0) then
-             message="could not select filespace selection for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          deallocate(readSelectionMap)
-          ! Set the size of the data to read in.
-          datasetDimensions(1)=size(readSelection)
-          ! Construct a suitable memory space ID to read this data into.
-          call h5screate_simple_f(1,int(shape(datasetValue),kind=HSIZE_T),memorySpaceID,errorCode)
-          if (errorCode < 0) then
-             message="unable to get create memory dataspace for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-          ! Select hyperslab to read to.
-          referenceStart=0
-          call h5sselect_hyperslab_f(memorySpaceID,H5S_SELECT_SET_F,referenceStart,datasetDimensions,errorCode)
-          if (errorCode < 0) then
-             message="could not select memory space hyperslab for dataset '"//datasetObject%objectName//"'"
-             call Error_Report(message//self%locationReport()//{introspection:location})
-          end if
-       else
-          ! Set the default memory space ID.
-          memorySpaceID=H5S_ALL_F
-       end if
-    end if
-
-    ! Allocate the array to the appropriate size.
-    if (allocated(datasetValue)) deallocate(datasetValue)
-    allocate(datasetValue (datasetDimensions(1)))
-    allocate(datasetValueC(datasetDimensions(1)))
-    ! Read the dataset.
-    dataBuffer=c_loc(datasetValueC)
-    call h5dread_f(datasetObject%objectID,H5T_VLEN_INTEGER8(1),dataBuffer,errorCode,memorySpaceID,datasetDataspaceID,H5P_DEFAULT_F)
-    if (errorCode /= 0) then
-       message="unable to read dataset '"//trim(datasetNameActual)//"' in object '"//self%objectName//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    do i=1,datasetDimensions(1)
-       call c_f_pointer(datasetValueC(i)%p,datasetValue(i)%row,shape=[datasetValueC(i)%length])
-    end do
-    deallocate(datasetValueC)
-
-    ! Close the dataspace.
-    call h5sclose_f(datasetDataspaceID,errorCode)
-    if (errorCode /= 0) then
-       message="unable to close dataspace of dataset '"//datasetObject%objectName//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-
-    ! Close the memory dataspace if necessary.
-    if (memorySpaceID /= H5S_ALL_F) then
-       call h5sclose_f(memorySpaceID,errorCode)
-       if (errorCode /= 0) then
-          message="unable to close memory dataspace for dataset '"//datasetObject%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-    end if
-
-    ! Determine how to close the object.
-    if (self%hdf5ObjectType == hdf5ObjectTypeDataset .and. datasetObject%isReference()) then
-       ! It was, so close the referenced dataset.
-       call h5dclose_f(datasetObject%objectID,errorCode)
-       if (errorCode < 0) then
-          message="unable to close referenced dataset for '"//datasetObject%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       ! Restore the object ID of the original dataset.
-       self%objectID=storedDatasetID
-    end if
-    return
-  end subroutine IO_HDF5_Read_Dataset_VarInteger8_2D_Array_Allocatable
-  
-  subroutine IO_HDF5_Write_Dataset_VarInteger8_2D(self,datasetValue,datasetName,comment,appendTo,chunkSize,compressionLevel,datasetReturned)
-    !!{RST
-    Open and write a variable-length integer-8 2-D array dataset in ``self``.
-    !!}
-    use, intrinsic :: ISO_C_Binding     , only : c_loc
-    use            :: Error             , only : Error_Report
-    use            :: HDF5              , only : H5P_DEFAULT_F, H5S_SELECT_SET_F  , h5sget_simple_extent_dims_f, HID_T     , &
-          &                                      HSIZE_T      , h5dget_space_f    , h5dset_extent_f            , h5dwrite_f, &
-          &                                      h5sclose_f   , h5screate_simple_f, h5sselect_hyperslab_f      , hsize_t
-    use            :: ISO_Varying_String, only : assignment(=), operator(//)      , trim
-    implicit none
-    class           (hdf5Object     ), intent(inout)                       :: self
-    character       (len=*          ), intent(in   ), optional             :: comment                    , datasetName
-    type            (hdf5VarInteger8), intent(in   ), dimension(:)         :: datasetValue
-    logical                          , intent(in   ), optional             :: appendTo
-    integer         (hsize_t        ), intent(in   ), optional             :: chunkSize
-    integer                          , intent(in   ), optional             :: compressionLevel
-    type            (hdf5Object     ), intent(  out), optional             :: datasetReturned
-    integer         (kind=HSIZE_T   )               , dimension(1)         :: datasetDimensions          , hyperslabCount      , &
-         &                                                                    hyperslabStart             , newDatasetDimensions, &
-         &                                                                    newDatasetDimensionsMaximum
-    type            (hdf5VlenC      ), allocatable  , dimension(:), target :: datasetValueC
-    type            (c_ptr          )                                      :: datasetValueC_
-    integer         (kind=HSIZE_T   )                                      :: i
-    integer                                                                :: datasetRank                , errorCode
-    integer         (kind=HID_T     )                                      :: dataspaceID                , newDataspaceID
-    logical                                                                :: appendToActual             , preExisted
-    type            (hdf5Object     )                                      :: datasetObject
-    type            (varying_string )                                      :: datasetNameActual          , message
-
-    ! Check that this module is initialized.
-    call IO_HDF_Assert_Is_Initialized()
-
-    ! Get the name of the dataset.
-    if (present(datasetName)) then
-       datasetNameActual=     datasetName
-    else
-       datasetNameActual=self% objectName
-    end if
-
-    ! Check that the object is already open.
-    if (.not.self%isOpenValue) then
-       message="attempt to write dataset '"//trim(datasetNameActual)//"' in unopen object '"//self%objectName//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-
-    ! Determine append status.
-    if (present(appendTo)) then
-       appendToActual=appendTo
-    else
-       appendToActual=.false.
-    end if
-    ! Determine dataset dimensions
-    datasetDimensions=shape(datasetValue)
-    ! Check if the object is a dataset, or something else.
-    if (self%hdf5ObjectType == hdf5ObjectTypeDataset) then
-       ! If this dataset if not overwritable, report an error.
-       if (.not.(self%isOverwritable.or.appendToActual)) then
-          message="dataset '"//trim(datasetNameActual)//"' is not overwritable"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       else
-          ! Check that the object is a 1D vlen integer8.
-          call self%assertDatasetType(H5T_VLEN_INTEGER8,1)
-       end if
-       select type (self)
-       type is (hdf5Object)
-          datasetObject=self
-       end select
-       datasetNameActual=self%objectName
-       preExisted       =.true.
-    else
-       ! Check that an dataset name was supplied.
-       if (.not.present(datasetName)) then
-          message="no name was supplied for dataset in '"//self%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       ! Record if dataset already exists.
-       preExisted=self%hasDataset(datasetName)
-       ! Open the dataset.
-       datasetObject=self%openDataset(datasetName,comment,hdf5DataTypeVlenInteger8,datasetDimensions,appendTo&
-            &=appendTo,chunkSize=chunkSize,compressionLevel=compressionLevel)
-       ! Check that pre-existing object is a variable-length 2D integer-8.
-       if (preExisted) call datasetObject%assertDatasetType(H5T_VLEN_INTEGER8,1)
-       ! If this dataset if not overwritable, report an error.
-       if (preExisted.and..not.(datasetObject%isOverwritable.or.appendToActual)) then
-          message="dataset '"//trim(datasetName)//"' is not overwritable"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-    end if
-
-    ! If appending is requested, get the size of the existing dataset.
-    if (appendToActual.and.preExisted) then
-       ! Get size of existing dataset here.
-       call h5dget_space_f(datasetObject%objectID,dataspaceID,errorCode)
-       if (errorCode < 0) then
-          message="could not get dataspace for dataset '"//trim(datasetNameActual)//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       call h5sget_simple_extent_dims_f(dataspaceID,newDatasetDimensions,newDatasetDimensionsMaximum,errorCode)
-       if (errorCode < 0) then
-          message="could not get dataspace extent for dataset '"//trim(datasetNameActual)//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       call h5sclose_f(dataspaceID,errorCode)
-       if (errorCode < 0) then
-          message="could not close dataspace for dataset '"//trim(datasetNameActual)//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       hyperslabStart      =newDatasetDimensions
-       hyperslabCount      =dataSetDimensions
-       newDatasetDimensions=newDatasetDimensions+datasetDimensions
-    else
-       newDatasetDimensions=datasetDimensions
-       hyperslabStart      =0
-       hyperslabCount      =datasetDimensions
-    end if
-
-    ! Set extent of the dataset.
-    if (datasetObject%chunkSize /= -1) then
-       call h5dset_extent_f(datasetObject%objectID,newDatasetDimensions,errorCode)
-       if (errorCode < 0) then
-          message="could not set extent of dataset '"//trim(datasetNameActual)//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-    end if
-    ! Get the dataspace for the dataset.
-    call h5dget_space_f(datasetObject%objectID,dataspaceID,errorCode)
-    if (errorCode < 0) then
-       message="could not get dataspace for dataset '"//trim(datasetNameActual)//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    ! Select hyperslab to write.
-    call h5sselect_hyperslab_f(dataspaceID,H5S_SELECT_SET_F,hyperslabStart,hyperslabCount,errorCode)
-    if (errorCode < 0) then
-       message="could not select hyperslab for dataset '"//trim(datasetNameActual)//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    ! Create a dataspace for the data to be written.
-    datasetRank=1
-    call h5screate_simple_f(datasetRank,datasetDimensions,newDataspaceID,errorCode)
-    if (errorCode < 0) then
-       message="could not create dataspace for data to be written to dataset '"//trim(datasetNameActual)//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-
-    ! Write the dataset.
-    allocate(datasetValueC(datasetDimensions(1)))
-    do i=1,datasetDimensions(1)
-       datasetValueC(i)%length=size (datasetValue(i)%row,kind=c_size_t)
-       datasetValueC(i)%p     =c_loc(datasetValue(i)%row              )
-    end do
-    datasetValueC_=c_loc(datasetValueC)
-    call h5dwrite_f(datasetObject%objectID,H5T_VLEN_INTEGER8(1),datasetValueC_,errorCode,newDataspaceID,dataspaceID,H5P_DEFAULT_F)
-    if (errorCode /= 0) then
-       message="unable to write dataset '"//datasetNameActual//"' in object '"//self%objectName//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    deallocate(datasetValueC)
-
-    ! Close the dataspaces.
-    call h5sclose_f(dataspaceID,errorCode)
-    if (errorCode < 0) then
-       message="unable to close dataspace for dataset '"//trim(datasetNameActual)//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    call h5sclose_f(newDataspaceID,errorCode)
-    if (errorCode < 0) then
-       message="unable to close new dataspace for dataset '"//trim(datasetNameActual)//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-
-    ! Copy the dataset to return if necessary.
-    if (present(datasetReturned)) datasetReturned=datasetObject
-    return
-  end subroutine IO_HDF5_Write_Dataset_VarInteger8_2D
-  
   !! Table routines.
 
-  subroutine IO_HDF5_Read_Table_Real_1D_Array_Allocatable(self,tableName,columnName,datasetValue,readBegin,readCount)
+  subroutine IO_HDF5_Read_Table_{TableType¦label}_1D_Array_Allocatable(self,tableName,columnName,datasetValue,readBegin,readCount)
     !!{RST
-    Open and read a real 1D array from a table ``self``.
+    Open and read a {TableType¦typeName} 1D array from a table ``self``.
     !!}
     use :: Error             , only : Error_Report
     use :: H5TB              , only : h5tbget_table_info_f, h5tbread_field_name_f
     use :: HDF5              , only : H5T_NATIVE_REAL     , HSIZE_T              , h5tget_size_f
     use :: ISO_Varying_String, only : assignment(=)       , operator(//)
     implicit none
-    real                     , allocatable, dimension(:), intent(  out)           :: datasetValue
+    {TableType¦intrinsic}, allocatable, dimension(:), intent(  out)           :: datasetValue
     class    (hdf5Object    )                           , intent(inout)           :: self
     character(len=*         )                           , intent(in   )           :: tableName      , columnName
     integer  (kind=HSIZE_T  )                           , intent(in   ), optional :: readBegin      , readCount
@@ -7974,7 +7425,8 @@ attributeValue=trim(attributeValue)
     if (allocated(datasetValue)) deallocate(datasetValue)
     allocate(datasetValue(readCountActual))
 
-    ! Read the column.
+    ! Read the column. Note that H5T_NATIVE_REAL is used here solely to obtain the (4 byte) record size in memory - it is
+    ! valid for both real and integer columns.
     call h5tget_size_f(H5T_NATIVE_REAL,recordTypeSize,errorCode)
     if (errorCode /= 0) then
        message="unable to get real datatype size"
@@ -7986,90 +7438,7 @@ attributeValue=trim(attributeValue)
        call Error_Report(message//self%locationReport()//{introspection:location})
     end if
     return
-  end subroutine IO_HDF5_Read_Table_Real_1D_Array_Allocatable
-
-  subroutine IO_HDF5_Read_Table_Integer_1D_Array_Allocatable(self,tableName,columnName,datasetValue,readBegin,readCount)
-    !!{RST
-    Open and read an integer 1D array from a table ``self``.
-    !!}
-    use :: Error             , only : Error_Report
-    use :: H5TB              , only : h5tbget_table_info_f, h5tbread_field_name_f
-    use :: HDF5              , only : H5T_NATIVE_REAL     , HSIZE_T              , h5tget_size_f
-    use :: ISO_Varying_String, only : assignment(=)       , operator(//)
-    implicit none
-    integer                  , allocatable, dimension(:), intent(  out)           :: datasetValue
-    class    (hdf5Object    )                           , intent(inout)           :: self
-    character(len=*         )                           , intent(in   )           :: tableName      , columnName
-    integer  (kind=HSIZE_T  )                           , intent(in   ), optional :: readBegin      , readCount
-    integer  (kind=HSIZE_T  )                                                     :: readBeginActual, readCountActual, &
-         &                                                                           fieldCount     , recordCount
-    integer  (kind=SIZE_T   )                                                     :: recordTypeSize
-    integer                                                                       :: errorCode
-    logical                                                                       :: readSubsection
-    type     (varying_string)                                                     :: message
-
-    ! Check that this module is initialized.
-    call IO_HDF_Assert_Is_Initialized
-    ! Check that the object is already open.
-    if (.not.self%isOpenValue) then
-       message="attempt to read table '"//trim(tableName)//"' in unopen object '"//self%objectName//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    ! If a subsection is to be read, we need both start and count values.
-    if (present(readBegin)) then
-       if (.not.present(readCount)) then
-          message="reading a subsection of dataset '"//trim(tableName)//"' requires both readBegin and readCount to be specified"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       readSubsection=.true.
-    else
-       if (present(readCount)) then
-          message="reading a subsection of dataset '"//trim(tableName)//"' requires both readBegin and readCount to be specified"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-       readSubsection=.false.
-    end if
-    ! Check that the object is a group or a file
-    if (self%hdf5ObjectType == hdf5ObjectTypeFile .or. self%hdf5ObjectType == hdf5ObjectTypeGroup) then
-       ! Check that the dataset exists.
-       if (.not.self%hasDataset(tableName)) then
-          message="table '"//trim(tableName)//"' does not exist in '"//self%objectName//"'"
-          call Error_Report(message//self%locationReport()//{introspection:location})
-       end if
-    else
-       message="attempt to read table from '"//self%objectName//"' which is neither a file or a group"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    ! Get the table dimensions.
-    call h5tbget_table_info_f(self%objectID,tableName,fieldCount,recordCount,errorCode)
-    if (errorCode < 0) then
-       message="unable to get dimensions of table '"//tableName//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    ! Determine records to read.
-    if (readSubsection) then
-       readBeginActual=readBegin
-       readCountActual=readCount
-    else
-       readBeginActual=0
-       readCountActual=recordCount
-    end if
-    ! Allocate the array to the appropriate size.
-    if (allocated(datasetValue)) deallocate(datasetValue)
-    allocate(datasetValue(readCountActual))
-    ! Read the column.
-    call h5tget_size_f(H5T_NATIVE_REAL,recordTypeSize,errorCode)
-    if (errorCode /= 0) then
-       message="unable to get real datatype size"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    call h5tbread_field_name_f(self%objectID,tableName,columnName,readBeginActual,readCountActual,recordTypeSize,datasetValue,errorCode)
-    if (errorCode /= 0) then
-       message="unable to read table '"//trim(tableName)//"' in object '"//self%objectName//"'"
-       call Error_Report(message//self%locationReport()//{introspection:location})
-    end if
-    return
-  end subroutine IO_HDF5_Read_Table_Integer_1D_Array_Allocatable
+  end subroutine IO_HDF5_Read_Table_{TableType¦label}_1D_Array_Allocatable
 
   subroutine IO_HDF5_Read_Table_Integer8_1D_Array_Allocatable(self,tableName,columnName,datasetValue,readBegin,readCount)
     !!{RST

--- a/source/utility/IO/HDF5/_module.F90
+++ b/source/utility/IO/HDF5/_module.F90
@@ -84,8 +84,8 @@ module IO_HDF5
   !![
   <generic identifier="Type">
    <instance label="Integer"  intrinsic="integer"            h5Type="H5T_NATIVE_INTEGER" h5TypesWrite="H5T_NATIVE_INTEGERS"   h5TypesRead="H5T_NATIVE_INTEGERS"    dataType="hdf5DataTypeInteger"  typeName="integer"      h5TypeImport="H5T_NATIVE_INTEGER, "/>
-   <instance label="Integer8" intrinsic="integer(kind_int8)" h5Type="H5T_INTEGER8"       h5TypesWrite="H5T_NATIVE_INTEGER_8S" h5TypesRead="H5T_NATIVE_INTEGER_8AS" dataType="hdf5DataTypeInteger8" typeName="long integer" h5TypeImport=""/>
-   <instance label="Double"   intrinsic="double precision"   h5Type="H5T_NATIVE_DOUBLE"  h5TypesWrite="H5T_NATIVE_DOUBLES"    h5TypesRead="H5T_NATIVE_DOUBLES"     dataType="hdf5DataTypeDouble"   typeName="double"       h5TypeImport="H5T_NATIVE_DOUBLE, "/>
+   <instance label="Integer8" intrinsic="integer(kind_int8)" h5Type="H5T_INTEGER8"       h5TypesWrite="H5T_NATIVE_INTEGER_8S" h5TypesRead="H5T_NATIVE_INTEGER_8AS" dataType="hdf5DataTypeInteger8" typeName="long integer" h5TypeImport=""                    />
+   <instance label="Double"   intrinsic="double precision"   h5Type="H5T_NATIVE_DOUBLE"  h5TypesWrite="H5T_NATIVE_DOUBLES"    h5TypesRead="H5T_NATIVE_DOUBLES"     dataType="hdf5DataTypeDouble"   typeName="double"       h5TypeImport="H5T_NATIVE_DOUBLE, " />
   </generic>
   <generic identifier="VlenType">
    <instance label="VarDouble"   intrinsic="hdf5VarDouble"   h5VlenType="H5T_VLEN_DOUBLE"   dataType="hdf5DataTypeVlenDouble"   typeName="varying-length double"      />
@@ -225,18 +225,18 @@ module IO_HDF5
      procedure :: IO_HDF5_Read_Dataset_VarDouble_2D_Array_Allocatable
      generic   :: readDataset         => IO_HDF5_Read_Dataset_{Type¦label}_Array_Allocatable
      generic   :: readDataset         => IO_HDF5_Read_Dataset_{VlenType¦label}_Array_Allocatable
-     generic   :: readDataset         => IO_HDF5_Read_Dataset_Character_1D_Array_Allocatable   , &
-          &                              IO_HDF5_Read_Dataset_VarString_1D_Array_Allocatable   , &
-          &                              IO_HDF5_Read_Dataset_VarVarDouble_1D_Array_Allocatable, &
+     generic   :: readDataset         => IO_HDF5_Read_Dataset_Character_1D_Array_Allocatable    , &
+          &                              IO_HDF5_Read_Dataset_VarString_1D_Array_Allocatable    , &
+          &                              IO_HDF5_Read_Dataset_VarVarDouble_1D_Array_Allocatable , &
           &                              IO_HDF5_Read_Dataset_VarDouble_2D_Array_Allocatable
      generic   :: readDatasetStatic   => IO_HDF5_Read_Dataset_{Type¦label}_Array_Static
-     generic   :: readDatasetStatic   => IO_HDF5_Read_Dataset_Character_1D_Array_Static        , &
+     generic   :: readDatasetStatic   => IO_HDF5_Read_Dataset_Character_1D_Array_Static         , &
           &                              IO_HDF5_Read_Dataset_VarString_1D_Array_Static
      procedure :: IO_HDF5_Read_Table_{TableType¦label}_1D_Array_Allocatable
      procedure :: IO_HDF5_Read_Table_Integer8_1D_Array_Allocatable
      procedure :: IO_HDF5_Read_Table_Character_1D_Array_Allocatable
      generic   :: readTable          =>IO_HDF5_Read_Table_{TableType¦label}_1D_Array_Allocatable
-     generic   :: readTable          =>IO_HDF5_Read_Table_Integer8_1D_Array_Allocatable, &
+     generic   :: readTable          =>IO_HDF5_Read_Table_Integer8_1D_Array_Allocatable         , &
           &                            IO_HDF5_Read_Table_Character_1D_Array_Allocatable
      procedure :: size               =>IO_HDF5_Dataset_Size
      procedure :: rank               =>IO_HDF5_Dataset_Rank
@@ -1563,15 +1563,15 @@ contains
     use, intrinsic :: ISO_C_Binding     , only : c_loc
     use            :: ISO_Varying_String, only : assignment(=), operator(//), trim
     implicit none
-    class    (hdf5Object    ), intent(inout)                                     :: self
-    character(len=*         ), intent(in   ), optional                           :: attributeName
-    {Type¦intrinsic}, intent(in   ), dimension(..), target, contiguous :: attributeValue
-    integer  (kind=HSIZE_T  ), dimension(max(1,rank(attributeValue)))            :: attributeDimensions
-    integer                                                                      :: errorCode
-    logical                                                                      :: preExisted
-    type     (hdf5Object    )                                                    :: attributeObject
-    type     (varying_string)                                                    :: attributeNameActual, message
-    type     (c_ptr         )                                                    :: dataBuffer
+    class    (hdf5Object    ), intent(inout)                                                             :: self
+    character(len=*         ), intent(in   ), optional                                                   :: attributeName
+    {Type¦intrinsic}         , intent(in   ), dimension(..)                         , target, contiguous :: attributeValue
+    integer  (kind=HSIZE_T  )               , dimension(max(1,rank(attributeValue)))                     :: attributeDimensions
+    integer                                                                                              :: errorCode
+    logical                                                                                              :: preExisted
+    type     (hdf5Object    )                                                                            :: attributeObject
+    type     (varying_string)                                                                            :: attributeNameActual, message
+    type     (c_ptr         )                                                                            :: dataBuffer
 
     ! Check that this module is initialized.
     call IO_HDF_Assert_Is_Initialized
@@ -1626,7 +1626,7 @@ contains
        preExisted=self%hasAttribute(attributeName)
        ! Open the attribute.
        if (rank(attributeValue) == 0) then
-          attributeObject=self%openAttribute(attributeName,{Type¦dataType})
+          attributeObject=self%openAttribute(attributeName,{Type¦dataType}                    )
        else
           attributeObject=self%openAttribute(attributeName,{Type¦dataType},attributeDimensions)
        end if
@@ -1885,7 +1885,7 @@ contains
     class    (hdf5Object    )              , intent(inout)           :: self
     character(len=*         )              , intent(in   ), optional :: attributeName
     logical                                , intent(in   ), optional :: allowPseudoScalar
-    {Type¦intrinsic}, dimension(1) :: pseudoScalarValue
+    {Type¦intrinsic}         , dimension(1)                          :: pseudoScalarValue
     integer  (kind=HSIZE_T  ), dimension(1)                          :: attributeDimensions    , attributeMaximumDimensions
     integer  (kind=HID_T    )                                        :: attributeDataspaceID
     integer                                                          :: errorCode
@@ -1996,7 +1996,7 @@ contains
     use, intrinsic :: ISO_C_Binding     , only : c_loc
     use            :: ISO_Varying_String, only : assignment(=), operator(//), trim
     implicit none
-    {Type¦intrinsic}, allocatable, dimension(:), intent(  out), target :: attributeValue
+    {Type¦intrinsic}         , allocatable, dimension(:), intent(  out), target   :: attributeValue
     class    (hdf5Object    )                           , intent(inout)           :: self
     character(len=*         )                           , intent(in   ), optional :: attributeName
     integer  (kind=HSIZE_T  )             , dimension(1)                          :: attributeDimensions , attributeMaximumDimensions
@@ -2094,15 +2094,15 @@ contains
     use, intrinsic :: ISO_C_Binding     , only : c_loc
     use            :: ISO_Varying_String, only : assignment(=), operator(//), trim
     implicit none
-    {Type¦intrinsic}, dimension(:), intent(  out), target, contiguous :: attributeValue
-    class    (hdf5Object    )              , intent(inout)           :: self
-    character(len=*         )              , intent(in   ), optional :: attributeName
-    integer  (kind=HSIZE_T  ), dimension(1)                          :: attributeDimensions , attributeMaximumDimensions
-    integer                                                          :: errorCode
-    integer  (kind=HID_T    )                                        :: attributeDataspaceID
-    type     (hdf5Object    )                                        :: attributeObject
-    type     (varying_string)                                        :: attributeNameActual , message
-    type     (c_ptr         )                                        :: dataBuffer
+    {Type¦intrinsic}         , dimension(:), intent(  out), target  , contiguous :: attributeValue
+    class    (hdf5Object    )              , intent(inout)                       :: self
+    character(len=*         )              , intent(in   ), optional             :: attributeName
+    integer  (kind=HSIZE_T  ), dimension(1)                                      :: attributeDimensions , attributeMaximumDimensions
+    integer                                                                      :: errorCode
+    integer  (kind=HID_T    )                                                    :: attributeDataspaceID
+    type     (hdf5Object    )                                                    :: attributeObject
+    type     (varying_string)                                                    :: attributeNameActual , message
+    type     (c_ptr         )                                                    :: dataBuffer
 
     ! Check that this module is initialized.
     call IO_HDF_Assert_Is_Initialized
@@ -3652,26 +3652,28 @@ attributeValue=trim(attributeValue)
     Open and write a {Type¦typeName} array dataset of any rank in ``self``.
     !!}
     use            :: Error             , only : Error_Report
-    use            :: HDF5              , only : {Type¦h5TypeImport}H5P_DEFAULT_F, H5S_SELECT_SET_F, HID_T, HSIZE_T, h5dget_space_f, h5dset_extent_f, h5dwrite_f, h5sclose_f, h5screate_simple_f, h5sget_simple_extent_dims_f, h5sselect_hyperslab_f, hsize_t
+    use            :: HDF5              , only : {Type¦h5TypeImport}H5P_DEFAULT_F, H5S_SELECT_SET_F           , HID_T                , HSIZE_T   , &
+         &                                       h5dget_space_f                  , h5dset_extent_f            , h5dwrite_f           , h5sclose_f, &
+         &                                       h5screate_simple_f              , h5sget_simple_extent_dims_f, h5sselect_hyperslab_f, hsize_t
     use, intrinsic :: ISO_C_Binding     , only : c_loc
-    use            :: ISO_Varying_String, only : assignment(=)     , operator(//)               , trim
+    use            :: ISO_Varying_String, only : assignment(=)                   , operator(//)    , trim
     implicit none
-    class    (hdf5Object    ), intent(inout)           :: self
-    character(len=*         ), intent(in   ), optional :: comment                     , datasetName
-    {Type¦intrinsic}, intent(in   ), dimension(..), target, contiguous :: datasetValue
-    logical                  , intent(in   ), optional :: appendTo
-    integer  (hsize_t       ), intent(in   ), optional :: chunkSize
-    integer                  , intent(in   ), optional :: appendDimension             , compressionLevel
-    type     (hdf5Object    ), intent(  out), optional :: datasetReturned
-    integer  (kind=HSIZE_T  ), dimension(rank(datasetValue)) :: datasetDimensions           , hyperslabCount             , &
-         &                                                      hyperslabStart              , newDatasetDimensions       , &
-         &                                                      newDatasetDimensionsFiltered, newDatasetDimensionsMaximum
-    integer                                            :: appendDimensionActual       , errorCode
-    integer  (kind=HID_T    )                          :: dataspaceID                 , newDataspaceID
-    logical                                            :: appendToActual              , preExisted
-    type     (hdf5Object    )                          :: datasetObject
-    type     (varying_string)                          :: datasetNameActual           , message
-    type     (c_ptr         )                          :: dataBuffer
+    class    (hdf5Object    ), intent(inout)                                                    :: self
+    character(len=*         ), intent(in   ), optional                                          :: comment                     , datasetName
+    {Type¦intrinsic}         , intent(in   ), dimension(..)                , target, contiguous :: datasetValue
+    logical                  , intent(in   ), optional                                          :: appendTo
+    integer  (hsize_t       ), intent(in   ), optional                                          :: chunkSize
+    integer                  , intent(in   ), optional                                          :: appendDimension             , compressionLevel
+    type     (hdf5Object    ), intent(  out), optional                                          :: datasetReturned
+    integer  (kind=HSIZE_T  )               , dimension(rank(datasetValue))                     :: datasetDimensions           , hyperslabCount             , &
+         &                                                                                         hyperslabStart              , newDatasetDimensions       , &
+         &                                                                                         newDatasetDimensionsFiltered, newDatasetDimensionsMaximum
+    integer                                                                                     :: appendDimensionActual       , errorCode
+    integer  (kind=HID_T    )                                                                   :: dataspaceID                 , newDataspaceID
+    logical                                                                                     :: appendToActual              , preExisted
+    type     (hdf5Object    )                                                                   :: datasetObject
+    type     (varying_string)                                                                   :: datasetNameActual           , message
+    type     (c_ptr         )                                                                   :: dataBuffer
 
     ! Check that this module is initialized.
     call IO_HDF_Assert_Is_Initialized
@@ -3839,11 +3841,15 @@ attributeValue=trim(attributeValue)
     Open and read a {Type¦typeName} array dataset of any rank in ``self``, into a static array.
     !!}
     use            :: Error             , only : Error_Report
-    use            :: HDF5              , only : {Type¦h5TypeImport}H5P_DEFAULT_F, H5S_ALL_F, H5S_SELECT_SET_F, H5T_STD_REF_DSETREG, HID_T, HSIZE_T, h5dclose_f, h5dget_space_f, h5dread_f, h5rdereference_f, h5rget_region_f, h5sclose_f, h5screate_simple_f, h5sget_select_bounds_f, h5sget_simple_extent_dims_f, h5sselect_elements_f, h5sselect_hyperslab_f, hdset_reg_ref_t_f, hsize_t, size_t
+    use            :: HDF5              , only : {Type¦h5TypeImport}H5P_DEFAULT_F, H5S_ALL_F             , H5S_SELECT_SET_F           , H5T_STD_REF_DSETREG , &
+         &                                       HID_T                           , HSIZE_T               , h5dclose_f                 , h5dget_space_f      , &
+         &                                       h5dread_f                       , h5rdereference_f      , h5rget_region_f            , h5sclose_f          , &
+         &                                       h5screate_simple_f              , h5sget_select_bounds_f, h5sget_simple_extent_dims_f, h5sselect_elements_f, &
+         &                                       h5sselect_hyperslab_f           , hdset_reg_ref_t_f     , hsize_t                    , size_t
     use, intrinsic :: ISO_C_Binding     , only : c_loc
     use            :: ISO_Varying_String, only : assignment(=), operator(//), trim
     implicit none
-    {Type¦intrinsic}, intent(  out), dimension(..), target, contiguous :: datasetValue
+    {Type¦intrinsic}                   , contiguous , dimension(..) , intent(  out), target   :: datasetValue
     class           (hdf5Object       )                             , intent(inout)           :: self
     character       (len=*            )                             , intent(in   ), optional :: datasetName
     integer         (kind=HSIZE_T     )             , dimension(:  ), intent(in   ), optional :: readBegin         , readCount
@@ -3855,7 +3861,7 @@ attributeValue=trim(attributeValue)
     ! in an invalid pointer error. According to valgrind, this happens because the wrong deallocation function is used (delete
     ! instead of delete[] or vice-verse). Presumably this is an HDF5 library error. Saving the variable prevents it from being
     ! deallocated. This is not an elegant solution, but it works.
-    type            (hdset_reg_ref_t_f), save       , target                                  :: referencedRegion
+    type            (hdset_reg_ref_t_f), save                                       , target  :: referencedRegion
     integer                                                                                   :: errorCode         , dimensionIndex
     integer         (kind=HSIZE_T     )                                                       :: pointIndex        , pointLeadingCount       , &
          &                                                                                       pointLeadingIndex , pointRemainder
@@ -4234,11 +4240,15 @@ attributeValue=trim(attributeValue)
     Open and read a {Type¦typeName} array dataset of any rank in ``self``, into an allocatable array.
     !!}
     use            :: Error             , only : Error_Report
-    use            :: HDF5              , only : {Type¦h5TypeImport}H5P_DEFAULT_F, H5S_ALL_F, H5S_SELECT_SET_F, H5T_STD_REF_DSETREG, HID_T, HSIZE_T, h5dclose_f, h5dget_space_f, h5dread_f, h5rdereference_f, h5rget_region_f, h5sclose_f, h5screate_simple_f, h5sget_select_bounds_f, h5sget_simple_extent_dims_f, h5sselect_elements_f, h5sselect_hyperslab_f, hdset_reg_ref_t_f, hsize_t, size_t
+    use            :: HDF5              , only : {Type¦h5TypeImport}H5P_DEFAULT_F, H5S_ALL_F             , H5S_SELECT_SET_F           , H5T_STD_REF_DSETREG , &
+         &                                       HID_T                           , HSIZE_T               , h5dclose_f                 , h5dget_space_f      , &
+         &                                       h5dread_f                       , h5rdereference_f      , h5rget_region_f            , h5sclose_f          , &
+         &                                       h5screate_simple_f              , h5sget_select_bounds_f, h5sget_simple_extent_dims_f, h5sselect_elements_f, &
+         &                                       h5sselect_hyperslab_f           , hdset_reg_ref_t_f     , hsize_t                    , size_t
     use, intrinsic :: ISO_C_Binding     , only : c_loc
     use            :: ISO_Varying_String, only : assignment(=), operator(//), trim
     implicit none
-    {Type¦intrinsic}, allocatable, dimension(..), intent(  out), target :: datasetValue
+    {Type¦intrinsic}                   , allocatable, dimension(..) , intent(  out), target   :: datasetValue
     class           (hdf5Object       )                             , intent(inout)           :: self
     character       (len=*            )                             , intent(in   ), optional :: datasetName
     integer         (kind=HSIZE_T     )             , dimension(:  ), intent(in   ), optional :: readBegin         , readCount
@@ -4250,7 +4260,7 @@ attributeValue=trim(attributeValue)
     ! in an invalid pointer error. According to valgrind, this happens because the wrong deallocation function is used (delete
     ! instead of delete[] or vice-verse). Presumably this is an HDF5 library error. Saving the variable prevents it from being
     ! deallocated. This is not an elegant solution, but it works.
-    type            (hdset_reg_ref_t_f), save       , target                                  :: referencedRegion
+    type            (hdset_reg_ref_t_f), save                                      , target   :: referencedRegion
     integer                                                                                   :: errorCode         , dimensionIndex
     integer         (kind=HSIZE_T     )                                                       :: pointIndex        , pointLeadingCount       , &
          &                                                                                       pointLeadingIndex , pointRemainder
@@ -5685,28 +5695,28 @@ attributeValue=trim(attributeValue)
     use, intrinsic :: ISO_C_Binding     , only : c_f_pointer         , c_loc
     use            :: ISO_Varying_String, only : assignment(=)       , operator(//)         , trim
     implicit none
-    type            ({VlenType¦intrinsic}    ), allocatable, dimension(:  ), intent(  out)           :: datasetValue
-    class           (hdf5Object       )                             , intent(inout)           :: self
-    character       (len=*            )                             , intent(in   ), optional :: datasetName
-    integer         (kind=HSIZE_T     )             , dimension(1  ), intent(in   ), optional :: readBegin         , readCount
-    integer         (kind=HSIZE_T     )             , dimension(:  ), intent(in   ), optional :: readSelection
-    integer         (kind=HSIZE_T     )             , dimension(1  )                          :: datasetDimensions , datasetMaximumDimensions, &
-         &                                                                                       referenceEnd      , referenceStart
-    integer         (kind=HSIZE_T     ), allocatable, dimension(:,:)                          :: readSelectionMap
+    type            ({VlenType¦intrinsic}), allocatable, dimension(:  ), intent(  out)           :: datasetValue
+    class           (hdf5Object          )                             , intent(inout)           :: self
+    character       (len=*               )                             , intent(in   ), optional :: datasetName
+    integer         (kind=HSIZE_T        )             , dimension(1  ), intent(in   ), optional :: readBegin         , readCount
+    integer         (kind=HSIZE_T        )             , dimension(:  ), intent(in   ), optional :: readSelection
+    integer         (kind=HSIZE_T        )             , dimension(1  )                          :: datasetDimensions , datasetMaximumDimensions, &
+         &                                                                                          referenceEnd      , referenceStart
+    integer         (kind=HSIZE_T        ), allocatable, dimension(:,:)                          :: readSelectionMap
     ! <HDF5> Why is "referencedRegion" saved? Because if it is not then it gets dynamically allocated on the stack, which results
     ! in an invalid pointer error. According to valgrind, this happens because the wrong deallocation function is used (delete
     ! instead of delete[] or vice-verse). Presumably this is an HDF5 library error. Saving the variable prevents it from being
     ! deallocated. This is not an elegant solution, but it works.
-    type            (hdset_reg_ref_t_f), save       , target                                  :: referencedRegion
-    integer                                                                                   :: errorCode
-    integer         (kind=HSIZE_T     )                                                       :: i
-    integer         (kind=HID_T       )                                                       :: datasetDataspaceID, dereferencedObjectID    , &
-         &                                                                                       memorySpaceID     , storedDatasetID
-    logical                                                                                   :: isReference       , readSubsection
-    type            (hdf5Object       )                                                       :: datasetObject
-    type            (varying_string   )                                                       :: datasetNameActual , message
-    type            (c_ptr            )                                                       :: dataBuffer
-    type            (hdf5VlenC        ), allocatable, dimension(:  ), target                  :: datasetValueC
+    type            (hdset_reg_ref_t_f   ), save       , target                                  :: referencedRegion
+    integer                                                                                      :: errorCode
+    integer         (kind=HSIZE_T        )                                                       :: i
+    integer         (kind=HID_T          )                                                       :: datasetDataspaceID, dereferencedObjectID    , &
+         &                                                                                          memorySpaceID     , storedDatasetID
+    logical                                                                                      :: isReference       , readSubsection
+    type            (hdf5Object          )                                                       :: datasetObject
+    type            (varying_string      )                                                       :: datasetNameActual , message
+    type            (c_ptr               )                                                       :: dataBuffer
+    type            (hdf5VlenC           ), allocatable, dimension(:  ), target                  :: datasetValueC
 
     ! Check that this module is initialized.
     call IO_HDF_Assert_Is_Initialized
@@ -6825,24 +6835,24 @@ attributeValue=trim(attributeValue)
           &                                      h5sclose_f   , h5screate_simple_f, h5sget_simple_extent_dims_f, h5sselect_hyperslab_f
     use            :: ISO_Varying_String, only : assignment(=), operator(//)      , trim
     implicit none
-    class           (hdf5Object    ), intent(inout)                       :: self
-    character       (len=*         ), intent(in   ), optional             :: comment                    , datasetName
-    type            ({VlenType¦intrinsic} ), intent(in   ), dimension(:)         :: datasetValue
-    logical                         , intent(in   ), optional             :: appendTo
-    integer         (hsize_t       ), intent(in   ), optional             :: chunkSize
-    integer                         , intent(in   ), optional             :: compressionLevel
-    type            (hdf5Object    ), intent(  out), optional             :: datasetReturned
-    integer         (kind=HSIZE_T  )               , dimension(1)         :: datasetDimensions          , hyperslabCount      , &
-         &                                                                   hyperslabStart             , newDatasetDimensions, &
-         &                                                                   newDatasetDimensionsMaximum
-    type            (hdf5VlenC     ), allocatable  , dimension(:), target :: datasetValueC
-    type            (c_ptr         )                                      :: datasetValueC_
-    integer         (kind=HSIZE_T  )                                      :: i
-    integer                                                               :: datasetRank                , errorCode
-    integer         (kind=HID_T    )                                      :: dataspaceID                , newDataspaceID
-    logical                                                               :: appendToActual             , preExisted
-    type            (hdf5Object    )                                      :: datasetObject
-    type            (varying_string)                                      :: datasetNameActual          , message
+    class           (hdf5Object          ), intent(inout)                       :: self
+    character       (len=*               ), intent(in   ), optional             :: comment                    , datasetName
+    type            ({VlenType¦intrinsic}), intent(in   ), dimension(:)         :: datasetValue
+    logical                               , intent(in   ), optional             :: appendTo
+    integer         (hsize_t             ), intent(in   ), optional             :: chunkSize
+    integer                               , intent(in   ), optional             :: compressionLevel
+    type            (hdf5Object          ), intent(  out), optional             :: datasetReturned
+    integer         (kind=HSIZE_T        )               , dimension(1)         :: datasetDimensions          , hyperslabCount      , &
+         &                                                                         hyperslabStart             , newDatasetDimensions, &
+         &                                                                         newDatasetDimensionsMaximum
+    type            (hdf5VlenC           ), allocatable  , dimension(:), target :: datasetValueC
+    type            (c_ptr               )                                      :: datasetValueC_
+    integer         (kind=HSIZE_T        )                                      :: i
+    integer                                                                     :: datasetRank                , errorCode
+    integer         (kind=HID_T          )                                      :: dataspaceID                , newDataspaceID
+    logical                                                                     :: appendToActual             , preExisted
+    type            (hdf5Object          )                                      :: datasetObject
+    type            (varying_string      )                                      :: datasetNameActual          , message
 
     ! Check that this module is initialized.
     call IO_HDF_Assert_Is_Initialized()
@@ -7186,15 +7196,15 @@ attributeValue=trim(attributeValue)
     use            :: ISO_Varying_String, only : assignment(=), operator(//)      , trim
     implicit none
     class           (hdf5Object    ), intent(inout)                         :: self
-    character       (len=*         ), intent(in   ), optional               :: comment                       , datasetName
+    character       (len=*         ), intent(in   ), optional               :: comment                    , datasetName
     type            (hdf5VarDouble ), intent(in   ), dimension(:,:)         :: datasetValue
     logical                         , intent(in   ), optional               :: appendTo
     integer         (hsize_t       ), intent(in   ), optional               :: chunkSize
     integer                         , intent(in   ), optional               :: compressionLevel
     type            (hdf5Object    ), intent(  out), optional               :: datasetReturned
     integer         (kind=HSIZE_T  )               , dimension(2  )         :: datasetDimensions          , hyperslabCount      , &
-         &                                                                   hyperslabStart             , newDatasetDimensions, &
-         &                                                                   newDatasetDimensionsMaximum
+         &                                                                     hyperslabStart             , newDatasetDimensions, &
+         &                                                                     newDatasetDimensionsMaximum
     type            (hdf5VlenC     ), allocatable  , dimension(:,:), target :: datasetValueC
     type            (c_ptr         )                                        :: datasetValueC_
     integer         (kind=HSIZE_T  )                                        :: i                          , j
@@ -7363,7 +7373,7 @@ attributeValue=trim(attributeValue)
     use :: HDF5              , only : H5T_NATIVE_REAL     , HSIZE_T              , h5tget_size_f
     use :: ISO_Varying_String, only : assignment(=)       , operator(//)
     implicit none
-    {TableType¦intrinsic}, allocatable, dimension(:), intent(  out)           :: datasetValue
+    {TableType¦intrinsic}    , allocatable, dimension(:), intent(  out)           :: datasetValue
     class    (hdf5Object    )                           , intent(inout)           :: self
     character(len=*         )                           , intent(in   )           :: tableName      , columnName
     integer  (kind=HSIZE_T  )                           , intent(in   ), optional :: readBegin      , readCount

--- a/testSuite/scripts/generate_h5py.py
+++ b/testSuite/scripts/generate_h5py.py
@@ -2,7 +2,7 @@
 import h5py
 import numpy as np
 
-# Generate an HDF5 file using h5py which contains a single string attribute. This is used to test reading of variable length
+# Generate an HDF5 file using h5py which contains a string attribute. This is used to test reading of variable length
 # strings as written by h5py.
 f                          = h5py.File("testSuite/outputs/h5py.hdf5","w")
 f.attrs["stringAttribute"] = "this is a variable length string"


### PR DESCRIPTION
## Purpose

Final step of the #94 deduplication campaign: sweep up the remaining type-duplicated pairs. Stacked on #1213 → #1212 → #1211 → #1210; merge in that order.

## What changed

**6 procedures → 3 templates** (net **−631 lines**), via two new generic directives:

- **`VlenType`** — the varying-length double and varying-length long integer 1-D dataset write/read pairs (`VarDouble_1D`/`VarInteger8_2D`) were verified to differ only in comments and trivial style (one nested-vs-combined `if`, `IO_HDF5_Open_Dataset(self,…)` vs `self%openDataset(…)`); they collapse into single write and read functions templated over {`hdf5VarDouble`, `hdf5VarInteger8`}. The VLEN marshaling through `hdf5VlenC` + `c_f_pointer` is fully element-type-agnostic.
- **`TableType`** — the real and integer table column readers were byte-identical apart from documentation (including both using `H5T_NATIVE_REAL` for the size lookup — now documented as intentional: only the 4-byte record size is used). They collapse into one templated reader.

Deliberately left hand-written: the long integer table reader (it uses the one remaining `H5TBread_fields_name` C-API wrapper, which we verified must survive at HDF5 1.14.5), the character variants, and the structurally distinct `VarVarDouble`/`VarDouble_2D` VLEN variants.

Also fixed en route: the `<generic>` directive schema requires `label` + `intrinsic` on every instance (caught by the pre-commit XML validation), so the new directives conform.

## Campaign totals

| | Start | Now |
|---|---|---|
| Module size | 18,340 lines | **8,473 lines (−54%)** |
| Hand-written read/write variants | ~90 | 72 collapsed into **11 templates** + specials |

Call sites were untouched throughout — every PR preserved the `writeAttribute`/`readAttribute`/`writeDataset`/`readDataset`/`readTable` generic bindings exactly.

## Verification

- All **210 assertions** pass (both VLEN round-trips, all four table column types, subsection table reads).
- Full `Galacticus.exe` build succeeds; `parameters/quickTest.xml` runs end-to-end.

Closes #94. Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
