### PR TITLE
Add a `perturbationSmall` input parameter to the baryonic spherical collapse solver

### DIFF
--- a/parameters/tutorials/darkMatterOnlySubHalos.xml
+++ b/parameters/tutorials/darkMatterOnlySubHalos.xml
@@ -59,8 +59,8 @@
   <!-- Power spectrum options -->
   <cosmologicalMassVariance value="filteredPower">
     <sigma_8                           value="0.8111"/> <!-- Planck 2018; https://ui.adsabs.harvard.edu/abs/2018arXiv180706211P -->
-    <tolerance                         value="3.0e-4"/>
-    <toleranceTopHat                   value="3.0e-4"/>
+    <tolerance                         value="3.0e-3"/>
+    <toleranceTopHat                   value="3.0e-3"/>
     <nonMonotonicIsFatal               value="false" />
     <monotonicInterpolation            value="true"  />
     <powerSpectrumWindowFunction value="topHat"/>
@@ -79,8 +79,12 @@
   <linearGrowth          value="baryonsDarkMatter"                     >
     <cambCountPerDecade value="100"/>
   </linearGrowth>
-  <criticalOverdensity   value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
-  <virialDensityContrast value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
+  <criticalOverdensity   value="sphericalCollapseBrynsDrkMttrDrkEnrgy"> 
+    <perturbationSmall value="5.0e-3"/>
+  </criticalOverdensity>
+  <virialDensityContrast value="sphericalCollapseBrynsDrkMttrDrkEnrgy">
+    <perturbationSmall value="5.0e-3"/>
+  </virialDensityContrast>
   <haloMassFunction      value="shethTormen"                           >
     <a             value="0.791"/> <!-- Best fit values from Benson, Ludlow, & Cole (2019). -->
     <normalization value="0.302"/>

--- a/source/structure_formation/critical_overdensity/spherical_collapse_baryons_darkMatter_darkEnergy.F90
+++ b/source/structure_formation/critical_overdensity/spherical_collapse_baryons_darkMatter_darkEnergy.F90
@@ -49,6 +49,7 @@
      double precision                                                                  :: tableClusteredTimeMinimum                   , tableClusteredTimeMaximum                    , &
           &                                                                               tableUnclusteredTimeMinimum                 , tableUnclusteredTimeMaximum
      double precision                                                                  :: normalization
+     double precision                                                                  :: perturbationSmall
      integer                                                                           :: tablePointsPerOctave
      logical                                                                           :: tableStore
      type            (enumerationCllsnlssMttrDarkEnergyFixedAtType      )              :: energyFixedAt
@@ -98,6 +99,7 @@ contains
     class           (darkMatterParticleClass                                 ), pointer       :: darkMatterParticle_
     class           (intergalacticMediumFilteringMassClass                   ), pointer       :: intergalacticMediumFilteringMass_
     double precision                                                                          :: normalization                    , countTimeCollapsePerUnit
+    double precision                                                                          :: perturbationSmall
     logical                                                                                   :: tableStore
     type            (varying_string                                          )                :: energyFixedAt
     integer                                                                                   :: tablePointsPerOctave
@@ -135,6 +137,14 @@ contains
       The number of evenly-spaced tabulation points per octave of cosmic time used when building the look-up table of spherical collapse critical overdensity vs.\ time; higher values give greater interpolation accuracy at the cost of longer initialization time.
       </description>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>perturbationSmall</name>
+      <source>parameters</source>
+      <defaultValue>1.0d-3</defaultValue>
+      <description>
+      The largest initial perturbation considered to be sufficiently small. Larger initial perturbations will trigger an error.
+      </description>
+    </inputParameter>
     <objectBuilder class="cosmologyFunctions"               name="cosmologyFunctions_"               source="parameters"/>
     <objectBuilder class="cosmologyParameters"              name="cosmologyParameters_"              source="parameters"/>
     <objectBuilder class="cosmologicalMassVariance"         name="cosmologicalMassVariance_"         source="parameters"/>
