### PR TITLE
clean(build): remove dead code from the build infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,6 @@ else
 CPPCOMPILER ?= g++
 endif
 
-# Linker for Condor standard universe executables. Uncomment the second line to link for submission to the Condor standard universe.
-CONDORLINKER = 
-#CONDORLINKER = condor_compile
-
 # Fortran compiler flags:
 FCFLAGS += -ffree-line-length-none -frecursive -DBUILDPATH=\'$(BUILDPATH)\' -J$(BUILDPATH)/moduleBuild/ -I$(BUILDPATH)/ ${GALACTICUS_FCFLAGS} -pthread
 # Fortran77 compiler flags:
@@ -104,7 +100,9 @@ F77FLAGS = ${GALACTICUS_F77FLAGS} -DBUILDPATH=\'$(BUILDPATH)\'
 FCFLAGS += -Wall -fbacktrace -ffpe-trap=invalid,zero,overflow -fdump-core
 # Add bounds checking.
 #FCFLAGS += -fbounds-check
-# A copy of the flags prior to any optimizations.
+# A copy of the flags prior to any optimizations. No longer used to compile anything: it is
+# recorded in output.build.environment.inc and reported as build provenance metadata by
+# source/output/build.F90.
 FCFLAGS_NOOPT := $(FCFLAGS)
 # Optimization flags.
 FCFLAGS += -O3 -ffinite-math-only -fno-math-errno
@@ -643,23 +641,10 @@ $(BUILDPATH)/%.cpp.gv : ./source/%.cpp
 $(BUILDPATH)/%.m : ./source/%.F90
 	@touch $(BUILDPATH)/$*.m
 
-# Executables (*.exe) are built by linking together all of the object files (*.o) specified in the associated dependency (*.d)
-# file.
-%.exe: $(BUILDPATH)/%.o $(BUILDPATH)/%.d `cat $(BUILDPATH)/$*.d` $(MAKE_DEPS)
-	./scripts/build/parameterDependencies.py `pwd` $*.exe
-	$(FCCOMPILER) -c $(BUILDPATH)/$*.parameters.F90 -o $(BUILDPATH)/$*.parameters.o $(FCFLAGS)
-	@if echo "$(MAKEFLAGS)" | grep -q -E -- ' -j1( |$$)'; then \
-	 useLocks=no; \
-	elif echo "$(MAKEFLAGS)" | grep -q -E -- ' -j( |$$)'; then \
-	 useLocks=$(LOCKMD5); \
-	elif echo "$(MAKEFLAGS)" | grep -q -E -- ' -j[0-9]+( |$$)'; then \
-	 useLocks=$(LOCKMD5); \
-	else \
-	 useLocks=no; \
-	fi; \
-	./scripts/build/sourceDigests.py `pwd` $*.exe $$useLocks
-	$(CCOMPILER) -c $(BUILDPATH)/$*.md5s.c -o $(BUILDPATH)/$*.md5s.o $(CFLAGS)
-	+$(CONDORLINKER) $(FCCOMPILER) `cat $*.d` $(BUILDPATH)/$*.parameters.o $(BUILDPATH)/$*.md5s.o -o $*.exe$(SUFFIX) $(FCFLAGS) $(FCFLAGS_LINK) `scripts/build/libraryDependencies.py $*.exe $(FCFLAGS)` 2>&1 | ./scripts/build/postprocessLinker.py
+# Executables (*.exe) are built by linking together all of the object files (*.o) specified in the
+# associated dependency (*.d) file. There is no generic `%.exe` pattern rule: findExecutables.py
+# discovers every program in the source tree and writes an explicit rule for each into
+# $(BUILDPATH)/Makefile_All_Execs (included below).
 
 # Library. These rules generate Fortran interface wrappers and their dependencies for the shared library build; the generator
 # scripts (libraryInterfaces.py, libraryInterfacesDependencies.py) are slow, so we only activate them when actually performing
