### PR TITLE
feat: record complete node evolution trajectories via a new nodeOperator

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1471,7 +1471,8 @@ jobs:
                 test-objectBuilder-recursion.py,
                 test-objectBuilder-recursion-success.py,
                 test-library-interfaces.py,
-                test-merger-tree-read-ties.py ]
+                test-merger-tree-read-ties.py,
+                test-node-trajectory.py ]
     uses: ./.github/workflows/testModel.yml
     with:
       file: ${{ matrix.file }}

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -2407,6 +2407,7 @@
           <xs:enumeration value="nodeMajorMergerTime"/>
           <xs:enumeration value="nuclearStarClusterGrowth"/>
           <xs:enumeration value="null"/>
+          <xs:enumeration value="outputTrajectory"/>
           <xs:enumeration value="positionDiscrete"/>
           <xs:enumeration value="positionInterpolated"/>
           <xs:enumeration value="positionOrphans"/>
@@ -2614,6 +2615,7 @@
           <xs:enumeration value="timeFirstInfall"/>
           <xs:enumeration value="timescaleBarInstability"/>
           <xs:enumeration value="trackOutflowedMass"/>
+          <xs:enumeration value="trajectoryEvent"/>
           <xs:enumeration value="treeWeight"/>
           <xs:enumeration value="tuple"/>
           <xs:enumeration value="uniqueIDBranchTip"/>

--- a/source/merger_trees/outputter/_class.F90
+++ b/source/merger_trees/outputter/_class.F90
@@ -37,10 +37,11 @@ module Merger_Tree_Outputters
    </description>
    <decodeFunction>yes</decodeFunction>
    <visibility>public</visibility>
-   <entry label="tree"     />
-   <entry label="node"     />
-   <entry label="snapshot" />
-   <entry label="lightcone"/>
+   <entry label="tree"      />
+   <entry label="node"      />
+   <entry label="snapshot"  />
+   <entry label="lightcone" />
+   <entry label="trajectory"/>
   </enumeration>
   !!]
 

--- a/source/merger_trees/outputter/standard.F90
+++ b/source/merger_trees/outputter/standard.F90
@@ -283,7 +283,7 @@ contains
              ! Get the basic component.
              basic => node%basic()
              ! Perform our output for nodes at the output time.