@@ -154,7 +164,7 @@ contains
     end if
     !![
     <conditionalCall>
-      <call>self=criticalOverdensitySphericalCollapseBrynsDrkMttrDrkEnrgy(cosmologyParameters_,cosmologyFunctions_,cosmologicalMassVariance_,darkMatterParticle_,intergalacticMediumFilteringMass_,tableStore,tablePointsPerOctave,enumerationCllsnlssMttrDarkEnergyFixedAtEncode(char(energyFixedAt),includesPrefix=.false.),normalization{conditions})</call>
+      <call>self=criticalOverdensitySphericalCollapseBrynsDrkMttrDrkEnrgy(cosmologyParameters_,cosmologyFunctions_,cosmologicalMassVariance_,darkMatterParticle_,intergalacticMediumFilteringMass_,tableStore,tablePointsPerOctave,enumerationCllsnlssMttrDarkEnergyFixedAtEncode(char(energyFixedAt),includesPrefix=.false.),perturbationSmall,normalization{conditions})</call>
       <argument name="countTimeCollapsePerUnit" value="countTimeCollapsePerUnit" parameterPresent="parameters"/>
     </conditionalCall>
     <inputParametersValidate source="parameters"/>
@@ -167,7 +177,7 @@ contains
     return
   end function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorParameters
 
-  function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorInternal(cosmologyParameters_,cosmologyFunctions_,cosmologicalMassVariance_,darkMatterParticle_,intergalacticMediumFilteringMass_,tableStore,tablePointsPerOctave,energyFixedAt,normalization,countTimeCollapsePerUnit) result(self)
+  function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorInternal(cosmologyParameters_,cosmologyFunctions_,cosmologicalMassVariance_,darkMatterParticle_,intergalacticMediumFilteringMass_,tableStore,tablePointsPerOctave,energyFixedAt,perturbationSmall,normalization,countTimeCollapsePerUnit) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`criticalOverdensitySphericalCollapseBrynsDrkMttrDrkEnrgy` critical overdensity class.
     !!}
@@ -183,18 +193,19 @@ contains
     logical                                                                             , intent(in   ) :: tableStore
     integer                                                                             , intent(in   ) :: tablePointsPerOctave
     type            (enumerationCllsnlssMttrDarkEnergyFixedAtType            )          , intent(in   ) :: energyFixedAt
+    double precision                                                                    , intent(in   ) :: perturbationSmall
     double precision                                                          , optional, intent(in   ) :: normalization                    , countTimeCollapsePerUnit
     !![
     <optionalArgument name="normalization" defaultsTo="1.0d0" />
-    <constructorAssign variables="*cosmologyParameters_, *cosmologyFunctions_, *cosmologicalMassVariance_, *darkMatterParticle_, *intergalacticMediumFilteringMass_, tableStore, tablePointsPerOctave, energyFixedAt, normalization, countTimeCollapsePerUnit"/>
+    <constructorAssign variables="*cosmologyParameters_, *cosmologyFunctions_, *cosmologicalMassVariance_, *darkMatterParticle_, *intergalacticMediumFilteringMass_, tableStore, tablePointsPerOctave, energyFixedAt, perturbationSmall, normalization, countTimeCollapsePerUnit"/>
     !!]
 
     self%tableInitialized=.false.
     allocate(self%sphericalCollapseSolverClustered_  )
     allocate(self%sphericalCollapseSolverUnclustered_)
     !![
-    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverClustered_"   constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.true. ,self%tablePointsPerOctave,self%energyFixedAt,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
-    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverUnclustered_" constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.false.,self%tablePointsPerOctave,self%energyFixedAt,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
+    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverClustered_"   constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.true. ,self%tablePointsPerOctave,self%energyFixedAt,self%perturbationSmall,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
+    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverUnclustered_" constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.false.,self%tablePointsPerOctave,self%energyFixedAt,self%perturbationSmall,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
     !!]
     ! Require that the dark matter be cold dark matter.
     select type (darkMatterParticle_)

--- a/source/structure_formation/spherical_collapse/solver/baryons_darkMatter_darkEnergy.F90
+++ b/source/structure_formation/spherical_collapse/solver/baryons_darkMatter_darkEnergy.F90
@@ -35,9 +35,10 @@
      A spherical collapse solver for universes consisting of baryons, collisionless matter, and dark energy.
      !!}
      private
