### PR TITLE
fix(build): propagate compiler, linker, and profiler exit statuses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,9 +305,22 @@ FCFLAGS_AARCH64_ICE_OBJECTS = \
 $(FCFLAGS_AARCH64_ICE_OBJECTS): FCFLAGS += -O0
 endif
 
+# The compiler writes diagnostics to a file which is then fed to postprocess.py, rather than piping
+# compiler output directly into postprocess.py. In a pipeline the compiler's exit status would be
+# discarded (the recipe's status would be postprocess.py's, and /bin/sh has no pipefail), so a hard
+# compiler failure that emits no "Error:" line — an internal compiler error, a segfault, an OOM
+# kill — would be reported as success, leaving a missing or stale object file that only surfaces
+# later as a confusing link error. Capturing and testing both statuses makes such failures fail the
+# recipe immediately. (libraryInterfacesDependencies.py emits a mirror of this recipe for the
+# library wrapper units — keep the two in sync.)
 $(BUILDPATH)/%.o : $(BUILDPATH)/%.p.F90 $(BUILDPATH)/%.m $(BUILDPATH)/%.d $(BUILDPATH)/%.fl Makefile
 	@mkdir -p $(BUILDPATH)/moduleBuild
-	$(FCCOMPILER) -c $(BUILDPATH)/$*.p.F90 -o $(BUILDPATH)/$*.o $(FCFLAGS) 2>&1 | ./scripts/build/postprocess.py $(BUILDPATH)/$*.p.F90
+	$(FCCOMPILER) -c $(BUILDPATH)/$*.p.F90 -o $(BUILDPATH)/$*.o $(FCFLAGS) > $(BUILDPATH)/$*.o.diag 2>&1; \
+	compileStatus=$$?; \
+	./scripts/build/postprocess.py $(BUILDPATH)/$*.p.F90 < $(BUILDPATH)/$*.o.diag; \
+	postprocessStatus=$$?; \
+	rm -f $(BUILDPATH)/$*.o.diag; \
+	[ $$compileStatus -eq 0 ] && [ $$postprocessStatus -eq 0 ]
 	@mlist=`cat $(BUILDPATH)/$*.m` ; \
 	for mod in $$mlist ; \
 	do \

--- a/scripts/build/findExecutables.py
+++ b/scripts/build/findExecutables.py
@@ -91,6 +91,11 @@ def _scan_one(file_name):
 
     exe_name = None if exclude_from_all else exe_root + '.exe'
 
+    # The link step writes diagnostics to a file rather than piping them directly into
+    # postprocessLinker.py: in a pipeline the linker's exit status would be discarded, so a failed
+    # link (`undefined reference`, `ld returned 1 exit status`) would be recorded by make as a
+    # successful build of the executable. Capturing and testing both statuses makes link failures
+    # fail the recipe immediately.
     rule = f"""\
 {exe_root}.exe: {work_dir}{obj_root}.o {work_dir}{obj_root}.d $(MAKE_DEPS) $(UPDATE_DEPS)
 \t./scripts/build/parameterDependencies.py `pwd` {obj_root}.exe
@@ -106,7 +111,12 @@ def _scan_one(file_name):
 \tfi; \\
 \t./scripts/build/sourceDigests.py `pwd` {obj_root}.exe $$useLocks
 \t$(CCOMPILER) -c {work_dir}{obj_root}.md5s.c -o {work_dir}{obj_root}.md5s.o $(CFLAGS)
-\t+$(FCCOMPILER) `cat {work_dir}{obj_root}.d` {work_dir}{obj_root}.parameters.o {work_dir}{obj_root}.md5s.o -o {exe_root}.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `./scripts/build/libraryDependencies.py {obj_root}.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
+\t+$(FCCOMPILER) `cat {work_dir}{obj_root}.d` {work_dir}{obj_root}.parameters.o {work_dir}{obj_root}.md5s.o -o {exe_root}.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `./scripts/build/libraryDependencies.py {obj_root}.exe $(FCFLAGS)` > {work_dir}{obj_root}.link.diag 2>&1; \\
+\tlinkStatus=$$?; \\
+\t./scripts/build/postprocessLinker.py < {work_dir}{obj_root}.link.diag; \\
+\tpostprocessStatus=$$?; \\
+\trm -f {work_dir}{obj_root}.link.diag; \\
+\t[ $$linkStatus -eq 0 ] && [ $$postprocessStatus -eq 0 ]
 
 """
     return rule, exe_name

--- a/scripts/build/libraryInterfacesDependencies.py
+++ b/scripts/build/libraryInterfacesDependencies.py
@@ -51,13 +51,23 @@ for name in units:
         f"{build_path}libgalacticus/{name}.p.F90 :"
         f" {build_path}libgalacticus/{name}.p.F90.up\n"
         f"\t@true\n"
