### PR TITLE
perf(schema): scan the parameter catalog once, in parallel, and cache it

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,9 +70,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           export GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE
-          python3 scripts/build/parameterSchema.py `pwd` schema/parameters.xsd
-          git diff --exit-code -- schema/parameters.xsd \
-            || { echo "schema/parameters.xsd is out of date; run 'make parameters-schema' and commit."; exit 1; }
+          python3 scripts/build/parameterSchema.py `pwd` schema/parameters.xsd --check
       - run: echo "This job's status is ${{ job.status }}."
   # Build and deploy
   ## Linux

--- a/Makefile
+++ b/Makefile
@@ -870,5 +870,13 @@ parameters-catalog: $(BUILDPATH)/parameters.catalog.json
 # committed (so editors can reference it). Regenerate with `make parameters-schema`
 # after changing functionClass implementations or enumerations; CI checks it is
 # up to date.
+# The `+` marks these as recipes that participate in the jobserver, so the source
+# scan sizes its worker pool from the job slots `make` actually has free.
 parameters-schema:
-	./scripts/build/parameterSchema.py `pwd` schema/parameters.xsd
+	+./scripts/build/parameterSchema.py `pwd` schema/parameters.xsd
+
+# Report whether the committed schema is up to date, without rewriting it. Exits
+# non-zero if it would change (used by CI and by the pre-commit hook installed
+# from scripts/build/hooks/pre-commit).
+parameters-schema-check:
+	+./scripts/build/parameterSchema.py `pwd` schema/parameters.xsd --check

--- a/python/Galacticus/Build/Jobserver.py
+++ b/python/Galacticus/Build/Jobserver.py
@@ -1,0 +1,174 @@
+"""Client for GNU make's jobserver, used to size a build script's own pool.
+
+`MAKEFLAGS` carries make's `-jN`, but N is the limit for the build *as a whole*:
+every recipe make is running concurrently shares it. A script that reads `-j8`
+and forks eight workers while make is already compiling seven files
+oversubscribes the machine eightfold. The jobserver exists to arbitrate this --
+make publishes a fixed pool of tokens, and a job may only run as many parallel
+tasks as it holds tokens for.
+
+This module implements the client side of that protocol (documented in the GNU
+make manual, "Sharing Job Slots with GNU make"):
+
+* make advertises the pool in `MAKEFLAGS` as `--jobserver-auth=<spec>`
+  (`--jobserver-fds=<spec>` before make 4.2);
+* `<spec>` is either `fifo:PATH` -- a named pipe, the default since make 4.4 --
+  or `R,W`, a pair of inherited pipe file descriptors;
+* the pool holds N-1 tokens; every job implicitly owns one slot for itself, so
+  it reads a byte per *additional* task it wants to run in parallel;
+* a read that would block means the pool is empty: someone else holds the
+  tokens, and we run with fewer workers rather than waiting;
+* every token read MUST be written back, byte-for-byte -- the bytes differ and
+  make checks them. Losing one shrinks the build's parallelism permanently.
+
+Tokens are taken once, up front, and held for the scan's duration. That is
+coarser than acquiring per task, but a scan is a single short burst of work and
+it keeps the failure mode safe: we can only ever under-subscribe, never over.
+
+Whether a recipe can reach the pool depends on the transport, so recipes running
+a scan should be marked `+` in the Makefile:
+
+* with the `R,W` transport make only passes the descriptors down to `+`-marked
+  recipes, so an unmarked recipe finds them closed and gets no pool (reported
+  here as simply having no jobserver, leaving the caller's own `-j` policy);
+* with `fifo:` the path is in `MAKEFLAGS` regardless, so an unmarked recipe can
+  still reach the pool. Honouring it is the conservative outcome either way --
+  we only ever take tokens that are genuinely free, and always give them back --
+  but `+` is what the manual requires and the only portable way to get the
+  descriptors.
+
+Andrew Benson (2026).
+"""
+
+import contextlib
+import errno
+import fcntl
+import os
+import re
+import select
+
+__all__ = ['slots', 'jobserver_available']
+
+_AUTH_RE = re.compile(r'--jobserver-(?:auth|fds)=(\S+)')
+
+
+def _spec():
+    """Return the `--jobserver-auth` spec from `MAKEFLAGS`, or None."""
+    makeflags = os.environ.get('MAKEFLAGS')
+    if not makeflags:
+        return None
+    match = _AUTH_RE.search(makeflags)
+    return match.group(1) if match else None
+
+
+def _open_fifo(path):
+    """Open make's named-pipe jobserver.
+
+    Opened O_RDWR: a read-only open would see EOF whenever no writer happens to
+    hold the pipe, and O_NONBLOCK keeps an empty pool from blocking us. The file
+    description is ours alone, so setting O_NONBLOCK cannot disturb make.
+    """
+    try:
+        fd = os.open(path, os.O_RDWR | os.O_NONBLOCK)
+    except OSError:
+        return None
+    return fd, fd, [fd]
+
+
+def _open_fds(spec):
+    """Adopt make's inherited pipe file descriptors (`R,W`, pre-4.4 style)."""
+    try:
+        read_text, write_text = spec.split(',', 1)
+        read_fd, write_fd = int(read_text), int(write_text)
+    except ValueError:
+        return None
+    for fd in (read_fd, write_fd):
+        try:
+            fcntl.fcntl(fd, fcntl.F_GETFD)
+        except OSError:
+            # Not inherited -- the recipe is not marked `+`, so make deliberately
+            # withheld the pool.
+            return None
+    # These descriptors are shared with make: do NOT set O_NONBLOCK on them, as
+    # the flag lives on the open file description and would leak into make
+    # itself. `_take` polls instead.
+    return read_fd, write_fd, []
+
+
+def _connect():
+    """Return `(read_fd, write_fd, fds_to_close)` for make's jobserver, or None."""
+    spec = _spec()
+    if spec is None:
+        return None
+    if spec.startswith('fifo:'):
+        return _open_fifo(spec[len('fifo:'):])
+    return _open_fds(spec)
+
+
+def _take(read_fd, own_fd):
+    """Read one token, or return None if the pool is empty.
+
+    When the descriptor is ours (`fifo:`) it is already non-blocking. When it is
+    make's own we must not touch its flags, so readiness is polled first; the
+    poll/read gap is a benign race -- another job may take the token between the
+    two, and we simply get fewer workers.
+    """
+    if not own_fd:
+        if not select.select([read_fd], [], [], 0)[0]:
+            return None
+    try:
+        token = os.read(read_fd, 1)
+    except OSError as exc:
+        if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK, errno.EBADF):
+            return None
+        raise
+    return token or None
+
+
+def jobserver_available():
+    """True when a usable make jobserver is reachable (diagnostics/tests)."""
+    connection = _connect()
+    if connection is None:
+        return False
+    for fd in connection[2]:
+        os.close(fd)
+    return True
+
+
+@contextlib.contextmanager
+def slots(desired):
+    """Yield the number of tasks we may actually run in parallel, <= `desired`.
+
+    With no jobserver, `desired` is yielded unchanged (the caller's own policy
+    applies). Otherwise up to `desired - 1` tokens are acquired -- the caller
+    always owns one slot implicitly -- and released on exit, including on error.
+    """
+    connection = _connect()
+    if connection is None or desired <= 1:
+        yield desired
+        return
+
+    read_fd, write_fd, close_fds = connection
+    own_fd = bool(close_fds)
+    tokens = bytearray()
+    try:
+        while len(tokens) < desired - 1:
+            token = _take(read_fd, own_fd)
+            if token is None:
+                break
+            tokens += token
+        yield 1 + len(tokens)
+    finally:
+        # Returning tokens is not optional: a dropped token is a slot the whole
+        # build loses until make exits. Push back byte-for-byte and keep going
+        # even if one write fails.
+        for index in range(len(tokens)):
+            try:
+                os.write(write_fd, tokens[index:index + 1])
+            except OSError:
+                pass
+        for fd in close_fds:
+            try:
+                os.close(fd)
+            except OSError:
+                pass

