### PR TITLE
clean(satellite): remove the dead acceptUnboundOrbits option from the orbiting component

### DIFF
--- a/source/objects/nodes/components/satellite/orbiting.F90
+++ b/source/objects/nodes/components/satellite/orbiting.F90
@@ -106,9 +106,6 @@ module Node_Component_Satellite_Orbiting
   class(darkMatterHaloScaleClass), pointer :: darkMatterHaloScale_
   !$omp threadprivate(darkMatterHaloScale_)
 
-  ! Option controlling whether or not unbound virial orbits are acceptable.
-  logical :: acceptUnboundOrbits
-
   ! A threadprivate object used to track to which thread events are attached.
   integer :: thread
   !$omp threadprivate(thread)
@@ -122,27 +119,15 @@ contains
     !!{RST
     Initializes the orbiting satellite methods module.
     !!}
-    use :: Galacticus_Nodes  , only : defaultSatelliteComponent, nodeComponentSatelliteOrbiting
-    use :: Input_Parameters  , only : inputParameter           , inputParameters
+    use :: Galacticus_Nodes, only : defaultSatelliteComponent, nodeComponentSatelliteOrbiting
+    use :: Input_Parameters, only : inputParameters
     implicit none
     type(inputParameters               ), intent(inout) :: parameters
     type(nodeComponentSatelliteOrbiting)                :: satellite
-    type(inputParameters               )                :: subParameters
+    !$GLC attributes unused :: parameters
 
     ! Initialize the module if necessary.
     if (defaultSatelliteComponent%orbitingIsActive()) then
-       ! Find our parameters.
-       subParameters=parameters%subParameters('componentSatellite')
-       !![
-       <inputParameter docformat="rst">
-         <name>acceptUnboundOrbits</name>
-         <defaultValue>.false.</defaultValue>
-         <description>
-         If true, accept unbound virial orbits for satellites, otherwise reject them.
-         </description>
-         <source>subParameters</source>
-       </inputParameter>
-       !!]
        ! Specify the function to use for setting virial orbits.
        call satellite%virialOrbitSetFunction(Node_Component_Satellite_Orbiting_Virial_Orbit_Set)
        call satellite%virialOrbitFunction   (Node_Component_Satellite_Orbiting_Virial_Orbit    )


### PR DESCRIPTION
## Summary

Removes a dead `acceptUnboundOrbits` option from the orbiting satellite component. The option was still read from the parameter file, but nothing consulted the value.

## Background

Commit `3148b7292` moved satellite orbit initialization out of the orbiting satellite component and into `nodeOperatorSatelliteOrbit`. That took with it the only code which read this module's copy of the option — the `virialOrbit_%orbit(node,nodeHost,acceptUnboundOrbits)` call — leaving the module variable and its `inputParameter` directive orphaned.

## Verified dead before removal

- The variable appears only **twice** in the module: its declaration, and the directive which writes it. Nothing reads it.
- It is **not in the module's public list**, and the module defaults to `private`.
- **No other source file `use`s this module**, so it cannot be reached externally.
- Every other occurrence of the name in the source tree is unrelated: dummy arguments throughout the `virialOrbit` class hierarchy, local `parameter`s fixed to `.false.`, and the separate, still-live options belonging to `nodeOperatorSatelliteOrbit` and `darkMatterProfileScaleRadiusJohnson2021`. **None of those are touched.**

## No migration required

Checked rather than assumed: the existing migration for `3148b7292` (`satellite_orbit_initializor`) already relocates `acceptUnboundOrbits` from `componentSatellite` to the `satelliteOrbit` node operator, and calls `parent.remove(accept_type)` on the original. Parameter files migrated past that commit therefore no longer set it on the component, so removing the directive cannot orphan a setting in an existing file.

## Knock-on changes

Removing the directive leaves `subParameters` and the `inputParameter` import unused in `Node_Component_Satellite_Orbiting_Initialize`, as well as the `parameters` argument itself, which now carries an unused attribute in the style used elsewhere (e.g. the standard satellite component). The similarly-named `subParameters` usage in `Node_Component_Satellite_Orbiting_Thread_Initialize` belongs to a different routine, is used for building `darkMatterHaloScale`, and is unaffected.

## Verification

- Builds cleanly.
- `parameters/quickTest.xml` runs to completion (6 trees).
- The pre-commit hook confirms the generated parameter schema (`schema/parameters.xsd`) remains up to date, so no schema regeneration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
