### PR TITLE
feat: support positional (`[N]`) XPath predicates in element lookup

### DIFF
--- a/source/tests/IO/XML.F90
+++ b/source/tests/IO/XML.F90
@@ -25,25 +25,25 @@ program Tests_IO_XML
   !!{RST
   Tests the XML I/O module.
   !!}
-  use            :: Unit_Tests    , only : Assert                        , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
-  use            :: IO_XML        , only : XML_Count_Elements_By_Tag_Name                        , XML_Array_Read      , XML_Array_Read_Static, XML_Get_First_Element_By_Tag_Name, &
-          &                                XML_Parse                                             , XML_Path_Exists     , xmlNodeList          , XML_Get_ELements_By_Tag_Name
-  use            :: Display       , only : displayVerbositySet           , verbosityLevelStandard
-  use            :: FoX_DOM       , only : destroy                       , node                  , serialize           , extractDataContent
-  use            :: Error         , only : Error_Report
-  use, intrinsic :: ISO_C_Binding , only : c_size_t
-  use            :: System_Command, only : System_Command_Do
-  use            :: ISO_Varying_String, only : varying_string             , char
+  use            :: Unit_Tests        , only : Assert                        , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
+  use            :: IO_XML            , only : XML_Count_Elements_By_Tag_Name                        , XML_Array_Read      , XML_Array_Read_Static, XML_Get_First_Element_By_Tag_Name, &
+          &                                    XML_Parse                                             , XML_Path_Exists     , xmlNodeList          , XML_Get_ELements_By_Tag_Name
+  use            :: Display           , only : displayVerbositySet           , verbosityLevelStandard
+  use            :: FoX_DOM           , only : destroy                       , node                  , serialize           , extractDataContent
+  use            :: Error             , only : Error_Report
+  use, intrinsic :: ISO_C_Binding     , only : c_size_t
+  use            :: System_Command    , only : System_Command_Do
+  use            :: ISO_Varying_String, only : varying_string                , char
   implicit none
-  type            (node          )                        , pointer :: doc        , xmlElement
-  type            (xmlNodeList   ), allocatable, dimension(:)        :: xmlElements
-  double precision                , allocatable, dimension(:)        :: array1     , array2
-  integer                         , allocatable, dimension(:)        :: iarray1
-  character       (len=1         ), allocatable, dimension(:)        :: carray1
-  integer                                      , dimension(1)        :: iValue
-  integer                                                           :: ioErr      , status
-  type            (varying_string)                                  :: pathFailed
-  logical                                                           :: pathExists
+  type            (node          ), pointer                   :: doc        , xmlElement
+  type            (xmlNodeList   ), allocatable, dimension(:) :: xmlElements
+  double precision                , allocatable, dimension(:) :: array1     , array2
+  integer                         , allocatable, dimension(:) :: iarray1
+  character       (len=1         ), allocatable, dimension(:) :: carray1
+  integer                                      , dimension(1) :: iValue
+  integer                                                     :: ioErr      , status
+  type            (varying_string)                            :: pathFailed
+  logical                                                     :: pathExists
 
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)

--- a/source/tests/IO/XML.F90
+++ b/source/tests/IO/XML.F90
@@ -33,14 +33,17 @@ program Tests_IO_XML
   use            :: Error         , only : Error_Report
   use, intrinsic :: ISO_C_Binding , only : c_size_t
   use            :: System_Command, only : System_Command_Do
+  use            :: ISO_Varying_String, only : varying_string             , char
   implicit none
-  type            (node       )                           , pointer :: doc        , xmlElement
-  type            (xmlNodeList), allocatable, dimension(:)          :: xmlElements
-  double precision             , allocatable, dimension(:)          :: array1     , array2
-  integer                      , allocatable, dimension(:)          :: iarray1
-  character       (len=1      ), allocatable, dimension(:)          :: carray1
-  integer                                   , dimension(1)          :: iValue
+  type            (node          )                        , pointer :: doc        , xmlElement
+  type            (xmlNodeList   ), allocatable, dimension(:)        :: xmlElements
+  double precision                , allocatable, dimension(:)        :: array1     , array2
+  integer                         , allocatable, dimension(:)        :: iarray1
+  character       (len=1         ), allocatable, dimension(:)        :: carray1
+  integer                                      , dimension(1)        :: iValue
   integer                                                           :: ioErr      , status
+  type            (varying_string)                                  :: pathFailed
+  logical                                                           :: pathExists
 
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
@@ -93,6 +96,34 @@ program Tests_IO_XML
   ! Test path detection.
   call Assert("Extant path correctly detected"    ,XML_Path_Exists(doc,"test/level1/level2/level3"),.true. )
   call Assert("Non-extant path correctly detected",XML_Path_Exists(doc,"test/level1/level4/level3"),.false.)
+
+  ! Test positional (`[N]`) XPath predicates. The `test/some/path` element contains three `to` child elements, which we address
+  ! by position here.
+  call Unit_Tests_Begin_Group("Positional XPath predicates")
+  ! Select the third `to` element by its position and read its content.
+  xmlElement => XML_Get_First_Element_By_Tag_Name(doc,"test/some/path/to[3]",directChildrenOnly=.true.)
+  call extractDataContent(xmlElement,iValue)
+  call Assert("Select element by positional predicate",iValue,[653728])
+  ! Combine an attribute predicate with a positional predicate to select the (only) `to` element with `value='scoobydoo'`.
+  xmlElement => XML_Get_First_Element_By_Tag_Name(doc,"test/some/path/to[@value='scoobydoo'][1]/find",directChildrenOnly=.true.)
+  call extractDataContent(xmlElement,iValue)
+  call Assert("Combine attribute and positional predicates",iValue,[9275932])
+  ! Count direct-child elements, with and without a positional predicate.
+  xmlElement => XML_Get_First_Element_By_Tag_Name(doc,"test/some/path",directChildrenOnly=.true.)
+  call Assert("Count direct-child matches"                  ,XML_Count_Elements_By_Tag_Name(xmlElement,"to"   ,directChildrenOnly=.true.),3_c_size_t)
+  call Assert("Count direct-child matches (positional)"     ,XML_Count_Elements_By_Tag_Name(xmlElement,"to[2]",directChildrenOnly=.true.),1_c_size_t)
+  call Assert("Count direct-child matches (index too large)",XML_Count_Elements_By_Tag_Name(xmlElement,"to[9]",directChildrenOnly=.true.),0_c_size_t)
+  ! Retrieve the element list for a positional predicate - it should contain exactly the single indexed element.
+  call XML_Get_Elements_By_Tag_Name(xmlElement,"to[2]",xmlElements,directChildrenOnly=.true.)
+  call Assert("Retrieve single element for positional predicate",size(xmlElements),1)
+  ! Detect existence of positional paths.
+  call Assert("Extant positional path detected"    ,XML_Path_Exists(doc,"test/some/path/to[2]/find"),.true. )
+  call Assert("Non-extant positional path detected",XML_Path_Exists(doc,"test/some/path/to[3]/find"),.false.)
+  ! On failure, `pathFailed` should report the path up to and including the first segment that could not be matched.
+  pathExists=XML_Path_Exists(doc,"test/some/path/to[3]/find",pathFailed=pathFailed)
+  call Assert("Non-extant positional path returns false"  ,pathExists      ,.false.                    )
+  call Assert("Report location of path resolution failure",char(pathFailed),"test/some/path/to[3]/find")
+  call Unit_Tests_End_Group()
 
   ! Destroy the XML document.
   call destroy(doc)

--- a/source/utility/IO/XML.F90
+++ b/source/utility/IO/XML.F90
@@ -287,50 +287,101 @@ contains
     return
   end subroutine XML_Get_Child_Elements
   
-  recursive subroutine XML_Get_Elements_By_Tag_Name(xmlElement,tagName,elements)
+  subroutine XML_Tag_Name_Parse(tagName,tagName_,attributeName,attributeValue,elementIndex)
     !!{RST
-    Return a list of pointers to all nodes matching a given ``tagName``.
+    Parse an XPath-like ``tagName`` that may contain an attribute predicate (``[@attribute='value']``) and/or a positional
+    predicate (``[N]``). Returns the bare tag name in ``tagName_``, the attribute name and value (empty strings if no attribute
+    predicate is present), and the 1-based positional index in ``elementIndex`` (zero if no positional predicate is present). A
+    positional predicate, if present, must be the final component of the tag name.
+    !!}
+    implicit none
+    character(len=*           ), intent(in   ) :: tagName
+    character(len=*           ), intent(  out) :: tagName_    , attributeName, &
+         &                                        attributeValue
+    integer                    , intent(  out) :: elementIndex
+    character(len=len(tagName))                :: tagBase
+    integer                                    :: openBracket , closeBracket
+
+    ! Extract any trailing positional predicate `[N]`. Such a predicate is always the final component of the tag name, so we
+    ! find the last `[` and treat it as a positional predicate only if its contents consist solely of digits.
+    elementIndex=0
+    tagBase     =tagName
+    openBracket =index(tagName,"[",back=.true.)
+    if (openBracket > 0) then
+       closeBracket=index(tagName(openBracket:),"]")
+       if (closeBracket > 0) then
+          closeBracket=closeBracket+openBracket-1
+          if (closeBracket > openBracket+1 .and. verify(tagName(openBracket+1:closeBracket-1),"0123456789") == 0) then
+             read (tagName(openBracket+1:closeBracket-1),*) elementIndex
+             tagBase=tagName(1:openBracket-1)
+          end if
+       end if
+    end if
+    ! Extract any attribute predicate `[@attribute='value']` from the remaining tag name.
+    if (index(tagBase,"[@") > 0) then
+       tagName_      =tagBase(                    1:index(tagBase,"[@")-1)
+       attributeName =tagBase(index(tagBase,"[@")+2:index(tagBase,"=" )-1)
+       attributeValue=tagBase(index(tagBase,"=" )+2:index(tagBase,"]" )-2)
+    else
+       tagName_      =tagBase
+       attributeName =""
+       attributeValue=""
+    end if
+    return
+  end subroutine XML_Tag_Name_Parse
+
+  recursive subroutine XML_Get_Elements_By_Tag_Name(xmlElement,tagName,elements,directChildrenOnly)
+    !!{RST
+    Return a list of pointers to all nodes matching a given ``tagName``. By default the search descends recursively through all
+    descendants of ``xmlElement``. If ``directChildrenOnly`` is set then only the direct children of ``xmlElement`` are
+    considered---this mode is required to use a positional (``[N]``) predicate in the ``tagName``, since such a predicate selects
+    the ``N``-th matching direct child.
     !!}
     use, intrinsic :: ISO_C_Binding, only : c_size_t
     use            :: FoX_DOM      , only : Element_Node, getFirstChild, getNextSibling, getNodeName , &
           &                                 getNodeType , hasChildNodes, node          , getAttribute
+    use            :: Error        , only : Error_Report
     implicit none
     type     (xmlNodeList     ), intent(inout), allocatable, dimension(:) :: elements
     integer  (c_size_t        )                                           :: countElements , offset
     type     (node            ), intent(in   ), pointer                   :: xmlElement
     character(len=*           ), intent(in   )                            :: tagName
+    logical                    , intent(in   ), optional                  :: directChildrenOnly
     type     (node            )               , pointer                   :: childNode
     type     (xmlNodeList     )               , allocatable, dimension(:) :: childElements
     logical                                                               :: matchAll      , matches
+    integer                                                               :: elementIndex  , matchCount
     character(len=len(tagName))                                           :: tagName_      , attributeName, &
          &                                                                   attributeValue
+    !![
+    <optionalArgument name="directChildrenOnly" defaultsTo=".false."/>
+    !!]
 
-    countElements=XML_Count_Elements_By_Tag_Name(xmlElement,tagName)    
+    call XML_Tag_Name_Parse(tagName,tagName_,attributeName,attributeValue,elementIndex)
+    if (elementIndex > 0 .and. .not.directChildrenOnly_) call Error_Report('positional XPath predicate (e.g. `[15]`) is only supported when `directChildrenOnly` is set'//{introspection:location})
+    countElements=XML_Count_Elements_By_Tag_Name(xmlElement,tagName,directChildrenOnly=directChildrenOnly_)
     offset       =0_c_size_t
+    matchCount   =0
     if (allocated(elements)) deallocate(elements)
     allocate(elements(0:countElements-1))
+    matchAll=trim(tagName_) == "*"
     if (hasChildNodes(xmlElement)) then
-      if (index(tagName,"[@") > 0) then
-         tagName_      =tagName(                    1:index(tagName,"[@")-1)
-         attributeName =tagName(index(tagName,"[@")+2:index(tagName,"=" )-1)
-         attributeValue=tagName(index(tagName,"=" )+2:index(tagName,"]" )-2)
-      else
-          tagName_      =tagName
-          attributeName =""
-          attributeValue=""
-       end if
-       matchAll  =  trim(tagName_) == "*"
        childNode => getFirstChild(xmlElement)
        do while (associated(childNode))
-          call XML_Get_Elements_By_Tag_Name(childNode,tagName,childElements)
-          elements(offset:offset+size(childElements)-1)=childElements
-          offset=offset+size(childElements)
-          deallocate(childElements)
+          if (.not.directChildrenOnly_) then
+             call XML_Get_Elements_By_Tag_Name(childNode,tagName,childElements)
+             elements(offset:offset+size(childElements)-1)=childElements
+             offset=offset+size(childElements)
+             deallocate(childElements)
+          end if
           if (getNodeType(childNode) == Element_Node .and. (matchAll .or. getNodeName(childNode) == trim(tagName_))) then
              matches=attributeName == "" .or. getAttribute(childNode,trim(attributeName)) == trim(attributeValue)
              if (matches) then
-                elements(offset)%element => childNode
-                offset=offset+1_c_size_t
+                matchCount=matchCount+1
+                if (elementIndex == 0 .or. matchCount == elementIndex) then
+                   elements(offset)%element => childNode
+                   offset=offset+1_c_size_t
+                end if
              end if
           end if
           childNode => getNextSibling(childNode)
@@ -339,39 +390,43 @@ contains
     return
   end subroutine XML_Get_Elements_By_Tag_Name
   
-  recursive function XML_Count_Elements_By_Tag_Name(xmlElement,tagName) result(countElements)
+  recursive function XML_Count_Elements_By_Tag_Name(xmlElement,tagName,directChildrenOnly) result(countElements)
     !!{RST
-    Return a count of all nodes matching a given ``tagName``.
+    Return a count of all nodes matching a given ``tagName``. See {\normalfont \ttfamily XML\_Get\_Elements\_By\_Tag\_Name} for a
+    description of the ``directChildrenOnly`` argument.
     !!}
     use, intrinsic :: ISO_C_Binding, only : c_size_t
     use            :: FoX_DOM      , only : Element_Node, getFirstChild, getNextSibling, getNodeName, &
           &                                 getNodeType , hasChildNodes, node          , getAttribute
+    use            :: Error        , only : Error_Report
     implicit none
     integer  (c_size_t        )                         :: countElements
     type     (node            ), intent(in   ), pointer :: xmlElement
     character(len=*           ), intent(in   )          :: tagName
+    logical                    , intent(in   ), optional :: directChildrenOnly
     type     (node            )               , pointer :: childNode
     logical                                             :: matchAll
+    integer                                             :: elementIndex  , matchCount
     character(len=len(tagName))                         :: tagName_      , attributeName, &
          &                                                 attributeValue
+    !![
+    <optionalArgument name="directChildrenOnly" defaultsTo=".false."/>
+    !!]
 
+    call XML_Tag_Name_Parse(tagName,tagName_,attributeName,attributeValue,elementIndex)
+    if (elementIndex > 0 .and. .not.directChildrenOnly_) call Error_Report('positional XPath predicate (e.g. `[15]`) is only supported when `directChildrenOnly` is set'//{introspection:location})
     countElements=0_c_size_t
+    matchCount   =0
+    matchAll     =trim(tagName_) == "*"
     if (hasChildNodes(xmlElement)) then
-       if (index(tagName,"[@") > 0) then
-          tagName_      =tagName(                    1:index(tagName,"[@")-1)
-          attributeName =tagName(index(tagName,"[@")+2:index(tagName,"=" )-1)
-          attributeValue=tagName(index(tagName,"=" )+2:index(tagName,"]" )-2)
-       else
-          tagName_      =tagName
-          attributeName =""
-          attributeValue=""
-       end if
-       matchAll  =  trim(tagName_) == "*"
        childNode => getFirstChild(xmlElement)
        do while (associated(childNode))
-          countElements=countElements+XML_Count_Elements_By_Tag_Name(childNode,tagName)
+          if (.not.directChildrenOnly_) countElements=countElements+XML_Count_Elements_By_Tag_Name(childNode,tagName)
           if (getNodeType(childNode) == Element_Node .and. (matchAll .or. getNodeName(childNode) == trim(tagName_))) then
-             if (attributeName == "" .or. getAttribute(childNode,trim(attributeName)) == trim(attributeValue)) countElements=countElements+1_c_size_t
+             if (attributeName == "" .or. getAttribute(childNode,trim(attributeName)) == trim(attributeValue)) then
+                matchCount=matchCount+1
+                if (elementIndex == 0 .or. matchCount == elementIndex) countElements=countElements+1_c_size_t
+             end if
           end if
           childNode => getNextSibling(childNode)
        end do
@@ -414,7 +469,7 @@ contains
           currentTagName=path(             1:pathPosition-1)
           path          =path(pathPosition+1:len(path)     )
        endif
-       call XML_Get_Elements_By_Tag_Name(element,currentTagName,elementList)
+       call XML_Get_Elements_By_Tag_Name(element,currentTagName,elementList,directChildrenOnly=directChildrenOnly_)
        if (size(elementList) < 1) then
           call Error_Report('no elements match tag name "'//trim(currentTagName)//'"'//{introspection:location})
        else
@@ -437,24 +492,31 @@ contains
     return
   end function XML_Get_First_Element_By_Tag_Name
 
-  logical function XML_Path_Exists(xmlElement,path)
+  logical function XML_Path_Exists(xmlElement,path,pathFailed)
     !!{RST
-    Return true if the supplied ``path`` exists in the supplied ``xmlElement``.
+    Return true if the supplied ``path`` exists in the supplied ``xmlElement``. If the path does not exist and the optional
+    ``pathFailed`` argument is present, it is set to the portion of ``path`` up to and including the first segment that could not
+    be matched. This is useful for constructing informative error messages that indicate where in the path resolution failed.
     !!}
-    use :: FoX_dom, only : ELEMENT_NODE , getElementsByTagName, getLength, getNodeType, &
-          &                getParentNode, node
+    use :: FoX_dom           , only : ELEMENT_NODE , getElementsByTagName, getLength, getNodeType, &
+          &                           getParentNode, node
+    use :: ISO_Varying_String, only : assignment(=), operator(//)
     implicit none
-    type     (node         ), intent(in   ), pointer      :: xmlElement
-    character(len=*        ), intent(in   )               :: path
-    type     (node         )               , pointer      :: element     , child         , &
-         &                                                   parent
-    character(len=len(path))                              :: currentPath , currentTagName
-    integer                                               :: pathPosition, i
-    type     (xmlNodeList  ), allocatable  , dimension(:) :: elementList
+    type     (node          ), intent(in   ), pointer      :: xmlElement
+    character(len=*         ), intent(in   )               :: path
+    type     (varying_string), intent(  out), optional     :: pathFailed
+    type     (node          )               , pointer      :: element     , child         , &
+         &                                                    parent
+    character(len=len(path) )                              :: currentPath , currentTagName
+    type     (varying_string)                              :: pathSoFar
+    logical                                                :: firstSegment
+    integer                                                :: pathPosition, i
+    type     (xmlNodeList   ), allocatable  , dimension(:) :: elementList
 
     XML_Path_Exists =  .true.
     element         => xmlElement
     currentPath     =  path
+    firstSegment    =  .true.
     do while (currentPath /= "")
        pathPosition=index(currentPath,"/")
        if (pathPosition == 0) then
@@ -464,9 +526,16 @@ contains
           currentTagName=currentPath(             1:pathPosition-1)
           currentPath   =currentPath(pathPosition+1:len(path)     )
        endif
-       call XML_Get_Elements_By_Tag_Name(element,currentTagName,elementList)
+       if (firstSegment) then
+          pathSoFar   =                 trim(currentTagName)
+          firstSegment=.false.
+       else
+          pathSoFar   =pathSoFar//"/"//trim(currentTagName)
+       end if
+       call XML_Get_Elements_By_Tag_Name(element,currentTagName,elementList,directChildrenOnly=.true.)
        if (size(elementList) < 1) then
           XML_Path_Exists=.false.
+          if (present(pathFailed)) pathFailed=pathSoFar
           return
        else
           XML_Path_Exists=.false.
@@ -479,7 +548,10 @@ contains
                 exit
              end if
           end do
-          if (.not.XML_Path_Exists) return
+          if (.not.XML_Path_Exists) then
+             if (present(pathFailed)) pathFailed=pathSoFar
+             return
+          end if
        end if
     end do
     return

--- a/source/utility/IO/XML.F90
+++ b/source/utility/IO/XML.F90
@@ -296,11 +296,11 @@ contains
     !!}
     implicit none
     character(len=*           ), intent(in   ) :: tagName
-    character(len=*           ), intent(  out) :: tagName_    , attributeName, &
+    character(len=*           ), intent(  out) :: tagName_      , attributeName, &
          &                                        attributeValue
     integer                    , intent(  out) :: elementIndex
     character(len=len(tagName))                :: tagBase
-    integer                                    :: openBracket , closeBracket
+    integer                                    :: openBracket   , closeBracket
 
     ! Extract any trailing positional predicate `[N]`. Such a predicate is always the final component of the tag name, so we
     ! find the last `[` and treat it as a positional predicate only if its contents consist solely of digits.
@@ -343,22 +343,22 @@ contains
     use            :: Error        , only : Error_Report
     implicit none
     type     (xmlNodeList     ), intent(inout), allocatable, dimension(:) :: elements
-    integer  (c_size_t        )                                           :: countElements , offset
+    integer  (c_size_t        )                                           :: countElements     , offset
     type     (node            ), intent(in   ), pointer                   :: xmlElement
     character(len=*           ), intent(in   )                            :: tagName
     logical                    , intent(in   ), optional                  :: directChildrenOnly
     type     (node            )               , pointer                   :: childNode
     type     (xmlNodeList     )               , allocatable, dimension(:) :: childElements
-    logical                                                               :: matchAll      , matches
-    integer                                                               :: elementIndex  , matchCount
-    character(len=len(tagName))                                           :: tagName_      , attributeName, &
+    logical                                                               :: matchAll          , matches
+    integer                                                               :: elementIndex      , matchCount
+    character(len=len(tagName))                                           :: tagName_          , attributeName, &
          &                                                                   attributeValue
     !![
     <optionalArgument name="directChildrenOnly" defaultsTo=".false."/>
     !!]
 
     call XML_Tag_Name_Parse(tagName,tagName_,attributeName,attributeValue,elementIndex)
-    if (elementIndex > 0 .and. .not.directChildrenOnly_) call Error_Report('positional XPath predicate (e.g. `[15]`) is only supported when `directChildrenOnly` is set'//{introspection:location})
+    if (elementIndex > 0 .and. .not.directChildrenOnly_) call Error_Report('positional XPath predicate (e.g. `[15]`) is supported only when `directChildrenOnly` is set'//{introspection:location})
     countElements=XML_Count_Elements_By_Tag_Name(xmlElement,tagName,directChildrenOnly=directChildrenOnly_)
     offset       =0_c_size_t
     matchCount   =0
@@ -400,15 +400,15 @@ contains
           &                                 getNodeType , hasChildNodes, node          , getAttribute
     use            :: Error        , only : Error_Report
     implicit none
-    integer  (c_size_t        )                         :: countElements
-    type     (node            ), intent(in   ), pointer :: xmlElement
-    character(len=*           ), intent(in   )          :: tagName
+    integer  (c_size_t        )                          :: countElements
+    type     (node            ), intent(in   ), pointer  :: xmlElement
+    character(len=*           ), intent(in   )           :: tagName
     logical                    , intent(in   ), optional :: directChildrenOnly
-    type     (node            )               , pointer :: childNode
-    logical                                             :: matchAll
-    integer                                             :: elementIndex  , matchCount
-    character(len=len(tagName))                         :: tagName_      , attributeName, &
-         &                                                 attributeValue
+    type     (node            )               , pointer  :: childNode
+    logical                                              :: matchAll
+    integer                                              :: elementIndex      , matchCount
+    character(len=len(tagName))                          :: tagName_          , attributeName, &
+         &                                                  attributeValue
     !![
     <optionalArgument name="directChildrenOnly" defaultsTo=".false."/>
     !!]
@@ -447,8 +447,8 @@ contains
     logical                    , intent(in   ), optional     :: directChildrenOnly
     type     (xmlNodeList     ), allocatable  , dimension(:) :: elementList
     type     (node            )               , pointer      :: parent
-    character(len=len(tagName))                              :: currentTagName                   , path
-    integer                                                  :: pathPosition                     , i
+    character(len=len(tagName))                              :: currentTagName    , path
+    integer                                                  :: pathPosition      , i
     logical                                                  :: found
     !![
     <optionalArgument name="directChildrenOnly" defaultsTo=".false."/>

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -567,7 +567,7 @@ contains
     logical                                                           :: parseSuccess         , isException      , &
          &                                                               append
     type     (varying_string )                                        :: changePath           , targetPath       , &
-         &                                                               valueUpdated
+         &                                                               valueUpdated         , pathFailed
     character(len=32         )                                        :: changeType
 
     ! Check that the file exists.
@@ -646,7 +646,7 @@ contains
              changeType=getAttribute(childNode,"type")
              ! Find the node in the parameters document to be changed.
              changePath=getAttribute(childNode,"path")
-             if (XML_Path_Exists(parameterNode,char(changePath))) then
+             if (XML_Path_Exists(parameterNode,char(changePath),pathFailed=pathFailed)) then
                 if (changePath == "") then
                    changeNode =>                                   parameterNode
                 else
@@ -659,7 +659,7 @@ contains
                 changeNode => XML_Get_First_Element_By_Tag_Name(parameterNode,char(changePath),directChildrenOnly=.true.)
                 changeType =  "append"
              else
-                call Error_Report("path '"//trim(changePath)//"' does not exist"//{introspection:location})
+                call Error_Report("path '"//trim(changePath)//"' does not exist (resolution failed at '"//trim(pathFailed)//"')"//{introspection:location})
              end if
              ! Process each type of change.
              select case (trim(changeType))
@@ -714,7 +714,7 @@ contains
                 ! Replace a parameter with another parameter.
                 if (.not.hasAttribute(childNode,"target")) call Error_Report('`change` element with `type="replaceWith"` must have the `target` attribute'//{introspection:location})
                 targetPath=getAttribute(childNode,"target")
-                if (.not.XML_Path_Exists(parameterNode,char(targetPath))) call Error_Report("target path '"//trim(targetPath)//"' does not exist"//{introspection:location})
+                if (.not.XML_Path_Exists(parameterNode,char(targetPath),pathFailed=pathFailed)) call Error_Report("target path '"//trim(targetPath)//"' does not exist (resolution failed at '"//trim(pathFailed)//"')"//{introspection:location})
                 targetNode       => XML_Get_First_Element_By_Tag_Name(parameterNode,char(targetPath),directChildrenOnly=.true.)
                 clonedNode       => cloneNode    (targetNode                            ,deep=.true.)
                 changeNodeParent => getParentNode(                            changeNode            )


### PR DESCRIPTION
## Summary

Adds support for **positional XPath predicates** (`[N]`) in Galacticus's XPath-like element lookup, so expressions such as `nodePropertyExtractor[15]` resolve correctly. Previously only the attribute predicate form `[@value='...']` was supported, and an indexed segment produced a spurious *"no elements match tag name"* error.

Motivating case: `./Galacticus.exe <parameters>.xml <changes>.xml --dry-run` where the changes file addresses an extractor by index, e.g.

```xml
<change type="update"
        path="nodePropertyExtractor[@value='multi']/nodePropertyExtractor[15]/nodePropertyExtractor[@value='lmnstyEmssnLineAGN']/densityHydrogen"
        value="1.0d3"/>
```

## What changed

**`source/utility/IO/XML.F90`**
- New private helper `XML_Tag_Name_Parse` decomposes a tag name into: bare name, optional `[@attr='val']`, and optional 1-based positional index. Supports `name`, `name[@a='v']`, `name[N]`, and the combined `name[@a='v'][N]`.
- `XML_Get_Elements_By_Tag_Name` and `XML_Count_Elements_By_Tag_Name` gain an optional `directChildrenOnly` argument. A positional `[N]` predicate is only well-defined over the direct children of the context node (the default traversal recurses through, and flattens, all descendants), so it **requires** `directChildrenOnly`; using `[N]` without it raises an explicit `Error_Report` rather than silently returning a wrong result. This mirrors the existing guard in `XML_Get_First_Element_By_Tag_Name`.
- `XML_Path_Exists` and the direct-children branch of `XML_Get_First_Element_By_Tag_Name` pass the flag through, so existence checks and node resolution agree on indexed lookups.
- `XML_Path_Exists` gains an optional `intent(out)` `pathFailed` argument (boolean return unchanged / backward-compatible); on failure it is set to the path prefix up to and including the first unmatched segment.

**`source/utility/input_parameters.F90`**
- The change-application "path does not exist" / "target path does not exist" errors now report where resolution failed, e.g.:
  ```
  path '...nodePropertyExtractor[99]/densityHydrogen' does not exist
       (resolution failed at 'nodePropertyExtractor[@value='multi']/nodePropertyExtractor[99]')
  ```

## Testing

- Full rebuild (`make -j20 Galacticus.exe`) succeeds.
- The motivating `--dry-run` command now passes change-application cleanly (all indexed paths resolve) and proceeds into model construction; it only stops later on an unrelated missing dataset file in the local environment.
- An out-of-range index (`[99]`) fails during change-application with the new diagnostic, correctly pinpointing the failing segment.

## Notes

Fully backward-compatible: `directChildrenOnly` and `pathFailed` are optional and default to prior behavior; existing callers and non-indexed paths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)