--- a/python/Galacticus/Build/ParallelScan.py
+++ b/python/Galacticus/Build/ParallelScan.py
@@ -21,6 +21,8 @@ import os
 import re
 import sys
 
+from Galacticus.Build.Jobserver import slots as jobserver_slots
+
 # Worker count when run standalone (no `make`, no explicit override). Capped at
 # the task count by `resolve_jobs`. Oversubscribing cores is intentional: the
 # work is I/O-latency bound, so workers blocked on NFS still overlap waits.
@@ -79,6 +81,10 @@ def scan(tasks, worker, script_name, jobs=None):
     is requested or there is a single task. On a worker failure the underlying
     error is surfaced with a hint to re-run serially for a full traceback,
     rather than a raw pool traceback.
+
+    When run under a `make` jobserver (from a `+`-marked recipe) the requested
+    worker count is further capped by the job slots make actually has free, so a
+    scan running alongside other recipes cannot oversubscribe the build.
     """
     tasks = list(tasks)
     if not tasks:
@@ -88,6 +94,14 @@ def scan(tasks, worker, script_name, jobs=None):
     if jobs <= 1:
         return [worker(task) for task in tasks]
 
+    with jobserver_slots(jobs) as granted:
+        if granted <= 1:
+            return [worker(task) for task in tasks]
+        return _scan_pool(tasks, worker, script_name, granted)
+
+
+def _scan_pool(tasks, worker, script_name, jobs):
+    """Run `tasks` across a fork-based pool of `jobs` workers, in task order."""
     results = [None] * len(tasks)
     ctx = multiprocessing.get_context('fork')
     try:

--- a/python/Galacticus/Build/tests/test_jobserver.py
+++ b/python/Galacticus/Build/tests/test_jobserver.py
@@ -1,0 +1,196 @@
+"""Tests for Galacticus.Build.Jobserver.
+
+The contract that matters to the build: never take more slots than make has
+free, and never lose a token. A leaked token permanently shrinks the whole
+build's parallelism, so the release path is pinned here for both the `fifo:`
+(make >= 4.4) and legacy `R,W` descriptor transports, including when the body
+raises.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from Galacticus.Build.Jobserver import slots, jobserver_available
+
+
+@pytest.fixture
+def fifo_jobserver(tmp_path, monkeypatch):
+    """A `fifo:`-style jobserver holding `n` tokens, advertised via MAKEFLAGS."""
+    path = str(tmp_path / 'fifo')
+    os.mkfifo(path)
+    fd = os.open(path, os.O_RDWR | os.O_NONBLOCK)
+
+    def fill(n):
+        os.write(fd, b'+' * n)
+        monkeypatch.setenv('MAKEFLAGS', f' -j8 --jobserver-auth=fifo:{path}')
+        return fd
+
+    yield fill
+    os.close(fd)
+
+
+@pytest.fixture
+def fds_jobserver(monkeypatch):
+    """A legacy `R,W` descriptor-pair jobserver holding `n` tokens."""
+    read_fd, write_fd = os.pipe()
+
+    def fill(n):
+        os.write(write_fd, b'+' * n)
+        monkeypatch.setenv('MAKEFLAGS',
+                           f' -j8 --jobserver-auth={read_fd},{write_fd}')
+        return read_fd, write_fd
+
+    yield fill
+    os.close(read_fd)
+    os.close(write_fd)
+
+
+# ---------------------------------------------------------------------------
+# No jobserver -> caller's own policy is untouched
+# ---------------------------------------------------------------------------
+
+def test_no_makeflags_yields_desired(monkeypatch):
+    monkeypatch.delenv('MAKEFLAGS', raising=False)
+    with slots(8) as granted:
+        assert granted == 8
+
+
+def test_makeflags_without_auth_yields_desired(monkeypatch):
+    monkeypatch.setenv('MAKEFLAGS', ' -j8')
+    with slots(8) as granted:
+        assert granted == 8
+    assert not jobserver_available()
+
+
+def test_unreachable_fifo_yields_desired(monkeypatch, tmp_path):
+    monkeypatch.setenv('MAKEFLAGS',
+                       f" -j8 --jobserver-auth=fifo:{tmp_path / 'absent'}")
+    with slots(8) as granted:
+        assert granted == 8
+
+
+def test_stale_fds_yield_desired(monkeypatch):
+    # Descriptors make did not pass down (recipe not marked `+`).
+    monkeypatch.setenv('MAKEFLAGS', ' -j8 --jobserver-auth=71,72')
+    with slots(8) as granted:
+        assert granted == 8
+
+
+# ---------------------------------------------------------------------------
+# Token accounting
+# ---------------------------------------------------------------------------
+
+def test_fifo_grants_tokens_plus_implicit_slot(fifo_jobserver):
+    fifo_jobserver(3)
+    with slots(8) as granted:
+        # 3 tokens + the slot we implicitly own.
+        assert granted == 4
+
+
+def test_fifo_never_exceeds_desired(fifo_jobserver):
+    fifo_jobserver(32)
+    with slots(4) as granted:
+        assert granted == 4
+
+
+def test_fifo_empty_pool_falls_back_to_serial(fifo_jobserver):
+    fifo_jobserver(0)
+    with slots(8) as granted:
+        assert granted == 1
+
+
+def test_fds_transport_grants_tokens(fds_jobserver):
+    fds_jobserver(2)
+    with slots(8) as granted:
+        assert granted == 3
+
+
+def test_tokens_returned_to_pool(fifo_jobserver):
+    fd = fifo_jobserver(3)
+    with slots(8) as granted:
+        assert granted == 4
+    # All three must be back, or the build loses them for good.
+    assert os.read(fd, 16) == b'+++'
+
+
+def test_tokens_returned_on_exception(fifo_jobserver):
+    fd = fifo_jobserver(3)
+    with pytest.raises(RuntimeError):
+        with slots(8):
+            raise RuntimeError("boom")
+    assert os.read(fd, 16) == b'+++'
+
+
+def test_token_bytes_preserved_exactly(fifo_jobserver):
+    """make distinguishes its tokens by value; they must go back unaltered."""
+    fd = fifo_jobserver(0)
+    os.write(fd, b'abc')
+    with slots(4) as granted:
+        assert granted == 4      # 3 distinct tokens + our implicit slot
+    assert sorted(os.read(fd, 16)) == sorted(b'abc')
+
+
+def test_desired_one_takes_no_tokens(fifo_jobserver):
+    fd = fifo_jobserver(2)
+    with slots(1) as granted:
+        assert granted == 1
+    # Nothing was taken, so the pool is untouched.
+    assert os.read(fd, 16) == b'++'
+
+
+def test_jobserver_available(fifo_jobserver):
+    fifo_jobserver(1)
+    assert jobserver_available()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end under a real `make`
+# ---------------------------------------------------------------------------
+
+def _run_probe(tmp_path, make_args):
+    """Run a `+`-marked recipe that asks `slots` for 64 workers under make."""
+    package_root = os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__)))))
+    probe = tmp_path / 'probe.py'
+    probe.write_text(textwrap.dedent(f"""
+        import sys
+        sys.path.insert(0, {package_root!r})
+        from Galacticus.Build.Jobserver import slots
+        with slots(64) as granted:
+            print("GRANTED", granted)
+    """))
+    makefile = tmp_path / 'Makefile'
+    makefile.write_text(f"probe:\n\t+@{sys.executable} {probe}\n")
+    result = subprocess.run(['make', '-f', str(makefile), *make_args, 'probe'],
+                            capture_output=True, text=True, cwd=str(tmp_path))
+    assert result.returncode == 0, result.stderr
+    return int(result.stdout.split('GRANTED')[1].split()[0])
+
+
+@pytest.mark.parametrize("jobs", [2, 4])
+def test_under_real_make(tmp_path, jobs):
+    """A `+`-marked recipe asking for far more than make allows is capped to it.
+
+    This is the whole point of the module, so it is pinned against a real make
+    rather than a synthetic pipe: make -jN publishes N-1 tokens, and with our
+    probe as the only running job we should get exactly those plus our own slot.
+    """
+    if subprocess.run(['make', '--version'], capture_output=True).returncode != 0:
+        pytest.skip("make unavailable")
+    assert _run_probe(tmp_path, [f'-j{jobs}']) == jobs
+
+
+def test_under_real_make_j1_has_no_jobserver(tmp_path):
+    """`make -j1` is serial and publishes no jobserver, so `slots` cannot cap.
+
+    Nothing is over-subscribed in practice: `ParallelScan.resolve_jobs` reads the
+    `-j1` from MAKEFLAGS and asks for a single worker in the first place. Pinned
+    so the division of labour between the two stays deliberate.
+    """
+    if subprocess.run(['make', '--version'], capture_output=True).returncode != 0:
+        pytest.skip("make unavailable")
+    assert _run_probe(tmp_path, ['-j1']) == 64