@@ -839,7 +824,3 @@ parameters-catalog: $(BUILDPATH)/parameters.catalog.json
 # up to date.
 parameters-schema:
 	./scripts/build/parameterSchema.py `pwd` schema/parameters.xsd
-
-# Rules for XSpec code.
-aux/XSpec/%.o: ./aux/XSpec/%.f Makefile
-	$(FCCOMPILER) -c $< -o aux/XSpec/$*.o $(FCFLAGS)

--- a/scripts/build/buildCode.py
+++ b/scripts/build/buildCode.py
@@ -2,12 +2,12 @@
 # Scan source code for "!![…!!]" XML directives and dispatch the matching
 # generator.  Andrew Benson (ported to Python 2026)
 #
-# Mirrors scripts/build/buildCode.pl: the top-level driver that the build
-# system invokes once per `<directive>.xml` control file (see
-# codeDirectivesParse.py:327, where each include directive's Makefile rule
-# expands to `./scripts/build/buildCode.pl <install_dir> <directive_xml>`).
+# The top-level driver that the build system invokes once per
+# `<directive>.xml` control file: each include directive's Makefile rule
+# (written into Makefile_Directives by codeDirectivesParse.py) expands to
+# `./scripts/build/buildCode.py <install_dir> <directive_xml>`.
 #
-# The Perl driver scans every Fortran source file containing the named
+# The driver scans every Fortran source file containing the named
 # directive, accumulates each `<directive>` block's parsed XML body together
 # with the surrounding module name and source-file metadata, then dispatches
 # a `validate → parse → generate` pipeline registered by
@@ -228,29 +228,26 @@ def _xml_load(path):
 # ---------------------------------------------------------------------------
 
 def _scan_targets(directive, locations, source_directory):
-    """Return the list of files to scan for a given directive name.
+    """Return the list of files to scan for a given directive name, from the
+    pre-computed `directiveLocations.xml` map.
 
-    If the build cache `directiveLocations.xml` is available, take its
-    pre-computed list; otherwise fall back to every Fortran source file in
-    `source_directory`.
+    The map is required: the Makefile rules that invoke this script are
+    themselves written by codeDirectivesParse.py, which generates
+    `directiveLocations.xml` in the same run, so the file always exists in a
+    build. A missing map means this script was invoked out of sequence.
     """
-    if locations is not None and directive in locations:
-        files = locations[directive].get('file')
-        if files is None:
-            return []
-        return files if isinstance(files, list) else [files]
-
-    # Match `*.f`, `*.F`, `*.f90`, `*.F90`, `*.ft`, `*.Ft`, …
-    pattern = re.compile(r'\.[fF](90)?t?$')
-    out = []
-    for dirpath, dirnames, filenames in os.walk(source_directory):
-        dirnames[:] = sorted(d for d in dirnames if not d.startswith('.'))
-        for entry in filenames:
-            if entry.startswith('.#'):
-                continue
-            if pattern.search(entry):
-                out.append(os.path.join(dirpath, entry))
-    return out
+    if locations is None:
+        sys.exit(
+            "buildCode.py: directiveLocations.xml not found — run "
+            "./scripts/build/codeDirectivesParse.py first (in a build this "
+            "is done by the $(BUILDPATH)/directiveCatalogs.stamp rule)."
+        )
+    if directive not in locations:
+        return []
+    files = locations[directive].get('file')
+    if files is None:
+        return []
+    return files if isinstance(files, list) else [files]
 
 
 # ---------------------------------------------------------------------------
@@ -326,12 +323,9 @@ def _process_until_include_or_eof(fh, frame, build, source_directory,
     we exhausted the file.
     """
     while True:
-        try:
-            raw_line, processed_line, _ = get_fortran_line(fh) \
-                if build['codeType'] == 'fortran' \
-                else (fh.readline(), fh.readline(), '')
-        except StopIteration:
-            break
+        raw_line, processed_line, _ = get_fortran_line(fh) \
+            if build['codeType'] == 'fortran' \
+            else (fh.readline(), fh.readline(), '')
         if not raw_line and not processed_line:
             return None
 
