### PR TITLE
refactor: remove dead merger tree initializor code

### DIFF
--- a/source/objects/nodes/components/hot_halo/cold_mode/_class.F90
+++ b/source/objects/nodes/components/hot_halo/cold_mode/_class.F90
@@ -232,7 +232,7 @@ contains
   end subroutine Node_Component_Hot_Halo_Cold_Mode_Scale_Set
 
   !![
-  <mergerTreeInitializeTask function="Node_Component_Hot_Halo_Cold_Mode_Tree_Initialize" after="Node_Component_Hot_Halo_Standard_Tree_Initialize"/>
+  <mergerTreeInitializeTask function="Node_Component_Hot_Halo_Cold_Mode_Tree_Initialize"/>
   !!]
   subroutine Node_Component_Hot_Halo_Cold_Mode_Tree_Initialize(node)
     !!{RST

--- a/source/objects/nodes/components/hot_halo/standard/_class.F90
+++ b/source/objects/nodes/components/hot_halo/standard/_class.F90
@@ -25,7 +25,6 @@ module Node_Component_Hot_Halo_Standard
   !!{RST
   Implements the standard hot halo node component.
   !!}
-  use :: Accretion_Halos                           , only : accretionHaloClass
   use :: Chemical_Reaction_Rates                   , only : chemicalReactionRateClass
   use :: Chemical_States                           , only : chemicalStateClass
   use :: Cosmology_Functions                       , only : cosmologyFunctionsClass
@@ -43,10 +42,9 @@ module Node_Component_Hot_Halo_Standard
   implicit none
   private
   public :: Node_Component_Hot_Halo_Standard_Initialize         , Node_Component_Hot_Halo_Standard_Thread_Initialize, &
-       &    Node_Component_Hot_Halo_Standard_Scale_Set          , Node_Component_Hot_Halo_Standard_Tree_Initialize  , &
-       &    Node_Component_Hot_Halo_Standard_Post_Step          , Node_Component_Hot_Halo_Standard_State_Restore    , &
-       &    Node_Component_Hot_Halo_Standard_Thread_Uninitialize, Node_Component_Hot_Halo_Standard_Pre_Evolve       , &
-       &    Node_Component_Hot_Halo_Standard_State_Store
+       &    Node_Component_Hot_Halo_Standard_Scale_Set          , Node_Component_Hot_Halo_Standard_Post_Step        , &
+       &    Node_Component_Hot_Halo_Standard_State_Restore      , Node_Component_Hot_Halo_Standard_Pre_Evolve       , &
+       &    Node_Component_Hot_Halo_Standard_Thread_Uninitialize, Node_Component_Hot_Halo_Standard_State_Store
 
   !![
   <component>
@@ -205,7 +203,6 @@ module Node_Component_Hot_Halo_Standard
   class(darkMatterHaloScaleClass           ), pointer :: darkMatterHaloScale_
   class(hotHaloMassDistributionClass       ), pointer :: hotHaloMassDistribution_
   class(hotHaloTemperatureProfileClass     ), pointer :: hotHaloTemperatureProfile_
-  class(accretionHaloClass                 ), pointer :: accretionHalo_
   class(coolingInfallTorqueClass           ), pointer :: coolingInfallTorque_
   class(hotHaloRamPressureStrippingClass   ), pointer :: hotHaloRamPressureStripping_
   class(hotHaloRamPressureTimescaleClass   ), pointer :: hotHaloRamPressureTimescale_
@@ -213,7 +210,7 @@ module Node_Component_Hot_Halo_Standard
   class(hotHaloOutflowStrippingClass       ), pointer :: hotHaloOutflowStripping_
   class(chemicalStateClass                 ), pointer :: chemicalState_
   class(cosmologyParametersClass           ), pointer :: cosmologyParameters_
-  !$omp threadprivate(cosmologyFunctions_,darkMatterHaloScale_,hotHaloMassDistribution_,hotHaloTemperatureProfile_,accretionHalo_,chemicalState_,hotHaloRamPressureStripping_,hotHaloRamPressureTimescale_,cosmologyParameters_,hotHaloOutflowReincorporation_,hotHaloOutflowStripping_,coolingInfallTorque_)
+  !$omp threadprivate(cosmologyFunctions_,darkMatterHaloScale_,hotHaloMassDistribution_,hotHaloTemperatureProfile_,chemicalState_,hotHaloRamPressureStripping_,hotHaloRamPressureTimescale_,cosmologyParameters_,hotHaloOutflowReincorporation_,hotHaloOutflowStripping_,coolingInfallTorque_)
 
   ! Internal count of abundances and chemicals.
   integer                                                                         :: abundancesCount                                             , chemicalsCount
@@ -368,7 +365,6 @@ contains
        <objectBuilder class="darkMatterHaloScale"           name="darkMatterHaloScale_"           source="subParameters"/>
        <objectBuilder class="hotHaloMassDistribution"       name="hotHaloMassDistribution_"       source="subParameters"/>
        <objectBuilder class="hotHaloTemperatureProfile"     name="hotHaloTemperatureProfile_"     source="subParameters"/>
-       <objectBuilder class="accretionHalo"                 name="accretionHalo_"                 source="subParameters"/>
        <objectBuilder class="coolingInfallTorque"           name="coolingInfallTorque_"           source="subParameters"/>
        <objectBuilder class="chemicalState"                 name="chemicalState_"                 source="subParameters"/>
        <objectBuilder class="hotHaloRamPressureStripping"   name="hotHaloRamPressureStripping_"   source="subParameters"/>
@@ -414,7 +410,6 @@ contains
        <objectDestructor name="darkMatterHaloScale_"          />
        <objectDestructor name="hotHaloMassDistribution_"      />
        <objectDestructor name="hotHaloTemperatureProfile_"    />
-       <objectDestructor name="accretionHalo_"                />
        <objectDestructor name="coolingInfallTorque_"          />
        <objectDestructor name="chemicalState_"                />
        <objectDestructor name="hotHaloRamPressureStripping_"  />
@@ -842,57 +837,6 @@ contains
     return
   end subroutine Node_Component_Hot_Halo_Standard_Scale_Set
 
-  !![
-  <mergerTreeInitializeTask function="Node_Component_Hot_Halo_Standard_Tree_Initialize"/>
-  !!]
-  subroutine Node_Component_Hot_Halo_Standard_Tree_Initialize(node)
-    !!{RST
-    Initialize the contents of the hot halo component for any sub-resolution accretion (i.e. the gas that would have been accreted if the merger tree had infinite resolution).
-    !!}
-    use :: Accretion_Halos , only : accretionModeHot         , accretionModeTotal
-    use :: Galacticus_Nodes, only : defaultHotHaloComponent  , nodeComponentBasic, nodeComponentHotHalo, nodeEvent, &
-          &                         nodeEventSubhaloPromotion, treeNode          , nodeComponentSpin
-    implicit none
-    type            (treeNode            ), intent(inout), pointer :: node
-    class           (nodeComponentHotHalo)               , pointer :: currentHotHaloComponent
-    class           (nodeEvent           )               , pointer :: event
-    double precision                                               :: failedMass             , massHotHalo
-
-    ! If the node has a child or the standard hot halo is not active, then return immediately.
-    if (associated(node%firstChild).or..not.defaultHotHaloComponent%standardIsActive()) return
-
-    ! Search for a subhalo promotion events associated with this node.
-    event => node%event
-    do while (associated(event))
-       ! Check if this event:
-       !  a) is a subhalo promotion event;
-       !  b) has no associated task (which means this is the node being promoted to, not the node being promoted itself).
-       ! Do not assign any mass to such nodes, as they should receive gas from the node which is promoted to them.
-       select type (event)
-       type is (nodeEventSubhaloPromotion)
-          if (.not.associated(event%task)) return
-       end select
-       event => event%next
-    end do
-
-    ! Get the hot halo component.
-    currentHotHaloComponent => node%hotHalo()
-    ! Ensure that it is of unspecified class.
-    select type (currentHotHaloComponent)
-    type is (nodeComponentHotHalo)
-      ! Get the mass of hot gas accreted and the mass that failed to accrete.
-       massHotHalo=accretionHalo_%accretedMass      (node,accretionModeHot  )
-       failedMass =accretionHalo_%failedAccretedMass(node,accretionModeTotal)
-       ! If either is non-zero, then create a hot halo component and add these masses to it.
-       if (massHotHalo > 0.0d0 .or. failedMass > 0.0d0) then
-          ! NOTE: This call is required only to set up the initial outer radius. Once that is initialized by a nodeOperator, this
-          !       call (and the remainder of this function) can be removed.
-          call Node_Component_Hot_Halo_Standard_Create(node)
-       end if
-    end select
-    return
-  end subroutine Node_Component_Hot_Halo_Standard_Tree_Initialize
-
   subroutine Node_Component_Hot_Halo_Standard_Create(node)
     !!{RST
     Creates a hot halo component for ``node``.
@@ -1037,7 +981,7 @@ contains
 
     call displayMessage('Storing state for: componentHotHalo -> standard',verbosity=verbosityLevelInfo)
     !![
-    <stateStore variables="cosmologyFunctions_ darkMatterHaloScale_ hotHaloMassDistribution_ hotHaloTemperatureProfile_ accretionHalo_ chemicalState_ hotHaloRamPressureStripping_ hotHaloRamPressureTimescale_ cosmologyParameters_ hotHaloOutflowReincorporation_ hotHaloOutflowStripping_ coolingInfallTorque_"/>
+    <stateStore variables="cosmologyFunctions_ darkMatterHaloScale_ hotHaloMassDistribution_ hotHaloTemperatureProfile_ chemicalState_ hotHaloRamPressureStripping_ hotHaloRamPressureTimescale_ cosmologyParameters_ hotHaloOutflowReincorporation_ hotHaloOutflowStripping_ coolingInfallTorque_"/>
     !!]
     return
   end subroutine Node_Component_Hot_Halo_Standard_State_Store
@@ -1058,7 +1002,7 @@ contains
 
     call displayMessage('Retrieving state for: componentHotHalo -> standard',verbosity=verbosityLevelInfo)
     !![
-    <stateRestore variables="cosmologyFunctions_ darkMatterHaloScale_ hotHaloMassDistribution_ hotHaloTemperatureProfile_ accretionHalo_ chemicalState_ hotHaloRamPressureStripping_ hotHaloRamPressureTimescale_ cosmologyParameters_ hotHaloOutflowReincorporation_ hotHaloOutflowStripping_ coolingInfallTorque_"/>
+    <stateRestore variables="cosmologyFunctions_ darkMatterHaloScale_ hotHaloMassDistribution_ hotHaloTemperatureProfile_ chemicalState_ hotHaloRamPressureStripping_ hotHaloRamPressureTimescale_ cosmologyParameters_ hotHaloOutflowReincorporation_ hotHaloOutflowStripping_ coolingInfallTorque_"/>
     !!]
     return
   end subroutine Node_Component_Hot_Halo_Standard_State_Restore

--- a/source/tasks/evolve_forests/_class.F90
+++ b/source/tasks/evolve_forests/_class.F90
@@ -23,7 +23,6 @@
   use            :: Kind_Numbers                   , only : kind_int8
   use            :: Merger_Tree_Construction       , only : mergerTreeConstructorClass
   use            :: Meta_Tree_Compute_Times        , only : metaTreeProcessingTimeClass
-  use            :: Merger_Tree_Initialization     , only : mergerTreeInitializorClass
   use            :: Merger_Tree_Operators          , only : mergerTreeOperatorClass
   use            :: Merger_Tree_Outputters         , only : mergerTreeOutputter        , mergerTreeOutputterClass
   use            :: Merger_Trees_Evolve            , only : mergerTreeEvolver          , mergerTreeEvolverClass
@@ -73,7 +72,6 @@
      logical                                                :: estimateRunTimeOnly
      class           (mergerTreeEvolverClass     ), pointer :: mergerTreeEvolver_            => null()
      class           (mergerTreeOutputterClass   ), pointer :: mergerTreeOutputter_          => null()
-     class           (mergerTreeInitializorClass ), pointer :: mergerTreeInitializor_        => null()
      class           (nodeOperatorClass          ), pointer :: nodeOperator_                 => null()
      class           (evolveForestsWorkShareClass), pointer :: evolveForestsWorkShare_       => null()
      class           (outputTimesClass           ), pointer :: outputTimes_                  => null()
@@ -118,12 +116,11 @@
 
   ! Copies of objects used by each thread.
   class(mergerTreeOutputterClass  ), pointer :: mergerTreeOutputter_   => null()
-  class(mergerTreeInitializorClass), pointer :: mergerTreeInitializor_ => null()
   class(mergerTreeEvolverClass    ), pointer :: mergerTreeEvolver_     => null()
   class(mergerTreeConstructorClass), pointer :: mergerTreeConstructor_ => null()
   class(mergerTreeOperatorClass   ), pointer :: mergerTreeOperator_    => null()
   class(nodeOperatorClass         ), pointer :: nodeOperator_          => null()
-  !$omp threadprivate(mergerTreeOutputter_,mergerTreeInitializor_,mergerTreeEvolver_,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_)
+  !$omp threadprivate(mergerTreeOutputter_,mergerTreeEvolver_,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_)
 
 contains
 
@@ -145,7 +142,6 @@ contains
     class           (universeOperatorClass      ), pointer               :: universeOperator_
     class           (mergerTreeEvolverClass     ), pointer               :: mergerTreeEvolver_
     class           (mergerTreeOutputterClass   ), pointer               :: mergerTreeOutputter_
-    class           (mergerTreeInitializorClass ), pointer               :: mergerTreeInitializor_
     class           (randomNumberGeneratorClass ), pointer               :: randomNumberGenerator_
     class           (mergerTreeSeedsClass       ), pointer               :: mergerTreeSeeds_
     class           (*                          ), pointer               :: dummyPointer_
@@ -270,14 +266,13 @@ contains
     <objectBuilder class="universeOperator"       name="universeOperator_"       source="parameters"/>
     <objectBuilder class="mergerTreeEvolver"      name="mergerTreeEvolver_"      source="parameters"/>
     <objectBuilder class="mergerTreeOutputter"    name="mergerTreeOutputter_"    source="parameters"/>
-    <objectBuilder class="mergerTreeInitializor"  name="mergerTreeInitializor_"  source="parameters"/>
     <objectBuilder class="randomNumberGenerator"  name="randomNumberGenerator_"  source="parameters"/>
     <objectBuilder class="mergerTreeSeeds"        name="mergerTreeSeeds_"        source="parameters"/>
     !!]
     if (associated(parametersRoot)) then
