### PR TITLE
docs: document that commit hashes must be preserved for parameter migrations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,10 @@ When your changes are ready:
 
 5. **Respond to code review** - A maintainer will review your PR and may request changes. This is normal and helps maintain code quality!
 
+6. **Merging** - Pull requests are merged with a **merge commit**; we do not squash-merge or rebase-merge. This preserves commit hashes, which is a correctness requirement rather than a style preference: parameter file migrations in `scripts/aux/migrations.xml` are keyed by the hash of the commit that introduced each change, and a migration whose hash is absent from the history is *silently skipped*. See [Merging pull requests](https://galacticus.readthedocs.io/en/latest/manuals/developer-guide/continuous-integration.html#merging-pull-requests).
+
+   For the same reason, if you **rebase or amend** a branch that adds an entry to `migrations.xml`, update that entry's `commit` attribute to the new hash before pushing, and re-run the migration on a representative parameter file to confirm the expected `Updating to revision <hash>` line still appears.
+
 ## Contributor Attribution
 
 We use inline markers to track who contributed to each part of the code. This is automatically extracted to generate contributor lists.

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -735,6 +735,37 @@ The generated code gathers the names of all parameters that the object (includin
 ``extraAllowedNames``
    *(optional)* A space-separated list of additional parameter names which should be considered valid even though no ``inputParameter`` or ``objectBuilder`` directive reads them (e.g. parameters read indirectly by other means).
 
+.. _manual-sec-parameterMigrations:
+
+Parameter File Migrations
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a change to Galacticus alters the name, location, or meaning of an input parameter, a *migration* should be added so that existing parameter files continue to describe the same model. Migrations live in ``scripts/aux/migrations.xml`` and are applied by ``scripts/aux/parametersMigrate.py`` (see :galacticus-ref:`migratingParameterFiles` for how users run it).
+
+Each migration is keyed by the **full 40-character hash of the commit that introduced the change**:
+
+.. code-block:: xml
+
+   <migration commit="938122648f2740d19a67598157de78201a17e4b7">
+     <translation function="chandrasekhar_suppress_extended_mass"/>
+   </migration>
+
+A translation may either rewrite the parameter file declaratively, via an ``xpath`` attribute naming the elements to act on together with an action element (for example ``<remove/>``), or dispatch to a named Python function in ``parametersMigrate.py`` (registered in that script's ``SPECIAL_FUNCTIONS`` table) when the transformation is too involved to express as an XPath rewrite.
+
+.. warning::
+
+   **Commit hashes in** ``migrations.xml`` **must remain valid for the lifetime of the repository.**
+
+   To decide which migrations to apply, ``parametersMigrate.py`` walks the git ancestry between the parameter file's recorded ``lastModified`` revision and the current ``HEAD``, and matches each commit in that ancestry against the ``commit`` attributes in ``migrations.xml`` **by exact string equality**. A hash which is not present in the history therefore matches nothing: the migration is *silently skipped*. There is no error and no warning — parameter files simply fail to migrate, and models built from them quietly change behaviour.
+
+   The practical consequences are:
+
+   * Any operation which rewrites commit hashes (``git rebase``, ``git commit --amend``, or a squash merge) invalidates every ``migrations.xml`` entry that refers to a rewritten commit. If you rebase a branch that adds a migration, update the ``commit`` attribute to the new hash before pushing.
+   * A migration must never refer to the commit that contains it, since amending that commit to insert its own hash would change the hash again. Add the migration in a *later* commit than the change it migrates.
+   * For the same reason, pull requests which add migrations must be merged in a way that preserves commit hashes — see :galacticus-ref:`mergingPullRequests`.
+
+   After rebasing such a branch, confirm the hash is still reachable (``git cat-file -e <hash>`` succeeds *and* ``git branch --contains <hash>`` lists a branch), and re-run the migration on a representative parameter file to check that the expected ``Updating to revision <hash>`` line still appears.
+
 .. _manual-sec-functionClass:
 
 Function Classes

--- a/docs/manuals/developer-guide/continuous-integration.rst
+++ b/docs/manuals/developer-guide/continuous-integration.rst
@@ -131,3 +131,24 @@ tests; if your change touches the model, run the relevant ``testSuite/test-*.py`
 script(s) too. See the repository's `CONTRIBUTING.md
 <https://github.com/galacticusorg/galacticus/blob/master/CONTRIBUTING.md>`_ for
 the full checklist.
+
+.. _manual-sec-mergingPullRequests:
+
+Merging pull requests
+---------------------
+
+Pull requests are merged with a **merge commit**. Do not squash-merge or
+rebase-merge them.
+
+This is not merely a matter of taste in history: parameter file migrations
+(:galacticus-ref:`parameterMigrations`) are keyed by the full hash of the commit
+that introduced each change, and ``parametersMigrate.py`` matches those hashes
+against the repository's git ancestry by exact string equality. Squash- and
+rebase-merging both rewrite commit hashes, which would leave every affected
+``migrations.xml`` entry pointing at a commit that no longer exists in the
+history. Such a migration matches nothing and is silently skipped — no error is
+raised, and parameter files quietly stop migrating correctly.
+
+Preserving commit hashes on merge is therefore a correctness requirement, and
+applies to every pull request, since a later branch may add a migration keyed to
+a commit merged earlier.

--- a/docs/manuals/user-guide/troubleshooting/index.rst
+++ b/docs/manuals/user-guide/troubleshooting/index.rst
@@ -25,6 +25,8 @@ If you see a message similar to:
 
 this indicates that the named parameter, ``neutrinoMassSum`` in this case, was not recognized as a valid parameter name. Galacticus tells you where in your parameter file this parameter can be found (inside the ``parameters/transferFunction/`` section in this case), and also suggests what it thinks you might have intended - in this case the parameter name you probably wanted was ``neutrinoMassSummed``. If you correct the name of the variable, the warning message will no longer appear.
 
+.. _manual-sec-migratingParameterFiles:
+
 Migrating parameter files to new versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary

Records, in the developer guide and `CONTRIBUTING.md`, that commit hashes must be preserved when merging — and why that is a correctness requirement rather than a stylistic preference.

## The constraint

Parameter file migrations in `scripts/aux/migrations.xml` are keyed by the full hash of the commit that introduced each change:

```xml
<migration commit="938122648f2740d19a67598157de78201a17e4b7">
  <translation function="chandrasekhar_suppress_extended_mass"/>
</migration>
```

To decide which migrations to apply, `parametersMigrate.py` walks the git ancestry between a parameter file's recorded `lastModified` revision and `HEAD`, and matches each commit against those `commit` attributes **by exact string equality**.

A hash that is absent from the history therefore matches nothing, and the migration is **silently skipped** — no error, no warning. Parameter files simply stop migrating, and models built from them quietly change behaviour. This is a difficult failure to notice and an even harder one to attribute after the fact.

Consequently:

- Squash-merging or rebase-merging a pull request that adds a migration breaks that migration.
- Rebasing or amending such a branch breaks it too, unless the `commit` attribute is updated to the new hash.
- A migration can never refer to the commit that contains it, since amending that commit to insert its own hash would change the hash again.

None of this was written down anywhere.

## Changes

- **Developer guide, `coding.rst`** — a new "Parameter File Migrations" section describing how migrations are keyed and dispatched (XPath rewrite vs. dispatch to a registered Python function), with a warning covering the hash stability requirement, the self-reference rule, and how to verify a hash survived a rebase.
- **Developer guide, `continuous-integration.rst`** — a new "Merging pull requests" section recording the merge-commit policy and its rationale.
- **`CONTRIBUTING.md`** — a corresponding item under "Submitting a Pull Request", including the recovery procedure after rebasing a branch that adds a migration.
- **User guide, `troubleshooting/index.rst`** — a cross-reference label on the existing section describing how to run the migration script (no content change).

## Motivation

This came out of preparing #1283, where rebasing the branch onto current `master` orphaned the hash its migration referred to. The migration became dead code that would have merged without any complaint from CI or the pre-commit hooks.

## Verification

Documentation only; no code changes. The docs were built locally with Sphinx 8.1.3 and the extensions from `docs/requirements.txt`:

```
build succeeded, 220 warnings.
```

None of those warnings are attributable to this change. The eight warnings reported against `coding.rst` are pre-existing `term not in glossary` hits (lines 224, 814, 1315, 1321), all outside the section added here.

The warning count is not by itself sufficient evidence, because the custom `galacticus-ref` role in `docs/conf.py` sets `refwarn=False` and falls back to `return contnode` — so a cross-reference that fails to resolve renders as plain text and emits **no warning at all**. (That is the same silent-failure shape as the migration behaviour this PR documents.) The rendered HTML was therefore checked directly, and all three cross-references resolve to real anchors:

```html
<a class="reference internal" href="../user-guide/troubleshooting/index.html#manual-sec-migratingparameterfiles" …>
<a class="reference internal" href="continuous-integration.html#manual-sec-mergingpullrequests" …>
<a class="reference internal" href="coding.html#manual-sec-parametermigrations" …>
```

Each corresponding `id=` was confirmed present in the generated pages, so the references work in both directions.

Section underline lengths were also checked across all touched files (no problems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
