### PR TITLE
perf(build): eliminate redundant reads, parses, and rewrites in the build scripts

### DIFF
--- a/python/Galacticus/Build/Directives.py
+++ b/python/Galacticus/Build/Directives.py
@@ -41,12 +41,17 @@ def _matches_conditions(directive: dict, conditions: dict | None) -> bool:
     return True
 
 
-def extract_directives(file_name: str, directive_name: str,
+def extract_directives(file_name: str, directive_name,
                        conditions: dict | None = None,
                        set_root_element_type: bool = False) -> list[dict]:
     """Return every directive in `file_name` whose root element matches
-    `directive_name` (or whose root element is anything when `directive_name`
-    is `'*'`).
+    `directive_name` — a single name, a set/tuple/list of names, or `'*'`
+    to match any root element.
+
+    Passing several names in one call reads and parses the file once
+    (each call performs a full line-by-line read, so N single-name calls
+    cost N reads); use `set_root_element_type=True` to recover which name
+    each returned directive matched.
 
     Mirrors Perl Extract_Directives (Directives.pm:80-98) plus the underlying
     state machine from Extract_Directive (Directives.pm:11-78):
@@ -124,7 +129,7 @@ def extract_directive(file_name: str, directive_name: str, **kwargs: Any) -> dic
     return directives[0] if directives else None
 
 
-def _parse_xml_block(xml_text: str, file_name: str, directive_name: str,
+def _parse_xml_block(xml_text: str, file_name: str, directive_name,
                      conditions: dict | None,
                      set_root_element_type: bool) -> dict | None:
     """Parse one accumulated XML block and return a dict if the root matches
@@ -142,7 +147,10 @@ def _parse_xml_block(xml_text: str, file_name: str, directive_name: str,
             f"'{directive_name}' from '{file_name}': {exc}\nXML content was:\n{xml_text}"
         )
 
-    if directive_name != '*' and elem.tag != directive_name:
+    if isinstance(directive_name, str):
+        if directive_name != '*' and elem.tag != directive_name:
+            return None
+    elif elem.tag not in directive_name:
         return None
 
     directive = xml_to_dict(elem)

--- a/scripts/build/libraryInterfaces.py
+++ b/scripts/build/libraryInterfaces.py
@@ -9,6 +9,7 @@ import keyword
 
 import xml.etree.ElementTree as ET
 from Galacticus.Build import SourceTree
+from Galacticus.Build.FileChanges import update as file_changes_update
 from Galacticus.Build.SourceTree.Parse import Declarations
 from List.ExtraUtils import as_array
 from Sort.Topo import sort as topo_sort
@@ -248,8 +249,13 @@ def _process_implementations(func_class, directive_locations, state_storables,
 
     extensions = {}
     module_uses_impls = {}
+    class_id = 0
+    impls_list = []
 
-    # First pass: collect extensions and module uses per implementation file.
+    # Each implementation file is parsed once and its tree walked twice —
+    # first for extensions/module-uses, then for constructor discovery.
+    # (Previously two sequential passes each re-parsed every file; parsing
+    # dominates this script's cost.)
     for impl_file in as_array(impls):
         tree = SourceTree.parse_file(impl_file)
         impl_name = None
@@ -276,11 +282,7 @@ def _process_implementations(func_class, directive_locations, state_storables,
             if not is_excluded:
                 module_uses_impls[impl_name] = local_module_uses
 
-    # Second pass: find constructors and build the implementations list.
-    class_id = 0
-    impls_list = []
-    for impl_file in as_array(impls):
-        tree = SourceTree.parse_file(impl_file)
+        # Constructor discovery (second walk of the same tree).
         impl_name = None
         is_abstract = False
         name_constructor = None
@@ -1340,23 +1342,37 @@ def _write_fortran_code(code, build_path):
     written = set()
 
     if 'main' in code:
+        # Written unconditionally, NOT only-if-changed: libgalacticus.Inc is
+        # the target of the Makefile rule that runs this script, so its mtime
+        # must advance past the rule's prerequisites or make would re-run the
+        # (slow) generator on every invocation. The downstream re-preprocess
+        # of this single file is cheap.
         main_file = os.path.join(build_path, 'libgalacticus.Inc')
         with open(main_file, 'w') as fh:
             fh.write('\n'.join(code['main']) + '\n')
+
+    # The per-class/per-impl wrapper units are written only-if-changed
+    # (mtime preserved when identical): their generated make rules run this
+    # script only when the file is missing, so a stable mtime is safe here —
+    # and it stops an unrelated catalog change from cascading into a
+    # re-preprocess and recompile of every one of the ~1500 wrapper units.
+    def _write_unit(path, lines):
+        tmp = path + '.tmp'
+        with open(tmp, 'w') as fh:
+            fh.write('\n'.join(lines) + '\n')
+        file_changes_update(path, tmp)
 
     for class_name in sorted(k for k in code if k != 'main'):
         bucket = code[class_name]
         # Shared pieces (GetPtr, GetIdAndPtr, methods, destructor) go to
         # <class>.F90.
-        shared_file = os.path.join(out_dir, f'{class_name}.F90')
-        with open(shared_file, 'w') as fh:
-            fh.write('\n'.join(bucket['shared']) + '\n')
+        _write_unit(os.path.join(out_dir, f'{class_name}.F90'),
+                    bucket['shared'])
         written.add(f'{class_name}.F90')
         # One file per concrete impl's constructor wrapper.
         for impl_name, blocks in sorted(bucket['per_impl'].items()):
-            impl_file = os.path.join(out_dir, f'{class_name}__{impl_name}.F90')
-            with open(impl_file, 'w') as fh:
-                fh.write('\n'.join(blocks) + '\n')
+            _write_unit(os.path.join(out_dir, f'{class_name}__{impl_name}.F90'),
+                        blocks)
             written.add(f'{class_name}__{impl_name}.F90')
 
     # Remove any stale .F90 (and matching .p.F90, .o, .d, .m) files that
@@ -1364,7 +1380,8 @@ def _write_fortran_code(code, build_path):
     # exclude="yes" or whose constructor newly fails the predicate would
     # otherwise leave a dangling object the linker still pulls in.
     for fname in os.listdir(out_dir):
-        if fname.endswith('.F90') and fname not in written:
+        if (fname.endswith('.F90') and not fname.endswith('.p.F90')
+                and fname not in written):
             stem = fname[:-len('.F90')]
             for ext in ('.F90', '.p.F90', '.p.F90.up', '.o', '.d', '.m'):
                 stale = os.path.join(out_dir, stem + ext)

--- a/scripts/build/libraryInterfacesDependencies.py
+++ b/scripts/build/libraryInterfacesDependencies.py
@@ -34,7 +34,10 @@ if not os.path.isdir(out_dir):
 # and avoids spurious git diffs in the generated Makefile fragment).
 units = sorted(f[:-len('.F90')]
                for f in os.listdir(out_dir)
-               if f.endswith('.F90'))
+               # Exclude preprocessed `<unit>.p.F90` files, which live in the
+               # same directory: they are build products of the units, not
+               # units themselves.
+               if f.endswith('.F90') and not f.endswith('.p.F90'))
 
 rules = []
 for name in units:

--- a/scripts/build/postprocess.py
+++ b/scripts/build/postprocess.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import bisect
 import re
 import sys
 
@@ -11,6 +12,15 @@ if len(sys.argv) != 2:
     sys.exit(1)
 
 preprocessed_source = sys.argv[1]
+
+# Fast path: a clean compile produces no diagnostics at all. Read the first
+# input line before anything else — if there is none, skip the (relatively
+# expensive) pre-scan of the preprocessed source and the .lmap parse
+# entirely. Every compile pays this script's cost, and most compiles are
+# clean.
+_first_line = sys.stdin.readline()
+if not _first_line:
+    sys.exit(0)
 
 # Detect whether stdout is a terminal (for colour output).
 _have_color = sys.stdout.isatty()
@@ -41,6 +51,8 @@ try:
                 })
 except OSError:
     pass  # If there's no .lmap file, the map stays minimal.
