### PR TITLE
perf(merger-trees): fuse PCH+ progenitor mass function factor; use sqrt for 3/2 powers

### DIFF
--- a/source/merger_trees/branching_probability/PCH_plus.F90
+++ b/source/merger_trees/branching_probability/PCH_plus.F90
@@ -37,15 +37,19 @@ Implements a merger tree branching probability class using the algorithm of :cit
      A merger tree branching probability class using the algorithm of :cite:t:`parkinson_generating_2008` plus an additional term.
      !!}
      private
-     double precision                             :: gamma3                 , gamma4, &
+     double precision                             :: gamma3                      , gamma4       , &
           &                                          gamma5
-     class           (linearGrowthClass), pointer :: linearGrowth_ => null()
+     ! Precomputed exponents for the fused merging-rate × modifier form (see pchPlusProgenitorMassFunctionFactor):
+     !  exponentChildSigma = 2 + γ₁ - 2γ₃ ; exponentDelta = γ₃ - 3/2.
+     double precision                             :: exponentChildSigma          , exponentDelta
+     class           (linearGrowthClass), pointer :: linearGrowth_      => null()
    contains
-     final     ::                         pchPlusDestructor
-     procedure :: V                    => pchPlusV
-     procedure :: modifier             => pchPlusModifier
-     procedure :: hypergeometricA      => pchPlusHypergeometricA
-     procedure :: computeCommonFactors => pchPlusComputeCommonFactors
+     final     ::                                 pchPlusDestructor
+     procedure :: V                            => pchPlusV
+     procedure :: modifier                     => pchPlusModifier
+     procedure :: progenitorMassFunctionFactor => pchPlusProgenitorMassFunctionFactor
+     procedure :: hypergeometricA              => pchPlusHypergeometricA
+     procedure :: computeCommonFactors         => pchPlusComputeCommonFactors
   end type mergerTreeBranchingProbabilityPCHPlus
 
   interface mergerTreeBranchingProbabilityPCHPlus
