### PR TITLE
Document remaining preprocessor directives in the developer guide

### DIFF
--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -1118,6 +1118,23 @@ Each implementation of a ``functionClass`` is generated into its own submodule (
     !!]
     integer, parameter :: outputRootMassesBufferSize=1000
 
+Internal Infrastructure Directives
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A few directives are internal build infrastructure, each appearing at exactly one point in the source. They are listed here for completeness---developers will not normally need to use them.
+
+``parameterMigration``
+   Used in the input parameter reading code (``source/utility/input_parameters.F90``). Expands to an array of the commit hashes listed in ``scripts/aux/migrations.xml``, used to decide which parameter migrations must be applied to bring an input parameter file up to date. (New migrations are added to ``migrations.xml``, not via this directive.)
+
+``dependenciesInitialize``
+   Used in the ``Dependencies`` module (``source/utility/dependencies.F90``). Expands to code populating the registry of dependency versions (from the ``aux/dependencies.yml`` manifest) so that the versions of libraries used in the build can be queried at run time.
+
+``expiry``
+   An annotation marking code that supports a deprecated feature and is scheduled for removal. The ``version`` attribute gives the Galacticus version at which the code is expected to be removed.
+
+``interTreePositionInsert``
+   A legacy annotation (in the Cartesian position component) marking the function which transfers position histories when a satellite node is moved between trees. New code should instead attach to the inter-tree event hooks (e.g. ``interTreeSatelliteInsertEvent``; see Section :galacticus-ref:`eventHooks`).
+
 Numerical Tools
 ---------------
 

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -389,6 +389,25 @@ Galacticus supports storing its internal state to file to allow :ref:`restarts <
 
 This specifies that the ``table`` class (and all child classes) can and should be stored to file as part of the representation of the internal state. Code to store and restore all data associated with any object of this class (as well as restoring polymorphic objects to the correct type) will be generated. If certain variables of the class or subclass should be restored to specific values this can be specified through a ``restoreTo`` element placed within an element with the name of the class or subclass (e.g. the ``table1DGeneric`` in the above example). The ``restoreTo`` element should specify a comma-separated list of one or more variables to set in its ``variables`` attribute, and the state to which they should be restored in its ``state`` attribute. Any variables which should be excluded from state store/restore (e.g. if their values are known to be determined statically at construction) can be specified via a ``exclude`` element---a list of variables to exclude should be given as a comma-separated list in its ``variables`` attribute.
 
+In hand-written state store/restore subroutines (for example, those of node component classes, which are not generated via the ``functionClass`` machinery), the ``stateStore`` and ``stateRestore`` directives emit the necessary per-object serialization code. Each takes a ``variables`` attribute giving a space-separated list of pointers to ``functionClass`` objects. For example:
+
+.. code-block:: none
+
+     subroutine Node_Component_Spin_Vector_State_Store(stateFile,gslStateFile,stateOperationID)
+       use, intrinsic :: ISO_C_Binding, only : c_ptr, c_size_t
+       implicit none
+       integer          , intent(in   ) :: stateFile
+       integer(c_size_t), intent(in   ) :: stateOperationID
+       type   (c_ptr   ), intent(in   ) :: gslStateFile
+
+       !![
+       <stateStore variables="darkMatterHaloScale_"/>
+       !!]
+       return
+     end subroutine Node_Component_Spin_Vector_State_Store
+
+For each listed variable, the ``stateStore`` directive writes the association status of the pointer to the state file and, if associated, calls the object's ``stateStore`` method. The ``stateRestore`` directive generates the matching code for restoration: it reads the stored association status and, if the object was stored, calls its ``stateRestore`` method (reporting an error if the pointer is unexpectedly not associated on restore). These directives must be used within subroutines having the standard state store/restore interface, i.e. accepting the ``stateFile``, ``gslStateFile``, and ``stateOperationID`` arguments shown above.
+
 .. _manual-sec-eventHooks:
 
 Event Hooks
@@ -420,6 +439,8 @@ The ``name`` attribute gives the name of the event hook. The ``interface`` eleme
 When the preprocessor encounters this directive, it generates code to call all functions that have been attached to this event hook. The event hook infrastructure (defined in ``Events_Hooks``) handles the list of attached functions and ensures each is called in the correct order (respecting any dependencies specified at attachment time), and with the correct OpenMP thread binding.
 
 A simpler variant, ``eventHookStatic``, is available for cases where the set of hooked functions is fixed at compile time (i.e.\ the functions are known statically and do not change at runtime). In this case, the directive takes only a ``name`` attribute, and the hooked functions are identified by a matching directive of the same name, which specifies the function to call via a ``function`` attribute.
+
+The supporting infrastructure for all event hooks---a typed event class for each ``eventHook`` directive with a declared ``interface``, together with its ``attach``, ``detach``, and ``isAttached`` methods---is synthesized by the ``eventHookManager`` directive. This directive appears exactly once, in the ``Events_Hooks`` module (``source/events/hooks.F90``), and is internal build infrastructure: developers defining or attaching to event hooks never need to use it.
 
 .. _manual-sec-autoHook:
 
@@ -884,6 +905,31 @@ In addition to the deep copy functionality generated within ``functionClass`` ob
        !!]
 
 These three directives are typically used in sequence when manually deep-copying a ``functionClass`` member: first ``deepCopyReset`` to prepare the source, then ``deepCopy`` to perform the copy, then ``deepCopyFinalize`` to clean up.
+
+Deep Copy Actions
+^^^^^^^^^^^^^^^^^
+
+Some types which are *not* ``functionClass`` objects nevertheless require special actions to be performed on any copy of an object made during a deep copy---for example, resetting an "initialized" flag, or reallocating an external (e.g. GSL) resource that must not be shared between copies. The ``deepCopyActions`` directive, placed in the declaration section of the module defining such a type, declares these actions. For example, the ``rootFinder`` class uses:
+
+.. code-block:: none
+
+    !![
+    <deepCopyActions class="rootFinder">
+     <rootFinder>
+      <setTo variables="functionInitialized" state=".false."/>
+     </rootFinder>
+    </deepCopyActions>
+    !!]
+
+The ``class`` attribute names the base class to which the actions apply. The directive then contains one element per type in the class hierarchy (named for that type), each of which may contain:
+
+``setTo``
+   Sets each member variable in the comma-separated ``variables`` attribute to the value given by the ``state`` attribute.
+
+``methodCall``
+   Calls the type-bound method named by the ``method`` attribute (with any arguments given via an ``arguments`` attribute)---used, for example, by the ``interpolator`` class to reallocate its GSL interpolator objects in the copy.
+
+The preprocessor generates a type-bound ``deepCopyActions`` method for the class (with a ``select type`` branch for each non-abstract type descended from it, applying the actions declared at each level of the inheritance chain). The deep-copy code generated for ``functionClass`` objects automatically calls this method on any member object of such a class after it is copied.
 
 Generic Programming
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -415,6 +415,8 @@ This expands to a call which registers a meta-property named ``nodeFormationTime
 
 The error reporting described under ``isCreator`` is supported by the ``metaPropertyDatabase`` directive, which appears exactly once (in ``source/objects/nodes/_class.F90``) and synthesizes a database mapping each known meta-property name to the ``functionClass`` implementations that create it. It is internal build infrastructure, and never needs to be used when defining or using meta-properties.
 
+.. _manual-sec-stateStorable:
+
 State Storing
 ~~~~~~~~~~~~~
 
@@ -732,6 +734,8 @@ The generated code gathers the names of all parameters that the object (includin
 
 ``extraAllowedNames``
    *(optional)* A space-separated list of additional parameter names which should be considered valid even though no ``inputParameter`` or ``objectBuilder`` directive reads them (e.g. parameters read indirectly by other means).
+
+.. _manual-sec-functionClass:
 
 Function Classes
 ~~~~~~~~~~~~~~~~

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -1028,6 +1028,96 @@ When a generic instance attribute begins with ``regEx``, matching generic tags a
 
 Finally, the special generic tag ``match`` acts as a ternary operator. If the regular expression specified in the third element matches the ``label`` attribute of a specific instance, the generic tag is replaced with its fourth element, otherwise it is replaced with its fifth element.
 
+Allocations
+~~~~~~~~~~~
+
+The ``allocate`` directive emits an ``allocate()`` statement for an array whose rank is not known when the code is written---for example, in code templated over types of different rank via the generic programming infrastructure. The rank is inferred from the variable's declaration (after any generic expansion), and the shape is drawn from a second array or a size variable. For example:
+
+.. code-block:: none
+
+    !![
+    <allocate variable="luminosities" shape="shapeLines"/>
+    !!]
+
+expands, for a rank-2 ``luminosities``, to ``allocate(luminosities(shapeLines(1),shapeLines(2)))``. The directive accepts the following attributes:
+
+``variable``
+   The name of the allocatable variable to allocate.
+
+``shape``
+   *(optional)* The name of an array whose elements give the size of the allocated variable along each dimension.
+
+``size``
+   *(optional)* The name of an array whose extent along each dimension (i.e. ``size({array},dim=i)``) gives the size of the allocated variable along that dimension---used to allocate one array to match the shape of another.
+
+``rank``
+   *(optional)* Explicitly specifies the rank, overriding the rank inferred from the variable's declaration.
+
+Iterating Over Array Elements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``forEach`` directive wraps the code it contains in a set of loops over every element of a named array, for cases where the rank of the array is not known when the code is written (e.g. in code templated via the generic programming infrastructure). The ``variable`` attribute names the array, and the rank of the generated loop nest is inferred from that variable's declaration. Within the contained code, the placeholder ``{index}`` is replaced by the indexing expression for the current element (e.g. ``(foreach__1,foreach__2)``; empty for a scalar), ``{{index}}`` is replaced by the comma-separated list of index variables, and ``%index%`` is replaced by a suitable format specifier for writing those indices. This directive is used only in highly-generic infrastructure code (currently the unit testing framework)---most code knows the rank of its arrays and can use ordinary loops.
+
+Method Descriptions
+~~~~~~~~~~~~~~~~~~~
+
+The ``methods`` directive attaches documentation to the type-bound procedures of a derived type. It is placed inside the type definition, alongside the procedure bindings it describes, and contains one ``method`` element per method, with ``method`` and ``description`` attributes giving the method's name and a description of what it does. For example, from the ``rootFinder`` class:
+
+.. code-block:: none
+
+     type :: rootFinder
+        ...
+      contains
+        !![
+        <methods docformat="rst">
+          <method description="Set the function that evaluates :math:`f(x)` to use in a ``rootFinder`` object." method="rootFunction"/>
+          <method description="Set the type of algorithm to use in a ``rootFinder`` object."                    method="type"        />
+          <method description="Set the tolerance to use in a ``rootFinder`` object."                            method="tolerance"   />
+        </methods>
+        !!]
+        procedure :: rootFunction => rootFunctionSet
+        procedure :: type         => typeSet
+        procedure :: tolerance    => toleranceSet
+        ...
+     end type rootFinder
+
+The optional ``docformat="rst"`` attribute marks the descriptions as being written in reStructuredText (descriptions without it are treated as the older LaTeX dialect). These descriptions are extracted into this documentation, so should be provided for every type-bound procedure of a hand-written type. Note that for the *standard* methods of a ``functionClass`` implementation, descriptions are instead given via the ``description`` element of each ``method`` in the ``functionClass`` directive---explicit ``methods`` directives are needed only for methods unique to an implementation, and for types built outside of the ``functionClass`` system.
+
+Workarounds
+~~~~~~~~~~~
+
+The ``workaround`` directive annotates code that exists only to work around a bug in a compiler or other tool. It takes no action in the build---it exists to document the workaround (a list of all current workarounds, generated from these directives, appears in this documentation), and to make workarounds easy to find and remove once the underlying bug is fixed. Wrap the workaround code in the directive:
+
+.. code-block:: none
+
+    !![
+    <workaround type="gfortran" PR="105807" url="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105807">
+      <description>
+      ICE when passing a derived type component to a class(*) function argument.
+      </description>
+    !!]
+    dummyPointer_      => self%vector_
+    self%vectorManager =  resourceManager(dummyPointer_)
+    !![
+    </workaround>
+    !!]
+
+The ``type`` attribute (required) names the tool containing the bug (e.g. ``gfortran``), while the optional ``PR`` and ``url`` attributes identify the relevant bug report. A ``description`` element should explain the bug being worked around. Optional ``seeAlso`` elements (with the same ``type``/``PR``/``url`` attributes) can reference related bug reports.
+
+Module Scoping
+~~~~~~~~~~~~~~
+
+Each implementation of a ``functionClass`` is generated into its own submodule (see Section :galacticus-ref:`functionClass`). By default, private module-scope variables declared in an implementation's source file are moved into that submodule. The ``scoping`` directive overrides this for variables that must remain at *module* scope---for example, a ``parameter`` used in the declaration of a type component, which must be visible where the type itself is defined. It is placed in the declaration section of the file, and contains a ``module`` element whose ``variables`` attribute lists (comma-separated) the variables to keep at module scope:
+
+.. code-block:: none
+
+    !![
+    <scoping>
+     <module variables="outputRootMassesBufferSize"/>
+    </scoping>
+    !!]
+    integer, parameter :: outputRootMassesBufferSize=1000
+
 Numerical Tools
 ---------------
 
@@ -1133,6 +1223,8 @@ Galacticus provides for global functions which facilitate this---specifically, i
 
 Here, ``myFunction`` is the name of the function to make global, while the ``type`` and ``arguments`` (of which there may be more than one) elements are used to generate a suitable interface for the function. At run-time, a pointer to this function is then available from the ``Functions_Global`` module, named ``myFunction_``. Note that ``Functions_Global_Set`` provided by the ``Functions_Global_Utilities`` module must be called once to initialize these global function pointers prior to their use.
 
+The supporting code is synthesized by the ``functionsGlobal`` directive, which appears exactly twice: ``<functionsGlobal type="pointers"/>`` (in the ``Functions_Global`` module) expands to the procedure pointer declarations for every ``functionGlobal`` directive in the source, while ``<functionsGlobal type="establish"/>`` (in ``Functions_Global_Utilities``) expands to the code which associates each pointer with its target function. This is internal build infrastructure---to make a function globally callable only the ``functionGlobal`` directive above is needed.
+
 Galacticus Metadata
 -------------------
 
@@ -1170,6 +1262,43 @@ after which you can use this constant, e.g.:
 .. code-block:: none
 
       volumeSphere=4.0d0*Pi/3.0d0*radiusSphere**3
+
+Defining New Constants
+~~~~~~~~~~~~~~~~~~~~~~
+
+New constants are defined using the ``constant`` directive, placed in the declaration section of a module (most constants live in the modules under ``source/numerical/constants/``). The directive expands to a Fortran ``parameter`` declaration, and additionally provides the metadata (description, units, reference) from which the tables of constants in this documentation are generated. For example:
+
+.. code-block:: none
+
+    !![
+    <constant variable="atomicMassHydrogen" value="1.0078250322d0" symbol="A_{^1\mathrm{H}}" units="amu" unitsInSI="1.66053906892e-27" description="Atomic mass of the $^1$H isotope of hydrogen." reference="Commission on Isotopic Abundances and Atomic Weights" referenceURL="https://www.ciaaw.org/hydrogen.htm" group="atomic"/>
+    !!]
+
+The directive accepts the following attributes:
+
+``variable``
+   *(required)* The name of the constant.
+
+``value``
+   The value of the constant. Alternatively, the value may be extracted automatically from a GSL header by giving ``gslSymbol`` and ``gslHeader`` attributes (or from a Linux kernel header via ``kernelSymbol`` and ``kernelHeader``)---at build time a small C program is compiled and run to extract the value, ensuring it stays synchronized with the library. For GSL enumerations, use ``type="enum"`` together with a ``members`` attribute listing the enumeration members.
+
+``description``
+   *(required)* A description of the constant, used in this documentation.
+
+``reference``, ``referenceURL``
+   *(required/optional)* The source of the value of the constant, and a URL for it.
+
+``symbol``
+   *(optional)* The mathematical symbol for the constant (in LaTeX math syntax).
+
+``units``, ``unitsInSI``
+   *(optional)* The units of the constant, and the value of those units in the SI system.
+
+``group``
+   *(optional)* One or more (comma-separated) groups into which the constant should be collected in the documentation.
+
+``externalDescription``
+   *(optional)* A URL giving an external description of the constant.
 
 Indicating Units of Defined Constants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -296,6 +296,63 @@ This directive can (and should) be used to destroy objects built by the ``object
       return
      end subroutine simpleDestructor
 
+.. _manual-sec-referenceCounting:
+
+Reference Counting
+~~~~~~~~~~~~~~~~~~
+
+Every ``functionClass`` object carries an internal reference counter which tracks how many references to the object are held. The ``objectBuilder`` directive increments this counter automatically when it retrieves or builds an object, and the ``objectDestructor`` directive decrements it, deallocating the object only when the count reaches zero. When objects are constructed directly (i.e. not via ``objectBuilder``), or when additional references to an existing object are taken, the reference count must still be kept accurate so that ``objectDestructor`` behaves correctly. Three directives automate this.
+
+The ``referenceConstruct`` directive constructs an object via an explicit constructor, increments its reference count, and calls its ``autoHook`` method (see Section :galacticus-ref:`autoHook`). For example:
+
+.. code-block:: none
+
+    class(kinematicsDistributionClass), pointer :: kinematicDistribution_
+
+    allocate(kinematicDistribution_)
+    !![
+    <referenceConstruct object="kinematicDistribution_" constructor="kinematicsDistributionLocal(alpha=1.0d0/sqrt(2.0d0))"/>
+    !!]
+
+which expands to an assignment of the constructor result to the object, followed by calls to ``referenceCountIncrement`` and ``autoHook`` on that object. The directive accepts the following attributes:
+
+``object``
+   The name of the variable to which the constructed object is assigned.
+
+``constructor``
+   The constructor expression to use. For long constructor expressions this may instead be given as a ``constructor`` element contained within the directive.
+
+``owner``
+   *(optional)* The name of an object owning ``object``---the assignment target is then ``{owner}%{object}``.
+
+``nameAssociated``
+   *(optional)* An alternative name by which the object is accessible at the point of the directive (e.g.\ inside an ``associate`` block). If given, this name is used in the generated code in place of ``{owner}%{object}``.
+
+``isResult``
+   *(optional)* If set to ``yes``, annotates that the reference being created is the result of the enclosing function, so ownership of the reference passes to the caller. This attribute does not change the generated code---it exists to allow static analysis of reference counting.
+
+The ``referenceAcquire`` directive takes a new reference to an *existing* object, pointer-associating a target with a source and incrementing the reference count:
+
+.. code-block:: none
+
+    !![
+    <referenceAcquire target="kinematicsDistribution_" source="self%kinematicsDistribution_"/>
+    !!]
+
+The ``target`` and ``source`` attributes are required; ``owner`` and ``isResult`` attributes are also accepted with the same meanings as for ``referenceConstruct`` (with ``owner`` applying to the target).
+
+Finally, the ``referenceCountIncrement`` directive simply increments the reference count of an existing object, for cases where a new reference has been created by other means (e.g. an explicit pointer assignment):
+
+.. code-block:: none
+
+    !![
+    <referenceCountIncrement owner="filter_" object="filter_"/>
+    !!]
+
+It accepts ``object`` (required), plus optional ``owner`` and ``isResult`` attributes as above.
+
+Every reference created via these directives should be balanced by a matching ``objectDestructor`` directive when the reference is released.
+
 Constructor Assignments
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -370,6 +370,51 @@ A common requirement in object constructors is to assign the values of arguments
 
 will cause the value of the ``massThreshold`` argument to ``stellarMassConstructorInternal%massThreshold``. If an argument name is prefixed with ``*`` in the variables list, pointer assignment is used instead of standard assignment.
 
+.. _manual-sec-metaProperties:
+
+Meta-Properties
+~~~~~~~~~~~~~~~
+
+Node components define their properties statically via ``component`` directives. Sometimes, however, a class needs to attach additional per-node data without defining a new component---for example, a ``nodeOperator`` recording some quantity that a ``galacticFilter`` will later read. Such data can be attached as a *meta-property* of an existing component class, registered at runtime using the ``addMetaProperty`` directive:
+
+.. code-block:: none
+
+    !![
+    <addMetaProperty component="basic" name="nodeFormationTime" id="self%nodeFormationTimeID" isEvolvable="no" isCreator="no"/>
+    !!]
+
+This expands to a call which registers a meta-property named ``nodeFormationTime`` in the ``basic`` component class, and stores the resulting integer identifier in ``self%nodeFormationTimeID``. That identifier is then used to access the meta-property via the component's type-bound accessors, e.g.:
+
+.. code-block:: none
+
+    time=basic%floatRank0MetaPropertyGet(self%nodeFormationTimeID     )
+    call basic%floatRank0MetaPropertySet(self%nodeFormationTimeID,time)
+
+(with the accessor names following the pattern ``{type}Rank{rank}MetaPropertyGet``/``Set``). Registering the same name from multiple classes yields the same identifier, so meta-properties can be shared between classes. The directive accepts the following attributes:
+
+``component``
+   The name of the component class to which the meta-property is attached (e.g. ``basic``).
+
+``name``
+   The name of the meta-property. This may also be a Fortran ``character`` variable or expression, allowing names to be constructed at runtime (e.g. one meta-property per element of a list).
+
+``id``
+   The integer variable in which to store the identifier of the registered meta-property.
+
+``type``
+   *(optional)* The type of the meta-property: ``float`` (default), ``integer``, or ``longInteger``.
+
+``rank``
+   *(optional)* The rank of the meta-property: 0 (default) or 1.
+
+``isEvolvable``
+   *(optional)* If ``yes``, the meta-property behaves as an evolvable property of the component (i.e. it is included in ODE evolution, with the usual rate accessors). Only rank-0, ``float`` meta-properties can be evolvable. Default is ``no``.
+
+``isCreator``
+   *(optional)* Set to ``yes`` in the class which is responsible for *setting* the meta-property, and ``no`` in classes which merely read it. This allows a meaningful error message (naming the class that should have been included in the model) to be reported if the meta-property is read but was never created. Default is ``no``.
+
+The error reporting described under ``isCreator`` is supported by the ``metaPropertyDatabase`` directive, which appears exactly once (in ``source/objects/nodes/_class.F90``) and synthesizes a database mapping each known meta-property name to the ``functionClass`` implementations that create it. It is internal build infrastructure, and never needs to be used when defining or using meta-properties.
+
 State Storing
 ~~~~~~~~~~~~~
 

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -629,6 +629,44 @@ Input Parameter Lists
 
 The ``inputParameterList`` directive will construct a ``varying_string`` array containing the names of all input parameters which are defined in the unit in which the directive appears. The name of the array is specified by the ``label`` attribute of the ``inputParameterList`` directive. If a ``source`` attribute is specified in the directive then only parameters being read from the named variable will be included in the list, otherwise any parameters read will be included. Such a list can be used to validate the names of parameters passed to a function for example.
 
+.. _manual-sec-inputParametersValidate:
+
+Input Parameter Validation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``inputParametersValidate`` directive checks that every parameter supplied to an object under construction is recognized, catching mis-spelled or misplaced parameter names in input files. It should be placed in the parameter-based constructor of every ``functionClass`` implementation, *after* all ``inputParameter`` and ``objectBuilder`` directives (so that the full set of allowed names is known). For example:
+
+.. code-block:: none
+
+     function stellarMassConstructorParameters(parameters) result(self)
+       implicit none
+       type            (galacticFilterStellarMass)                :: self
+       type            (inputParameters          ), intent(inout) :: parameters
+       double precision                                           :: massThreshold
+
+       !![
+       <inputParameter>
+         <name>massThreshold</name>
+         <source>parameters</source>
+         <description>The threshold stellar mass.</description>
+       </inputParameter>
+       <inputParametersValidate source="parameters"/>
+       !!]
+       self=galacticFilterStellarMass(massThreshold)
+       return
+     end function stellarMassConstructorParameters
+
+The generated code gathers the names of all parameters that the object (including any sub-objects it built) is allowed to accept, and then checks the parameter set named in the ``source`` attribute against this list, reporting an error for any unrecognized parameter. The directive accepts the following attributes:
+
+``source``
+   The name of the ``inputParameters`` object to validate.
+
+``multiParameters``
+   *(optional)* A comma-separated list of parameter names which are permitted to appear multiple times in the parameter set. This is used by classes which accept lists of objects (e.g. the ``multi`` implementations of various classes, which read multiple instances of a parameter such as ``galacticFilter``).
+
+``extraAllowedNames``
+   *(optional)* A space-separated list of additional parameter names which should be considered valid even though no ``inputParameter`` or ``objectBuilder`` directive reads them (e.g. parameters read indirectly by other means).
+
 Function Classes
 ~~~~~~~~~~~~~~~~
 

--- a/docs/manuals/developer-guide/methods.rst
+++ b/docs/manuals/developer-guide/methods.rst
@@ -11,12 +11,12 @@ Galacticus is designed to be flexible and extensible, allowing you to add new cl
 .. code-block:: none
 
     !![
-    <accretionDisks>
-      <unitName>Accretion_Disks_Shakura_Sunyaev_Initialize</unitName>
+    <accretionDisks name="accretionDisksADAF">
+      <description>An accretion disk class for ADAF (advection-dominated accretion flow) disks.</description>
     </accretionDisks>
     !!]
 
-This directive would typically appear just prior to a subroutine which initializes the Shakura-Sunyaev accretion disk module (it could appear anywhere throughout that module, but it makes sense to keep it close to the subroutine that it references). The ``accretionDisks`` tag explains to the Galacticus build system that this module contains an implementation of black hole accretion disks. The ``unitName`` tag specifies the name of a program unit which (in this case) should be called to initialize this accretion disk implementation. The build system will then insert appropriate ``use`` and ``call`` statements into the Galacticus code such that this routine will be called if and when accretion disks are required by Galacticus.
+This directive appears just prior to the definition of a type which implements an advection-dominated accretion flow (ADAF) accretion disk. The ``accretionDisks`` tag explains to the Galacticus build system that this file contains an implementation of the black hole accretion disks class. The build system will then merge this implementation into the ``accretionDisks`` function class (see Section :galacticus-ref:`functionClass`), making it selectable at run time. A complete reference of the general-purpose preprocessor directives is given in Section :galacticus-ref:`sourceTreePreprocessor`; this chapter describes the directives used to define node components and to register task functions.
 
 .. _manual-sec-ComponentMassTypes:
 
@@ -311,7 +311,22 @@ Component Initialization
 
 Initialization of a component module (if necessary, for example, to read parameters or allocate workspace) can occur at a number of different points in the execution of Galacticus. Providing initialization occurs in advance of any calculations then any point is acceptable. One possibility is simply to call an initialization function at the head of all functions defined in the component module. This initialization function should return immediately if it has already been called (to avoid duplicate initialization). Another option is to use a :galacticus-class:`mergerTreeOperator` to perform initialization just before merger trees are constructed (the initialization function must again return immediately if it has been previously called).
 
-Optionally, a component may include a ``mergerTreeEvolveThreadInitialize`` directive, which gives the name of a subroutine in its ``unitName`` element. The routine specified by ``mergerTreeEvolveThreadInitialize`` is called by all threads prior to merger tree evolution, and can therefore be used to perform any "per thread" initialization. Note that this routine will be called many times during a given Galacticus run---it is the responsibility of the routine to ensure that it performs any initialization only once.
+Alternatively, a component may register initialization (and uninitialization) functions using the following directives. Each is placed immediately before the subroutine that it registers, and names that subroutine in a ``function`` attribute (these directives, like all of the task directives described in this chapter, attach their function to a static event hook point---see Section :galacticus-ref:`eventHooks`). For example:
+
+.. code-block:: none
+
+    !![
+    <nodeComponentThreadInitializationTask function="Node_Component_Black_Hole_Standard_Thread_Initialize"/>
+    !!]
+
+``nodeComponentInitializationTask``
+   The function is called once when node components are first initialized. It receives a single argument, ``parameters``, of type ``type(inputParameters), intent(inout)``, from which any required parameters can be read.
+
+``nodeComponentThreadInitializationTask``
+   The function is called by each thread prior to merger tree evolution (with the same interface as above), and can therefore be used to perform any "per thread" initialization---for example, constructing threadprivate objects, or attaching functions to event hooks.
+
+``nodeComponentThreadUninitializationTask``
+   The function (which takes no arguments) is called by each thread once merger tree evolution is complete, and should undo any per-thread initialization (e.g. detaching functions from event hooks, and releasing objects).
 
 Component Access, Creation and Destruction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -388,17 +403,15 @@ where :math:`epsilon_\mathrm{abs}=`\ ``[odeToleranceAbsolute]``, :math:`epsilon_
 .. code-block:: none
 
      !![
-     <scaleSetTask>
-       <unitName>Node_Component_Disk_Exponential_Scale_Set</unitName>
-     </scaleSetTask>
+     <scaleSetTask function="Node_Component_Disk_Exponential_Scale_Set"/>
      !!]