+
+_map_keys = [entry['lineOriginal'] for entry in _map]
 
 # --- Pre-scan the preprocessed source for compiler directives ---
 unused_functions       = {}   # function name → True
@@ -165,17 +177,18 @@ _opener_re = {
         re.IGNORECASE),
 }
 
-for line in sys.stdin:
+import itertools
+
+for line in itertools.chain([_first_line], sys.stdin):
     # --- Remap preprocessed file:line references ---
     m = re.match(r'^([a-zA-Z0-9_./]+\.p\.F90):(\d+):([\d\-]+):\s*$', line)
     if m:
         line_original = int(m.group(2))
         flag          = m.group(3)
-        source_entry  = _map[0]
-        for entry in _map:
-            if entry['lineOriginal'] > line_original:
-                break
-            source_entry = entry
+        # The .lmap entries are in ascending lineOriginal order; find the
+        # last entry at or before this line.
+        idx = bisect.bisect_right(_map_keys, line_original) - 1
+        source_entry = _map[idx]
         src = source_entry['source']
         if src.endswith('()'):
             line_descriptor = "auto-generated code (no line number)"

--- a/scripts/build/useDependencies.py
+++ b/scripts/build/useDependencies.py
@@ -72,10 +72,14 @@ def _scan_one(task):
         'libraryDependencies':  {},
     }
 