-     class  (cosmologyParametersClass), pointer :: cosmologyParameters_ => null()
-     logical                                    :: baryonsCluster
-     integer                                    :: tablePointsPerOctave
+     class           (cosmologyParametersClass), pointer :: cosmologyParameters_ => null()
+     logical                                             :: baryonsCluster
+     integer                                             :: tablePointsPerOctave
+     double precision                                    :: perturbationSmall
    contains
      final     ::             baryonsDarkMatterDarkEnergyDestructor
      procedure :: tabulate => baryonsDarkMatterDarkEnergyTabulate
@@ -52,9 +53,9 @@
   end interface sphericalCollapseSolverBaryonsDarkMatterDarkEnergy
 
   ! Variables used in root finding.
-  double precision :: OmegaBaryonEpochal, expansionFactor_, hubbleTimeEpochalSquared
+  double precision :: OmegaBaryonEpochal, expansionFactor_, hubbleTimeEpochalSquared, perturbationSmall_
   logical          :: baryonsCluster
-  !$omp threadprivate(OmegaBaryonEpochal,baryonsCluster,expansionFactor_,hubbleTimeEpochalSquared)
+  !$omp threadprivate(OmegaBaryonEpochal,baryonsCluster,expansionFactor_,hubbleTimeEpochalSquared,perturbationSmall_)
 
 contains
 
@@ -64,14 +65,15 @@ contains
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type   (sphericalCollapseSolverBaryonsDarkMatterDarkEnergy)                :: self
-    type   (inputParameters                                   ), intent(inout) :: parameters
-    class  (cosmologyFunctionsClass                           ), pointer       :: cosmologyFunctions_
-    class  (cosmologyParametersClass                          ), pointer       :: cosmologyParameters_
-    type   (varying_string                                    )                :: energyFixedAt
-    logical                                                                    :: baryonsCluster
-    integer                                                                    :: tablePointsPerOctave
-
+    type           (sphericalCollapseSolverBaryonsDarkMatterDarkEnergy)                :: self
+    type           (inputParameters                                   ), intent(inout) :: parameters
+    class          (cosmologyFunctionsClass                           ), pointer       :: cosmologyFunctions_
+    class          (cosmologyParametersClass                          ), pointer       :: cosmologyParameters_
+    type           (varying_string                                    )                :: energyFixedAt
+    logical                                                                            :: baryonsCluster
+    integer                                                                            :: tablePointsPerOctave
+    double precision                                                                   :: perturbationSmall
+    
     !![
     <inputParameter docformat="rst">
       <name>baryonsCluster</name>
@@ -96,10 +98,18 @@ contains
       The number of points per octave of time at which to tabulate solutions.
       </description>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>perturbationSmall</name>
+      <source>parameters</source>
+      <defaultValue>1.0d-3</defaultValue>
+      <description>
+	The largest initial perturbation considered to be sufficiently small. Larger initial perturbations will trigger an error.
+      </description>
+    </inputParameter>
     <objectBuilder class="cosmologyFunctions"  name="cosmologyFunctions_"  source="parameters"/>
     <objectBuilder class="cosmologyParameters" name="cosmologyParameters_" source="parameters"/>
     !!]
-    self=sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(baryonsCluster,tablePointsPerOctave,enumerationCllsnlssMttrDarkEnergyFixedAtEncode(char(energyFixedAt),includesPrefix=.false.),cosmologyParameters_,cosmologyFunctions_)
+    self=sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(baryonsCluster,tablePointsPerOctave,enumerationCllsnlssMttrDarkEnergyFixedAtEncode(char(energyFixedAt),includesPrefix=.false.),perturbationSmall,cosmologyParameters_,cosmologyFunctions_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyParameters_"/>
@@ -108,7 +118,7 @@ contains
     return
   end function baryonsDarkMatterDarkEnergyConstructorParameters
 
-  function baryonsDarkMatterDarkEnergyConstructorInternal(baryonsCluster,tablePointsPerOctave,energyFixedAt,cosmologyParameters_,cosmologyFunctions_) result(self)
+  function baryonsDarkMatterDarkEnergyConstructorInternal(baryonsCluster,tablePointsPerOctave,energyFixedAt,perturbationSmall,cosmologyParameters_,cosmologyFunctions_) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`sphericalCollapseSolverBaryonsDarkMatterDarkEnergy` spherical collapse solver class.
     !!}
