### PR TITLE
test(build): pin the build system's load-bearing invariants

### DIFF
--- a/python/Galacticus/Build/tests/test_file_changes.py
+++ b/python/Galacticus/Build/tests/test_file_changes.py
@@ -1,0 +1,62 @@
+"""Tests for Galacticus.Build.FileChanges.update — the only-if-changed file
+replacement that (with its ``.up`` sentinels) is the backbone of the build's
+incremental minimality: a generated file's mtime must advance only when its
+content actually changes.
+"""
+
+import os
+
+from Galacticus.Build.FileChanges import update
+
+
+def _write(path, text):
+    path.write_text(text)
+    return str(path)
+
+
+def test_missing_old_moves_new_into_place(tmp_path):
+    new = _write(tmp_path / 'x.tmp', 'content')
+    old = tmp_path / 'x'
+    update(str(old), new)
+    assert old.read_text() == 'content'
+    assert not os.path.exists(new)
+
+
+def test_identical_preserves_mtime_and_removes_new(tmp_path):
+    old = _write(tmp_path / 'x', 'same')
+    os.utime(old, (1000000, 1000000))          # ancient mtime
+    new = _write(tmp_path / 'x.tmp', 'same')
+    update(old, new)
+    assert os.stat(old).st_mtime == 1000000    # untouched
+    assert not os.path.exists(new)
+
+
+def test_different_replaces_and_advances_mtime(tmp_path):
+    old = _write(tmp_path / 'x', 'before')
+    os.utime(old, (1000000, 1000000))
+    new = _write(tmp_path / 'x.tmp', 'after')
+    update(old, new)
+    assert (tmp_path / 'x').read_text() == 'after'
+    assert os.stat(old).st_mtime > 1000000
+    assert not os.path.exists(new)
+
+
+def test_prove_update_touches_sentinel_even_when_unchanged(tmp_path):
+    # The `.up` sentinel is make's evidence that the generator ran; it must
+    # advance on EVERY run, including no-op ones where the output's own
+    # mtime is deliberately preserved.
+    old = _write(tmp_path / 'x', 'same')
+    sentinel = tmp_path / 'x.up'
+    _write(sentinel, '')
+    os.utime(old, (1000000, 1000000))
+    os.utime(sentinel, (1000000, 1000000))
+    new = _write(tmp_path / 'x.tmp', 'same')
+    update(old, new, prove_update=True)
+    assert os.stat(old).st_mtime == 1000000          # output untouched
+    assert os.stat(sentinel).st_mtime > 1000000      # sentinel advanced
+
+
+def test_prove_update_creates_sentinel(tmp_path):
+    new = _write(tmp_path / 'x.tmp', 'content')
+    update(str(tmp_path / 'x'), new, prove_update=True)
+    assert (tmp_path / 'x.up').exists()

