### PR TITLE
fix(hotHalo): avoid a spurious 0/0 when outflowing gas contains no hydrogen

### DIFF
--- a/source/objects/nodes/components/hot_halo/standard/_class.F90
+++ b/source/objects/nodes/components/hot_halo/standard/_class.F90
@@ -648,9 +648,18 @@ contains
           call radiation%timeSet(basic%time())
           ! Get the chemical densities.
           call chemicalState_%chemicalDensities(chemicalDensities,numberDensityHydrogen,temperature,outflowedAbundances,radiation)
-          ! Convert from densities to mass rates.
-          call chemicalDensities  %numberToMass(chemicalMassesRates                                         )
-          call chemicalMassesRates%scale       (rate*hydrogenByMass/numberDensityHydrogen/atomicMassHydrogen)
+          ! Convert from densities to mass rates. The scaling factor is, algebraically,
+          !  rate*hydrogenByMass/numberDensityHydrogen/atomicMassHydrogen,
+          ! but substituting the definition of numberDensityHydrogen above shows that both
+          ! hydrogenByMass and atomicMassHydrogen cancel exactly, leaving the form used here. Written
+          ! in the original form the expression evaluates to 0/0 (raising a floating point exception,
+          ! and giving a NaN if exceptions are not trapped) whenever the outflowing gas contains no
+          ! hydrogen, since numberDensityHydrogen is then zero. The equivalent form below has no such
+          ! removable singularity: self%outflowedMass() is guaranteed non-zero by the enclosing
+          ! conditional, and massToDensityConversion is strictly positive for any non-zero outer
+          ! radius (it diverges, rather than vanishing, as that radius tends to zero).
+          call chemicalDensities  %numberToMass(chemicalMassesRates                              )
+          call chemicalMassesRates%scale       (rate/self%outflowedMass()/massToDensityConversion)
           ! Compute the rate at which chemicals are returned to the hot reservoir.
           if (.not.hotHaloOutflowStripping_%neverStripped(node)) &
                &  call self% strippedChemicalsRate(chemicalMassesRates*       fractionOutflowStripped ,interrupt,interruptProcedure)


### PR DESCRIPTION
## Summary

The standard hot halo component could raise a floating point exception (or produce NaN chemical rates, where exceptions are not trapped) when converting outflowed chemical densities to mass rates. The offending division turns out to be a *removable* singularity, so this rewrites the expression in an equivalent form that cannot trap, rather than guarding it.

## The bug

In `Node_Component_Hot_Halo_Standard_Outflowing_Mass_Rate`, the chemical mass rates were scaled by

```fortran
rate*hydrogenByMass/numberDensityHydrogen/atomicMassHydrogen
```

with `numberDensityHydrogen` defined ten lines earlier as

```fortran
numberDensityHydrogen = hydrogenByMass*self%outflowedMass()*massToDensityConversion/atomicMassHydrogen
```

Substituting the second into the first, **both `hydrogenByMass` and `atomicMassHydrogen` cancel exactly**:

```
rate·hbm / (hbm·outflowedMass·conv/amu) / amu  ≡  rate / (outflowedMass · conv)
```

So the original expression manufactures a zero and then divides by it. When the outflowing gas contains no hydrogen, `hydrogenByMass` is zero, `numberDensityHydrogen` is zero, and the scale factor evaluates as `0/0`.

## The fix

Use the equivalent form. No guard, no special case, and no question about what the rates "should" be in the degenerate case — the degenerate expression is simply never evaluated.

The denominator was checked rather than assumed to be safe:

- the enclosing conditional already guarantees `rate /= 0` and `self%outflowedMass() > 0`;
- `Chemicals_Mass_To_Density_Conversion` is `3·Msun/amu/(4π(100·Mpc·r)³)`, strictly positive, and **diverges** as `r → 0` rather than vanishing, so it cannot introduce a zero denominator.

A zero hydrogen mass fraction was therefore the only route to the exception, and it is now closed.

`hydrogenByMass` and `numberDensityHydrogen` remain live — both are still required for the `chemicalState_%chemicalDensities` call — so nothing becomes unused.

## Why not simply guard the division?

An earlier version of this fix (used as a local patch while bisecting an unrelated regression) skipped the `scale` call when `numberDensityHydrogen` was below a tiny threshold. That works only because `chemicalDensities` happens to be zero whenever `numberDensityHydrogen` is zero, leaving the unscaled rates at zero by luck. That is an upstream invariant which was never verified and which nothing enforces. Removing the singularity avoids depending on it.

## Verification

- Builds cleanly.
- `parameters/quickTest.xml` runs to completion (6 trees, no exception).

**Not directly demonstrated:** the original exception has not been reproduced in a test model, so there is no before/after run showing the fix suppressing it. `quickTest` does not exercise zero-hydrogen outflow. The argument here is algebraic — the substitution above is exact — rather than empirical. Happy to construct a model with a zero hydrogen mass fraction if a regression test is wanted.

## Note on results

The rewritten expression involves one fewer multiplication and division, so results change at the level of floating point rounding. Physically irrelevant, but it may show up in any reference comparison made at very tight tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