@@ -397,8 +391,6 @@ def _process_until_include_or_eof(fh, frame, build, source_directory,
         if include_file is not None and os.path.exists(include_file):
             frame['position'] = fh.tell()
             return include_file, frame
-
-    return None
 
 
 def _consume_until_close(fh, build, xml_tag, frame, source_directory,

--- a/scripts/build/buildProfiler.py
+++ b/scripts/build/buildProfiler.py
@@ -94,14 +94,6 @@ with open(args.buildLogFile) as f:
         elif len(elements) > 2 and elements[0] == "./scripts/build/buildCode.py":
             elements[2] = elements[2].replace("./work/build/", "").replace("'", "")
             command = elements[2] + " (build)"
-        elif len(elements) > 8 and elements[1] == "-MRegexp::Common":
-            elements[8] = elements[8].replace("work/build/", "")
-            command = elements[8] + " (cpp)"
-        else:
-            if elements:
-                mb = re.match(r'\./scripts/build/(.*)\.pl', elements[0])
-                if mb:
-                    command = mb.group(1)
         tasks.append({
             'description': command,
             'startTime':   start_time,

--- a/scripts/build/codeDirectivesParse.py
+++ b/scripts/build/codeDirectivesParse.py
@@ -287,9 +287,11 @@ def main(argv):
     build_path        = os.environ['BUILDPATH']
     blob_path         = os.path.join(build_path, 'codeDirectives.blob')
 
-    # Load per-file cache and capture its mtime for freshness checks.
+    # Load per-file cache and capture its mtime for freshness checks. (A
+    # non-empty cache implies the blob file exists, since _load_cache returns
+    # `{}` when it is missing or unreadable.)
     directives_per_file = _load_cache(blob_path)
-    have_per_file       = bool(directives_per_file) and os.path.exists(blob_path)
+    have_per_file       = bool(directives_per_file)
     cache_mtime         = os.stat(blob_path).st_mtime if have_per_file else None
 
     # List source files under `<installDir>/source/`, recursing into
@@ -410,7 +412,12 @@ def main(argv):
             info      = include_directives[directive]
             file_name = re.sub(r'\.inc$', '.Inc', info['fileName'])
 
-            # Extra dependencies per directive-key suffix.
+            # Extra dependencies per directive-key suffix. NOTE: no directive
+            # of these kinds (`<base>.function`, `<base>.moduleUse`,
+            # `<base>.functionCall`) currently exists in the source tree — the
+            # only include directive is `type="component"` — so these branches
+            # are retained as future-proofing for directive types the
+            # generator machinery supports.
             extra_deps = []
             m = re.match(r'^([a-zA-Z0-9_]+)\.function$', directive)
             if m:

--- a/scripts/build/findExecutables.py
+++ b/scripts/build/findExecutables.py
@@ -86,7 +86,7 @@ def _scan_one(file_name):
     # name (e.g. `tests.nodes`) used for the user-facing executable so that
     # `make tests.nodes.exe`, CI matrices, and test harnesses keep working
     # unchanged after the source tree was made hierarchical.
-    obj_root = re.sub(r'\.[fF](90)?t?$', '', file_name)
+    obj_root = re.sub(r'\.[fF](90)?$', '', file_name)
     exe_root = obj_root.replace('/', '.')
 
     exe_name = None if exclude_from_all else exe_root + '.exe'
@@ -97,7 +97,7 @@ def _scan_one(file_name):
     # successful build of the executable. Capturing and testing both statuses makes link failures
     # fail the recipe immediately.
     rule = f"""\
-{exe_root}.exe: {work_dir}{obj_root}.o {work_dir}{obj_root}.d $(MAKE_DEPS) $(UPDATE_DEPS)
+{exe_root}.exe: {work_dir}{obj_root}.o {work_dir}{obj_root}.d $(MAKE_DEPS)
 \t./scripts/build/parameterDependencies.py `pwd` {obj_root}.exe
 \t$(FCCOMPILER) -c {work_dir}{obj_root}.parameters.F90 -o {work_dir}{obj_root}.parameters.o $(FCFLAGS)
 \t@if echo "$(MAKEFLAGS)" | grep -q -E -- ' -j1( |$$)'; then \\

--- a/scripts/build/includeDependencies.py
+++ b/scripts/build/includeDependencies.py
@@ -73,15 +73,18 @@ def _scan_one(file_name):
         with open(file_full, 'r', errors='replace') as fh:
             for line in fh:
                 m = re.match(
-                    r'''^\s*#??include\s*[<'"]((.+)\.(inc|h)\d*)['">](\s*!\s*NO_USES)?''',
+                    r'''^\s*#??include\s*[<'"](.+\.(inc|h)\d*)['">](\s*!\s*NO_USES)?''',
                     line
                 )
                 if not m:
                     continue
                 inc_name  = m.group(1)
-                ext       = m.group(3)
-                no_uses   = m.group(4) is not None
+                ext       = m.group(2)
+                no_uses   = m.group(3) is not None
                 if ext == 'inc':
+                    # The `automatic` flag records a `! NO_USES` marker, which
+                    # opts a generated include out of the auto-generated
+                    # dependency chain fed to Makefile_Use_Dependencies below.
                     included_files.append({'fileName': inc_name, 'automatic': not no_uses})
                 elif ext == 'h':
                     # Only include .h files not already present in source or system dirs.
@@ -90,7 +93,7 @@ def _scan_one(file_name):
                         os.path.exists(os.path.join(d, inc_name)) for d in c_include_dirs
                     )
                     if not in_source and not in_system:
-                        included_files.append({'fileName': inc_name, 'automatic': not no_uses})
+                        included_files.append({'fileName': inc_name})
     except OSError:
         return "", []
 
@@ -108,7 +111,7 @@ def _scan_one(file_name):
     # Collect auto-generated .inc dependencies for Makefile_Use_Dependencies.
     dependency_file_names = []
     for inc in included_files:
-        if inc['fileName'].endswith('.inc') and inc['automatic']:
+        if inc['fileName'].endswith('.inc') and inc.get('automatic'):
             unpp = re.sub(r'\.inc$', '.Inc', inc['fileName'])
             if os.path.exists(os.path.join(source_directory, unpp)):
                 dependency_file_names.append(unpp)

--- a/scripts/build/libraryInterfaces.py
+++ b/scripts/build/libraryInterfaces.py
@@ -6,18 +6,14 @@ import sys
 import os
 import re
 import keyword
-from pathlib import Path
-
-# Set up path for imports from python/
 
 import xml.etree.ElementTree as ET
 from Galacticus.Build import SourceTree
 from Galacticus.Build.SourceTree.Parse import Declarations
-from List.ExtraUtils import as_array, hash_list, sorted_keys
+from List.ExtraUtils import as_array
 from Sort.Topo import sort as topo_sort
 from XML.Utils import xml_to_dict
 
-from LibraryInterfaces.ArgSpec import ArgSpec
 from LibraryInterfaces.Pipeline import (
     assign_c_types,
     assign_c_attributes,
@@ -61,9 +57,9 @@ def main():
     _CLASS_HIERARCHY = build_type_hierarchy(
         os.path.join(exec_path, 'source'))
 
-    directive_locations = _load_xml(os.path.join(build_path, 'directiveLocations.xml'), required=True)
-    state_storables = _load_xml(os.path.join(build_path, 'stateStorables.xml'), required=True)
-    library_classes = _load_xml(os.path.join(exec_path, 'source', 'libraryClasses.xml'), required=True)
+    directive_locations = _load_xml(os.path.join(build_path, 'directiveLocations.xml'))
+    state_storables = _load_xml(os.path.join(build_path, 'stateStorables.xml'))
+    library_classes = _load_xml(os.path.join(exec_path, 'source', 'libraryClasses.xml'))
 
     # stateStorables.xml stores functionClasses as a flat list of elements each
     # carrying name= and module= attributes.  XML::Simple re-keys these by name
@@ -108,26 +104,20 @@ def main():
     _write_python_interface(python)
 
 
-def _load_xml(path, required=False):
-    """Load and parse XML file into nested dict structure.
-
-    If *required* is True, exits with a descriptive message when the file is
-    missing or cannot be parsed rather than silently returning an empty dict.
+def _load_xml(path):
+    """Load and parse an XML file into a nested dict structure, exiting with
+    a descriptive message when the file is missing or cannot be parsed.
     """
     if not os.path.exists(path):
-        if required:
-            sys.exit(f"libraryInterfaces.py: required XML file not found: {path}")
-        return {}
+        sys.exit(f"libraryInterfaces.py: required XML file not found: {path}")
     try:
         root = ET.parse(path).getroot()
         return xml_to_dict(root)
     except ET.ParseError as exc:
-        if required:
-            sys.exit(
-                f"libraryInterfaces.py: failed to parse required XML file"
-                f" '{path}': {exc}"
-            )
-        return {}
+        sys.exit(
+            f"libraryInterfaces.py: failed to parse required XML file"
+            f" '{path}': {exc}"
+        )
 
 
 

--- a/scripts/build/libraryInterfacesAudit.py
+++ b/scripts/build/libraryInterfacesAudit.py
@@ -44,10 +44,16 @@ be built first.  It does need the rest of the python/ tree on PYTHONPATH
 (or installed via ``pip install -e .``) so SourceTree.parse_file is
 available; the Makefile already exports PYTHONPATH for build commands.
 
+**This is a manual developer tool**: nothing in the Makefile or CI invokes
+it — run it by hand when planning library-interface coverage work.  Because
+it is not exercised automatically, its copies of the generator's
+classification regexes and predicates (marked "MUST stay in sync" below)
+can drift from libraryInterfaces.py without anything noticing; check them
+against the generator before trusting a READY report.
+
 Andrew Benson (drafted with assistance from Claude 2026)
 """
 
-import os
 import re
 import sys
 from collections import defaultdict

--- a/scripts/build/moduleDependencies.py
+++ b/scripts/build/moduleDependencies.py
@@ -3,16 +3,14 @@
 Makefile rules that tell the Galacticus build system how to produce `.mod`
 and `.smod` files from their owning object files.
 
-For every `.f` / `.f90` source file under `<installDir>/source/` (one level
-deep), this script:
+For every `.f` / `.f90` source file under `<installDir>/source/` (recursing
+into subdirectories to any depth), this script:
 
 * Extracts every `module <name>` and `submodule (<parent>[:<grand>]) <name>`
   declaration (skipping text inside `!!{…!!}` LaTeX and `!![…!!]` XML blocks).
 * For every `functionClass` directive in the file, walks each instance file
   listed in `directiveLocations.xml` to discover the concrete derived types
   and synthesises one functionClass-submodule entry per derived type.
-* Follows `include '<leaf>'` statements that reference files under the
-  top-level `source/` directory, scanning them for the same constructs.
 * Emits Makefile rules for each discovered module / submodule target: the
   `<mod>.mod`, `<mod>@<sub>.smod`, `<src>.o`, `<src>.p.F90`, `<mod>.mod.d`,
   `<mod>.mod.gv`, `<src>.m`, `<src>.smod` dependencies the main build
@@ -57,7 +55,6 @@ _SUBMODULE_LINE_RE = re.compile(
     r'\s*([a-zA-Z0-9_]+)$',
     re.IGNORECASE,
 )
-_INCLUDE_LINE_RE   = re.compile(r"""include\s+'(\w+)'""", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -128,7 +125,7 @@ def _list_source_files(directory):
 # ---------------------------------------------------------------------------
 
 def _find_function_class_submodules(directive_name, function_class_file,
-                                    locations, source_root):
+                                    source_root):
     """Return the list of submodule records produced by one `functionClass`
     directive.  Mirrors moduleDependencies.pl:97-133.
     """
@@ -188,70 +185,68 @@ def _find_function_class_submodules(directive_name, function_class_file,
 # Per-file Fortran scan
 # ---------------------------------------------------------------------------
 
-def _scan_file(stack, entry, source_root):
-    """Drive the include stack rooted at `stack`, populating `entry` (which
-    may be a plain dict; expected keys populated: `files`, `modulesProvided`,
-    `submodulesProvided`).
+def _scan_file(file_path, entry, source_root):
+    """Scan one source file, populating `entry` (a plain dict; keys
+    populated: `modulesProvided`, `submodulesProvided`).
+
+    `include`d files are not followed: a Fortran `include` cannot introduce
+    a `module`/`submodule` statement in this codebase (module declarations
+    are never placed in include files), and the include-following the Perl
+    original attempted was inert anyway — its `include\\s+'(\\w+)'` regex
+    could not match any real include in the tree (all include file names
+    contain a `.`, which `\\w` excludes).
     """
-    while stack:
-        file_path = stack.pop()
-        in_xml   = False
-        in_latex = False
-        try:
-            fh = open(file_path, 'r', errors='replace')
-        except OSError:
-            sys.exit("moduleDependencies.py: can not open input file: "
-                     + file_path)
-        try:
-            for line in fh:
-                # Leave XML/LaTeX blocks on their closing markers.
-                if _XML_CLOSE_RE.match(line):
-                    in_xml = False
-                if _LATEX_CLOSE_RE.match(line):
-                    in_latex = False
-                if in_xml or in_latex:
-                    continue
+    in_xml   = False
+    in_latex = False
+    try:
+        fh = open(file_path, 'r', errors='replace')
+    except OSError:
+        sys.exit("moduleDependencies.py: can not open input file: "
+                 + file_path)
+    try:
+        for line in fh:
+            # Leave XML/LaTeX blocks on their closing markers.
+            if _XML_CLOSE_RE.match(line):
+                in_xml = False
+            if _LATEX_CLOSE_RE.match(line):
+                in_latex = False
+            if in_xml or in_latex:
+                continue
 
-                stripped = _STRIP_COMMENT_RE.sub('', line)
+            stripped = _STRIP_COMMENT_RE.sub('', line)
 
-                m = _MODULE_LINE_RE.match(stripped)
-                if m:
-                    entry.setdefault('modulesProvided', []).append(
-                        m.group(1).lower() + '.mod',
-                    )
+            m = _MODULE_LINE_RE.match(stripped)
+            if m:
+                entry.setdefault('modulesProvided', []).append(
+                    m.group(1).lower() + '.mod',
+                )
 
-                m = _SUBMODULE_LINE_RE.match(stripped)
-                if m:
-                    parent_mod = m.group(1).lower() + '.mod'
-                    submodule_name = m.group(3).lower()
-                    leaf = re.sub(r'\.[fF]90$', '',
-                                  os.path.relpath(file_path, source_root))
-                    entry.setdefault('submodulesProvided', []).append({
-                        'moduleName': parent_mod,
-                        'submodule':  {
-                            'name':          submodule_name,
-                            'fileName':      leaf,
-                            'source':        file_path,
-                            'extends':       None,
-                            'functionClass': False,
-                        },
-                    })
+            m = _SUBMODULE_LINE_RE.match(stripped)
+            if m:
+                parent_mod = m.group(1).lower() + '.mod'
+                submodule_name = m.group(3).lower()
+                leaf = re.sub(r'\.[fF]90$', '',
+                              os.path.relpath(file_path, source_root))
+                entry.setdefault('submodulesProvided', []).append({
+                    'moduleName': parent_mod,
+                    'submodule':  {
+                        'name':          submodule_name,
+                        'fileName':      leaf,
+                        'source':        file_path,
+                        'extends':       None,
+                        'functionClass': False,
+                    },
+                })
 
-                m = _INCLUDE_LINE_RE.search(stripped)
-                if m:
-                    include_path = os.path.join(source_root, m.group(1))
-                    stack.append(include_path)
-                    entry.setdefault('files', []).append(include_path)
-
-                # Enter XML/LaTeX blocks on their opening markers (check
-                # AFTER processing the line so `!![` itself is not mistaken
-                # for code).
-                if _XML_OPEN_RE.match(line):
-                    in_xml = True
-                if _LATEX_OPEN_RE.match(line):
-                    in_latex = True
-        finally:
-            fh.close()
+            # Enter XML/LaTeX blocks on their opening markers (check
+            # AFTER processing the line so `!![` itself is not mistaken
+            # for code).
+            if _XML_OPEN_RE.match(line):
+                in_xml = True
+            if _LATEX_OPEN_RE.match(line):
+                in_latex = True
+    finally:
+        fh.close()
 
 
 # ---------------------------------------------------------------------------
@@ -290,7 +285,7 @@ def _scan_one(task):
         for fc_file in as_array((locations.get(fc['name']) or {}).get('file')):
             submodules_for_file.extend(
                 _find_function_class_submodules(
-                    fc['name'], fc_file, locations, source_root,
+                    fc['name'], fc_file, source_root,
                 )
             )
 
@@ -302,7 +297,7 @@ def _scan_one(task):
     entry['sourceDirectoryDescriptor'] = desc
     entry.setdefault('modulesProvided', [])
 
-    _scan_file([file_path], entry, source_root)
+    _scan_file(file_path, entry, source_root)
     return file_identifier, name, desc, entry
 
 

--- a/scripts/build/postprocess.py
+++ b/scripts/build/postprocess.py
@@ -13,17 +13,13 @@ if len(sys.argv) != 2:
 preprocessed_source = sys.argv[1]
 
 # Detect whether stdout is a terminal (for colour output).
-try:
-    import sys as _sys
-    _have_color = _sys.stdout.isatty()
-    if _have_color:
-        # ANSI colour codes.
-        _BRIGHT_MAGENTA_BOLD = '\033[1;35m'
-        _BRIGHT_GREEN_BOLD   = '\033[1;32m'
-        _BOLD                = '\033[1m'
-        _RESET               = '\033[0m'
-except Exception:
-    _have_color = False
+_have_color = sys.stdout.isatty()
+if _have_color:
+    # ANSI colour codes.
+    _BRIGHT_MAGENTA_BOLD = '\033[1;35m'
+    _BRIGHT_GREEN_BOLD   = '\033[1;32m'
+    _BOLD                = '\033[1m'
+    _RESET               = '\033[0m'
 
 # --- Parse the line-number map (.lmap file) ---
 _map = [

--- a/scripts/build/preprocess.py
+++ b/scripts/build/preprocess.py
@@ -6,6 +6,10 @@ runs every registered process hook, optionally analyzes the tree, and writes
 the resulting source — together with a `.lmap` line-number mapping file — to
 the requested output path.
 
+Setting `GALACTICUS_PREPROCESSOR_ANALYZE=yes` in the environment runs the
+tree analyzer after processing. This is a manual debugging hook only — no
+Makefile rule or CI workflow sets it.
+
 Mirrors scripts/build/preprocess.pl.
 Andrew Benson (ported to Python 2026).
 """

--- a/scripts/build/useDependencies.py
+++ b/scripts/build/useDependencies.py
@@ -571,9 +571,8 @@ _INCLUDE_LINE_RE    = re.compile(
 
 def _update_conditional_compile(stack, preprocessor_directives):
     """Mirrors the foreach loop at useDependencies.pl:374-383."""
-    preprocessor_directives_set = preprocessor_directives
     for entry in stack:
-        name_defined = entry['name'] in preprocessor_directives_set
+        name_defined = entry['name'] in preprocessor_directives
         active = entry['state'] if name_defined else 1 - entry['state']
         if active == 0:
             return False
@@ -588,10 +587,6 @@ def _scan_source_file(sources_entry, file_names_to_process, source_file,
     """
     while file_names_to_process:
         full_path = file_names_to_process.pop()
-        if not os.path.exists(full_path):
-            leaf_m = re.search(r'/([\w.]+?)$', full_path)
-            leaf = leaf_m.group(1) if leaf_m else full_path
-            subprocess.run(['make', leaf], check=False)
 
         if re.search(r'\.cpp$', full_path, re.IGNORECASE):
             sources_entry['libraryDependencies']['stdc++'] = True


### PR DESCRIPTION
**PR 3 of 3**, stacked on #1220 (`fix/build-dependency-graph`); merge that first — GitHub will retarget this PR when its base branch is deleted. Implements item 4 of the build-infrastructure review action plan: pure dead-code removal plus a few clarifying comments (net −39 lines; no behavior change on any live path).

Each removal was verified unreachable or unreferenced before deletion:

- **Makefile**: the generic `%.exe` pattern rule — every executable gets an explicit rule from `findExecutables.py`, and the pattern rule's backtick/`$*` prerequisites can't work without `.SECONDEXPANSION`, so it could never fire (a comment now points readers at the generated rules). With it go `CONDORLINKER` (Condor standard universe is long discontinued; that rule was its only user) and the `aux/XSpec` rule (`aux/XSpec/` doesn't exist). `FCFLAGS_NOOPT` is kept but documented as provenance-only.
- **findExecutables.py**: `$(UPDATE_DEPS)` (defined nowhere) dropped from generated prerequisites; unreachable `t?` in the stem regex.
- **moduleDependencies.py**: inert include-following — its `include\s+'(\w+)'` regex could not match any real include in the tree (all include names contain a `.`, which `\w` excludes), so the branch never fired; plus an unused parameter and stale docstring text.
- **useDependencies.py**: the near-unreachable, broken-if-reached `subprocess.run(['make', leaf])` missing-file fallback; a pointless alias.
- **buildCode.py**: the fallback tree walk (the Makefile ordering guarantees `directiveLocations.xml` exists; a missing map is now a clear out-of-sequence error), a dead `except StopIteration` and the unreachable return behind it, and a stale header comment still citing `buildCode.pl`.
- **buildProfiler.py**: Perl-era command simplifiers (no Perl remains in the build).
- **includeDependencies.py**: unused regex group; meaningless `automatic` flag on header entries (the flag's real meaning — the `! NO_USES` opt-out — is now documented where it's set).
- **libraryInterfaces.py**: unused imports, stale `sys.path`-shim comment, dead `required=False` branches in `_load_xml`.
- **postprocess.py**: the pointless `try: import sys as _sys` construct.
- **codeDirectivesParse.py**: redundant blob-existence re-check; the currently-unused `<base>.function`/`.moduleUse`/`.functionCall` branches are kept but documented as future-proofing.
- **preprocess.py**: `GALACTICUS_PREPROCESSOR_ANALYZE` documented as a manual-only debugging hook.
- **libraryInterfacesAudit.py**: unused import; docstring now states it is a manual developer tool invoked by nothing in the Makefile or CI, and warns that its deliberately duplicated classification predicates can silently drift from the generator (they already have, on `omp_lock_kind` — de-duplication is a planned follow-up; deleting the script outright remains an option).

## Verification

Clean full rebuild (`make -j20 Galacticus.exe`, 1,796 objects) and incremental rebuild with the complete three-PR stack applied; the stacked tip is byte-identical to the tree those builds ran on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)