### PR TITLE
fix(tests): make parametersDiff's xdiff download robust and its exit codes honest

### DIFF
--- a/scripts/parameters/parametersDiff.py
+++ b/scripts/parameters/parametersDiff.py
@@ -8,6 +8,7 @@ import tarfile
 import subprocess
 import sys
 import tempfile
+import time
 import re
 
 # Show differences between two Galacticus parameter files. 
@@ -26,11 +27,33 @@ dynamicPath = os.environ['GALACTICUS_DATA_PATH']+"/dynamic"
 xdiffPath   = dynamicPath+"/xdiff-2.4"
 xdiff       = Path(xdiffPath+"/xdiff.py")
 if not xdiff.is_file():
-    tarFile = xdiffPath+".tar.gz"
-    urllib.request.urlretrieve("https://hg.sr.ht/~nolda/xdiff/archive/2.4.tar.gz", tarFile)
-    tarball = tarfile.open(tarFile)
-    tarball.extractall(dynamicPath)
-    tarball.close()
+    # Retry the download: the upstream host (SourceHut) intermittently returns gateway errors,
+    # especially to CI address ranges. A failure here must not masquerade as a comparison result:
+    # this tool follows the diff exit convention (0 = no differences, 1 = differences, >= 2 =
+    # trouble), and an uncaught exception would exit with code 1 -- indistinguishable from
+    # "differences found". The URL can be overridden (e.g. to point at a mirror) via the
+    # GALACTICUS_XDIFF_URL environment variable.
+    xdiffURL = os.environ.get('GALACTICUS_XDIFF_URL',"https://hg.sr.ht/~nolda/xdiff/archive/2.4.tar.gz")
+    os.makedirs(dynamicPath,exist_ok=True)
+    tarFile         = xdiffPath+".tar.gz"
+    attemptsMaximum = 5
+    for attempt in range(attemptsMaximum):
+        try:
+            urllib.request.urlretrieve(xdiffURL, tarFile)
+            with tarfile.open(tarFile) as tarball:
+                tarball.extractall(dynamicPath)
+            break
+        except Exception as error:
+            if attempt+1 < attemptsMaximum:
+                delay = 2**(attempt+1)
+                print(f"attempt {attempt+1} of {attemptsMaximum} to obtain xdiff failed ({error}); retrying in {delay}s",file=sys.stderr)
+                time.sleep(delay)
+            else:
+                print(f"FATAL: failed to obtain xdiff from '{xdiffURL}' after {attemptsMaximum} attempts: {error}",file=sys.stderr)
+                sys.exit(2)
+    if not xdiff.is_file():
+        print(f"FATAL: the xdiff tarball from '{xdiffURL}' did not provide '{xdiff}'",file=sys.stderr)
+        sys.exit(2)
 
 # `xdiff` imports the `blessings` module solely for optional colored terminal output. That package is
 # unmaintained and unavailable on recent Python versions. If it is not installed, drop a minimal no-op shim

--- a/testSuite/test-parameters-diff.py
+++ b/testSuite/test-parameters-diff.py
@@ -4,17 +4,37 @@ import subprocess
 # Test parameter file differences tool.
 # Andrew Benson (07-September-2024)
 
+# `parametersDiff.py` follows the diff exit convention: 0 = no differences, 1 = differences,
+# >= 2 = trouble (e.g. the xdiff download failed). Interpreting any non-zero code as
+# "differences found" would let an infrastructure error masquerade as a pass (or a failure)
+# in the cases below, so match the expected codes exactly.
+
 print("Respect order; '.4f' format")
 status = subprocess.run("../scripts/parameters/parametersDiff.py --canonicalizeValues .4f --respectOrder parameters/parametersDiff1.xml parameters/parametersDiff2.xml",shell=True)
-result = "FAILED" if status.returncode == 0 else "SUCCESS"
+if status.returncode == 1:
+    result = "SUCCESS"
+elif status.returncode == 0:
+    result = "FAILED"
+else:
+    result = "FAILED (parametersDiff.py errored with exit code "+str(status.returncode)+")"
 print(result+": differences expected")
 
 print("Ignore order; '.4f' format")
 status = subprocess.run("../scripts/parameters/parametersDiff.py --canonicalizeValues .4f parameters/parametersDiff1.xml parameters/parametersDiff2.xml",shell=True)
-result = "FAILED" if status.returncode == 0 else "SUCCESS"
+if status.returncode == 1:
+    result = "SUCCESS"
+elif status.returncode == 0:
+    result = "FAILED"
+else:
+    result = "FAILED (parametersDiff.py errored with exit code "+str(status.returncode)+")"
 print(result+": differences expected")
 
 print("Ignore order; '.3f' format")
 status = subprocess.run("../scripts/parameters/parametersDiff.py --canonicalizeValues .3f parameters/parametersDiff1.xml parameters/parametersDiff2.xml",shell=True)
-result = "FAILED" if status.returncode != 0 else "SUCCESS"
+if status.returncode == 0:
+    result = "SUCCESS"
+elif status.returncode == 1:
+    result = "FAILED"
+else:
+    result = "FAILED (parametersDiff.py errored with exit code "+str(status.returncode)+")"
 print(result+": no differences expected")


### PR DESCRIPTION
The `test-parameters-diff.py` failure seen on #1222 (and unrelated to it — the stack touches neither file) was a transient HTTP 504 from `hg.sr.ht` during the xdiff tarball download. The download had no error handling, so the crash exited with code 1 — indistinguishable from xdiff's "differences found". Consequences: the two differences-expected cases **passed spuriously** and the no-differences case failed with a misleading message.

- `parametersDiff.py`: retry the download (5 attempts, exponential backoff), URL overridable via `GALACTICUS_XDIFF_URL` (mirror-ready), and exit **2** with a clear `FATAL` message when the tarball cannot be obtained — matching the diff exit convention (0 = same, 1 = differ, ≥2 = trouble) that xdiff itself follows.
- `test-parameters-diff.py`: match expected exit codes exactly (1 for differences-expected, 0 for no-differences) and report a distinct message when the tool errors, so an infrastructure failure can never masquerade as a comparison result.

Verified locally: all three cases pass with a fresh download into a clean `GALACTICUS_DATA_PATH`; an unreachable URL produces five logged attempts then exit 2.

If sr.ht flakiness recurs, the durable option is mirroring the (GPLv2, 10 kB) tarball under a `galacticusorg` release — the `GALACTICUS_XDIFF_URL` hook makes switching trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)