### PR TITLE
Add missed migration for `johnson2021` scale radius model

### DIFF
--- a/scripts/aux/migrations.xml
+++ b/scripts/aux/migrations.xml
@@ -285,6 +285,9 @@
   <migration commit="3148b72923e0261deb472182fee74ccd1a9a7a13">
     <translation function="satellite_orbit_initializor"/>
   </migration>
+  <migration commit="befbbb8d669ec76a2ddf0299ed7da8f31077700e">
+    <translation function="johnson2021_correlated_branches"/>
+  </migration>
 
   <!-- Known default values for parameters -->
   <default parameter="componentBlackHole"             value="standard"        />

--- a/scripts/aux/parametersMigrate.py
+++ b/scripts/aux/parametersMigrate.py
@@ -1309,6 +1309,33 @@ def _ensure_satellite_destruction_timestep(parameters, is_grid):
             multi_node.append(destruction_node)
             parameters.insert(idx, multi_node)
 
+def johnson2021_correlated_branches(input_doc, parameters, is_grid):
+    """Pin parameter settings to those consistent with behavior prior to adding correlated scale radii along branches."""
+    defaults = {
+        "factorMassResolution": "0.0",
+        "scatter": "0.0",
+        "scatterExcess": "0.0",
+        "correlationRateDecay": "0.0",
+        "correlationExponent": "0.0",
+        "countSampleEnergyUnresolved": "1",
+        "acceptUnboundOrbits": "true",
+    }
+    accept_type_nodes = parameters.xpath(".//darkMatterProfileScaleRadius[@value='johnson2021']")
+    if len(accept_type_nodes) == 0:
+        return
+    for accept_type in accept_type_nodes:
+        print(f"   translate special './/darkMatterProfileScaleRadius[@value=\"'johnson2021\"]'")
+        component_properties = {}
+        # Extract all sub-parameters.
+        for node_child in accept_type.xpath("*[@value]"):
+            component_properties[node_child.tag] = node_child.get("value")
+        for param_name, param_value in defaults.items():
+            if param_name not in component_properties:
+                param = etree.Element(param_name)
+                param.set("value", param_value)
+                accept_type.append(param)
+                print("append",param_name, param_value)
+
 
 # ---------------------------------------------------------------------------
 # Dispatch table for special migration functions
@@ -1331,6 +1358,7 @@ SPECIAL_FUNCTIONS = {
     "satellite_bound_mass_initializor": satellite_bound_mass_initializor,
     "disk_very_simple_analytic_solver": disk_very_simple_analytic_solver,
     "satellite_orbit_initializor": satellite_orbit_initializor,
+    "johnson2021_correlated_branches": johnson2021_correlated_branches,
 }
 
 


### PR DESCRIPTION
## Summary
- Pin `darkMatterProfileScaleRadius[@value='johnson2021']` sub-parameters to values matching behavior prior to the addition of correlated scale radii along branches, so older parameter files retain their original results after migration.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- 

## Checklist
- [x] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'