-       self=taskEvolveForests(tolerateFailures,evolveForestsInParallel,countForestsMaximum,walltimeMaximum,timeIntervalReportProgress,estimateRunTimeOnly,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,metaTreeProcessingTime_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,mergerTreeSeeds_,parametersRoot)
+       self=taskEvolveForests(tolerateFailures,evolveForestsInParallel,countForestsMaximum,walltimeMaximum,timeIntervalReportProgress,estimateRunTimeOnly,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,metaTreeProcessingTime_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,randomNumberGenerator_,mergerTreeSeeds_,parametersRoot)
     else
-       self=taskEvolveForests(tolerateFailures,evolveForestsInParallel,countForestsMaximum,walltimeMaximum,timeIntervalReportProgress,estimateRunTimeOnly,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,metaTreeProcessingTime_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,mergerTreeSeeds_,parameters    )
+       self=taskEvolveForests(tolerateFailures,evolveForestsInParallel,countForestsMaximum,walltimeMaximum,timeIntervalReportProgress,estimateRunTimeOnly,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,metaTreeProcessingTime_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,randomNumberGenerator_,mergerTreeSeeds_,parameters    )
     end if
     !![
     <inputParametersValidate source="parameters"/>
@@ -307,14 +302,13 @@ contains
     <objectDestructor name="universeOperator_"      />
     <objectDestructor name="mergerTreeEvolver_"     />
     <objectDestructor name="mergerTreeOutputter_"   />
-    <objectDestructor name="mergerTreeInitializor_" />
     <objectDestructor name="randomNumberGenerator_" />
     <objectDestructor name="mergerTreeSeeds_"       />
     !!]
     return
   end function evolveForestsConstructorParameters
 
-  function evolveForestsConstructorInternal(tolerateFailures,evolveForestsInParallel,countForestsMaximum,walltimeMaximum,timeIntervalReportProgress,estimateRunTimeOnly,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,metaTreeProcessingTime_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,mergerTreeSeeds_,parameters) result(self)
+  function evolveForestsConstructorInternal(tolerateFailures,evolveForestsInParallel,countForestsMaximum,walltimeMaximum,timeIntervalReportProgress,estimateRunTimeOnly,suspendToRAM,suspendPath,timeIntervalCheckpoint,fileNameCheckpoint,mergerTreeConstructor_,metaTreeProcessingTime_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,randomNumberGenerator_,mergerTreeSeeds_,parameters) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`taskEvolveForests` task class.
     !!}
@@ -337,14 +331,13 @@ contains
     class           (universeOperatorClass      ), intent(in   ), target :: universeOperator_
     class           (mergerTreeEvolverClass     ), intent(in   ), target :: mergerTreeEvolver_
     class           (mergerTreeOutputterClass   ), intent(in   ), target :: mergerTreeOutputter_
-    class           (mergerTreeInitializorClass ), intent(in   ), target :: mergerTreeInitializor_
     class           (randomNumberGeneratorClass ), intent(in   ), target :: randomNumberGenerator_
     class           (mergerTreeSeedsClass       ), intent(in   ), target :: mergerTreeSeeds_
     type            (inputParameters            ), intent(in   ), target :: parameters
     integer         (c_size_t                   )                        :: i
     double precision                                                     :: timeStepMinimum
     !![
-    <constructorAssign variables="tolerateFailures, evolveForestsInParallel, countForestsMaximum, walltimeMaximum, timeIntervalReportProgress, estimateRunTimeOnly, suspendToRAM, suspendPath, timeIntervalCheckpoint, fileNameCheckpoint, *mergerTreeConstructor_, *metaTreeProcessingTime_, *mergerTreeOperator_, *nodeOperator_, *evolveForestsWorkShare_, *outputTimes_, *universeOperator_, *mergerTreeEvolver_, *mergerTreeOutputter_, *mergerTreeInitializor_, *randomNumberGenerator_, *mergerTreeSeeds_"/>
+    <constructorAssign variables="tolerateFailures, evolveForestsInParallel, countForestsMaximum, walltimeMaximum, timeIntervalReportProgress, estimateRunTimeOnly, suspendToRAM, suspendPath, timeIntervalCheckpoint, fileNameCheckpoint, *mergerTreeConstructor_, *metaTreeProcessingTime_, *mergerTreeOperator_, *nodeOperator_, *evolveForestsWorkShare_, *outputTimes_, *universeOperator_, *mergerTreeEvolver_, *mergerTreeOutputter_, *randomNumberGenerator_, *mergerTreeSeeds_"/>
     !!]
 
     self%parameters  => parameters
@@ -395,7 +388,6 @@ contains
 
     call mergerTreeEvolver_    %stateStore(stateFile,gslStateFile,stateOperationID)
     call mergerTreeOutputter_  %stateStore(stateFile,gslStateFile,stateOperationID)
-    call mergerTreeInitializor_%stateStore(stateFile,gslStateFile,stateOperationID)
     call mergerTreeConstructor_%stateStore(stateFile,gslStateFile,stateOperationID)
     call mergerTreeOperator_   %stateStore(stateFile,gslStateFile,stateOperationID)
     call nodeOperator_         %stateStore(stateFile,gslStateFile,stateOperationID)
@@ -416,7 +408,6 @@ contains
 
     call mergerTreeEvolver_    %stateRestore(stateFile,gslStateFile,stateOperationID)
     call mergerTreeOutputter_  %stateRestore(stateFile,gslStateFile,stateOperationID)
-    call mergerTreeInitializor_%stateRestore(stateFile,gslStateFile,stateOperationID)
     call mergerTreeConstructor_%stateRestore(stateFile,gslStateFile,stateOperationID)
     call mergerTreeOperator_   %stateRestore(stateFile,gslStateFile,stateOperationID)
     call nodeOperator_         %stateRestore(stateFile,gslStateFile,stateOperationID)
@@ -472,7 +463,6 @@ contains
     <objectDestructor name="self%universeOperator_"      />
     <objectDestructor name="self%mergerTreeEvolver_"     />
     <objectDestructor name="self%mergerTreeOutputter_"   />
-    <objectDestructor name="self%mergerTreeInitializor_" />
     <objectDestructor name="self%randomNumberGenerator_" />
     <objectDestructor name="self%mergerTreeSeeds_"       />
     !!]
@@ -693,21 +683,19 @@ contains
     ! Create per-thread copies of the objects used in tree processing. The merger tree constructor's copy inherits the set of tree
     ! masses constructed by the census above, and so does not re-construct them.
     allocate(mergerTreeOutputter_  ,mold=self%mergerTreeOutputter_  )
-    allocate(mergerTreeInitializor_,mold=self%mergerTreeInitializor_)
     allocate(mergerTreeEvolver_    ,mold=self%mergerTreeEvolver_    )
     allocate(mergerTreeConstructor_,mold=self%mergerTreeConstructor_)
     allocate(mergerTreeOperator_   ,mold=self%mergerTreeOperator_   )
     allocate(nodeOperator_         ,mold=self%nodeOperator_         )
     !$omp critical(evolveForestsDeepCopy)
     !![
-    <deepCopyReset variables="self%mergerTreeEvolver_ self%mergerTreeOutputter_ self%mergerTreeInitializor_ self%mergerTreeConstructor_ self%mergerTreeOperator_ self%nodeOperator_"/>
+    <deepCopyReset variables="self%mergerTreeEvolver_ self%mergerTreeOutputter_ self%mergerTreeConstructor_ self%mergerTreeOperator_ self%nodeOperator_"/>
     <deepCopy source="self%mergerTreeEvolver_"     destination="mergerTreeEvolver_"    />
     <deepCopy source="self%mergerTreeOutputter_"   destination="mergerTreeOutputter_"  />
-    <deepCopy source="self%mergerTreeInitializor_" destination="mergerTreeInitializor_"/>
     <deepCopy source="self%mergerTreeConstructor_" destination="mergerTreeConstructor_"/>
     <deepCopy source="self%mergerTreeOperator_"    destination="mergerTreeOperator_"   />
     <deepCopy source="self%nodeOperator_"          destination="nodeOperator_"         />
-    <deepCopyFinalize variables="mergerTreeEvolver_ mergerTreeOutputter_ mergerTreeInitializor_ mergerTreeConstructor_ mergerTreeOperator_ nodeOperator_"/>
+    <deepCopyFinalize variables="mergerTreeEvolver_ mergerTreeOutputter_ mergerTreeConstructor_ mergerTreeOperator_ nodeOperator_"/>
     !!]
     !$omp end critical(evolveForestsDeepCopy)
     !$omp barrier
@@ -810,7 +798,7 @@ contains
              ! Walk over all nodes and perform "node tree" initialization. This typically includes initialization related to
              ! the static structure of the tree (e.g. assign scale radii, merging orbits, etc.). Initialization related to
              ! evolution of the tree (e.g. growth rates of scale radii, baryonic component initialization) are typically handled
-             ! by the mergerTreeInitializor class which is called later.
+             ! by the mergerTreeInitializor class, which is invoked by the mergerTreeEvolver class later.
              call    mergerTreeOperator_%operatePreInitialization(tree)
              if (.not.tree%isTreeInitialized) then
                 treeWalkerAll=mergerTreeWalkerAllNodes(tree,spanForest=.true.)
@@ -1132,7 +1120,6 @@ contains
     ! Explicitly deallocate objects.
     !![
     <objectDestructor name="mergerTreeOutputter_"  />
-    <objectDestructor name="mergerTreeInitializor_"/>
     <objectDestructor name="mergerTreeEvolver_"    />
     <objectDestructor name="mergerTreeConstructor_"/>
     <objectDestructor name="mergerTreeOperator_"   />

--- a/source/tasks/postprocess_forests.F90
+++ b/source/tasks/postprocess_forests.F90
@@ -25,7 +25,6 @@
   use :: Numerical_Random_Numbers  , only : randomNumberGeneratorClass
   use :: Output_Times              , only : outputTimesClass
   use :: Merger_Tree_Construction  , only : mergerTreeConstructorClass
-  use :: Merger_Tree_Initialization, only : mergerTreeInitializorClass
   use :: Merger_Tree_Operators     , only : mergerTreeOperatorClass
   use :: Merger_Trees_Evolve       , only : mergerTreeEvolverClass
   use :: Nodes_Operators           , only : nodeOperatorClass
@@ -48,7 +47,6 @@
      class  (mergerTreeOperatorClass    ), pointer :: mergerTreeOperator_       => null()
      class  (mergerTreeEvolverClass     ), pointer :: mergerTreeEvolver_        => null()
      class  (mergerTreeOutputterClass   ), pointer :: mergerTreeOutputter_      => null()
-     class  (mergerTreeInitializorClass ), pointer :: mergerTreeInitializor_    => null()
      class  (nodeOperatorClass          ), pointer :: nodeOperator_             => null()
      class  (evolveForestsWorkShareClass), pointer :: evolveForestsWorkShare_   => null()
      class  (outputTimesClass           ), pointer :: outputTimes_              => null()
@@ -96,7 +94,6 @@ contains
     class(universeOperatorClass      ), pointer               :: universeOperator_
     class(mergerTreeEvolverClass     ), pointer               :: mergerTreeEvolver_
     class(mergerTreeOutputterClass   ), pointer               :: mergerTreeOutputter_
-    class(mergerTreeInitializorClass ), pointer               :: mergerTreeInitializor_
     class(randomNumberGeneratorClass ), pointer               :: randomNumberGenerator_
     class(mergerTreeSeedsClass       ), pointer               :: mergerTreeSeeds_
     class(*                          ), pointer               :: dummyPointer_
@@ -135,14 +132,13 @@ contains
     <objectBuilder class="universeOperator"       name="universeOperator_"       source="parameters"/>
     <objectBuilder class="mergerTreeEvolver"      name="mergerTreeEvolver_"      source="parameters"/>
     <objectBuilder class="mergerTreeOutputter"    name="mergerTreeOutputter_"    source="parameters"/>
-    <objectBuilder class="mergerTreeInitializor"  name="mergerTreeInitializor_"  source="parameters"/>
     <objectBuilder class="randomNumberGenerator"  name="randomNumberGenerator_"  source="parameters"/>
     <objectBuilder class="mergerTreeSeeds"        name="mergerTreeSeeds_"        source="parameters"/>
     !!]
     if (associated(parametersRoot)) then
-       self=taskPostprocessForests(fileName,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,mergerTreeSeeds_,parametersRoot)
+       self=taskPostprocessForests(fileName,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,randomNumberGenerator_,mergerTreeSeeds_,parametersRoot)
     else
-       self=taskPostprocessForests(fileName,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,mergerTreeSeeds_,parameters    )
+       self=taskPostprocessForests(fileName,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,randomNumberGenerator_,mergerTreeSeeds_,parameters    )
     end if
     !![
     <inputParametersValidate source="parameters"/>
@@ -171,14 +167,13 @@ contains
     <objectDestructor name="universeOperator_"      />
     <objectDestructor name="mergerTreeEvolver_"     />
     <objectDestructor name="mergerTreeOutputter_"   />
-    <objectDestructor name="mergerTreeInitializor_" />
     <objectDestructor name="randomNumberGenerator_" />
     <objectDestructor name="mergerTreeSeeds_"       />
     !!]
     return
   end function postprocessForestsConstructorParameters
 
-  function postprocessForestsConstructorInternal(fileName,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,mergerTreeInitializor_,randomNumberGenerator_,mergerTreeSeeds_,parameters) result(self)
+  function postprocessForestsConstructorInternal(fileName,mergerTreeConstructor_,mergerTreeOperator_,nodeOperator_,evolveForestsWorkShare_,outputTimes_,universeOperator_,mergerTreeEvolver_,mergerTreeOutputter_,randomNumberGenerator_,mergerTreeSeeds_,parameters) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`taskPostprocessForests` task class.
     !!}
@@ -196,11 +191,10 @@ contains
     class(universeOperatorClass      ), intent(in   ), target :: universeOperator_
     class(mergerTreeEvolverClass     ), intent(in   ), target :: mergerTreeEvolver_
     class(mergerTreeOutputterClass   ), intent(in   ), target :: mergerTreeOutputter_
-    class(mergerTreeInitializorClass ), intent(in   ), target :: mergerTreeInitializor_
     class(randomNumberGeneratorClass ), intent(in   ), target :: randomNumberGenerator_
     class(mergerTreeSeedsClass       ), intent(in   ), target :: mergerTreeSeeds_
     !![
-    <constructorAssign variables="fileName, *mergerTreeConstructor_, *mergerTreeOperator_, *nodeOperator_, *evolveForestsWorkShare_, *outputTimes_, *universeOperator_, *mergerTreeEvolver_, *mergerTreeOutputter_, *mergerTreeInitializor_, *randomNumberGenerator_, *mergerTreeSeeds_, *parameters"/>
+    <constructorAssign variables="fileName, *mergerTreeConstructor_, *mergerTreeOperator_, *nodeOperator_, *evolveForestsWorkShare_, *outputTimes_, *universeOperator_, *mergerTreeEvolver_, *mergerTreeOutputter_, *randomNumberGenerator_, *mergerTreeSeeds_, *parameters"/>
     !!]
 
     return 
@@ -224,7 +218,6 @@ contains
     <objectDestructor name="self%universeOperator_"      />
     <objectDestructor name="self%mergerTreeEvolver_"     />
     <objectDestructor name="self%mergerTreeOutputter_"   />
-    <objectDestructor name="self%mergerTreeInitializor_" />
     <objectDestructor name="self%randomNumberGenerator_" />
     <objectDestructor name="self%mergerTreeSeeds_"       />
     !!]


### PR DESCRIPTION
## Summary
- Removes the unused `mergerTreeInitializor` members of `taskEvolveForests` and `taskPostprocessForests`. Both built, deep-copied, state-stored and destroyed the object, but neither ever called `initialize` on it.
- Removes `Node_Component_Hot_Halo_Standard_Tree_Initialize`, whose logic has already migrated to `nodeOperatorCGMAccretion%nodeInitialize`, plus the `accretionHalo_` object it was the last consumer of.
- Clears the now-dangling `after` attribute on the cold mode hook.

The `mergerTreeInitializor` **class itself is not dead** and is untouched: the merger tree evolvers (`standard`, `nonEvolving`, and `threaded` via the inherited `initializeTree`) call `initialize`, which is the only thing driving `nodeOperator%nodeInitialize` during tree evolution. Only the redundant task-level instances are removed.

Two invariants were checked before removing:
- Both tasks still build the same object set as each other, preserving the metaProperty registration consistency that the raw format serialization in `taskPostprocessForests` depends on (see the note at the top of `postprocessForestsConstructorParameters`).
- The residual effect of the hot halo hook was initializing the CGM outer radius. That is covered by `nodeOperatorCGMAccretion` creating the component under identical guards, and by `Node_Component_Hot_Halo_Standard_Pre_Evolve`.

⚠️ This changes the state file layout (both in the task and in the standard hot halo component), so checkpoints written by earlier versions can no longer be read.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [x] Other: dead code removal

## How to test
Targeted subset run locally, all passing:

| Test | Covers |
|---|---|
| `test-postprocessing.py` | `taskPostprocessForests` + raw format serialization consistency |
| `test-checkpointing.py` | `taskEvolveForests` state store/restore across interrupt and resume |
| `test-mass-conservation-standard.py` | standard hot halo + `CGMAccretion`; baryonic total within 1e-3 of unity |
| `test-mass-conservation-coldMode.py` | cold mode component and the surviving hook |
| `test-allowed-parameters.py` | no orphaned parameters from the removed `objectBuilder`s |
| `test-pruneLightcone.py`, `test-merger-tree-export.sh` | parameter files carrying an explicit root level `<mergerTreeInitializor/>` |

The last three confirm the main risk did not materialize: those parameter files declare `mergerTreeInitializor` at the root, which the task used to consume directly. It is now consumed only via the evolver's upward lookup, and `inputParametersValidate` still accepts it.

## Checklist
- [x] I ran relevant tests (or explain why not): subset above; full suite left to CI
- [x] I updated documentation/comments if needed: corrected a stale comment in `taskEvolveForests` that said the task called the initializor
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

## Follow-on
`Node_Component_Hot_Halo_Cold_Mode_Tree_Initialize` is deliberately left in place: no node operator yet sets the cold mode masses at initialization, so the `mergerTreeInitializeTask` event hook still has that one subscriber. Migrating it is part of a larger effort; once done, the hook and its `eventHookStatic` can be removed entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