@@ -117,14 +127,15 @@ contains
     use :: ISO_Varying_String, only : operator(//)
     use :: Linear_Growth     , only : linearGrowthCollisionlessMatter, linearGrowthNonClusteringBaryonsDarkMatter
     implicit none
-    type   (sphericalCollapseSolverBaryonsDarkMatterDarkEnergy)                        :: self
-    logical                                                    , intent(in   )         :: baryonsCluster
-    integer                                                    , intent(in   )         :: tablePointsPerOctave
-    type   (enumerationCllsnlssMttrDarkEnergyFixedAtType      ), intent(in   )         :: energyFixedAt
-    class  (cosmologyFunctionsClass                           ), intent(in   ), target :: cosmologyFunctions_
-    class  (cosmologyParametersClass                          ), intent(in   ), target :: cosmologyParameters_
+    type   (sphericalCollapseSolverBaryonsDarkMatterDarkEnergy)                                 :: self
+    logical                                                             , intent(in   )         :: baryonsCluster
+    integer                                                             , intent(in   )         :: tablePointsPerOctave
+    type            (enumerationCllsnlssMttrDarkEnergyFixedAtType      ), intent(in   )         :: energyFixedAt
+    double precision                                                    , intent(in   )         :: perturbationSmall
+    class           (cosmologyFunctionsClass                           ), intent(in   ), target :: cosmologyFunctions_
+    class           (cosmologyParametersClass                          ), intent(in   ), target :: cosmologyParameters_
     !![
-    <constructorAssign variables="baryonsCluster, tablePointsPerOctave, energyFixedAt, *cosmologyFunctions_, *cosmologyParameters_"/>
+    <constructorAssign variables="baryonsCluster, tablePointsPerOctave, energyFixedAt, perturbationSmall, *cosmologyFunctions_, *cosmologyParameters_"/>
     !!]
 
     self%fileNameCriticalOverdensity  =inputPath(pathTypeDataDynamic)                                                       // &
@@ -323,6 +334,8 @@ contains
              ! Get the current expansion factor.
              time_           =sphericalCollapse_ %x              (iTime)
              expansionFactor_=cosmologyFunctions_%expansionFactor(time_)
+             ! Store the "small perturbation" limit.
+             perturbationSmall_=self%perturbationSmall
              ! Initial guess for the range of the initial perturbation amplitude. Since we expect a collapsing perturbation to have
              ! linear theory amplitude of order unity at the time of collapse, and since linear perturbations grow proportional to
              ! the expansion factor in an Einstein-de Sitter universe with no baryons, we use an initial guess for the lower and
@@ -535,8 +548,27 @@ contains
     integer                                                           :: odeStatus
 
     ! Validate the perturbation overdensity.
-    if (perturbationOverdensityInitial < 0.0d+0) call Error_Report('initial overdensity of perturbation should be non-negative'//{introspection:location})
-    if (perturbationOverdensityInitial > 1.0d-3) call Error_Report('initial overdensity of perturbation should be small'       //{introspection:location})
+    if (perturbationOverdensityInitial < 0.0d+0                ) then
+       block
+         type     (varying_string) :: message
+         character(len=12        ) :: label
+         message='initial overdensity of perturbation should be non-negative'
+         write (label,'(e12.6)') perturbationOverdensityInitial
+         message=message//" ("//label//" < 0)"
+         call Error_Report(message//{introspection:location})
+       end block
+    end if
+    if (perturbationOverdensityInitial > perturbationSmall_) then
+       block
+         type     (varying_string) :: message
+         character(len=12        ) :: label1 , label2
+         message='initial overdensity of perturbation should be small'
+         write (label1,'(e12.6)') perturbationOverdensityInitial
+         write (label2,'(e12.6)') perturbationSmall_
+         message=message//" ("//label1//" > "//label2//")"
+         call Error_Report(message//{introspection:location})
+       end block
+    end if
     ! Specify a sufficiently early time.
     expansionFactorInitial=expansionFactorInitialFraction
     ! Find the corresponding cosmic time.

--- a/source/structure_formation/virial_density_contrast/spherical_collapse_baryons_darkMatter_darkEnergy.F90
+++ b/source/structure_formation/virial_density_contrast/spherical_collapse_baryons_darkMatter_darkEnergy.F90
@@ -51,6 +51,7 @@
           &                                                                               turnaroundClusteredTimeMinimum              , turnaroundClusteredTimeMaximum               , &
           &                                                                               turnaroundUnclusteredTimeMinimum            , turnaroundUnclusteredTimeMaximum
      integer                                                                           :: tablePointsPerOctave
+     double precision                                                                  :: perturbationSmall
      logical                                                                           :: tableStore
      type            (enumerationCllsnlssMttrDarkEnergyFixedAtType      )              :: energyFixedAt
      class           (table1D                                           ), allocatable :: deltaVirialClustered                        , deltaVirialUnclustered                       , &
@@ -99,6 +100,7 @@ contains
     logical                                                                            :: tableStore
     type   (varying_string                                            )                :: energyFixedAt
     integer                                                                            :: tablePointsPerOctave
+    double precision                                                                   :: perturbationSmall
 
     !![
     <inputParameter docformat="rst">
@@ -125,11 +127,19 @@ contains
       The number of points per octave of time at which to tabulate solutions.
       </description>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>perturbationSmall</name>
+      <source>parameters</source>
+      <defaultValue>1.0d-3</defaultValue>
+      <description>
+      The largest initial perturbation considered to be sufficiently small. Larger initial perturbations will trigger an error.
+      </description>
+    </inputParameter>
     <objectBuilder class="cosmologyParameters"              name="cosmologyParameters_"              source="parameters"/>
     <objectBuilder class="cosmologyFunctions"               name="cosmologyFunctions_"               source="parameters"/>
     <objectBuilder class="intergalacticMediumFilteringMass" name="intergalacticMediumFilteringMass_" source="parameters"/>
     !!]
-    self=virialDensityContrastSphericalCollapseBrynsDrkMttrDrkEnrgy(tableStore,tablePointsPerOctave,enumerationCllsnlssMttrDarkEnergyFixedAtEncode(char(energyFixedAt),includesPrefix=.false.),cosmologyParameters_,cosmologyFunctions_,intergalacticMediumFilteringMass_)
+    self=virialDensityContrastSphericalCollapseBrynsDrkMttrDrkEnrgy(tableStore,tablePointsPerOctave,enumerationCllsnlssMttrDarkEnergyFixedAtEncode(char(energyFixedAt),includesPrefix=.false.),perturbationSmall,cosmologyParameters_,cosmologyFunctions_,intergalacticMediumFilteringMass_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyParameters_"             />
@@ -139,7 +149,7 @@ contains
     return
   end function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorParameters
 
-  function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorInternal(tableStore,tablePointsPerOctave,energyFixedAt,cosmologyParameters_,cosmologyFunctions_,intergalacticMediumFilteringMass_) result(self)
+  function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorInternal(tableStore,tablePointsPerOctave,energyFixedAt,perturbationSmall,cosmologyParameters_,cosmologyFunctions_,intergalacticMediumFilteringMass_) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`virialDensityContrastSphericalCollapseBrynsDrkMttrDrkEnrgy` dark matter halo virial density contrast class.
     !!}
@@ -149,18 +159,19 @@ contains
     class  (cosmologyFunctionsClass                                   ), intent(in   ), target :: cosmologyFunctions_
     class  (intergalacticMediumFilteringMassClass                     ), intent(in   ), target :: intergalacticMediumFilteringMass_
     type   (enumerationCllsnlssMttrDarkEnergyFixedAtType              ), intent(in   )         :: energyFixedAt
+    double precision                                                  , intent(in   )         :: perturbationSmall
     logical                                                            , intent(in   )         :: tableStore
     integer                                                            , intent(in   )         :: tablePointsPerOctave
     !![
-    <constructorAssign variables="tableStore, tablePointsPerOctave, energyFixedAt, *cosmologyParameters_, *cosmologyFunctions_, *intergalacticMediumFilteringMass_"/>
+    <constructorAssign variables="tableStore, tablePointsPerOctave, energyFixedAt, perturbationSmall, *cosmologyParameters_, *cosmologyFunctions_, *intergalacticMediumFilteringMass_"/>
     !!]
 
     self%tableInitialized=.false.
     allocate(self%sphericalCollapseSolverClustered_  )
     allocate(self%sphericalCollapseSolverUnclustered_)
     !![
-    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverClustered_"   constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.true. ,self%tablePointsPerOctave,self%energyFixedAt,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
-    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverUnclustered_" constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.false.,self%tablePointsPerOctave,self%energyFixedAt,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
+    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverClustered_"   constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.true. ,self%tablePointsPerOctave,self%energyFixedAt,self%perturbationSmall,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
+    <referenceConstruct isResult="yes" owner="self" object="sphericalCollapseSolverUnclustered_" constructor="sphericalCollapseSolverBaryonsDarkMatterDarkEnergy(.false.,self%tablePointsPerOctave,self%energyFixedAt,self%perturbationSmall,self%cosmologyParameters_,self%cosmologyFunctions_)"/>
     !!]
     return
   end function sphericalCollapseBrynsDrkMttrDrkEnrgyConstructorInternal

--- a/source/tests/spherical_collapse/baryons_dark_matter.F90
+++ b/source/tests/spherical_collapse/baryons_dark_matter.F90
@@ -190,7 +190,8 @@ program Tests_Spherical_Collapse_Baryons_Dark_Matter
           &                                                                                                                      tablePointsPerOctave                    =300                                        , &
           &                                                                                                                      tableStore                              =.false.                                    , &
           &                                                                                                                      energyFixedAt                           =cllsnlssMttrDarkEnergyFixedAtTurnaround    , &
-          &                                                                                                                      normalization                           =1.0d0                                        &
+          &                                                                                                                      perturbationSmall                       =1.0d-3                                     , &
+          &                                                                                                                      normalization                           =1.0d+0                                       &
           &                                                                                                                     )
      virialDensityContrastSphrclCllpsCllsnlssMttrCsmlgclCnstnt_ =virialDensityContrastSphericalCollapseClsnlssMttrCsmlgclCnstnt(                                                                                       &
           &                                                                                                                      tableStore                              =.false.                                    , &
@@ -201,6 +202,7 @@ program Tests_Spherical_Collapse_Baryons_Dark_Matter
           &                                                                                                                      tableStore                              =.true.                                     , &
           &                                                                                                                      tablePointsPerOctave                    =300                                        , &
           &                                                                                                                      energyFixedAt                           =cllsnlssMttrDarkEnergyFixedAtTurnaround    , &
+          &                                                                                                                      perturbationSmall                       =1.0d-3                                     , &
           &                                                                                                                      cosmologyParameters_                    =cosmologyParametersDMO_                    , &
           &                                                                                                                      cosmologyFunctions_                     =cosmologyFunctionsMatterLambda_            , &
           &                                                                                                                      intergalacticMediumFilteringMass_       =intergalacticMediumFilteringMassGnedin2000_  &


### PR DESCRIPTION
## Summary
- Add a `perturbationSmall` input parameter (default `1.0d-3`) to the baryonic spherical collapse solver and its critical overdensity and virial density contrast users, so the largest initial perturbation treated as "small" is configurable rather than hard-coded. Also report the offending values in the validation error messages to aid diagnosis when a perturbation exceeds the threshold.
- Loosen mass variance tolerances and set small-perturbation threshold. Allows the dark matter only subhalos tutorial model to run successfully.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- Run `./Galacticus.exe parameters/tutorials/darkMatterOnlySubHalos.xml` and verify that it completes.

## Checklist
- [x] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'