--- a/python/Galacticus/Build/tests/test_parallel_scan.py
+++ b/python/Galacticus/Build/tests/test_parallel_scan.py
@@ -1,0 +1,109 @@
+"""Tests for Galacticus.Build.ParallelScan.
+
+Pins the two contracts every cataloging script relies on:
+
+* results come back in task order, identical to a serial run (the emitted
+  makefiles/catalogs must be byte-identical whatever the parallelism);
+* the worker count follows GALACTICUS_BUILD_JOBS, then make's ``-j`` from
+  MAKEFLAGS (bare ``-j`` = unlimited, absent ``-j`` under make = serial),
+  then the standalone default, clamped to the task count.
+"""
+
+import pytest
+
+from Galacticus.Build.ParallelScan import resolve_jobs, scan, _DEFAULT_STANDALONE
+
+
+# Workers must be module-level so the process pool can pickle them.
+
+def _square(task):
+    return task * task
+
+
+def _fail_on_three(task):
+    if task == 3:
+        raise ValueError("worker exploded")
+    return task
+
+
+# ---------------------------------------------------------------------------
+# scan(): ordering and serial equivalence
+# ---------------------------------------------------------------------------
+
+def test_results_in_task_order_parallel():
+    tasks = list(range(50))
+    assert scan(tasks, _square, 'test', jobs=8) == [t * t for t in tasks]
+
+
+def test_parallel_matches_serial():
+    tasks = list(range(23))
+    serial   = scan(tasks, _square, 'test', jobs=1)
+    parallel = scan(tasks, _square, 'test', jobs=4)
+    assert parallel == serial
+
+
+def test_empty_tasks():
+    assert scan([], _square, 'test') == []
+
+
+def test_single_task_runs_serially():
+    assert scan([7], _square, 'test', jobs=16) == [49]
+
+
+def test_worker_failure_exits_with_serial_hint(capsys):
+    with pytest.raises(SystemExit) as exc:
+        scan(list(range(8)), _fail_on_three, 'myScript.py', jobs=4)
+    message = str(exc.value)
+    assert 'myScript.py' in message
+    assert 'GALACTICUS_BUILD_JOBS=1' in message
+
+
+# ---------------------------------------------------------------------------
+# resolve_jobs(): precedence and clamping
+# ---------------------------------------------------------------------------
+
+def test_override_wins(monkeypatch):
+    monkeypatch.setenv('GALACTICUS_BUILD_JOBS', '3')
+    monkeypatch.setenv('MAKEFLAGS', ' -j16')
+    assert resolve_jobs(100) == 3
+
+
+def test_override_zero_means_cpu_count(monkeypatch):
+    monkeypatch.setenv('GALACTICUS_BUILD_JOBS', '0')
+    assert resolve_jobs(10000) >= 1
+
+
+def test_makeflags_jN(monkeypatch):
+    monkeypatch.delenv('GALACTICUS_BUILD_JOBS', raising=False)
+    monkeypatch.setenv('MAKEFLAGS', ' -j4 --jobserver-auth=fifo:/tmp/x')
+    assert resolve_jobs(100) == 4
+
+
+def test_makeflags_without_j_is_serial(monkeypatch):
+    # Under make with no -j the build itself is serial; forking a pool of
+    # workers on top of it would oversubscribe unasked.
+    monkeypatch.delenv('GALACTICUS_BUILD_JOBS', raising=False)
+    monkeypatch.setenv('MAKEFLAGS', '')
+    assert resolve_jobs(100) == 1
+
+
+def test_makeflags_bare_j_means_cpu_count(monkeypatch):
+    monkeypatch.delenv('GALACTICUS_BUILD_JOBS', raising=False)
+    monkeypatch.setenv('MAKEFLAGS', ' -j')
+    assert resolve_jobs(100000) >= 1
+
+
+def test_standalone_default(monkeypatch):
+    monkeypatch.delenv('GALACTICUS_BUILD_JOBS', raising=False)
+    monkeypatch.delenv('MAKEFLAGS', raising=False)
+    assert resolve_jobs(10000) == _DEFAULT_STANDALONE
+
+
+def test_clamped_to_task_count(monkeypatch):
+    monkeypatch.setenv('GALACTICUS_BUILD_JOBS', '64')
+    assert resolve_jobs(2) == 2
+
+
+def test_at_least_one(monkeypatch):
+    monkeypatch.setenv('GALACTICUS_BUILD_JOBS', '-5')
+    assert resolve_jobs(10) >= 1

