### PR TITLE
fix: read guarded local copies of optional dummy arguments

### DIFF
--- a/source/mass_distributions/cylindrical/scaler.F90
+++ b/source/mass_distributions/cylindrical/scaler.F90
@@ -250,7 +250,7 @@ contains
          &                                                                               coordinatesScaled, &
          &                                                                               logarithmic        &
          &                                                                              )
-    if (.not.logarithmic)                                                                 &
+    if (.not.logarithmic_)                                                                &
          & cylindricalScalerDensityGradientRadial=+cylindricalScalerDensityGradientRadial &
          &                                        *self%factorScalingMass                 &
          &                                        /self%factorScalingLength**4

--- a/source/mass_distributions/spherical/accretion_flow/Shi2016.F90
+++ b/source/mass_distributions/spherical/accretion_flow/Shi2016.F90
@@ -255,6 +255,10 @@ contains
     else
        densityGradientRadial=self%interpolatorDensityPhysical%derivative(coordinates%rSpherical())
     end if
+    ! Convert to a logarithmic gradient if requested.
+    if (logarithmic_) densityGradientRadial=+            densityGradientRadial              &
+         &                                  *coordinates%rSpherical           (           ) &
+         &                                  /self       %density              (coordinates)
     return
   end function shi2016DensityGradientRadial
   

--- a/source/mass_distributions/spherical/accretion_flow/correlation_function.F90
+++ b/source/mass_distributions/spherical/accretion_flow/correlation_function.F90
@@ -191,5 +191,9 @@ contains
     
     densityGradientRadial=+self%correlationFunction_%derivative          (coordinates%rSpherical()) &
          &                *self%cosmologyFunctions_ %matterDensityEpochal(self       %time        )
+    ! Convert to a logarithmic gradient if requested.
+    if (logarithmic_) densityGradientRadial=+            densityGradientRadial              &
+         &                                  *coordinates%rSpherical           (           ) &
+         &                                  /self       %density              (coordinates)
     return
   end function correlationFunctionDensityGradientRadial

--- a/source/mass_distributions/spherical/scaler.F90
+++ b/source/mass_distributions/spherical/scaler.F90
@@ -228,7 +228,7 @@ contains
          &                                                                             coordinatesScaled, &
          &                                                                             logarithmic        &
          &                                                                            )
-    if (.not.logarithmic)                                                             &
+    if (.not.logarithmic_)                                                            &
          & sphericalScalerDensityGradientRadial=+sphericalScalerDensityGradientRadial &
          &                                      *self%factorScalingMass               &
          &                                      /self%factorScalingLength**4

--- a/source/mass_distributions/spherical/soliton/_class.F90
+++ b/source/mass_distributions/spherical/soliton/_class.F90
@@ -291,7 +291,7 @@
      if (coordinates%rSpherical() <= 0.0d0) then
         ! Zero radius.
         densityGradient=+0.0d0
-     else if (logarithmic) then
+     else if (logarithmic_) then
         densityGradient=-16.0d0                                       &
              &          *       coefficientCore*radiusCoreFree**2     &
              &          /(1.0d0+coefficientCore*radiusCoreFree**2)

--- a/source/mass_distributions/spherical/soliton_NFW.F90
+++ b/source/mass_distributions/spherical/soliton_NFW.F90
@@ -431,7 +431,7 @@
         densityGradient   =0.0d0
      else if (coordinates%rSpherical() < self%radiusSoliton) then
         ! Soliton regime.
-        if (logarithmic) then
+        if (logarithmic_) then
            densityGradient=-16.0d0                                       &
                 &          *       coefficientCore*radiusCoreFree**2     &
                 &          /(1.0d0+coefficientCore*radiusCoreFree**2)
@@ -444,7 +444,7 @@
         end if
      else
         ! NFW regime.
-        if (logarithmic) then
+        if (logarithmic_) then
            densityGradient=  -1.0d0                  &
                 &            -2.0d0*radiusScaleFree  &
                 &          /(+1.0d0+radiusScaleFree)

--- a/source/numerical/ODE_solver/solver.F90
+++ b/source/numerical/ODE_solver/solver.F90
@@ -625,7 +625,7 @@ contains
              active=active-1
              return
           end if
-          call Error_Report(var_str('ODE integration failed with status ')//status//{introspection:location})
+          call Error_Report(var_str('ODE integration failed with status ')//status_//{introspection:location})
        end select
     end do
     ! Return the new value of x.

--- a/source/numerical/multi_dimensional_minimizer.F90
+++ b/source/numerical/multi_dimensional_minimizer.F90
@@ -583,7 +583,7 @@ contains
        status_=gsl_multimin_fminimizer_iterate  (self%minimizer_%gsl)
     end if
     if (present(status)) status=status_
-    if (status /= GSL_Success .and. .not.present(status)) call Error_Report('failed to iterate minimizer'//{introspection:location})
+    if (status_ /= GSL_Success .and. .not.present(status)) call Error_Report('failed to iterate minimizer'//{introspection:location})
     self_ => null()
     return
   end subroutine multiDMinimizerIterate

--- a/source/tests/mass_distributions.F90
+++ b/source/tests/mass_distributions.F90
@@ -38,16 +38,17 @@ program Test_Mass_Distributions
        &                                    massDistributionList                 , massDistributionSymmetryCylindrical, enumerationMassDistributionSymmetryType, massDistributionSphericalScaler             , &
        &                                    massDistributionCylindricalScaler    , massDistributionCylindrical        , massDistributionPatejLoeb2015          , massDistributionNFW                         , &
        &                                    massDistributionIsothermal           , kinematicsDistributionClass        , kinematicsDistributionLocal            , kinematicsDistributionCollisionlessTabulated, &
-       &                                    massDistributionSIDMParametricProfile, massDistributionBlackHole
+       &                                    massDistributionSIDMParametricProfile, massDistributionBlackHole          , massDistributionSoliton                , massDistributionSolitonNFW
   use :: Numerical_Constants_Math  , only : Pi                                   , e
   use :: Tensors                   , only : assignment(=)
   use :: Unit_Tests                , only : Assert                               , Unit_Tests_Begin_Group             , Unit_Tests_End_Group                   , Unit_Tests_Finish                           , &
        &                                    compareEquals                        , compareNotEqual
   implicit none
-  class           (massDistributionClass                  )                                    , allocatable :: massDistribution_                                                                                                       , massDistributionRotated   , &
-       &                                                                                                        massDistributionDisk                                                                                                    , massDistributionSpheroid  , &
-       &                                                                                                        massDistributionDMO
-  class           (massDistributionClass                  )                                    , pointer     :: massDistributionDisk_                                                                                                   , massDistributionSpheroid_ , &
+  class           (massDistributionClass                  )                                    , allocatable :: massDistribution_                                                                                                       , massDistributionRotated         , &
+       &                                                                                                        massDistributionDisk                                                                                                    , massDistributionSpheroid        , &
+       &                                                                                                        massDistributionDMO                                                                                                     , massDistributionWrappedSpherical, &
+       &                                                                                                        massDistributionWrappedCylindrical
+  class           (massDistributionClass                  )                                    , pointer     :: massDistributionDisk_                                                                                                   , massDistributionSpheroid_       , &
        &                                                                                                        massDistributionAll_                                                                                                    , massDistributionDiskAgain_
   class           (kinematicsDistributionClass            )                                    , pointer     :: kinematicsDistribution_
   type            (massDistributionList                   )                                    , pointer     :: massDistributions
@@ -955,6 +956,93 @@ program Test_Mass_Distributions
      call Assert("re-use A->B: mass enclosed" ,massDistribution_%massEnclosedBySphere(radiusBlackHoleTest),enclosedReferenceB,relTol=1.0d-9)
      call Assert("re-use A->B: rotation curve",massDistribution_%rotationCurve       (radiusBlackHoleTest),rotationReferenceB,relTol=1.0d-9)
   end select
+  deallocate(massDistribution_)
+  call Unit_Tests_End_Group()
+
+  ! Optional `logarithmic` argument in radial density gradients.
+  ! The `<optionalArgument>` directive generates a guarded local copy (`logarithmic_`) of the optional
+  ! `logarithmic` dummy argument. Several classes read the dummy argument itself instead, which is
+  ! invalid when the argument is not supplied by the caller. Check that omitting the argument gives
+  ! the same answer as passing `.false.` explicitly (its documented default).
+  call Unit_Tests_Begin_Group("Optional `logarithmic` argument in radial density gradients")
+  position=[1.0d0,0.0d0,0.0d0]
+  allocate(massDistributionSoliton :: massDistribution_)
+  select type (massDistribution_)
+  type is (massDistributionSoliton)
+     massDistribution_=massDistributionSoliton(radiusCore=1.0d0,densitySolitonCentral=1.0d0,dimensionless=.true.)
+  end select
+  call Assert(                                                                        &
+       &      "soliton"                                                             , &
+       &      +massDistribution_%densityGradientRadial(position                    ), &
+       &      +massDistribution_%densityGradientRadial(position,logarithmic=.false.), &
+       &      relTol=1.0d-12                                                          &
+       &     )
+  deallocate(massDistribution_)
+  allocate(massDistributionSolitonNFW :: massDistribution_)
+  select type (massDistribution_)
+  type is (massDistributionSolitonNFW)
+     massDistribution_=massDistributionSolitonNFW(radiusScale=1.0d0,radiusCore=0.1d0,radiusSoliton=0.3d0,densitySolitonCentral=1.0d0,densityNormalizationNFW=1.0d0,dimensionless=.true.)
+  end select
+  ! Test both sides of the soliton-to-NFW transition.
+  position=[0.2d0,0.0d0,0.0d0]
+  call Assert(                                                                        &
+       &      "solitonNFW (soliton regime)"                                         , &
+       &      +massDistribution_%densityGradientRadial(position                    ), &
+       &      +massDistribution_%densityGradientRadial(position,logarithmic=.false.), &
+       &      relTol=1.0d-12                                                          &
+       &     )
+  position=[1.0d0,0.0d0,0.0d0]
+  call Assert(                                                                        &
+       &      "solitonNFW (NFW regime)"                                             , &
+       &      +massDistribution_%densityGradientRadial(position                    ), &
+       &      +massDistribution_%densityGradientRadial(position,logarithmic=.false.), &
+       &      relTol=1.0d-12                                                          &
+       &     )
+  deallocate(massDistribution_)
+  ! Scaled distributions forward the argument to the distribution that they wrap. Note that the
+  ! scaler takes a reference to the wrapped distribution and releases it when the scaler itself is
+  ! destroyed - so the wrapped distributions must not be deallocated here.
+  allocate(massDistributionHernquist       :: massDistributionWrappedSpherical)
+  select type (massDistributionWrappedSpherical)
+  type is (massDistributionHernquist      )
+     massDistributionWrappedSpherical=massDistributionHernquist      (dimensionless=.true.)
+  end select
+  allocate(massDistributionSphericalScaler :: massDistribution_)
+  select type (massDistribution_)
+  type is (massDistributionSphericalScaler)
+     select type (massDistributionWrappedSpherical)
+     class is (massDistributionSpherical  )
+        massDistribution_=massDistributionSphericalScaler(factorScalingLength=0.7d-3,factorScalingMass=9.0d09,massDistribution_=massDistributionWrappedSpherical)
+     end select
+  end select
+  position=[1.0d-3,0.0d0,0.0d0]
+  call Assert(                                                                        &
+       &      "sphericalScaler"                                                     , &
+       &      +massDistribution_%densityGradientRadial(position                    ), &
+       &      +massDistribution_%densityGradientRadial(position,logarithmic=.false.), &
+       &      relTol=1.0d-12                                                          &
+       &     )
+  deallocate(massDistribution_)
+  allocate(massDistributionExponentialDisk   :: massDistributionWrappedCylindrical)
+  select type (massDistributionWrappedCylindrical)
+  type is (massDistributionExponentialDisk  )
+     massDistributionWrappedCylindrical=massDistributionExponentialDisk  (scaleHeight=0.3d-3/2.9d-3,dimensionless=.true.)
+  end select
+  allocate(massDistributionCylindricalScaler :: massDistribution_)
+  select type (massDistribution_)
+  type is (massDistributionCylindricalScaler)
+     select type (massDistributionWrappedCylindrical)
+     class is (massDistributionCylindrical)
+        massDistribution_=massDistributionCylindricalScaler(factorScalingLength=2.9d-3,factorScalingMass=5.7d10,massDistribution_=massDistributionWrappedCylindrical)
+     end select
+  end select
+  positionCartesian=[1.0d-3,0.0d0,0.0d0]
+  call Assert(                                                                                 &
+       &      "cylindricalScaler"                                                            , &
+       &      +massDistribution_%densityGradientRadial(positionCartesian                    ), &
+       &      +massDistribution_%densityGradientRadial(positionCartesian,logarithmic=.false.), &
+       &      relTol=1.0d-12                                                                   &
+       &     )
   deallocate(massDistribution_)
   call Unit_Tests_End_Group()
 

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -2263,7 +2263,7 @@ contains
              else
                 copyInstance_=1
              end if
-             groupName=groupName//"["//copyInstance//"]"
+             groupName=groupName//"["//copyInstance_//"]"
           end if
           allocate(inputParametersSubParameters%outputParameters)
           inputParametersSubParameters%outputParameters=self%outputParameters%openGroup(char(groupName))


### PR DESCRIPTION
## Summary

Fixes nine sites that read an optional dummy argument **directly** instead of the guarded local copy (`x_`) generated by the `<optionalArgument>` directive (or by a hand-rolled `present()` block). Referencing a dummy argument the caller omitted is invalid, so these read a null/garbage value. In every case the guarded copy was already being computed and then discarded.

| File | Was | Now |
|---|---|---|
| `utility/input_parameters.F90` | `copyInstance` | `copyInstance_` |
| `numerical/ODE_solver/solver.F90` | `status` | `status_` |
| `numerical/multi_dimensional_minimizer.F90` | `status` | `status_` |
| `mass_distributions/spherical/scaler.F90` | `logarithmic` | `logarithmic_` |
| `mass_distributions/cylindrical/scaler.F90` | `logarithmic` | `logarithmic_` |
| `mass_distributions/spherical/soliton/_class.F90` | `logarithmic` | `logarithmic_` |
| `mass_distributions/spherical/soliton_NFW.F90` (×2) | `logarithmic` | `logarithmic_` |

Two of these are worth calling out:

- **`ODE_solver/solver.F90`** — the offending line sits *after* an `if (present(status)) … return`, so it is reached **only** when `status` is absent. It was an unconditional bad read on the integration-failure path, turning a diagnostic message into undefined behaviour. The sibling branch immediately above already used `status_`, so this was a copy-paste slip.
- **`multi_dimensional_minimizer.F90`** — `if (status /= GSL_Success .and. .not.present(status))` reads an `intent(out)` optional precisely in the case where it is absent.

Additionally, the two accretion-flow distributions **`Shi2016`** and **`correlationFunction`** declared `logarithmic`, generated `logarithmic_`, and then never used it — silently returning a *linear* gradient when a logarithmic one was requested. `massDistributionSpherical` reaches both polymorphically with `logarithmic=.true.` (e.g. `spherical/_class.F90:1139`). Both now apply the `× r / ρ` conversion, matching their own parent (`accretion_flow/_class.F90`) and consistent with the base-class numerical implementation `sphericalDensityGradientRadialNumerical`, which converts the other direction with `× ρ / r`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test

```bash
make -j20 tests.mass_distributions.exe tests.ODE_solver.exe tests.multi_dimensional_minimizer.exe tests.parameters.exe
./tests.mass_distributions.exe
./tests.ODE_solver.exe
./tests.multi_dimensional_minimizer.exe
./tests.parameters.exe
```

This PR adds a unit-test group to `source/tests/mass_distributions.F90` asserting that **omitting** `logarithmic` gives the same result as passing `.false.` explicitly — precisely the call pattern that was previously undefined — for `soliton`, `solitonNFW` (both sides of the soliton→NFW transition), `sphericalScaler` and `cylindricalScaler`.

## Checklist
- [x] I ran relevant tests (or explain why not):

| Suite | Assertions | Failed |
|---|---|---|
| `tests.mass_distributions` | 153 (148 pre-existing + 5 new) | 0 |
| `tests.ODE_solver` | 40 | 0 |
| `tests.multi_dimensional_minimizer` | 4 | 0 |
| `tests.parameters` | 27 | 0 |

All four build with zero errors and zero warnings under `gfortran-16`.

Note: the four affected test executables were built and run locally, but a full `Galacticus.exe` build + `parameters/quickTest.xml` was **not** run locally — leaving that to CI.

- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

## Notes

These were found by an automated sweep for procedures in which a shadow local `x_` exists but is never read. Two related findings were deliberately left out of scope:

- **105 sites** of `if (present(x) .and. x)` — technically non-conforming, since Fortran does not mandate short-circuit evaluation of `.and.`, but it is a pervasive and evidently deliberate idiom here. Worth a separate discussion rather than a drive-by 105-site rewrite.
- `pyproject.toml` declares a `lint` extra (`mypy`, `pyflakes`) that no CI workflow currently runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