--- a/python/Galacticus/Parameters/catalog.py
+++ b/python/Galacticus/Parameters/catalog.py
@@ -16,18 +16,57 @@ three phases:
 The harvesting reuses the existing SourceTree parser so that parameter→variable
 declaration lookups (for type inference) are available, and so the directive
 scoping (which constructor a directive belongs to) is exact.
+
+Phases 1 and 2, and the pre-filter that opens phase 3, all need nothing but the
+directives of a file, so they share a single read of it (`_scan_directives`);
+phase 3 then re-reads only those files that actually register an implementation,
+to build a full parse tree. Both passes run over a process pool
+(`Galacticus.Build.ParallelScan`), which also sizes itself against make's
+jobserver. Results are collected in source-file order, so the catalog is
+identical whatever the parallelism.
 """
 
+import hashlib
+import importlib
 import os
+import pickle
 import re
 from collections import Counter
 
+from Galacticus.Build import FileChanges
 from Galacticus.Build.Directives import extract_directives
+from Galacticus.Build.ParallelScan import scan as parallel_scan
+from Galacticus.Build.ScanCache import file_identifier, load_cache
 from Galacticus.Build.SourceTree import parse_file, walk_tree
 from Galacticus.Build.SourceTree.Parse.Declarations import get_declaration
 from Galacticus.Parameters.inference import infer_parameter_type, _scalar
 
 _DIRECTIVE_TYPES = ('inputParameter', 'objectBuilder')
+
+# Bump when the layout of a cache entry changes, so old blobs are discarded
+# rather than misread. Stored under keys no `file_identifier` can produce.
+_CACHE_FORMAT     = 1
+_CACHE_FORMAT_KEY = '__format__'
+_CACHE_CODE_KEY   = '__code__'
+
+# Modules whose code determines what a cache entry *contains*, as opposed to the
+# source files it describes. A cached entry is only meaningful for the logic that
+# produced it, so editing any of these invalidates the blob -- without this,
+# working on the catalog itself silently yields results computed by the previous
+# version of the code, and `--check` would answer with them.
+_CACHE_CODE_MODULES = (
+    'Galacticus.Build.Directives',
+    'Galacticus.Build.SourceTree',
+    'Galacticus.Parameters',
+    'XML.Utils',
+)
+
+# ---------------------------------------------------------------------------
+# Read-only data shared with forked workers via copy-on-write. Populated in
+# `build_catalog` BEFORE `parallel_scan` is called, so each worker inherits it
+# without anything being pickled per task.
+# ---------------------------------------------------------------------------
+_WORKER = {}
 
 
 def _iter_source_files(source_root):
@@ -39,6 +78,67 @@ def _iter_source_files(source_root):
                 yield os.path.join(dirpath, name)
 
 
+def _base_entry(directive, path):
+    """Build a phase-1 base-class record from a `functionClass` directive.
+
+    Describes only what the directive itself says. The `implementations` list is
+    deliberately NOT included: it is accumulated later, and this record is cached
+    across runs, so owning a mutable accumulator here would let one run's labels
+    be pickled and then be appended to again by the next.
+    """
+    return {
+        'default':         _scalar(directive.get('default')),
+        'descriptiveName': _scalar(directive.get('descriptiveName')),
+        'sourceFile':      path,
+    }
+
+
+def _base_record(entry):
+    """A fresh, private base-class record ready to accumulate implementations.
+
+    Copies `entry`, which may be owned by the scan cache and must not be mutated.
+    """
+    return {**entry, 'implementations': []}
+
+
+def _enumeration_labels(directive):
+    """Extract the label list from an `enumeration` directive, or None."""
+    entries = directive.get('entry')
+    if entries is None:
+        return None
+    if isinstance(entries, dict):
+        entries = [entries]
+    return [e.get('label') for e in entries
+            if isinstance(e, dict) and e.get('label')]
+
+
+def _scan_directives(path):
+    """Read one source file once and return everything the early phases need.
+
+    Returns ``(bases, enumerations, named_roots)`` where `bases` and
+    `enumerations` are ``(name, value)`` lists in file order, and `named_roots`
+    is the set of root element names of every directive carrying a `name`. The
+    caller intersects `named_roots` with the discovered base classes to decide,
+    without another read, whether this file registers an implementation.
+    """
+    bases        = []
+    enumerations = []
+    named_roots  = set()
+    for directive in extract_directives(path, '*', set_root_element_type=True):
+        root = directive.get('rootElementType')
+        name = _scalar(directive.get('name'))
+        if name:
+            named_roots.add(root)
+        if root == 'functionClass':
+            if name:
+                bases.append((name, _base_entry(directive, path)))
+        elif root == 'enumeration':
+            labels = _enumeration_labels(directive)
+            if name and labels is not None:
+                enumerations.append((name, labels))
+    return bases, enumerations, named_roots
+
+
 def discover_base_classes(source_files):
     """Phase 1: return ``{base_name: {default, descriptiveName, sourceFile}}``."""
     bases = {}
@@ -47,12 +147,7 @@ def discover_base_classes(source_files):
             name = _scalar(directive.get('name'))
             if not name:
                 continue
-            bases[name] = {
-                'default':         _scalar(directive.get('default')),
-                'descriptiveName': _scalar(directive.get('descriptiveName')),
-                'sourceFile':      path,
-                'implementations': [],
-            }
+            bases[name] = _base_record(_base_entry(directive, path))
     return bases
 
 
@@ -167,13 +262,9 @@ def discover_enumerations(source_files):
             name = _scalar(directive.get('name'))
             if not name:
                 continue
-            entries = directive.get('entry')
-            if entries is None:
+            labels = _enumeration_labels(directive)
+            if labels is None:
                 continue
-            if isinstance(entries, dict):
-                entries = [entries]
-            labels = [e.get('label') for e in entries
-                      if isinstance(e, dict) and e.get('label')]
             enumerations[name] = labels
     return enumerations
 
@@ -396,7 +487,141 @@ def harvest_file(path, base_names, source_root):
     return entries
 
 
-def build_catalog(source_root, log=None):
+def _harvest_worker(path):
+    """Phase 3 for one file, in a pool worker: return ``(entries, error)``.
+
+    A parse failure is returned rather than raised: one unparseable file must
+    not abort the whole catalog (and would otherwise take the pool down with
+    it), so the caller reports it and carries on -- matching the serial
+    behaviour this replaced.
+    """
+    try:
+        entries = harvest_file(path, _WORKER['base_names'], _WORKER['source_root'])
+    except Exception as exc:  # noqa: BLE001 -- reported by the caller.
+        return [], str(exc)
+    return entries, None
+
+
+def default_cache_path(source_root):
+    """Where to keep the scan cache for the tree at `source_root`.
+
+    Under ``$BUILDPATH`` alongside the other build blobs when make exports it
+    (used as-is, relative to the cwd, as every other build script does);
+    otherwise the same default the Makefile itself uses, so a hand-run or
+    git-hook invocation shares one cache with the build.
+    """
+    build_path = os.environ.get('BUILDPATH')
+    if not build_path:
+        build_path = os.path.join(os.path.dirname(source_root.rstrip(os.sep))
+                                  or '.', 'work', 'build')
+    return os.path.join(build_path, 'parameters.catalog.blob')
+
+
+def _module_sources(name):
+    """Every ``.py`` file belonging to `name`, whether module or package."""
+    module = importlib.import_module(name)
+    roots = getattr(module, '__path__', None)
+    if roots is None:
+        return [module.__file__] if getattr(module, '__file__', None) else []
+    sources = []
+    for root in roots:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = sorted(d for d in dirnames if d != '__pycache__')
+            sources += [os.path.join(dirpath, filename)
+                        for filename in sorted(filenames)
+                        if filename.endswith('.py')]
+    return sources
+
+
+def _code_fingerprint():
+    """Digest the code that decides what a cache entry contains.
+
+    Cheap next to the scan it guards (a few dozen small local files against
+    ~1900 over NFS), and it means a blob is silently reused only while the logic
+    that built it is byte-for-byte the same.
+    """
+    digest = hashlib.sha256()
+    for name in sorted(_CACHE_CODE_MODULES):
+        try:
+            sources = _module_sources(name)
+        except ImportError:
+            digest.update(f'{name}:missing'.encode())
+            continue
+        for path in sorted(sources):
+            digest.update(path.encode())
+            try:
+                with open(path, 'rb') as fh:
+                    digest.update(fh.read())
+            except OSError:
+                digest.update(b'unreadable')
+    return digest.hexdigest()
+
+
+def _load_scan_cache(cache_path):
+    """Load the scan cache, returning ``(entries, mtime)``.
+
+    Degrades to a full rescan (``({}, None)``) on anything unexpected -- a
+    missing, corrupt, foreign-format blob, or one written by different catalog
+    code, must never fail a build (nor be believed).
+    """
+    if not cache_path:
+        return {}, None
+    cache, mtime = load_cache(cache_path)
+    if cache.get(_CACHE_FORMAT_KEY) != _CACHE_FORMAT:
+        return {}, None
+    if cache.get(_CACHE_CODE_KEY) != _code_fingerprint():
+        return {}, None
+    return cache, mtime
+
+
+def _save_scan_cache(cache_path, cache, log):
+    """Write the scan cache, only-if-changed (preserving mtime when identical).
+
+    Failures are reported and swallowed: the cache is an optimisation, and an
+    unwritable `$BUILDPATH` must not break a catalog that is already built.
+    """
+    if not cache_path:
+        return
+    try:
+        os.makedirs(os.path.dirname(cache_path) or '.', exist_ok=True)
+        temporary = cache_path + '.new'
+        with open(temporary, 'wb') as fh:
+            pickle.dump(cache, fh)
+        # Only-if-changed: an unchanged blob keeps its mtime, so the freshness
+        # window against which source files are compared does not creep forward.
+        FileChanges.update(cache_path, temporary)
+    except OSError as exc:
+        log(f"  [cache] could not write {cache_path}: {exc}")
+
+
+def _fresh_entry(cache, cache_mtime, path, identifier):
+    """Return this file's cache entry if it is still valid, else None.
+
+    Freshness is the blob's own mtime, per the shared blob-cache protocol: an
+    entry is good only while the file it describes has not been touched since
+    the blob was written.
+
+    That protocol carries a known race, shared with every other blob cache here:
+    a file edited *during* a scan is recorded with the pre-edit content but keeps
+    an mtime below the blob's, so the stale entry is reused until the file is
+    touched again. `--no-cache` forces the issue, and CI always scans cold (a
+    fresh checkout has no blob), so a schema staleness the cache masked locally
+    is still caught before merge.
+    """
+    if cache_mtime is None:
+        return None
+    entry = cache.get(identifier)
+    if entry is None:
+        return None
+    try:
+        if os.stat(path).st_mtime >= cache_mtime:
+            return None
+    except OSError:
+        return None
+    return entry
+
+
+def build_catalog(source_root, log=None, jobs=None, cache_path=None):
     """Build the full catalog dict for the source tree rooted at `source_root`.
 
     Parameters
