### PR TITLE
docs: remove obsolete inline !@ / //@ embedded-parameter markers

### DIFF
--- a/docs/manuals/developer-guide/development.rst
+++ b/docs/manuals/developer-guide/development.rst
@@ -168,8 +168,6 @@ The build scripts key on a number of special comment markers in the source. None
 
 Two ordinary Fortran constructs also carry hard-wired dependency implications in ``useDependencies.py``: a named ``!$omp critical(<name>)`` section implies a dependency on ``openmp_utilities_data.mod`` (the section enumeration — see :galacticus-ref:`buildOpenMPCritical`), a ``!$omp parallel`` construct implies ``events_filters.mod``, and a ``program`` unit implies ``iso_varying_string.mod``.
 
-Additionally, embedded input-parameter definitions in comment lines beginning ``!@`` (Fortran) or ``//@`` (C++) are read by ``parameterDependencies.py`` (see Section :galacticus-ref:`parameterDependencies`).
-
 .. _manual-sec-buildDiscovery:
 
 Automatic Discovery
@@ -270,7 +268,7 @@ All Fortran and C/C++ source files in the ``source`` directory are parsed. Files
 Parameter Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^
 
-All runtime parameters upon which a given executable may depend are discovered by the ``scripts/build/parameterDependencies.py`` script, which runs at link time (from ``LINK_METADATA``). It reads the target's ``.d`` file to find the participating objects, scans each corresponding source (preferring the preprocessed ``.p.F90``, and including the per-functionClass ``<stem>.p`` parameter listings dropped by the preprocessor) for ``inputParameter`` and ``objectBuilder`` directives and embedded parameter definitions (comment lines beginning ``!@`` for Fortran or ``//@`` for C++), and writes ``$(BUILDPATH)/<stem>.parameters.F90`` — a ``knownParameterNames`` subroutine enumerating the de-duplicated, sorted parameter names, which the executable uses to detect unrecognized input parameters. Per-file results are cached in ``<stem>.blob``, and entries for files that leave the target are pruned.
+All runtime parameters upon which a given executable may depend are discovered by the ``scripts/build/parameterDependencies.py`` script, which runs at link time (from ``LINK_METADATA``). It reads the target's ``.d`` file to find the participating objects, scans each corresponding source (preferring the preprocessed ``.p.F90``, and including the per-functionClass ``<stem>.p`` parameter listings dropped by the preprocessor) for ``inputParameter`` and ``objectBuilder`` directives, and writes ``$(BUILDPATH)/<stem>.parameters.F90`` — a ``knownParameterNames`` subroutine enumerating the de-duplicated, sorted parameter names, which the executable uses to detect unrecognized input parameters. Per-file results are cached in ``<stem>.blob``, and entries for files that leave the target are pruned.
 
 .. _manual-sec-buildSourceDigests:
 


### PR DESCRIPTION
## Summary

The developer guide (`docs/manuals/developer-guide/development.rst`) documented inline embedded input-parameter markers — `!@` for Fortran and `//@` for C++ — as being read by `parameterDependencies.py`. This is outdated: the markers are no longer used or supported anywhere.

Verification:
- The active `scripts/build/parameterDependencies.py` (invoked at `Makefile:649`) contains no `@` handling at all; it discovers parameters solely from `<inputParameter>`/`<objectBuilder>` directives plus the preprocessor-emitted `.p` listings.
- The old `parameterDependencies.pl` it was ported from no longer exists.
- A full-repo sweep found zero `!@`/`//@` embedded-parameter markers in any source (`source/`, `scripts/`, C/C++/Fortran/Python/Perl).

Removes both mentions (the standalone paragraph and the inline clause in the `parameterDependencies` section). No functional change.

> [!NOTE]
> Stacked on #1230 — base is `perf/build-sourcedigests-parallel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)