### PR TITLE
fix(build): read C/C++ sources one line at a time in buildCode

### DIFF
--- a/scripts/build/buildCode.py
+++ b/scripts/build/buildCode.py
@@ -293,9 +293,18 @@ def _process_until_include_or_eof(fh, frame, build, source_directory,
     we exhausted the file.
     """
     while True:
-        raw_line, processed_line, _ = get_fortran_line(fh) \
-            if build['codeType'] == 'fortran' \
-            else (fh.readline(), fh.readline(), '')
+        if build['codeType'] == 'fortran':
+            raw_line, processed_line, _ = get_fortran_line(fh)
+        else:
+            # For C/C++ the raw and processed forms are the same single line;
+            # `get_fortran_line`'s continuation-joining does not apply. Read
+            # ONE line and use it for both — mirrors `_consume_until_close`
+            # below and the Perl original. (A previous
+            # `(fh.readline(), fh.readline(), '')` here read two lines per
+            # iteration, so `raw_line`/`processed_line` were different,
+            # consecutive lines and every other line was skipped.)
+            line = fh.readline()
+            raw_line, processed_line = line, line
         if not raw_line and not processed_line:
             return None
 

--- a/scripts/build/tests/test_build_code_c_scan.py
+++ b/scripts/build/tests/test_build_code_c_scan.py
@@ -1,0 +1,67 @@
+"""Regression test for buildCode.py's per-line read of C/C++ sources.
+
+`_process_until_include_or_eof` previously read C/C++ files with
+`(fh.readline(), fh.readline(), '')`, consuming TWO lines per iteration —
+so `raw_line` and `processed_line` were different, consecutive lines and
+every other line was skipped. A directive block spanning three consecutive
+lines (`!![` / `<tag .../>` / `!!]`) was therefore missed entirely. Latent
+in the current tree (the only include directive, `component`, lives in
+Fortran), but a real correctness bug for any C/C++ source carrying a
+directive.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir))
+import buildCode as bc  # noqa: E402
+
+
+def _scan_c(tmp_path, content, directive='myDirective'):
+    src = tmp_path / 'probe.c'
+    src.write_text(content)
+    build = {'codeType': 'c', 'directive': directive,
+             'moduleName': '', 'currentFileName': str(src)}
+    frame = {'name': str(src), 'position': -1, 'in_xml': False}
+    entry = {'files': [str(src)], 'directives': []}
+    with open(src) as fh:
+        bc._process_until_include_or_eof(fh, frame, build, '.', entry, {})
+    return entry['directives']
+
+
+def test_c_directive_is_found(tmp_path):
+    # The directive occupies the three lines that a two-lines-per-iteration
+    # read would straddle; a correct single-line read captures it.
+    directives = _scan_c(tmp_path,
+                         'int x;\n'
+                         '!![\n'
+                         '<myDirective foo="bar"/>\n'
+                         '!!]\n'
+                         'int y;\n')
+    assert len(directives) == 1
+    assert directives[0]['directive'] == {'foo': 'bar'}
+
+
+def test_c_directive_after_odd_offset_is_found(tmp_path):
+    # An extra leading line shifts the directive's parity; it must still be
+    # found (the buggy double-read only ever saw one parity of lines).
+    directives = _scan_c(tmp_path,
+                         'int a;\n'
+                         'int b;\n'
+                         '!![\n'
+                         '<myDirective n="2"/>\n'
+                         '!!]\n')
+    assert len(directives) == 1
+    assert directives[0]['directive'] == {'n': '2'}
+
+
+def test_c_non_matching_directive_ignored(tmp_path):
+    # A directive whose tag is not the one being built is not recorded
+    # (confirms the scan still discriminates by tag, not that it records
+    # everything it happens to see).
+    directives = _scan_c(tmp_path,
+                         '!![\n'
+                         '<otherThing/>\n'
+                         '!!]\n')
+    assert directives == []


### PR DESCRIPTION
Stacked on #1227 (the tip of the build-infrastructure series). Fixes a latent correctness bug the review flagged but the plan deferred.

`buildCode.py`'s `_process_until_include_or_eof` read C/C++ files with `(fh.readline(), fh.readline(), '')` — which evaluates `readline()` **twice**, consuming two lines per iteration. So `raw_line` and `processed_line` were different, consecutive lines and every other line was skipped. A directive block spanning three consecutive lines (`!![` / `<tag .../>` / `!!]`) was missed entirely: the opener set `in_xml` on one line, `!!]` cleared it two lines later, and the `<tag>` line in between was never examined.

The C/C++ branch now reads one line and uses it for both the raw and processed forms — matching `_consume_until_close`, which already does this correctly a few lines below, and the Perl original. The Fortran branch (which relies on `get_fortran_line`'s continuation-joining) is untouched.

**Latency:** not currently triggered — the only include directive (`component`) lives in Fortran sources — but a real bug for any C/C++ source carrying a directive, which `codeDirectivesParse.py`'s directive-location map can include.

**Tests:** adds `scripts/build/tests/test_build_code_c_scan.py`, which drives the real scanner over C fixtures whose directive straddles the two-line read window. I verified these fixtures return no directives against the buggy code and the correct directive against the fix (a genuine regression guard, not a vacuous one). The Fortran path was re-verified end-to-end by regenerating the 5.3 MB component include, and the full build-script suite passes (234 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)