--- a/python/Galacticus/Build/tests/test_scan_cache.py
+++ b/python/Galacticus/Build/tests/test_scan_cache.py
@@ -1,0 +1,51 @@
+"""Tests for Galacticus.Build.ScanCache — the shared per-file blob-cache
+helpers: cache keys must be stable (they key every incremental rescan) and
+cache loading must degrade to a full rescan on any problem, never fail.
+"""
+
+import os
+import pickle
+
+from Galacticus.Build.ScanCache import file_identifier, load_cache
+
+
+def test_identifier_replaces_slashes():
+    assert file_identifier('a/b/c.F90') == 'a_b_c.F90'
+
+
+def test_identifier_strips_leading_dot_slash():
+    # `./`-relative invocations must produce the same key as bare-relative
+    # ones (the strip is a no-op for the absolute paths make passes).
+    assert file_identifier('./a/b.F90') == 'a_b.F90'
+    assert file_identifier('a/b.F90') == file_identifier('./a/b.F90')
+
+
+def test_identifier_absolute_path():
+    assert file_identifier('/x/y.F90') == '_x_y.F90'
+
+
+def test_load_missing(tmp_path):
+    cache, mtime = load_cache(str(tmp_path / 'nope.blob'))
+    assert cache == {} and mtime is None
+
+
+def test_load_corrupt(tmp_path):
+    blob = tmp_path / 'x.blob'
+    blob.write_bytes(b'not a pickle \x00\x01')
+    cache, mtime = load_cache(str(blob))
+    assert cache == {} and mtime is None
+
+
+def test_load_non_dict(tmp_path):
+    blob = tmp_path / 'x.blob'
+    blob.write_bytes(pickle.dumps(['a', 'list']))
+    cache, mtime = load_cache(str(blob))
+    assert cache == {} and mtime is None
+
+
+def test_load_valid_returns_dict_and_mtime(tmp_path):
+    blob = tmp_path / 'x.blob'
+    blob.write_bytes(pickle.dumps({'k': 1}))
+    cache, mtime = load_cache(str(blob))
+    assert cache == {'k': 1}
+    assert mtime == os.stat(blob).st_mtime