@@ -405,6 +630,13 @@ def build_catalog(source_root, log=None):
         Path to the ``source`` directory.
     log : callable, optional
         ``f(message)`` for progress/diagnostics.
+    jobs : int, optional
+        Worker count for the parallel passes. Defaults to `ParallelScan`'s own
+        resolution (``GALACTICUS_BUILD_JOBS``, then make's ``-j``/jobserver).
+    cache_path : str, optional
+        Per-file scan cache (see `default_cache_path`). When given, files whose
+        mtime has not advanced past the cache are not re-read at all. Omit to
+        scan the tree from scratch.
 
     Returns
     -------
@@ -416,29 +648,66 @@ def build_catalog(source_root, log=None):
             log(message)
 
     source_files = list(_iter_source_files(source_root))
-    _log(f"scanning {len(source_files)} source files for functionClass bases")
-    bases = discover_base_classes(source_files)
+    identifiers  = {path: file_identifier(path) for path in source_files}
+    cache, cache_mtime = _load_scan_cache(cache_path)
+    reusable = {path: _fresh_entry(cache, cache_mtime, path, identifiers[path])
+                for path in source_files}
+
+    # --- Phases 1 and 2, plus the phase-3 pre-filter, from one read per file.
+    scans     = {path: entry['scan']
+                 for path, entry in reusable.items() if entry is not None}
+    to_scan   = [path for path in source_files if path not in scans]
+    _log(f"scanning {len(to_scan)} of {len(source_files)} source files "
+         f"for functionClass bases ({len(scans)} cached)")
+    for path, result in zip(to_scan, parallel_scan(
+            to_scan, _scan_directives, 'Galacticus.Parameters.catalog', jobs=jobs)):
+        scans[path] = result
+
+    bases        = {}
+    enumerations = {}
+    for path in source_files:                      # file order: later files win,
+        file_bases, file_enumerations, _ = scans[path]   # exactly as the serial
+        for name, entry in file_bases:                   # loop this replaced.
+            # A fresh record per run: `scans` may be cache-owned, and the
+            # implementation labels appended below must not leak into the blob.
+            bases[name] = _base_record(entry)
+        for name, labels in file_enumerations:
+            enumerations[name] = labels
+
     base_names = set(bases)
     _log(f"found {len(base_names)} functionClass base classes")
-    enumerations = discover_enumerations(source_files)
     _log(f"found {len(enumerations)} enumerations")
+
+    # --- Phase 3. A file needs a full parse only if it registers an
+    # implementation, i.e. carries a named directive whose root is a base class.
+    registering  = [path for path in source_files if scans[path][2] & base_names]
+    # `harvest_file` reads `base_names` only to recognise those registrations, so
+    # a cached harvest stays valid exactly while this file's own registrations
+    # do -- letting an unrelated new base class avoid invalidating the tree.
+    registered   = {path: sorted(scans[path][2] & base_names)
+                    for path in registering}
+    harvests     = {}
+    for path in registering:
+        entry = reusable[path]
+        if (entry is not None and entry.get('harvest') is not None
+                and entry.get('registered') == registered[path]):
+            harvests[path] = entry['harvest']
+    to_harvest = [path for path in registering if path not in harvests]
+    _log(f"parsing {len(to_harvest)} of {len(registering)} files that register "
+         f"implementations ({len(harvests)} cached)")
+
+    _WORKER['base_names']  = base_names
+    _WORKER['source_root'] = source_root
+    for path, result in zip(to_harvest, parallel_scan(
+            to_harvest, _harvest_worker, 'Galacticus.Parameters.catalog', jobs=jobs)):
+        harvests[path] = result
 
     implementations = {}
     parsed_files = 0
-    for path in source_files:
-        # Cheap pre-filter: only parse files that register an implementation.
-        registrations = [
-            directive for directive in extract_directives(
-                path, '*', set_root_element_type=True)
-            if directive.get('rootElementType') in base_names
-            and _scalar(directive.get('name'))
-        ]
-        if not registrations:
-            continue
-        try:
-            entries = harvest_file(path, base_names, source_root)
-        except Exception as exc:  # noqa: BLE001 -- report and continue.
-            _log(f"  [parse-error] {os.path.relpath(path, source_root)}: {exc}")
+    for path in registering:
+        entries, error = harvests[path]
+        if error is not None:
+            _log(f"  [parse-error] {os.path.relpath(path, source_root)}: {error}")
             continue
         parsed_files += 1
         for entry in entries:
@@ -446,6 +715,17 @@ def build_catalog(source_root, log=None):
             base = entry['functionClass']
             if base in bases and entry['label'] not in bases[base]['implementations']:
                 bases[base]['implementations'].append(entry['label'])
+
+    # Rebuilt from the files that exist now, so entries for deleted files are
+    # dropped rather than accumulating.
+    _save_scan_cache(cache_path, {
+        _CACHE_FORMAT_KEY: _CACHE_FORMAT,
+        _CACHE_CODE_KEY:   _code_fingerprint(),
+        **{identifiers[path]: {'scan':       scans[path],
+                               'harvest':    harvests.get(path),
+                               'registered': registered.get(path)}
+           for path in source_files},
+    }, _log)
 
     for base in bases.values():
         base['implementations'].sort()

--- a/python/Galacticus/Parameters/tests/test_catalog.py
+++ b/python/Galacticus/Parameters/tests/test_catalog.py
@@ -11,14 +11,17 @@ Covers the two pieces most likely to drift from the rest of the build system:
      three provenance paths, and the `source`->nested-element resolution.
 """
 
+import os
+import pickle
 import textwrap
+import time
 
 import pytest
 
 from Galacticus.Parameters.catalog import (
     derive_label, _resolve_source_elements, harvest_file,
     discover_enumerations, _enumeration_links, _capture_constraints,
-    _normalize_default,
+    _normalize_default, _scan_directives, build_catalog,
 )
 from Galacticus.Build.SourceTree import parse_file
 
@@ -264,3 +267,316 @@ def test_harvest_file_end_to_end(tmp_path):
     assert objects['cosmologyFunctions']['class'] == 'cosmologyFunctions'
     assert objects['cosmologyFunctions']['sourceElement'] is None
     assert objects['cosmologyFunctions']['repeatable'] is False
+
+
+# ---------------------------------------------------------------------------
+# `_scan_directives` / `build_catalog`: the single-read early phases
+# ---------------------------------------------------------------------------
+
+def _write_tree(tmp_path):
+    """A miniature source tree: one base class, one enumeration, one
+    implementation, and one file that registers nothing."""
+    source_root = tmp_path / "source"
+    (source_root / "my").mkdir(parents=True)
+    (source_root / "my" / "base.F90").write_text(textwrap.dedent("""\
+        module Base
+          !![
+          <functionClass>
+           <name>myClass</name>
+           <descriptiveName>My Class</descriptiveName>
+           <default>enum</default>
+          </functionClass>
+          <enumeration>
+           <name>fixedDensityType</name>
+           <entry label="critical"/>
+           <entry label="mean"/>
+          </enumeration>
+          !!]
+        end module Base
+        """))
+    (source_root / "my" / "impl.F90").write_text(_SNIPPET_ENUM)
+    (source_root / "my" / "plain.F90").write_text(
+        "module Plain\nend module Plain\n")
+    return source_root
+
+
+def test_scan_directives_collects_all_phases_in_one_read(tmp_path):
+    """One read must yield the bases, the enumerations, and enough information
+    to decide whether the file needs a full parse."""
+    source_root = _write_tree(tmp_path)
+
+    bases, enumerations, named_roots = _scan_directives(
+        str(source_root / "my" / "base.F90"))
+    assert [name for name, _ in bases] == ['myClass']
+    assert enumerations == [('fixedDensityType', ['critical', 'mean'])]
+    # `base.F90` declares the class but registers no implementation of it.
+    assert 'myClass' not in named_roots
+
+    bases, enumerations, named_roots = _scan_directives(
+        str(source_root / "my" / "impl.F90"))
+    assert bases == [] and enumerations == []
+    # `impl.F90` carries `<myClass name="myClassEnum">` -> needs a parse.
+    assert 'myClass' in named_roots
+
+
+def test_scan_directives_on_file_without_directives(tmp_path):
+    source_root = _write_tree(tmp_path)
+    assert _scan_directives(str(source_root / "my" / "plain.F90")) == (
+        [], [], set())
+
+
+def test_build_catalog_end_to_end(tmp_path):
+    source_root = _write_tree(tmp_path)
+    catalog = build_catalog(str(source_root), jobs=1)
+
+    assert catalog['enumerations'] == {'fixedDensityType': ['critical', 'mean']}
+    assert catalog['functionClasses']['myClass']['implementations'] == ['enum']
+    assert catalog['functionClasses']['myClass']['descriptiveName'] == 'My Class'
+    implementation = catalog['implementations']['myClassEnum']
+    assert implementation['functionClass'] == 'myClass'
+    assert implementation['label'] == 'enum'
+
+
+def test_build_catalog_parallel_matches_serial(tmp_path):
+    """The catalog feeds a committed, diffed artefact: it must not depend on the
+    worker count."""
+    source_root = _write_tree(tmp_path)
+    assert build_catalog(str(source_root), jobs=4) == \
+           build_catalog(str(source_root), jobs=1)
+
+
+def test_harvest_worker_contains_parse_failure(tmp_path, monkeypatch):
+    """A file the parser chokes on is reported, not raised.
+
+    `ParallelScan` aborts the run if a worker raises, so a single bad file would
+    otherwise take the whole catalog down -- where the serial code it replaced
+    logged it and carried on. The failure is injected because the real parser is
+    forgiving enough that a genuinely unparseable fixture would be contrived.
+    """
+    import Galacticus.Parameters.catalog as catalog_module
+
+    def _explode(path, base_names, source_root):
+        raise RuntimeError("parser exploded")
+
+    monkeypatch.setattr(catalog_module, 'harvest_file', _explode)
+    monkeypatch.setitem(catalog_module._WORKER, 'base_names', {'myClass'})
+    monkeypatch.setitem(catalog_module._WORKER, 'source_root', str(tmp_path))
+
+    entries, error = catalog_module._harvest_worker(str(tmp_path / "any.F90"))
+    assert entries == []
+    assert "parser exploded" in error
+
+
+def test_build_catalog_logs_parse_error_and_keeps_the_rest(tmp_path, monkeypatch):
+    """One bad file must not lose the rest of the catalog."""
+    import Galacticus.Parameters.catalog as catalog_module
+    source_root = _write_tree(tmp_path)
+    (source_root / "my" / "broken.F90").write_text(
+        _SNIPPET_ENUM.replace('myClassEnum', 'myClassBroken')
+                     .replace('enumConstructorParameters',
+                              'brokenConstructorParameters'))
+
+    real_harvest = catalog_module.harvest_file
+
+    def _explode_on_broken(path, base_names, source_root_):
+        if path.endswith('broken.F90'):
+            raise RuntimeError("parser exploded")
+        return real_harvest(path, base_names, source_root_)
+
+    monkeypatch.setattr(catalog_module, 'harvest_file', _explode_on_broken)
+
+    messages = []
+    # jobs=1: the monkeypatch lives in this process, so it must not be forked away.
+    catalog = build_catalog(str(source_root), log=messages.append, jobs=1)
+
+    assert 'myClassEnum' in catalog['implementations']
+    assert 'myClassBroken' not in catalog['implementations']
+    assert catalog['functionClasses']['myClass']['implementations'] == ['enum']
+    assert any('parse-error' in m and 'broken.F90' in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# The scan cache
+# ---------------------------------------------------------------------------
+
+def _backdate(source_root, seconds=10):
+    """Age the source files so they are unambiguously older than a cache written
+    now (mtime comparison is `>=`, so equal timestamps force a rescan)."""
+    past = time.time() - seconds
+    for dirpath, _, filenames in os.walk(str(source_root)):
+        for name in filenames:
+            os.utime(os.path.join(dirpath, name), (past, past))
+
+
+def test_cache_matches_uncached(tmp_path):
+    """The cache is an optimisation: it must never change the catalog."""
+    source_root = _write_tree(tmp_path)
+    blob = str(tmp_path / 'cache.blob')
+
+    uncached = build_catalog(str(source_root), jobs=1)
+    build_catalog(str(source_root), jobs=1, cache_path=blob)   # populate
+    _backdate(source_root)
+    warm = build_catalog(str(source_root), jobs=1, cache_path=blob)
+
+    assert warm == uncached
+
+
+def test_repeated_cached_runs_are_stable(tmp_path):
+    """Regression: the cached base-class record must not accumulate labels.
+
+    `build_catalog` appends implementation labels to each base record. When that
+    record was owned by the scan cache, every run appended to the *same* list and
+    then pickled it, so labels piled up run over run (and survived deleting the
+    file that declared them).
+    """
+    source_root = _write_tree(tmp_path)
+    blob = str(tmp_path / 'cache.blob')
+
+    first = build_catalog(str(source_root), jobs=1, cache_path=blob)
+    _backdate(source_root)
+    for _ in range(3):
+        again = build_catalog(str(source_root), jobs=1, cache_path=blob)
+        assert again['functionClasses']['myClass']['implementations'] == ['enum']
+        assert again == first
+
+
+def test_cache_detects_modified_file(tmp_path):
+    source_root = _write_tree(tmp_path)
+    blob = str(tmp_path / 'cache.blob')
+    build_catalog(str(source_root), jobs=1, cache_path=blob)
+
+    (source_root / "my" / "impl.F90").write_text(
+        _SNIPPET_ENUM.replace('myClassEnum', 'myClassRenamed'))
+    catalog = build_catalog(str(source_root), jobs=1, cache_path=blob)
+
+    assert 'myClassRenamed' in catalog['implementations']
+    assert 'myClassEnum' not in catalog['implementations']
+    assert catalog['functionClasses']['myClass']['implementations'] == ['renamed']
+
+
+def test_cache_detects_new_and_deleted_files(tmp_path):
+    source_root = _write_tree(tmp_path)
+    blob = str(tmp_path / 'cache.blob')
+    build_catalog(str(source_root), jobs=1, cache_path=blob)
+    _backdate(source_root)
+
+    extra = source_root / "my" / "extra.F90"
+    extra.write_text(_SNIPPET_ENUM.replace('myClassEnum', 'myClassExtra')
+                                  .replace('enumConstructorParameters',
+                                           'extraConstructorParameters'))
+    catalog = build_catalog(str(source_root), jobs=1, cache_path=blob)
+    assert catalog['functionClasses']['myClass']['implementations'] == \
+        ['enum', 'extra']
+
+    extra.unlink()
+    catalog = build_catalog(str(source_root), jobs=1, cache_path=blob)
+    assert catalog['functionClasses']['myClass']['implementations'] == ['enum']
+    assert 'myClassExtra' not in catalog['implementations']
+
+
+def test_cache_drops_entries_for_deleted_files(tmp_path):
+    """A deleted file must not linger in the blob forever."""
+    source_root = _write_tree(tmp_path)
+    blob = str(tmp_path / 'cache.blob')
+    extra = source_root / "my" / "extra.F90"
+    extra.write_text("module Extra\nend module Extra\n")
+    build_catalog(str(source_root), jobs=1, cache_path=blob)
+    assert any('extra.F90' in key for key in pickle.load(open(blob, 'rb')))
+
+    extra.unlink()
+    build_catalog(str(source_root), jobs=1, cache_path=blob)
+    assert not any('extra.F90' in key for key in pickle.load(open(blob, 'rb')))
+
+
+def test_cache_reuses_harvest_when_an_unrelated_base_is_added(tmp_path,
+                                                              monkeypatch):
+    """A new functionClass elsewhere must not force the tree to be re-harvested.
+
+    A cached harvest depends on `base_names` only through this file's own
+    registrations, so it stays valid while those are unchanged.
+    """
+    import Galacticus.Parameters.catalog as catalog_module
+    source_root = _write_tree(tmp_path)
+    blob = str(tmp_path / 'cache.blob')
+    build_catalog(str(source_root), jobs=1, cache_path=blob)
+    _backdate(source_root)
+
+    (source_root / "my" / "other.F90").write_text(textwrap.dedent("""\
+        module Other
+          !![
+          <functionClass>
+           <name>otherClass</name>
+           <descriptiveName>Other</descriptiveName>
+          </functionClass>
+          !!]
+        end module Other
+        """))
+
+    harvested = []
+    real_harvest = catalog_module.harvest_file
+    monkeypatch.setattr(catalog_module, 'harvest_file',
+                        lambda p, b, s: (harvested.append(p),
+                                         real_harvest(p, b, s))[1])
+    catalog = build_catalog(str(source_root), jobs=1, cache_path=blob)
+
+    assert 'otherClass' in catalog['functionClasses']
+    # impl.F90's registrations are unchanged, so it is not re-parsed.
+    assert not any('impl.F90' in p for p in harvested)
+
+
+def test_corrupt_cache_falls_back_to_full_scan(tmp_path):
+    source_root = _write_tree(tmp_path)
+    blob = tmp_path / 'cache.blob'
+    blob.write_bytes(b'not a pickle at all')
+    catalog = build_catalog(str(source_root), jobs=1, cache_path=str(blob))
+    assert catalog == build_catalog(str(source_root), jobs=1)
+
+
+def test_foreign_format_cache_is_discarded(tmp_path):
+    """A blob from an older entry layout must be rebuilt, not misread."""
+    source_root = _write_tree(tmp_path)
+    blob = tmp_path / 'cache.blob'
+    with open(blob, 'wb') as fh:
+        pickle.dump({'__format__': -1, 'source_my_impl.F90': 'garbage'}, fh)
+    catalog = build_catalog(str(source_root), jobs=1, cache_path=str(blob))
+    assert catalog == build_catalog(str(source_root), jobs=1)
+
+
+def test_unwritable_cache_does_not_fail_the_build(tmp_path):
+    source_root = _write_tree(tmp_path)
+    messages = []
+    catalog = build_catalog(str(source_root), jobs=1, log=messages.append,
+                            cache_path='/proc/nonexistent/cache.blob')
+    assert catalog == build_catalog(str(source_root), jobs=1)
+    assert any('cache' in m for m in messages)
+
+
+def test_cache_invalidated_when_catalog_code_changes(tmp_path, monkeypatch):
+    """Editing the code that builds entries must invalidate the blob.
+
+    Otherwise working on the catalog itself silently reuses results computed by
+    the previous version -- and `--check`, whose whole job is to answer whether
+    the schema is stale, would answer from them.
+    """
+    import Galacticus.Parameters.catalog as catalog_module
+    source_root = _write_tree(tmp_path)
+    blob = str(tmp_path / 'cache.blob')
+    build_catalog(str(source_root), jobs=1, cache_path=blob)
+    _backdate(source_root)
+
+    # Same sources, same mtimes -- but different catalog code.
+    monkeypatch.setattr(catalog_module, '_code_fingerprint',
+                        lambda: 'a-different-version-of-the-code')
+    rescanned = []
+    real_scan = catalog_module._scan_directives
+    monkeypatch.setattr(catalog_module, '_scan_directives',
+                        lambda p: (rescanned.append(p), real_scan(p))[1])
+
+    build_catalog(str(source_root), jobs=1, cache_path=blob)
+    assert rescanned, "cache was reused despite the code having changed"
+
+
+def test_code_fingerprint_is_stable_and_specific():
+    from Galacticus.Parameters.catalog import _code_fingerprint
+    assert _code_fingerprint() == _code_fingerprint()
+    assert len(_code_fingerprint()) == 64      # sha256 hex

--- a/scripts/build/parameterSchema.py
+++ b/scripts/build/parameterSchema.py
@@ -18,12 +18,22 @@ implementation) is provided separately by scripts/build/parameterValidate.py.
 
 Usage:
     parameterSchema.py <sourceDirectory> [<outputFile>]
+                       [--check] [--jobs N] [--no-cache]
 
 `<outputFile>` defaults to `<sourceDirectory>/schema/parameters.xsd`.
+
+`--check` writes nothing and exits 1 if the committed schema is not what would
+be generated -- for CI and for the pre-commit hook.
+
+The catalog scan runs over a process pool sized from `GALACTICUS_BUILD_JOBS`,
+make's `-j`, or make's jobserver when invoked from a `+`-marked recipe, and
+re-reads only those source files whose mtime has advanced past the scan cache
+under `$BUILDPATH` (`--no-cache` to rescan everything).
 
 Andrew Benson (2026).
 """
 
+import argparse
 import collections
 import os
 import sys
@@ -31,7 +41,7 @@ import sys
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.abspath(__file__)), os.pardir, os.pardir, 'python'))
 