+        # The compile recipe mirrors the main Makefile's `%.o` pattern rule
+        # (see the comment there): diagnostics go to a file so the compiler's
+        # exit status is preserved rather than being masked by the
+        # postprocess.py pipe. Keep the two recipes in sync.
         f"{build_path}libgalacticus/{name}.o :"
         f" {build_path}libgalacticus/{name}.p.F90"
         f" {build_path}libgalacticus/{name}.d Makefile\n"
         f"\t@mkdir -p {build_path}/moduleBuild\n"
         f"\t$(FCCOMPILER) -c {build_path}libgalacticus/{name}.p.F90"
-        f" -o {build_path}libgalacticus/{name}.o $(FCFLAGS) 2>&1"
-        f" | ./scripts/build/postprocess.py {build_path}libgalacticus/{name}.p.F90\n"
+        f" -o {build_path}libgalacticus/{name}.o $(FCFLAGS)"
+        f" > {build_path}libgalacticus/{name}.o.diag 2>&1; \\\n"
+        f"\tcompileStatus=$$?; \\\n"
+        f"\t./scripts/build/postprocess.py {build_path}libgalacticus/{name}.p.F90"
+        f" < {build_path}libgalacticus/{name}.o.diag; \\\n"
+        f"\tpostprocessStatus=$$?; \\\n"
+        f"\trm -f {build_path}libgalacticus/{name}.o.diag; \\\n"
+        f"\t[ $$compileStatus -eq 0 ] && [ $$postprocessStatus -eq 0 ]\n"
         f"\n"
     )
 

--- a/scripts/build/postprocessLinker.py
+++ b/scripts/build/postprocessLinker.py
@@ -18,7 +18,13 @@ for line in sys.stdin:
     ):
         continue
     sys.stdout.write(line)
-    if re.match(r'^Error:', line):
+    # Fail on any diagnostic that indicates the link actually failed. Real link failures usually
+    # appear as `collect2: error: ld returned 1 exit status` or `undefined reference to ...` (not
+    # as `Error:` lines), so match broadly. The Makefile link recipe also checks the linker's own
+    # exit status; this is a second line of defense.
+    if (re.search(r'\berror:', line, re.IGNORECASE)
+            or 'undefined reference' in line
+            or re.search(r'ld returned [0-9]+ exit status', line)):
         status = 1
 
 sys.exit(status)

--- a/scripts/build/profiler.sh
+++ b/scripts/build/profiler.sh
@@ -27,8 +27,10 @@ start=`date --rfc-3339=seconds`
 maxRSS=-1
 if [ -n "$gnuTime" ] && memFile=`mktemp 2>/dev/null`; then
     # Use GNU `time` to measure the peak resident set size of the task, writing the result to the
-    # temporary file so that it is not mixed into the build log.
+    # temporary file so that it is not mixed into the build log. GNU `time` exits with the wrapped
+    # command's exit status, so capturing it here preserves the recipe's status.
     "$gnuTime" -f '%M' -o "$memFile" sh -c "$@"
+    status=$?
     if [ -s "$memFile" ]; then
         read maxRSS < "$memFile"
     fi
@@ -41,8 +43,14 @@ else
     # without measuring memory usage.
     memFile=
     eval "$@"
+    status=$?
 fi
 stop=`date --rfc-3339=seconds`
 
 # Write our report.
 echo "++Task: {$start|$stop|$maxRSS} '$@'"
+
+# Propagate the wrapped command's exit status. This script is used as make's SHELL, so exiting 0
+# unconditionally would make every recipe appear to succeed — make would be unable to detect any
+# failed compile or link during a profiled ('compileprof') build.
+exit $status

--- a/scripts/build/staticRelinker.py
+++ b/scripts/build/staticRelinker.py
@@ -204,9 +204,23 @@ if dylibs_to_hide:
     subprocess.run(mv_cmd, shell=True)
 
 print(f"Relinking with: {compile_command}")
-status = subprocess.run(compile_command, shell=True)
+# Record the current executable's timestamp so we can later tell whether the relink
+# actually (re)wrote it. -1 stands in for "does not exist yet".
+executable_mtime_before = os.path.getmtime(executable) if os.path.exists(executable) else -1
 
