### PR TITLE
fix: make raw merger-tree state serialization self-describing

### DIFF
--- a/python/Galacticus/Build/Components/Implementations/Serialization.py
+++ b/python/Galacticus/Build/Components/Implementations/Serialization.py
@@ -374,6 +374,7 @@ def Implementation_Serialize_Raw(build, class_dict, member):
             f"Serialize the contents of a {member['name']} implementation "
             f"of the {class_dict['name']} component to raw (binary) file."
         ),
+        'modules':     ['ISO_Varying_String'],
         'variables':   [
             {
                 'intrinsic':  'class',
@@ -437,6 +438,14 @@ def Implementation_Serialize_Raw(build, class_dict, member):
             content += "end if\n"
 
     if class_dict['name'] in (build.get('componentClassListActive') or []):
+        # Meta-properties are written in a self-describing form: for each
+        # meta-property type we write a count, and then for each meta-property
+        # its name (length followed by characters) alongside its value(s). This
+        # makes the on-disk format independent of the set of meta-properties
+        # registered by the (task-dependent) run performing the store, so that a
+        # run performing the restore can map values back by name regardless of
+        # which meta-properties it has itself registered. See the matching
+        # deserialization in `Implementation_Deserialize_Raw`.
         for mpt in meta_property_types:
             cap_label = _ucfirst(mpt['label'])
             rank      = mpt['rank']
@@ -444,16 +453,29 @@ def Implementation_Serialize_Raw(build, class_dict, member):
             var_pref  = f"{class_dict['name']}{prefix}"
             if rank == 0:
                 content += (
-                    f"if (allocated({var_pref}MetaPropertyNames)) "
-                    f"write (fileHandle) self%{prefix}MetaProperties\n"
+                    f"if (allocated({var_pref}MetaPropertyNames)) then\n"
+                    f" write (fileHandle) size({var_pref}MetaPropertyNames)\n"
+                    f" do i=1,size({var_pref}MetaPropertyNames)\n"
+                    f"  write (fileHandle) len({var_pref}MetaPropertyNames(i))\n"
+                    f"  write (fileHandle) char({var_pref}MetaPropertyNames(i))\n"
+                    f"  write (fileHandle) self%{prefix}MetaProperties(i)\n"
+                    " end do\n"
+                    "else\n"
+                    " write (fileHandle) 0\n"
+                    "end if\n"
                 )
             elif rank == 1:
                 content += (
                     f"if (allocated({var_pref}MetaPropertyNames)) then\n"
+                    f" write (fileHandle) size({var_pref}MetaPropertyNames)\n"
                     f" do i=1,size({var_pref}MetaPropertyNames)\n"
+                    f"  write (fileHandle) len({var_pref}MetaPropertyNames(i))\n"
+                    f"  write (fileHandle) char({var_pref}MetaPropertyNames(i))\n"
                     f"  write (fileHandle) size(self%{prefix}MetaProperties(i)%values)\n"
                     f"  write (fileHandle) self%{prefix}MetaProperties(i)%values\n"
                     " end do\n"
+                    "else\n"
+                    " write (fileHandle) 0\n"
                     "end if\n"
                 )
             else:
@@ -478,6 +500,7 @@ def Implementation_Deserialize_Raw(build, class_dict, member):
             f"Deserialize the contents of a {member['name']} implementation "
             f"of the {class_dict['name']} component from raw (binary) file."
         ),
+        'modules':     ['ISO_Varying_String', 'Kind_Numbers'],
         'variables':   [
             {
                 'intrinsic':  'class',
@@ -497,6 +520,46 @@ def Implementation_Deserialize_Raw(build, class_dict, member):
         ],
         'content':     '',
     }
+
+    active = class_dict['name'] in (build.get('componentClassListActive') or [])
+    if active:
+        # Scratch variables used to read the self-describing meta-property
+        # block and map stored values back onto the currently-registered
+        # meta-properties by name (see `Implementation_Serialize_Raw`).
+        function['variables'].append({
+            'intrinsic': 'integer',
+            'variables': ['j', 'metaPropertyCount', 'metaPropertyNameLength',
+                          'metaPropertyMatch'],
+        })
+        function['variables'].append({
+            'intrinsic':  'character',
+            'type':       'len=:',
+            'attributes': ['allocatable'],
+            'variables':  ['metaPropertyName'],
+        })
+        for mpt in meta_property_types:
+            if mpt['rank'] != 0:
+                continue
+            cap_label = _ucfirst(mpt['label'])
+            var = {
+                'intrinsic': mpt['intrinsic'],
+                'variables': [f"metaPropertyScalar{cap_label}"],
+            }
+            if mpt.get('type'):
+                var['type'] = mpt['type']
+            function['variables'].append(var)
+        for mpt in meta_property_types:
+            if mpt['rank'] != 1:
+                continue
+            cap_label = _ucfirst(mpt['label'])
+            var = {
+                'intrinsic':  mpt['intrinsic'],
+                'attributes': ['allocatable', 'dimension(:)'],
+                'variables':  [f"metaPropertyBuffer{cap_label}"],
+            }
+            if mpt.get('type'):
+                var['type'] = mpt['type']
+            function['variables'].append(var)
 
     has_rank1_real = any(
         not (p.get('attributes') or {}).get('isVirtual')
@@ -561,31 +624,84 @@ def Implementation_Deserialize_Raw(build, class_dict, member):
                 )
             content += "end if\n"
 
-    if class_dict['name'] in (build.get('componentClassListActive') or []):
+    if active:
+        # Read the self-describing meta-property block written by
+        # `Implementation_Serialize_Raw`. For each meta-property type we read a
+        # count and then, for each stored meta-property, its name and value(s).
+        # Every stored entry is consumed from the stream regardless of whether
+        # this run has the meta-property registered (so the stream never
+        # desyncs), and values are assigned by matching the stored name against
+        # the currently-registered names. Registered meta-properties absent from
+        # the file retain their default (zero / unallocated) value.
+        zero_literal = {
+            'float':       '0.0d0',
+            'longInteger': '0_kind_int8',
+            'integer':     '0',
+        }
         for mpt in meta_property_types:
             cap_label = _ucfirst(mpt['label'])
             rank      = mpt['rank']
             prefix    = f"{cap_label}Rank{rank}"
             var_pref  = f"{class_dict['name']}{prefix}"
+            match_head = (
+                "read (fileHandle) metaPropertyNameLength\n"
+                "if (allocated(metaPropertyName)) deallocate(metaPropertyName)\n"
+                "allocate(character(len=metaPropertyNameLength) :: "
+                "metaPropertyName)\n"
+                "read (fileHandle) metaPropertyName\n"
+                "metaPropertyMatch=0\n"
+                f"if (allocated({var_pref}MetaPropertyNames)) then\n"
+                f" do j=1,size({var_pref}MetaPropertyNames)\n"
+                f"  if ({var_pref}MetaPropertyNames(j) == metaPropertyName) then\n"
+                "   metaPropertyMatch=j\n"
+                "   exit\n"
+                "  end if\n"
+                " end do\n"
+                "end if\n"
+            )
             if rank == 0:
                 content += (
                     f"if (allocated({var_pref}MetaPropertyNames)) then\n"
+                    f" if (allocated(self%{prefix}MetaProperties)) "
+                    f"deallocate(self%{prefix}MetaProperties)\n"
                     f" allocate(self%{prefix}MetaProperties(size("
                     f"{var_pref}MetaPropertyNames)))\n"
-                    f" read (fileHandle) self%{prefix}MetaProperties\n"
+                    f" self%{prefix}MetaProperties={zero_literal[mpt['label']]}\n"
                     "end if\n"
+                    "read (fileHandle) metaPropertyCount\n"
+                    "do i=1,metaPropertyCount\n"
+                    + match_head +
+                    " if (metaPropertyMatch > 0) then\n"
+                    f"  read (fileHandle) self%{prefix}MetaProperties(metaPropertyMatch)\n"
+                    " else\n"
+                    f"  read (fileHandle) metaPropertyScalar{cap_label}\n"
+                    " end if\n"
+                    "end do\n"
                 )
             elif rank == 1:
                 content += (
-                    f"if (allocated({var_pref}MetaPropertyNames  )) then\n"
+                    f"if (allocated({var_pref}MetaPropertyNames)) then\n"
+                    f" if (allocated(self%{prefix}MetaProperties)) "
+                    f"deallocate(self%{prefix}MetaProperties)\n"
                     f" allocate(self%{prefix}MetaProperties(size("
                     f"{var_pref}MetaPropertyNames)))\n"
-                    f" do i=1,size({var_pref}MetaPropertyNames)\n"
-                    "  read (fileHandle) metaPropertySize\n"
-                    f"  allocate(self%{prefix}MetaProperties(i)%values(metaPropertySize))\n"
-                    f"  read (fileHandle) self%{prefix}MetaProperties(i)%values\n"
-                    " end do\n"
                     "end if\n"
+                    "read (fileHandle) metaPropertyCount\n"
+                    "do i=1,metaPropertyCount\n"
+                    + match_head +
+                    " read (fileHandle) metaPropertySize\n"
+                    " if (metaPropertyMatch > 0) then\n"
+                    f"  if (allocated(self%{prefix}MetaProperties(metaPropertyMatch)%values)) "
+                    f"deallocate(self%{prefix}MetaProperties(metaPropertyMatch)%values)\n"
+                    f"  allocate(self%{prefix}MetaProperties(metaPropertyMatch)%values(metaPropertySize))\n"
+                    f"  read (fileHandle) self%{prefix}MetaProperties(metaPropertyMatch)%values\n"
+                    " else\n"
+                    f"  if (allocated(metaPropertyBuffer{cap_label})) "
+                    f"deallocate(metaPropertyBuffer{cap_label})\n"
+                    f"  allocate(metaPropertyBuffer{cap_label}(metaPropertySize))\n"
+                    f"  read (fileHandle) metaPropertyBuffer{cap_label}\n"
+                    " end if\n"
+                    "end do\n"
                 )
             else:
                 raise RuntimeError(

--- a/python/Galacticus/Build/Components/TreeNodes/Serialization.py
+++ b/python/Galacticus/Build/Components/TreeNodes/Serialization.py
@@ -18,6 +18,11 @@ _TREE_NODE_POINTERS = (
 )
 _TREE_NODE_STATES = ('isPhysicallyPlausible', 'isSolvable')
 
+# Magic marker written to the raw stream after each component class, and checked
+# on restore to detect desynchronization (see Tree_Node_Serialize_Raw /
+# Tree_Node_Deserialize_Raw).
+_RAW_SENTINEL = 987654321
+
 
 def Tree_Node_Serialize_ASCII(build):
     """Generate `treeNodeSerializeASCII`.  Mirrors `Tree_Node_Serialize_ASCII`."""
@@ -229,6 +234,12 @@ def Tree_Node_Serialize_Raw(build):
             f"    call self%component{cap}(i)%serializeRaw(fileHandle)\n"
             f"  end do\n"
             f"end if\n"
+            # Sentinel written after each component class. On restore this is
+            # checked to detect (and report, rather than silently corrupting a
+            # later read) any desynchronization of the raw stream — e.g. from a
+            # component property whose stored size depends on globally-registered
+            # state that differs between the storing and restoring runs.
+            f"write (fileHandle) {_RAW_SENTINEL}\n"
         )
 
     function['content'] = content
@@ -241,6 +252,7 @@ def Tree_Node_Deserialize_Raw(build):
         'type':        'void',
         'name':        'treeNodeDeserializeRaw',
         'description': "Deserialize a tree node object from a raw (binary) file.",
+        'modules':     ['Error'],
         'variables':   [
             {
                 'intrinsic':  'class',
@@ -255,7 +267,7 @@ def Tree_Node_Deserialize_Raw(build):
             },
             {
                 'intrinsic':  'integer',
-                'variables':  ['i', 'componentCount'],
+                'variables':  ['i', 'componentCount', 'nodeSentinel'],
             },
             {
                 'intrinsic':  'logical',
@@ -274,12 +286,25 @@ def Tree_Node_Deserialize_Raw(build):
             f"  read (fileHandle) componentCount\n"
             f"  if (allocated(self%component{cap})) "
             f"deallocate(self%component{cap})\n"
+            # gfortran bug workaround (array-descriptor `dtype`/`rank` not set):
+            # `allocate(class_array(n), mold=/source=<non-polymorphic type
+            # scalar>)` sets the descriptor's data/bounds/span but does NOT write
+            # its `dtype` (which holds the rank). For these `class(...),
+            # allocatable, dimension(:)` component arrays the descriptor then
+            # keeps whatever garbage was in the (heap-allocated) node's memory,
+            # and when the array is finalized during tree destruction the
+            # compiler-generated finalizer reads a bogus (possibly negative)
+            # rank, under-allocates an internal temporary (malloc of 1 byte) and
+            # overflows it — corrupting the heap and hanging. Allocation forms
+            # that DO set `dtype`: a polymorphic `mold=`, a type-spec allocate,
+            # and a bare allocate. So: use the polymorphic `mold=default...` for
+            # the default-implementation branch, and a bare allocate (which
+            # allocates the declared base type) for the base-type/null branches.
             f"  if (isAllocated) then\n"
             f"    allocate(self%component{cap}(componentCount),"
-            f"source=default{cap}Component)\n"
+            f"mold=default{cap}Component)\n"
             f"  else\n"
-            f"    allocate(self%component{cap}(componentCount),"
-            f"source={cap}Class)\n"
+            f"    allocate(self%component{cap}(componentCount))\n"
             f"  end if\n"
             f"  do i=1,componentCount\n"
             f"    self%component{cap}(i)%hostNode => self\n"
@@ -290,8 +315,23 @@ def Tree_Node_Deserialize_Raw(build):
             f"else\n"
             f"   if (allocated(self%component{cap})) "
             f"deallocate(self%component{cap})\n"
+            # Bare allocate of the size-1 "null" placeholder: allocates the
+            # declared base type AND sets the descriptor `dtype`/rank (see the
+            # gfortran-bug note above; `mold=<base type scalar>` would leave the
+            # rank as garbage and hang on finalization during tree destruction).
             f"   allocate(self%component{cap}(1))\n"
             f"end if\n"
+            # Verify the sentinel written after this component class. A mismatch
+            # means the raw stream desynchronized while reading this component,
+            # so fail loudly (with the offending component named) rather than
+            # letting a corrupted array descriptor cause an eventual hang in
+            # tree destruction.
+            f"read (fileHandle) nodeSentinel\n"
+            f"if (nodeSentinel /= {_RAW_SENTINEL}) call Error_Report("
+            f"'raw tree-node deserialization desynchronized while reading the "
+            f"\"{class_dict['name']}\" component (stored file is incompatible "
+            f"with the currently-registered component/property configuration)'"
+            f"//char(10)//'   file:objects.nodes.components.Inc')\n"
         )
 
     function['content'] = content

--- a/python/Galacticus/Build/Components/TreeNodes/Serialization.py
+++ b/python/Galacticus/Build/Components/TreeNodes/Serialization.py
@@ -300,6 +300,11 @@ def Tree_Node_Deserialize_Raw(build):
             # and a bare allocate. So: use the polymorphic `mold=default...` for
             # the default-implementation branch, and a bare allocate (which
             # allocates the declared base type) for the base-type/null branches.
+            #
+            # (Note: the gfortran bug is fixed in GCC commit
+            # 9decb8a07ac764f2a39885b2a5905515f188da06, but the workaround must
+            # be maintained here until that fix makes it into actual GCC
+            # releases that Galacticus uses.)
             f"  if (isAllocated) then\n"
             f"    allocate(self%component{cap}(componentCount),"
             f"mold=default{cap}Component)\n"

--- a/source/objects/abundances.F90
+++ b/source/objects/abundances.F90
@@ -331,8 +331,15 @@ contains
     class  (abundances    ), intent(in   ) :: self
     integer                , intent(in   ) :: fileHandle
 
+    ! Dump in a self-describing form (independent of the global elementsCount,
+    ! which can differ between the storing and restoring runs) so that the raw
+    ! stream never desynchronizes on restore.
     write (fileHandle) self%metallicityValue
-    if (elementsCount > 0) write (fileHandle) self%elementalValue
+    write (fileHandle) allocated(self%elementalValue)
+    if (allocated(self%elementalValue)) then
+       write (fileHandle) size(self%elementalValue)
+       write (fileHandle) self%elementalValue
+    end if
     return
   end subroutine Abundances_Dump_Raw
 
@@ -343,14 +350,22 @@ contains
     implicit none
     class  (abundances    ), intent(inout) :: self
     integer                , intent(in   ) :: fileHandle
+    logical                                :: isAllocated
+    integer                                :: elementalCount
 
     read (fileHandle) self%metallicityValue
-    ! If no individual elements are tracked, our work is done.
-    if (elementsCount == 0) return
-    ! Ensure elemental values array exists.
-    call Abundances_Allocate_Elemental_Values(self)
-    ! Read values from file.
-    read (fileHandle) self%elementalValue    
+    ! Read the elemental values in the self-describing form written by
+    ! Abundances_Dump_Raw. The stored count is used (rather than the current
+    ! global elementsCount) so the stream stays synchronized even when the
+    ! restoring run tracks a different number of elements than the run that
+    ! stored the state.
+    read (fileHandle) isAllocated
+    if (isAllocated) then
+       read (fileHandle) elementalCount
+       if (allocated(self%elementalValue)) deallocate(self%elementalValue)
+       allocate(self%elementalValue(elementalCount))
+       read (fileHandle) self%elementalValue
+    end if
     return
   end subroutine Abundances_Read_Raw
 

--- a/source/objects/stellar_luminosities/structure.F90
+++ b/source/objects/stellar_luminosities/structure.F90
@@ -546,8 +546,12 @@ contains
     class  (stellarLuminosities), intent(in   ) :: self
     integer                     , intent(in   ) :: fileHandle
 
-    ! Dump the content.
-    if (luminosityCount > 0) then
+    ! Dump the content in a self-describing form (i.e. independent of the value
+    ! of the global luminosityCount, which can differ between the run that
+    ! stored the state and the run that restores it). This ensures the raw
+    ! stream never desynchronizes on restore.
+    write (fileHandle) allocated(self%luminosityValue)
+    if (allocated(self%luminosityValue)) then
        write (fileHandle) size(self%luminosityValue)
        write (fileHandle) self%luminosityValue
     end if
@@ -562,13 +566,18 @@ contains
     class  (stellarLuminosities), intent(inout) :: self
     integer                     , intent(in   ) :: fileHandle
     integer                                     :: luminosityActiveCount
+    logical                                     :: isAllocated
 
-    ! Read the content.
-    if (luminosityCount > 0) then
-       call Stellar_Luminosities_Create(self)
+    ! Read the content in the self-describing form written by
+    ! Stellar_Luminosities_Dump_Raw. The stored count is used (rather than the
+    ! current global luminosityCount) so the stream stays synchronized even when
+    ! the restoring run tracks a different number of luminosities than the run
+    ! that stored the state.
+    read (fileHandle) isAllocated
+    if (isAllocated) then
        read (fileHandle) luminosityActiveCount
-       deallocate(self%luminosityValue                       )
-       allocate  (self%luminosityValue(luminosityActiveCount))
+       if (allocated(self%luminosityValue)) deallocate(self%luminosityValue)
+       allocate(self%luminosityValue(luminosityActiveCount))
        read (fileHandle) self%luminosityValue
     end if
     return

--- a/source/utility/IO/HDF5/_module.F90
+++ b/source/utility/IO/HDF5/_module.F90
@@ -86,8 +86,8 @@ module IO_HDF5
      !!}
      private
      logical                           :: isOpenValue      =  .false.
-     logical                           :: isOverwritable
-     logical                           :: readOnly
+     logical                           :: isOverwritable   =.false.
+     logical                           :: readOnly         =.false.
      logical                           :: isTemporary      =  .false.
      integer(hid_t          ), pointer :: objectID         => null() , fileID             => null()
      type   (resourceManager)          :: objectManager              , fileManager
@@ -97,7 +97,7 @@ module IO_HDF5
      integer                           :: hdf5ObjectType
      integer(hsize_t        )          :: chunkSize
      integer                           :: compressionLevel
-     logical                           :: chunkSizeSet               , compressionLevelSet
+     logical                           :: chunkSizeSet    =.false.    , compressionLevelSet=.false.
      type   (hdf5Object     ), pointer :: parentObject     => null()
    contains
      !![


### PR DESCRIPTION
## Summary

Fixes a hang during merger-tree destruction when restoring merger-tree
`fullState` in a `taskPostprocessForests` run (`./Galacticus.exe sachiModel.xml postprocess.xml`).

State is **stored** during `taskEvolveForests` but **restored** during
`taskPostprocessForests`. Several raw serializers wrote their payload gated on
task-dependent global registration state — component meta-property
registration, `elementsCount`, and `luminosityCount` — which can differ
between the storing and restoring runs. When it did, the unformatted stream
desynchronized on restore, yielding garbage array descriptors that made the
compiler-generated node-component finalizer spin in `free()` during tree
destruction. This presented as a silent hang rather than an error, and as
many "uninitialised value" reports under valgrind.

## Changes

**Serialization self-describing (commit 1):**
- **Meta-properties**: write a per-type count and, for each entry, its name
  (length + characters) with the value; restore maps entries to storage *by
  name* and tolerates names present in only one of the two runs.
- **abundances / stellarLuminosities**: write an `allocated` flag plus an
  explicit count, and restore using the stored count rather than the current
  global `elementsCount` / `luminosityCount`.
- **Tree-node raw serialization**: write a sentinel after each
  component-class block and verify it on restore, reporting a clear error
  naming the offending component if the stream ever desynchronizes — so a
  future desync fails loudly instead of hanging.

**HDF5 (commit 2):**
- Default-initialize the `isOverwritable`, `readOnly`, `chunkSizeSet`, and
  `compressionLevelSet` logical members of `hdf5Object` to `.false.`,
  eliminating use-of-uninitialized-value reports under `-fsanitize=` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)