@@ -203,6 +207,10 @@ contains
     if (cdmAssumptions .and. gamma3 > 1.5d0) call Error_Report('γ₃>³/₂ violates CDM assumptions'//{introspection:location})
     ! Initialize.
     self%mergerTreeBranchingProbabilityParkinsonColeHelly=mergerTreeBranchingProbabilityParkinsonColeHelly(G0,gamma1,gamma2,accuracyFirstOrder,precisionHypergeometric,hypergeometricTabulate,cdmAssumptions,tolerateRoundOffErrors,cosmologicalMassVariance_,criticalOverdensity_)
+    ! Precompute the exponents used by the fused merging-rate × modifier form (see pchPlusProgenitorMassFunctionFactor):
+    !  childSigma^{2+γ₁-2γ₃} · (childSigma²-σ_p²)^{γ₃-3/2}.
+    self%exponentChildSigma=+2.0d0+gamma1-2.0d0*gamma3
+    self%exponentDelta     =-1.5d0       +      gamma3
     return
   end function pchPlusConstructorInternal
 
@@ -226,14 +234,13 @@ contains
     implicit none
     class           (mergerTreeBranchingProbabilityPCHPlus), intent(inout) :: self
     double precision                                       , intent(in   ) :: massFraction     , haloMass
-    double precision                                                       :: childSigmaSquared
+    double precision                                                       :: childSigmaSquared, varianceDifference
 
-    childSigmaSquared=+self%cosmologicalMassVariance_%rootVariance(massFraction*haloMass,self%timeParent)**2
-    pchPlusV         =+       childSigmaSquared  &
-         &            /(                         &
-         &              +     childSigmaSquared  &
-         &              -self%sigmaParentSquared &
-         &             )**1.5d0                  &
+    childSigmaSquared =+self%cosmologicalMassVariance_%rootVariance(massFraction*haloMass,self%timeParent)**2
+    ! (childSigma²-σ_p²)^{3/2} written as d·√d to use a square root instead of a general power.
+    varianceDifference=+childSigmaSquared-self%sigmaParentSquared
+    pchPlusV          =+       childSigmaSquared         &
+         &            /(varianceDifference*sqrt(varianceDifference)) &
          &            *(                         &
          &              +1.0d0                   &
          &              -self%sigmaParentSquared &
@@ -253,6 +260,30 @@ contains
     pchPlusModifier=childSigma**self%gamma1*(1.0d0-self%sigmaParentSquared/childSigma**2)**self%gamma3
     return
   end function pchPlusModifier
+
+  double precision function pchPlusProgenitorMassFunctionFactor(self,childSigma,childAlpha)
+    !!{RST
+    Fused evaluation of the merging rate × modifier product appearing in the progenitor mass function. Algebraically
+    combining the base merging rate :math:`\sigma_\mathrm{c}^2/(\sigma_\mathrm{c}^2-\sigma_\mathrm{p}^2)^{3/2}|\alpha|`
+    with the PCH+ modifier :math:`\sigma_\mathrm{c}^{\gamma_1}(1-\sigma_\mathrm{p}^2/\sigma_\mathrm{c}^2)^{\gamma_3}`
+    collapses three general powers to two:
+    :math:`|\alpha|\,\sigma_\mathrm{c}^{2+\gamma_1-2\gamma_3}(\sigma_\mathrm{c}^2-\sigma_\mathrm{p}^2)^{\gamma_3-3/2}`.
+    !!}
+    implicit none
+    class           (mergerTreeBranchingProbabilityPCHPlus), intent(inout) :: self
+    double precision                                       , intent(in   ) :: childSigma       , childAlpha
+    double precision                                                       :: childSigmaSquared
+
+    childSigmaSquared=childSigma**2
+    if (childSigmaSquared > self%sigmaParentSquared .and. childAlpha < 0.0d0) then
+       pchPlusProgenitorMassFunctionFactor=+abs(childAlpha)                                        &
+            &                              *      childSigma **self%exponentChildSigma             &
+            &                              *(childSigmaSquared-self%sigmaParentSquared)**self%exponentDelta
+    else
+       pchPlusProgenitorMassFunctionFactor=+0.0d0
+    end if
+    return
+  end function pchPlusProgenitorMassFunctionFactor
 
   function pchPlusHypergeometricA(self,gamma) result(a)
     !!{RST

--- a/source/merger_trees/branching_probability/Parkinson_Cole_Helly.F90
+++ b/source/merger_trees/branching_probability/Parkinson_Cole_Helly.F90
@@ -76,17 +76,18 @@ Implements a merger tree branching probability class using the algorithm of :cit
        <method description="Compute the :math:`a` parameter of the hypergeometric function."                   method="hypergeometricA"     />
      </methods>
      !!]
-     final     ::                          parkinsonColeHellyDestructor
-     procedure :: V                     => parkinsonColeHellyV
-     procedure :: modifier              => parkinsonColeHellyModifier
-     procedure :: hypergeometricA       => parkinsonColeHellyHypergeometricA
-     procedure :: rate                  => parkinsonColeHellyRate
-     procedure :: probability           => parkinsonColeHellyProbability
-     procedure :: probabilityBound      => parkinsonColeHellyProbabilityBound
-     procedure :: fractionSubresolution => parkinsonColeHellyFractionSubresolution
-     procedure :: massBranch            => parkinsonColeHellyMassBranch
-     procedure :: stepMaximum           => parkinsonColeHellyStepMaximum
-     procedure :: computeCommonFactors  => parkinsonColeHellyComputeCommonFactors
+     final     ::                                 parkinsonColeHellyDestructor
+     procedure :: V                            => parkinsonColeHellyV
+     procedure :: modifier                     => parkinsonColeHellyModifier
+     procedure :: progenitorMassFunctionFactor => parkinsonColeHellyProgenitorMassFunctionFactor
+     procedure :: hypergeometricA              => parkinsonColeHellyHypergeometricA
+     procedure :: rate                         => parkinsonColeHellyRate
+     procedure :: probability                  => parkinsonColeHellyProbability
+     procedure :: probabilityBound             => parkinsonColeHellyProbabilityBound
+     procedure :: fractionSubresolution        => parkinsonColeHellyFractionSubresolution
+     procedure :: massBranch                   => parkinsonColeHellyMassBranch
+     procedure :: stepMaximum                  => parkinsonColeHellyStepMaximum
+     procedure :: computeCommonFactors         => parkinsonColeHellyComputeCommonFactors
   end type mergerTreeBranchingProbabilityParkinsonColeHelly
 
   interface mergerTreeBranchingProbabilityParkinsonColeHelly
@@ -430,14 +431,12 @@ contains
     implicit none
     class           (mergerTreeBranchingProbabilityParkinsonColeHelly), intent(inout) :: self
     double precision                                                  , intent(in   ) :: massFraction     , haloMass
-    double precision                                                                  :: childSigmaSquared
+    double precision                                                                  :: childSigmaSquared, varianceDifference
 
     childSigmaSquared  =+self%cosmologicalMassVariance_%rootVariance(massFraction*haloMass,self%timeParent)**2
-    parkinsonColeHellyV=+       childSigmaSquared  &
-         &              /(                         &
-         &                +     childSigmaSquared  &
-         &                -self%sigmaParentSquared &
-         &               )**1.5d0
+    ! (childSigma²-σ_p²)^{3/2} written as d·√d to use a square root instead of a general power.
+    varianceDifference =+childSigmaSquared-self%sigmaParentSquared
+    parkinsonColeHellyV=+childSigmaSquared/(varianceDifference*sqrt(varianceDifference))
     return
   end function parkinsonColeHellyV
 
@@ -645,11 +644,25 @@ contains
     implicit none
     double precision, intent(in   ) :: childAlpha, childHaloMass, childSigma
 
-    parkinsonColeHellyProgenitorMassFunction=+      parkinsonColeHellyMergingRate(childSigma   ,childAlpha)    &
-         &                                   *self_%modifier                     (childSigma              )    &
-         &                                   /                                    childHaloMass            **2
+    ! The merging-rate × modifier product is obtained through a bindable function so that subclasses (e.g.
+    ! PCHPlus) can supply an algebraically-fused form that avoids redundant power evaluations.
+    parkinsonColeHellyProgenitorMassFunction=+self_%progenitorMassFunctionFactor(childSigma,childAlpha) &
+         &                                   /childHaloMass**2
     return
   end function parkinsonColeHellyProgenitorMassFunction
+
+  double precision function parkinsonColeHellyProgenitorMassFunctionFactor(self,childSigma,childAlpha)
+    !!{RST
+    The unnormalized progenitor mass function factor---the merging rate multiplied by the modifier. Provided
+    as a bindable function so that subclasses can override it with an algebraically-fused form.
+    !!}
+    implicit none
+    class           (mergerTreeBranchingProbabilityParkinsonColeHelly), intent(inout) :: self
+    double precision                                                  , intent(in   ) :: childSigma, childAlpha
+
+    parkinsonColeHellyProgenitorMassFunctionFactor=+parkinsonColeHellyMergingRate(childSigma,childAlpha)*self%modifier(childSigma)
+    return
+  end function parkinsonColeHellyProgenitorMassFunctionFactor
 
   double precision function parkinsonColeHellyMergingRate(childSigma,childAlpha)
     !!{RST
@@ -657,11 +670,14 @@ contains
     !!}
     implicit none
     double precision, intent(in   ) :: childAlpha       , childSigma
-    double precision                :: childSigmaSquared
+    double precision                :: childSigmaSquared, varianceDifference
 
     childSigmaSquared=childSigma**2
     if (childSigmaSquared > self_%sigmaParentSquared .and. childAlpha < 0.0d0) then
-       parkinsonColeHellyMergingRate=(childSigmaSquared/((childSigmaSquared-self_%sigmaParentSquared)**1.5d0))*abs(childAlpha)
+       ! The denominator (childSigma²-σ_p²)^{3/2} is written as d·√d to use a (cheaper) square root in place
+       ! of a general power.
+       varianceDifference           =childSigmaSquared-self_%sigmaParentSquared
+       parkinsonColeHellyMergingRate=(childSigmaSquared/(varianceDifference*sqrt(varianceDifference)))*abs(childAlpha)
     else
        parkinsonColeHellyMergingRate=0.0d0
     end if


### PR DESCRIPTION
## Summary

The Parkinson-Cole-Helly progenitor mass function evaluates a **merging rate × modifier** product for every branching-integrand sample — one of the hottest paths when building merger trees. For the **PCH+** variant this cost **three libm `pow` calls** per evaluation:

- `(σc²−σp²)^{3/2}` in the merging rate, plus
- `σc^{γ₁}` and `(1−σp²/σc²)^{γ₃}` in the modifier.

This PR introduces a bindable `progenitorMassFunctionFactor` method (the merging-rate × modifier product) so subclasses can supply an algebraically-fused form. The PCH+ override collapses the three powers to **two**:

```
|α| · σc^{2+γ₁−2γ₃} · (σc²−σp²)^{γ₃−3/2}
```

with the two exponents precomputed in the constructor. It also replaces the half-integer `(σc²−σp²)**1.5d0` powers in the base merging rate and in `V` (both PCH and PCH+) with `d*sqrt(d)`, which is cheaper than a general `pow`.

This is an **exact algebraic rewrite** — no change to the physics.

## Performance

On the `progenitorMassFunction` validation model (`cole2000` builder, `PCHPlus`, real production γ parameters), a `perf` profile shows libm `pow` self-time drop **~20%** (~12.0% → ~9.6%), with `pchPlusModifier` removed from the hot branching path entirely.

## Correctness / validation

- **`tests.merger_tree_branching`**: 28/28 pass — analytic branching + accretion rates at relTol 1e-4, at z=0 and z=1. This exercises the base `parkinsonColeHelly` path, which now routes through the new factor method and the sqrt substitutions.
- **End-to-end PCH+ model** vs. pre-change code: aggregate output matches to **1.6e-10** (floating-point reordering noise through the chaotic tree builder; 108/180 datasets remain bitwise-identical, the rest differ only at ~1e-10).
- **Determinism baseline**: same binary run twice is bitwise-identical (0.0), confirming the 1.6e-10 is the algebra change and not run-to-run jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)