-# Restore any temporarily moved dynamic libraries.
+# Run the relink, capturing combined stdout+stderr so the diagnostics can be screened
+# for a genuine link failure. On macOS gfortran can exit non-zero for benign reasons
+# (e.g. deprecated linker-flag warnings emitted by the modern ld) even when it produces
+# a valid static executable. The historical build recipe absorbed this by piping the
+# relink through postprocessLinker.py and taking the pipe's exit status; parsing that
+# tail off the grepped link line (above) dropped that behavior, so a cosmetic non-zero
+# exit now fails the CI job. Re-apply the screening explicitly (below).
+relink = subprocess.run(
+    compile_command, shell=True,
+    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+)
+
+# Restore any temporarily moved dynamic libraries before exiting.
 if dylibs_to_hide:
     print("Must restore temporarily moved dylibs (requires sudo):")
     mv_cmd = "sudo -- sh -c '" + '; '.join(
@@ -214,5 +228,36 @@ if dylibs_to_hide:
     ) + "'"
     subprocess.run(mv_cmd, shell=True)
 
-# Exit with status.
-sys.exit(status.returncode)
+# Screen the linker diagnostics: postprocessLinker.py re-emits them (dropping the
+# known-benign warnings) and exits non-zero only on a message that indicates the link
+# genuinely failed ('error:', 'undefined reference', 'ld returned N exit status').
+postprocess = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'postprocessLinker.py')
+screen = subprocess.run([sys.executable, postprocess], input=relink.stdout, text=True)
+
+# Decide the relink's fate:
+#  * a genuine-failure diagnostic always fails the relink;
+#  * otherwise a clean gfortran exit succeeds;
+#  * a non-zero gfortran exit with no such diagnostic is treated as benign ONLY if the
+#    executable was actually (re)written -- this tolerates the cosmetic macOS non-zero
+#    exit while still failing on silent breakage that produces no matching diagnostic
+#    (compiler not found, killed by a signal/OOM, disk full, etc.), where the executable
+#    is never updated.
+if screen.returncode != 0:
+    sys.exit(screen.returncode)
+if relink.returncode == 0:
+    sys.exit(0)
+executable_written = (
+    os.path.exists(executable) and os.path.getmtime(executable) > executable_mtime_before
+)
+if executable_written:
+    print(
+        f"Warning: relink command exited with status {relink.returncode} but emitted no "
+        f"failure diagnostic and (re)wrote '{executable}'; treating as success.",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+print(
+    f"Error: relink failed (exit {relink.returncode}) and '{executable}' was not updated.",
+    file=sys.stderr,
+)
+sys.exit(relink.returncode)

--- a/scripts/build/staticRelinker.py
+++ b/scripts/build/staticRelinker.py
@@ -11,6 +11,20 @@ import shlex
 
 arguments = list(sys.argv[1:])
 
+# Environment for backtick sub-expression expansion. The link line grepped from the
+# build log invokes helper scripts (notably libraryDependencies.py) that import from
+# the repository's python/ tree. Inside `make` that works because the Makefile exports
+# PYTHONPATH, but this script runs as a bare workflow step where PYTHONPATH is unset --
+# there the import dies with ModuleNotFoundError and, if the failure were swallowed,
+# the relink would silently run with no -l flags at all (undefined symbols for every
+# statically-linked library). Derive the python/ path from this script's own location
+# and prepend it, preserving any PYTHONPATH already present.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_EXPANSION_ENV = dict(os.environ)
+_EXPANSION_ENV['PYTHONPATH'] = os.path.join(_REPO_ROOT, 'python') + (
+    os.pathsep + _EXPANSION_ENV['PYTHONPATH'] if _EXPANSION_ENV.get('PYTHONPATH') else ''
+)
+
 # Find the output executable name from the -o flag.
 executable = None
 for i, arg in enumerate(arguments):
@@ -55,10 +69,22 @@ while i < len(arguments):
             i += 1
             to_expand += ' ' + arguments[i]
         to_expand = to_expand.strip('`')
-        expanded = subprocess.run(
-            to_expand, shell=True, capture_output=True, text=True
-        ).stdout.replace('\n', ' ')
-        compile_parts.append(expanded.strip())
+        expansion = subprocess.run(
+            to_expand, shell=True, capture_output=True, text=True,
+            env=_EXPANSION_ENV,
+        )
+        # A failed expansion must be fatal, not silently empty: an empty expansion of
+        # the libraryDependencies.py sub-expression would relink with no -l flags and
+        # fail with undefined symbols for every statically-linked library.
+        if expansion.returncode != 0:
+            sys.stderr.write(expansion.stderr)
+            print(
+                f"Error: expansion of backtick sub-expression failed "
+                f"(exit {expansion.returncode}): {to_expand}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        compile_parts.append(expansion.stdout.replace('\n', ' ').strip())
     else:
         compile_parts.append(arg)
     i += 1

--- a/scripts/build/staticRelinker.py
+++ b/scripts/build/staticRelinker.py
@@ -24,22 +24,24 @@ if executable is None:
 
 print(f"Executable is '{executable}'")
 
-# Split arguments into compile command and optional post-process command (after '2>&1').
-compile_parts      = []
-post_process_parts = []
-post_processing    = False
+# Shell operators that begin the plumbing appended to the link recipe in the
+# build log this line was grepped from: output redirection, pipes, command
+# terminators, and a trailing line-continuation backslash. None of it is part
+# of the link command this script must re-run (it reconstructs its own
+# invocation and lets its output flow to the console), so parsing stops at the
+# first such token and the remainder is discarded. This handles both the older
+# recipe shape ('... 2>&1 | ./scripts/build/postprocessLinker.py') and the
+# current one ('... > <stem>.link.diag 2>&1; \'), which redirects diagnostics
+# to a file for exit-status capture.
+_SHELL_PLUMBING = {'2>&1', '&>', '1>', '2>', '|', '||', '&&', ';', '&', '\\'}
+
+# Assemble the link command, expanding backtick-quoted sub-expressions.
+compile_parts = []
 i = 0
 while i < len(arguments):
     arg = arguments[i]
-    if arg == '2>&1':
-        post_processing = True
-        post_process_parts.append(arg)
-        i += 1
-        continue
-    if post_processing:
-        post_process_parts.append(arg)
-        i += 1
-        continue
+    if arg in _SHELL_PLUMBING or arg.startswith('>') or arg.startswith('<'):
+        break
     # Expand backtick-quoted shell expressions.
     if arg.startswith('`'):
         to_expand = arg
@@ -136,8 +138,8 @@ for line in otool_out.splitlines():
     elif os.path.exists(static_name):
         print(f" -> Found static library at '{static_name}'")
         escaped = re.escape(library_name_original)
-        if re.search(r'-l' + escaped + '(\s|$)', compile_command):
-            compile_command = re.sub(r'-l' + escaped + '(\s|$)', static_name + ' ', compile_command)
+        if re.search(r'-l' + escaped + r'(\s|$)', compile_command):
+            compile_command = re.sub(r'-l' + escaped + r'(\s|$)', static_name + ' ', compile_command)
         else:
             compile_command += ' ' + static_name
             if library_name in hide_dylib_libraries:
@@ -189,10 +191,6 @@ if is_gcc:
     compile_command += ' -static-libgcc'
 if is_gpp:
     compile_command += ' -static-libstdc++'
-
-# Append post-process command if present.
-if post_process_parts:
-    compile_command += ' ' + ' '.join(post_process_parts)
 
 # Temporarily move aside any dynamic libraries that would otherwise be preferred over the static
 # archives being linked, forcing the linker to use the static versions. They are restored below.


### PR DESCRIPTION
**PR 1 of 3** (stacked: this → `fix/build-dependency-graph` → `clean/build-dead-code`), implementing the first item of the build-infrastructure review action plan.

## Problem

Three paths in the build masked hard failures, letting `make` record failed steps as successful:

1. **Compile recipes** piped compiler output into `postprocess.py`, so the recipe's exit status was the postprocessor's (fails only on `^Error:` lines), not the compiler's. An ICE, segfault, or OOM kill emits no such line → the recipe "succeeded" and the missing object surfaced later as a confusing link error.
2. **Link recipes** piped through `postprocessLinker.py` the same way — and real link failures print `undefined reference` / `collect2: error: ld returned 1 exit status`, neither matching `^Error:`, so a failed link exited 0 and make recorded the executable as built.
3. **`profiler.sh`** (the SHELL under `GALACTICUS_BUILD_OPTION=compileprof`) discarded the wrapped command's status entirely and always exited 0 — make could not detect *any* failed recipe during a profiled build (CI survives today only by grepping the build log afterwards).

## Fix

Compiler/linker diagnostics now go to a temporary file which is postprocessed after capturing the tool's own exit status; the recipe fails if either the tool or the postprocessor reports failure. Applied to the Makefile `%.o` rule, the mirrored wrapper-unit recipe emitted by `libraryInterfacesDependencies.py` (sync-obligation comments added on both sides), and the link recipes generated by `findExecutables.py`. `postprocessLinker.py` additionally flags `error:` (case-insensitive), `undefined reference`, and `ld returned N exit status` lines as a second line of defense. `profiler.sh` captures and propagates the wrapped command's status.

## Verification

- Failure injection at each level: missing input file, type error, ICE-style silent failure (`f951: Fatal Error` with no `Error:` line), synthetic linker errors, and a failing recipe under the profiler SHELL — all now fail the recipe; clean compiles/links still pass, and the filtered-warning cases still exit 0.
- Clean full rebuild (`make -j20 Galacticus.exe`, 1,796 objects) and an incremental rebuild both succeed.

Note: merging this invalidates all existing objects (the `%.o` recipe changed and every object depends on the Makefile), so everyone's next build is a full rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)