### PR TITLE
ci: pin MacOS builds to the versioned gcc@16 formula

### DIFF
--- a/.github/actions/buildMacOS/action.yml
+++ b/.github/actions/buildMacOS/action.yml
@@ -67,12 +67,32 @@ runs:
         # `brew update`. Remove the unused tap to keep CI logs clean. The `|| true`
         # guards against runner images that don't ship the tap.
         brew untap aws/tap 2>/dev/null || true
-        # Refresh the formula index first: the runner image ships an older
-        # `gcc` (e.g. 15.2.0) and a stale tap that reports it as current, so a
-        # bare `brew install gcc` is a no-op and no `gcc-16` binary appears.
+        # Refresh the formula index first so the versioned `gcc@16` formula and
+        # its current bottle are visible to the install below.
         brew update
-        brew install gcc
-        brew upgrade gcc
+        # Install GCC 16 via the versioned `gcc@16` formula rather than the
+        # unversioned `gcc`. The unversioned formula tracks whatever Homebrew
+        # calls latest, so when it eventually moves to GCC 17 a bare
+        # `brew install gcc` would stop providing the `gcc-16` binary that
+        # CCOMPILER expects; `gcc@16` pins us deterministically until we choose
+        # to bump. Guard the commands so the common already-current case stays
+        # silent instead of emitting a "gcc@16 <version> already installed"
+        # warning on every build: install only when absent, upgrade only when
+        # actually outdated.
+        if ! brew list --versions gcc@16 >/dev/null 2>&1; then
+          brew install gcc@16
+        elif [[ -n "$(brew outdated gcc@16)" ]]; then
+          brew upgrade gcc@16
+        fi
+        # The runner image pre-installs the unversioned `gcc` formula, which
+        # (while it is still GCC 16) provides the same `gcc-16`/`g++-16`/
+        # `gfortran-16` symlinks as `gcc@16` and would collide with them. Unlink
+        # it (no-op once Homebrew's `gcc` moves to 17 and stops owning `*-16`,
+        # or if the image ever drops it) and force `gcc@16` to own the links so
+        # the `*-16` binaries CCOMPILER/FCCOMPILER/CPPCOMPILER expect resolve to
+        # the pinned toolchain.
+        brew unlink gcc 2>/dev/null || true
+        brew link --overwrite gcc@16
     - name: Install guile
       shell: bash
       run: |


### PR DESCRIPTION
## Motivation

The MacOS build jobs emit a `gcc 16.1.0 already installed` warning on every run. The `Install GCC 16` step in `.github/actions/buildMacOS/action.yml` ran:

```bash
brew install gcc
brew upgrade gcc
```

unconditionally. When the runner image already ships the current gcc (16.1.0), each of those commands warns that it is already installed — the `brew upgrade` in particular is redundant belt-and-suspenders.

## Changes

**Quiet the warning.** Install only when `gcc@16` is absent, and upgrade only when `brew outdated` reports it actually stale, so the common already-current case runs nothing and stays silent.

**Pin to `gcc@16`.** The unversioned `gcc` formula tracks whatever Homebrew calls latest. Once Homebrew moves to GCC 17, `brew install gcc` would stop providing the `gcc-16` / `g++-16` / `gfortran-16` binaries that `CCOMPILER` / `CPPCOMPILER` / `FCCOMPILER` (lines 16-18 of the action) reference by name, silently breaking the MacOS builds. The versioned formula keeps the toolchain deterministic until we deliberately bump it.

**Resolve the symlink collision.** The runner image pre-installs the unversioned `gcc`, and while it is still GCC 16 it owns the same `*-16` symlinks that `gcc@16` provides. Left alone, installing `gcc@16` on top would collide on those links, re-introducing "Could not symlink" warnings and leaving `gcc@16` unlinked. The step now unlinks the unversioned formula and force-links `gcc@16` so the versioned binaries resolve to the pinned toolchain. Once Homebrew's `gcc` moves to 17 it no longer owns `*-16`, so the unlink becomes a harmless no-op.

Affects all three MacOS jobs that consume this composite action: `Build-Executable-MacOS`, `Build-Executable-MacOS-M1`, and `Build-Library-MacOS`.

## Verification

Not reproducible locally — the warning and the Homebrew linking behavior only manifest on GitHub's MacOS runner images, so this needs the CI run on this PR to confirm. Two things worth watching in the MacOS job logs:

- The `gcc ... already installed` warning should be gone from the `Install GCC 16` step.
- `brew link --overwrite gcc@16` is intentionally left unguarded (no `|| true`) so a genuinely missing `gcc-16` fails loudly rather than silently. If it turns out to error on an already-linked state under Actions' `set -eo pipefail`, it will need a guard.

Note this is a "pin until deliberately bumped" strategy: Homebrew does eventually remove very old `gcc@N` formulae from core, so a future move to GCC 17 means bumping `gcc@16` here and the three `*-16` variables at lines 16-18 together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)