### PR TITLE
fix(build): keep all instances when one file implements two functionClasses

### DIFF
--- a/scripts/build/stateStorables.py
+++ b/scripts/build/stateStorables.py
@@ -235,9 +235,19 @@ def main(argv):
                 p2_tasks.append(
                     (instance_identifier, instance_file, function_class_name)
                 )
+    # The cache entry for a freshly-scanned instance file is popped ONCE (to
+    # discard any stale instances left from a previous run), then every task's
+    # names are appended. A single instance file that implements instances of
+    # more than one functionClass yields one task per class; popping only on
+    # the first of them lets those tasks accumulate, instead of a later task's
+    # pop discarding an earlier one's names (which silently dropped that file's
+    # instances of every class but the last).
+    popped = set()
     for instance_identifier, names in parallel_scan(
             p2_tasks, _scan_instance, 'stateStorables.py'):
-        storables_per_file.pop(instance_identifier, None)
+        if instance_identifier not in popped:
+            storables_per_file.pop(instance_identifier, None)
+            popped.add(instance_identifier)
         instance_entry = storables_per_file.setdefault(instance_identifier, {})
         for name in names:
             instance_entry.setdefault('functionClassInstances', []).append(name)

--- a/scripts/build/tests/test_state_storables_multiclass.py
+++ b/scripts/build/tests/test_state_storables_multiclass.py
@@ -1,0 +1,84 @@
+"""Regression test for stateStorables.py's Pass 2 merge.
+
+Pass 2 builds one scan task per (instance-file, functionClass) pair. A
+single source file that declares concrete instances of *two* different
+functionClasses yields two tasks for that file. The merge previously
+popped the file's cache entry before every task, so the second task's pop
+discarded the first task's instance names — silently dropping that file's
+instances of every class but the last from the emitted
+`functionClassInstances` list (which drives state store/restore code
+generation). The fix pops each instance file's entry only once per run, so
+sibling tasks accumulate.
+
+Latent in the current tree (no source file implements instances of two
+functionClasses), so this drives stateStorables.main() end-to-end over a
+fixture tree that does.
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir))
+import stateStorables as ss  # noqa: E402
+
+
+def _emitted_instances(tmp_path, monkeypatch, *, share_file):
+    """Run stateStorables over a fixture tree declaring two functionClasses
+    (classA, classB) whose instances live either in one shared file or in
+    two separate files, and return the emitted functionClassInstances list.
+    """
+    install = tmp_path
+    source  = install / 'source'
+    build   = install / 'build'
+    source.mkdir()
+    build.mkdir()
+    monkeypatch.setenv('BUILDPATH', str(build))
+    monkeypatch.setenv('GALACTICUS_BUILD_JOBS', '1')   # deterministic, no fork
+
+    base = source / 'base.F90'
+    base.write_text(
+        'module Bases\n'
+        '  !![\n  <functionClass>\n   <name>classA</name>\n  </functionClass>\n  !!]\n'
+        '  !![\n  <functionClass>\n   <name>classB</name>\n  </functionClass>\n  !!]\n'
+        'end module Bases\n'
+    )
+
+    a_block = '  !![\n  <classA name="classAImpl"/>\n  !!]\n'
+    b_block = '  !![\n  <classB name="classBImpl"/>\n  !!]\n'
+    if share_file:
+        (source / 'impls.F90').write_text(
+            'module Impls\n' + a_block + b_block + 'end module Impls\n')
+        a_file = b_file = source / 'impls.F90'
+    else:
+        (source / 'implsA.F90').write_text(
+            'module ImplsA\n' + a_block + 'end module ImplsA\n')
+        (source / 'implsB.F90').write_text(
+            'module ImplsB\n' + b_block + 'end module ImplsB\n')
+        a_file = source / 'implsA.F90'
+        b_file = source / 'implsB.F90'
+
+    (build / 'directiveLocations.xml').write_text(
+        '<directiveLocations>\n'
+        f'  <functionClass><file>{base}</file></functionClass>\n'
+        f'  <classA><file>{a_file}</file></classA>\n'
+        f'  <classB><file>{b_file}</file></classB>\n'
+        '</directiveLocations>\n'
+    )
+
+    ss.main(['stateStorables.py', str(install)])
+    root = ET.parse(build / 'stateStorables.xml').getroot()
+    return [e.text for e in root.findall('functionClassInstances')]
+
+
+def test_two_classes_in_one_file_keep_both_instances(tmp_path, monkeypatch):
+    names = _emitted_instances(tmp_path, monkeypatch, share_file=True)
+    assert 'classAImpl' in names
+    assert 'classBImpl' in names
+
+
+def test_two_classes_in_separate_files_unaffected(tmp_path, monkeypatch):
+    # The one-class-per-file case (every real file today) must be unchanged.
+    names = _emitted_instances(tmp_path, monkeypatch, share_file=False)
+    assert sorted(names) == ['classAImpl', 'classBImpl']


### PR DESCRIPTION
Stacked on #1228. Fixes the last of the review's deferred correctness bugs.

`stateStorables.py`'s Pass 2 builds one scan task per `(instance-file, functionClass)` pair, then merges each result with a pop-then-append. A single source file declaring concrete instances of *two* different functionClasses produces two tasks for that file, and the per-task **pop** meant the second task discarded the first task's instance names — silently dropping that file's instances of every class but the last from the emitted `functionClassInstances` list (which drives the state store/restore code generation).

The pop exists to clear a stale entry left by a *previous run*; it now fires only once per instance file per run (tracked in a `popped` set), so sibling tasks for the same file accumulate. The across-run freshness behavior is unchanged.

**Latency:** verified none of the 198 functionClasses currently shares an instance file with another, so it never fires today — and it's faithful to the Perl original's delete-then-push-per-pair semantics. But it's a real bug for any file that comes to implement instances of two classes.

**Tests:** `scripts/build/tests/test_state_storables_multiclass.py` drives `stateStorables.main()` end-to-end over a fixture tree where one file implements instances of two functionClasses (verified to emit only the *last* class's instance against the buggy code, both against the fix), plus a two-separate-files control confirming the common one-class-per-file case is unchanged. The real-tree `stateStorables.xml` regenerates byte-identical before and after, and the full build-script suite passes (236 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)