### PR TITLE
docs: add pointers to the Galacticus Publications repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ We welcome many types of contributions:
 - **Documentation** - Updates to comments, docstrings, wiki pages, and guides
 - **Performance improvements** - Optimizations and efficiency gains
 - **AI-assisted contributions** - Code developed with tools like GitHub Copilot, Claude, ChatGPT, etc.
+- **Published results** - Parameter files and commit details for papers that use Galacticus, contributed to the separate [Galacticus Publications](https://github.com/galacticusorg/galacticusPublications) repository (see its [contribution guidelines](https://github.com/galacticusorg/galacticusPublications/blob/master/Contributing.md))
 
 *All contributions, regardless of source, must be thoroughly verified by a human developer before submission.*
 

--- a/README.md
+++ b/README.md
@@ -102,3 +102,9 @@ Analysis and visualization of Galacticus outputs - including plotting of on-the-
 ```bash
 python3 -m pip install dendros
 ```
+
+## Publications
+
+The [Galacticus Publications](https://github.com/galacticusorg/galacticusPublications) repository collects the parameter files and the exact Galacticus commit hash used to run the models in published papers, so that those results are easy to find and reproduce. The commit behind each paper is also tagged in this repository (e.g. `publication/arXiv/XXXX.XXXXX`), letting you check out the precise version of the code used.
+
+Written a paper that uses Galacticus? We'd welcome your contribution — see the [contribution guidelines](https://github.com/galacticusorg/galacticusPublications/blob/master/Contributing.md) for how to add it.

--- a/docs/manuals/user-guide/about.rst
+++ b/docs/manuals/user-guide/about.rst
@@ -28,6 +28,13 @@ Getting Galacticus
 
 Galacticus is available in many different forms: a precompiled binary, a `Docker <https://www.docker.com/>`_ image, and the full source code. See :doc:`installation/index` for downloads and installation instructions.
 
+Published results
+-----------------
+
+The companion `Galacticus Publications <https://github.com/galacticusorg/galacticusPublications>`_ repository collects the parameter files and the exact Galacticus commit hash used to run the models in published papers, making those results easy to find, reproduce, and build upon. The commit behind each paper is also tagged in the main Galacticus repository (for example ``publication/arXiv/XXXX.XXXXX``), so you can check out the precise version of the code used.
+
+If you have written a paper that uses Galacticus, we would welcome your contribution — see the `contribution guidelines <https://github.com/galacticusorg/galacticusPublications/blob/master/Contributing.md>`_ for how to add it.
+
 License
 -------
 


### PR DESCRIPTION
## Summary
- Adds pointers to the [`galacticusorg/galacticusPublications`](https://github.com/galacticusorg/galacticusPublications) repository — describing its purpose (parameter files and the exact Galacticus commit hash used to run the models in published papers, so results are reproducible) and linking to its newly added [contribution guidelines](https://github.com/galacticusorg/galacticusPublications/blob/master/Contributing.md).
- **RTD docs** (`docs/manuals/user-guide/about.rst`): new "Published results" section alongside the existing companion-package (Dendros) mention, noting the `publication/...` commit tags in this repo.
- **`README.md`**: new "Publications" section after "Analyzing Galacticus output".
- **`CONTRIBUTING.md`**: a bullet under "Types of Contributions" pointing to the separate repo and its guidelines.

## Type of change
- [x] Docs / tooling

## How to test
- Render the docs and confirm the new "Published results" section appears on the user-guide *About Galacticus* page with a working link to the Publications repository and its contribution guidelines.
- Confirm the new links in `README.md` and `CONTRIBUTING.md` resolve.

## Checklist
- [x] I ran relevant tests (or explain why not): docs-only change; verified the RST section-underline length is valid for the Sphinx build.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcefxkFAefkuBYmuZi1naT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcefxkFAefkuBYmuZi1naT)_