### PR TITLE
fix(scripts): target only the job's own processes in backtraceSlurm.py

### DIFF
--- a/scripts/aux/backtraceSlurm.py
+++ b/scripts/aux/backtraceSlurm.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 import sys
-import os
 import re
 import argparse
 import subprocess
 
 # Obtain stack traces from all threads of all running Galacticus processes that are part of a given Slurm job and output to file.
 # Andrew Benson (14-May-2025)
+# Job-based process selection and process identity reporting added with assistance from Claude (23-July-2026).
 
 parser = argparse.ArgumentParser(prog='backtraceSlurm.py', description='Obtain stack traces from all threads of all running Galacticus processes in a Slurm job.')
 parser.add_argument('slurmJobID', help='Slurm job ID')
@@ -36,16 +36,45 @@ for line in result.stdout.splitlines():
     if line:
         node_names.append(line)
 
+# Script to be run on each node. Processes are taken from the process list of the job itself (via `scontrol listpids`), rather than
+# from a simple match on process name for the user - matching on process name alone will also find Galacticus processes belonging to
+# any other job of the same user that happens to share the node, resulting in stack traces that do not correspond to the job being
+# debugged. The identity of each process (command line, working directory, start time, and state) is recorded alongside its stack
+# trace so that any such misattribution is immediately apparent.
+remoteScript = r"""
+found=0
+while read -r pid rest; do
+  case "$pid" in
+    ""|PID) continue ;;
+  esac
+  comm=$(cat /proc/$pid/comm 2>/dev/null)
+  if [ "$comm" != "Galacticus.exe" ]; then continue; fi
+  found=$((found+1))
+  echo "===================================================================="
+  echo "PID              : $pid"
+  echo "Command          : $(tr "\0" " " < /proc/$pid/cmdline)"
+  echo "Working directory: $(readlink /proc/$pid/cwd)"
+  echo "Started          : $(ps -o lstart= -p $pid)"
+  echo "Elapsed          : $(ps -o etime= -p $pid)"
+  echo "State            : $(ps -o stat= -p $pid)"
+  echo "===================================================================="
+  gdb --pid $pid -batch -ex "info threads" -ex "thread apply all where"
+done < <(scontrol listpids {JOBID})
+if [ $found -eq 0 ]; then
+  echo "WARNING: no Galacticus.exe processes belonging to job {JOBID} were found on this node"
+fi
+""".replace("{JOBID}", args.slurmJobID)
+
 # Open output file and iterate over nodes.
-user = os.environ.get('USER', '')
 with open(args.outputFile, 'w') as output:
     for node_name in node_names:
         print(f"Connecting to node '{node_name}'....")
         output.write(f"Node: {node_name}\n")
+        # The `--overlap` option (Slurm ≥ 20.11) allows this step to share the resources already allocated to the job - without it
+        # the step will block until resources become free, which will never happen for a job that is fully occupying its allocation.
         cmd = (
-            f"srun --jobid={args.slurmJobID} -w {node_name} --pty bash -c "
-            f"'pgrep -u {user} \"Galacticus.exe\" | xargs -i{{}} gdb --pid {{}} -batch "
-            f"-ex \"info threads\" -ex \"thread apply all where\"'"
+            f"srun --jobid={args.slurmJobID} --overlap -w {node_name} --pty bash -c "
+            f"'{remoteScript}'"
         )
         result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         output.write(result.stdout)


### PR DESCRIPTION
## Summary
- `backtraceSlurm.py` selected targets with `pgrep -u $USER Galacticus.exe`, which matches *every* Galacticus process owned by the user on the node. The Slurm job ID was used only to determine the node list, so a Galacticus belonging to another job of the same user sharing the node could be traced instead — and nothing in the output revealed the misattribution. This was hit in practice: a trace was taken for a job whose log ended with `MM: <- Done task: merger tree evolution`, yet every thread was inside the `evolveForests` OpenMP parallel region, which is closed before that message is emitted (`source/tasks/evolve_forests/_class.F90:1151` vs `:1173`).
- Targets are now taken from the job's own process list via `scontrol listpids`, with each candidate confirmed to be Galacticus via `/proc/<pid>/comm` before gdb attaches (this also excludes the step's own shell).
- Each trace is preceded by the process command line, working directory, start time, elapsed time and state, so a mismatch is obvious on inspection and a computing process can be told from a blocked one. In the case above, `Elapsed: 03:33:02` against a log reporting `1.05 d` of wall time identified the stale log immediately.
- Nodes with no matching process now report that explicitly instead of leaving an empty block.
- Added `--overlap` to the `srun` invocation, without which the step blocks waiting for resources the job already holds.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Docs / tooling
- [ ] Other:

## How to test
Run against a live job:

```bash
./scripts/aux/backtraceSlurm.py <jobid> backtrace.log
```

Each process block should be headed by the identity information, and the command line should name the parameter file you expect.

The process-selection logic was also exercised offline with a stand-in `Galacticus.exe` and a fake `scontrol listpids`, confirming that the header line is skipped, non-Galacticus pids are skipped, the identity block is correct, gdb attaches and produces a trace, and the no-match warning path works.

Note: `--overlap` requires Slurm >= 20.11.

## Checklist
- [x] I ran relevant tests (or explain why not): this script is not covered by the test suite; verified manually against a live job and offline as described above. No Galacticus source is touched, so no build/quick-test impact.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

🤖 Generated with [Claude Code](https://claude.com/claude-code)