-    directives = {
-        name: extract_directives(file_path, name)
-        for name in _DIRECTIVE_NAMES
-    }
+    # One read/parse of the file for all directive names (extract_directives
+    # performs a full file read per call, so per-name calls would cost
+    # len(_DIRECTIVE_NAMES) reads). rootElementType is popped so the per-name
+    # directive dicts are identical to those a single-name call returns.
+    directives = {name: [] for name in _DIRECTIVE_NAMES}
+    for directive in extract_directives(file_path, _DIRECTIVE_NAMES,
+                                        set_root_element_type=True):
+        directives[directive.pop('rootElementType')].append(directive)
 
     file_names_to_process = [file_path]
     event_hook_modules = []
@@ -329,6 +333,50 @@ def _method_module_names(method):
     return []
 
 
+# Per-process memos for _apply_directive_requirements: every file carrying a
+# `functionsGlobal` (or `eventHookStatic`) directive needs the same
+# information about the functionGlobal location files, which previously was
+# re-derived — including full re-reads of those files — once per requesting
+# source file. Workers are forked processes, so each builds these at most
+# once per run.
+_FG_POINTER_MODULES    = None
+_CONTAINING_MODULE_MEMO = {}
+
+
+def _functionglobal_pointer_modules(locations):
+    """Module names imported by `functionsGlobal type="pointers"` users: the
+    (deduplicated-in-order) modules declared by every `functionGlobal`
+    directive, excluding iso_c_binding."""
+    global _FG_POINTER_MODULES
+    if _FG_POINTER_MODULES is None:
+        modules = []
+        for fg_file in as_array(
+            (locations.get('functionGlobal') or {}).get('file')
+            if locations else None,
+        ):
+            for d in extract_directives(fg_file, 'functionGlobal'):
+                module_val = d.get('module')
+                if module_val is None:
+                    continue
+                for module in as_array(module_val):
+                    name = str(module).strip()
+                    m = re.match(r'^([a-zA-Z0-9_]+)', name)
+                    if m and m.group(1).lower() != 'iso_c_binding':
+                        modules.append(m.group(1).lower())
+        _FG_POINTER_MODULES = modules
+    return _FG_POINTER_MODULES
+
+
+def _find_containing_module_memo(file_name, fc_map):
+    """Memoized _find_containing_module (the fc_map is identical across all
+    calls within one run)."""
+    if file_name not in _CONTAINING_MODULE_MEMO:
+        _CONTAINING_MODULE_MEMO[file_name] = _find_containing_module(
+            file_name, {'functionClasses': fc_map},
+        )
+    return _CONTAINING_MODULE_MEMO[file_name]
+
+
 def _apply_directive_requirements(entry, source_file, directives,
                                   locations, state_storables,
                                   work_dir, file_identifier,
@@ -390,28 +438,17 @@ def _apply_directive_requirements(entry, source_file, directives,
         if has_pointers:
             entry['modulesUsed'].append(work_dir + 'error.mod')
             entry['modulesUsed'].append(work_dir + 'input_parameters.mod')
-            for fg_file in as_array(
-                (locations.get('functionGlobal') or {}).get('file')
-                if locations else None,
-            ):
-                for d in extract_directives(fg_file, 'functionGlobal'):
-                    module_val = d.get('module')
-                    if module_val is None:
-                        continue
-                    for module in as_array(module_val):
-                        name = str(module).strip()
-                        m = re.match(r'^([a-zA-Z0-9_]+)', name)
-                        if m and m.group(1).lower() != 'iso_c_binding':
-                            entry['modulesUsed'].append(
-                                work_dir + m.group(1).lower() + '.mod'
-                            )
+            for module_name in _functionglobal_pointer_modules(locations):
+                entry['modulesUsed'].append(
+                    work_dir + module_name + '.mod'
+                )
 
         if has_establish:
             for fg_file in as_array(
                 (locations.get('functionGlobal') or {}).get('file')
                 if locations else None,
             ):
-                module_name = _find_containing_module(fg_file, {'functionClasses': fc_map})
+                module_name = _find_containing_module_memo(fg_file, fc_map)
                 if module_name is None:
                     sys.exit(
                         "useDependencies.py: unable to locate containing "
@@ -429,9 +466,7 @@ def _apply_directive_requirements(entry, source_file, directives,
                 if locations else None,
             )
             for ehs_file in ehs_files:
-                module_name = _find_containing_module(
-                    ehs_file, {'functionClasses': fc_map},
-                )
+                module_name = _find_containing_module_memo(ehs_file, fc_map)
                 if module_name is None:
                     sys.exit(
                         "useDependencies.py: unable to locate containing "


### PR DESCRIPTION
**PR 6 of 7**, stacked on #1223. Implements item 7 of the review action plan in three commits.

- **Library-interface generation**: each implementation file is parsed once (two walks of one tree) instead of twice — parsing dominates the generator's cost, and a full generation run roughly halves. The per-class/per-impl wrapper `.F90` units are written only-if-changed, so an unrelated catalog change no longer cascades into re-preprocessing and recompiling all ~1,500 wrapper units (`libgalacticus.Inc` itself stays an unconditional write — it is the target of the rule that runs the generator, so its mtime must advance). Prerequisite fix shipped first: the stale-wrapper sweep (and the unit enumeration in `libraryInterfacesDependencies.py`) matched live `<unit>.p.F90` files; both were masked by the unconditional rewrites and would have deleted live build products once write-if-changed landed.
- **useDependencies**: `extract_directives` now accepts a set of names, and the per-file worker makes one call instead of eight (each call is a full file read — nine reads per file per scan, counting the main scan). The functionGlobal module list and containing-module lookups are memoized per worker process instead of being re-derived (with full file re-reads) once per requesting source file. A full uncached rescan of the source tree drops to ~5s.
- **postprocess.py**: exits immediately when the compiler emitted no diagnostics (the common case, previously paying a full pre-scan of the preprocessed source per object file), and uses binary search over the line map.

One review sub-item deliberately deferred: parallelizing `sourceDigests.py` — its `find_hash` `.md5` sidecar writes would race *within* a run whenever `useLocks=no`, so it needs the locking design reworked first.

## Verification

Byte-identical outputs for every refactored path: full lib-generation run (all 1,518 wrappers), `Makefile_Use_Dependencies` from a full uncached rescan, and postprocess output/exit-status A/B on a failing compile. A planted `<unit>.p.F90` survives the fixed sweep; a no-op generator rerun rewrites zero files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)