### PR TITLE
fix: correct per-module physics links on the docs modules page

### DIFF
--- a/scripts/doc/extractDocsRST.py
+++ b/scripts/doc/extractDocsRST.py
@@ -218,8 +218,8 @@ def scan_source(source_dir: str):
       ``functionClass``.
     * ``implementations``: ``{family: [{name, description, file}, …]}`` keyed by
       the root element name.
-    * ``params_by_file``: ``{file_base: [{name, default, description}, …]}``.
-    * ``methods_by_file``: ``{file_base: [{name, description}, …]}`` — the
+    * ``params_by_file``: ``{file_path: [{name, default, description}, …]}``.
+    * ``methods_by_file``: ``{file_path: [{name, description}, …]}`` — the
       type-bound methods declared in that file's ``<methods>`` block(s).
     * ``modules``: ``[{name, file, description, classRef}, …]`` — one per
       documented module (``classRef`` links class modules to their page).
@@ -239,8 +239,13 @@ def scan_source(source_dir: str):
             if not fn.endswith('.F90') or fn.startswith('.#'):
                 continue
             base = os.path.splitext(fn)[0]
-            with open(os.path.join(root, fn), encoding='utf-8',
-                      errors='replace') as fh:
+            # Use the full path (not ``base``) as the per-file key: every
+            # pluggable physics class lives in a file literally named
+            # ``_class.F90`` (in a per-class directory), so ``base`` collides
+            # across all 267 of them.  Keying on the path keeps each file's
+            # class/parameter/method docs distinct.
+            path = os.path.join(root, fn)
+            with open(path, encoding='utf-8', errors='replace') as fh:
                 text = fh.read()
             mmod = re.search(r'(?im)^[ \t]*module[ \t]+([a-z0-9_]+)[ \t]*$', text)
             module_name = mmod.group(1) if mmod else base
@@ -250,11 +255,11 @@ def scan_source(source_dir: str):
                 md = re.match(r'\s*!!\{RST\b(.*?)!!\}',
                               text[mmod.end():mmod.end() + 800], re.DOTALL)
                 if md and md.group(1).strip():
-                    modules.append({'name': module_name, 'file': base,
+                    modules.append({'name': module_name, 'file': path,
                                     'description': md.group(1).strip()})
             tmeths = _extract_type_methods(text)
             if tmeths:
-                methods_by_file[base] = tmeths
+                methods_by_file[path] = tmeths
             for bm in _BLOCK_RE.finditer(text):
                 block = bm.group(1)
                 if 'docformat="rst"' not in block:
@@ -272,7 +277,7 @@ def scan_source(source_dir: str):
                     if not name:
                         continue
                     pdesc = _DESC_RE.search(pbody)
-                    params_by_file.setdefault(base, []).append({
+                    params_by_file.setdefault(path, []).append({
                         'name':        name,
                         'default':     _child(pbody, 'defaultValue'),
                         'description': pdesc.group(1) if pdesc else None,
@@ -292,7 +297,7 @@ def scan_source(source_dir: str):
                                          'url':  _attr(s, 'url')}
                                         for s in re.findall(
                                             r'<seeAlso\b([^>]*?)/?>', wbody)],
-                        'file':        base,
+                        'file':        path,
                     })
 
                 # Container / root directive (one per block): functionClass,
@@ -317,7 +322,7 @@ def scan_source(source_dir: str):
                         'default':         _child(block, 'default'),
                         'methods':         _extract_methods(block),
                     }
-                    class_by_file[base] = name
+                    class_by_file[path] = name
                 elif rtype == 'enumeration':
                     name = _child(block, 'name')
                     if not name:
@@ -335,7 +340,7 @@ def scan_source(source_dir: str):
                     by_root.setdefault(rtype, []).append({
                         'name':        name,
                         'description': desc_raw,
-                        'file':        base,
+                        'file':        path,
                     })
 
     implementations = {fam: by_root[fam] for fam in by_root if fam in families}


### PR DESCRIPTION
## Problem

On the [modules page](https://galacticus.readthedocs.io/en/latest/modules.html), every physics-implementing module linked to the **same** physics page (`cosmologyFunctions`) regardless of the module.

## Cause

The docs are generated at build time by `scripts/doc/extractDocsRST.py` (run on Read the Docs via `.readthedocs.yaml`). In `scan_source()`, each source file was keyed by its **base filename**.

Every pluggable physics `functionClass` lives in a file literally named `_class.F90` inside a per-class directory (e.g. `source/cosmology/functions/_class.F90`) — 267 of them. So the base filename was `"_class"` for all of them, and they collided under a single key in `class_by_file`: each `functionClass` overwrote the previous, so every module resolved to whichever `_class.F90` was scanned last (on RTD, `cosmologyFunctions`).

The same collision also silently cross-contaminated parameter docs (`params_by_file`) and type-method docs (`methods_by_file`).

## Fix

Key each file by its full path instead of the base filename, and store that path as each module/implementation's `file` identifier. One targeted change in `scan_source()`.

## Verification

Regenerating the docs:

- **Before:** 186 physics links, only **3 distinct** targets (all collapsed).
- **After:** 186 physics links, **186 distinct** targets — one per module.
- **Zero dangling references** — every `physics-<name>` link resolves to an actual anchor.
- Spot-checks correct: `Cosmology_Functions` → `physics-cosmologyFunctions`, `Cooling_Rates` → `physics-coolingRate`, `Star_Formation_Rates_Disks` → `physics-starFormationRateDisks`.

The generated `docs/*.rst` files are gitignored build artifacts (regenerated on every RTD build), so no committed files need updating — the script change alone fixes the live docs on the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)