### PR TITLE
fix: render citations in the constants documentation page

### DIFF
--- a/scripts/doc/extractDocsRST.py
+++ b/scripts/doc/extractDocsRST.py
@@ -676,8 +676,14 @@ def render_constants(constants: list[dict], glsmap: dict) -> str:
             if c.get('gslSymbol'):
                 extras.append(f'value from GSL ``{c["gslSymbol"]}``')
             if c.get('reference'):
-                extras.append(f'`{c["reference"]} <{c["referenceURL"]}>`_'
-                              if c.get('referenceURL') else c['reference'])
+                # References are LaTeX — often a bare ``\cite{…}`` — so convert
+                # them, except when they label an explicit URL (then the text is
+                # the link text and must stay literal).
+                extras.append(
+                    f'`{c["reference"]} <{c["referenceURL"]}>`_'
+                    if c.get('referenceURL') else
+                    re.sub(r'\s*\n\s*', ' ',
+                           latex_to_rst(c['reference'], glsmap)).strip())
             if c.get('externalDescription'):
                 extras.append(f'`more <{c["externalDescription"]}>`_')
             body = (desc or '—') + ('\n\n' + '; '.join(extras) if extras else '')


### PR DESCRIPTION
## Problem

On the generated `constants.html` page, citations rendered as literal text, e.g. `cite{cyburt_update_2008}`, instead of as linked citations.

## Cause

In `render_constants` (`scripts/doc/extractDocsRST.py`), the `reference` attribute of `<constant>` source directives was emitted into RST verbatim. Values such as `\cite{cyburt_update_2008}` are LaTeX, and in RST a backslash before a letter is simply an escape character — so the backslash was consumed and the rest appeared as plain text.

Every other description-like field in the extractor already goes through `latex_to_rst`, which maps natbib `\cite*` commands to `sphinxcontrib-bibtex` roles; this one field was missed.

## Fix

Pass `reference` through `latex_to_rst`, except when a `referenceURL` is present — there the reference text is the hyperlink label and must stay literal (e.g. `` `NIST <https://…>`_ ``). None of the `\cite`-bearing constants carry a `referenceURL`, so URL-labelled references are unchanged.

## Result

Rendered output for the affected constants is now:

```
   :cite:t:`cyburt_update_2008`
   :cite:t:`jackson_classical_1999`; `more <https://en.wikipedia.org/wiki/Erg>`_
   :cite:t:`oke_secondary_1983`; `more <https://en.wikipedia.org/wiki/AB_magnitude>`_
```

All three keys resolve in `docs/Galacticus.bib`, so the citations link correctly. Since `references.rst` uses `:filter: cited`, these three works are now also added to the References page — which is the intended behavior.

## Testing

Ran the extractor directly and inspected the generated `constants.rst`; verified the citation keys exist in the bibliography. A full Sphinx build was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)