### PR TITLE
perf(nodes): lock-free node unique-ID assignment via atomic capture

### DIFF
--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -2616,6 +2616,7 @@
           <xs:enumeration value="trackOutflowedMass"/>
           <xs:enumeration value="treeWeight"/>
           <xs:enumeration value="tuple"/>
+          <xs:enumeration value="uniqueID"/>
           <xs:enumeration value="uniqueIDBranchTip"/>
           <xs:enumeration value="velocityDispersion"/>
           <xs:enumeration value="velocityMaximum"/>

--- a/source/nodes/property_extractor/node_unique_id.F90
+++ b/source/nodes/property_extractor/node_unique_id.F90
@@ -1,0 +1,122 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{RST
+Implements a node unique ID property extractor.
+!!}
+
+  !![
+  <nodePropertyExtractor name="nodePropertyExtractorUniqueID" docformat="rst">
+   <description>
+   Extracts the internal unique global identifier (the {\normalfont \ttfamily uniqueID}) assigned to each node when it is created. This is the value drawn from the process-global unique-ID counter; under MPI it is guaranteed to be distinct across processes.
+   </description>
+  </nodePropertyExtractor>
+  !!]
+  type, extends(nodePropertyExtractorIntegerScalar) :: nodePropertyExtractorUniqueID
+     !!{RST
+     A node unique ID property extractor.
+     !!}
+     private
+   contains
+     procedure :: extract     => uniqueIDExtract
+     procedure :: name        => uniqueIDName
+     procedure :: description => uniqueIDDescription
+     procedure :: units       => uniqueIDUnits
+  end type nodePropertyExtractorUniqueID
+
+  interface nodePropertyExtractorUniqueID
+     !!{RST
+     Constructors for the :galacticus-class:`nodePropertyExtractorUniqueID` property extractor class.
+     !!}
+     module procedure uniqueIDConstructorParameters
+  end interface nodePropertyExtractorUniqueID
+
+contains
+
+  function uniqueIDConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`nodePropertyExtractorUniqueID` property extractor class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type(nodePropertyExtractorUniqueID)                :: self
+    type(inputParameters              ), intent(inout) :: parameters
+
+    self=nodePropertyExtractorUniqueID()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function uniqueIDConstructorParameters
+
+  function uniqueIDExtract(self,node,time,instance)
+    !!{RST
+    Implement a ``uniqueID`` node property extractor.
+    !!}
+    implicit none
+    integer         (kind_int8                    )                          :: uniqueIDExtract
+    class           (nodePropertyExtractorUniqueID), intent(inout)           :: self
+    type            (treeNode                     ), intent(inout), target   :: node
+    double precision                               , intent(in   )           :: time
+    type            (multiCounter                 ), intent(inout), optional :: instance
+    !$GLC attributes unused :: self, time, instance
+
+    uniqueIDExtract=node%uniqueID()
+    return
+  end function uniqueIDExtract
+
+  function uniqueIDName(self)
+    !!{RST
+    Return the name of the unique ID property.
+    !!}
+    implicit none
+    type (varying_string               )                :: uniqueIDName
+    class(nodePropertyExtractorUniqueID), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    uniqueIDName=var_str('nodeUniqueID')
+    return
+  end function uniqueIDName
+
+  function uniqueIDDescription(self)
+    !!{RST
+    Return a description of the unique ID property.
+    !!}
+    implicit none
+    type (varying_string               )                :: uniqueIDDescription
+    class(nodePropertyExtractorUniqueID), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    uniqueIDDescription=var_str('The internal unique global identifier of the node.')
+    return
+  end function uniqueIDDescription
+
+  function uniqueIDUnits(self) result(units)
+    !!{RST
+    Return the units of the unique ID property.
+    !!}
+    use :: Units_MetaData, only : unitType
+    implicit none
+    type (unitType                     )                :: units
+    class(nodePropertyExtractorUniqueID), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    units=unitType(1.0d0)
+    return
+  end function uniqueIDUnits

--- a/source/objects/nodes/_class.F90
+++ b/source/objects/nodes/_class.F90
@@ -44,9 +44,9 @@ module Galacticus_Nodes
   use            :: Stellar_Luminosities_Structure     , only : stellarLuminosities
   use            :: Tensors                            , only : tensorNullR2D3Sym            , tensorRank2Dimension3Symmetric
   private
-  public :: nodeClassHierarchyInitialize    , nodeClassHierarchyFinalize, Galacticus_Nodes_Unique_ID_Set, interruptTask   , &
-       &    nodeEventBuildFromRaw           , propertyEvaluate          , propertyActive                , propertyInactive, &
-       &    massDistributionCalculationReset, massDistributionsLast     , massDistributionsDestroy
+  public :: nodeClassHierarchyInitialize    , nodeClassHierarchyFinalize, Galacticus_Nodes_Unique_ID_Set, interruptTask            , &
+       &    nodeEventBuildFromRaw           , propertyEvaluate          , propertyActive                , propertyInactive         , &
+       &    massDistributionCalculationReset, massDistributionsLast     , massDistributionsDestroy      , Node_Unique_ID_Initialize
 
   type, public :: nodeHierarchyWrapper
      !!{RST
@@ -225,12 +225,12 @@ module Galacticus_Nodes
   integer                         , parameter, public               :: reductionSummation  =1
   integer                         , parameter, public               :: reductionProduct    =2
 
-  ! Unique ID counter.
+  ! Unique ID counter. IDs advance from "uniqueIdCount" in steps of "uniqueIdIncrement". These are set
+  ! once at node-component initialization (see Node_Unique_ID_Initialize): under MPI to the process rank
+  ! and process count respectively, so that IDs are globally distinct across ranks; otherwise the 0/1
+  ! defaults are used, so the per-node assignment is a lock-free atomic increment in both configurations.
   integer         (kind=kind_int8)                                  :: uniqueIdCount       =0
-#ifdef USEMPI
   integer         (kind=kind_int8)                                  :: uniqueIdIncrement   =1_kind_int8
-  logical                                                           :: uniqueIdInitialized =.false.
-#endif
 
   ! Event ID counter.
   integer         (kind=kind_int8)                                  :: eventID             =0
@@ -368,7 +368,7 @@ module Galacticus_Nodes
     !!}
     implicit none
     class  (treeNode      ), intent(in   ) :: self
-    integer(kind=kind_int8)                        :: uniqueID
+    integer(kind=kind_int8)                :: uniqueID
 
     uniqueID=self%uniqueIdValue
     return
@@ -379,9 +379,6 @@ module Galacticus_Nodes
     Sets the index of a ``treeNode``.
     !!}
     use :: Error, only : Error_Report
-#ifdef USEMPI
-    use :: MPI_Utilities, only : mpiSelf
-#endif
     implicit none
     class  (treeNode      ), intent(inout)           :: self
     integer(kind=kind_int8), intent(in   ), optional :: uniqueID
@@ -389,23 +386,48 @@ module Galacticus_Nodes
     if (present(uniqueID)) then
        self%uniqueIdValue=uniqueID
     else