-             if (basic%time() == time) call self%output(node,indexOutput,time)
+             if (basic%time() == time) call self%output(node,indexOutput,time,outputType_)
           end do
           ! Finished output.
           if     (                                                                     &
@@ -372,7 +372,7 @@ contains
     self%integerPropertiesWritten=0
     self%doublePropertiesWritten =0
     ! Perform our output.
-    call self%output(node,indexOutput,basic%time())
+    call self%output(node,indexOutput,basic%time(),outputType_)
     ! Finished output.
     if     (                                                                     &
          &   (                                                                   &
@@ -389,7 +389,7 @@ contains
     return
   end subroutine standardOutputNode
 
-  subroutine standardOutput(self,node,indexOutput,time)
+  subroutine standardOutput(self,node,indexOutput,time,outputType)
     !!{RST
     Output the provided node.
     !!}
@@ -400,23 +400,24 @@ contains
          &                                  nodePropertyExtractorArray, nodePropertyExtractorList, nodePropertyExtractorList2D       , nodePropertyExtractorIntegerList
     use :: Poly_Ranks              , only : polyRankInteger           , polyRankDouble           , assignment(=)
     implicit none
-    class           (mergerTreeOutputterStandard), intent(inout)                   :: self
-    type            (treeNode                   ), intent(inout)                   :: node
-    integer         (c_size_t                   ), intent(in   )                   :: indexOutput
-    double precision                             , intent(in   )                   :: time
-    integer         (kind_int8                  ), allocatable  , dimension(:    ) :: integerTuple
-    double precision                             , allocatable  , dimension(:    ) :: doubleTuple
-    integer         (kind_int8                  ), allocatable  , dimension(:,:  ) :: integerArray
-    double precision                             , allocatable  , dimension(:,:  ) :: doubleArray
-    double precision                             , allocatable  , dimension(:,:,:) :: doubleArray2D
-    type            (polyRankInteger            ), allocatable  , dimension(:    ) :: integerProperties
-    type            (polyRankDouble             ), allocatable  , dimension(:    ) :: doubleProperties
-    integer                                      , allocatable  , dimension(:    ) :: doubleRanks      , integerRanks
-    integer         (c_size_t                   ), allocatable  , dimension(:    ) :: shape_
-    integer                                                                        :: doubleProperty   , integerProperty, &
-         &                                                                            i
-    logical                                                                        :: nodePassesFilter
-    type            (multiCounter               )                                  :: instance
+    class           (mergerTreeOutputterStandard   ), intent(inout)                   :: self
+    type            (treeNode                      ), intent(inout)                   :: node
+    integer         (c_size_t                      ), intent(in   )                   :: indexOutput
+    double precision                                , intent(in   )                   :: time
+    type            (enumerationOutputGroupTypeType), intent(in   )                   :: outputType
+    integer         (kind_int8                     ), allocatable  , dimension(:    ) :: integerTuple
+    double precision                                , allocatable  , dimension(:    ) :: doubleTuple
+    integer         (kind_int8                     ), allocatable  , dimension(:,:  ) :: integerArray
+    double precision                                , allocatable  , dimension(:,:  ) :: doubleArray
+    double precision                                , allocatable  , dimension(:,:,:) :: doubleArray2D
+    type            (polyRankInteger               ), allocatable  , dimension(:    ) :: integerProperties
+    type            (polyRankDouble                ), allocatable  , dimension(:    ) :: doubleProperties
+    integer                                         , allocatable  , dimension(:    ) :: doubleRanks      , integerRanks
+    integer         (c_size_t                      ), allocatable  , dimension(:    ) :: shape_
+    integer                                                                           :: doubleProperty   , integerProperty, &
+         &                                                                               i
+    logical                                                                           :: nodePassesFilter
+    type            (multiCounter                  )                                  :: instance
 
     ! Reset calculations (necessary in case the last node to be evolved is the first one we output, in which case
     ! calculations would not be automatically reset because the node unique ID will not have changed).
@@ -681,11 +682,15 @@ contains
           if (self% doubleBufferCount == self% doubleBufferSize) call self%extendDoubleBuffer ()
        end do
     end if
-    ! Perform any extra output tasks.
+    ! Perform any extra output tasks. These are skipped for trajectory output. Subscribers to this event hook (e.g. the standard
+    ! disk, spheroid, and nuclear star cluster components) *modify* the state of the node - specifically, they advance the star
+    ! formation history to the next output. Since trajectory output occurs during differential evolution (and many times per node)
+    ! allowing that to happen would corrupt the star formation histories and inject spurious data into the regular outputs.
+    if (outputType == outputGroupTypeTrajectory) return
     !![
     <eventHook name="mergerTreeExtraOutput">
       <callWith>node,indexOutput,node%hostTree,nodePassesFilter,treeLock</callWith>
-    </eventHook>  
+    </eventHook>
     !!]
     return
   end subroutine standardOutput
@@ -1288,11 +1293,16 @@ contains
     !$ call hdf5Access%unset()
     ! Create the group if it has not been created.
     if (.not.self%outputGroups(indexOutput)%opened) then
-       ! Create a name for the group.
-       groupName='Output'
-       groupName=groupName//indexOutput
-       ! Create a comment for the group.
-       description='Data for output number '
+       ! Create a name and comment for the group. Trajectory output groups accumulate records for a single node over many times, so
+       ! are named accordingly (and, below, are not given the time-related attributes which would be meaningless in that case).
+       if (outputType == outputGroupTypeTrajectory) then
+          groupName  ='Trajectory'
+          description='Trajectory data for tracked node number '
+       else
+          groupName  ='Output'
+          description='Data for output number '
+       end if
+       groupName  =groupName  //indexOutput
        description=description//indexOutput
        ! Create a group for the tree.
        !$ call hdf5Access%set()
@@ -1303,20 +1313,27 @@ contains
        self%outputGroups(indexOutput)%doubleAttributesWritten =.false.
        ! Record the "type" of output for this group.
        call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(enumerationOutputGroupTypeDecode(outputType,includePrefix=.false.),'outputType')
-       ! Add the time to this group.
-       expansionFactor    =+self%cosmologyFunctions_%expansionFactor (time)
-       if (expansionFactor > 1.0d0) then
-          distanceComoving=-1.0d0
-       else if (expansionFactor == 1.0d0) then
-          distanceComoving=+0.0d0
+       ! Add the time to this group. For trajectory output the group accumulates records spanning a range of times, so a single
+       ! time attribute would be meaningless - the time of each record is instead available on a per-record basis via the
+       ! `nodePropertyExtractorTime` property extractor.
+       if (outputType == outputGroupTypeTrajectory) then
+          call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(gigaYear        ,'timeUnitInSI'          )
+          call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(megaParsec      ,'distanceUnitInSI'      )
        else
-          distanceComoving=+self%cosmologyFunctions_%distanceComoving(time)
+          expansionFactor    =+self%cosmologyFunctions_%expansionFactor (time)
+          if (expansionFactor > 1.0d0) then
+             distanceComoving=-1.0d0
+          else if (expansionFactor == 1.0d0) then
+             distanceComoving=+0.0d0
+          else
+             distanceComoving=+self%cosmologyFunctions_%distanceComoving(time)
+          end if
+          call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(time            ,'outputTime'            )
+          call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(gigaYear        ,'timeUnitInSI'          )
+          call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(megaParsec      ,'distanceUnitInSI'      )
+          call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(expansionFactor ,'outputExpansionFactor' )
+          call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(distanceComoving,'outputComovingDistance')
        end if
-       call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(time            ,'outputTime'            )
-       call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(gigaYear        ,'timeUnitInSI'          )
-       call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(megaParsec      ,'distanceUnitInSI'      )
-       call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(expansionFactor ,'outputExpansionFactor' )
-       call self%outputGroups(indexOutput)%hdf5Group%writeAttribute(distanceComoving,'outputComovingDistance')
        !$ call hdf5Access%unset()
     end if
     return

--- a/source/merger_trees/outputter/utilities.F90
+++ b/source/merger_trees/outputter/utilities.F90
@@ -1,0 +1,239 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{RST
+Contains a module of globally-accessible functions supporting the :galacticus-class:`mergerTreeOutputterClass` class.
+!!}
+
+module Merger_Tree_Outputters_Utilities
+  !!{RST
+  Provides globally-accessible functions supporting the :galacticus-class:`mergerTreeOutputterClass` class.
+
+  These exist so that a class may own a :galacticus-class:`mergerTreeOutputterClass` object without its module having to
+  ``use`` the ``Merger_Tree_Outputters`` module. That matters because ``Merger_Tree_Outputters`` itself (transitively, via
+  :galacticus-class:`mergerTreeOutputterFullState`) depends on ``Merger_Tree_Construction``, which in turn depends on
+  ``Nodes_Operators``. A :galacticus-class:`nodeOperatorClass` which named the outputter class directly would therefore close a
+  circular dependency between those modules; routing the accesses through these globally-callable functions avoids that.
+  !!}
+  private
+  public :: mergerTreeOutputterConstruct       , mergerTreeOutputterDestruct        , &
+       &    mergerTreeOutputterDeepCopy        , mergerTreeOutputterDeepCopyReset   , &
+       &    mergerTreeOutputterDeepCopyFinalize, mergerTreeOutputterOutputTrajectory
+
+  ! Module-scope pointer to our outputter object. This is used for reference counting so that debugging information is consistent
+  ! between the increments and decrements.
+  class(*), pointer :: mergerTreeOutputter__
+  !$omp threadprivate(mergerTreeOutputter__)
+
+contains
+
+  !![
+  <functionGlobal>
+   <unitName>mergerTreeOutputterConstruct</unitName>
+   <type>void</type>
+   <module>Input_Parameters, only : inputParameters</module>
+   <arguments>type (inputParameters), intent(inout), target  :: parameters          </arguments>
+   <arguments>class(*              ), intent(  out), pointer :: mergerTreeOutputter_</arguments>
+  </functionGlobal>
+  !!]
+  subroutine mergerTreeOutputterConstruct(parameters,mergerTreeOutputter_)
+    !!{RST
+    Build a ``mergerTreeOutputter`` object from a given parameter set. This is a globally-callable function to allow us to subvert
+    the class/module hierarchy.
+
+    Note that, unlike some similar functions, we do *not* search parent parameter sets for a ``mergerTreeOutputter`` definition.
+    Doing so would cause a caller which failed to specify its own outputter to silently acquire the outputter used for regular
+    outputs---and so to write its data into the regular ``Outputs`` group. Instead, if no outputter is specified, a default
+    outputter writing to the ``nodeTrajectories`` group is constructed.
+    !!}
+    use :: Error             , only : Error_Report
+    use :: Input_Parameters  , only : inputParameter          , inputParameters
+    use :: ISO_Varying_String, only : varying_string          , var_str
+    use :: Merger_Tree_Outputters, only : mergerTreeOutputterClass, mergerTreeOutputter
+    implicit none
+    type (inputParameters), intent(inout), target  :: parameters
+    class(*              ), intent(  out), pointer :: mergerTreeOutputter_
+    type (inputParameters)                         :: parametersDefault
+    type (varying_string ), dimension(1)           :: allowedParameterName__
+    type (varying_string )                         :: defaultXML__
+
+    if (parameters%isPresent('mergerTreeOutputter')) then
+       mergerTreeOutputter__ => mergerTreeOutputter(parameters       )
+    else
+       defaultXML__             =var_str('<parameters><mergerTreeOutputter value="standard"><outputsGroupName value="nodeTrajectories"/><outputReferences value="false"/><nodePropertyExtractor value="multi"><nodePropertyExtractor value="time"/><nodePropertyExtractor value="indicesTree"/><nodePropertyExtractor value="nodeIndices"/><nodePropertyExtractor value="trajectoryEvent"/></nodePropertyExtractor></mergerTreeOutputter></parameters>')
+       allowedParameterName__(1)=var_str('mergerTreeOutputter')
+       parametersDefault        =inputParameters(defaultXML__,allowedParameterNames=allowedParameterName__,noOutput=.true.)
+       mergerTreeOutputter__ => mergerTreeOutputter(parametersDefault)
+    end if
+    select type (mergerTreeOutputter__)
+    class is (mergerTreeOutputterClass)
+       !![
+       <referenceCountIncrement object="mergerTreeOutputter__"/>
+       !!]
+    class default
+       call Error_Report('unexpected class'//{introspection:location})
+    end select
+    mergerTreeOutputter_ => mergerTreeOutputter__
+    return
+  end subroutine mergerTreeOutputterConstruct
+
+  !![
+  <functionGlobal>
+   <unitName>mergerTreeOutputterOutputTrajectory</unitName>
+   <type>void</type>
+   <module>Galacticus_Nodes, only : treeNode</module>
+   <module>ISO_C_Binding, only : c_size_t</module>
+   <arguments>class  (*       ), intent(inout) :: mergerTreeOutputter_</arguments>
+   <arguments>type   (treeNode), intent(inout) :: node                </arguments>
+   <arguments>integer(c_size_t), intent(in   ) :: indexOutput         </arguments>
+  </functionGlobal>
+  !!]
+  subroutine mergerTreeOutputterOutputTrajectory(mergerTreeOutputter_,node,indexOutput)
+    !!{RST
+    Output a single node as a trajectory record, using a ``mergerTreeOutputter`` object passed to us as an unlimited polymorphic
+    object. The output type is fixed to ``trajectory`` here so that callers need not name the ``outputGroupType`` enumeration
+    (which would reintroduce the module dependency that these functions exist to avoid).
+    !!}
+    use, intrinsic :: ISO_C_Binding         , only : c_size_t
+    use            :: Error                 , only : Error_Report
+    use            :: Galacticus_Nodes      , only : treeNode
+    use            :: Merger_Tree_Outputters, only : mergerTreeOutputterClass, outputGroupTypeTrajectory
+    implicit none
+    class  (*       ), intent(inout) :: mergerTreeOutputter_
+    type   (treeNode), intent(inout) :: node
+    integer(c_size_t), intent(in   ) :: indexOutput
+
+    select type (mergerTreeOutputter_)
+    class is (mergerTreeOutputterClass)
+       call mergerTreeOutputter_%outputNode(node,indexOutput,outputGroupTypeTrajectory)
+    class default
+       call Error_Report('unexpected class'//{introspection:location})
+    end select
+    return
+  end subroutine mergerTreeOutputterOutputTrajectory
+
+  !![
+  <functionGlobal>
+   <unitName>mergerTreeOutputterDestruct</unitName>
+   <type>void</type>
+   <arguments>class(*), intent(inout), pointer :: mergerTreeOutputter_</arguments>
+  </functionGlobal>
+  !!]
+  subroutine mergerTreeOutputterDestruct(mergerTreeOutputter_)
+    !!{RST
+    Destruct a ``mergerTreeOutputter`` object passed to us as an unlimited polymorphic object.
+    !!}
+    use :: Error                 , only : Error_Report
+    use :: Merger_Tree_Outputters, only : mergerTreeOutputterClass
+    implicit none
+    class(*), intent(inout), pointer :: mergerTreeOutputter_
+
+    mergerTreeOutputter__ => mergerTreeOutputter_
+    select type (mergerTreeOutputter__)
+    class is (mergerTreeOutputterClass)
+       !![
+       <objectDestructor name="mergerTreeOutputter__"/>
+       !!]
+    class default
+       call Error_Report('unexpected class'//{introspection:location})
+    end select
+    return
+  end subroutine mergerTreeOutputterDestruct
+
+  !![
+  <functionGlobal>
+   <unitName>mergerTreeOutputterDeepCopyReset</unitName>
+   <type>void</type>
+   <arguments>class(*), intent(inout) :: self</arguments>
+  </functionGlobal>
+  !!]
+  subroutine mergerTreeOutputterDeepCopyReset(self)
+    !!{RST
+    Perform a deep copy reset of a ``mergerTreeOutputter`` object.
+    !!}
+    use :: Error                 , only : Error_Report
+    use :: Merger_Tree_Outputters, only : mergerTreeOutputterClass
+    implicit none
+    class(*), intent(inout) :: self
+
+    select type (self)
+    class is (mergerTreeOutputterClass)
+       call self%deepCopyReset()
+    class default
+       call Error_Report("unexpected class"//{introspection:location})
+    end select
+    return
+  end subroutine mergerTreeOutputterDeepCopyReset
+
+  !![
+  <functionGlobal>
+   <unitName>mergerTreeOutputterDeepCopyFinalize</unitName>
+   <type>void</type>
+   <arguments>class(*), intent(inout) :: self</arguments>
+  </functionGlobal>
+  !!]
+  subroutine mergerTreeOutputterDeepCopyFinalize(self)
+    !!{RST
+    Finalize a deep copy of a ``mergerTreeOutputter`` object.
+    !!}
+    use :: Error                 , only : Error_Report
+    use :: Merger_Tree_Outputters, only : mergerTreeOutputterClass
+    implicit none
+    class(*), intent(inout) :: self
+
+    select type (self)
+    class is (mergerTreeOutputterClass)
+       call self%deepCopyFinalize()
+    class default
+       call Error_Report("unexpected class"//{introspection:location})
+    end select
+    return
+  end subroutine mergerTreeOutputterDeepCopyFinalize
+
+  !![
+  <functionGlobal>
+   <unitName>mergerTreeOutputterDeepCopy</unitName>
+   <type>void</type>
+   <arguments>class(*), intent(inout) :: self, destination</arguments>
+  </functionGlobal>
+  !!]
+  subroutine mergerTreeOutputterDeepCopy(self,destination)
+    !!{RST
+    Perform a deep copy of a ``mergerTreeOutputter`` object.
+    !!}
+    use :: Error                 , only : Error_Report
+    use :: Merger_Tree_Outputters, only : mergerTreeOutputterClass
+    implicit none
+    class(*), intent(inout) :: self, destination
+
+    select type (self)
+    class is (mergerTreeOutputterClass)
+       select type (destination)
+       class is (mergerTreeOutputterClass)
+          call self%deepCopy(destination)
+       class default
+          call Error_Report("unexpected class"//{introspection:location})
+       end select
+    class default
+       call Error_Report("unexpected class"//{introspection:location})
+    end select
+    return
+  end subroutine mergerTreeOutputterDeepCopy
+
+end module Merger_Tree_Outputters_Utilities

--- a/source/nodes/operators/output/trajectory.F90
+++ b/source/nodes/operators/output/trajectory.F90
@@ -1,0 +1,559 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{RST
+  Implements a node operator class that records the complete evolutionary trajectory of selected nodes.
+  !!}
+
+  use            :: Node_Trajectory_Events, only : enumerationNodeTrajectoryEventType
+  use            :: Kind_Numbers          , only : kind_int8
+  use, intrinsic :: ISO_C_Binding         , only : c_size_t
+
+  !![
+  <nodeOperator name="nodeOperatorOutputTrajectory" docformat="rst">
+   <description>
+   A node operator class which records the complete evolutionary trajectory of one or more selected nodes to the Galacticus
+   output file. This is intended as a debugging tool---it makes it possible to inspect how the properties of a specific galaxy
+   evolve *between* the regular output times, without having to add temporary output statements to the code.
+
+   The nodes to follow are specified either by matching pairs of ``[treeIndex]`` and ``[nodeIndex]`` values, or by ``[uniqueID]``
+   values. Note that ``uniqueID`` values are assigned from a global counter which is incremented as nodes are created, and which
+   is strided by MPI rank---consequently they are *not* reproducible between runs which use differing numbers of OpenMP threads
+   or MPI processes, and selection by ``[treeIndex]``/``[nodeIndex]`` should normally be preferred.
+
+   Records are made at whichever of the available events are enabled via the ``[recordNodeInitialize]``,
+   ``[recordDifferentialEvolutionPostStep]``, ``[recordDifferentialEvolutionPost]``, ``[recordNodePromote]``,
+   ``[recordNodesMerge]``, and ``[recordGalaxiesMerge]`` parameters. ``[recordDifferentialEvolutionPostStep]`` records after every
+   step accepted by the ODE solver and so gives the finest-grained view of the evolution, while
+   ``[recordDifferentialEvolutionPost]`` records once per call to the node evolver (i.e. at the end of each timestep). The event
+   responsible for each record is available in the output via the
+   :galacticus-class:`nodePropertyExtractorTrajectoryEvent` property extractor.
+
+   The properties recorded are entirely determined by the :galacticus-class:`mergerTreeOutputterClass` object supplied as a
+   sub-parameter of this operator---in particular, by the :galacticus-class:`nodePropertyExtractorClass` objects given to a
+   :galacticus-class:`mergerTreeOutputterStandard` outputter. That outputter's ``[outputsGroupName]`` parameter should be set to
+   something other than ``Outputs`` so that trajectory data are kept separate from the regular outputs. If no outputter is
+   given, a :galacticus-class:`mergerTreeOutputterStandard` writing the ``time``, ``indicesTree``, ``nodeIndices``, and
+   ``trajectoryEvent`` properties to the ``nodeTrajectories`` group is used. Note that the outputter is looked for only among
+   this operator's own sub-parameters---the outputter used for regular outputs is deliberately *not* inherited, as that would
+   cause trajectory records to be written into the regular ``Outputs`` group. Records are written to
+   ``&lt;outputsGroupName&gt;/Trajectory&lt;N&gt;/nodeData``, where ``N`` is the position of the node in the list of tracked nodes if
+   ``[groupPerNode]`` is true, or ``1`` (so that all tracked nodes share a single table) if it is false.
+
+   Because each record is appended to the output file immediately there is a significant cost per record. This class is intended
+   for use with a small number of nodes; the ``[countRecordsMaximum]`` parameter provides a safety limit on the number of records
+   made for each tracked node.
+
+   When a node is promoted its components are moved to its parent and the node itself is destroyed. This class detects such
+   promotions and re-targets its tracking to the parent node, so that the trajectory of a galaxy continues uninterrupted across
+   promotions.
+
+   Note that property extractors which modify the state of the node, or which assume that they are being evaluated at a regular
+   output time, are not safe to use with this class.
+   </description>
+   <deepCopy>
+    <ignore variables="mergerTreeOutputter_"/>
+   </deepCopy>
+   <assignment>
+    <functionClass variables="mergerTreeOutputter_"/>
+   </assignment>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorOutputTrajectory
+     !!{RST
+     A node operator class that records the complete evolutionary trajectory of selected nodes.
+     !!}
+     private
+     ! Held as an unlimited polymorphic pointer, and manipulated via the globally-callable functions in
+     ! `Merger_Tree_Outputters_Utilities`. Naming `mergerTreeOutputterClass` here would make `Nodes_Operators` depend on
+     ! `Merger_Tree_Outputters`, which depends (via `mergerTreeOutputterFullState`) on `Merger_Tree_Construction`, which depends
+     ! back on `Nodes_Operators` - a circular module dependency.
+     class  (*                       ), pointer                   :: mergerTreeOutputter_            => null()
+     integer(kind_int8               ), allocatable, dimension(:) :: indexTree                                , indexNode                          , &
+          &                                                          idUnique                                 , idTracked
+     integer(c_size_t                ), allocatable, dimension(:) :: countRecords
+     integer(c_size_t                )                            :: countRecordsMaximum
+     logical                                                      :: selectByUniqueID                         , groupPerNode
+     logical                                                      :: recordNodeInitialize                     , recordNodePromote                  , &
+          &                                                          recordNodesMerge                         , recordGalaxiesMerge                , &
+          &                                                          recordDifferentialEvolutionPost          , recordDifferentialEvolutionPostStep
+   contains
+     !![
+     <methods docformat="rst">
+       <method description="Return the position of ``node`` in the list of tracked nodes, or zero if it is not tracked." method="slot"  />
+       <method description="Record the current properties of ``node`` if it is being tracked."                           method="record"/>
+     </methods>
+     !!]
+     final     ::                                  outputTrajectoryDestructor
+     procedure :: deepCopy                      => outputTrajectoryDeepCopy
+     procedure :: deepCopyReset                 => outputTrajectoryDeepCopyReset
+     procedure :: deepCopyFinalize              => outputTrajectoryDeepCopyFinalize
+     procedure :: slot                          => outputTrajectorySlot
+     procedure :: record                        => outputTrajectoryRecord
+     procedure :: nodeInitialize                => outputTrajectoryNodeInitialize
+     procedure :: differentialEvolutionPostStep => outputTrajectoryDifferentialEvolutionPostStep
+     procedure :: differentialEvolutionPost     => outputTrajectoryDifferentialEvolutionPost
+     procedure :: nodePromote                   => outputTrajectoryNodePromote
+     procedure :: nodesMerge                    => outputTrajectoryNodesMerge
+     procedure :: galaxiesMerge                 => outputTrajectoryGalaxiesMerge
+  end type nodeOperatorOutputTrajectory
+
+  interface nodeOperatorOutputTrajectory
+     !!{RST
+     Constructors for the :galacticus-class:`nodeOperatorOutputTrajectory` node operator class.
+     !!}
+     module procedure outputTrajectoryConstructorParameters
+     module procedure outputTrajectoryConstructorInternal
+  end interface nodeOperatorOutputTrajectory
+
+contains
+
+  function outputTrajectoryConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`nodeOperatorOutputTrajectory` node operator class which takes a parameter set as
+    input.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Functions_Global, only : mergerTreeOutputterConstruct_, mergerTreeOutputterDestruct_
+    use :: Input_Parameters, only : inputParameter               , inputParameters
+    implicit none
+    type   (nodeOperatorOutputTrajectory)                              :: self
+    type   (inputParameters             ), intent(inout)               :: parameters
+    class  (*                           ), pointer                     :: mergerTreeOutputter_
+    integer(kind_int8                   ), allocatable  , dimension(:) :: indexTree                      , indexNode                          , &
+         &                                                                idUnique
+    integer(c_size_t                    )                              :: countNodes                     , countRecordsMaximum
+    logical                                                            :: selectByUniqueID               , groupPerNode                       , &
+         &                                                                recordNodeInitialize           , recordNodePromote                  , &
+         &                                                                recordNodesMerge               , recordGalaxiesMerge                , &
+         &                                                                recordDifferentialEvolutionPost, recordDifferentialEvolutionPostStep
+
+    ! Determine how nodes are to be selected.
+    selectByUniqueID=parameters%isPresent('uniqueID')
+    if (selectByUniqueID) then
+       if (parameters%isPresent('treeIndex').or.parameters%isPresent('nodeIndex'))                                      &
+            & call Error_Report(                                                                                        &
+            &                   "specify nodes using either [uniqueID], or [treeIndex] and [nodeIndex], but not both"// &
+            &                   {introspection:location}                                                                &
+            &                  )
+       countNodes=parameters%count('uniqueID')
+       allocate(idUnique (countNodes))
+       allocate(indexTree(0         ))
+       allocate(indexNode(0         ))
+       !![
+       <inputParameter docformat="rst">
+         <name>uniqueID</name>
+         <source>parameters</source>
+         <variable>idUnique</variable>
+         <type>integer</type>
+         <cardinality>1..*</cardinality>
+         <description>
+         The unique IDs of the nodes whose evolutionary trajectories are to be recorded. Note that unique IDs are not
+         reproducible between runs which use differing numbers of OpenMP threads or MPI processes.
+         </description>
+       </inputParameter>
+       !!]
+    else
+       if (.not.(parameters%isPresent('treeIndex').and.parameters%isPresent('nodeIndex')))                &
+            & call Error_Report(                                                                          &
+            &                   "specify nodes using either [uniqueID], or [treeIndex] and [nodeIndex]"// &
+            &                   {introspection:location}                                                  &
+            &                  )
+       countNodes=parameters%count('treeIndex')
+       if (parameters%count('nodeIndex') /= countNodes)                                                   &
+            & call Error_Report(                                                                          &
+            &                   "[treeIndex] and [nodeIndex] must contain the same number of values"   // &
+            &                   {introspection:location}                                                  &
+            &                  )
+       allocate(indexTree(countNodes))
+       allocate(indexNode(countNodes))
+       allocate(idUnique (0         ))
+       !![
+       <inputParameter docformat="rst">
+         <name>treeIndex</name>
+         <source>parameters</source>
+         <variable>indexTree</variable>
+         <type>integer</type>
+         <cardinality>1..*</cardinality>
+         <description>
+         The indices of the merger trees containing the nodes whose evolutionary trajectories are to be recorded.
+         </description>
+       </inputParameter>
+       <inputParameter docformat="rst">
+         <name>nodeIndex</name>
+         <source>parameters</source>
+         <variable>indexNode</variable>
+         <type>integer</type>
+         <cardinality>1..*</cardinality>
+         <description>
+         The indices, within the corresponding merger tree, of the nodes whose evolutionary trajectories are to be recorded.
+         </description>
+       </inputParameter>
+       !!]
+    end if
+    !![
+    <inputParameter docformat="rst">
+      <name>groupPerNode</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, the trajectory of each tracked node is written to its own HDF5 group. If false, the trajectories of all tracked
+      nodes are written to a single group (in which case the nodes may be distinguished using, for example, the ``indicesTree``
+      and ``nodeIndices`` property extractors).
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>countRecordsMaximum</name>
+      <source>parameters</source>
+      <defaultValue>100000_c_size_t</defaultValue>
+      <description>
+      The maximum number of records to make for each tracked node. Once this many records have been made for a node no further
+      records are made for it. Set to zero for no limit.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>recordNodeInitialize</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, a record is made when a tracked node is initialized prior to evolution.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>recordDifferentialEvolutionPostStep</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, a record is made after every step of the ODE solver which is accepted for a tracked node. This gives the
+      finest-grained view of the evolution, but also generates the largest volume of output.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>recordDifferentialEvolutionPost</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, a record is made each time a tracked node has been evolved to the end of its current timestep.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>recordNodePromote</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, a record is made immediately before a tracked node is promoted to its parent.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>recordNodesMerge</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, a record is made when a tracked node merges with another node.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>recordGalaxiesMerge</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, a record is made when the galaxy in a tracked node merges with another galaxy.
+      </description>
+    </inputParameter>
+    !!]
+    call mergerTreeOutputterConstruct_(parameters,mergerTreeOutputter_)
+    self=nodeOperatorOutputTrajectory(                                     &
+         &                            indexTree                          , &
+         &                            indexNode                          , &
+         &                            idUnique                           , &
+         &                            selectByUniqueID                   , &
+         &                            groupPerNode                       , &
+         &                            countRecordsMaximum                , &
+         &                            recordNodeInitialize               , &
+         &                            recordDifferentialEvolutionPostStep, &
+         &                            recordDifferentialEvolutionPost    , &
+         &                            recordNodePromote                  , &
+         &                            recordNodesMerge                   , &
+         &                            recordGalaxiesMerge                , &
+         &                            mergerTreeOutputter_                 &
+         &                           )
+    !![
+    <inputParametersValidate source="parameters" extraAllowedNames="mergerTreeOutputter"/>
+    !!]
+    call mergerTreeOutputterDestruct_(mergerTreeOutputter_)
+    return
+  end function outputTrajectoryConstructorParameters
+
+  function outputTrajectoryConstructorInternal(indexTree,indexNode,idUnique,selectByUniqueID,groupPerNode,countRecordsMaximum,recordNodeInitialize,recordDifferentialEvolutionPostStep,recordDifferentialEvolutionPost,recordNodePromote,recordNodesMerge,recordGalaxiesMerge,mergerTreeOutputter_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`nodeOperatorOutputTrajectory` node operator class.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    type   (nodeOperatorOutputTrajectory)                              :: self
+    integer(kind_int8                   ), intent(in   ), dimension(:) :: indexTree                      , indexNode                          , &
+         &                                                                idUnique
+    integer(c_size_t                    ), intent(in   )               :: countRecordsMaximum
+    logical                              , intent(in   )               :: selectByUniqueID               , groupPerNode                       , &
+         &                                                                recordNodeInitialize           , recordNodePromote                  , &
+         &                                                                recordNodesMerge               , recordGalaxiesMerge                , &
+         &                                                                recordDifferentialEvolutionPost, recordDifferentialEvolutionPostStep
+    class  (*                           ), intent(in   ), target       :: mergerTreeOutputter_
+    integer(c_size_t                    )                              :: countNodes
+    !![
+    <constructorAssign variables="indexTree, indexNode, idUnique, selectByUniqueID, groupPerNode, countRecordsMaximum, recordNodeInitialize, recordDifferentialEvolutionPostStep, recordDifferentialEvolutionPost, recordNodePromote, recordNodesMerge, recordGalaxiesMerge, *mergerTreeOutputter_"/>
+    !!]
+
+    if (selectByUniqueID) then
+       countNodes=size(idUnique ,kind=c_size_t)
+    else
+       countNodes=size(indexTree,kind=c_size_t)
+    end if
+    if (countNodes < 1_c_size_t) call Error_Report('at least one node must be specified'//{introspection:location})
+    allocate(self%idTracked   (countNodes))
+    allocate(self%countRecords(countNodes))
+    self%idTracked   =-1_kind_int8
+    self%countRecords= 0_c_size_t
+    return
+  end function outputTrajectoryConstructorInternal
+
+  subroutine outputTrajectoryDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`nodeOperatorOutputTrajectory` node operator class.
+    !!}
+    use :: Functions_Global, only : mergerTreeOutputterDestruct_
+    implicit none
+    type(nodeOperatorOutputTrajectory), intent(inout) :: self
+
+    if (associated(self%mergerTreeOutputter_)) call mergerTreeOutputterDestruct_(self%mergerTreeOutputter_)
+    return
+  end subroutine outputTrajectoryDestructor
+
+  function outputTrajectorySlot(self,node) result(slot)
+    !!{RST
+    Return the position of ``node`` in the list of tracked nodes, or zero if it is not being tracked.
+    !!}
+    implicit none
+    integer(c_size_t                    )                :: slot
+    class  (nodeOperatorOutputTrajectory), intent(inout) :: self
+    type   (treeNode                    ), intent(inout) :: node
+    integer(c_size_t                    )                :: i
+    integer(kind_int8                   )                :: idUnique_
+
+    slot     =0_c_size_t
+    idUnique_=node%uniqueID()
+    ! First look for a tracked node which we have already resolved to a unique ID.
+    do i=1_c_size_t,size(self%idTracked,kind=c_size_t)
+       if (self%idTracked(i) == idUnique_) then
+          slot=i
+          return
+       end if
+    end do
+    ! Otherwise, attempt to resolve any as-yet-unresolved tracked node. Note that resolution is attempted only once for each
+    ! tracked node. This matters because, once our tracked node has been promoted (at which point we re-target to its parent),
+    ! some other node may acquire the original indices of our tracked node - this happens, for example, if the
+    ! `nodeOperatorIndexShift` node operator is in use. Resolving only once ensures that such a node can not be mistaken for the
+    ! node that we are tracking.
+    do i=1_c_size_t,size(self%idTracked,kind=c_size_t)
+       if (self%idTracked(i) >= 0_kind_int8) cycle
+       if (self%selectByUniqueID) then
+          if (idUnique_ /= self%idUnique(i)) cycle
+       else
+          if (.not.associated(node%hostTree)) cycle
+          if (node%hostTree%index /= self%indexTree(i) .or. node%index() /= self%indexNode(i)) cycle
+       end if
+       self%idTracked(i)=idUnique_
+       slot             =i
+       return
+    end do
+    return
+  end function outputTrajectorySlot
+
+  subroutine outputTrajectoryRecord(self,node,event)
+    !!{RST
+    Record the current properties of ``node``, if it is one of the nodes that we are tracking.
+    !!}
+    use :: Functions_Global      , only : mergerTreeOutputterOutputTrajectory_
+    use :: Node_Trajectory_Events, only : nodeTrajectoryEventCurrent
+    implicit none
+    class  (nodeOperatorOutputTrajectory      ), intent(inout) :: self
+    type   (treeNode                          ), intent(inout) :: node
+    type   (enumerationNodeTrajectoryEventType), intent(in   ) :: event
+    integer(c_size_t                          )                :: slot_, indexOutput
+
+    slot_=self%slot(node)
+    if (slot_ == 0_c_size_t) return
+    ! Impose the limit on the number of records made for this node.
+    if     (                                                             &
+         &   self%countRecordsMaximum        >  0_c_size_t               &
+         &  .and.                                                        &
+         &   self%countRecords       (slot_) >= self%countRecordsMaximum &
+         & ) return
+    ! Record the event responsible for this record so that it can be extracted by the `trajectoryEvent` property extractor during
+    ! the output which we trigger below.
+    nodeTrajectoryEventCurrent=event%ID
+    ! Output the node. Each tracked node is given its own output group (i.e. its own index) unless all nodes are to share a
+    ! single group.
+    if (self%groupPerNode) then
+       indexOutput=slot_
+    else
+       indexOutput=1_c_size_t
+    end if
+    call mergerTreeOutputterOutputTrajectory_(self%mergerTreeOutputter_,node,indexOutput)
+    self%countRecords(slot_)=self%countRecords(slot_)+1_c_size_t
+    return
+  end subroutine outputTrajectoryRecord
+
+  subroutine outputTrajectoryNodeInitialize(self,node)
+    !!{RST
+    Record the properties of a tracked node as it is initialized.
+    !!}
+    use :: Node_Trajectory_Events, only : nodeTrajectoryEventNodeInitialize
+    implicit none
+    class(nodeOperatorOutputTrajectory), intent(inout), target :: self
+    type (treeNode                    ), intent(inout), target :: node
+
+    if (self%recordNodeInitialize) call self%record(node,nodeTrajectoryEventNodeInitialize)
+    return
+  end subroutine outputTrajectoryNodeInitialize
+
+  subroutine outputTrajectoryDifferentialEvolutionPostStep(self,node,status)
+    !!{RST
+    Record the properties of a tracked node after each accepted step of the ODE solver.
+    !!}
+    use :: Node_Trajectory_Events, only : nodeTrajectoryEventDifferentialEvolutionPostStep
+    implicit none
+    class  (nodeOperatorOutputTrajectory), intent(inout) :: self
+    type   (treeNode                    ), intent(inout) :: node
+    integer                              , intent(inout) :: status
+    !$GLC attributes unused :: status
+
+    ! Note that `status` is deliberately left unchanged - we make no modification to the state of the node, so the ODE solver
+    ! must not be asked to reset.
+    if (self%recordDifferentialEvolutionPostStep) call self%record(node,nodeTrajectoryEventDifferentialEvolutionPostStep)
+    return
+  end subroutine outputTrajectoryDifferentialEvolutionPostStep
+
+  subroutine outputTrajectoryDifferentialEvolutionPost(self,node)
+    !!{RST
+    Record the properties of a tracked node once it has been evolved to the end of its timestep.
+    !!}
+    use :: Node_Trajectory_Events, only : nodeTrajectoryEventDifferentialEvolutionPost
+    implicit none
+    class(nodeOperatorOutputTrajectory), intent(inout) :: self
+    type (treeNode                    ), intent(inout) :: node
+
+    if (self%recordDifferentialEvolutionPost) call self%record(node,nodeTrajectoryEventDifferentialEvolutionPost)
+    return
+  end subroutine outputTrajectoryDifferentialEvolutionPost
+
+  subroutine outputTrajectoryNodePromote(self,node)
+    !!{RST
+    Record the properties of a tracked node as it is promoted, and re-target our tracking to its parent.
+    !!}
+    use :: Node_Trajectory_Events, only : nodeTrajectoryEventNodePromote
+    implicit none
+    class  (nodeOperatorOutputTrajectory), intent(inout) :: self
+    type   (treeNode                    ), intent(inout) :: node
+    integer(c_size_t                    )                :: slot_
+
+    slot_=self%slot(node)
+    if (slot_ == 0_c_size_t) return
+    if (self%recordNodePromote) call self%record(node,nodeTrajectoryEventNodePromote)
+    ! The components of this node are about to be moved to its parent, after which this node will be destroyed. The parent has a
+    ! different unique ID (and, unless the `nodeOperatorIndexShift` operator is in use, a different index), so re-target our
+    ! tracking to the parent to allow the trajectory to continue uninterrupted.
+    if (associated(node%parent)) self%idTracked(slot_)=node%parent%uniqueID()
+    return
+  end subroutine outputTrajectoryNodePromote
+
+  subroutine outputTrajectoryNodesMerge(self,node)
+    !!{RST
+    Record the properties of a tracked node as it merges with another node.
+    !!}
+    use :: Node_Trajectory_Events, only : nodeTrajectoryEventNodesMerge
+    implicit none
+    class(nodeOperatorOutputTrajectory), intent(inout) :: self
+    type (treeNode                    ), intent(inout) :: node
+
+    if (self%recordNodesMerge) call self%record(node,nodeTrajectoryEventNodesMerge)
+    return
+  end subroutine outputTrajectoryNodesMerge
+
+  subroutine outputTrajectoryGalaxiesMerge(self,node)
+    !!{RST
+    Record the properties of a tracked node as its galaxy merges with another galaxy.
+    !!}
+    use :: Node_Trajectory_Events, only : nodeTrajectoryEventGalaxiesMerge
+    implicit none
+    class(nodeOperatorOutputTrajectory), intent(inout) :: self
+    type (treeNode                    ), intent(inout) :: node
+
+    if (self%recordGalaxiesMerge) call self%record(node,nodeTrajectoryEventGalaxiesMerge)
+    return
+  end subroutine outputTrajectoryGalaxiesMerge
+
+  subroutine outputTrajectoryDeepCopyReset(self)
+    !!{RST
+    Perform a deep copy reset of the object.
+    !!}
+    use :: Functions_Global, only : mergerTreeOutputterDeepCopyReset_
+    implicit none
+    class(nodeOperatorOutputTrajectory), intent(inout) :: self
+
+    self%copiedSelf => null()
+    if (associated(self%mergerTreeOutputter_)) call mergerTreeOutputterDeepCopyReset_(self%mergerTreeOutputter_)
+    return
+  end subroutine outputTrajectoryDeepCopyReset
+
+  subroutine outputTrajectoryDeepCopyFinalize(self)
+    !!{RST
+    Finalize a deep copy of the object.
+    !!}
+    use :: Functions_Global, only : mergerTreeOutputterDeepCopyFinalize_
+    implicit none
+    class(nodeOperatorOutputTrajectory), intent(inout) :: self
+
+    if (associated(self%mergerTreeOutputter_)) call mergerTreeOutputterDeepCopyFinalize_(self%mergerTreeOutputter_)
+    return
+  end subroutine outputTrajectoryDeepCopyFinalize
+
+  subroutine outputTrajectoryDeepCopy(self,destination)
+    !!{RST
+    Perform a deep copy of the object.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Functions_Global, only : mergerTreeOutputterDeepCopy_
+    implicit none
+    class(nodeOperatorOutputTrajectory), intent(inout), target :: self
+    class(nodeOperatorClass           ), intent(inout)         :: destination
+
+    call self%deepCopy_(destination)
+    select type (destination)
+    type is (nodeOperatorOutputTrajectory)
+       nullify(destination%mergerTreeOutputter_)
+       if (associated(self%mergerTreeOutputter_)) then
+          allocate(destination%mergerTreeOutputter_,mold=self%mergerTreeOutputter_)
+          call mergerTreeOutputterDeepCopy_(self%mergerTreeOutputter_,destination%mergerTreeOutputter_)
+       end if
+    class default
+       call Error_Report('destination and source types do not match'//{introspection:location})
+    end select
+    return
+  end subroutine outputTrajectoryDeepCopy

--- a/source/nodes/operators/output/trajectory_events.F90
+++ b/source/nodes/operators/output/trajectory_events.F90
@@ -1,0 +1,58 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{RST
+Contains a module which enumerates the events at which node evolution trajectories may be recorded.
+!!}
+
+module Node_Trajectory_Events
+  !!{RST
+  Enumerates the events at which node evolution trajectories may be recorded by the
+  :galacticus-class:`nodeOperatorOutputTrajectory` node operator. The identifier of the event which caused each record to be made
+  is available in the output via the :galacticus-class:`nodePropertyExtractorTrajectoryEvent` property extractor.
+  !!}
+  private
+
+  !![
+  <enumeration docformat="rst">
+   <name>nodeTrajectoryEvent</name>
+   <description>
+   Enumeration of the events at which the evolutionary trajectory of a node may be recorded.
+   </description>
+   <decodeFunction>yes</decodeFunction>
+   <validator>yes</validator>
+   <visibility>public</visibility>
+   <entry label="nodeInitialize"               description="Recorded when the node is initialized prior to evolution."       />
+   <entry label="differentialEvolutionPostStep" description="Recorded after each accepted step of the ODE solver."           />
+   <entry label="differentialEvolutionPost"    description="Recorded after the node has been evolved to the end of its step."/>
+   <entry label="nodePromote"                  description="Recorded immediately before the node is promoted to its parent." />
+   <entry label="nodesMerge"                   description="Recorded when the node merges with another node."                />
+   <entry label="galaxiesMerge"                description="Recorded when the galaxy in the node merges with another galaxy."/>
+  </enumeration>
+  !!]
+
+  ! The identifier of the event responsible for the trajectory record currently being made. This is set by the
+  ! :galacticus-class:`nodeOperatorOutputTrajectory` node operator immediately before it triggers output of a node, and is read by
+  ! the :galacticus-class:`nodePropertyExtractorTrajectoryEvent` property extractor during that output. Since the extractor is
+  ! always called synchronously, on the same thread, from within the output triggered by the operator, a thread-private module
+  ! variable suffices here - and avoids having to store a meta-property on every node.
+  integer, public :: nodeTrajectoryEventCurrent=0
+  !$omp threadprivate(nodeTrajectoryEventCurrent)
+
+end module Node_Trajectory_Events

--- a/source/nodes/property_extractor/trajectory_event.F90
+++ b/source/nodes/property_extractor/trajectory_event.F90
@@ -1,0 +1,121 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{RST
+Implements a node evolution trajectory event property extractor.
+!!}
+
+  !![
+  <nodePropertyExtractor name="nodePropertyExtractorTrajectoryEvent" docformat="rst">
+   <description>
+   Extracts the identifier of the event which caused the current record of a node's evolutionary trajectory to be made by the
+   :galacticus-class:`nodeOperatorOutputTrajectory` node operator. This is meaningful only in trajectory output---in a regular
+   output it simply reports whichever event caused the most recent trajectory record to be made on the current thread (or zero if
+   no trajectory record has been made at all). The mapping from identifier to event name is given in the description of the
+   ``trajectoryEvent`` dataset.
+   </description>
+  </nodePropertyExtractor>
+  !!]
+  type, extends(nodePropertyExtractorIntegerScalar) :: nodePropertyExtractorTrajectoryEvent
+     !!{RST
+     A node evolution trajectory event property extractor.
+     !!}
+     private
+   contains
+     procedure :: extract     => trajectoryEventExtract
+     procedure :: name        => trajectoryEventName
+     procedure :: description => trajectoryEventDescription
+  end type nodePropertyExtractorTrajectoryEvent
+
+  interface nodePropertyExtractorTrajectoryEvent
+     !!{RST
+     Constructors for the :galacticus-class:`nodePropertyExtractorTrajectoryEvent` property extractor class.
+     !!}
+     module procedure trajectoryEventConstructorParameters
+  end interface nodePropertyExtractorTrajectoryEvent
+
+contains
+
+  function trajectoryEventConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`nodePropertyExtractorTrajectoryEvent` property extractor class which takes a parameter
+    set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type(nodePropertyExtractorTrajectoryEvent)                :: self
+    type(inputParameters                     ), intent(inout) :: parameters
+
+    self=nodePropertyExtractorTrajectoryEvent()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function trajectoryEventConstructorParameters
+
+  function trajectoryEventExtract(self,node,time,instance)
+    !!{RST
+    Implement a ``trajectoryEvent`` node property extractor.
+    !!}
+    use :: Node_Trajectory_Events, only : nodeTrajectoryEventCurrent
+    implicit none
+    integer         (kind_int8                           )                          :: trajectoryEventExtract
+    class           (nodePropertyExtractorTrajectoryEvent), intent(inout)           :: self
+    type            (treeNode                            ), intent(inout), target   :: node
+    double precision                                      , intent(in   )           :: time
+    type            (multiCounter                        ), intent(inout), optional :: instance
+    !$GLC attributes unused :: self, node, instance, time
+
+    trajectoryEventExtract=int(nodeTrajectoryEventCurrent,kind=kind_int8)
+    return
+  end function trajectoryEventExtract
+
+  function trajectoryEventName(self)
+    !!{RST
+    Return the name of the trajectory event property.
+    !!}
+    implicit none
+    type (varying_string                      )                :: trajectoryEventName
+    class(nodePropertyExtractorTrajectoryEvent), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    trajectoryEventName=var_str('trajectoryEvent')
+    return
+  end function trajectoryEventName
+
+  function trajectoryEventDescription(self)
+    !!{RST
+    Return a description of the trajectory event property.
+    !!}
+    use :: Node_Trajectory_Events, only : enumerationNodeTrajectoryEventDecode, nodeTrajectoryEventMin, nodeTrajectoryEventMax
+    use :: ISO_Varying_String    , only : varying_string                      , var_str               , assignment(=)         , &
+         &                                operator(//)
+    use :: String_Handling       , only : operator(//)
+    implicit none
+    type   (varying_string                      )                :: trajectoryEventDescription
+    class  (nodePropertyExtractorTrajectoryEvent), intent(inout) :: self
+    integer                                                      :: event
+    !$GLC attributes unused :: self
+
+    trajectoryEventDescription=var_str('Identifier of the event at which this trajectory record was made:')
+    do event=nodeTrajectoryEventMin,nodeTrajectoryEventMax
+       trajectoryEventDescription=trajectoryEventDescription//' '//event//'='//enumerationNodeTrajectoryEventDecode(event)//';'
+    end do
+    return
+  end function trajectoryEventDescription

--- a/testSuite/parameters/nodeTrajectory.xml
+++ b/testSuite/parameters/nodeTrajectory.xml
@@ -1,0 +1,148 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Test of recording of node evolutionary trajectories. Identical to nodeTrajectoryBase.xml apart from the addition of the
+     outputTrajectory node operator, so that the two may be compared to verify that trajectory recording does not perturb the
+     model. -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="7b83820825e0dd5e1c0c53b5d3ec06deb0b18e40" time="2026-07-21T00:00:00"/>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="null">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+  </componentSpheroid>
+  <componentSpin value="null"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/nodeTrajectoryTree.xml"/>
+  </mergerTreeConstructor>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Gas cooling -->
+    <nodeOperator value="massCooled"/>
+    <!-- CGM physics -->
+    <nodeOperator value="CGMAccretion">
+      <allowNegativeCGMMass value="true"/>
+      <angularMomentumAlwaysGrows value="false"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOutflowReincorporation">
+      <includeSatellites value="true"/>
+    </nodeOperator>
+    <nodeOperator value="CGMCoolingHeating">
+      <component value="disk"/>
+      <coolingFrom value="currentNode"/>
+      <excessHeatDrivesOutflow value="true"/>
+      <rateMaximumExpulsion value="1.0"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
+    <!-- Record the complete evolutionary trajectory of node 1 in tree 1. Note that this node is promoted (twice) during
+         evolution, so this also tests that the trajectory is followed across promotions. -->
+    <nodeOperator value="outputTrajectory">
+      <treeIndex value="1"/>
+      <nodeIndex value="1"/>
+      <groupPerNode value="true"/>
+      <mergerTreeOutputter value="standard">
+        <outputsGroupName value="nodeTrajectories"/>
+        <outputReferences value="false"/>
+        <nodePropertyExtractor value="multi">
+          <nodePropertyExtractor value="time"/>
+          <nodePropertyExtractor value="indicesTree"/>
+          <nodePropertyExtractor value="nodeIndices"/>
+          <nodePropertyExtractor value="trajectoryEvent"/>
+        </nodePropertyExtractor>
+      </mergerTreeOutputter>
+    </nodeOperator>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="massCooled"/>
+  </nodePropertyExtractor>
+
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/nodeTrajectory.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/nodeTrajectoryBase.xml
+++ b/testSuite/parameters/nodeTrajectoryBase.xml
@@ -1,0 +1,129 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Base model used to test that recording node evolutionary trajectories does not perturb the model. -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="7b83820825e0dd5e1c0c53b5d3ec06deb0b18e40" time="2026-07-21T00:00:00"/>
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="null">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+  </componentSpheroid>
+  <componentSpin value="null"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/nodeTrajectoryTree.xml"/>
+  </mergerTreeConstructor>
+
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Gas cooling -->
+    <nodeOperator value="massCooled"/>
+    <!-- CGM physics -->
+    <nodeOperator value="CGMAccretion">
+      <allowNegativeCGMMass value="true"/>
+      <angularMomentumAlwaysGrows value="false"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOutflowReincorporation">
+      <includeSatellites value="true"/>
+    </nodeOperator>
+    <nodeOperator value="CGMCoolingHeating">
+      <component value="disk"/>
+      <coolingFrom value="currentNode"/>
+      <excessHeatDrivesOutflow value="true"/>
+      <rateMaximumExpulsion value="1.0"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="massCooled"/>
+  </nodePropertyExtractor>
+
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/nodeTrajectoryBase.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/nodeTrajectoryTree.xml
+++ b/testSuite/parameters/nodeTrajectoryTree.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test of recording of node evolutionary trajectories -->
+<!-- A simple chain of three nodes, such that two promotions occur during evolution. -->
+<tree>
+  <node>
+    <index>1</index>
+    <parent>2</parent>
+    <firstChild>-1</firstChild>
+    <sibling>-1</sibling>
+    <basic>
+      <time>1.0</time>
+      <mass>1.0e12</mass>
+    </basic>
+    <hotHalo>
+      <mass>1.0e12</mass>
+      <angularMomentum>2.0e12</angularMomentum>
+    </hotHalo>
+    <disk>
+      <massStellar>0.0</massStellar>
+      <massGas>0.0</massGas>
+     </disk>
+  </node>
+  <node>
+    <index>2</index>
+    <parent>3</parent>
+    <firstChild>1</firstChild>
+    <sibling>-1</sibling>
+    <basic>
+      <time>6.0</time>
+      <mass>1.0e12</mass>
+    </basic>
+  </node>
+  <node>
+    <index>3</index>
+    <parent>-1</parent>
+    <firstChild>2</firstChild>
+    <sibling>-1</sibling>
+    <basic>
+      <time>13.8</time>
+      <mass>1.0e12</mass>
+    </basic>
+ </node>
+</tree>

--- a/testSuite/test-node-trajectory.py
+++ b/testSuite/test-node-trajectory.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import h5py
+import numpy as np
+
+# Check recording of node evolutionary trajectories by the `outputTrajectory` node operator.
+# Andrew Benson
+
+# Event identifiers, as enumerated in source/nodes/operators/output/trajectory_events.F90.
+eventNodeInitialize                = 0
+eventDifferentialEvolutionPostStep = 1
+eventDifferentialEvolutionPost     = 2
+eventNodePromote                   = 3
+
+# Run the base model (no trajectory recording), and the identical model with trajectory recording enabled.
+for name in ( "nodeTrajectoryBase", "nodeTrajectory" ):
+    status = subprocess.run(f"cd ..; ./Galacticus.exe testSuite/parameters/{name}.xml", shell=True)
+    if status.returncode != 0:
+        print(f"FAILED: {name} model run")
+        sys.exit(0)
+print("SUCCESS: model runs")
+
+modelBase = h5py.File("outputs/nodeTrajectoryBase.hdf5", "r")
+model     = h5py.File("outputs/nodeTrajectory.hdf5"    , "r")
+
+# Recording trajectories must not perturb the model in any way. In particular, the `mergerTreeExtraOutput` event hook (which
+# modifies the star formation histories of nodes) must not be triggered by trajectory output. Verify that every regular output
+# dataset is unchanged.
+nodeDataBase = modelBase["Outputs/Output1/nodeData"]
+nodeData     = model    ["Outputs/Output1/nodeData"]
+if set(nodeDataBase.keys()) != set(nodeData.keys()):
+    print("FAILED: regular output datasets differ between models")
+    sys.exit(0)
+perturbed = [
+    name for name in nodeDataBase.keys()
+    if not np.array_equal(nodeDataBase[name][:], nodeData[name][:])
+]
+if perturbed:
+    print(f"FAILED: trajectory recording perturbed the model; datasets differ: {perturbed}")
+else:
+    print("SUCCESS: trajectory recording does not perturb the model")
+
+# The trajectory itself must have been recorded.
+if "nodeTrajectories/Trajectory1/nodeData" not in model:
+    print("FAILED: trajectory group was not created")
+    sys.exit(0)
+print("SUCCESS: trajectory group created")
+
+trajectory = model["nodeTrajectories/Trajectory1/nodeData"]
+time       = trajectory["time"           ][:]
+event      = trajectory["trajectoryEvent"][:]
+nodeIndex  = trajectory["nodeIndex"      ][:]
+treeIndex  = trajectory["mergerTreeIndex"][:]
+
+# Records must be ordered in time, and span the full evolution of the node (from its own time of 1.0 Gyr to the final output
+# time of 13.8 Gyr).
+if np.all(np.diff(time) >= 0.0):
+    print("SUCCESS: trajectory records are ordered in time")
+else:
+    print("FAILED: trajectory records are not ordered in time")
+if time[0] <= 1.0 + 1.0e-6 and time[-1] >= 13.8 - 1.0e-6:
+    print("SUCCESS: trajectory spans the full evolution")
+else:
+    print(f"FAILED: trajectory spans only {time[0]} to {time[-1]} Gyr")
+
+# Records should have been made at ODE solver steps - which is the whole point of this class, and is the only way to obtain many
+# more records than there are output times.
+if np.count_nonzero(event == eventDifferentialEvolutionPostStep) > 1:
+    print("SUCCESS: trajectory records were made at ODE solver steps")
+else:
+    print("FAILED: no trajectory records were made at ODE solver steps")
+if np.any(event == eventNodeInitialize) and np.any(event == eventDifferentialEvolutionPost):
+    print("SUCCESS: trajectory records were made at initialization and post-evolution")
+else:
+    print("FAILED: trajectory records missing for initialization and/or post-evolution")
+
+# All records must refer to the tree that we asked to follow.
+if np.all(treeIndex == 1):
+    print("SUCCESS: all trajectory records belong to the requested tree")
+else:
+    print("FAILED: trajectory records belong to more than one tree")
+
+# The node is promoted twice during evolution (node 1 → 2 at 6 Gyr, node 2 → 3 at 13.8 Gyr). The trajectory must follow the
+# galaxy across those promotions - i.e. the node index recorded must change, and records must continue to be made after the
+# first promotion.
+if np.count_nonzero(event == eventNodePromote) == 2:
+    print("SUCCESS: both promotions were recorded")
+else:
+    print(f"FAILED: {np.count_nonzero(event == eventNodePromote)} promotions recorded, expected 2")
+timePromotionFirst = time[event == eventNodePromote][0] if np.any(event == eventNodePromote) else None
+if timePromotionFirst is not None and np.count_nonzero(time > timePromotionFirst) > 1:
+    print("SUCCESS: trajectory continues after promotion")
+else:
+    print("FAILED: trajectory does not continue after promotion")
+# The node index recorded must change across the first promotion: before it the galaxy lives in node 1, after it in node 2. Note
+# that a promotion record is made *before* the promotion takes place, so it carries the index of the node being promoted - and
+# that node 3 never appears, because the second promotion (node 2 -> node 3) occurs at the final time, after which there is no
+# further evolution to record.
+if timePromotionFirst is not None:
+    indicesBefore = set(np.unique(nodeIndex[time <= timePromotionFirst]).tolist())
+    indicesAfter  = set(np.unique(nodeIndex[time >  timePromotionFirst]).tolist())
+    if indicesBefore == {1} and indicesAfter == {2}:
+        print("SUCCESS: trajectory follows the galaxy across the promotion into its parent node")
+    else:
+        print(f"FAILED: node indices before/after first promotion are {sorted(indicesBefore)}/{sorted(indicesAfter)}, expected [1]/[2]")
+
+# The trajectory must be far more finely sampled than the regular output - which is the whole point of this class.
+countRegular = len(nodeDataBase["basicMass"][:])
+if len(time) > 10 * countRegular:
+    print(f"SUCCESS: trajectory is finely sampled ({len(time)} records vs {countRegular} regular output row(s))")
+else:
+    print(f"FAILED: trajectory has only {len(time)} records vs {countRegular} regular output row(s)")
+
+# The trajectory group must not carry the time-related attributes of a regular output, which would be meaningless for a group
+# spanning many times.
+attributes = set(model["nodeTrajectories/Trajectory1"].attrs.keys())
+if attributes.isdisjoint({"outputTime", "outputExpansionFactor", "outputComovingDistance"}):
+    print("SUCCESS: trajectory group omits the regular-output time attributes")
+else:
+    print("FAILED: trajectory group carries misleading regular-output time attributes")
+
+modelBase.close()
+model    .close()


### PR DESCRIPTION
## Goal

Provide a supported, parameter-file-driven way to dump the complete evolutionary trajectory of specific galaxies, so that debugging no longer requires hacking temporary `write` statements into physics modules.

`nodeOperatorOutputTrajectory` follows one or more selected nodes and, at each enabled event, writes a record whose contents are determined entirely by an ordinary `mergerTreeOutputter` — so the full `nodePropertyExtractor` machinery is reused rather than reimplemented.

```xml
<nodeOperator value="outputTrajectory">
  <treeIndex value="1"/>
  <nodeIndex value="1"/>
  <mergerTreeOutputter value="standard">
    <outputsGroupName value="nodeTrajectories"/>
    <nodePropertyExtractor value="multi">
      <nodePropertyExtractor value="time"/>
      <nodePropertyExtractor value="indicesTree"/>
      <nodePropertyExtractor value="nodeIndices"/>
      <nodePropertyExtractor value="trajectoryEvent"/>
    </nodePropertyExtractor>
  </mergerTreeOutputter>
</nodeOperator>
```

Records are written to `<outputsGroupName>/Trajectory<N>/nodeData`. Events are `nodeInitialize`, `differentialEvolutionPostStep` (every accepted ODE step — the finest-grained view), `differentialEvolutionPost`, `nodePromote`, `nodesMerge`, and `galaxiesMerge`, each individually switchable; the event responsible for each record is recoverable via the new `trajectoryEvent` property extractor, whose dataset comment carries the identifier legend.

## Three things that required care

**Suppressing `mergerTreeExtraOutput`.** `standardOutput` fires this event hook, and its subscribers — the standard disk, spheroid, and nuclear star cluster components — *advance the star formation history and write it back into the node*. Firing that on every ODE step would corrupt star formation histories and inject spurious data into the regular outputs. `outputType` is now threaded into the private `standardOutput` and the hook is skipped for the new `trajectory` output type. This is a correctness issue, not a tidiness one, so the test suite asserts the regular outputs are **bit-identical** with and without the operator active.

**A circular module dependency.** A node operator naming `mergerTreeOutputterClass` closes a cycle:

```
Nodes_Operators          ──> Merger_Tree_Outputters      (the new edge)
Merger_Tree_Outputters   ──> Merger_Tree_Construction    merger_trees/outputter/full_state.F90:98
Merger_Tree_Construction ──> Nodes_Operators             merger_trees/construct/filter.F90:41
```

Make drops the circular edge, compiles submodules against inconsistent `.mod`/`.smod` state, and gfortran then segfaults in `gfc_get_derived_type` — which reads as a compiler bug but is not. The operator therefore holds the outputter as `class(*), pointer` and reaches it through new `functionGlobal` wrappers in `merger_trees/outputter/utilities.F90`, following the established `nodes/operators/utilities.F90` + `geometry/lightcones/square.F90` idiom. The tree builds with zero `Circular ... dependency dropped` warnings.

Note this is a *module*-level cycle only: `full_state.F90` uses `Merger_Tree_Construction` for a procedure, not an `objectBuilder`, so it has no parameter-file counterpart and no `recursive="yes"` is required. The one parameter-level route back to `nodeOperator` (via `geometryLightconeSquare`) was tested explicitly and does not recurse — and pre-exists this change via `nodeOperatorGalaxyMergerTree`.

**Promotion.** Promotion moves a node's components to its parent and destroys the node, so the parent carries a different index and `uniqueID`. The operator implements `nodePromote` to re-target its tracking to the parent, so a trajectory continues uninterrupted; it resolves each tracked node's identity only once, so that a node later acquiring the original indices (as happens under `nodeOperatorIndexShift`) cannot be mistaken for it.

## Testing

`testSuite/test-node-trajectory.py` — 13 checks, all passing, ~0.3 s:

- regular `Outputs` bit-identical with and without the operator (covers the event-hook suppression and the `Calculations_Reset` performed per record);
- on a three-node chain with two promotions, recorded `nodeIndex` is `1` before the first promotion and `2` after;
- records made at ODE steps, ordered in time, spanning the full evolution;
- trajectory group omits `outputTime`/`outputExpansionFactor`/`outputComovingDistance`, which the regular output group still carries.

Wired into the `Miscellaneous` matrix in `cicd.yml`. `schema/parameters.xsd` regenerated via `make parameters-schema` (two new enumeration entries). Locally verified: `pytest` 819 passed; parameter catalog check OK; `parameterValidate.py` 567 files / 0 errors; `test-CGM-mass-cooled.py` still passes.

## Caveats (documented in the class description)

- Intended as a **debugging tool** — one flush per record, so there is a real per-record cost; `countRecordsMaximum` (default 100000) is the safety valve.
- `uniqueID` selection is not reproducible across runs with differing OpenMP thread or MPI process counts; `(treeIndex, nodeIndex)` is preferred and documented as such.
- Extractors with side effects, or which assume evaluation at a regular output time, are not safe here.
- Time sampling is irregular and solver-dependent, and shifts if tolerances change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
