### PR TITLE
Handle spaces in file-system paths passed to shell commands

### DIFF
--- a/source/accretion_disks/spectra/Hopkins2007.F90
+++ b/source/accretion_disks/spectra/Hopkins2007.F90
@@ -147,7 +147,7 @@ contains
     use            :: Units_MetaData                  , only : unitType
     use            :: Numerical_Ranges                , only : Make_Range             , rangeTypeLogarithmic
     use            :: String_Handling                 , only : operator(//)
-    use            :: System_Command                  , only : System_Command_Do
+    use            :: System_Command                  , only : System_Command_Do      , shellEscape
     use            :: System_Compilers                , only : languageC              , compilerValidate
     use            :: System_Download                 , only : download
     implicit none
@@ -201,7 +201,7 @@ contains
        ! Compile the AGN SED code.
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")) then
           call compilerValidate(languageC,'AGN spectrum')
-          call System_Command_Do("cd "//char(inputPath(pathTypeDataStatic))//"aux/AGN_Spectrum; gcc agn_spectrum.c -o agn_spectrum.x -lm");
+          call System_Command_Do("cd "//char(shellEscape(inputPath(pathTypeDataStatic)//"aux/AGN_Spectrum"))//"; gcc agn_spectrum.c -o agn_spectrum.x -lm");
           if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")) call Error_Report('failed to compile agn_spectrum.c'//{introspection:location})
        end if
        ! Generate a tabulation of AGN spectra over a sufficiently large range of AGN luminosity.
@@ -211,7 +211,7 @@ contains
        do i=1,luminosityBolometricCount
           call displayCounter(int(100.0*dble(i-1)/dble(luminosityBolometricCount)),isNew=i==1,verbosity=verbosityLevelWorking)
           write (label,'(e12.6)') log10(luminosityBolometric(i))
-          call System_Command_Do(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x "//label//" > "//inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt")
+          call System_Command_Do(shellEscape(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")//" "//label//" > "//shellEscape(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt"))
           wavelengthCount=Count_Lines_in_File(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt",";")-4
           if (allocated(wavelength)) then
              if (wavelengthCount /= size(wavelength)) call Error_Report('inconsistent number of wavelengths'//{introspection:location})

--- a/source/accretion_disks/spectra/Hopkins2007.F90
+++ b/source/accretion_disks/spectra/Hopkins2007.F90
@@ -214,10 +214,10 @@ contains
        do i=1,luminosityBolometricCount
           call displayCounter(int(100.0*dble(i-1)/dble(luminosityBolometricCount)),isNew=i==1,verbosity=verbosityLevelWorking)
           write (label,'(e12.6)') log10(luminosityBolometric(i))
-          escapedExecutable=inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x"
-          escapedExecutable=shellEscape(escapedExecutable)
-          escapedSEDFile=inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt"        
-          escapedSEDFile=shellEscape(escapedSEDFile)
+          escapedExecutable=inputPath  (pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x"
+          escapedExecutable=shellEscape(escapedExecutable  )
+          escapedSEDFile   =inputPath  (pathTypeDataDynamic)//"AGN_Spectrum/SED.txt"        
+          escapedSEDFile   =shellEscape(escapedSEDFile     )
           call System_Command_Do(escapedExecutable//" "//label//" > "//escapedSEDFile)
           wavelengthCount=Count_Lines_in_File(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt",";")-4
           if (allocated(wavelength)) then

--- a/source/accretion_disks/spectra/Hopkins2007.F90
+++ b/source/accretion_disks/spectra/Hopkins2007.F90
@@ -202,7 +202,8 @@ contains
        ! Compile the AGN SED code.
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")) then
           call compilerValidate(languageC,'AGN spectrum')
-          escapedBuildDir=shellEscape(inputPath(pathTypeDataStatic)//"aux/AGN_Spectrum")
+          escapedBuildDir=inputPath(pathTypeDataStatic)//"aux/AGN_Spectrum"
+          escapedBuildDir=shellEscape(escapedBuildDir)
           call System_Command_Do("cd "//char(escapedBuildDir)//"; gcc agn_spectrum.c -o agn_spectrum.x -lm");
           if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")) call Error_Report('failed to compile agn_spectrum.c'//{introspection:location})
        end if
@@ -213,8 +214,10 @@ contains
        do i=1,luminosityBolometricCount
           call displayCounter(int(100.0*dble(i-1)/dble(luminosityBolometricCount)),isNew=i==1,verbosity=verbosityLevelWorking)
           write (label,'(e12.6)') log10(luminosityBolometric(i))
-          escapedExecutable=shellEscape(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")
-          escapedSEDFile   =shellEscape(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt"        )
+          escapedExecutable=inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x"
+          escapedExecutable=shellEscape(escapedExecutable)
+          escapedSEDFile=inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt"        
+          escapedSEDFile=shellEscape(escapedSEDFile)
           call System_Command_Do(escapedExecutable//" "//label//" > "//escapedSEDFile)
           wavelengthCount=Count_Lines_in_File(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt",";")-4
           if (allocated(wavelength)) then

--- a/source/accretion_disks/spectra/Hopkins2007.F90
+++ b/source/accretion_disks/spectra/Hopkins2007.F90
@@ -165,7 +165,8 @@ contains
     character       (len= 16                        )                              :: label
     character       (len=256                        )                              :: line
     double precision                                                               :: frequencyLogarithmic              , spectrumLogarithmic
-    type            (varying_string                 )                              :: fileNameLock
+    type            (varying_string                 )                              :: fileNameLock                     , escapedBuildDir    , &
+         &                                                                            escapedExecutable                , escapedSEDFile
 
     ! Determine if we need to make the file.
     ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
@@ -201,7 +202,8 @@ contains
        ! Compile the AGN SED code.
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")) then
           call compilerValidate(languageC,'AGN spectrum')
-          call System_Command_Do("cd "//char(shellEscape(inputPath(pathTypeDataStatic)//"aux/AGN_Spectrum"))//"; gcc agn_spectrum.c -o agn_spectrum.x -lm");
+          escapedBuildDir=shellEscape(inputPath(pathTypeDataStatic)//"aux/AGN_Spectrum")
+          call System_Command_Do("cd "//char(escapedBuildDir)//"; gcc agn_spectrum.c -o agn_spectrum.x -lm");
           if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")) call Error_Report('failed to compile agn_spectrum.c'//{introspection:location})
        end if
        ! Generate a tabulation of AGN spectra over a sufficiently large range of AGN luminosity.
@@ -211,7 +213,9 @@ contains
        do i=1,luminosityBolometricCount
           call displayCounter(int(100.0*dble(i-1)/dble(luminosityBolometricCount)),isNew=i==1,verbosity=verbosityLevelWorking)
           write (label,'(e12.6)') log10(luminosityBolometric(i))
-          call System_Command_Do(shellEscape(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")//" "//label//" > "//shellEscape(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt"))
+          escapedExecutable=shellEscape(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/agn_spectrum.x")
+          escapedSEDFile   =shellEscape(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt"        )
+          call System_Command_Do(escapedExecutable//" "//label//" > "//escapedSEDFile)
           wavelengthCount=Count_Lines_in_File(inputPath(pathTypeDataDynamic)//"AGN_Spectrum/SED.txt",";")-4
           if (allocated(wavelength)) then
              if (wavelengthCount /= size(wavelength)) call Error_Report('inconsistent number of wavelengths'//{introspection:location})

--- a/source/geometry/mangle.F90
+++ b/source/geometry/mangle.F90
@@ -331,7 +331,7 @@ contains
     use :: ISO_Varying_String, only : operator(//)     , varying_string       , char           , assignment(=)
     use :: String_Handling   , only : stringSubstitute
     use :: System_Download   , only : download
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do, shellEscape
     use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran, languageC, &
          &                            compilerValidate
     implicit none
@@ -362,12 +362,12 @@ contains
              if (status /= 0 .or. .not.File_Exists(manglePath//".tar.gz")) call Error_Report("unable to download mangle"//{introspection:location})
           end if
           call displayMessage("unpacking mangle code....",verbosityLevelWorking)
-          call System_Command_Do("tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//manglePath//".tar.gz",status)
+          call System_Command_Do("tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(manglePath//".tar.gz"),status)
           if (status /= 0 .or. .not.File_Exists(manglePath//"src/Makefile.in")) call Error_Report('failed to unpack mangle code'//{introspection:location})
        end if
        staticOptions=""
        if (static_) staticOptions=" -Wl,--whole-archive -lpthread -ldl -Wl,--no-whole-archive"
-       command=         'cd '//manglePath//'src; ./configure; '
+       command=         'cd '//shellEscape(manglePath//"src")//'; ./configure; '
        command=command//'sed -E -i~ s/"^F77[[:space:]]*=[[:space:]]*[a-zA-Z0-9]+"/"F77 = '//                 compiler       (languageFortran)                         //'"/ Makefile; '
        command=command//'sed -E -i~ s/"^CC[[:space:]]*=[[:space:]]*[a-zA-Z0-9]+"/"CC = '  //                 compiler       (languageC      )                         //'"/ Makefile; '
        command=command//'sed -E -i~ s/"^FFLAGS[[:space:]]*:=(.*)"/"FFLAGS:=\1 '           //stringSubstitute(compilerOptions(languageFortran),"/","\/")//staticOptions//'"/ Makefile; '
@@ -394,7 +394,7 @@ contains
           &                                 operator(==)      , varying_string
     use :: Numerical_Constants_Math, only : Pi
     use :: String_Handling         , only : String_Count_Words, String_Join        , String_Split_Words, char
-    use :: System_Command          , only : System_Command_Do
+    use :: System_Command          , only : System_Command_Do , shellEscape
     implicit none
     type            (varying_string), intent(in   ), dimension(             : ) :: fileNames
     character       (len=*         ), intent(in   ), optional                   :: solidAngleFileName
@@ -437,7 +437,7 @@ contains
              multiplier=-1.0d0
           end if
           fileNameTmp=File_Name_Temporary('geometryMangleSolidAngle')
-          call System_Command_Do(manglePath//"bin/harmonize "//fileName//" "//fileNameTmp,status)
+          call System_Command_Do(shellEscape(manglePath//"bin/harmonize")//" "//shellEscape(fileName)//" "//shellEscape(fileNameTmp),status)
           if (status /= 0) call Error_Report('failed to run mangle harmonize'//{introspection:location})
           open(newUnit=wlmFile,file=char(fileNameTmp),status="old",form="formatted")
           read (wlmFile,*)
@@ -474,7 +474,7 @@ contains
     use :: ISO_Varying_String, only : char              , extract            , len               , operator(//), &
           &                           operator(==)      , var_str            , varying_string
     use :: String_Handling   , only : String_Count_Words, String_Join        , String_Split_Words, operator(//)
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do , shellEscape
     implicit none
     type            (varying_string), intent(in   ), dimension(             :                                                               ) :: fileNames
     integer                         , intent(in   )                                                                                           :: degreeMaximum
@@ -529,7 +529,7 @@ contains
              multiplier=-1.0d0
           end if
           fileNameTmp=File_Name_Temporary('geometryMangleAngularPower')
-          call System_Command_Do(manglePath//"bin/harmonize -l "//degreeMaximum//" "//fileName//" "//fileNameTmp,status)
+          call System_Command_Do(shellEscape(manglePath//"bin/harmonize")//" -l "//degreeMaximum//" "//shellEscape(fileName)//" "//shellEscape(fileNameTmp),status)
           if (status /= 0) call Error_Report('failed to run mangle harmonize'//{introspection:location})
           open(newUnit=wlmFile,file=char(fileNameTmp),status="old",form="formatted")
           read (wlmFile,*)

--- a/source/geometry/mangle.F90
+++ b/source/geometry/mangle.F90
@@ -339,7 +339,9 @@ contains
     logical                , intent(in   ), optional :: static
     integer                                          :: status
     type   (lockDescriptor)                          :: fileLock
-    type   (varying_string)                          :: command   , staticOptions
+    type   (varying_string)                          :: command         , staticOptions, &
+         &                                              escapedToolsPath, escapedTarFile, &
+         &                                              escapedSrcDir
     !![
     <optionalArgument name="static" defaultsTo=".false." />
     !!]
@@ -362,12 +364,15 @@ contains
              if (status /= 0 .or. .not.File_Exists(manglePath//".tar.gz")) call Error_Report("unable to download mangle"//{introspection:location})
           end if
           call displayMessage("unpacking mangle code....",verbosityLevelWorking)
-          call System_Command_Do("tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(manglePath//".tar.gz"),status)
+          escapedToolsPath=shellEscape(inputPath(pathTypeTools))
+          escapedTarFile  =shellEscape(manglePath//".tar.gz"   )
+          call System_Command_Do("tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile,status)
           if (status /= 0 .or. .not.File_Exists(manglePath//"src/Makefile.in")) call Error_Report('failed to unpack mangle code'//{introspection:location})
        end if
        staticOptions=""
        if (static_) staticOptions=" -Wl,--whole-archive -lpthread -ldl -Wl,--no-whole-archive"
-       command=         'cd '//shellEscape(manglePath//"src")//'; ./configure; '
+       escapedSrcDir=shellEscape(manglePath//"src")
+       command=         'cd '//escapedSrcDir//'; ./configure; '
        command=command//'sed -E -i~ s/"^F77[[:space:]]*=[[:space:]]*[a-zA-Z0-9]+"/"F77 = '//                 compiler       (languageFortran)                         //'"/ Makefile; '
        command=command//'sed -E -i~ s/"^CC[[:space:]]*=[[:space:]]*[a-zA-Z0-9]+"/"CC = '  //                 compiler       (languageC      )                         //'"/ Makefile; '
        command=command//'sed -E -i~ s/"^FFLAGS[[:space:]]*:=(.*)"/"FFLAGS:=\1 '           //stringSubstitute(compilerOptions(languageFortran),"/","\/")//staticOptions//'"/ Makefile; '
@@ -402,8 +407,10 @@ contains
     type            (varying_string), allocatable  , dimension(             : ) :: subFiles
     integer                                                                     :: i                       , j            , &
          &                                                                         status                  , wlmFile
-    type            (varying_string)                                            :: fileName                , fileNameTmp  , &
-         &                                                                         manglePath              , mangleVersion
+    type            (varying_string)                                            :: fileName                , fileNameTmp       , &
+         &                                                                         manglePath              , mangleVersion     , &
+         &                                                                         escapedHarmonize        , escapedFileName   , &
+         &                                                                         escapedFileNameTmp
     double precision                                                            :: multiplier              , subSolidAngle, &
          &                                                                         w00
     type            (hdf5Object    )                                            :: solidAngleFile
@@ -437,7 +444,10 @@ contains
              multiplier=-1.0d0
           end if
           fileNameTmp=File_Name_Temporary('geometryMangleSolidAngle')
-          call System_Command_Do(shellEscape(manglePath//"bin/harmonize")//" "//shellEscape(fileName)//" "//shellEscape(fileNameTmp),status)
+          escapedHarmonize  =shellEscape(manglePath//"bin/harmonize")
+          escapedFileName   =shellEscape(fileName                   )
+          escapedFileNameTmp=shellEscape(fileNameTmp                )
+          call System_Command_Do(escapedHarmonize//" "//escapedFileName//" "//escapedFileNameTmp,status)
           if (status /= 0) call Error_Report('failed to run mangle harmonize'//{introspection:location})
           open(newUnit=wlmFile,file=char(fileNameTmp),status="old",form="formatted")
           read (wlmFile,*)
@@ -483,8 +493,10 @@ contains
     double precision                               , dimension(                                      2                                      ) :: coefficient
     double precision                               , dimension(size(fileNames)                      ,2,(degreeMaximum+1)*(degreeMaximum+2)/2) :: coefficients
     type            (varying_string), allocatable  , dimension(             :                                                               ) :: subFiles
-    type            (varying_string)                                                                                                          :: fileName                  , fileNameTmp  , &
-         &                                                                                                                                       manglePath                , mangleVersion
+    type            (varying_string)                                                                                                          :: fileName                  , fileNameTmp      , &
+         &                                                                                                                                       manglePath                , mangleVersion    , &
+         &                                                                                                                                       escapedHarmonize          , escapedFileName  , &
+         &                                                                                                                                       escapedFileNameTmp
     integer                                                                                                                                   :: degree                    , order        , &
          &                                                                                                                                       status                    , wlmFile      , &
          &                                                                                                                                       i                         , j            , &
@@ -529,7 +541,10 @@ contains
              multiplier=-1.0d0
           end if
           fileNameTmp=File_Name_Temporary('geometryMangleAngularPower')
-          call System_Command_Do(shellEscape(manglePath//"bin/harmonize")//" -l "//degreeMaximum//" "//shellEscape(fileName)//" "//shellEscape(fileNameTmp),status)
+          escapedHarmonize  =shellEscape(manglePath//"bin/harmonize")
+          escapedFileName   =shellEscape(fileName                   )
+          escapedFileNameTmp=shellEscape(fileNameTmp                )
+          call System_Command_Do(escapedHarmonize//" -l "//degreeMaximum//" "//escapedFileName//" "//escapedFileNameTmp,status)
           if (status /= 0) call Error_Report('failed to run mangle harmonize'//{introspection:location})
           open(newUnit=wlmFile,file=char(fileNameTmp),status="old",form="formatted")
           read (wlmFile,*)

--- a/source/geometry/mangle.F90
+++ b/source/geometry/mangle.F90
@@ -364,7 +364,8 @@ contains
              if (status /= 0 .or. .not.File_Exists(manglePath//".tar.gz")) call Error_Report("unable to download mangle"//{introspection:location})
           end if
           call displayMessage("unpacking mangle code....",verbosityLevelWorking)
-          escapedToolsPath=shellEscape(inputPath(pathTypeTools))
+          escapedToolsPath=inputPath(pathTypeTools)
+          escapedToolsPath=shellEscape(escapedToolsPath)
           escapedTarFile  =shellEscape(manglePath//".tar.gz"   )
           call System_Command_Do("tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile,status)
           if (status /= 0 .or. .not.File_Exists(manglePath//"src/Makefile.in")) call Error_Report('failed to unpack mangle code'//{introspection:location})

--- a/source/geometry/surveys/Bernardi-2013-SDSS.F90
+++ b/source/geometry/surveys/Bernardi-2013-SDSS.F90
@@ -218,6 +218,7 @@ contains
     type   (varying_string                ), allocatable, dimension(:), intent(inout) :: mangleFiles
     type   (lockDescriptor                )                                           :: lock
     integer                                                                           :: status
+    type   (varying_string                )                                           :: escapedGzFile
 
     allocate(mangleFiles(1))
     mangleFiles(1)=self%mangleDirectory()//"sdss_dr72safe0_res6d.pol"
@@ -228,7 +229,8 @@ contains
           call download("https://zenodo.org/records/10998446/files/sdss_dr72safe0_res6d.pol.gz",char(mangleFiles(1))//".gz",status=status)
           if (status /= 0 .or. .not.File_Exists(mangleFiles(1)//".gz")) &
                & call Error_Report('failed to download mangle polygon file'//{introspection:location})
-          call System_Command_Do("gunzip "//shellEscape(mangleFiles(1)//".gz"),status)
+          escapedGzFile=shellEscape(mangleFiles(1)//".gz")
+          call System_Command_Do("gunzip "//escapedGzFile,status)
           if (status /= 0 .or. .not.File_Exists(mangleFiles(1))) &
                & call Error_Report('failed to decompress mangle polygon file'//{introspection:location})
        end if

--- a/source/geometry/surveys/Bernardi-2013-SDSS.F90
+++ b/source/geometry/surveys/Bernardi-2013-SDSS.F90
@@ -212,7 +212,7 @@ contains
          &                         Directory_Make
     use :: Error          , only : Error_Report
     use :: System_Download, only : download
-    use :: System_Command , only : System_Command_Do
+    use :: System_Command , only : System_Command_Do, shellEscape
     implicit none
     class  (surveyGeometryBernardi2013SDSS)                           , intent(inout) :: self
     type   (varying_string                ), allocatable, dimension(:), intent(inout) :: mangleFiles
@@ -228,7 +228,7 @@ contains
           call download("https://zenodo.org/records/10998446/files/sdss_dr72safe0_res6d.pol.gz",char(mangleFiles(1))//".gz",status=status)
           if (status /= 0 .or. .not.File_Exists(mangleFiles(1)//".gz")) &
                & call Error_Report('failed to download mangle polygon file'//{introspection:location})
-          call System_Command_Do("gunzip "//mangleFiles(1)//".gz",status)
+          call System_Command_Do("gunzip "//shellEscape(mangleFiles(1)//".gz"),status)
           if (status /= 0 .or. .not.File_Exists(mangleFiles(1))) &
                & call Error_Report('failed to decompress mangle polygon file'//{introspection:location})
        end if

--- a/source/geometry/surveys/Caputi-2011-UKIDSS-UDS.F90
+++ b/source/geometry/surveys/Caputi-2011-UKIDSS-UDS.F90
@@ -266,7 +266,7 @@ contains
     use :: HDF5_Access    , only : hdf5Access
     use :: IO_HDF5        , only : hdf5Object
     use :: String_Handling, only : operator(//)
-    use :: System_Command , only : System_Command_Do
+    use :: System_Command , only : System_Command_Do, shellEscape
     implicit none
     class(surveyGeometryCaputi2011UKIDSSUDS), intent(inout) :: self
     type (hdf5Object                       )                :: surveyGeometryRandomsFile
@@ -274,7 +274,7 @@ contains
     ! Generate the randoms file if necessary.
     if (.not.File_Exists(inputPath(pathTypeDataDynamic)//&
          & "surveys/UKIDSS_UDS/data/surveyGeometryRandoms.hdf5")) then
-       call System_Command_Do(inputPath(pathTypeDataStatic)//"surveyGeometry/UKIDSS_UDS/surveyGeometryRandoms.py")
+       call System_Command_Do(shellEscape(inputPath(pathTypeDataStatic)//"surveyGeometry/UKIDSS_UDS/surveyGeometryRandoms.py"))
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"surveys/UKIDSS_UDS/surveyGeometryRandoms.hdf5")) call Error_Report('unable to create survey geometry randoms file'//{introspection:location})
     end if
     ! Read the distribution of random points from file.

--- a/source/geometry/surveys/Caputi-2011-UKIDSS-UDS.F90
+++ b/source/geometry/surveys/Caputi-2011-UKIDSS-UDS.F90
@@ -267,14 +267,17 @@ contains
     use :: IO_HDF5        , only : hdf5Object
     use :: String_Handling, only : operator(//)
     use :: System_Command , only : System_Command_Do, shellEscape
+    use :: ISO_Varying_String, only : varying_string, assignment(=)
     implicit none
     class(surveyGeometryCaputi2011UKIDSSUDS), intent(inout) :: self
     type (hdf5Object                       )                :: surveyGeometryRandomsFile
+    type (varying_string                   )                :: escapedScript
 
     ! Generate the randoms file if necessary.
     if (.not.File_Exists(inputPath(pathTypeDataDynamic)//&
          & "surveys/UKIDSS_UDS/data/surveyGeometryRandoms.hdf5")) then
-       call System_Command_Do(shellEscape(inputPath(pathTypeDataStatic)//"surveyGeometry/UKIDSS_UDS/surveyGeometryRandoms.py"))
+       escapedScript=shellEscape(inputPath(pathTypeDataStatic)//"surveyGeometry/UKIDSS_UDS/surveyGeometryRandoms.py")
+       call System_Command_Do(escapedScript)
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"surveys/UKIDSS_UDS/surveyGeometryRandoms.hdf5")) call Error_Report('unable to create survey geometry randoms file'//{introspection:location})
     end if
     ! Read the distribution of random points from file.

--- a/source/geometry/surveys/Caputi-2011-UKIDSS-UDS.F90
+++ b/source/geometry/surveys/Caputi-2011-UKIDSS-UDS.F90
@@ -276,7 +276,8 @@ contains
     ! Generate the randoms file if necessary.
     if (.not.File_Exists(inputPath(pathTypeDataDynamic)//&
          & "surveys/UKIDSS_UDS/data/surveyGeometryRandoms.hdf5")) then
-       escapedScript=shellEscape(inputPath(pathTypeDataStatic)//"surveyGeometry/UKIDSS_UDS/surveyGeometryRandoms.py")
+       escapedScript=inputPath(pathTypeDataStatic)//"surveyGeometry/UKIDSS_UDS/surveyGeometryRandoms.py"
+       escapedScript=shellEscape(escapedScript)
        call System_Command_Do(escapedScript)
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"surveys/UKIDSS_UDS/surveyGeometryRandoms.hdf5")) call Error_Report('unable to create survey geometry randoms file'//{introspection:location})
     end if

--- a/source/geometry/surveys/Caputi-2011-UKIDSS-UDS.F90
+++ b/source/geometry/surveys/Caputi-2011-UKIDSS-UDS.F90
@@ -276,8 +276,8 @@ contains
     ! Generate the randoms file if necessary.
     if (.not.File_Exists(inputPath(pathTypeDataDynamic)//&
          & "surveys/UKIDSS_UDS/data/surveyGeometryRandoms.hdf5")) then
-       escapedScript=inputPath(pathTypeDataStatic)//"surveyGeometry/UKIDSS_UDS/surveyGeometryRandoms.py"
-       escapedScript=shellEscape(escapedScript)
+       escapedScript=inputPath  (pathTypeDataStatic)//"surveyGeometry/UKIDSS_UDS/surveyGeometryRandoms.py"
+       escapedScript=shellEscape(escapedScript     )
        call System_Command_Do(escapedScript)
        if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"surveys/UKIDSS_UDS/surveyGeometryRandoms.hdf5")) call Error_Report('unable to create survey geometry randoms file'//{introspection:location})
     end if

--- a/source/interface/AxionCAMB.F90
+++ b/source/interface/AxionCAMB.F90
@@ -72,7 +72,7 @@ contains
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//), replace       , &
           &                           varying_string
     use :: String_Handling   , only : stringSubstitute
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do, shellEscape
     use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran, compilerValidate
     implicit none
     type   (varying_string), intent(  out)           :: axionCambPath, axionCambVersion
@@ -97,11 +97,11 @@ contains
        if (.not.File_Exists(axionCambPath)) then
           ! Download AxionCAMB if necessary.
           call displayMessage("downloading AxionCAMB code....",verbosityLevelWorking)
-          call System_Command_Do("git clone https://github.com/dgrin1/axionCAMB.git "//axionCambPath,status)
+          call System_Command_Do("git clone https://github.com/dgrin1/axionCAMB.git "//shellEscape(axionCambPath),status)
           if (status /= 0 .or. .not.File_Exists(axionCambPath)) call Error_Report("unable to download AxionCAMB"//{introspection:location})
        end if
        call displayMessage("compiling AxionCAMB code",verbosityLevelWorking)
-       command='cd '//axionCambPath//'; sed -E -i~ s/"Ini_Read_Double\('//"'"//'omega_axion'//"'"//'\)\/\(P%H0\/100\)\*\*2"/"Ini_Read_Double\('//"'"//'omega_axion'//"'"//'\)"/ inidriver_axion.F90; sed -E -i~ s/"^F90C[[:space:]]*=[[:space:]]*[[:alpha:]]+"/"F90C = '//stringSubstitute(compiler(languageFortran),"/","\/")//'\nFFLAGS = -O3 '// &
+       command='cd '//shellEscape(axionCambPath)//'; sed -E -i~ s/"Ini_Read_Double\('//"'"//'omega_axion'//"'"//'\)\/\(P%H0\/100\)\*\*2"/"Ini_Read_Double\('//"'"//'omega_axion'//"'"//'\)"/ inidriver_axion.F90; sed -E -i~ s/"^F90C[[:space:]]*=[[:space:]]*[[:alpha:]]+"/"F90C = '//stringSubstitute(compiler(languageFortran),"/","\/")//'\nFFLAGS = -O3 '// &
             &  stringSubstitute(compilerOptions(languageFortran),"/","\/")
        if (static_) command=command//" -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
        command=command//'"/ Makefile; find . -name "*.f90" | xargs sed -E -i~ s/"error stop"/"error stop "/; make -j1 camb'
@@ -137,7 +137,7 @@ contains
     !$ use            :: OMP_Lib                         , only : OMP_Get_Thread_Num
     use               :: Sorting                         , only : sortIndex
     use               :: String_Handling                 , only : operator(//)                , String_C_To_Fortran
-    use               :: System_Command                  , only : System_Command_Do
+    use               :: System_Command                  , only : System_Command_Do           , shellEscape
     use               :: Table_Labels                    , only : extrapolationTypeExtrapolate, extrapolationTypeFix
     use               :: Tables                          , only : table                       , table1DGeneric
     implicit none
@@ -449,7 +449,7 @@ contains
        write (axionCambParameterFile,'(a,1x,"=",1x,i1   )') 'l_sample_boost               ',1
        close(axionCambParameterFile)
        ! Run AxionCAMB.
-       call System_Command_Do(axionCambPath//"camb "//parameterFile)
+       call System_Command_Do(shellEscape(axionCambPath//"camb")//" "//shellEscape(parameterFile))
        ! Read the AxionCAMB transfer function file.
        if (allocated(wavenumbers      )) deallocate(wavenumbers      )
        if (allocated(transferFunctions)) deallocate(transferFunctions)

--- a/source/interface/AxionCAMB.F90
+++ b/source/interface/AxionCAMB.F90
@@ -80,7 +80,8 @@ contains
     integer                                          :: status
     type   (varying_string)                          :: command
     type   (lockDescriptor)                          :: fileLock
-    type   (varying_string)                          :: lockPath     , exePath
+    type   (varying_string)                          :: lockPath     , exePath, &
+         &                                              escapedAxionCambPath
     !![
     <optionalArgument name="static" defaultsTo=".false." />
     !!]
@@ -97,11 +98,13 @@ contains
        if (.not.File_Exists(axionCambPath)) then
           ! Download AxionCAMB if necessary.
           call displayMessage("downloading AxionCAMB code....",verbosityLevelWorking)
-          call System_Command_Do("git clone https://github.com/dgrin1/axionCAMB.git "//shellEscape(axionCambPath),status)
+          escapedAxionCambPath=shellEscape(axionCambPath)
+          call System_Command_Do("git clone https://github.com/dgrin1/axionCAMB.git "//escapedAxionCambPath,status)
           if (status /= 0 .or. .not.File_Exists(axionCambPath)) call Error_Report("unable to download AxionCAMB"//{introspection:location})
        end if
        call displayMessage("compiling AxionCAMB code",verbosityLevelWorking)
-       command='cd '//shellEscape(axionCambPath)//'; sed -E -i~ s/"Ini_Read_Double\('//"'"//'omega_axion'//"'"//'\)\/\(P%H0\/100\)\*\*2"/"Ini_Read_Double\('//"'"//'omega_axion'//"'"//'\)"/ inidriver_axion.F90; sed -E -i~ s/"^F90C[[:space:]]*=[[:space:]]*[[:alpha:]]+"/"F90C = '//stringSubstitute(compiler(languageFortran),"/","\/")//'\nFFLAGS = -O3 '// &
+       escapedAxionCambPath=shellEscape(axionCambPath)
+       command='cd '//escapedAxionCambPath//'; sed -E -i~ s/"Ini_Read_Double\('//"'"//'omega_axion'//"'"//'\)\/\(P%H0\/100\)\*\*2"/"Ini_Read_Double\('//"'"//'omega_axion'//"'"//'\)"/ inidriver_axion.F90; sed -E -i~ s/"^F90C[[:space:]]*=[[:space:]]*[[:alpha:]]+"/"F90C = '//stringSubstitute(compiler(languageFortran),"/","\/")//'\nFFLAGS = -O3 '// &
             &  stringSubstitute(compilerOptions(languageFortran),"/","\/")
        if (static_) command=command//" -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
        command=command//'"/ Makefile; find . -name "*.f90" | xargs sed -E -i~ s/"error stop"/"error stop "/; make -j1 camb'
@@ -171,7 +174,8 @@ contains
     character       (len=32                  )                                  :: parameterLabel                          , datasetName                   , &
          &                                                                         redshiftLabel                           , indexLabel
     type            (varying_string          )                                  :: uniqueLabel                             , workPath                      , &
-         &                                                                         transferFileName                        , fileName_
+         &                                                                         transferFileName                        , fileName_                     , &
+         &                                                                         escapedExecutable                       , escapedParameterFile
     type            (inputParameters         )                                  :: descriptor
     logical                                                                     :: allEpochsFound
     !![
@@ -449,7 +453,9 @@ contains
        write (axionCambParameterFile,'(a,1x,"=",1x,i1   )') 'l_sample_boost               ',1
        close(axionCambParameterFile)
        ! Run AxionCAMB.
-       call System_Command_Do(shellEscape(axionCambPath//"camb")//" "//shellEscape(parameterFile))
+       escapedExecutable   =shellEscape(axionCambPath//"camb")
+       escapedParameterFile=shellEscape(parameterFile        )
+       call System_Command_Do(escapedExecutable//" "//escapedParameterFile)
        ! Read the AxionCAMB transfer function file.
        if (allocated(wavenumbers      )) deallocate(wavenumbers      )
        if (allocated(transferFunctions)) deallocate(transferFunctions)

--- a/source/interface/CAMB.F90
+++ b/source/interface/CAMB.F90
@@ -76,10 +76,13 @@ contains
     type     (varying_string), intent(  out)           :: cambPath       , cambVersion
     logical                  , intent(in   ), optional :: static
     integer                                            :: status
-    type     (varying_string)                          :: command        , forutilsVersion , &
-         &                                                makeFile       , makeFileForUtils, &
-         &                                                tarBall        , executable      , &
-         &                                                url            , tarBallForUtils
+    type     (varying_string)                          :: command          , forutilsVersion   , &
+         &                                                makeFile         , makeFileForUtils  , &
+         &                                                tarBall          , executable        , &
+         &                                                url              , tarBallForUtils   , &
+         &                                                escapedToolsPath , escapedTarFile    , &
+         &                                                escapedForUtilsDir, escapedForUtilsTar, &
+         &                                                escapedCambPath
     type     (lockDescriptor)                          :: fileLock
     !![
     <optionalArgument name="static" defaultsTo=".false." />
@@ -109,7 +112,9 @@ contains
              if (status /= 0 .or. .not.File_Exists(tarBall)) call Error_Report("unable to download CAMB"//{introspection:location})
           end if
           call displayMessage("unpacking CAMB code....",verbosityLevelWorking)
-          command="tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz")
+          escapedToolsPath=shellEscape(inputPath(pathTypeTools))
+          escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz")
+          command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
           call System_Command_Do(command,status);
           if (status /= 0 .or. .not.File_Exists(cambPath)) call Error_Report('failed to unpack CAMB code'//{introspection:location})
           ! Download the "forutils" package if necessary.
@@ -121,16 +126,19 @@ contains
                 if (status /= 0 .or. .not.File_Exists(tarBallForUtils)) call Error_Report("unable to download forutils"//{introspection:location})
              end if
              call displayMessage("unpacking forutils code....",verbosityLevelWorking)
-             command="tar -x -v -z -C "//shellEscape(cambPath//"../forutils")//" -f "//shellEscape(cambPath//"../forutils_"//forutilsVersion//".tar.gz")//" --strip-components 1"
-             call System_Command_Do(command);          
+             escapedForUtilsDir=shellEscape(cambPath//"../forutils")
+             escapedForUtilsTar=shellEscape(cambPath//"../forutils_"//forutilsVersion//".tar.gz")
+             command="tar -x -v -z -C "//escapedForUtilsDir//" -f "//escapedForUtilsTar//" --strip-components 1"
+             call System_Command_Do(command);
              if (status /= 0 .or. .not.File_Exists(makeFileForUtils)) call Error_Report('failed to unpack forutils code'//{introspection:location})
           end if
        end if       
        call displayMessage("compiling CAMB code",verbosityLevelWorking)
-       command='cd '//shellEscape(cambPath)//'; sed -E -i~ s/"ifortErr[[:space:]]*=.*"/"ifortErr = 1"/ Makefile; sed -E -i~ s/"gfortErr[[:space:]]*=.*"/"gfortErr = 0"/ Makefile; sed -E -i~ s/"gfortran"/"'//stringSubstitute(compiler(languageFortran),"/","\/")//'"/ Makefile; sed -E -i~ s/"gfortran"/"'//stringSubstitute(compiler(languageFortran),"/","\/")//'"/ ../forutils/Makefile_compiler; sed -E -i~ s/"^FFLAGS[[:space:]]*\+=[[:space:]]*\-march=native"/"FFLAGS+="/ Makefile; sed -E -i~ s/"^FFLAGS[[:space:]]*=[[:space:]]*.*"/"FFLAGS = -cpp -Ofast -fopenmp '//stringSubstitute(compilerOptions(languageFortran),"/","\/")
+       escapedCambPath=shellEscape(cambPath)
+       command='cd '//escapedCambPath//'; sed -E -i~ s/"ifortErr[[:space:]]*=.*"/"ifortErr = 1"/ Makefile; sed -E -i~ s/"gfortErr[[:space:]]*=.*"/"gfortErr = 0"/ Makefile; sed -E -i~ s/"gfortran"/"'//stringSubstitute(compiler(languageFortran),"/","\/")//'"/ Makefile; sed -E -i~ s/"gfortran"/"'//stringSubstitute(compiler(languageFortran),"/","\/")//'"/ ../forutils/Makefile_compiler; sed -E -i~ s/"^FFLAGS[[:space:]]*\+=[[:space:]]*\-march=native"/"FFLAGS+="/ Makefile; sed -E -i~ s/"^FFLAGS[[:space:]]*=[[:space:]]*.*"/"FFLAGS = -cpp -Ofast -fopenmp '//stringSubstitute(compilerOptions(languageFortran),"/","\/")
        if (static_) command=command//" -static -Wl,--whole-archive -lpthread -ldl -Wl,--no-whole-archive"
        command=command//'"/ Makefile'
-       if (static_) command=command//'; cp "$GALACTICUS_EXEC_PATH/source/utility/OpenMP/workaround.c" '//shellEscape(cambPath)//'; gcc -DSTATIC -c workaround.c -o workaround.o; sed -E -i~ s/"\-o camb$"/"workaround\.o \-o camb"/ Makefile_main'
+       if (static_) command=command//'; cp "$GALACTICUS_EXEC_PATH/source/utility/OpenMP/workaround.c" '//escapedCambPath//'; gcc -DSTATIC -c workaround.c -o workaround.o; sed -E -i~ s/"\-o camb$"/"workaround\.o \-o camb"/ Makefile_main'
        command=command//'; find . -name "*.f90" | xargs sed -E -i~ s/"error stop"/"error stop "/; make -j1 camb'
        call System_Command_Do(command,status);
        if (status /= 0 .or. .not.File_Exists(executable)) call Error_Report("failed to build CAMB code"//{introspection:location})
@@ -194,7 +202,8 @@ contains
          &                                                                                 redshiftLabel                           , indexLabel              , &
          &                                                                                 extracted
     type            (varying_string                  )                                  :: uniqueLabel                             , workPath                , &
-         &                                                                                 transferFileName                        , fileName_
+         &                                                                                 transferFileName                        , fileName_               , &
+         &                                                                                 escapedExecutable                       , escapedParameterFile
     type            (inputParameters                 )                                  :: descriptor
     logical                                                                             :: allEpochsFound
     !![
@@ -437,7 +446,9 @@ contains
              write (cambParameterFile,'(a,1x,"=",1x,i1   )') 'l_sample_boost               ',1
              close(cambParameterFile)
              ! Run CAMB.
-             call System_Command_Do(shellEscape(cambPath//"camb")//" "//shellEscape(parameterFile))
+             escapedExecutable   =shellEscape(cambPath//"camb")
+             escapedParameterFile=shellEscape(parameterFile   )
+             call System_Command_Do(escapedExecutable//" "//escapedParameterFile)
              ! Read the CAMB transfer function file.
              if (allocated(wavenumbers      )) deallocate(wavenumbers      )
              if (allocated(transferFunctions)) deallocate(transferFunctions)

--- a/source/interface/CAMB.F90
+++ b/source/interface/CAMB.F90
@@ -114,7 +114,8 @@ contains
           call displayMessage("unpacking CAMB code....",verbosityLevelWorking)
           escapedToolsPath=inputPath(pathTypeTools)
           escapedToolsPath=shellEscape(escapedToolsPath)
-          escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz")
+          escapedTarFile=inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz"
+          escapedTarFile=shellEscape(escapedTarFile)
           command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
           call System_Command_Do(command,status);
           if (status /= 0 .or. .not.File_Exists(cambPath)) call Error_Report('failed to unpack CAMB code'//{introspection:location})

--- a/source/interface/CAMB.F90
+++ b/source/interface/CAMB.F90
@@ -112,7 +112,7 @@ contains
              if (status /= 0 .or. .not.File_Exists(tarBall)) call Error_Report("unable to download CAMB"//{introspection:location})
           end if
           call displayMessage("unpacking CAMB code....",verbosityLevelWorking)
-          escapedToolsPath=shellEscape(inputPath(pathTypeTools))
+          escapedToolsPath=shellEscape(inputPath(pathTypeTools)                                 )
           escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz")
           command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
           call System_Command_Do(command,status);
@@ -126,7 +126,7 @@ contains
                 if (status /= 0 .or. .not.File_Exists(tarBallForUtils)) call Error_Report("unable to download forutils"//{introspection:location})
              end if
              call displayMessage("unpacking forutils code....",verbosityLevelWorking)
-             escapedForUtilsDir=shellEscape(cambPath//"../forutils")
+             escapedForUtilsDir=shellEscape(cambPath//"../forutils"                             )
              escapedForUtilsTar=shellEscape(cambPath//"../forutils_"//forutilsVersion//".tar.gz")
              command="tar -x -v -z -C "//escapedForUtilsDir//" -f "//escapedForUtilsTar//" --strip-components 1"
              call System_Command_Do(command);

--- a/source/interface/CAMB.F90
+++ b/source/interface/CAMB.F90
@@ -114,8 +114,8 @@ contains
           call displayMessage("unpacking CAMB code....",verbosityLevelWorking)
           escapedToolsPath=inputPath(pathTypeTools)
           escapedToolsPath=shellEscape(escapedToolsPath)
-          escapedTarFile=inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz"
-          escapedTarFile=shellEscape(escapedTarFile)
+          escapedTarFile=inputPath    (pathTypeTools   )//"CAMB_"//cambVersion//".tar.gz"
+          escapedTarFile=shellEscape  (escapedTarFile  )
           command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
           call System_Command_Do(command,status);
           if (status /= 0 .or. .not.File_Exists(cambPath)) call Error_Report('failed to unpack CAMB code'//{introspection:location})

--- a/source/interface/CAMB.F90
+++ b/source/interface/CAMB.F90
@@ -69,7 +69,7 @@ contains
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)   , replace    , &
           &                           varying_string
     use :: String_Handling   , only : stringSubstitute
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do, shellEscape
     use :: System_Download   , only : download
     use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran, compilerValidate
     implicit none
@@ -109,7 +109,7 @@ contains
              if (status /= 0 .or. .not.File_Exists(tarBall)) call Error_Report("unable to download CAMB"//{introspection:location})
           end if
           call displayMessage("unpacking CAMB code....",verbosityLevelWorking)
-          command="tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz"
+          command="tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz")
           call System_Command_Do(command,status);
           if (status /= 0 .or. .not.File_Exists(cambPath)) call Error_Report('failed to unpack CAMB code'//{introspection:location})
           ! Download the "forutils" package if necessary.
@@ -121,16 +121,16 @@ contains
                 if (status /= 0 .or. .not.File_Exists(tarBallForUtils)) call Error_Report("unable to download forutils"//{introspection:location})
              end if
              call displayMessage("unpacking forutils code....",verbosityLevelWorking)
-             command="tar -x -v -z -C "//cambPath//"../forutils -f "//cambPath//"../forutils_"//forutilsVersion//".tar.gz --strip-components 1"
+             command="tar -x -v -z -C "//shellEscape(cambPath//"../forutils")//" -f "//shellEscape(cambPath//"../forutils_"//forutilsVersion//".tar.gz")//" --strip-components 1"
              call System_Command_Do(command);          
              if (status /= 0 .or. .not.File_Exists(makeFileForUtils)) call Error_Report('failed to unpack forutils code'//{introspection:location})
           end if
        end if       
        call displayMessage("compiling CAMB code",verbosityLevelWorking)
-       command='cd '//cambPath//'; sed -E -i~ s/"ifortErr[[:space:]]*=.*"/"ifortErr = 1"/ Makefile; sed -E -i~ s/"gfortErr[[:space:]]*=.*"/"gfortErr = 0"/ Makefile; sed -E -i~ s/"gfortran"/"'//stringSubstitute(compiler(languageFortran),"/","\/")//'"/ Makefile; sed -E -i~ s/"gfortran"/"'//stringSubstitute(compiler(languageFortran),"/","\/")//'"/ ../forutils/Makefile_compiler; sed -E -i~ s/"^FFLAGS[[:space:]]*\+=[[:space:]]*\-march=native"/"FFLAGS+="/ Makefile; sed -E -i~ s/"^FFLAGS[[:space:]]*=[[:space:]]*.*"/"FFLAGS = -cpp -Ofast -fopenmp '//stringSubstitute(compilerOptions(languageFortran),"/","\/")
+       command='cd '//shellEscape(cambPath)//'; sed -E -i~ s/"ifortErr[[:space:]]*=.*"/"ifortErr = 1"/ Makefile; sed -E -i~ s/"gfortErr[[:space:]]*=.*"/"gfortErr = 0"/ Makefile; sed -E -i~ s/"gfortran"/"'//stringSubstitute(compiler(languageFortran),"/","\/")//'"/ Makefile; sed -E -i~ s/"gfortran"/"'//stringSubstitute(compiler(languageFortran),"/","\/")//'"/ ../forutils/Makefile_compiler; sed -E -i~ s/"^FFLAGS[[:space:]]*\+=[[:space:]]*\-march=native"/"FFLAGS+="/ Makefile; sed -E -i~ s/"^FFLAGS[[:space:]]*=[[:space:]]*.*"/"FFLAGS = -cpp -Ofast -fopenmp '//stringSubstitute(compilerOptions(languageFortran),"/","\/")
        if (static_) command=command//" -static -Wl,--whole-archive -lpthread -ldl -Wl,--no-whole-archive"
        command=command//'"/ Makefile'
-       if (static_) command=command//'; cp $GALACTICUS_EXEC_PATH/source/utility/OpenMP/workaround.c '//cambPath//'; gcc -DSTATIC -c workaround.c -o workaround.o; sed -E -i~ s/"\-o camb$"/"workaround\.o \-o camb"/ Makefile_main'
+       if (static_) command=command//'; cp "$GALACTICUS_EXEC_PATH/source/utility/OpenMP/workaround.c" '//shellEscape(cambPath)//'; gcc -DSTATIC -c workaround.c -o workaround.o; sed -E -i~ s/"\-o camb$"/"workaround\.o \-o camb"/ Makefile_main'
        command=command//'; find . -name "*.f90" | xargs sed -E -i~ s/"error stop"/"error stop "/; make -j1 camb'
        call System_Command_Do(command,status);
        if (status /= 0 .or. .not.File_Exists(executable)) call Error_Report("failed to build CAMB code"//{introspection:location})
@@ -161,7 +161,7 @@ contains
     use            :: Numerical_Interpolation         , only : GSL_Interp_cSpline
     use            :: Sorting                         , only : sortIndex
     use            :: String_Handling                 , only : String_C_To_Fortran         , operator(//)
-    use            :: System_Command                  , only : System_Command_Do
+    use            :: System_Command                  , only : System_Command_Do           , shellEscape
     use            :: Table_Labels                    , only : extrapolationTypeExtrapolate, enumerationExtrapolationTypeType
     use            :: Tables                          , only : table                       , table1DGeneric
     implicit none
@@ -437,7 +437,7 @@ contains
              write (cambParameterFile,'(a,1x,"=",1x,i1   )') 'l_sample_boost               ',1
              close(cambParameterFile)
              ! Run CAMB.
-             call System_Command_Do(cambPath//"camb "//parameterFile)
+             call System_Command_Do(shellEscape(cambPath//"camb")//" "//shellEscape(parameterFile))
              ! Read the CAMB transfer function file.
              if (allocated(wavenumbers      )) deallocate(wavenumbers      )
              if (allocated(transferFunctions)) deallocate(transferFunctions)

--- a/source/interface/CAMB.F90
+++ b/source/interface/CAMB.F90
@@ -112,7 +112,8 @@ contains
              if (status /= 0 .or. .not.File_Exists(tarBall)) call Error_Report("unable to download CAMB"//{introspection:location})
           end if
           call displayMessage("unpacking CAMB code....",verbosityLevelWorking)
-          escapedToolsPath=shellEscape(inputPath(pathTypeTools)                                 )
+          escapedToolsPath=inputPath(pathTypeTools)
+          escapedToolsPath=shellEscape(escapedToolsPath)
           escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"CAMB_"//cambVersion//".tar.gz")
           command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
           call System_Command_Do(command,status);

--- a/source/interface/CLASS.F90
+++ b/source/interface/CLASS.F90
@@ -101,7 +101,8 @@ contains
              if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")) call Error_Report("unable to download CLASS"//{introspection:location})
           end if
           call displayMessage("unpacking CLASS code....",verbosityLevelWorking)
-          escapedToolsPath=shellEscape(inputPath(pathTypeTools)                                                )
+          escapedToolsPath=inputPath(pathTypeTools)
+          escapedToolsPath=shellEscape(escapedToolsPath)
           escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")
           call System_Command_Do("tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile,status)
           if (status /= 0 .or. .not.File_Exists(classPath)) call Error_Report('failed to unpack CLASS code'//{introspection:location})

--- a/source/interface/CLASS.F90
+++ b/source/interface/CLASS.F90
@@ -101,7 +101,7 @@ contains
              if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")) call Error_Report("unable to download CLASS"//{introspection:location})
           end if
           call displayMessage("unpacking CLASS code....",verbosityLevelWorking)
-          escapedToolsPath=shellEscape(inputPath(pathTypeTools))
+          escapedToolsPath=shellEscape(inputPath(pathTypeTools)                                                )
           escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")
           call System_Command_Do("tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile,status)
           if (status /= 0 .or. .not.File_Exists(classPath)) call Error_Report('failed to unpack CLASS code'//{introspection:location})
@@ -841,8 +841,8 @@ contains
     write (classParameterFile,'(a)') ''
     close(classParameterFile)
     ! Run CLASS.
-    escapedExecutable   =shellEscape(classPath//"class"  )
-    escapedParameterFile=shellEscape(parameterFile       )
+    escapedExecutable   =shellEscape(classPath//"class"    )
+    escapedParameterFile=shellEscape(parameterFile         )
     escapedLogFile      =shellEscape(workPath//"/class.log")
     call System_Command_Do(escapedExecutable//" "//escapedParameterFile//" > "//escapedLogFile)
     ! Extract the ratio σ₈²/Aₛ.

--- a/source/interface/CLASS.F90
+++ b/source/interface/CLASS.F90
@@ -103,7 +103,8 @@ contains
           call displayMessage("unpacking CLASS code....",verbosityLevelWorking)
           escapedToolsPath=inputPath(pathTypeTools)
           escapedToolsPath=shellEscape(escapedToolsPath)
-          escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")
+          escapedTarFile=inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz"
+          escapedTarFile=shellEscape(escapedTarFile)
           call System_Command_Do("tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile,status)
           if (status /= 0 .or. .not.File_Exists(classPath)) call Error_Report('failed to unpack CLASS code'//{introspection:location})
        end if

--- a/source/interface/CLASS.F90
+++ b/source/interface/CLASS.F90
@@ -77,7 +77,8 @@ contains
     type   (varying_string), intent(  out)           :: classPath, classVersion
     logical                , intent(in   ), optional :: static
     integer                                          :: status
-    type   (varying_string)                          :: command
+    type   (varying_string)                          :: command         , escapedToolsPath, &
+         &                                              escapedTarFile  , escapedClassPath
     type   (lockDescriptor)                          :: fileLock
     !![
     <optionalArgument name="static" defaultsTo=".false." />
@@ -100,11 +101,14 @@ contains
              if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")) call Error_Report("unable to download CLASS"//{introspection:location})
           end if
           call displayMessage("unpacking CLASS code....",verbosityLevelWorking)
-          call System_Command_Do("tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz"),status)
-          if (status /= 0 .or. .not.File_Exists(classPath)) call Error_Report('failed to unpack CLASS code'//{introspection:location})        
+          escapedToolsPath=shellEscape(inputPath(pathTypeTools))
+          escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")
+          call System_Command_Do("tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile,status)
+          if (status /= 0 .or. .not.File_Exists(classPath)) call Error_Report('failed to unpack CLASS code'//{introspection:location})
        end if
        call displayMessage("compiling CLASS code",verbosityLevelWorking)
-       command='cd '//shellEscape(classPath)//'; cp Makefile Makefile.tmp; '
+       escapedClassPath=shellEscape(classPath)
+       command='cd '//escapedClassPath//'; cp Makefile Makefile.tmp; '
        ! Include Galacticus compilation flags here.
        command=command//'sed -E -i~ s/"^CC[[:space:]]+=[[:space:]]+gcc"/"CC='//char(stringSubstitute(compiler(languageC),"/","\/"))//'"/ Makefile.tmp; sed -E -i~ s/"^(CC|LD)FLAG = "/"\1FLAG = '//char(stringSubstitute(compilerOptions(languageC),"/","\/"))
        if (static_) command=command//' -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive'
@@ -744,7 +748,8 @@ contains
          &                                                                                                j
     type            (varying_string          )                                                         :: classVersion                     , parameterFile          , &
          &                                                                                                classPath                        , workPath               , &
-         &                                                                                                transferFileName
+         &                                                                                                transferFileName                 , escapedExecutable      , &
+         &                                                                                                escapedParameterFile             , escapedLogFile
     logical                                                                                            :: found                            , haveTransferFunctions  , &
          &                                                                                                haveNormalization                , havePerturbations
     double precision                                                                                   :: sigma8                           , wavenumberCLASS
@@ -836,7 +841,10 @@ contains
     write (classParameterFile,'(a)') ''
     close(classParameterFile)
     ! Run CLASS.
-    call System_Command_Do(shellEscape(classPath//"class")//" "//shellEscape(parameterFile)//" > "//shellEscape(workPath//"/class.log"))
+    escapedExecutable   =shellEscape(classPath//"class"  )
+    escapedParameterFile=shellEscape(parameterFile       )
+    escapedLogFile      =shellEscape(workPath//"/class.log")
+    call System_Command_Do(escapedExecutable//" "//escapedParameterFile//" > "//escapedLogFile)
     ! Extract the ratio σ₈²/Aₛ.
     if (haveNormalization) then
        found=.false.

--- a/source/interface/CLASS.F90
+++ b/source/interface/CLASS.F90
@@ -70,7 +70,7 @@ contains
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//), replace    , &
           &                           varying_string
     use :: String_Handling   , only : stringSubstitute
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do, shellEscape
     use :: System_Download   , only : download
     use :: System_Compilers  , only : compiler         , compilerOptions      , languageC   , compilerValidate
     implicit none
@@ -100,11 +100,11 @@ contains
              if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")) call Error_Report("unable to download CLASS"//{introspection:location})
           end if
           call displayMessage("unpacking CLASS code....",verbosityLevelWorking)
-          call System_Command_Do("tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz",status)
+          call System_Command_Do("tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz"),status)
           if (status /= 0 .or. .not.File_Exists(classPath)) call Error_Report('failed to unpack CLASS code'//{introspection:location})        
        end if
        call displayMessage("compiling CLASS code",verbosityLevelWorking)
-       command='cd '//classPath//'; cp Makefile Makefile.tmp; '
+       command='cd '//shellEscape(classPath)//'; cp Makefile Makefile.tmp; '
        ! Include Galacticus compilation flags here.
        command=command//'sed -E -i~ s/"^CC[[:space:]]+=[[:space:]]+gcc"/"CC='//char(stringSubstitute(compiler(languageC),"/","\/"))//'"/ Makefile.tmp; sed -E -i~ s/"^(CC|LD)FLAG = "/"\1FLAG = '//char(stringSubstitute(compilerOptions(languageC),"/","\/"))
        if (static_) command=command//' -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive'
@@ -722,7 +722,7 @@ contains
     use               :: Numerical_Constants_Astronomical, only : heliumByMassPrimordial
     use               :: Sorting                         , only : sortIndex
     use               :: String_Handling                 , only : operator(//)
-    use               :: System_Command                  , only : System_Command_Do
+    use               :: System_Command                  , only : System_Command_Do       , shellEscape
     implicit none
     class           (cosmologyParametersClass), intent(inout)                                          :: cosmologyParameters_
     double precision                          , intent(in   ), optional, dimension(:    )              :: redshifts
@@ -836,7 +836,7 @@ contains
     write (classParameterFile,'(a)') ''
     close(classParameterFile)
     ! Run CLASS.
-    call System_Command_Do(classPath//"class "//parameterFile//" > "//workPath//"/class.log")
+    call System_Command_Do(shellEscape(classPath//"class")//" "//shellEscape(parameterFile)//" > "//shellEscape(workPath//"/class.log"))
     ! Extract the ratio σ₈²/Aₛ.
     if (haveNormalization) then
        found=.false.

--- a/source/interface/CLASS.F90
+++ b/source/interface/CLASS.F90
@@ -101,10 +101,10 @@ contains
              if (status /= 0 .or. .not.File_Exists(inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz")) call Error_Report("unable to download CLASS"//{introspection:location})
           end if
           call displayMessage("unpacking CLASS code....",verbosityLevelWorking)
-          escapedToolsPath=inputPath(pathTypeTools)
+          escapedToolsPath=inputPath  (pathTypeTools   )
           escapedToolsPath=shellEscape(escapedToolsPath)
-          escapedTarFile=inputPath(pathTypeTools)//"class_public-"//char(classVersion)//".tar.gz"
-          escapedTarFile=shellEscape(escapedTarFile)
+          escapedTarFile  =inputPath  (pathTypeTools   )//"class_public-"//char(classVersion)//".tar.gz"
+          escapedTarFile  =shellEscape(escapedTarFile  )
           call System_Command_Do("tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile,status)
           if (status /= 0 .or. .not.File_Exists(classPath)) call Error_Report('failed to unpack CLASS code'//{introspection:location})
        end if

--- a/source/interface/Cloudy/_module.F90
+++ b/source/interface/Cloudy/_module.F90
@@ -53,7 +53,7 @@ contains
     use :: Input_Paths       , only : inputPath        , pathTypeTools
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)     , varying_string
     use :: String_Handling   , only : stringSubstitute
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do, shellEscape
     use :: System_Download   , only : download
     use :: System_Compilers  , only : compiler         , compilerOptions      , languageCPlusPlus, compilerValidate
     implicit none
@@ -90,15 +90,15 @@ contains
           end if
           ! Unpack and patch the code.
           call displayMessage("unpacking and patching Cloudy code....",verbosityLevelWorking)
-          call System_Command_Do("tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//cloudyPath//".tar.gz",status)
+          call System_Command_Do("tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(cloudyPath//".tar.gz"),status)
           if (status /= 0 .or. .not.File_Exists(cloudyPath)) call Error_Report("failed to unpack Cloudy code"//{introspection:location})
-          call System_Command_Do('sed -i~ -E s/"^#\!\/bin\/sh"/"#\!\/usr\/bin\/env bash"/ '//cloudyPath//'/source/configure.sh',status)
+          call System_Command_Do('sed -i~ -E s/"^#\!\/bin\/sh"/"#\!\/usr\/bin\/env bash"/ '//shellEscape(cloudyPath//"/source/configure.sh"),status)
           if (status /= 0                                  ) call Error_Report("failed to patch Cloudy code"//{introspection:location})
-          call System_Command_Do('sed -i~ -E s/"^is_repo=(.*)"/"is_repo=\"false\""/ '//cloudyPath//'/source/gitversion.sh',status)
+          call System_Command_Do('sed -i~ -E s/"^is_repo=(.*)"/"is_repo=\"false\""/ '//shellEscape(cloudyPath//"/source/gitversion.sh"),status)
           if (status /= 0                                  ) call Error_Report("failed to patch Cloudy code"//{introspection:location})
-          call System_Command_Do('sed -i~ -E s/"\\\$res[[:space:]]+\.=[[:space:]]+\"native \""/"print \"skip march=native as it breaks the build\\n\""/ '//cloudyPath//'/source/capabilities.pl',status)
+          call System_Command_Do('sed -i~ -E s/"\\\$res[[:space:]]+\.=[[:space:]]+\"native \""/"print \"skip march=native as it breaks the build\\n\""/ '//shellEscape(cloudyPath//"/source/capabilities.pl"),status)
           if (status /= 0                                  ) call Error_Report("failed to patch Cloudy code"//{introspection:location})
-          call System_Command_Do('sed -i~ -E s/"which[[:space:]]+g\+\+"/"which '//stringSubstitute(compiler(languageCPlusPlus),"/","\/")//'"/ '//cloudyPath//'/source/Makefile',status)
+          call System_Command_Do('sed -i~ -E s/"which[[:space:]]+g\+\+"/"which '//stringSubstitute(compiler(languageCPlusPlus),"/","\/")//'"/ '//shellEscape(cloudyPath//"/source/Makefile"),status)
           if (status /= 0                                  ) call Error_Report("failed to patch Cloudy code"//{introspection:location})
        end if
        ! Build the code.
@@ -108,16 +108,16 @@ contains
           if (statusEnvironment <= 0) static_=staticDefault == "yes"
        end if
        if (static_) then
-          call System_Command_Do("cd "//cloudyPath//"/source; sed -i~ -E s/'^EXTRA[[:space:]]*=.*'/'EXTRA = -static "//stringSubstitute(stringSubstitute(compilerOptions(languageCPlusPlus),"/","\/"),"-","\-")//"'/g Makefile")
+          call System_Command_Do("cd "//shellEscape(cloudyPath//"/source")//"; sed -i~ -E s/'^EXTRA[[:space:]]*=.*'/'EXTRA = -static "//stringSubstitute(stringSubstitute(compilerOptions(languageCPlusPlus),"/","\/"),"-","\-")//"'/g Makefile")
        else
-          call System_Command_Do("cd "//cloudyPath//"/source; sed -i~ -E s/'^EXTRA[[:space:]]*=.*'/'EXTRA = "        //stringSubstitute(stringSubstitute(compilerOptions(languageCPlusPlus),"/","\/"),"-","\-")//"'/g Makefile")
+          call System_Command_Do("cd "//shellEscape(cloudyPath//"/source")//"; sed -i~ -E s/'^EXTRA[[:space:]]*=.*'/'EXTRA = "        //stringSubstitute(stringSubstitute(compilerOptions(languageCPlusPlus),"/","\/"),"-","\-")//"'/g Makefile")
        end if
-       command="cd "//cloudyPath//"/source; chmod u=wrx configure.sh capabilities.pl;"
+       command="cd "//shellEscape(cloudyPath//"/source")//"; chmod u=wrx configure.sh capabilities.pl;"
        call Get_Environment_Variable('CLOUDY_COMPILER_PATH',compilerPath,status=statusPath)
        if      (statusPath == -1) then
           call Error_Report("can not read Cloudy compiler path environment variable"//{introspection:location})
        else if (statusPath ==  0) then
-          command=command//"export PATH="//trim(compilerPath)//":$PATH; "
+          command=command//"export PATH="//shellEscape(trim(compilerPath))//":$PATH; "
        end if
        command=command//" make"
        call System_Command_Do(char(command),status)

--- a/source/interface/Cloudy/_module.F90
+++ b/source/interface/Cloudy/_module.F90
@@ -63,7 +63,10 @@ contains
          &                                                statusPath
     character(len=   3      )                          :: staticDefault
     character(len=1024      )                          :: compilerPath
-    type     (varying_string)                          :: command      , cloudyVersionMajor
+    type     (varying_string)                          :: command          , cloudyVersionMajor, &
+         &                                                escapedToolsPath , escapedTarFile    , &
+         &                                                escapedSourceFile, escapedSource     , &
+         &                                                escapedCompilerPath
     !![
     <optionalArgument name="static" defaultsTo=".false." />
     !!]
@@ -90,15 +93,21 @@ contains
           end if
           ! Unpack and patch the code.
           call displayMessage("unpacking and patching Cloudy code....",verbosityLevelWorking)
-          call System_Command_Do("tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(cloudyPath//".tar.gz"),status)
+          escapedToolsPath =shellEscape(inputPath(pathTypeTools))
+          escapedTarFile   =shellEscape(cloudyPath//".tar.gz"   )
+          call System_Command_Do("tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile,status)
           if (status /= 0 .or. .not.File_Exists(cloudyPath)) call Error_Report("failed to unpack Cloudy code"//{introspection:location})
-          call System_Command_Do('sed -i~ -E s/"^#\!\/bin\/sh"/"#\!\/usr\/bin\/env bash"/ '//shellEscape(cloudyPath//"/source/configure.sh"),status)
+          escapedSourceFile=shellEscape(cloudyPath//"/source/configure.sh")
+          call System_Command_Do('sed -i~ -E s/"^#\!\/bin\/sh"/"#\!\/usr\/bin\/env bash"/ '//escapedSourceFile,status)
           if (status /= 0                                  ) call Error_Report("failed to patch Cloudy code"//{introspection:location})
-          call System_Command_Do('sed -i~ -E s/"^is_repo=(.*)"/"is_repo=\"false\""/ '//shellEscape(cloudyPath//"/source/gitversion.sh"),status)
+          escapedSourceFile=shellEscape(cloudyPath//"/source/gitversion.sh")
+          call System_Command_Do('sed -i~ -E s/"^is_repo=(.*)"/"is_repo=\"false\""/ '//escapedSourceFile,status)
           if (status /= 0                                  ) call Error_Report("failed to patch Cloudy code"//{introspection:location})
-          call System_Command_Do('sed -i~ -E s/"\\\$res[[:space:]]+\.=[[:space:]]+\"native \""/"print \"skip march=native as it breaks the build\\n\""/ '//shellEscape(cloudyPath//"/source/capabilities.pl"),status)
+          escapedSourceFile=shellEscape(cloudyPath//"/source/capabilities.pl")
+          call System_Command_Do('sed -i~ -E s/"\\\$res[[:space:]]+\.=[[:space:]]+\"native \""/"print \"skip march=native as it breaks the build\\n\""/ '//escapedSourceFile,status)
           if (status /= 0                                  ) call Error_Report("failed to patch Cloudy code"//{introspection:location})
-          call System_Command_Do('sed -i~ -E s/"which[[:space:]]+g\+\+"/"which '//stringSubstitute(compiler(languageCPlusPlus),"/","\/")//'"/ '//shellEscape(cloudyPath//"/source/Makefile"),status)
+          escapedSourceFile=shellEscape(cloudyPath//"/source/Makefile")
+          call System_Command_Do('sed -i~ -E s/"which[[:space:]]+g\+\+"/"which '//stringSubstitute(compiler(languageCPlusPlus),"/","\/")//'"/ '//escapedSourceFile,status)
           if (status /= 0                                  ) call Error_Report("failed to patch Cloudy code"//{introspection:location})
        end if
        ! Build the code.
@@ -107,17 +116,19 @@ contains
           call Get_Environment_Variable('CLOUDY_STATIC_BUILD',staticDefault,status=statusEnvironment)
           if (statusEnvironment <= 0) static_=staticDefault == "yes"
        end if
+       escapedSource=shellEscape(cloudyPath//"/source")
        if (static_) then
-          call System_Command_Do("cd "//shellEscape(cloudyPath//"/source")//"; sed -i~ -E s/'^EXTRA[[:space:]]*=.*'/'EXTRA = -static "//stringSubstitute(stringSubstitute(compilerOptions(languageCPlusPlus),"/","\/"),"-","\-")//"'/g Makefile")
+          call System_Command_Do("cd "//escapedSource//"; sed -i~ -E s/'^EXTRA[[:space:]]*=.*'/'EXTRA = -static "//stringSubstitute(stringSubstitute(compilerOptions(languageCPlusPlus),"/","\/"),"-","\-")//"'/g Makefile")
        else
-          call System_Command_Do("cd "//shellEscape(cloudyPath//"/source")//"; sed -i~ -E s/'^EXTRA[[:space:]]*=.*'/'EXTRA = "        //stringSubstitute(stringSubstitute(compilerOptions(languageCPlusPlus),"/","\/"),"-","\-")//"'/g Makefile")
+          call System_Command_Do("cd "//escapedSource//"; sed -i~ -E s/'^EXTRA[[:space:]]*=.*'/'EXTRA = "        //stringSubstitute(stringSubstitute(compilerOptions(languageCPlusPlus),"/","\/"),"-","\-")//"'/g Makefile")
        end if
-       command="cd "//shellEscape(cloudyPath//"/source")//"; chmod u=wrx configure.sh capabilities.pl;"
+       command="cd "//escapedSource//"; chmod u=wrx configure.sh capabilities.pl;"
        call Get_Environment_Variable('CLOUDY_COMPILER_PATH',compilerPath,status=statusPath)
        if      (statusPath == -1) then
           call Error_Report("can not read Cloudy compiler path environment variable"//{introspection:location})
        else if (statusPath ==  0) then
-          command=command//"export PATH="//shellEscape(trim(compilerPath))//":$PATH; "
+          escapedCompilerPath=shellEscape(trim(compilerPath))
+          command=command//"export PATH="//escapedCompilerPath//":$PATH; "
        end if
        command=command//" make"
        call System_Command_Do(char(command),status)

--- a/source/interface/Cloudy/_module.F90
+++ b/source/interface/Cloudy/_module.F90
@@ -93,7 +93,8 @@ contains
           end if
           ! Unpack and patch the code.
           call displayMessage("unpacking and patching Cloudy code....",verbosityLevelWorking)
-          escapedToolsPath =shellEscape(inputPath(pathTypeTools))
+          escapedToolsPath=inputPath(pathTypeTools)
+          escapedToolsPath=shellEscape(escapedToolsPath)
           escapedTarFile   =shellEscape(cloudyPath//".tar.gz"   )
           call System_Command_Do("tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile,status)
           if (status /= 0 .or. .not.File_Exists(cloudyPath)) call Error_Report("failed to unpack Cloudy code"//{introspection:location})

--- a/source/interface/Cloudy/collisional_ionization_equilibrium.F90
+++ b/source/interface/Cloudy/collisional_ionization_equilibrium.F90
@@ -85,7 +85,7 @@ contains
     type            (varying_string)                                  :: cloudyPath                             , cloudyVersion                        , &
          &                                                               fileNameTempCooling                    , fileNameTempOverview                 , &
          &                                                               fileNameTempContinuum                  , fileNameCoolingFunctionLock          , &
-         &                                                               fileNameChemicalStateLock
+         &                                                               fileNameChemicalStateLock              , escapedSource
     character       (len=   8      )                                  :: label
     character       (len=1024      )                                  :: line
     double precision                                                  :: dummy                                  , abundanceHelium                      , &
@@ -200,7 +200,8 @@ contains
              if (includeContinuum_) &
                   & write (cloudyScript,'(a)') 'save emitted continuum units _keV "'//char(fileNameTempContinuum)//'"'
              close(cloudyScript)
-             call System_Command_Do("cd "//shellEscape(cloudyPath//"/source")//"; ./cloudy.exe -r input",status);
+             escapedSource=shellEscape(cloudyPath//"/source")
+             call System_Command_Do("cd "//escapedSource//"; ./cloudy.exe -r input",status);
              if (status /= 0) call Error_Report('Cloudy failed'//{introspection:location})
              ! Extract the cooling rate.
              open(newUnit=inputFile,file=char(cloudyPath//"/source/"//fileNameTempCooling),status='old')

--- a/source/interface/Cloudy/collisional_ionization_equilibrium.F90
+++ b/source/interface/Cloudy/collisional_ionization_equilibrium.F90
@@ -56,7 +56,7 @@ contains
     use :: Units_MetaData                  , only : unitType
     use :: Numerical_Ranges                , only : Make_Range                         , rangeTypeLinear               , rangeTypeLogarithmic
     use :: String_Handling                 , only : operator(//)
-    use :: System_Command                  , only : System_Command_Do
+    use :: System_Command                  , only : System_Command_Do                  , shellEscape
     implicit none
     double precision                , intent(in   )                   :: metallicityMaximumLogarithmic
     type            (varying_string), intent(in   )                   :: fileNameCoolingFunction                , fileNameChemicalState
@@ -200,7 +200,7 @@ contains
              if (includeContinuum_) &
                   & write (cloudyScript,'(a)') 'save emitted continuum units _keV "'//char(fileNameTempContinuum)//'"'
              close(cloudyScript)
-             call System_Command_Do("cd "//cloudyPath//"/source; ./cloudy.exe -r input",status);
+             call System_Command_Do("cd "//shellEscape(cloudyPath//"/source")//"; ./cloudy.exe -r input",status);
              if (status /= 0) call Error_Report('Cloudy failed'//{introspection:location})
              ! Extract the cooling rate.
              open(newUnit=inputFile,file=char(cloudyPath//"/source/"//fileNameTempCooling),status='old')

--- a/source/interface/FSPS.F90
+++ b/source/interface/FSPS.F90
@@ -99,9 +99,10 @@ contains
              if (.not.File_Exists(tarPath) .or. status /= 0) call Error_Report("failed to download FSPS"//{introspection:location})
           end if
           call displayMessage("unpacking FSPS code....",verbosityLevelWorking)
-          escapedToolsPath=inputPath(pathTypeTools)
+          escapedToolsPath=inputPath  (pathTypeTools)
           escapedToolsPath=shellEscape(escapedToolsPath)
-          escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz")
+          escapedTarFile  =inputPath  (pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz"
+          escapedTarFile  =shellEscape(escapedTarFile)
           command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
           call System_Command_Do(command,status)
           if (status /= 0 .or. .not.File_Exists(fspsPath)) call Error_Report('failed to unpack FSPS code'//{introspection:location})
@@ -110,29 +111,35 @@ contains
        patchPath=fspsPath//"/src/patched.status"
        if (.not.File_Exists(patchPath)) then
           patch=which('patch')
-          escapedPatch      =shellEscape(patch            )
-          escapedSrcPath    =shellEscape(fspsPath//"/src/")
-          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/galacticus_IMF.f90")
+          escapedPatch      =shellEscape(patch             )
+          escapedSrcPath    =shellEscape(fspsPath//"/src/" )
+          escapedPatchSource=inputPath  (pathTypeDataStatic)//"patches/FSPS/galacticus_IMF.f90"
+          escapedPatchSource=shellEscape(escapedPatchSource)
           command="cp "//escapedPatchSource//" "//escapedSrcPath
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to copy FSPS patch 'galacticus_IMF.f90'"//{introspection:location})
-          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/imf.f90.patch")
+          escapedPatchSource=inputPath(pathTypeDataStatic)//"patches/FSPS/imf.f90.patch"
+          escapedPatchSource=shellEscape(escapedPatchSource)
           command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < imf.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'imf.f90'"           //{introspection:location})
-          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/ssp_gen.f90.patch")
+          escapedPatchSource=inputPath(pathTypeDataStatic)//"patches/FSPS/ssp_gen.f90.patch"
+          escapedPatchSource=shellEscape(escapedPatchSource)
           command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < ssp_gen.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'ssp_gen.f90'"       //{introspection:location})
-          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/sps_vars.f90.patch")
+          escapedPatchSource=inputPath(pathTypeDataStatic)//"patches/FSPS/sps_vars.f90.patch"
+          escapedPatchSource=shellEscape(escapedPatchSource)
           command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < sps_vars.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'sps_vars.f90'"      //{introspection:location})
-          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/autosps.f90.patch")
+          escapedPatchSource=inputPath(pathTypeDataStatic)//"patches/FSPS/autosps.f90.patch"
+          escapedPatchSource=shellEscape(escapedPatchSource)
           command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < autosps.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'autosps.f90'"       //{introspection:location})
-          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/Makefile.patch")
+          escapedPatchSource=inputPath(pathTypeDataStatic)//"patches/FSPS/Makefile.patch"
+          escapedPatchSource=shellEscape(escapedPatchSource)
           command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < Makefile.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'Makefile'"          //{introspection:location})

--- a/source/interface/FSPS.F90
+++ b/source/interface/FSPS.F90
@@ -60,7 +60,7 @@ contains
     use :: Input_Paths       , only : inputPath        , pathTypeTools        , pathTypeDataStatic
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)      , varying_string
     use :: String_Handling   , only : operator(//)     , stringSubstitute
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do, shellEscape
     use :: System_Download   , only : download
     use :: System_Compilers  , only : compiler         , compilerOptions      , languageFortran   , compilerValidate
     use :: System_Which      , only : which
@@ -96,7 +96,7 @@ contains
              if (.not.File_Exists(tarPath) .or. status /= 0) call Error_Report("failed to download FSPS"//{introspection:location})
           end if
           call displayMessage("unpacking FSPS code....",verbosityLevelWorking)
-          command="tar -x -v -z -C "//inputPath(pathTypeTools)//" -f "//inputPath(pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz"
+          command="tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(inputPath(pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz")
           call System_Command_Do(command,status)          
           if (status /= 0 .or. .not.File_Exists(fspsPath)) call Error_Report('failed to unpack FSPS code'//{introspection:location})
        end if
@@ -104,22 +104,22 @@ contains
        patchPath=fspsPath//"/src/patched.status"
        if (.not.File_Exists(patchPath)) then
           patch=which('patch')
-          command="cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/galacticus_IMF.f90 "//fspsPath//"/src/"
+          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/galacticus_IMF.f90")//" "//shellEscape(fspsPath//"/src/")
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to copy FSPS patch 'galacticus_IMF.f90'"//{introspection:location})
-          command="cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/imf.f90.patch "     //fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < imf.f90.patch" 
+          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/imf.f90.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < imf.f90.patch" 
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'imf.f90'"           //{introspection:location})
-          command="cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/ssp_gen.f90.patch " //fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < ssp_gen.f90.patch"
+          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/ssp_gen.f90.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < ssp_gen.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'ssp_gen.f90'"       //{introspection:location})
-          command="cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/sps_vars.f90.patch "//fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < sps_vars.f90.patch"
+          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/sps_vars.f90.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < sps_vars.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'sps_vars.f90'"      //{introspection:location})
-          command="cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/autosps.f90.patch " //fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < autosps.f90.patch"
+          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/autosps.f90.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < autosps.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'autosps.f90'"       //{introspection:location})
-          command="cp "//inputPath(pathTypeDataStatic)//"patches/FSPS/Makefile.patch "    //fspsPath//"/src/; cd "//fspsPath//"/src/; "//patch//" < Makefile.patch"
+          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/Makefile.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < Makefile.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'Makefile'"          //{introspection:location})
           open(newUnit=statusUnit,file=char(fspsPath//"/src/patched.status"),status='unknown',form='formatted')
@@ -129,13 +129,13 @@ contains
        end if
        call displayMessage("compiling autosps.exe code",verbosityLevelWorking)
        if (static_) then
-          command="cd "//fspsPath//"/src; "                                                    // &
+          command="cd "//shellEscape(fspsPath//"/src")//"; "                                   // &
 #ifndef __APPLE__
                &  "grep -P '^F90FLAGS := ' Makefile && "                                       // &
 #endif
                &  "sed -i~ -E s/'^(F90FLAGS := [^#]*)'/'\1 \-static'/g Makefile"  
        else
-          command="cd "//fspsPath//"/src; "                                                    // &
+          command="cd "//shellEscape(fspsPath//"/src")//"; "                                   // &
 #ifndef __APPLE__
                &  "grep -P '^F90FLAGS := ' Makefile && "                                       // &
 #endif
@@ -143,7 +143,7 @@ contains
        end if
        call System_Command_Do(command,status)
        if (status /= 0) call Error_Report("failed to patch FSPS file 'Makefile' for static/dynamic build"//{introspection:location})
-       command="cd "//fspsPath//"/src; export SPS_HOME="//fspsPath//'; export F90FLAGS="'                                                                   // &
+       command="cd "//shellEscape(fspsPath//"/src")//"; export SPS_HOME="//shellEscape(fspsPath)//'; export F90FLAGS="'                                     // &
 #ifndef __aarch64__
             &  '-mcmodel=medium '                                                                                                                           // & ! Larger memory model required except on Arm64.
 #endif
@@ -171,7 +171,7 @@ contains
     use :: Numerical_Constants_Units       , only : metersToAngstroms
     use :: Units_MetaData                  , only : unitType
     use :: String_Handling                 , only : operator(//)
-    use :: System_Command                  , only : System_Command_Do
+    use :: System_Command                  , only : System_Command_Do      , shellEscape
     use :: Tables                          , only : table1D
     implicit none
     class           (table1D       ), intent(inout)                              :: imf
@@ -220,7 +220,7 @@ contains
              write (outputFile,'(a)' ) "no"                 ! Do not include dust.
              write (outputFile,'(a)' ) char(outputFileName) ! Specify filename.
              close(outputFile)
-             call System_Command_Do("export SPS_HOME="//fspsPath//"; "//fspsPath//"/src/autosps.exe < "//fspsInputFileName)
+             call System_Command_Do("export SPS_HOME="//shellEscape(fspsPath)//"; "//shellEscape(fspsPath//"/src/autosps.exe")//" < "//shellEscape(fspsInputFileName))
              call File_Remove(fspsInputFileName)
           end if
           call File_Unlock(imfLock)

--- a/source/interface/FSPS.F90
+++ b/source/interface/FSPS.F90
@@ -99,7 +99,8 @@ contains
              if (.not.File_Exists(tarPath) .or. status /= 0) call Error_Report("failed to download FSPS"//{introspection:location})
           end if
           call displayMessage("unpacking FSPS code....",verbosityLevelWorking)
-          escapedToolsPath=shellEscape(inputPath(pathTypeTools)                                       )
+          escapedToolsPath=inputPath(pathTypeTools)
+          escapedToolsPath=shellEscape(escapedToolsPath)
           escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz")
           command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
           call System_Command_Do(command,status)

--- a/source/interface/FSPS.F90
+++ b/source/interface/FSPS.F90
@@ -99,10 +99,10 @@ contains
              if (.not.File_Exists(tarPath) .or. status /= 0) call Error_Report("failed to download FSPS"//{introspection:location})
           end if
           call displayMessage("unpacking FSPS code....",verbosityLevelWorking)
-          escapedToolsPath=inputPath  (pathTypeTools)
+          escapedToolsPath=inputPath  (pathTypeTools   )
           escapedToolsPath=shellEscape(escapedToolsPath)
-          escapedTarFile  =inputPath  (pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz"
-          escapedTarFile  =shellEscape(escapedTarFile)
+          escapedTarFile  =inputPath  (pathTypeTools   )//"FSPS_"//char(fspsVersion)//".tar.gz"
+          escapedTarFile  =shellEscape(escapedTarFile  )
           command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
           call System_Command_Do(command,status)
           if (status /= 0 .or. .not.File_Exists(fspsPath)) call Error_Report('failed to unpack FSPS code'//{introspection:location})

--- a/source/interface/FSPS.F90
+++ b/source/interface/FSPS.F90
@@ -99,7 +99,7 @@ contains
              if (.not.File_Exists(tarPath) .or. status /= 0) call Error_Report("failed to download FSPS"//{introspection:location})
           end if
           call displayMessage("unpacking FSPS code....",verbosityLevelWorking)
-          escapedToolsPath=shellEscape(inputPath(pathTypeTools))
+          escapedToolsPath=shellEscape(inputPath(pathTypeTools)                                       )
           escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz")
           command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
           call System_Command_Do(command,status)
@@ -236,9 +236,9 @@ contains
              write (outputFile,'(a)' ) "no"                 ! Do not include dust.
              write (outputFile,'(a)' ) char(outputFileName) ! Specify filename.
              close(outputFile)
-             escapedFspsPath  =shellEscape(fspsPath                  )
+             escapedFspsPath  =shellEscape(fspsPath                    )
              escapedExecutable=shellEscape(fspsPath//"/src/autosps.exe")
-             escapedInputFile =shellEscape(fspsInputFileName         )
+             escapedInputFile =shellEscape(fspsInputFileName           )
              call System_Command_Do("export SPS_HOME="//escapedFspsPath//"; "//escapedExecutable//" < "//escapedInputFile)
              call File_Remove(fspsInputFileName)
           end if

--- a/source/interface/FSPS.F90
+++ b/source/interface/FSPS.F90
@@ -68,10 +68,13 @@ contains
     type     (varying_string), intent(  out)           :: fspsPath, fspsVersion
     logical                  , intent(in   ), optional :: static
     integer                                            :: status  , statusUnit
-    type     (varying_string)                          :: lockPath, execPath   , &
-         &                                                tarPath , patchPath  , &
-         &                                                url     , command    , &
-         &                                                patch
+    type     (varying_string)                          :: lockPath          , execPath        , &
+         &                                                tarPath           , patchPath       , &
+         &                                                url               , command         , &
+         &                                                patch             , escapedToolsPath, &
+         &                                                escapedTarFile    , escapedSrcPath  , &
+         &                                                escapedSrcDir     , escapedFspsPath , &
+         &                                                escapedPatch      , escapedPatchSource
     !![
     <optionalArgument name="static" defaultsTo=".false." />
     !!]
@@ -96,30 +99,40 @@ contains
              if (.not.File_Exists(tarPath) .or. status /= 0) call Error_Report("failed to download FSPS"//{introspection:location})
           end if
           call displayMessage("unpacking FSPS code....",verbosityLevelWorking)
-          command="tar -x -v -z -C "//shellEscape(inputPath(pathTypeTools))//" -f "//shellEscape(inputPath(pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz")
-          call System_Command_Do(command,status)          
+          escapedToolsPath=shellEscape(inputPath(pathTypeTools))
+          escapedTarFile  =shellEscape(inputPath(pathTypeTools)//"FSPS_"//char(fspsVersion)//".tar.gz")
+          command="tar -x -v -z -C "//escapedToolsPath//" -f "//escapedTarFile
+          call System_Command_Do(command,status)
           if (status /= 0 .or. .not.File_Exists(fspsPath)) call Error_Report('failed to unpack FSPS code'//{introspection:location})
        end if
        ! Patch the code if not already patched.
        patchPath=fspsPath//"/src/patched.status"
        if (.not.File_Exists(patchPath)) then
           patch=which('patch')
-          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/galacticus_IMF.f90")//" "//shellEscape(fspsPath//"/src/")
+          escapedPatch      =shellEscape(patch            )
+          escapedSrcPath    =shellEscape(fspsPath//"/src/")
+          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/galacticus_IMF.f90")
+          command="cp "//escapedPatchSource//" "//escapedSrcPath
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to copy FSPS patch 'galacticus_IMF.f90'"//{introspection:location})
-          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/imf.f90.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < imf.f90.patch" 
+          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/imf.f90.patch")
+          command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < imf.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'imf.f90'"           //{introspection:location})
-          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/ssp_gen.f90.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < ssp_gen.f90.patch"
+          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/ssp_gen.f90.patch")
+          command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < ssp_gen.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'ssp_gen.f90'"       //{introspection:location})
-          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/sps_vars.f90.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < sps_vars.f90.patch"
+          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/sps_vars.f90.patch")
+          command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < sps_vars.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'sps_vars.f90'"      //{introspection:location})
-          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/autosps.f90.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < autosps.f90.patch"
+          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/autosps.f90.patch")
+          command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < autosps.f90.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'autosps.f90'"       //{introspection:location})
-          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/Makefile.patch")//" "//shellEscape(fspsPath//"/src/")//"; cd "//shellEscape(fspsPath//"/src/")//"; "//shellEscape(patch)//" < Makefile.patch"
+          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/FSPS/Makefile.patch")
+          command="cp "//escapedPatchSource//" "//escapedSrcPath//"; cd "//escapedSrcPath//"; "//escapedPatch//" < Makefile.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch FSPS file 'Makefile'"          //{introspection:location})
           open(newUnit=statusUnit,file=char(fspsPath//"/src/patched.status"),status='unknown',form='formatted')
@@ -128,14 +141,15 @@ contains
           call File_Remove(execPath)
        end if
        call displayMessage("compiling autosps.exe code",verbosityLevelWorking)
+       escapedSrcDir=shellEscape(fspsPath//"/src")
        if (static_) then
-          command="cd "//shellEscape(fspsPath//"/src")//"; "                                   // &
+          command="cd "//escapedSrcDir//"; "                                                   // &
 #ifndef __APPLE__
                &  "grep -P '^F90FLAGS := ' Makefile && "                                       // &
 #endif
-               &  "sed -i~ -E s/'^(F90FLAGS := [^#]*)'/'\1 \-static'/g Makefile"  
+               &  "sed -i~ -E s/'^(F90FLAGS := [^#]*)'/'\1 \-static'/g Makefile"
        else
-          command="cd "//shellEscape(fspsPath//"/src")//"; "                                   // &
+          command="cd "//escapedSrcDir//"; "                                                   // &
 #ifndef __APPLE__
                &  "grep -P '^F90FLAGS := ' Makefile && "                                       // &
 #endif
@@ -143,7 +157,8 @@ contains
        end if
        call System_Command_Do(command,status)
        if (status /= 0) call Error_Report("failed to patch FSPS file 'Makefile' for static/dynamic build"//{introspection:location})
-       command="cd "//shellEscape(fspsPath//"/src")//"; export SPS_HOME="//shellEscape(fspsPath)//'; export F90FLAGS="'                                     // &
+       escapedFspsPath=shellEscape(fspsPath)
+       command="cd "//escapedSrcDir//"; export SPS_HOME="//escapedFspsPath//'; export F90FLAGS="'                                     // &
 #ifndef __aarch64__
             &  '-mcmodel=medium '                                                                                                                           // & ! Larger memory model required except on Arm64.
 #endif
@@ -184,7 +199,8 @@ contains
     integer                         , parameter                                  :: fileFormatCurrent= 1
     type            (varying_string)                                             :: fspsVersion         , fspsPath         , &
          &                                                                          outputFileName      , fspsInputFileName, &
-         &                                                                          imfFileName
+         &                                                                          imfFileName         , escapedFspsPath  , &
+         &                                                                          escapedExecutable   , escapedInputFile
     integer                                                                      :: iIMF                , outputFile       , &
          &                                                                          iMetallicity        , inputFile        , &
          &                                                                          iAge                , ageCount         , &
@@ -220,7 +236,10 @@ contains
              write (outputFile,'(a)' ) "no"                 ! Do not include dust.
              write (outputFile,'(a)' ) char(outputFileName) ! Specify filename.
              close(outputFile)
-             call System_Command_Do("export SPS_HOME="//shellEscape(fspsPath)//"; "//shellEscape(fspsPath//"/src/autosps.exe")//" < "//shellEscape(fspsInputFileName))
+             escapedFspsPath  =shellEscape(fspsPath                  )
+             escapedExecutable=shellEscape(fspsPath//"/src/autosps.exe")
+             escapedInputFile =shellEscape(fspsInputFileName         )
+             call System_Command_Do("export SPS_HOME="//escapedFspsPath//"; "//escapedExecutable//" < "//escapedInputFile)
              call File_Remove(fspsInputFileName)
           end if
           call File_Unlock(imfLock)

--- a/source/interface/RecFast.F90
+++ b/source/interface/RecFast.F90
@@ -49,9 +49,10 @@ contains
     logical                  , intent(in   ), optional :: static
     integer                                            :: status     , recFastUnit
     character(len=32        )                          :: line       , versionLabel
-    type     (varying_string)                          :: command    , pathExe       , &
-         &                                                pathPatched, pathFor       , &
-         &                                                pathVersion
+    type     (varying_string)                          :: command           , pathExe          , &
+         &                                                pathPatched       , pathFor          , &
+         &                                                pathVersion       , escapedRecfastPath, &
+         &                                                escapedPatchSource, escapedPatched
     type     (lockDescriptor)                          :: fileLock
     !![
     <optionalArgument name="static" defaultsTo=".false." />
@@ -83,14 +84,18 @@ contains
              end block
           end if
           call displayMessage("patching RecFast code....",verbosityLevelWorking)
-          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/RecFast/recfast.for.patch")//" "//shellEscape(recfastPath)//"; cd "//shellEscape(recfastPath)//"; patch < recfast.for.patch"
+          escapedRecfastPath=shellEscape(recfastPath)
+          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/RecFast/recfast.for.patch")
+          command="cp "//escapedPatchSource//" "//escapedRecfastPath//"; cd "//escapedRecfastPath//"; patch < recfast.for.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch RecFast file 'recfast.for'"//{introspection:location})
-          command="touch "//shellEscape(recfastPath//"patched")
+          escapedPatched=shellEscape(recfastPath//"patched")
+          command="touch "//escapedPatched
           call System_Command_Do(command)
        end if
        call displayMessage("compiling RecFast code....",verbosityLevelWorking)
-       command="cd "//shellEscape(recfastPath)//"; "//compiler(languageFortran)//" recfast.for -o recfast.exe -O3 -ffixed-form -ffixed-line-length-none"
+       escapedRecfastPath=shellEscape(recfastPath)
+       command="cd "//escapedRecfastPath//"; "//compiler(languageFortran)//" recfast.for -o recfast.exe -O3 -ffixed-form -ffixed-line-length-none"
        if (static_) command=command//" -static"
        call System_Command_Do(char(command))
        if (.not.File_Exists(pathExe)) &

--- a/source/interface/RecFast.F90
+++ b/source/interface/RecFast.F90
@@ -84,7 +84,7 @@ contains
              end block
           end if
           call displayMessage("patching RecFast code....",verbosityLevelWorking)
-          escapedRecfastPath=shellEscape(recfastPath)
+          escapedRecfastPath=shellEscape(recfastPath                                                       )
           escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/RecFast/recfast.for.patch")
           command="cp "//escapedPatchSource//" "//escapedRecfastPath//"; cd "//escapedRecfastPath//"; patch < recfast.for.patch"
           call System_Command_Do(command,status)

--- a/source/interface/RecFast.F90
+++ b/source/interface/RecFast.F90
@@ -84,8 +84,8 @@ contains
              end block
           end if
           call displayMessage("patching RecFast code....",verbosityLevelWorking)
-          escapedRecfastPath=shellEscape(recfastPath                                                       )
-          escapedPatchSource=inputPath(pathTypeDataStatic)//"patches/RecFast/recfast.for.patch"
+          escapedRecfastPath=shellEscape(recfastPath       )
+          escapedPatchSource=inputPath  (pathTypeDataStatic)//"patches/RecFast/recfast.for.patch"
           escapedPatchSource=shellEscape(escapedPatchSource)
           command="cp "//escapedPatchSource//" "//escapedRecfastPath//"; cd "//escapedRecfastPath//"; patch < recfast.for.patch"
           call System_Command_Do(command,status)

--- a/source/interface/RecFast.F90
+++ b/source/interface/RecFast.F90
@@ -85,7 +85,8 @@ contains
           end if
           call displayMessage("patching RecFast code....",verbosityLevelWorking)
           escapedRecfastPath=shellEscape(recfastPath                                                       )
-          escapedPatchSource=shellEscape(inputPath(pathTypeDataStatic)//"patches/RecFast/recfast.for.patch")
+          escapedPatchSource=inputPath(pathTypeDataStatic)//"patches/RecFast/recfast.for.patch"
+          escapedPatchSource=shellEscape(escapedPatchSource)
           command="cp "//escapedPatchSource//" "//escapedRecfastPath//"; cd "//escapedRecfastPath//"; patch < recfast.for.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch RecFast file 'recfast.for'"//{introspection:location})

--- a/source/interface/RecFast.F90
+++ b/source/interface/RecFast.F90
@@ -41,7 +41,7 @@ contains
     use :: Input_Paths       , only : inputPath        , pathTypeTools        , pathTypeDataStatic
     use :: ISO_Varying_String, only : assignment(=)    , char                 , operator(//)      , varying_string, &
          &                            var_str
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do, shellEscape
     use :: System_Download   , only : download
     use :: System_Compilers  , only : compiler         , languageFortran      , compilerValidate
     implicit none
@@ -83,14 +83,14 @@ contains
              end block
           end if
           call displayMessage("patching RecFast code....",verbosityLevelWorking)
-          command="cp "//inputPath(pathTypeDataStatic)//"patches/RecFast/recfast.for.patch "//recfastPath//"; cd "//recfastPath//"; patch < recfast.for.patch"
+          command="cp "//shellEscape(inputPath(pathTypeDataStatic)//"patches/RecFast/recfast.for.patch")//" "//shellEscape(recfastPath)//"; cd "//shellEscape(recfastPath)//"; patch < recfast.for.patch"
           call System_Command_Do(command,status)
           if (status /= 0) call Error_Report("failed to patch RecFast file 'recfast.for'"//{introspection:location})
-          command="touch "//recfastPath//"patched"
+          command="touch "//shellEscape(recfastPath//"patched")
           call System_Command_Do(command)
        end if
        call displayMessage("compiling RecFast code....",verbosityLevelWorking)
-       command="cd "//recfastPath//"; "//compiler(languageFortran)//" recfast.for -o recfast.exe -O3 -ffixed-form -ffixed-line-length-none"
+       command="cd "//shellEscape(recfastPath)//"; "//compiler(languageFortran)//" recfast.for -o recfast.exe -O3 -ffixed-form -ffixed-line-length-none"
        if (static_) command=command//" -static"
        call System_Command_Do(char(command))
        if (.not.File_Exists(pathExe)) &

--- a/source/intergalactic_medium/state/RecFast.F90
+++ b/source/intergalactic_medium/state/RecFast.F90
@@ -99,7 +99,8 @@ contains
          &                                                                            matterTemperature
     character       (len=32                         )                              :: parameterLabel
     type            (varying_string                 )                              :: parameterFile       , recFastFile      , &
-         &                                                                            recfastPath         , recfastVersion
+         &                                                                            recfastPath         , recfastVersion   , &
+         &                                                                            escapedExecutable   , escapedParameterFile
     double precision                                                               :: omegaDarkMatter
     integer                                                                        :: fileFormatVersion   , i                , &
          &                                                                            countRedshift       , parametersUnit   , &
@@ -163,7 +164,9 @@ contains
        close(parametersUnit)
        ! Run RecFast.
        call File_Lock(char(recfastPath//"recfast.exe"),fileLock,lockIsShared=.false.)
-       call System_Command_Do(shellEscape(recfastPath//"recfast.exe")//" < "//shellEscape(parameterFile))
+       escapedExecutable   =shellEscape(recfastPath//"recfast.exe")
+       escapedParameterFile=shellEscape(parameterFile             )
+       call System_Command_Do(escapedExecutable//" < "//escapedParameterFile)
        call File_Unlock(fileLock)
        ! Parse the output file.
        countRedshift=Count_Lines_in_File(recFastFile)-1

--- a/source/intergalactic_medium/state/RecFast.F90
+++ b/source/intergalactic_medium/state/RecFast.F90
@@ -89,7 +89,7 @@ contains
     use :: Interfaces_RecFast              , only : Interface_RecFast_Initialize
     use :: Numerical_Constants_Astronomical, only : heliumByMassPrimordial
     use :: Units_MetaData                  , only : unitType
-    use :: System_Command                  , only : System_Command_Do
+    use :: System_Command                  , only : System_Command_Do           , shellEscape
     implicit none
     type            (intergalacticMediumStateRecFast)                              :: self
     class           (cosmologyFunctionsClass        ), intent(in   ), target       :: cosmologyFunctions_
@@ -163,7 +163,7 @@ contains
        close(parametersUnit)
        ! Run RecFast.
        call File_Lock(char(recfastPath//"recfast.exe"),fileLock,lockIsShared=.false.)
-       call System_Command_Do(recfastPath//"recfast.exe < "//parameterFile)
+       call System_Command_Do(shellEscape(recfastPath//"recfast.exe")//" < "//shellEscape(parameterFile))
        call File_Unlock(fileLock)
        ! Parse the output file.
        countRedshift=Count_Lines_in_File(recFastFile)-1

--- a/source/output/version.F90
+++ b/source/output/version.F90
@@ -144,7 +144,8 @@ contains
     ! Git2 library is not available. If we have the command line `git` installed, use it instead.
     gitHashDatasets="unknown"
     hashFileName   =File_Name_Temporary("repoHash.txt")
-    escapedStaticPath=shellEscape(inputPath(pathTypeDataStatic))
+    escapedStaticPath=inputPath(pathTypeDataStatic)
+    escapedStaticPath=shellEscape(escapedStaticPath)
     escapedHashFile  =shellEscape(hashFileName                 )
     call System_Command_Do("cd "//char(escapedStaticPath)//"; if which git > /dev/null && git rev-parse --is-inside-work-tree > /dev/null 2>&1 ; then git rev-parse HEAD > "//char(escapedHashFile)//"; else echo unknown > "//char(escapedHashFile)//"; fi",iStatus=status)
     if (status == 0) then

--- a/source/output/version.F90
+++ b/source/output/version.F90
@@ -117,7 +117,8 @@ contains
     type     (varying_string)          :: runTime        , inputPathStatic
 #ifndef GIT2AVAIL
     integer                            :: status         , hashUnit
-    type     (varying_string)          :: hashFileName
+    type     (varying_string)          :: hashFileName   , escapedStaticPath, &
+         &                                escapedHashFile
 #endif
 
     ! Record the count of the system clock.
@@ -143,7 +144,9 @@ contains
     ! Git2 library is not available. If we have the command line `git` installed, use it instead.
     gitHashDatasets="unknown"
     hashFileName   =File_Name_Temporary("repoHash.txt")
-    call System_Command_Do("cd "//char(shellEscape(inputPath(pathTypeDataStatic)))//"; if which git > /dev/null && git rev-parse --is-inside-work-tree > /dev/null 2>&1 ; then git rev-parse HEAD > "//char(shellEscape(hashFileName))//"; else echo unknown > "//char(shellEscape(hashFileName))//"; fi",iStatus=status)
+    escapedStaticPath=shellEscape(inputPath(pathTypeDataStatic))
+    escapedHashFile  =shellEscape(hashFileName                 )
+    call System_Command_Do("cd "//char(escapedStaticPath)//"; if which git > /dev/null && git rev-parse --is-inside-work-tree > /dev/null 2>&1 ; then git rev-parse HEAD > "//char(escapedHashFile)//"; else echo unknown > "//char(escapedHashFile)//"; fi",iStatus=status)
     if (status == 0) then
        open(newUnit=hashUnit,file=char(hashFileName),status="old",form="formatted",iostat=ioErr)
        if (ioErr == 0) read (hashUnit,'(a)') gitHashDatasets

--- a/source/output/version.F90
+++ b/source/output/version.F90
@@ -92,7 +92,7 @@ contains
     use, intrinsic :: ISO_C_Binding     , only : c_null_char
 #else
     use            :: Input_Paths       , only : pathTypeDataDynamic
-    use            :: System_Command    , only : System_Command_Do
+    use            :: System_Command    , only : System_Command_Do                , shellEscape
     use            :: File_Utilities    , only : File_Name_Temporary              , File_Remove
 #endif
     use            :: Dates_and_Times   , only : Formatted_Date_and_Time
@@ -143,7 +143,7 @@ contains
     ! Git2 library is not available. If we have the command line `git` installed, use it instead.
     gitHashDatasets="unknown"
     hashFileName   =File_Name_Temporary("repoHash.txt")
-    call System_Command_Do("cd "//char(inputPath(pathTypeDataStatic))//"; if which git > /dev/null && git rev-parse --is-inside-work-tree > /dev/null 2>&1 ; then git rev-parse HEAD > "//char(hashFileName)//"; else echo unknown > "//char(hashFileName)//"; fi",iStatus=status)
+    call System_Command_Do("cd "//char(shellEscape(inputPath(pathTypeDataStatic)))//"; if which git > /dev/null && git rev-parse --is-inside-work-tree > /dev/null 2>&1 ; then git rev-parse HEAD > "//char(shellEscape(hashFileName))//"; else echo unknown > "//char(shellEscape(hashFileName))//"; fi",iStatus=status)
     if (status == 0) then
        open(newUnit=hashUnit,file=char(hashFileName),status="old",form="formatted",iostat=ioErr)
        if (ioErr == 0) read (hashUnit,'(a)') gitHashDatasets

--- a/source/output/version.F90
+++ b/source/output/version.F90
@@ -142,11 +142,11 @@ contains
     gitHashDatasets=char(String_C_to_Fortran(gitHashDatasets))
 #else
     ! Git2 library is not available. If we have the command line `git` installed, use it instead.
-    gitHashDatasets="unknown"
-    hashFileName   =File_Name_Temporary("repoHash.txt")
-    escapedStaticPath=inputPath(pathTypeDataStatic)
-    escapedStaticPath=shellEscape(escapedStaticPath)
-    escapedHashFile  =shellEscape(hashFileName                 )
+    gitHashDatasets  ="unknown"
+    hashFileName     =File_Name_Temporary("repoHash.txt"    )
+    escapedStaticPath=inputPath          (pathTypeDataStatic)
+    escapedStaticPath=shellEscape        (escapedStaticPath )
+    escapedHashFile  =shellEscape        (hashFileName      )
     call System_Command_Do("cd "//char(escapedStaticPath)//"; if which git > /dev/null && git rev-parse --is-inside-work-tree > /dev/null 2>&1 ; then git rev-parse HEAD > "//char(escapedHashFile)//"; else echo unknown > "//char(escapedHashFile)//"; fi",iStatus=status)
     if (status == 0) then
        open(newUnit=hashUnit,file=char(hashFileName),status="old",form="formatted",iostat=ioErr)

--- a/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
@@ -256,24 +256,27 @@ contains
                 end if
                 ! Unpack the code.
                 call displayMessage("unpacking CosmicEmu code....",verbosityLevelWorking)
-                escapedZipFile    =shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master.zip")
-                escapedDynamicPath=inputPath(pathTypeDataDynamic)
-                escapedDynamicPath=shellEscape(escapedDynamicPath)
+                escapedZipFile=inputPath(pathTypeDataDynamic)//"CosmicEmu-master.zip"
+                escapedZipFile=shellEscape(escapedZipFile)
+                escapedDynamicPath=inputPath  (pathTypeDataDynamic                                   )
+                escapedDynamicPath=shellEscape(escapedDynamicPath                                    )
                 call System_Command_Do("unzip "//escapedZipFile//" -d "//escapedDynamicPath)
                 if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.c")) &
                      & call Error_Report("failed to unpack CosmicEmu code"//{introspection:location})
              end if
              ! Build the code.
              call displayMessage("compiling CosmicEmu code....",verbosityLevelWorking)
-             escapedBuildDir=shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb")
+             escapedBuildDir=inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb"
+             escapedBuildDir=shellEscape(escapedBuildDir)
              call System_Command_Do("cd "//escapedBuildDir//"; sed -i~ -r s/""^(\s*gcc.*\-lm)(\s+.*)$""/""\1 \-I\`gsl\-config \-\-prefix\`\2\n""/ makefile; make");
              if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe")) &
                   & call Error_Report("failed to build Cosmic_Emu code"//{introspection:location})
           end if
           ! Generate the power spectrum.
-          escapedWorkDir=File_Path(parameterFile)
-          escapedWorkDir=shellEscape(escapedWorkDir)
-          escapedExecutable   =shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe")
+          escapedWorkDir      =File_Path  (parameterFile                                                                     )
+          escapedWorkDir      =shellEscape(escapedWorkDir                                                                    )
+          escapedExecutable=inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe"
+          escapedExecutable=shellEscape(escapedExecutable)
           escapedParameterFile=shellEscape(parameterFile                                                                     )
           escapedPowerSpectrum=shellEscape(powerSpectrumFile                                                                 )
           call System_Command_Do("cd "//escapedWorkDir//"; "//escapedExecutable//" < "//escapedParameterFile//"; mv EMU0.txt "//escapedPowerSpectrum)

--- a/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
@@ -270,10 +270,10 @@ contains
                   & call Error_Report("failed to build Cosmic_Emu code"//{introspection:location})
           end if
           ! Generate the power spectrum.
-          escapedWorkDir      =shellEscape(File_Path(parameterFile))
+          escapedWorkDir      =shellEscape(File_Path(parameterFile)                                                          )
           escapedExecutable   =shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe")
-          escapedParameterFile=shellEscape(parameterFile)
-          escapedPowerSpectrum=shellEscape(powerSpectrumFile)
+          escapedParameterFile=shellEscape(parameterFile                                                                     )
+          escapedPowerSpectrum=shellEscape(powerSpectrumFile                                                                 )
           call System_Command_Do("cd "//escapedWorkDir//"; "//escapedExecutable//" < "//escapedParameterFile//"; mv EMU0.txt "//escapedPowerSpectrum)
           ! Destroy the parameter file and temporary directory.
           call      File_Remove(          parameterFile )

--- a/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
@@ -256,10 +256,10 @@ contains
                 end if
                 ! Unpack the code.
                 call displayMessage("unpacking CosmicEmu code....",verbosityLevelWorking)
-                escapedZipFile=inputPath(pathTypeDataDynamic)//"CosmicEmu-master.zip"
-                escapedZipFile=shellEscape(escapedZipFile)
-                escapedDynamicPath=inputPath  (pathTypeDataDynamic                                   )
-                escapedDynamicPath=shellEscape(escapedDynamicPath                                    )
+                escapedZipFile    =inputPath  (pathTypeDataDynamic)//"CosmicEmu-master.zip"
+                escapedZipFile    =shellEscape(escapedZipFile     )
+                escapedDynamicPath=inputPath  (pathTypeDataDynamic)
+                escapedDynamicPath=shellEscape(escapedDynamicPath )
                 call System_Command_Do("unzip "//escapedZipFile//" -d "//escapedDynamicPath)
                 if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.c")) &
                      & call Error_Report("failed to unpack CosmicEmu code"//{introspection:location})
@@ -273,12 +273,12 @@ contains
                   & call Error_Report("failed to build Cosmic_Emu code"//{introspection:location})
           end if
           ! Generate the power spectrum.
-          escapedWorkDir      =File_Path  (parameterFile                                                                     )
-          escapedWorkDir      =shellEscape(escapedWorkDir                                                                    )
-          escapedExecutable=inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe"
-          escapedExecutable=shellEscape(escapedExecutable)
-          escapedParameterFile=shellEscape(parameterFile                                                                     )
-          escapedPowerSpectrum=shellEscape(powerSpectrumFile                                                                 )
+          escapedWorkDir      =File_Path  (parameterFile      )
+          escapedWorkDir      =shellEscape(escapedWorkDir     )
+          escapedExecutable   =inputPath  (pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe"
+          escapedExecutable   =shellEscape(escapedExecutable  )
+          escapedParameterFile=shellEscape(parameterFile      )
+          escapedPowerSpectrum=shellEscape(powerSpectrumFile  )
           call System_Command_Do("cd "//escapedWorkDir//"; "//escapedExecutable//" < "//escapedParameterFile//"; mv EMU0.txt "//escapedPowerSpectrum)
           ! Destroy the parameter file and temporary directory.
           call      File_Remove(          parameterFile )

--- a/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
@@ -183,8 +183,11 @@ contains
     class           (powerSpectrumNonlinearCosmicEmu), intent(inout) :: self
     double precision                                 , intent(in   ) :: time          , waveNumber
     double precision                                                 :: redshift
-    type            (varying_string                 )                :: parameterFile , powerSpectrumFile, &
-         &                                                              parameters
+    type            (varying_string                 )                :: parameterFile     , powerSpectrumFile   , &
+         &                                                              parameters        , escapedZipFile      , &
+         &                                                              escapedDynamicPath , escapedBuildDir     , &
+         &                                                              escapedWorkDir     , escapedExecutable   , &
+         &                                                              escapedParameterFile, escapedPowerSpectrum
     character       (len=32                         )                :: parameterLabel
     integer                                                          :: iWavenumber   , powerSpectrumUnit, &
          &                                                              status
@@ -253,18 +256,25 @@ contains
                 end if
                 ! Unpack the code.
                 call displayMessage("unpacking CosmicEmu code....",verbosityLevelWorking)
-                call System_Command_Do("unzip "//shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master.zip")//" -d "//shellEscape(inputPath(pathTypeDataDynamic)))
+                escapedZipFile    =shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master.zip")
+                escapedDynamicPath=shellEscape(inputPath(pathTypeDataDynamic)                        )
+                call System_Command_Do("unzip "//escapedZipFile//" -d "//escapedDynamicPath)
                 if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.c")) &
                      & call Error_Report("failed to unpack CosmicEmu code"//{introspection:location})
              end if
              ! Build the code.
              call displayMessage("compiling CosmicEmu code....",verbosityLevelWorking)
-             call System_Command_Do("cd "//shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb")//"; sed -i~ -r s/""^(\s*gcc.*\-lm)(\s+.*)$""/""\1 \-I\`gsl\-config \-\-prefix\`\2\n""/ makefile; make");
+             escapedBuildDir=shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb")
+             call System_Command_Do("cd "//escapedBuildDir//"; sed -i~ -r s/""^(\s*gcc.*\-lm)(\s+.*)$""/""\1 \-I\`gsl\-config \-\-prefix\`\2\n""/ makefile; make");
              if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe")) &
                   & call Error_Report("failed to build Cosmic_Emu code"//{introspection:location})
           end if
           ! Generate the power spectrum.
-          call System_Command_Do("cd "//shellEscape(File_Path(parameterFile))//"; "//shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe")//" < "//shellEscape(parameterFile)//"; mv EMU0.txt "//shellEscape(powerSpectrumFile))
+          escapedWorkDir      =shellEscape(File_Path(parameterFile))
+          escapedExecutable   =shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe")
+          escapedParameterFile=shellEscape(parameterFile)
+          escapedPowerSpectrum=shellEscape(powerSpectrumFile)
+          call System_Command_Do("cd "//escapedWorkDir//"; "//escapedExecutable//" < "//escapedParameterFile//"; mv EMU0.txt "//escapedPowerSpectrum)
           ! Destroy the parameter file and temporary directory.
           call      File_Remove(          parameterFile )
           call Directory_Remove(File_Path(parameterFile))

--- a/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
@@ -257,7 +257,8 @@ contains
                 ! Unpack the code.
                 call displayMessage("unpacking CosmicEmu code....",verbosityLevelWorking)
                 escapedZipFile    =shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master.zip")
-                escapedDynamicPath=shellEscape(inputPath(pathTypeDataDynamic)                        )
+                escapedDynamicPath=inputPath(pathTypeDataDynamic)
+                escapedDynamicPath=shellEscape(escapedDynamicPath)
                 call System_Command_Do("unzip "//escapedZipFile//" -d "//escapedDynamicPath)
                 if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.c")) &
                      & call Error_Report("failed to unpack CosmicEmu code"//{introspection:location})
@@ -270,7 +271,8 @@ contains
                   & call Error_Report("failed to build Cosmic_Emu code"//{introspection:location})
           end if
           ! Generate the power spectrum.
-          escapedWorkDir      =shellEscape(File_Path(parameterFile)                                                          )
+          escapedWorkDir=File_Path(parameterFile)
+          escapedWorkDir=shellEscape(escapedWorkDir)
           escapedExecutable   =shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe")
           escapedParameterFile=shellEscape(parameterFile                                                                     )
           escapedPowerSpectrum=shellEscape(powerSpectrumFile                                                                 )

--- a/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
@@ -175,7 +175,7 @@ contains
     use :: Input_Paths         , only : inputPath                   , pathTypeDataDynamic
     use :: ISO_Varying_String  , only : varying_string
     use :: Numerical_Comparison, only : Values_Differ
-    use :: System_Command      , only : System_Command_Do
+    use :: System_Command      , only : System_Command_Do           , shellEscape
     use :: System_Compilers    , only : languageC                   , compilerValidate
     use :: System_Download     , only : download
     use :: Table_Labels        , only : extrapolationTypeExtrapolate
@@ -253,18 +253,18 @@ contains
                 end if
                 ! Unpack the code.
                 call displayMessage("unpacking CosmicEmu code....",verbosityLevelWorking)
-                call System_Command_Do("unzip "//inputPath(pathTypeDataDynamic)//"CosmicEmu-master.zip -d "//inputPath(pathTypeDataDynamic))
+                call System_Command_Do("unzip "//shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master.zip")//" -d "//shellEscape(inputPath(pathTypeDataDynamic)))
                 if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.c")) &
                      & call Error_Report("failed to unpack CosmicEmu code"//{introspection:location})
              end if
              ! Build the code.
              call displayMessage("compiling CosmicEmu code....",verbosityLevelWorking)
-             call System_Command_Do("cd "//inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb; sed -i~ -r s/""^(\s*gcc.*\-lm)(\s+.*)$""/""\1 \-I\`gsl\-config \-\-prefix\`\2\n""/ makefile; make");
+             call System_Command_Do("cd "//shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb")//"; sed -i~ -r s/""^(\s*gcc.*\-lm)(\s+.*)$""/""\1 \-I\`gsl\-config \-\-prefix\`\2\n""/ makefile; make");
              if (.not.File_Exists(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe")) &
                   & call Error_Report("failed to build Cosmic_Emu code"//{introspection:location})
           end if
           ! Generate the power spectrum.
-          call System_Command_Do("cd "//File_Path(parameterFile)//"; "//inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe < "//parameterFile//"; mv EMU0.txt "//powerSpectrumFile)
+          call System_Command_Do("cd "//shellEscape(File_Path(parameterFile))//"; "//shellEscape(inputPath(pathTypeDataDynamic)//"CosmicEmu-master/2022-Mira-Titan-IV/P_cb/emu.exe")//" < "//shellEscape(parameterFile)//"; mv EMU0.txt "//shellEscape(powerSpectrumFile))
           ! Destroy the parameter file and temporary directory.
           call      File_Remove(          parameterFile )
           call Directory_Remove(File_Path(parameterFile))

--- a/source/system/command.F90
+++ b/source/system/command.F90
@@ -52,6 +52,11 @@ contains
     command string. The result of ``shellEscape`` must {\normalfont \bfseries not} be used directly as an actual argument (for
     example inline within a ``System_Command_Do`` argument, or as an operand of a concatenation that is passed as an actual
     argument), as gfortran leaks the function result in that case.
+
+    For the same reason, the {\normalfont \ttfamily token} argument passed to ``shellEscape`` must not itself be a bare
+    function call that returns a {\normalfont \ttfamily varying\_string} (e.g. {\normalfont \ttfamily shellEscape(inputPath(...))}),
+    since gfortran leaks that nested function result. Assign such a result to a local variable first, then pass the variable:
+    {\normalfont \ttfamily localVar=inputPath(...)} followed by {\normalfont \ttfamily localVar=shellEscape(localVar)}.
     !!}
     use :: ISO_Varying_String, only : varying_string, replace, operator(//)
     implicit none

--- a/source/system/command.F90
+++ b/source/system/command.F90
@@ -47,6 +47,11 @@ contains
     safely as a single token (e.g. a file system path) in a shell command even if it contains spaces or other characters
     that are special to the shell. This should be applied to any path substituted into a command passed to
     ``System_Command_Do``.
+
+    Note that the result of ``shellEscape`` must first be assigned to a local variable, which is then used in building the
+    command string. The result of ``shellEscape`` must {\normalfont \bfseries not} be used directly as an actual argument (for
+    example inline within a ``System_Command_Do`` argument, or as an operand of a concatenation that is passed as an actual
+    argument), as gfortran leaks the function result in that case.
     !!}
     use :: ISO_Varying_String, only : varying_string, replace, operator(//)
     implicit none

--- a/source/system/command.F90
+++ b/source/system/command.F90
@@ -53,10 +53,13 @@ contains
     example inline within a ``System_Command_Do`` argument, or as an operand of a concatenation that is passed as an actual
     argument), as gfortran leaks the function result in that case.
 
-    For the same reason, the {\normalfont \ttfamily token} argument passed to ``shellEscape`` must not itself be a bare
-    function call that returns a {\normalfont \ttfamily varying\_string} (e.g. {\normalfont \ttfamily shellEscape(inputPath(...))}),
-    since gfortran leaks that nested function result. Assign such a result to a local variable first, then pass the variable:
-    {\normalfont \ttfamily localVar=inputPath(...)} followed by {\normalfont \ttfamily localVar=shellEscape(localVar)}.
+    For the same reason, the {\normalfont \ttfamily token} argument passed to ``shellEscape`` must not contain a call to a
+    function that returns a {\normalfont \ttfamily varying\_string} (such as {\normalfont \ttfamily inputPath}), whether as the
+    bare argument ({\normalfont \ttfamily shellEscape(inputPath(...))}) or nested within a concatenation
+    ({\normalfont \ttfamily shellEscape(inputPath(...)//"...")}), since gfortran leaks that nested function result. Assign the
+    argument to a local variable first, then escape the variable, e.g. {\normalfont \ttfamily localVar=inputPath(...)//"..."}
+    followed by {\normalfont \ttfamily localVar=shellEscape(localVar)}. Building the value in an assignment is safe; only a
+    {\normalfont \ttfamily varying\_string}-returning function call that appears inside another call's argument list leaks.
     !!}
     use :: ISO_Varying_String, only : varying_string, replace, operator(//)
     implicit none

--- a/source/system/command.F90
+++ b/source/system/command.F90
@@ -27,14 +27,51 @@ module System_Command
   !!}
   implicit none
   private
-  public :: System_Command_Do
+  public :: System_Command_Do, shellEscape
 
   interface System_Command_Do
      module procedure System_Command_Char
      module procedure System_Command_VarStr
   end interface System_Command_Do
 
+  interface shellEscape
+     module procedure shellEscapeChar
+     module procedure shellEscapeVarStr
+  end interface shellEscape
+
 contains
+
+  function shellEscapeVarStr(token) result(escaped)
+    !!{RST
+    Return the string ``token`` wrapped in single quotes, with any embedded single quotes escaped, such that it can be used
+    safely as a single token (e.g. a file system path) in a shell command even if it contains spaces or other characters
+    that are special to the shell. This should be applied to any path substituted into a command passed to
+    ``System_Command_Do``.
+    !!}
+    use :: ISO_Varying_String, only : varying_string, replace, operator(//)
+    implicit none
+    type(varying_string), intent(in   ) :: token
+    type(varying_string)                :: escaped
+
+    ! Wrap in single quotes, replacing each embedded single quote with the sequence '\'' (close quote, escaped quote, reopen
+    ! quote), which is the standard POSIX-shell-safe encoding.
+    escaped="'"//replace(token,"'","'\''",every=.true.)//"'"
+    return
+  end function shellEscapeVarStr
+
+  function shellEscapeChar(token) result(escaped)
+    !!{RST
+    Return the string ``token`` wrapped in single quotes, with any embedded single quotes escaped. See {\normalfont \ttfamily
+    shellEscapeVarStr}.
+    !!}
+    use :: ISO_Varying_String, only : varying_string, var_str
+    implicit none
+    character(len=*), intent(in   ) :: token
+    type(varying_string)            :: escaped
+
+    escaped=shellEscapeVarStr(var_str(token))
+    return
+  end function shellEscapeChar
 
   subroutine System_Command_VarStr(command,iStatus)
     !!{RST

--- a/source/system/downloader.F90
+++ b/source/system/downloader.F90
@@ -228,7 +228,7 @@ contains
          &                                                    timeout
     integer                  , intent(  out), optional     :: status
     integer                                                :: status_       , tries    , i
-    type     (varying_string)                              :: urlList
+    type     (varying_string)                              :: urlList       , escapedOutputFile
     character(len=12        )                              :: timeoutLabel
     !![
     <optionalArgument name="retries"   defaultsTo="0"  />
@@ -239,6 +239,7 @@ contains
     call downloadInitialize()
     ! Build a string representation of the per-attempt timeout (in seconds) for use in the downloader commands below.
     write (timeoutLabel,'(i0)') timeout_
+    escapedOutputFile=shellEscape(trim(outputFileName))
     if (present(status)) status=0
     status_=errorStatusFail
     do i=1,size(url)
@@ -250,12 +251,12 @@ contains
              ! here, so allowing `wget` to also retry internally results in a multiplicative number of attempts (and can cause the
              ! download to far exceed any time limit when each internal attempt hangs until its read-timeout). The `--timeout`
              ! option bounds the time spent on DNS lookup, connection, and reads for the single attempt.
-             call System_Command_Do('wget --no-check-certificate --tries=1 --timeout='//trim(timeoutLabel)//' "'//char(url(i))//'" -O '       //char(shellEscape(trim(outputFileName))),status_)
+             call System_Command_Do('wget --no-check-certificate --tries=1 --timeout='//trim(timeoutLabel)//' "'//char(url(i))//'" -O '       //char(escapedOutputFile),status_)
           else if (downloadUsingCurl) then
              ! Force `curl` to make only a single attempt (i.e. disable its own retrying) so that retries are handled solely by the
              ! loop here, consistent with the behavior of `wget` above. The `--max-time` option bounds the total time allowed for
              ! the single attempt.
-             call System_Command_Do('curl --insecure --location --retry 0 --max-time '//trim(timeoutLabel)//' "' //char(url(i))//'" --output '//char(shellEscape(trim(outputFileName))),status_)
+             call System_Command_Do('curl --insecure --location --retry 0 --max-time '//trim(timeoutLabel)//' "' //char(url(i))//'" --output '//char(escapedOutputFile),status_)
           else if (.not.present(status)) then
              call Error_Report('no downloader available'//{introspection:location})
           end if

--- a/source/system/downloader.F90
+++ b/source/system/downloader.F90
@@ -220,7 +220,7 @@ contains
     use :: Error             , only : Error_Report     , errorStatusFail, errorStatusSuccess
     use :: File_Utilities    , only : File_Exists      , File_Remove
     use :: ISO_Varying_String, only : varying_string   , char           , operator(//)      , assignment(=)
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do, shellEscape
     implicit none
     type     (varying_string), intent(in   ), dimension(:) :: url
     character(len=*         ), intent(in   )               :: outputFileName
@@ -250,12 +250,12 @@ contains
              ! here, so allowing `wget` to also retry internally results in a multiplicative number of attempts (and can cause the
              ! download to far exceed any time limit when each internal attempt hangs until its read-timeout). The `--timeout`
              ! option bounds the time spent on DNS lookup, connection, and reads for the single attempt.
-             call System_Command_Do('wget --no-check-certificate --tries=1 --timeout='//trim(timeoutLabel)//' "'//char(url(i))//'" -O '      //trim(outputFileName),status_)
+             call System_Command_Do('wget --no-check-certificate --tries=1 --timeout='//trim(timeoutLabel)//' "'//char(url(i))//'" -O '       //char(shellEscape(trim(outputFileName))),status_)
           else if (downloadUsingCurl) then
              ! Force `curl` to make only a single attempt (i.e. disable its own retrying) so that retries are handled solely by the
              ! loop here, consistent with the behavior of `wget` above. The `--max-time` option bounds the total time allowed for
              ! the single attempt.
-             call System_Command_Do('curl --insecure --location --retry 0 --max-time '//trim(timeoutLabel)//' "' //char(url(i))//'" --output '//trim(outputFileName),status_)
+             call System_Command_Do('curl --insecure --location --retry 0 --max-time '//trim(timeoutLabel)//' "' //char(url(i))//'" --output '//char(shellEscape(trim(outputFileName))),status_)
           else if (.not.present(status)) then
              call Error_Report('no downloader available'//{introspection:location})
           end if

--- a/source/system/which.F90
+++ b/source/system/which.F90
@@ -64,11 +64,12 @@ contains
     integer                  , intent(  out), optional :: status
     character(len=1024      )                          :: commandFull_
     integer                                            :: status_     , commandUnit
-    type     (varying_string)                          :: tempFile
-    
+    type     (varying_string)                          :: tempFile    , escapedTempFile
+
     if (present(status)) status=errorStatusSuccess
     tempFile=File_Name_Temporary("which")
-    call System_Command_Do('which '//trim(command)//' > '//char(shellEscape(tempFile)),status_)
+    escapedTempFile=shellEscape(tempFile)
+    call System_Command_Do('which '//trim(command)//' > '//char(escapedTempFile),status_)
     if (status_ == 0) then
        open(newUnit=commandUnit,file=char(tempFile),status='unknown',form='formatted')
        read (commandUnit,'(a)') commandFull_ 

--- a/source/system/which.F90
+++ b/source/system/which.F90
@@ -55,7 +55,7 @@ contains
     Find the path to the given ``command``, optionally returning status.
     !!}
     use :: Error             , only : Error_Report       , errorStatusFail, errorStatusSuccess
-    use :: System_Command    , only : System_Command_Do
+    use :: System_Command    , only : System_Command_Do  , shellEscape
     use :: File_Utilities    , only : File_Name_Temporary, File_Remove
     use :: ISO_Varying_String, only : varying_string     , char           , trim              , assignment(=)
     implicit none
@@ -68,7 +68,7 @@ contains
     
     if (present(status)) status=errorStatusSuccess
     tempFile=File_Name_Temporary("which")
-    call System_Command_Do('which '//trim(command)//' > '//char(tempFile),status_)
+    call System_Command_Do('which '//trim(command)//' > '//char(shellEscape(tempFile)),status_)
     if (status_ == 0) then
        open(newUnit=commandUnit,file=char(tempFile),status='unknown',form='formatted')
        read (commandUnit,'(a)') commandFull_ 

--- a/source/system/which.F90
+++ b/source/system/which.F90
@@ -67,7 +67,7 @@ contains
     type     (varying_string)                          :: tempFile    , escapedTempFile
 
     if (present(status)) status=errorStatusSuccess
-    tempFile=File_Name_Temporary("which")
+    tempFile       =File_Name_Temporary("which")
     escapedTempFile=shellEscape(tempFile)
     call System_Command_Do('which '//trim(command)//' > '//char(escapedTempFile),status_)
     if (status_ == 0) then


### PR DESCRIPTION
## Problem

Galacticus builds shell commands by concatenating file-system paths into
command strings executed via `System_Command_Do`. Those paths were
substituted unquoted, so any path containing a space (or other
shell-special character) is word-split by the shell. This breaks the
`pip install galacticus` layout on macOS, where the install path is
`~/Library/Application Support/galacticus/...`:

    sh: /Users/andrewbenson/Library/Application: No such file or directory
    Fatal error: failed to execute system command:
     --> /Users/.../Library/Application Support/galacticus/v0.9.8/tools/RecFast/recfast.exe < /tmp/recFastParameters.50051.1

## Fix

- Add a `shellEscape` helper to the `System_Command` module that wraps a
  token in single quotes with POSIX-safe escaping of embedded single
  quotes, so a path reaches the shell as a single argument regardless of
  spaces/quotes.
- Apply it to every path substituted into a command across all
  `System_Command_Do` call sites: RecFast, FSPS, Cloudy, CAMB, CLASS,
  AxionCAMB, CosmicEmu, mangle, plus downloader, which, version,
  Hopkins2007, and the survey geometries.

`System_Command_Do` (wrapping the sole raw `System()` call) is the single
choke point for shell execution; there are no `execute_command_line` call
sites. Already-quoted URLs are untouched, and CAMB's static-build
`$GALACTICUS_EXEC_PATH` reference is switched to double quotes so it still
expands while tolerating spaces.

## Testing

- All 17 changed files compile cleanly with the gcc-16 macOS toolchain.
- `galacticus run parameters/quickTest.xml` now runs on the macOS
  `pip install` layout (exercises RecFast, Cloudy, and FSPS).