### PR TITLE
fix: access gsl_rng_default via a C accessor to avoid a macOS common-symbol link error

### DIFF
--- a/source/numerical/random_numbers/GSL.F90
+++ b/source/numerical/random_numbers/GSL.F90
@@ -78,9 +78,6 @@
 
   ! GSL RNG initialization status.
   logical                                         :: rngInitialized=.false.
-  
-  ! RNG types.
-  type   (c_ptr), bind(C, name="gsl_rng_default") :: gsl_rng_default
 
   interface
      function gsl_rng_alloc(T) bind(c,name='gsl_rng_alloc')
@@ -207,6 +204,17 @@
        Template for function used to set up default GSL random number generator.
        !!}
      end subroutine gsl_rng_env_setup
+
+     function GSL_Get_Rng_Default() bind(c,name='GSL_Get_Rng_Default')
+       !!{RST
+       Template for a C function that returns a pointer to the GSL default random number generator type. This accessor is used
+       in preference to binding directly to the `gsl_rng_default` global variable so that the reference is resolved against
+       the definition exported by the GSL shared library (a direct Fortran binding emits a "common" symbol that the modern
+       macOS linker refuses to reconcile with the library's definition).
+       !!}
+       import c_ptr
+       type(c_ptr) :: GSL_Get_Rng_Default
+     end function GSL_Get_Rng_Default
   end interface
   
 contains
@@ -289,7 +297,7 @@ contains
        !$omp end critical(GSL_RNG_Initialize)
     end if
     allocate(self%randomNumberGenerator)
-    self%randomNumberGenerator%rng=GSL_RNG_Alloc(GSL_Rng_Default)
+    self%randomNumberGenerator%rng=GSL_RNG_Alloc(GSL_Get_Rng_Default())
     !![
     <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
       <description>

--- a/source/numerical/random_numbers/GSL.F90
+++ b/source/numerical/random_numbers/GSL.F90
@@ -24,6 +24,9 @@
   ! Add dependency on GSL library.
   !; gsl
 
+  ! Specify an explicit dependence on the gsl_rng_default.o object file.
+  !: $(BUILDPATH)/system/gsl_rng_default.o
+
   use, intrinsic :: ISO_C_Binding   , only : c_long         , c_ptr, c_null_ptr
   use            :: Resource_Manager, only : resourceManager
 

--- a/source/system/gsl_rng_default.c
+++ b/source/system/gsl_rng_default.c
@@ -1,0 +1,31 @@
+// Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+//           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+//    Andrew Benson <abenson@carnegiescience.edu>
+//
+// This file is part of Galacticus.
+//
+//    Galacticus is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Galacticus is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+/* Function that returns a pointer to the GSL default random number generator type. */
+
+#include "gsl/gsl_rng.h"
+
+/* Return the GSL default random number generator type. Accessing the `gsl_rng_default` global variable through this
+   accessor (rather than binding to it directly from Fortran) ensures that the reference is resolved against the definition in
+   the GSL shared library. Binding to the variable directly from Fortran emits it as a "common" symbol which the modern macOS
+   linker refuses to reconcile with the definition exported by libgsl. */
+const void * GSL_Get_Rng_Default(void)
+{
+  return gsl_rng_default;
+}


### PR DESCRIPTION
## Problem

On macOS, linking `Galacticus.exe` fails with:

```
ld: warning: -commons use_dylibs is no longer supported, using error treatment instead
ld: common symbol '_gsl_rng_default' from '.../work/build/numerical/random_numbers/GSL.o'
    conflicts with definition from dylib '_gsl_rng_default' from '/opt/local/lib/libgsl.28.dylib'
collect2: error: ld returned 1 exit status
make: *** [Galacticus.exe] Error 1
```

`source/numerical/random_numbers/GSL.F90` bound a Fortran module variable directly to GSL's `gsl_rng_default` global:

```fortran
type (c_ptr), bind(C, name="gsl_rng_default") :: gsl_rng_default
```

A `bind(C)` module variable is a *definition*, which gfortran emits as a **common symbol**. GSL's shared library also defines `gsl_rng_default`. Older linkers silently merged the common symbol into the dylib's strong definition; Apple's newer `ld` treats that conflict as a hard error (`-commons use_dylibs is no longer supported`).

This is environment-dependent rather than a code regression — it surfaces only on runner images with the newer linker (it broke on a `macos-14` runner while identical code passed on `macos-15`/`macos-15-intel` in the same run).

## Fix

Read `gsl_rng_default` through a small C accessor instead of binding to it directly, mirroring the existing `gsl_Version.c` / `GSL_Get_Version()` pattern:

- **New `source/system/gsl_rng_default.c`** — `#include`s `gsl/gsl_rng.h` (where `gsl_rng_default` is `extern`) and returns it. Because the C translation unit sees it as extern, the object emits an *undefined reference* that resolves cleanly against libgsl, rather than a common symbol.
- **`GSL.F90`** — dropped the direct variable binding, added an interface to `GSL_Get_Rng_Default()`, and updated the single call site to `GSL_RNG_Alloc(GSL_Get_Rng_Default())`.

Semantically identical: `gsl_rng_env_setup()` still populates the library's `gsl_rng_default`, and it is now read back through the accessor.

## Verification

- C file compiles against the real GSL headers.
- `nm` on the object confirms `U gsl_rng_default` (undefined external reference) and `T GSL_Get_Rng_Default` (defined) — the common symbol is gone, so the link conflict cannot occur.
- The Makefile already auto-compiles and links any `.c` under `source/`, so no build-system change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)