### PR TITLE
fix(build): make useDependencies' conditional-compilation parsing sound

### DIFF
--- a/scripts/build/tests/test_use_dependencies_conditionals.py
+++ b/scripts/build/tests/test_use_dependencies_conditionals.py
@@ -1,0 +1,231 @@
+"""Tests for useDependencies.py's conditional-compilation handling.
+
+Covers the two state machines that previously mis-parsed real inputs:
+
+* the Makefile-conditional scanner (`_collect_preprocessor_directives`),
+  which desynchronized its stack on `ifneq` (no push, but its `endif`
+  still popped) and ignored `else`;
+* the source-side preprocessor stack, which treated `#if <expression>`
+  blocks as *inactive* (silently dropping the `use` statements inside
+  them), did not recognize `#elif`, and rejected lowercase `#ifndef`
+  macro names.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir))
+import useDependencies as ud  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _update_conditional_compile
+# ---------------------------------------------------------------------------
+
+def test_ifdef_defined_active():
+    stack = [{'name': 'USEMPI', 'state': 1}]
+    assert ud._update_conditional_compile(stack, {'USEMPI'})
+
+
+def test_ifdef_undefined_inactive():
+    stack = [{'name': 'USEMPI', 'state': 1}]
+    assert not ud._update_conditional_compile(stack, set())
+
+
+def test_ifndef_undefined_active():
+    stack = [{'name': 'USEMPI', 'state': 0}]
+    assert ud._update_conditional_compile(stack, set())
+
+
+def test_unknown_entry_always_active():
+    # `#if <expression>` blocks are unevaluable: every branch is scanned.
+    stack = [{'name': None, 'state': 1, 'unknown': True}]
+    assert ud._update_conditional_compile(stack, set())
+    # ...even after an #else flip.
+    stack[0]['state'] = 0
+    assert ud._update_conditional_compile(stack, set())
+
+
+def test_nested_false_branch_wins():
+    stack = [
+        {'name': None, 'state': 1, 'unknown': True},
+        {'name': 'USEMPI', 'state': 1},
+    ]
+    assert not ud._update_conditional_compile(stack, set())
+
+
+# ---------------------------------------------------------------------------
+# Source-side stack, driven through a real file scan
+# ---------------------------------------------------------------------------
+
+def _scan_modules(tmp_path, source_text, defined=frozenset()):
+    """Run _scan_source_file over `source_text` and return the module names
+    recorded in modulesUsed (stripped of the work-dir prefix)."""
+    src = tmp_path / 'probe.F90'
+    src.write_text(source_text)
+    entry = {
+        'files':                [str(src)],
+        'modulesUsed':          [],
+        'dependenciesExplicit': [],
+        'modulesProvided':      {},
+        'submodules':           [],
+        'submodulesProvided':   [],
+        'libraryDependencies':  {},
+    }
+    ud._scan_source_file(
+        entry, [str(src)],
+        {'fileName': 'probe.F90', 'subDirectoryName': ''},
+        {name: [] for name in ud._DIRECTIVE_NAMES},
+        {}, str(tmp_path), 'WORK/', frozenset(defined),
+    )
+    return {m[len('WORK/'):-len('.mod')] for m in entry['modulesUsed']}
+
+
+def test_plain_use_recorded(tmp_path):
+    mods = _scan_modules(tmp_path, (
+        'module probe\n'
+        '  use Module_A\n'
+        'end module probe\n'
+    ))
+    assert 'module_a' in mods
+
+
+def test_ifdef_branches(tmp_path):
+    text = (
+        'module probe\n'
+        '#ifdef USEMPI\n'
+        '  use Module_Mpi_Side\n'
+        '#else\n'
+        '  use Module_Serial_Side\n'
+        '#endif\n'
+        'end module probe\n'
+    )
+    assert _scan_modules(tmp_path, text, {'USEMPI'}) == {'module_mpi_side'}
+    assert _scan_modules(tmp_path, text) == {'module_serial_side'}
+
+
+def test_hash_if_block_is_scanned(tmp_path):
+    # Previously a `use` inside `#if defined(A) || defined(B)` was silently
+    # dropped from the dependency graph.
+    mods = _scan_modules(tmp_path, (
+        'module probe\n'
+        '#if defined(OFDAVAIL) || defined(OFDLOCKS)\n'
+        '  use Module_Locks\n'
+        '#else\n'
+        '  use Module_No_Locks\n'
+        '#endif\n'
+        'end module probe\n'
+    ))
+    # Both branches of an unevaluable conditional are scanned.
+    assert {'module_locks', 'module_no_locks'} <= mods
+
+
+def test_elif_degrades_chain_to_all_branches(tmp_path):
+    text = (
+        'module probe\n'
+        '#ifdef USEMPI\n'
+        '  use Module_A\n'
+        '#elif defined(OTHER)\n'
+        '  use Module_B\n'
+        '#else\n'
+        '  use Module_C\n'
+        '#endif\n'
+        'end module probe\n'
+    )
+    # The leading #ifdef is evaluable and stays exact; from the #elif onward
+    # the chain is unevaluable, so every later branch is scanned.
+    mods = _scan_modules(tmp_path, text)
+    assert 'module_a' not in mods         # USEMPI known-undefined
+    assert {'module_b', 'module_c'} <= mods
+    mods = _scan_modules(tmp_path, text, {'USEMPI'})
+    assert {'module_a', 'module_b', 'module_c'} <= mods
+
+
+def test_lowercase_ifndef(tmp_path):
+    # `#ifndef __aarch64__` was previously unmatched (uppercase-only regex),
+    # leaving its `#endif` to unbalance the stack.
+    mods = _scan_modules(tmp_path, (
+        'module probe\n'
+        '#ifndef __aarch64__\n'
+        '  use Module_X86\n'
+        '#endif\n'
+        '  use Module_Always\n'
+        'end module probe\n'
+    ))
+    assert 'module_always' in mods
+    assert 'module_x86' in mods  # __aarch64__ not in the defined set
+
+
+# ---------------------------------------------------------------------------
+# Makefile-conditional scanner
+# ---------------------------------------------------------------------------
+
+def _collect_from(tmp_path, monkeypatch, makefile_text, env=()):
+    (tmp_path / 'Makefile').write_text(makefile_text)
+    build = tmp_path / 'build'
+    build.mkdir(exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+    for name in env:
+        monkeypatch.setenv(name, '1')
+    monkeypatch.setenv('GALACTICUS_FCFLAGS', '')
+    # Neutralize the compiler-macro merge so tests see only Makefile flags.
+    monkeypatch.setenv('CCOMPILER', '/bin/true')
+    return set(ud._collect_preprocessor_directives(str(build)))
+
+
+def test_ifneq_no_longer_desynchronizes(tmp_path, monkeypatch):
+    # Previously `ifneq` did not push but its `endif` popped, so the endif
+    # here re-activated the enclosing false `ifdef` branch and -DWRONG was
+    # collected.
+    flags = _collect_from(tmp_path, monkeypatch, (
+        'ifdef NOT_SET_ANYWHERE_XYZ\n'
+        'ifneq ($(THING),)\n'
+        'FCFLAGS += -DINNER\n'
+        'endif\n'
+        'FCFLAGS += -DWRONG\n'
+        'endif\n'
+        'FCFLAGS += -DALWAYS\n'
+    ))
+    assert 'ALWAYS' in flags
+    assert 'WRONG' not in flags
+    assert 'INNER' not in flags
+
+
+def test_else_of_env_ifdef(tmp_path, monkeypatch):
+    text = (
+        'ifdef SOME_TEST_ENV_FLAG\n'
+        'FCFLAGS += -DWITH\n'
+        'else\n'
+        'FCFLAGS += -DWITHOUT\n'
+        'endif\n'
+    )
+    assert 'WITHOUT' in _collect_from(tmp_path, monkeypatch, text)
+    assert 'WITH' not in _collect_from(tmp_path, monkeypatch, text)
+    with_env = _collect_from(tmp_path, monkeypatch, text,
+                             env=('SOME_TEST_ENV_FLAG',))
+    assert 'WITH' in with_env
+    assert 'WITHOUT' not in with_env
+
+
+def test_ifeq_collects_all_branches(tmp_path, monkeypatch):
+    # Unevaluable make-variable conditions: deliberately over-approximate.
+    flags = _collect_from(tmp_path, monkeypatch, (
+        "ifeq '$(OPT)' 'a'\n"
+        'FCFLAGS += -DBRANCH_A\n'
+        "else ifeq '$(OPT)' 'b'\n"
+        'FCFLAGS += -DBRANCH_B\n'
+        'else\n'
+        'FCFLAGS += -DBRANCH_C\n'
+        'endif\n'
+    ))
+    assert {'BRANCH_A', 'BRANCH_B', 'BRANCH_C'} <= flags
+
+
+def test_dash_d_with_underscore(tmp_path, monkeypatch):
+    flags = _collect_from(tmp_path, monkeypatch,
+                          'FCFLAGS += -DUSE_MPI -Dmixed_Case1\n')
+    assert 'USE_MPI' in flags
+    assert 'mixed_Case1' in flags

--- a/scripts/build/useDependencies.py
+++ b/scripts/build/useDependencies.py
@@ -36,6 +36,10 @@ from Galacticus.Build.ScanCache import (
 )
 
 
+# Version stamp for the Makefile_Use_Dependencies.blob cache. Bump when the
+# scan rules change so stale-rule entries are discarded.
+_BLOB_VERSION = 2
+
 # Directives consulted per source file (module-level so the parallel worker can
 # see it). Order matters only in that it is fixed.
 _DIRECTIVE_NAMES = (
@@ -112,11 +116,13 @@ def _load_xml(path):
 # Preprocessor directive collection
 # ---------------------------------------------------------------------------
 
-_IFDEF_RE   = re.compile(r'^ifdef\s+([A-Z]+)')
-_IFEQ_RE    = re.compile(r'^ifeq\s')
-_ENDIF_RE   = re.compile(r'^endif')
+_IFDEF_RE   = re.compile(r'^\s*ifdef\s+([A-Za-z_][A-Za-z0-9_]*)')
+_IFNDEF_RE  = re.compile(r'^\s*ifndef\s+([A-Za-z_][A-Za-z0-9_]*)')
+_IFEQ_RE    = re.compile(r'^\s*if(?:n?)eq\s')
+_ELSE_RE    = re.compile(r'^\s*else\b(.*)$')
+_ENDIF_RE   = re.compile(r'^\s*endif\b')
 _FCFLAGS_RE = re.compile(r'^\s*FCFLAGS\s*\+??=')
-_DASH_D_RE  = re.compile(r'-D([0-9A-Z]+)')
+_DASH_D_RE  = re.compile(r'-D([0-9A-Za-z_]+)')
 
 
 def _collect_preprocessor_directives(build_path):
@@ -141,21 +147,51 @@ def _collect_preprocessor_directives(build_path):
     for makefile in makefiles:
         if not os.path.exists(makefile):
             continue
-        conditions_stack = [1]
+        # Stack entries: True (branch known active), False (known
+        # inactive), None (unevaluable — `ifeq`/`ifneq` conditions over make
+        # variables, and any `else <condition>` chain). A -D flag is
+        # collected unless a *definitely false* branch encloses it: for
+        # unevaluable conditions every branch is collected, deliberately
+        # over-approximating the macro set (over-depending is benign;
+        # under-depending silently drops dependencies). `ifdef`/`ifndef` are
+        # approximated against the environment. Every opener pushes and
+        # every `endif` pops, so an unrecognized condition can no longer
+        # desynchronize the stack (previously `ifneq` did not push but its
+        # `endif` still popped, deactivating or reactivating outer branches
+        # at random).
+        conditions_stack = [True]
         with open(makefile, 'r', errors='replace') as fh:
             for line in fh:
                 m = _IFDEF_RE.match(line)
                 if m:
-                    conditions_stack.append(1 if m.group(1) in os.environ else 0)
+                    conditions_stack.append(m.group(1) in os.environ)
+                    continue
+                m = _IFNDEF_RE.match(line)
+                if m:
+                    conditions_stack.append(m.group(1) not in os.environ)
                     continue
                 if _IFEQ_RE.match(line):
-                    conditions_stack.append(1)
+                    conditions_stack.append(None)
+                    continue
+                m = _ELSE_RE.match(line)
+                if m:
+                    if len(conditions_stack) > 1:
+                        taken = conditions_stack.pop()
+                        if m.group(1).strip():
+                            # `else if…`: a chained condition — unevaluable
+                            # in general, so collect from it.
+                            conditions_stack.append(None)
+                        elif taken is None:
+                            conditions_stack.append(None)
+                        else:
+                            conditions_stack.append(not taken)
                     continue
                 if _ENDIF_RE.match(line):
                     if len(conditions_stack) > 1:
                         conditions_stack.pop()
                     continue
-                if _FCFLAGS_RE.match(line) and all(conditions_stack):
+                if (_FCFLAGS_RE.match(line)
+                        and all(c is not False for c in conditions_stack)):
                     for tok in line.split():
                         m = _DASH_D_RE.match(tok)
                         if m:
@@ -528,8 +564,9 @@ _LATEX_CLOSE_RE = re.compile(r'^\s*!!\}')
 _LIB_HINT_RE        = re.compile(r'^\s*!;\s*([a-zA-Z0-9_]+)\s*$')
 _C_INCLUDE_RE       = re.compile(r'^\s*#include\s+<([a-zA-Z0-9_]+)\.h>')
 _PP_IFDEF_RE        = re.compile(r'^#ifdef\s+([0-9A-Za-z_]+)\s*$')
-_PP_IFNDEF_RE       = re.compile(r'^#ifndef\s+([0-9A-Z_]+)\s*$')
+_PP_IFNDEF_RE       = re.compile(r'^#ifndef\s+([0-9A-Za-z_]+)\s*$')
 _PP_IF_RE           = re.compile(r'^#if\s')
+_PP_ELIF_RE         = re.compile(r'^#elif\s')
 _PP_ENDIF_RE        = re.compile(r'^#endif\s*$')
 _PP_ELSE_RE         = re.compile(r'^#else\s*$')
 _USE_LINE_RE        = re.compile(
@@ -560,8 +597,16 @@ _INCLUDE_LINE_RE    = re.compile(
 
 
 def _update_conditional_compile(stack, preprocessor_directives):
-    """Mirrors the foreach loop at useDependencies.pl:374-383."""
+    """Return True when every conditional block on `stack` is active.
+
+    Entries flagged `unknown` (a `#if <expression>` or a chain containing
+    `#elif`) are treated as active regardless of `#else` flips — every
+    branch of an unevaluable conditional is scanned. Mirrors the foreach
+    loop at useDependencies.pl:374-383, with the unknown-entry extension.
+    """
     for entry in stack:
+        if entry.get('unknown'):
+            continue
         name_defined = entry['name'] in preprocessor_directives
         active = entry['state'] if name_defined else 1 - entry['state']
         if active == 0:
@@ -620,8 +665,13 @@ def _scan_source_file(sources_entry, file_names_to_process, source_file,
                             'name': m.group(1), 'state': 1,
                         })
                     elif _PP_IF_RE.match(line):
+                        # A general `#if <expression>` cannot be evaluated
+                        # here; treat every branch of it as active so its
+                        # `use` statements are still recorded (over-depending
+                        # is benign; the previous behavior treated the block
+                        # as inactive and silently dropped dependencies).
                         preprocessor_stack.append({
-                            'name': 'conditional', 'state': 1,
+                            'name': None, 'state': 1, 'unknown': True,
                         })
                     else:
                         m = _PP_IFNDEF_RE.match(line)
@@ -632,6 +682,13 @@ def _scan_source_file(sources_entry, file_names_to_process, source_file,
                         elif _PP_ENDIF_RE.match(line):
                             if preprocessor_stack:
                                 preprocessor_stack.pop()
+                        elif _PP_ELIF_RE.match(line):
+                            # A chain containing `#elif` can no longer be
+                            # tracked by defined-ness flips — degrade the
+                            # whole chain to unevaluable (all branches
+                            # active).
+                            if preprocessor_stack:
+                                preprocessor_stack[-1]['unknown'] = True
                         elif _PP_ELSE_RE.match(line):
                             if preprocessor_stack:
                                 preprocessor_stack[-1]['state'] = (
@@ -1000,6 +1057,11 @@ def main(argv):
     uses_per_file, cache_mtime = _load_cache(
         work_dir + 'Makefile_Use_Dependencies.blob',
     )
+    # Discard caches written under older scan rules (the conditional-
+    # compilation handling changed what a scan records); a mismatch costs
+    # one full rescan.
+    if uses_per_file.pop('blobVersion', None) != _BLOB_VERSION:
+        uses_per_file, cache_mtime = {}, None
     have_per_file = cache_mtime is not None
 
     source_files = _source_files_to_process(root_source_dir, build_path)
@@ -1066,6 +1128,7 @@ def main(argv):
     )
 
     with open(work_dir + 'Makefile_Use_Dependencies.blob', 'wb') as fh:
+        uses_per_file['blobVersion'] = _BLOB_VERSION
         pickle.dump(uses_per_file, fh, protocol=pickle.HIGHEST_PROTOCOL)
 
 


### PR DESCRIPTION
**PR 7 of 7**, stacked on #1224. Implements item 8 of the review action plan.

The two state machines deciding which conditionally compiled code the dependency scanner honors mis-parsed real inputs:

**Makefile-conditional scanner** — `ifneq` was unrecognized: it pushed nothing, but its `endif` still popped, desynchronizing the stack and randomly (de)activating enclosing branches; `else` was ignored entirely; `ifdef` names were uppercase-only and `-D` macro names uppercase-and-digits (a future `-DUSE_MPI` would truncate to `USE`). The stack now pushes on every opener and pops on every `endif`, with three-valued entries: known-active / known-inactive (ifdef/ifndef, evaluated against the environment) / unevaluable (`ifeq`/`ifneq`/chained `else if…`), whose branches are all collected — deliberate over-approximation, since over-depending is benign while under-depending silently drops dependencies.

**Source-side preprocessor stack** — `#if <expression>` blocks were treated as *inactive*, silently dropping any `use` statement inside them from the dependency graph; they are now unevaluable-active (every branch scanned). `#elif` is recognized (degrading its chain to unevaluable from that point, keeping an evaluable leading `#ifdef` exact), and `#ifndef` accepts lowercase macro names (`#ifndef __aarch64__` previously left its `#endif` to unbalance the stack).

The `Makefile_Use_Dependencies` blob is version-stamped so caches built under the old rules are discarded (one ~5s full rescan on first build after merging).

## Verification

Adds `scripts/build/tests/test_use_dependencies_conditionals.py` (10 tests) pinning both machines, including regression cases for the `ifneq` desync, the dropped `#if` dependencies, and lowercase `#ifndef`. On the current source tree the regenerated dependency graph is byte-identical (today's `#if` blocks carry no unique `use` statements) — i.e. no regression — and the full `make -j20 Galacticus.exe` at this stack tip builds and links cleanly with all 174 build-script tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)