-       !$omp critical(UniqueID_Assign)
-#ifdef USEMPI
-       if (.not.uniqueIdInitialized) then
-          uniqueIdCount      =int(mpiSelf%rank (),kind=kind_int8)
-          uniqueIdIncrement  =int(mpiSelf%count(),kind=kind_int8)
-          uniqueIdInitialized=.true.
-       end if
-       uniqueIDCount=uniqueIDCount+uniqueIdIncrement
-#else
-       uniqueIDCount=uniqueIDCount+1
-#endif
-       if (uniqueIDCount <= 0) call Error_Report('ran out of unique ID numbers'//{introspection:location})
+       ! Lock-free fetch-and-increment (replaces an "!$omp critical"): atomically advance the global
+       ! counter and capture this node's value in a single atomic operation, removing the per-node-creation
+       ! lock contention that otherwise serializes tree building across threads. The counter's start and
+       ! stride are initialized once, before any node is created, in Node_Unique_ID_Initialize (to the
+       ! process rank and process count under MPI, or the 0/1 defaults otherwise), so no per-call
+       ! initialization is needed here for either configuration. The overflow check tests the captured
+       ! (thread-local) value.
+       !$omp atomic capture
+       uniqueIDCount     =uniqueIDCount+uniqueIdIncrement
        self%uniqueIdValue=uniqueIDCount
-       !$omp end critical(UniqueID_Assign)
+       !$omp end atomic
+       if (self%uniqueIdValue <= 0) call Error_Report('ran out of unique ID numbers'//{introspection:location})
     end if
     return
   end subroutine Tree_Node_Unique_ID_Set
+
+  !![
+  <nodeComponentInitializationTask function="Node_Unique_ID_Initialize"/>
+  !!]
+  subroutine Node_Unique_ID_Initialize(parameters_)
+    !!{RST
+    Initialize the global unique-ID counter used by {\normalfont \ttfamily Tree\_Node\_Unique\_ID\_Set}.
+    This runs once, at node-component initialization---after MPI has been initialized and before any node
+    is created---so that per-node ID assignment can be a lock-free atomic increment (with no per-call
+    initialization) in both serial and MPI runs. Under MPI the counter starts at this process's rank and
+    strides by the number of processes, ensuring unique IDs are globally distinct across ranks; otherwise
+    the 0/1 defaults are left unchanged.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+#ifdef USEMPI
+    use :: MPI_Utilities   , only : mpiSelf
+#endif
+    implicit none
+    type(inputParameters), intent(inout) :: parameters_
+    !$GLC attributes unused :: parameters_
+
+#ifdef USEMPI
+    uniqueIdCount    =int(mpiSelf%rank (),kind=kind_int8)
+    uniqueIdIncrement=int(mpiSelf%count(),kind=kind_int8)
+#endif
+    return
+  end subroutine Node_Unique_ID_Initialize
 
   double precision function Tree_Node_Time_Step(self)
     !!{RST


### PR DESCRIPTION
## Summary

Node unique-ID assignment is on the hot path of merger-tree building — every node creation calls `Tree_Node_Unique_ID_Set`. That routine took an `!$omp critical(UniqueID_Assign)` per node, which serialized tree building across OpenMP threads (2.91% of self time, and contention that grows with thread count — bad for MCMC-style workloads).

This replaces the critical section with an **`!$omp atomic capture`** fetch-and-increment, and moves the counter's start/stride initialization out of the per-node hot path into a one-time, serial `nodeComponentInitializationTask` hook (`Node_Unique_ID_Initialize`) that runs after MPI initialization and before any node is created:

- **non-MPI:** counter starts at 0, strides by 1 (unchanged sequence).
- **MPI:** counter starts at `mpiSelf%rank()`, strides by `mpiSelf%count()`, so IDs remain globally distinct across ranks.

Both configurations now share the same lock-free hot path. The MPI branch previously kept a critical section solely for its lazy one-time initialization; the `uniqueIdInitialized` flag is no longer needed.

Also adds a **`nodeUniqueID`** node property extractor (with its parameter-schema entry) — used to verify the MPI behavior below, and generally useful for tracing node identity.

## Validation

- **Reproducibility suite:** 13/13 assertions pass (cooling, closedBox, leakyBox, adiabaticContraction) — physics unchanged.
- **MPI build** (`GALACTICUS_BUILD_OPTION=MPI`): the `#ifdef USEMPI` handler compiles; full MPI binary links.
- **2-rank MPI residue-class test** (the definitive gate): with `nProcs=2`, every ID must satisfy `id ≡ rank (mod 2)`.

  | rank | distinct IDs | residue check |
  |---:|---:|---|
  | 0 | 1447 | all even (≡ 0 mod 2) ✓ |
  | 1 | 1469 | all odd  (≡ 1 mod 2) ✓ |

  **Cross-rank ID collisions: 0** (even/odd sets disjoint → globally distinct). np=1 control reproduces the serial sequence (1,2,3,…).
- **Profiling** (progenitorMassFunction, non-MPI): `GOMP_critical_name_start` (the `UniqueID_Assign` lock) drops from **2.91% → 0.00%** self time; `tree_node_unique_id_set` / `treeNodeInitialize` fall out of the profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)