-     subroutine Node_Component_Disk_Exponential_Scale_Set(thisNode)
+     subroutine Node_Component_Disk_Exponential_Scale_Set(node)
        implicit none
-       type (treeNode         ), pointer, intent(inout) :: thisNode
+       type (treeNode         ), pointer, intent(inout) :: node
        class(nodeComponentDisk), pointer                :: disk
 
        ! Get the disk component.
-       disk => thisNode%disk()
+       disk => node%disk()
        ! Check if an exponential disk component exists.
        select type (disk)
        class is (nodeComponentDiskExponential)
@@ -410,6 +423,20 @@ where :math:`epsilon_\mathrm{abs}=`\ ``[odeToleranceAbsolute]``, :math:`epsilon_
      end subroutine Node_Component_Disk_Exponential_Scale_Set
 
 Sensible choices for the :math:`s_i` factors can significantly speed-up execution of Galacticus.
+
+Other Component Task Directives
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Several further task directives allow a component to hook into specific points of the evolution cycle. Each takes the same form as ``scaleSetTask`` above---the directive is placed immediately before the subroutine to be registered, and names it in a ``function`` attribute:
+
+``preEvolveTask``
+   The function is called for each node before differential evolution of that node begins. The interface is ``(node)`` with ``node`` of type ``type(treeNode), intent(inout), pointer``. This is useful, for example, to ensure a component has been initialized before evolution starts.
+
+``inactiveSetTask``
+   The function is called (when an ODE solver making use of inactive-property optimizations is in use) before evolution of each node, and should mark as inactive any properties of the component which are known to not affect the evolution of other (active) properties, by calling their ``JacobianZero`` methods. The interface is the same as for ``preEvolveTask``.
+
+``stateStoreTask`` and ``stateRetrieveTask``
+   The functions are called when the internal state is written to (or restored from) file to allow :ref:`restarts <manual-sec-restarting>`, and should store (or restore) any state held by the component (typically making use of the ``stateStore``/``stateRestore`` directives---see Section :galacticus-ref:`stateStorable`). The interface is ``(stateFile,gslStateFile,stateOperationID)`` where ``stateFile`` is an ``integer``, ``gslStateFile`` is a ``type(c_ptr)``, and ``stateOperationID`` is an ``integer(c_size_t)``, all ``intent(in)``.
 
 Evolution Interrupts
 ^^^^^^^^^^^^^^^^^^^^
@@ -450,40 +477,142 @@ where ``MyImplementation`` is an appropriate name for the implementation. This f
 Events
 ~~~~~~
 
-Events are triggered during merger tree evolution. Examples are when a node needs to be promoted to its parent node, or when a minor node merges with its parent.
+Events are triggered during merger tree evolution. Examples are when a node needs to be promoted to its parent node, or when a minor node merges with its parent. Code responds to such events by attaching functions to the corresponding event hooks (see Section :galacticus-ref:`eventHooks`)---for example, the ``nodePromotion`` event (triggered when a primary progenitor reaches the time of its parent halo), the ``haloFormation`` event (triggered when a halo is deemed to have formed, or reformed), the ``satelliteHostChange`` event (triggered when a satellite node moves to a new host), and the ``mergerTreeExtraOutput`` event (triggered for each node at each output time, allowing extra, non-standard output to be written). Attachment is done at run time via the event's ``attach`` method (typically from a ``functionClass`` object's ``autoHook`` method, or from a node component's thread initialization task).
 
-Node Promotion Events
-^^^^^^^^^^^^^^^^^^^^^
-
-Additional methods for node promotion (i.e. when a primary progenitor reaches its parent halo) can be added using the ``nodePromotionTask`` directive. The directive should contain a single argument, giving the name of a subroutine to be called to initialize the method. For example, the ``basic`` tree node method uses this directive as follows:
-
-.. code-block:: none
-
-     !![
-     <nodePromotionTask>
-      <unitName>Tree_Node_Basic_Promote</unitName>
-     </nodePromotionTask>
-     !!]
-
-Here, ``Tree_Node_Basic_Promote`` is the name of a subroutine which will be called to perform whatever tasks are required prior to the promotion. The subroutine must have the following form:
-
-.. code-block:: none
-
-      subroutine Node_Promotion_Task(thisNode)
-       implicit none
-       type(treeNode), pointer, intent(inout) :: thisNode
-       .
-       .
-       .
-       return
-     end subroutine Node_Promotion_Task
-
-where ``thisNode`` is the node about to be promoted.
+.. note::
+   In older versions of Galacticus these events were handled by dedicated directives (``nodePromotionTask``, ``haloFormationTask``, ``satelliteHostChangeTask``, ``mergerTreeExtraOutputTask``, ``hdfPreCloseTask``, and the ``mergerTreeOutputPropertyCount``/``mergerTreeOutputNames``/``mergerTreeOutputTask`` family). These directives no longer exist---use the event hooks described above instead (for output tasks, use a :galacticus-class:`nodePropertyExtractorClass` implementation, or attach to the ``mergerTreeExtraOutput`` or ``outputFileClose`` events).
 
 Tasks
 ~~~~~
 
-Tasks are any processing which must be performed on a node as a result of some specific event (such as a merger).
+Tasks are any processing which must be performed at some specific point in the execution of Galacticus (e.g. before or after evolving a node, or when the output file is opened or closed). A function is registered as a task by a directive placed immediately before it, naming it in a ``function`` attribute. Each such directive corresponds to a static event hook point (an ``eventHookStatic`` directive of the same name---see Section :galacticus-ref:`eventHooks`) at which all registered functions are called. An optional ``after`` attribute (naming another registered function) may be used to constrain the order in which the registered functions are called.
+
+The component-related task directives (``nodeComponentInitializationTask``, ``nodeComponentThreadInitializationTask``, ``nodeComponentThreadUninitializationTask``, ``scaleSetTask``, ``preEvolveTask``, ``inactiveSetTask``, ``postStepTask``, ``stateStoreTask``, and ``stateRetrieveTask``) are described in Section :galacticus-ref:`ComponentImplement`. In addition, the following global task directives are available:
+
+``outputFileOpen``
+   The function is called immediately after the Galacticus output HDF5 file is opened (useful for writing one-time datasets, e.g. version or build information). The function takes no arguments.
+
+``outputFileClose``
+   The function is called immediately prior to closing the Galacticus output HDF5 file (typically to write accumulated data to that file). The function takes no arguments.
+
+``universePostEvolveTask``
+   The function is called once evolution of all merger trees is complete. The function takes no arguments.
+
+Merger Tree Initialization Tasks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Additional tasks to be performed during merger tree initialization can be added using the ``mergerTreeInitializeTask`` directive. For example, the ``standard`` basic component uses this directive as follows:
+
+.. code-block:: none
+
+     !![
+     <mergerTreeInitializeTask function="Halo_Mass_Accretion_Rate"/>
+     !!]
+
+Here, ``Halo_Mass_Accretion_Rate`` is the name of a subroutine which will be called to perform whatever initialization is required. The subroutine must have the following form:
+
+.. code-block:: none
+
+      subroutine Merger_Tree_Initialize_Task(node)
+       implicit none
+       type(treeNode), pointer, intent(inout) :: node
+       .
+       .
+       .
+       return
+     end subroutine Merger_Tree_Initialize_Task
+
+where ``node`` is the node to be initialized. The subroutine will be called once for each node in the tree.
+
+Post-step Tasks
+^^^^^^^^^^^^^^^
+
+Additional methods for post-step tasks (i.e. things that should be done after each ODE solver step when evolving a node differentially) can be added using the ``postStepTask`` directive. For example, the standard hot halo component adds a task as follows:
+
+.. code-block:: none
+
+     !![
+     <postStepTask function="Node_Component_Hot_Halo_Standard_Post_Step"/>
+     !!]
+
+Here, ``Node_Component_Hot_Halo_Standard_Post_Step`` is the name of a subroutine which will be called to perform whatever tasks are required. The subroutine must have the following form:
+
+.. code-block:: none
+
+      subroutine Post_Step_Task(node,status)
+       implicit none
+       type   (treeNode), intent(inout), pointer :: node
+       integer          , intent(inout)          :: status
+       .
+       .
+       .
+       return
+     end subroutine Post_Step_Task
+
+where ``node`` is the node for which tasks should be performed. If any change is made to the state of the node then ``status`` should be set equal to ``GSL_Failure``. Tasks typically involve cleaning up after differential evolution.
+
+.. _manual-sec-radius-solver:
+
+Radius Solver Tasks
+^^^^^^^^^^^^^^^^^^^
+
+Galactic radii solver functions (see :galacticus-class:`galacticStructureSolver`) need to be able to interact with the components of a tree node to
+
+#. Determine whether the node is physically plausible (and hence whether radii should be solved for at all);
+#. Determine which components want a radius to be solved for, and get and set the properties of those components.
+
+The ``radiusSolverPlausibility`` and ``radiusSolverTask`` directives facilitate this. A component which has a radius to be solved for should include directives of the form:
+
+.. code-block:: none
+
+    !![
+    <radiusSolverPlausibility function="Component_Radius_Solver_Plausibility"/>
+    !!]
+
+and
+
+.. code-block:: none
+
+    !![
+    <radiusSolverTask function="Component_Radius_Solver"/>
+    !!]
+
+where ``Component_Radius_Solver_Plausibility`` is the name of a subroutine which will specify whether or not the component is physically plausible for radius solving (e.g. has non-negative mass) and should have the following form:
+
+.. code-block:: none
+
+    subroutine Component_Radius_Solver_Plausibility(node)
+       implicit none
+       type(treeNode), intent(inout) :: node
+       .
+       .
+       .
+       return
+    end subroutine Component_Radius_Solver_Plausibility
+
+which should set ``node%isPhysicallyPlausible`` (and/or ``node%isSolvable``) to false if the component is not physically plausible, but should otherwise leave them unchanged. Additionally, ``Component_Radius_Solver`` is the name of a subroutine which will supply the necessary information about the node, and which should have the following form:
+
+.. code-block:: none
+
+    subroutine Component_Radius_Solver(node,componentActive,component,specificAngularMomentumRequired,specificAngularMomentum, &
+         &                             Radius_Get,Radius_Set,Velocity_Get,Velocity_Set)
+       implicit none
+       type            (treeNode                    ), intent(inout)          :: node
+       logical                                       , intent(  out)          :: componentActive
+       type            (enumerationComponentTypeType), intent(  out)          :: component
+       logical                                       , intent(in   )          :: specificAngularMomentumRequired
+       double precision                              , intent(  out)          :: specificAngularMomentum
+       procedure       (...                         ), intent(  out), pointer :: Radius_Get,Velocity_Get
+       procedure       (...                         ), intent(  out), pointer :: Radius_Set,Velocity_Set
+       .
+       .
+       .
+       return
+    end subroutine Component_Radius_Solver
+
+When called, the subroutine should set ``componentActive`` to indicate whether or not this node contains an active component of the type, and ``component`` to the corresponding component type (e.g. ``componentTypeDisk``; see Section :galacticus-ref:`ComponentMassTypes`). If the component is active, it should also set ``specificAngularMomentum`` to reflect the specific angular momentum (in km s\ :math:`^{-1}` Mpc) of the component (at whatever point in its profile the radius is required; this is required only if ``specificAngularMomentumRequired`` is true) and should point the four procedure pointers to routines which get and set the radius and circular velocity properties of the component (which should have the standard form for component get and set methods). It is acceptable for the set procedures to point to dummy routines.
+
+The galactic structure radii solver routines will use this information to determine (and set) the radius and circular velocity of the component. An advantage of this approach is that different radii solver methods can all use this same system, ensuring that just a single interface is needed in each component.
 
 Analytic Solvers
 ----------------
@@ -502,279 +631,6 @@ This solver, which can be activated by setting ``[diskVerySimpleUseAnalyticSolve
 * Disk star formation and outflow rates must scale as :math:`M_\mathrm{gas}/\tau` where :math:`M_\mathrm{gas}` is the instantaneous mass of gas in the galaxy disk, and :math:`\tau` is a fixed timescale for any given satellite galaxy.
 
 Under these conditions, the flow of mass between gas, stellar, and outflowed phases is analytically solvable.
-
-.. _manual-sec-HaloFormationEvents:
-
-Halo Formation Events
-^^^^^^^^^^^^^^^^^^^^^
-
-Tasks to be performed when a halo is deemed to have "formed" (or reformed) can be registered using the ``haloFormationTask`` directive. For example, the ``Tree_Node_Methods_Hot_Halo`` module registers a task using
-
-.. code-block:: none
-
-    !![
-    <haloFormationTask>
-      <unitName>Hot_Halo_Formation_Task</unitName>
-    </haloFormationTask>
-    !!]
-
-The contents of ``<unitName>`` should give the name of the subroutine to be called on halo formation. The subroutine should have a single argument, ``thisNode``, which is the node that has (re)formed.
-
-.. _manual-sec-HDFFileClose:
-
-HDF5 File Close
-^^^^^^^^^^^^^^^
-
-Tasks to be performed just prior to closing the Galacticus output HDF5 file (typically involving writing accumulated data to that file) can be registered using the ``hdfPreCloseTask`` directive. For example, the ``Merger_Tree_Timesteps_History`` module registers a task using
-
-.. code-block:: none
-
-    !![
-    <hdfPreCloseTask>
-      <unitName>Merger_Tree_History_Write</unitName>
-    </hdfPreCloseTask>
-    !!]
-
-The contents of ``<unitName>`` should give the name of the subroutine to be called prior to HDF5 file closure. The subroutine should have no arguments.
-
-Merger Tree Extra Output Tasks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Extra outputs for merger trees (i.e. those which do not involve output of a fixed number of properties for every node---examples might be star formation histories for a subset of galaxies) can be added using the directive: ``mergerTreeExtraOutputTask``. The directive should give the name of the subroutine to be called to perform the task. A template for this task is:
-
-.. code-block:: none
-
-     !![
-     <mergerTreeExtraOutputTask>
-      <unitName>Galacticus_Extra_Output_Example</unitName>
-     </mergerTreeExtraOutputTask>
-     !!]
-     subroutine Galacticus_Extra_Output_Example(thisNode,iOutput,treeIndex,nodePassesFilter)
-       implicit none
-       type(treeNode),          intent(inout), pointer :: thisNode
-       integer,                 intent(in)             :: iOutput
-       integer(kind=kind_int8), intent(in)             :: treeIndex
-       logical,                 intent(in)             :: nodePassesFilter
-       .
-       .
-       .
-       return
-     end subroutine Galacticus_Extra_Output_Example
-
-The subroutine will be called for each node in each merger tree at each output, and should perform whatever extra output related to ``thisNode``. The index of the output and tree are provided as ``iOutput`` and ``treeIndex`` for reference, and may be used in organizing output. The ``nodePassesFilter`` flag will be set to ``true`` if ``thisNode`` passed all active output filters (see :galacticus-class:`galacticFilter`). If it is ``false`` then typically no output should occur (although other tasks may still be undertaken).
-
-Merger Tree Output Tasks
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Additional outputs for merger trees can be added using three directives: ``mergerTreeOutputPropertyCount``, ``mergerTreeOutputNames`` and ``mergerTreeOutputTask``. Each directive should give the name of the subroutine to be called to perform the task and, additionally, a name for sorting (this should be the same for all three directives and ensures that output tasks are always called in the correct order). Templates for these tasks are:
-
-.. code-block:: none
-
-     !![
-     <mergerTreeOutputNames>
-      <unitName>Galacticus_Output_Tree_Example_Names</unitName>
-      <sortName>Galacticus_Output_Tree_Example</sortName>
-     </mergerTreeOutputNames>
-     !!]
-     subroutine Galacticus_Output_Tree_Example_Names(integerProperty,integerPropertyNames,integerPropertyComments,integerPropertyUnitsSI &
-          &,doubleProperty,doublePropertyNames,doublePropertyComments,doublePropertyUnitsSI,time)
-       implicit none
-       double precision, intent(in)                  :: time
-       integer,          intent(inout)               :: integerProperty,doubleProperty
-       character(len=*), intent(inout), dimension(:) :: integerPropertyNames,integerPropertyComments,doublePropertyNames &
-            &,doublePropertyComments
-       double precision, intent(inout), dimension(:) :: integerPropertyUnitsSI,doublePropertyUnitsSI
-       .
-       .
-       .
-       return
-     end subroutine Galacticus_Output_Tree_Example_Names
-
-     !![
-     <mergerTreeOutputPropertyCount>
-      <unitName>Galacticus_Output_Tree_Example_Property_Count</unitName>
-      <sortName>Galacticus_Output_Tree_Example</sortName>
-     </mergerTreeOutputPropertyCount>
-     !!]
-     subroutine Galacticus_Output_Tree_Example_Property_Count(integerPropertyCount,doublePropertyCount)
-       implicit none
-       integer, intent(inout) :: integerPropertyCount,doublePropertyCount
-       .
-       .
-       .
-       return
-     end subroutine Galacticus_Output_Tree_Example_Property_Count
-
-     !![
-     <mergerTreeOutputTask>
-      <unitName>Galacticus_Output_Tree_Example</unitName>
-      <sortName>Galacticus_Output_Tree_Example</sortName>
-     </mergerTreeOutputTask>
-     !!]
-     subroutine Galacticus_Output_Tree_Example(thisNode,integerProperty,integerBufferCount,integerBuffer,doubleProperty&
-          &,doubleBufferCount,doubleBuffer)
-       implicit none
-       type(treeNode),          intent(inout), pointer :: thisNode
-       integer,                 intent(inout)          :: integerProperty,integerBufferCount,doubleProperty,doubleBufferCount
-       integer(kind=kind_int8), intent(inout)          :: integerBuffer(:,:)
-       double precision,        intent(inout)          :: doubleBuffer(:,:)
-       .
-       .
-       .
-       return
-     end subroutine Galacticus_Output_Tree_Example
-
-The ``mergerTreeOutputPropertyCount`` subroutine must simply increment ``integerPropertyCount`` and ``doublePropertyCount`` by the number of integer and double precision properties that will be output respectively. The ``mergerTreeOutputNames`` subroutine must store the dataset names, comments and units in the SI system\ [#]_ for each integer and double precision property in the supplied arrays. The value of ``integerProperty`` and ``doubleProperty`` should be incremented by 1 before each property name/comment is set---these then supply the position within the input arrays in which to store the name. The ``mergerTreeOutputTask`` subroutine must similarly place the desired property values for ``thisNode`` into the supplied arrays. The value of ``integerProperty`` and ``doubleProperty`` should be incremented by 1 before each property value is set. The value can then be stored in, for example, ``integerBuffer(integerBufferCount,integerProperty)``.
-
-Merger Tree Initialization Tasks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Additional tasks to be performed during merger tree initialization can be added using the ``mergerTreeInitializeTask`` directive. The directive should contain a single argument, giving the name of a subroutine to be called to initialize the method. For example, the ``standard`` basic component method uses this directive as follows:
-
-.. code-block:: none
-
-     !![
-     <mergerTreeInitializeTask>
-      <unitName>Halo_Mass_Accretion_Rate</unitName>
-     </mergerTreeInitializeTask>
-     !!]
-
-Here, ``Halo_Mass_Accretion_Rate`` is the name of a subroutine which will be called to perform whatever tasks are required as a result of the merger. The subroutine must have the following form:
-
-.. code-block:: none
-
-      subroutine Merger_Tree_Initialize_Task(thisNode)
-       implicit none
-       type(treeNode), pointer, intent(inout) :: thisNode
-       .
-       .
-       .
-       return
-     end subroutine Merger_Tree_Initialize_Task
-
-where ``thisNode`` is the node to be initialized. The subroutine will be called once for each node in the tree.
-
-Post-step Tasks
-^^^^^^^^^^^^^^^
-
-Additional methods for post-step tasks (i.e. things that should be done after each ODE solver step when evolving a node differentially) can be added using the ``postStepTask`` directive. The directive should contain a single argument, giving the name of a subroutine to be called to perform the task. For example, the standard hot halo component adds a task as follows:
-
-.. code-block:: none
-
-     !![
-     <postStepTask>
-      <unitName>Tree_Node_Hot_Halo_Poststep_Standard</unitName>
-     </postStepTask>
-     !!]
-
-Here, ``Tree_Node_Hot_Halo_Poststep_Standard`` is the name of a subroutine which will be called to perform whatever tasks are required. The subroutine must have the following form:
-
-.. code-block:: none
-
-      subroutine Post_Step_Task(node,status)
-       implicit none
-       type   (treeNode), intent(inout) :: node
-       integer          , intent(inout) :: status
-       .
-       .
-       .
-       return
-     end subroutine Post_Step_Task
-
-where ``node`` is the node for which tasks should be performed. If any change is made to the state of the node then ``status`` should be set equal to ``GSL_Failure``. Tasks typically involve cleaning up after differential evolution.
-
-.. _manual-sec-radius-solver:
-
-Radius Solver Tasks
-^^^^^^^^^^^^^^^^^^^
-
-Galactic radii solver functions (see :galacticus-class:`galacticStructureSolver`) need to be able to interact with the components of a tree node to
-
-#. Determine which components want a radius to be solved for;
-#. Get and set the properties of those components.
-
-The  ``radiusSolverPlausibility`` and ``radiusSolverTask`` directives facilitate this. A component which has a radius to be solved for should include directives of the form:
-
-.. code-block:: none
-
-    !![
-    <radiusSolverTask>
-     <unitName>Component_Radius_Solver_Plausibility</unitName>
-    </radiusSolverTask>
-     !!]
-
-and
-
-.. code-block:: none
-
-    !![
-    <radiusSolverTask>
-     <unitName>Component_Radius_Solver</unitName>
-    </radiusSolverTask>
-     !!]
-
-where ``Component_Radius_Solver_Plausibility`` is the name of a subroutine which will specify whether or not the component is physically plausible for radius solving (e.g. has non-negative mass) and should have the following form:
-
-.. code-block:: none
-
-    subroutine Component_Radius_Solver_Plausibility(thisNode,galaxyIsPhysicallyPlausible)
-       implicit none
-       type(treeNode), pointer, intent(inout) :: thisNode
-       logical,                 intent(inout) :: galaxyIsPhysicallyPlausible
-       .
-       .
-       .
-       return
-    end subroutine Component_Radius_Solver_Plausibility
-
-which should set ``galaxyIsPhysicallyPlausible`` to false if the component is not physically plausible, but should otherwise leave ``galaxyIsPhysicallyPlausible`` unchanged. Additionally, ``Component_Radius_Solver`` is the name of a subroutine which will supply the necessary information about the node, and which should have the following form:
-
-.. code-block:: none
-
-    subroutine Component_Radius_Solver(thisNode,componentActive,specificAngularMomentum,Radius_Get,Radius_Set,Velocity_Get,Velocity_Set)
-       implicit none
-       type(treeNode),   pointer, intent(inout) :: thisNode
-       logical,                   intent(out)   :: componentActive
-       double precision,          intent(out)   :: specificAngularMomentum
-       procedure(),      pointer, intent(out)   :: Radius_Get,Velocity_Get
-       procedure(),      pointer, intent(out)   :: Radius_Set,Velocity_Set
-       .
-       .
-       .
-       return
-    end subroutine Component_Radius_Solver
-
-When called, the subroutine should set ``componentActive`` to indicate whether or not this nod contains an active component of the type. If it does, it should also set ``specificAngularMomentum`` to reflect the specific angular momentum (in km s\ :math:`^{-1}` Mpc) of the component (at whatever point in its profile the radius is required) and should point the four procedure pointers to routines which get and set the radius and circular velocity properties of the component (which should have the standard form for component get and set methods). It is acceptable for the set procedures to point to dummy routines.
-
-The galactic structure radii solver routines will use this information to determine (and set) the radius and circular velocity of the component. An advantage of this approach is that different radii solver methods can all use this same system, ensuring that just a single interface is needed in each component.
-
-Satellite Host Change Tasks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Additional methods for satellite host change events (i.e. when a satellite node moves to a new host) can be added using the ``satelliteHostChangeTask`` directive. The directive should contain a single argument, giving the name of a subroutine to be called to initialize the method. For example, the ``simple`` satellite orbits components uses this directive as follows:
-
-.. code-block:: none
-
-     !![
-     <satelliteHostChangeTask>
-      <unitName>Satellite_Orbit_New_Host</unitName>
-     </satelliteHostChangeTask>
-     !!]
-
-Here, ``Satellite_Orbit_New_Host`` is the name of a subroutine which will be called to perform whatever tasks are required as a result of the host change. The subroutine must have the following form:
-
-.. code-block:: none
-
-      subroutine New_Host_Task(thisNode)
-       implicit none
-       type(treeNode), pointer, intent(inout) :: thisNode
-       .
-       .
-       .
-       return
-     end subroutine New_Host_Task
-
-where ``thisNode`` is the node which has changed host (the new host halo is ``thisNode%parentNode``).
 
 Subsystems
 ----------

--- a/docs/manuals/developer-guide/methods.rst
+++ b/docs/manuals/developer-guide/methods.rst
@@ -732,5 +732,4 @@ and thereby allow a position to be passed to it in any coordinate system.
 
 .. [#] Data objects in components can be real, integer, boolean or of derived type. For derived types, currently ``history``, ``abundances``, ``chemicals``, and ``keplerOrbit`` are supported. Adding additional derived types is possible, providing that the type supports the required methods for output, serialization, etc. Data objects can currently be scalar or rank-1 arrays.
 .. [#] Or some other value if a ``classDefault`` has been specified (see Section :galacticus-ref:`ComponentImplement`).
-.. [#] For dimensionless quantities, the units may be set to zero. In such cases, the ``unitsInSI`` attribute for the dataset will not be written to the Galacticus output file.
 .. [#] The ``keplerOrbit`` object works by trying to convert to the combination radius, radial and tangential velocities. Once these are defined, all other parameters can be computed. However, for orbits defined in terms of other parameters, the ``keplerOrbit`` object does not know how to convert from every such combination of parameters.

--- a/docs/manuals/physics/components.rst
+++ b/docs/manuals/physics/components.rst
@@ -512,7 +512,7 @@ Event Evolution
 
 *Node promotion:* Any hot halo properties of the parent :term:`node` are added to those of the :term:`node` prior to promotion.
 
-*Halo formation:* If ``[hotHaloOutflowReturnOnFormation]``\ :math:`=`\ ``true`` then all outflowed gas is returned to the hot gas reservoir on :ref:`halo formation events <manual-sec-haloformationevents>`.
+*Halo formation:* If ``[hotHaloOutflowReturnOnFormation]``\ :math:`=`\ ``true`` then all outflowed gas is returned to the hot gas reservoir on halo formation events (i.e. when the ``haloFormation`` event is triggered; see Section :galacticus-ref:`eventHooks`).
 
 "Outflow Tracking" Implementation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
- Audit of all directives recognized by the build system (`python/Galacticus/Build/SourceTree/Process/*`, `schema/*.xsd`) against the developer guide found ~25 undocumented or under-documented directives, plus several documented `*Task` directives that no longer exist in the source. This PR documents everything missing and prunes the stale documentation (issue #110).
- New sections in `docs/manuals/developer-guide/coding.rst`: Reference Counting (`referenceConstruct`, `referenceAcquire`, `referenceCountIncrement`), Input Parameter Validation (`inputParametersValidate`), Meta-Properties (`addMetaProperty`, `metaPropertyDatabase`), `stateStore`/`stateRestore` call-site directives, Deep Copy Actions (`deepCopyActions`), `eventHookManager`, Allocations (`allocate`), Iterating Over Array Elements (`forEach`), Method Descriptions (`methods`), Workarounds (`workaround`), Module Scoping (`scoping`), Defining New Constants (`constant`), `functionsGlobal`, and brief docs for the internal `parameterMigration`, `dependenciesInitialize`, `expiry`, and `interTreePositionInsert` directives.
- Updated `docs/manuals/developer-guide/methods.rst`: documented the live task directives (`nodeComponentInitializationTask`, `nodeComponentThreadInitializationTask`/`...Uninitialization...`, `preEvolveTask`, `inactiveSetTask`, `stateStoreTask`/`stateRetrieveTask`, `outputFileOpen`/`outputFileClose`, `universePostEvolveTask`), updated stale examples to the current `function="..."` attribute form (`scaleSetTask`, `postStepTask`, `mergerTreeInitializeTask`, `radiusSolverPlausibility`/`radiusSolverTask`), and removed documentation for directives that no longer exist (`nodePromotionTask`, `haloFormationTask`, `hdfPreCloseTask`, `mergerTreeExtraOutputTask`, the `mergerTreeOutput*` family, `satelliteHostChangeTask`, `mergerTreeEvolveThreadInitialize`), replaced by a note pointing at the event-hook system.
- One commit per thematic group for easier review.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Docs / tooling
- [ ] Other:

## How to test
- `pip install -r docs/requirements.txt`
- `PYTHONPATH=python python scripts/doc/extractDocsRST.py source docs`
- `python -m sphinx -b html docs <outdir>` — builds with no new warnings (the two warnings introduced by the pruning, an orphaned footnote and a dangling `manual-sec-haloformationevents` label in `docs/manuals/physics/components.rst`, are fixed in the final commit).

## Checklist
- [x] I ran relevant tests (or explain why not): documentation-only change; verified with a full Sphinx build (no new warnings) and inspected the rendered HTML for the new sections and cross-references.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSx5EYoxDFyMJVuUdCPgDv

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSx5EYoxDFyMJVuUdCPgDv)_