--- a/python/LibraryInterfaces/tests/test_classification.py
+++ b/python/LibraryInterfaces/tests/test_classification.py
@@ -1,0 +1,185 @@
+"""Tests for LibraryInterfaces.Classification — the argument/return-type
+rules shared by the library-interface generator and the audit tool. These
+pin the rules that decide which functionClass implementations get exposed
+through libgalacticus, including the generator/audit divergences the shared
+module was created to prevent (e.g. the omp_lock_kind rejection the audit
+had silently lost).
+"""
+
+import pytest
+
+from LibraryInterfaces.Classification import (
+    classify_arg,
+    is_internal_constructor_name,
+    normalize_method_return_type,
+    unsupported_arg,
+)
+
+REGISTERED = {'cosmologyFunctions': {}, 'darkMatterHaloScale': {}}
+KNOWN      = set(REGISTERED) | {'unregisteredThing'}
+
+
+def _arg(intrinsic, type_spec='', attributes=(), name='x'):
+    return {'name': name, 'intrinsic': intrinsic, 'type': type_spec,
+            'attributes': list(attributes)}
+
+
+# ---------------------------------------------------------------------------
+# Scalars and outright rejections
+# ---------------------------------------------------------------------------
+
+def test_plain_scalar_supported():
+    assert classify_arg(_arg('double precision'), REGISTERED) is None
+    assert classify_arg(_arg('integer'), REGISTERED) is None
+
+
+@pytest.mark.parametrize('intrinsic', ['complex', 'double complex'])
+def test_complex_rejected(intrinsic):
+    verdict = classify_arg(_arg(intrinsic), REGISTERED)
+    assert verdict[0] == 'blocked'
+
+
+def test_procedure_rejected():
+    verdict = classify_arg(_arg('procedure', 'integrand'), REGISTERED)
+    assert verdict[0] == 'blocked'
+    assert 'procedure' in verdict[1]
+
+
+def test_omp_lock_kind_nonoptional_rejected():
+    # The rule whose absence from the audit's hand-synced copy was the
+    # original drift this module exists to prevent.
+    verdict = classify_arg(_arg('integer', 'omp_lock_kind'), REGISTERED)
+    assert verdict[0] == 'blocked'
+    assert 'omp_lock_kind' in verdict[1]
+
+
+def test_omp_lock_kind_optional_accepted():
+    arg = _arg('integer', 'omp_lock_kind', attributes=['optional'])
+    assert classify_arg(arg, REGISTERED) is None
+
+
+# ---------------------------------------------------------------------------
+# class(...) arguments
+# ---------------------------------------------------------------------------
+
+def test_registered_class_supported():
+    arg = _arg('class', 'cosmologyFunctionsClass')
+    assert classify_arg(arg, REGISTERED) is None
+
+
+def test_unregistered_class_blocked_in_generator_mode():
+    arg = _arg('class', 'unregisteredThingClass')
+    verdict = classify_arg(arg, REGISTERED)
+    assert verdict[0] == 'blocked'
+    assert unsupported_arg(arg, REGISTERED) == verdict[1]
+
+
+def test_unregistered_class_is_missing_dep_in_audit_mode():
+    arg = _arg('class', 'unregisteredThingClass')
+    verdict = classify_arg(arg, REGISTERED, known_function_classes=KNOWN)
+    assert verdict == ('missing-dep', {'unregisteredThing'})
+
+
+def test_unknown_class_blocked_in_both_modes():
+    arg = _arg('class', 'treeNode')
+    assert classify_arg(arg, REGISTERED)[0] == 'blocked'
+    assert classify_arg(arg, REGISTERED,
+                        known_function_classes=KNOWN)[0] == 'blocked'
+
+
+def test_class_star_needs_override():
+    arg = _arg('class', '*')
+    assert classify_arg(arg, REGISTERED)[0] == 'blocked'
+    assert classify_arg(arg, REGISTERED,
+                        constructor_overrides=[{'name': 'x'}]) is None
+
+
+def test_abstract_intermediate_resolved_through_hierarchy():
+    # An intermediate type whose extends-chain reaches a registered
+    # <base>Class is routed through <base>GetPtr.
+    hierarchy = {'cosmologyFunctionsMatterLambda':
+                 {'parent': 'cosmologyFunctionsClass', 'module': 'm'}}
+    arg = _arg('class', 'cosmologyFunctionsMatterLambda')
+    assert classify_arg(arg, REGISTERED, class_hierarchy=hierarchy) is None
+    # ...but with no hierarchy the same arg is blocked.
+    assert classify_arg(arg, REGISTERED)[0] == 'blocked'
+
+
+# ---------------------------------------------------------------------------
+# Overrides
+# ---------------------------------------------------------------------------
+
+def test_null_override_accepts_procedure_and_class_star():
+    overrides = [{'name': 'x', 'value': 'null'}]
+    assert classify_arg(_arg('procedure', 'integrand'), REGISTERED,
+                        constructor_overrides=overrides) is None
+    assert classify_arg(_arg('class', '*'), REGISTERED,
+                        constructor_overrides=overrides) is None
+    verdict = classify_arg(_arg('integer'), REGISTERED,
+                           constructor_overrides=overrides)
+    assert verdict[0] == 'blocked'
+
+
+def test_absent_override_requires_optional():
+    overrides = [{'name': 'x', 'value': 'absent'}]
+    assert classify_arg(_arg('integer', attributes=['optional']), REGISTERED,
+                        constructor_overrides=overrides) is None
+    assert classify_arg(_arg('integer'), REGISTERED,
+                        constructor_overrides=overrides)[0] == 'blocked'
+
+
+# ---------------------------------------------------------------------------
+# Array shapes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('intrinsic,type_spec,dim', [
+    ('double precision', '',      'dimension(:)'),
+    ('double precision', '',      'dimension(:,:)'),
+    ('integer',          '',      'dimension(3)'),
+    ('logical',          '',      'dimension(:)'),
+    ('character',        'len=5', 'dimension(:)'),
+    ('type',             'varying_string', 'dimension(:)'),
+])
+def test_supported_array_shapes(intrinsic, type_spec, dim):
+    arg = _arg(intrinsic, type_spec, attributes=[dim, 'intent(in   )'])
+    assert classify_arg(arg, REGISTERED) is None
+
+
+def test_allocatable_array_rejected():
+    arg = _arg('double precision', '',
+               attributes=['dimension(:)', 'allocatable'])
+    verdict = classify_arg(arg, REGISTERED)
+    assert verdict[0] == 'blocked'
+    assert 'allocatable' in verdict[1]
+
+
+@pytest.mark.parametrize('intrinsic,type_spec,dim', [
+    ('character', 'len=*', 'dimension(:)'),   # no fixed byte stride
+    ('logical',   '',      'dimension(3)'),   # fixed-size logical unsupported
+    ('class',     'cosmologyFunctionsClass', 'dimension(:)'),
+])
+def test_unsupported_array_shapes(intrinsic, type_spec, dim):
+    arg = _arg(intrinsic, type_spec, attributes=[dim])
+    verdict = classify_arg(arg, REGISTERED)
+    assert verdict[0] == 'blocked'
+    assert 'dimensioned argument' in verdict[1]
+
+
+# ---------------------------------------------------------------------------
+# Small shared helpers
+# ---------------------------------------------------------------------------
+
+def test_return_type_aliases():
+    assert normalize_method_return_type('integer(kind=c_size_t)') \
+        == 'integer(c_size_t)'
+    assert normalize_method_return_type('integer(kind_int8)') \
+        == 'integer(c_long)'
+    assert normalize_method_return_type('double precision') \
+        == 'double precision'
+
+
+def test_internal_constructor_names():
+    assert is_internal_constructor_name('coleConstructorInternal')
+    assert is_internal_constructor_name('allAndFormationNodesInternal')
+    assert is_internal_constructor_name('fooConstructorInternalType')
+    assert not is_internal_constructor_name('fooConstructorParameters')