-from Galacticus.Parameters.catalog import build_catalog
+from Galacticus.Parameters.catalog import build_catalog, default_cache_path
 
 
 # Root elements of non-parameter files that live in the same directories as
@@ -176,23 +186,66 @@ def build_schema(catalog):
     return '\n'.join(out)
 
 
+def _parse_arguments(argv):
+    parser = argparse.ArgumentParser(
+        prog='parameterSchema.py',
+        description='Generate the Galacticus parameter-file XSD from the '
+                    'parameter catalog.')
+    parser.add_argument('sourceDirectory',
+                        help='Galacticus root directory (containing `source/`).')
+    parser.add_argument('outputFile', nargs='?', default=None,
+                        help='Schema to write. Default: '
+                             '<sourceDirectory>/schema/parameters.xsd')
+    parser.add_argument('--check', action='store_true',
+                        help='Do not write; exit 1 if <outputFile> differs from '
+                             'the schema that would be generated.')
+    parser.add_argument('--jobs', '-j', type=int, default=None, metavar='N',
+                        help='Parallel workers for the source scan. Default: '
+                             'GALACTICUS_BUILD_JOBS, else make\'s -j/jobserver.')
+    parser.add_argument('--no-cache', action='store_true',
+                        help='Ignore (and do not update) the per-file scan '
+                             'cache, rescanning every source file.')
+    return parser.parse_args(argv[1:])
+
+
 def main(argv):
