### PR TITLE
Work around an LTO double-free in the preset named property extractors

### DIFF
--- a/source/nodes/property_extractor/preset_named_integers.F90
+++ b/source/nodes/property_extractor/preset_named_integers.F90
@@ -142,10 +142,16 @@ contains
     class           (nodePropertyExtractorPresetNamedIntegers), intent(inout)                             :: self
     double precision                                          , intent(in   )                             :: time
     type            (varying_string                          ), intent(inout), dimension(:) , allocatable :: names
+    integer                                                                                               :: i
     !$GLC attributes unused :: time
 
     allocate(names(size(self%presetNames)))
-    names='preset:'//self%presetNames
+    ! Note: an explicit loop is used here (rather than a whole-array elemental assignment) as the elemental concatenation is
+    ! miscompiled under link-time optimization (observed with gfortran 16), resulting in a double-free of the temporary - see
+    ! https://github.com/galacticusorg/galacticus/issues/1216.
+    do i=1,size(self%presetNames)
+       names(i)='preset:'//self%presetNames(i)
+    end do
     return
   end subroutine presetNamedIntegersNames
 

--- a/source/nodes/property_extractor/preset_named_reals.F90
+++ b/source/nodes/property_extractor/preset_named_reals.F90
@@ -142,10 +142,16 @@ contains
     class           (nodePropertyExtractorPresetNamedReals), intent(inout)                             :: self
     double precision                                       , intent(in   )                             :: time
     type            (varying_string                       ), intent(inout), dimension(:) , allocatable :: names
+    integer                                                                                            :: i
     !$GLC attributes unused :: time
 
     allocate(names(size(self%presetNames)))
-    names='preset:'//self%presetNames
+    ! Note: an explicit loop is used here (rather than a whole-array elemental assignment) as the elemental concatenation is
+    ! miscompiled under link-time optimization (observed with gfortran 16), resulting in a double-free of the temporary - see
+    ! https://github.com/galacticusorg/galacticus/issues/1216.
+    do i=1,size(self%presetNames)
+       names(i)='preset:'//self%presetNames(i)
+    end do
     return
   end subroutine presetNamedRealsNames
 


### PR DESCRIPTION
Works around a link-time-optimization miscompilation (gfortran 16) of the whole-array elemental concatenation in the `names` methods of the `presetNamedReals` and `presetNamedIntegers` property extractors, which caused a glibc double-free abort at output time in any model outputting these properties (e.g. `testSuite/parameters/bolshoiTestTreesGLC.xml`).

Root cause (full analysis on the issue): the LTO-inlined assignment frees the elemental temporary's character buffer directly, and the `varying_string` finalizer then frees the same block again. Deterministic (independent of thread count); reproduces in a ~40-line test case with `-O3 -flto` and disappears without `-flto`, so the Fortran source appears conforming and an upstream GCC report is warranted. The fix replaces the whole-array assignment with an explicit element-wise loop (verified to avoid the miscompilation) at the only two sites using this idiom.

Verified: the previously-aborting Bolshoi model now runs to completion with the `preset:*` datasets present in its output, and `test-Bolshoi-tree-builder.py` passes.

Fixes #1216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