--- a/scripts/build/buildProfiler.py
+++ b/scripts/build/buildProfiler.py
@@ -229,9 +229,12 @@ with open(args.profileFile, 'w') as out:
             f"(at {memory_peak_time} seconds, summed over tasks running for "
             f"{args.durationMinimum} seconds or longer)<p>\n"
         )
+    # A build whose tasks all completed within one second has time_maximum=0
+    # (timestamps have 1s resolution); treat it as one second rather than
+    # dividing by zero.
     out.write(
         f"Build profile (all tasks which ran for {args.durationMinimum} seconds or longer: "
-        f"{100.0 * cost_total / time_maximum:5.2f}% of total time)<br>\n"
+        f"{100.0 * cost_total / max(time_maximum, 1):5.2f}% of total time)<br>\n"
     )
     out.write("<div>\n")
     out.write("<table id=\"chart\" style=\"border-spacing: 0; border-collapse: separate; border-top: 1px\">\n")
@@ -247,7 +250,7 @@ with open(args.profileFile, 'w') as out:
         out.write(
             f"<tr><td>{task['description']}</td>"
             f"<td>{task['cost']:7.2f}</td>"
-            f"<td>({100.0 * task['cost'] / time_maximum:5.2f}%)</td>"
+            f"<td>({100.0 * task['cost'] / max(time_maximum, 1):5.2f}%)</td>"
             f"<td>{format_memory(task['memoryKB'])}</td></tr>\n"
         )
     out.write("</table>\n")