-    if len(argv) not in (2, 3):
-        print("Usage: parameterSchema.py <sourceDirectory> [<outputFile>]",
-              file=sys.stderr)
-        return 1
-    source_directory = argv[1]
-    output_path = argv[2] if len(argv) == 3 else os.path.join(
+    arguments = _parse_arguments(argv)
+    source_directory = arguments.sourceDirectory
+    output_path = arguments.outputFile or os.path.join(
         source_directory, 'schema', 'parameters.xsd')
     os.environ.setdefault('GALACTICUS_EXEC_PATH', source_directory)
-    catalog = build_catalog(os.path.join(source_directory, 'source'))
-    with open(output_path, 'w') as fh:
-        fh.write(build_schema(catalog))
+
+    source_root = os.path.join(source_directory, 'source')
+    catalog = build_catalog(
+        source_root,
+        jobs=arguments.jobs,
+        cache_path=None if arguments.no_cache else default_cache_path(source_root))
+    schema = build_schema(catalog)
+
     n_fc = sum(1 for b in catalog['functionClasses'].values()
                if b.get('implementations'))
-    print(f"wrote {output_path} ({n_fc} functionClass selectors, "
-          f"{len(_enum_parameter_elements(catalog))} enumeration parameters)",
-          file=sys.stderr)
+    summary = (f"{n_fc} functionClass selectors, "
+               f"{len(_enum_parameter_elements(catalog))} enumeration parameters")
+
+    if arguments.check:
+        try:
+            with open(output_path) as fh:
+                current = fh.read()
+        except OSError:
+            current = None
+        if current == schema:
+            print(f"{output_path} is up to date ({summary})", file=sys.stderr)
+            return 0
+        reason = ("does not exist" if current is None
+                  else "is out of date")
+        print(f"{output_path} {reason} ({summary}).\n"
+              f"Run `make parameters-schema` and commit the result.",
+              file=sys.stderr)
+        return 1
+
+    with open(output_path, 'w') as fh:
+        fh.write(schema)
+    print(f"wrote {output_path} ({summary})", file=sys.stderr)
     return 0
 
 

--- a/scripts/build/tests/test_parameter_schema.py
+++ b/scripts/build/tests/test_parameter_schema.py
@@ -79,3 +79,99 @@ def test_schema_compiles_and_validates():
     # parameter files) is tolerated rather than rejected
     assert schema.validate(etree.fromstring(
         b'<changes><change type="update"/></changes>'))
+
+
+# ---------------------------------------------------------------------------
+# `main`: --check reports drift without writing (used by CI and the git hook)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fake_tree(tmp_path, monkeypatch):
+    """A source directory whose catalog is stubbed out, so the CLI's write /
+    check / exit-code behaviour is exercised without parsing real Fortran."""
+    import parameterSchema
+
+    (tmp_path / 'source').mkdir()
+    (tmp_path / 'schema').mkdir()
+    monkeypatch.setattr(parameterSchema, 'build_catalog',
+                        lambda source_root, **keywords: CATALOG)
+    # Keep any cache the CLI resolves inside the fixture's own directory.
+    monkeypatch.setenv('BUILDPATH', str(tmp_path / 'build'))
+    return tmp_path
+
+
+def _run(tmp_path, *arguments):
+    import parameterSchema
+    return parameterSchema.main(
+        ['parameterSchema.py', str(tmp_path), str(tmp_path / 'out.xsd'),
+         *arguments])
+
+
+def test_writes_schema(fake_tree):
+    assert _run(fake_tree) == 0
+    assert (fake_tree / 'out.xsd').read_text() == build_schema(CATALOG)
+
+
+def test_check_passes_when_up_to_date(fake_tree):
+    assert _run(fake_tree) == 0
+    assert _run(fake_tree, '--check') == 0
+
+
+def test_check_fails_when_out_of_date(fake_tree, capsys):
+    (fake_tree / 'out.xsd').write_text('<xs:schema/>\n')
+    assert _run(fake_tree, '--check') == 1
+    assert 'out of date' in capsys.readouterr().err
+
+
+def test_check_fails_when_absent(fake_tree, capsys):
+    assert _run(fake_tree, '--check') == 1
+    assert 'does not exist' in capsys.readouterr().err
+
+
+def test_check_does_not_write(fake_tree):
+    """The whole point of --check: CI and the pre-commit hook must not have the
+    working tree mutated underneath them."""
+    stale = '<xs:schema/>\n'
+    (fake_tree / 'out.xsd').write_text(stale)
+    assert _run(fake_tree, '--check') == 1
+    assert (fake_tree / 'out.xsd').read_text() == stale
+
+
+def test_check_does_not_create_the_file(fake_tree):
+    assert _run(fake_tree, '--check') == 1
+    assert not (fake_tree / 'out.xsd').exists()
+
+
+def test_default_output_path(fake_tree):
+    import parameterSchema
+    assert parameterSchema.main(['parameterSchema.py', str(fake_tree)]) == 0
+    assert (fake_tree / 'schema' / 'parameters.xsd').read_text() == \
+        build_schema(CATALOG)
+
+
+def test_cli_wiring(tmp_path, monkeypatch):
+    """--jobs and --no-cache must reach `build_catalog`, and the cache must be
+    on by default (the pre-commit hook depends on it)."""
+    import parameterSchema
+
+    (tmp_path / 'source').mkdir()
+    monkeypatch.setenv('BUILDPATH', str(tmp_path / 'build'))
+    calls = []
+
+    def _stub_catalog(source_root, **keywords):
+        calls.append(keywords)
+        return CATALOG
+
+    monkeypatch.setattr(parameterSchema, 'build_catalog', _stub_catalog)
+
+    def run(*arguments):
+        calls.clear()
+        parameterSchema.main(['parameterSchema.py', str(tmp_path),
+                              str(tmp_path / 'out.xsd'), *arguments])
+        return calls[0]
+
+    assert run('--jobs', '3')['jobs'] == 3
+    assert run()['jobs'] is None                     # left to ParallelScan
+    assert run('--no-cache')['cache_path'] is None
+    assert run()['cache_path'] == str(
+        tmp_path / 'build' / 'parameters.catalog.blob')


### PR DESCRIPTION
Regenerating `schema/parameters.xsd` took **~68s**, too slow to run as a pre-commit hook. It now takes **~0.25s** when no source file has changed, and ~21s from cold.

| | wall |
|---|---|
| before | ~68s |
| single-pass reads, serial | ~44s |
| + parallel | ~21s |
| + warm cache | **0.25s** |

Measured on a 4-core node at load ~13 with sources on NFS, so the parallel figure is contention-limited rather than code-limited.

## What was slow

The work is `parse_file` over the 1355 files that register an implementation — 59 of the original 66 seconds. But `build_catalog` also read every one of the ~1900 source files **three times**: once for `functionClass` bases, once for enumerations, and once for the pre-filter deciding which files to parse. `Directives.extract_directives` can match several root elements in a single read (its own docstring warns that N single-name calls cost N reads).

## Changes

* **One read per file.** The three early passes become one (`_scan_directives`), with the pre-filter riding on its result. Serial time 68s → 44s.
* **Parallel.** Both passes now use `Galacticus.Build.ParallelScan`, which every other cataloguing script already used — `parameterSchema.py` was the odd one out. 44s → 21s.
* **Scan cache.** Per-file results cached in a blob under `$BUILDPATH`, following the existing `Galacticus.Build.ScanCache` protocol used by 8 other build scripts. `--no-cache` opts out.
* **`--check`.** Writes nothing; exits non-zero if the committed schema is not what would be generated. CI now uses it directly instead of regenerating and diffing.

## Jobserver

`ParallelScan.resolve_jobs` read `-j8` from `MAKEFLAGS`, but that is the limit for the **whole build**, shared by every recipe make is running — so a scan that forked 8 workers while make compiled 7 files oversubscribed. A new `Galacticus.Build.Jobserver` implements the actual token protocol, so a scan takes only the slots that are genuinely free:

```
-j4, 2 rival jobs running -> resolve_jobs wanted 4 | jobserver granted 2
```

Both the `fifo:` (make ≥ 4.4) and legacy `R,W` descriptor transports are handled, tokens are always returned (including on exceptions — a leaked token permanently shrinks the build's parallelism), and scan recipes are marked `+` so make shares the pool. This benefits all ten scripts using `ParallelScan`, not just this one.

## Correctness

The generated schema is **byte-identical** to the committed one, verified serial and at 4/8/16/24 workers, cold and warm, and with the cache disabled.

Two things worth reviewer attention:

* **A bug the cache surfaced.** `_base_entry` owned a mutable `'implementations': []` that `build_catalog` appended to — and that same object was pickled, so labels accumulated run over run. Renaming an implementation left *both* names in the schema; deleting the file didn't remove it. The cached record now describes only the directive, with the accumulator created fresh per run (`test_repeated_cached_runs_are_stable`).
* **The cache is keyed on the code that fills it**, not just source mtimes — a digest of the modules producing the entries (~5ms for 80 files). Without it, working on the catalog itself silently reuses results from the previous version, and `--check` — whose entire job is answering "is this stale?" — would answer from them.

A known race is documented rather than fixed: a file edited *during* a scan keeps an mtime below the blob's, so the stale entry is reused until it is touched again. Every blob cache in the repo shares this; closing it means either local-vs-NFS clock skew or diverging from the shared protocol. CI is a real backstop — `work/` is gitignored, so a fresh checkout always scans cold.

## Hook

No new hook here. `pre-commit.d/00-galacticus` in the gitHooks repo already checks schema freshness, already guards on the generator existing (so it no-ops outside Galacticus repos), and compares against the **staged** schema via `git show :schema/parameters.xsd` — which `--check` deliberately cannot do, since it reads the working tree. It picks up the speedup for free; verified end-to-end by staging a new implementation:

```
✕ Parameter schema is out of date with the sources     real 0m0.451s
```

## Tests

769 pass (up from 730). New coverage: jobserver token accounting and release-on-exception against a real `make`; the single-read scanner; cache parity with uncached, invalidation on modify/add/delete/code-change, and graceful degradation on corrupt, foreign-format, and unwritable blobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)