--- a/scripts/build/tests/test_code_directives_canonicalize.py
+++ b/scripts/build/tests/test_code_directives_canonicalize.py
@@ -1,0 +1,80 @@
+"""Pin codeDirectivesParse's `_canonicalize` pickle-identity invariant.
+
+The per-file blob cache is rewritten only-if-changed, and "changed" is a
+byte comparison of the pickle. Entries built in-process share the interned
+literal strings (`'files'`, `'includeDirectives'`, ...) across entries, so
+pickle writes them once with back-references; entries returned from forked
+pool workers are unpickled into fresh, de-interned strings, which would
+make the merged blob pickle differently from a serial run — bumping the
+blob mtime on every scan and defeating the freshness window.
+`_canonicalize` re-interns exactly the literal set `_ENTRY_LITERALS` to
+restore byte-identity. That set must be kept in sync with the literals
+`_scan_one` produces — an obligation this test enforces: it drives the real
+`_scan_one` over fixtures exercising every top-level entry shape (a
+functionClass directive with its implicit task dependencies, plus an
+include directive), simulates the worker round-trip, and requires the
+canonicalized blob to pickle byte-identically to the serial one.
+"""
+
+import os
+import pickle
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir))
+import codeDirectivesParse as cdp  # noqa: E402
+
+
+_PROBE = '''!![
+<functionClass docformat="rst">
+ <name>{name}Widget</name>
+ <descriptiveName>Widgets</descriptiveName>
+</functionClass>
+!!]
+module {name}_Widgets
+  !![
+  <include directive="{name}Inc" type="function">
+  !!]
+  include '{name}.widgets.inc'
+  !![
+  </include>
+  !!]
+end module {name}_Widgets
+'''
+
+
+def _entries(tmp_path, roundtrip):
+    source = tmp_path / 'source'
+    source.mkdir(exist_ok=True)
+    (tmp_path / 'build').mkdir(exist_ok=True)
+    cdp._WORKER['source_directory'] = str(source)
+    cdp._WORKER['build_path']       = str(tmp_path / 'build')
+    blob = {}
+    for name in ('test', 'other'):
+        path = source / f'{name}.F90'
+        path.write_text(_PROBE.format(name=name))
+        identifier, entry = cdp._scan_one((f'{name}.F90', str(path),
+                                           f'id_{name}'))
+        if roundtrip:
+            # Simulate the per-task pickle round-trip through the process
+            # pool: strings lose their interned identity.
+            entry = pickle.loads(pickle.dumps(entry))
+        blob[identifier] = entry
+    return blob
+
+
+def test_fixture_exercises_full_entry_shape(tmp_path):
+    entry = next(iter(_entries(tmp_path, roundtrip=False).values()))
+    assert sorted(entry) == ['files', 'functionClasses',
+                             'includeDirectives', 'nonIncludeDirectives']
+
+
+def test_canonicalized_worker_blob_pickles_identically(tmp_path):
+    serial = _entries(tmp_path, roundtrip=False)
+    worker = _entries(tmp_path, roundtrip=True)
+    # Guard: the round-trip really does de-intern (otherwise this test —
+    # and _canonicalize itself — would be vacuous; if this ever fails,
+    # pickle semantics changed and _canonicalize may be removable).
+    assert pickle.dumps(worker) != pickle.dumps(serial)
+    canonical = {k: cdp._canonicalize(v) for k, v in worker.items()}
+    assert pickle.dumps(canonical) == pickle.dumps(serial)

--- a/scripts/build/tests/test_profiler_contract.py
+++ b/scripts/build/tests/test_profiler_contract.py
@@ -1,0 +1,74 @@
+"""Integration tests for the `++Task:` contract between profiler.sh
+(producer, the SHELL wrapper of `GALACTICUS_BUILD_OPTION=compileprof`
+builds) and buildProfiler.py (consumer, the report generator) — an
+undocumented-by-code format pair where neither side knows the other exists.
+
+Also pins profiler.sh's exit-status propagation: as make's SHELL it must
+forward the wrapped command's status, or make cannot detect any failed
+recipe during a profiled build.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+import pytest
+
+_REPO      = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          os.pardir, os.pardir, os.pardir)
+_PROFILER  = os.path.join(_REPO, 'scripts', 'build', 'profiler.sh')
+_REPORTER  = os.path.join(_REPO, 'scripts', 'build', 'buildProfiler.py')
+
+# The consumer's parse regex (mirrors buildProfiler.py).
+_TASK_RE = re.compile(
+    r"^\+\+Task: \{([\s\d\+\-:]+)\|([\s\d\+\-:]+)(?:\|(-?\d+))?\} '(.*)")
+
+# profiler.sh uses GNU `date --rfc-3339=seconds`; skip where unsupported
+# (e.g. BSD date on macOS).
+_HAVE_GNU_DATE = subprocess.run(
+    ['date', '--rfc-3339=seconds'], capture_output=True).returncode == 0
+
+pytestmark = pytest.mark.skipif(
+    not _HAVE_GNU_DATE, reason='requires GNU date (--rfc-3339)')
+
+
+def _run(command):
+    """Invoke profiler.sh the way make does: `$(SHELL) -c '<command>'`."""
+    return subprocess.run([_PROFILER, '-c', command],
+                          capture_output=True, text=True)
+
+
+def test_task_line_parses_with_consumer_regex():
+    result = _run('true')
+    task_lines = [l for l in result.stdout.splitlines()
+                  if l.startswith('++Task:')]
+    assert len(task_lines) == 1
+    m = _TASK_RE.match(task_lines[0])
+    assert m, f'consumer regex rejected: {task_lines[0]!r}'
+    assert m.group(4) == "true'"          # command, with closing quote
+    assert int(m.group(3)) >= -1          # maxRSS in kB, or -1 sentinel
+
+
+def test_exit_status_propagated():
+    assert _run('true').returncode == 0
+    assert _run('false').returncode == 1
+    assert _run('exit 7').returncode == 7
+
+
+def test_command_output_passes_through():
+    result = _run('echo recipe-output')
+    assert 'recipe-output' in result.stdout
+
+
+def test_report_generated_from_task_lines(tmp_path):
+    # End-to-end: a profiler-produced log renders to an HTML report.
+    log = tmp_path / 'build.log'
+    log.write_text(_run('sleep 0').stdout)
+    html = tmp_path / 'profile.html'
+    result = subprocess.run(
+        [sys.executable, _REPORTER, str(log), str(html),
+         '--durationMinimum', '0'],
+        capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert html.exists() and html.stat().st_size > 0


### PR DESCRIPTION
**PR 9 of 9** — the final PR of the build-infrastructure series, stacked on #1226. Implements item 10 (the last item) of the review action plan: tests for the shared plumbing whose invariants were previously enforced by nothing.

57 new tests, in the review's priority order:

- **`ParallelScan`** — the byte-identical-to-serial and task-order contracts that keep every generated makefile deterministic under any parallelism; the `GALACTICUS_BUILD_JOBS` → `MAKEFLAGS -j` → standalone-default worker-count precedence (bare `-j`, no `-j` under make, clamping); the fail-with-serial-repro-hint behavior.
- **`FileChanges.update`** — only-if-changed replacement with mtime preservation, and the `.up` sentinel advancing on every run even when the output is untouched: the backbone of incremental-build minimality documented in #1226.
- **`ScanCache`** — stable cache keys and graceful degradation on missing/corrupt/wrong-type blobs.
- **`_canonicalize` pickle-identity** (codeDirectivesParse) — the most over-clever construct in the build scripts, whose "keep `_ENTRY_LITERALS` in sync with `_scan_one`" obligation had no enforcement. The test drives the real `_scan_one` over fixtures exercising every top-level entry shape (functionClass directive with implicit task dependencies, plus an include directive), simulates the worker pickle round-trip, and requires the canonicalized blob to pickle byte-identically to a serial one — with a guard asserting the round-trip genuinely de-interns, so the test cannot silently go vacuous.
- **`LibraryInterfaces.Classification`** — table-driven coverage of the shared argument rules from #1223, including the `omp_lock_kind` rejection (the rule whose silent loss from the audit's hand-synced copy motivated sharing the module), generator-mode vs audit-mode `class(...)` handling, overrides, hierarchy resolution, and the array-shape matrix.
- **The `++Task:` profiler contract** — end-to-end subprocess tests that profiler.sh's output parses with buildProfiler.py's regex and renders to a report, plus its exit-status propagation from #1219 (skipped where GNU `date` is unavailable, e.g. macOS).

The profiler test immediately earned its keep: `buildProfiler.py` divided by zero on any log whose tasks all completed within one second (timestamps have 1s resolution) — fixed here.

Full suite: 356 tests passing.

This completes the review action plan: with this PR merged, all ten items are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)