### PR TITLE
fix: avoid OpenMP lock contention in once-only initializers, and fix latent out-of-bounds in hydrogen network

### DIFF
--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -1254,6 +1254,51 @@ The first feature is the "unique ID"---an integer number assigned to each node i
 
 The second feature accounts for the fact that the properties of a node will change, so even if a function is called on a node with the same unique ID it may occasionally need to recompute its result. Galacticus provides a calculation reset task (see Section :galacticus-ref:`autoHook`). All such tasks are performed just prior to the computation of derivatives for a node being evolved. A function can register a calculation reset task and use it to flag that it must update its calculations even if called again with the same node.
 
+.. _manual-sec-onceOnlyInitialization:
+
+Once-Only Initialization Under OpenMP
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A common pattern in Galacticus is a module holding static, read-only data (atomic data, chemical structures, filter transmissions, tabulated databases) which must be read from file exactly once, no matter how many OpenMP threads are running. The obvious implementation guards the initialization with a named critical section:
+
+.. code-block:: fortran
+
+     !$omp critical(myDataInitialize)
+     if (.not.myDataInitialized) then
+        ! ...read the data...
+        myDataInitialized=.true.
+     end if
+     !$omp end critical(myDataInitialize)
+
+This is correct, but it takes the lock on **every** call, including the overwhelmingly common case where the data are already loaded and nothing needs to be done. Named critical sections are *global* locks, so when such an initializer is called from a hot path---particularly one reached during ODE evolution---and the model is run with a large number of threads, the resulting contention can dominate the run time. The problem was found in ``Atomic_Data_Initialize`` (``source/atomic/data.F90``), which is called from every public entry point of the ``Atomic_Data`` module, several of which are reached for every element, for every derivative evaluation.
+
+The fix is a double-checked lock, but the *naive* form of it---simply testing the shared ``myDataInitialized`` flag before taking the lock---is a data race under the OpenMP memory model. An unsynchronized read of the flag establishes no happens-before relationship with the initializing thread's writes, so a thread which observes the flag as ``.true.`` has no guarantee that it will also observe the data those writes produced; the compiler and hardware are both free to reorder around the unsynchronized read.
+
+Galacticus therefore uses a ``threadprivate`` flag recording that *this thread* has already passed through the critical section:
+
+.. code-block:: fortran
+
+     logical :: myDataInitialized      =.false.
+     logical :: myDataInitializedThread=.false.
+     !$omp threadprivate(myDataInitializedThread)
+     ...
+     if (myDataInitializedThread) return
+     !$omp critical(myDataInitialize)
+     if (.not.myDataInitialized) then
+        ! ...read the data...
+        myDataInitialized=.true.
+     end if
+     !$omp end critical(myDataInitialize)
+     myDataInitializedThread=.true.
+
+The ordering is supplied by the flush implied on exit from the critical section, which the code already relies upon: any thread which has left that section is guaranteed to see the fully-initialized data, so it need never enter it again. Each thread therefore acquires the lock exactly once for the lifetime of the run, and the hot path reduces to a load of a thread-local logical---no fence, no shared cache line, and no possibility of false sharing.
+
+This form also fails safe. OpenMP guarantees the persistence of ``threadprivate`` values between parallel regions only under certain conditions (unchanged team size, dynamic thread adjustment disabled). If those conditions are not met the per-thread flag can only revert to ``.false.``, never spuriously to ``.true.``, so the worst outcome is one redundant---and harmless---lock acquisition, not an unsynchronized read of uninitialized data.
+
+An alternative is to keep the shared flag and read it via ``!$omp atomic read seq_cst``, pairing it with an ``!$omp atomic write seq_cst`` when the flag is set; the listless flush implied by the ``seq_cst`` clause supplies the necessary release/acquire pair. This is also correct, and is preferable when a per-thread flag is inconvenient, but it pays a full memory fence on every call, so the ``threadprivate`` form is preferred on genuinely hot paths. (See Section :galacticus-ref:`eventHooksLocking` for a related case, where an atomic read replaces a read/write lock on a hot dispatch path.)
+
+Two points to note when writing such an initializer. First, the double check is *not* optional: the test inside the critical section must be retained, since several threads may pass the outer test before any of them acquires the lock. Omitting it allows two threads to run the initialization concurrently, which typically manifests as an attempt to allocate an already-allocated array. Second, the guard should be placed so that the fast path returns before any other work is done; in particular, an initializer called from several public entry points of the same module may be reached more than once per logical operation, so the fast path must be genuinely cheap.
+
 Global Functions
 ----------------
 

--- a/source/atomic/data.F90
+++ b/source/atomic/data.F90
@@ -41,7 +41,7 @@ module Atomic_Data
   end type atomicData
 
   ! Flag indicating if module has been initialized.
-  logical                                                                   :: atomicDataInitialized =.false.
+  logical                                                                   :: atomicDataInitialized      =.false.
 
   ! Per-thread flag recording that this thread has already passed through the initialization critical section (see
   ! `Atomic_Data_Initialize`), and so is guaranteed to see the fully-initialized module data.

--- a/source/atomic/data.F90
+++ b/source/atomic/data.F90
@@ -43,6 +43,11 @@ module Atomic_Data
   ! Flag indicating if module has been initialized.
   logical                                                                   :: atomicDataInitialized =.false.
 
+  ! Per-thread flag recording that this thread has already passed through the initialization critical section (see
+  ! `Atomic_Data_Initialize`), and so is guaranteed to see the fully-initialized module data.
+  logical                                                                   :: atomicDataInitializedThread=.false.
+  !$omp threadprivate(atomicDataInitializedThread)
+
   ! Array used to store atomic data.
   type            (atomicData), allocatable, dimension(:                  ) :: atoms
 
@@ -211,7 +216,13 @@ contains
     character       (len=100       )                            :: abundanceType
     type            (varying_string)                            :: fileName            , abundancePatternFile
 
-    ! Check if module is initialized.
+    ! Check if module is initialized. Any thread which has previously passed through the critical section below is guaranteed,
+    ! by the flush implied on exit from that section, to see the fully-initialized module data, and so can skip the lock
+    ! entirely. This matters because this subroutine is called on the hot path of ODE evolution (via, e.g.,
+    ! `abundancesMetallicitySet`), and a named critical section is a global lock, so with large numbers of OpenMP threads the
+    ! contention for it is severe. See the "Once-Only Initialization Under OpenMP" section of the developer guide for the full
+    ! rationale, including why the naive form of this double-checked lock would be a data race.
+    if (atomicDataInitializedThread) return
     !$omp critical(atomicDataInitialize)
     if (.not.atomicDataInitialized) then
 
@@ -312,6 +323,11 @@ contains
        atomicDataInitialized=.true.
     end if
     !$omp end critical(atomicDataInitialize)
+    ! This thread has now synchronized with the initialization, so record that it need never take the lock again. Note that if
+    ! this per-thread flag is not preserved across parallel regions (e.g. if dynamic thread adjustment changes the team size) it
+    ! can only revert to "false", which costs one redundant---but harmless---lock acquisition, never an unsynchronized read of
+    ! uninitialized data.
+    atomicDataInitializedThread=.true.
     return
   end subroutine Atomic_Data_Initialize
 

--- a/source/chemical/reaction_rates/hydrogen.F90
+++ b/source/chemical/reaction_rates/hydrogen.F90
@@ -486,7 +486,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                  =.false., reactionInitialized        =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread       =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex        , atomicHydrogenChemicalIndex        , &
          &                                                                  chemicalHydrogenChemicalIndex           , electronChemicalIndex
@@ -586,7 +586,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                     =.false., reactionInitialized        =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread          =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex          , atomicHydrogenChemicalIndex        , &
          &                                                                  chemicalHydrogenCationChemicalIndex
@@ -651,7 +651,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                                              :: reactionActive                     =.false., reactionInitialized          =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread          =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex          , atomicHydrogenChemicalIndex          , &
          &                                                                  chemicalHydrogenCationChemicalIndex        , chemicalHydrogenChemicalIndex
@@ -715,7 +715,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                     =.false., reactionInitialized          =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread          =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex          , atomicHydrogenChemicalIndex          , &
          &                                                                  chemicalHydrogenCationChemicalIndex        , chemicalHydrogenChemicalIndex
@@ -796,7 +796,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive             =.false., reactionInitialized          =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread  =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenChemicalIndex        , chemicalHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
@@ -855,7 +855,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive             =.false., reactionInitialized          =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread  =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenChemicalIndex        , chemicalHydrogenChemicalIndex
     double precision                                                     :: log10Temperature                   , rate                                 , &
@@ -917,7 +917,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                  =.false., reactionInitialized        =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread       =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex        , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
@@ -1006,7 +1006,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                    =.false., reactionInitialized        =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread         =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex          , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
@@ -1083,7 +1083,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                  =.false., reactionInitialized              =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread       =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex        , atomicHydrogenCationChemicalIndex        , &
          &                                                                  atomicHydrogenChemicalIndex
@@ -1154,7 +1154,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                     =.false., reactionInitialized              =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread          =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex           , atomicHydrogenCationChemicalIndex        , &
          &                                                                  chemicalHydrogenCationChemicalIndex        , electronChemicalIndex
@@ -1232,7 +1232,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive             =.false., reactionInitialized                =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread  =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenChemicalIndex        , chemicalHydrogenCationChemicalIndex        , &
          &                                                                  electronChemicalIndex
@@ -1293,7 +1293,7 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                     =.false., reactionInitialized          =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread          =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex           , atomicHydrogenChemicalIndex          , &
          &                                                                  chemicalHydrogenCationChemicalIndex        , chemicalHydrogenChemicalIndex
@@ -1366,7 +1366,7 @@ contains
     ! Wavelength range for the cross-section.
     double precision                                     , parameter     :: crossSectionWavelengthHigh      =plancksConstant*speedLight*metersToAngstroms/electronVolt/crossSectionEnergyLow
     logical                                              , save          :: reactionActive                  =.false.                                                                        , reactionInitialized        =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread       =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex                                                                                , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
@@ -1479,7 +1479,7 @@ contains
     double precision                                     , parameter     :: crossSectionWavelengthLow          =plancksConstant*speedLight*metersToAngstroms/electronVolt/crossSectionEnergyHigh
     double precision                                     , parameter     :: crossSectionWavelengthHigh         =plancksConstant*speedLight*metersToAngstroms/electronVolt/crossSectionEnergyLow
     logical                                              , save          :: reactionActive                     =.false.                                                                         , reactionInitialized        =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread          =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex                                                                                   , atomicHydrogenChemicalIndex        , &
          &                                                                  chemicalHydrogenCationChemicalIndex
@@ -1595,7 +1595,7 @@ contains
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     type            (treeNode                           ), intent(inout) :: node
     logical                                              , save          :: reactionActive             =.false.                                                                    , reactionInitialized                     =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread  =.false.
     !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenChemicalIndex                                                                            , chemicalHydrogenChemicalIndex
     ! Median energy of the Lyman band in chemical hydrogen (in eV).
@@ -1690,7 +1690,7 @@ contains
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     type            (treeNode                           ), intent(inout) :: node
     logical                                              , save          :: reactionActive                     =.false.                                                                         , reactionInitialized          =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread          =.false.
     !$omp threadprivate(reactionInitializedThread)
     ! Energy of the edge in the cross-section.
     double precision                                     , parameter     :: crossSectionEdgeEnergy             =15.42d0
@@ -1916,7 +1916,7 @@ contains
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     type            (treeNode                           ), intent(inout) :: node
     logical                                              , save          :: reactionActive             =.false.                                                                         , reactionInitialized          =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save          :: reactionInitializedThread  =.false.
     !$omp threadprivate(reactionInitializedThread)
     ! Energy range for the cross-section.
     double precision                                     , parameter     :: crossSectionEnergyLow      =14.159d0
@@ -2046,7 +2046,7 @@ contains
     type            (chemicalAbundances                 )           , intent(inout) :: chemicalRates
     type            (treeNode                           )           , intent(inout) :: node
     logical                                              , save                     :: reactionActive                   =.false.                                                                        , reactionInitialized        =.false.
-    logical                                              , save          :: reactionInitializedThread        =.false.
+    logical                                              , save                     :: reactionInitializedThread        =.false.
     !$omp threadprivate(reactionInitializedThread)
     ! Energy range for the cross-section (in eV).
     double precision                                     , parameter                :: crossSectionEnergyLow            =13.60d0

--- a/source/chemical/reaction_rates/hydrogen.F90
+++ b/source/chemical/reaction_rates/hydrogen.F90
@@ -286,13 +286,15 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                   =.false., reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex        , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
     double precision                                                     :: rate                                     , rateCoefficient
     !$GLC attributes unused :: self, radiation
 
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH_Electron_to_Hplus_2Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -305,6 +307,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH_Electron_to_Hplus_2Electron_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -339,13 +342,15 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                   =.false., reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex        , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
     double precision                                                     :: rate                                     , rateCoefficient
     !$GLC attributes unused :: self, radiation
 
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateHplus_Electron_to_H_Photon_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -358,6 +363,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateHplus_Electron_to_H_Photon_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -392,6 +398,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                  =.false., reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex        , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
     double precision                                                     :: rate                                    , rateCoefficient
@@ -400,7 +408,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -413,6 +421,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -477,6 +486,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                  =.false., reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex        , atomicHydrogenChemicalIndex        , &
          &                                                                  chemicalHydrogenChemicalIndex           , electronChemicalIndex
     integer                                                              :: status
@@ -484,7 +495,7 @@ contains
     !$GLC attributes unused :: radiation
 
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH_Hminus_to_H2_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -501,6 +512,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH_Hminus_to_H2_Electron_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -574,6 +586,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                     =.false., reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex          , atomicHydrogenChemicalIndex        , &
          &                                                                  chemicalHydrogenCationChemicalIndex
     double precision                                                     :: rate                                       , rateCoefficient                    , &
@@ -583,7 +597,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH_Hplus_to_H2plus_Photon_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -596,6 +610,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH_Hplus_to_H2plus_Photon_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -636,6 +651,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                                              :: reactionActive                     =.false., reactionInitialized          =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex          , atomicHydrogenChemicalIndex          , &
          &                                                                  chemicalHydrogenCationChemicalIndex        , chemicalHydrogenChemicalIndex
     double precision                                     , parameter     :: rateCoefficient                    =6.4d-10
@@ -645,7 +662,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2plus_H_to_H2_Hplus_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -660,6 +677,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2plus_H_to_H2_Hplus_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -697,6 +715,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                     =.false., reactionInitialized          =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex          , atomicHydrogenChemicalIndex          , &
          &                                                                  chemicalHydrogenCationChemicalIndex        , chemicalHydrogenChemicalIndex
     double precision                                                     :: logNaturalTemperatureElectronVolts         , rate                                 , &
@@ -706,7 +726,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2_Hplus_to_H2plus_H_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -721,6 +741,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2_Hplus_to_H2plus_H_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -775,13 +796,15 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive             =.false., reactionInitialized          =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenChemicalIndex        , chemicalHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
     double precision                                                     :: rate                               , rateCoefficient
     !$GLC attributes unused :: self, radiation
 
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2_Electron_to_2H_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -794,6 +817,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2_Electron_to_2H_Electron_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -831,6 +855,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive             =.false., reactionInitialized          =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenChemicalIndex        , chemicalHydrogenChemicalIndex
     double precision                                                     :: log10Temperature                   , rate                                 , &
          &                                                                  rateCoefficient                    , temperatureElectronVolts
@@ -839,7 +865,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2_H_to_3H_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -851,6 +877,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2_H_to_3H_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -890,6 +917,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                  =.false., reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex        , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
     double precision                                                     :: rate                                    , rateCoefficient
@@ -898,7 +927,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -911,6 +940,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -976,6 +1006,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                    =.false., reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex          , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
     double precision                                                     :: logNaturalTemperatureElectronVolts        , rate                               , &
@@ -985,7 +1017,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -998,6 +1030,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1050,6 +1083,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                  =.false., reactionInitialized              =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex        , atomicHydrogenCationChemicalIndex        , &
          &                                                                  atomicHydrogenChemicalIndex
     double precision                                                     :: rate                                    , rateCoefficient
@@ -1058,7 +1093,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateHminus_Hplus_to_2H_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1071,6 +1106,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateHminus_Hplus_to_2H_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1118,6 +1154,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                     =.false., reactionInitialized              =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex           , atomicHydrogenCationChemicalIndex        , &
          &                                                                  chemicalHydrogenCationChemicalIndex        , electronChemicalIndex
     double precision                                                     :: rate                                       , rateCoefficient                          , &
@@ -1127,7 +1165,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateHminus_Hplus_to_H2plus_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1145,6 +1183,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateHminus_Hplus_to_H2plus_Electron_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1191,6 +1230,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive             =.false., reactionInitialized                =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenChemicalIndex        , chemicalHydrogenCationChemicalIndex        , &
          &                                                                  electronChemicalIndex
     double precision                                                     :: rate                               , rateCoefficient
@@ -1199,7 +1240,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2plus_Electron_to_2H_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1212,6 +1253,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2plus_Electron_to_2H_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1249,6 +1291,8 @@ contains
     type            (chemicalAbundances                 ), intent(in   ) :: chemicalDensity
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     logical                                              , save          :: reactionActive                     =.false., reactionInitialized          =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex           , atomicHydrogenChemicalIndex          , &
          &                                                                  chemicalHydrogenCationChemicalIndex        , chemicalHydrogenChemicalIndex
     double precision                                                     :: rate                                       , rateCoefficient
@@ -1257,7 +1301,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2plus_Hminus_to_H2_H_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1272,6 +1316,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2plus_Hminus_to_H2_H_Init)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1319,6 +1364,8 @@ contains
     ! Wavelength range for the cross-section.
     double precision                                     , parameter     :: crossSectionWavelengthHigh      =plancksConstant*speedLight*metersToAngstroms/electronVolt/crossSectionEnergyLow
     logical                                              , save          :: reactionActive                  =.false.                                                                        , reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenAnionChemicalIndex                                                                                , atomicHydrogenChemicalIndex        , &
          &                                                                  electronChemicalIndex
     double precision                                                     :: rate                                                                                                            , rateCoefficient
@@ -1326,7 +1373,7 @@ contains
     !$GLC attributes unused :: self, temperature
 
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateHminus_Gamma_to_H_Electron)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1339,6 +1386,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateHminus_Gamma_to_H_Electron)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1429,6 +1477,8 @@ contains
     double precision                                     , parameter     :: crossSectionWavelengthLow          =plancksConstant*speedLight*metersToAngstroms/electronVolt/crossSectionEnergyHigh
     double precision                                     , parameter     :: crossSectionWavelengthHigh         =plancksConstant*speedLight*metersToAngstroms/electronVolt/crossSectionEnergyLow
     logical                                              , save          :: reactionActive                     =.false.                                                                         , reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenCationChemicalIndex                                                                                   , atomicHydrogenChemicalIndex        , &
          &                                                                  chemicalHydrogenCationChemicalIndex
     double precision                                                     :: rate                                                                                                                , rateCoefficient
@@ -1437,7 +1487,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2plus_Gamma_to_H_Hplus)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1450,6 +1500,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2plus_Gamma_to_H_Hplus)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1542,6 +1593,8 @@ contains
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     type            (treeNode                           ), intent(inout) :: node
     logical                                              , save          :: reactionActive             =.false.                                                                    , reactionInitialized                     =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     integer                                              , save          :: atomicHydrogenChemicalIndex                                                                            , chemicalHydrogenChemicalIndex
     ! Median energy of the Lyman band in chemical hydrogen (in eV).
     double precision                                     , parameter     :: energyLymanBand            =12.87d0
@@ -1556,7 +1609,7 @@ contains
     !$GLC attributes unused :: self, temperature
 
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2_Gamma_to_H2star_to_2H)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1568,6 +1621,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2_Gamma_to_H2star_to_2H)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1634,6 +1688,8 @@ contains
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     type            (treeNode                           ), intent(inout) :: node
     logical                                              , save          :: reactionActive                     =.false.                                                                         , reactionInitialized          =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     ! Energy of the edge in the cross-section.
     double precision                                     , parameter     :: crossSectionEdgeEnergy             =15.42d0
     ! Wavelength of the edge in the cross-section.
@@ -1646,7 +1702,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2_Gamma_to_H2plus_Electron)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1661,6 +1717,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2_Gamma_to_H2plus_Electron)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1744,6 +1801,8 @@ contains
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     type            (treeNode                           ), intent(inout) :: node
     logical                                              , save          :: reactionActive                   =.false.                                                                         , reactionInitialized                =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     ! Energy range for the cross-section.
     double precision                                     , parameter     :: crossSectionEnergyLow            =30.0d0
     double precision                                     , parameter     :: crossSectionEnergyHigh           =90.0d0
@@ -1758,7 +1817,7 @@ contains
     ! If using the fast network, this reaction is ignored so simply return in such cases.
     if (self%fast) return
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2plus_Gamma_to_2Hplus_Electron)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1773,6 +1832,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2plus_Gamma_to_2Hplus_Electron)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1854,6 +1914,8 @@ contains
     type            (chemicalAbundances                 ), intent(inout) :: chemicalRates
     type            (treeNode                           ), intent(inout) :: node
     logical                                              , save          :: reactionActive             =.false.                                                                         , reactionInitialized          =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     ! Energy range for the cross-section.
     double precision                                     , parameter     :: crossSectionEnergyLow      =14.159d0
     double precision                                     , parameter     :: crossSectionEnergyHigh     =17.700d0
@@ -1865,7 +1927,7 @@ contains
     !$GLC attributes unused :: self, temperature
 
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH2_Gamma_to_2H)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -1878,6 +1940,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH2_Gamma_to_2H)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then
@@ -1981,6 +2044,8 @@ contains
     type            (chemicalAbundances                 )           , intent(inout) :: chemicalRates
     type            (treeNode                           )           , intent(inout) :: node
     logical                                              , save                     :: reactionActive                   =.false.                                                                        , reactionInitialized        =.false.
+    logical                                              , save          :: reactionInitializedThread        =.false.
+    !$omp threadprivate(reactionInitializedThread)
     ! Energy range for the cross-section (in eV).
     double precision                                     , parameter                :: crossSectionEnergyLow            =13.60d0
     ! Wavelength range for the cross-section (in Angstroms).
@@ -1991,7 +2056,7 @@ contains
     !$GLC attributes unused :: self, temperature
 
     ! Check if this reaction needs initializing.
-    if (.not.reactionInitialized) then
+    if (.not.reactionInitializedThread) then
        !$omp critical(hydrogenNetworkRateH_Gamma_to_H_Electron)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
@@ -2006,6 +2071,7 @@ contains
           reactionInitialized=.true.
        end if
        !$omp end critical(hydrogenNetworkRateH_Gamma_to_H_Electron)
+       reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
     if (reactionActive) then

--- a/source/chemical/reaction_rates/hydrogen.F90
+++ b/source/chemical/reaction_rates/hydrogen.F90
@@ -811,8 +811,8 @@ contains
           atomicHydrogenChemicalIndex  =Chemicals_Index("AtomicHydrogen"   )
           chemicalHydrogenChemicalIndex=Chemicals_Index("MolecularHydrogen")
           electronChemicalIndex        =Chemicals_Index("Electron"         )
-          ! This reaction is active if both species were found.
-          reactionActive=atomicHydrogenChemicalIndex > 0 .and. chemicalHydrogenChemicalIndex > 0
+          ! This reaction is active if all species were found.
+          reactionActive=atomicHydrogenChemicalIndex > 0 .and. chemicalHydrogenChemicalIndex > 0 .and. electronChemicalIndex > 0
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
@@ -934,8 +934,8 @@ contains
           atomicHydrogenChemicalIndex     =Chemicals_Index("AtomicHydrogen"     )
           atomicHydrogenAnionChemicalIndex=Chemicals_Index("AtomicHydrogenAnion")
           electronChemicalIndex           =Chemicals_Index("Electron"           )
-          ! This reaction is active if both species were found.
-          reactionActive=atomicHydrogenChemicalIndex > 0 .and. atomicHydrogenAnionChemicalIndex > 0
+          ! This reaction is active if all species were found.
+          reactionActive=atomicHydrogenChemicalIndex > 0 .and. atomicHydrogenAnionChemicalIndex > 0 .and. electronChemicalIndex > 0
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
@@ -1024,8 +1024,8 @@ contains
           atomicHydrogenChemicalIndex     =Chemicals_Index("AtomicHydrogen"     )
           atomicHydrogenAnionChemicalIndex=Chemicals_Index("AtomicHydrogenAnion")
           electronChemicalIndex           =Chemicals_Index("Electron"           )
-          ! This reaction is active if both species were found.
-          reactionActive=atomicHydrogenChemicalIndex > 0 .and. atomicHydrogenAnionChemicalIndex > 0
+          ! This reaction is active if all species were found.
+          reactionActive=atomicHydrogenChemicalIndex > 0 .and. atomicHydrogenAnionChemicalIndex > 0 .and. electronChemicalIndex > 0
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
@@ -1173,12 +1173,14 @@ contains
           atomicHydrogenAnionChemicalIndex   =Chemicals_Index("AtomicHydrogenAnion"    )
           chemicalHydrogenCationChemicalIndex=Chemicals_Index("MolecularHydrogenCation")
           electronChemicalIndex              =Chemicals_Index("Electron"               )
-          ! This reaction is active if both species were found.
+          ! This reaction is active if all species were found.
           reactionActive= atomicHydrogenCationChemicalIndex   > 0 &
                &         .and.                                    &
                &          atomicHydrogenAnionChemicalIndex    > 0 &
                &         .and.                                    &
-               &          chemicalHydrogenCationChemicalIndex > 0
+               &          chemicalHydrogenCationChemicalIndex > 0 &
+               &         .and.                                    &
+               &          electronChemicalIndex               > 0
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
@@ -1247,8 +1249,8 @@ contains
           atomicHydrogenChemicalIndex        =Chemicals_Index("AtomicHydrogen"         )
           chemicalHydrogenCationChemicalIndex=Chemicals_Index("MolecularHydrogenCation")
           electronChemicalIndex              =Chemicals_Index("Electron"               )
-          ! This reaction is active if both species were found.
-          reactionActive=atomicHydrogenChemicalIndex > 0 .and. chemicalHydrogenCationChemicalIndex > 0
+          ! This reaction is active if all species were found.
+          reactionActive=atomicHydrogenChemicalIndex > 0 .and. chemicalHydrogenCationChemicalIndex > 0 .and. electronChemicalIndex > 0
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if

--- a/source/chemical/reaction_rates/hydrogen.F90
+++ b/source/chemical/reaction_rates/hydrogen.F90
@@ -906,7 +906,7 @@ contains
 
   subroutine hydrogenNetworkRateHminus_Electron_to_H_2Electron(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^- + \hbox{e}^- \rightarrow \hbox{H} + 2 \hbox{e}^-`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{e}^- \rightarrow \hbox{H} + 2 \hbox{e}^-`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -928,7 +928,7 @@ contains
     if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp critical(hydrogenNetworkRateHminus_Electron_to_H_2Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenChemicalIndex     =Chemicals_Index("AtomicHydrogen"     )
@@ -939,7 +939,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp end critical(hydrogenNetworkRateHminus_Electron_to_H_2Electron_Init)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
@@ -964,7 +964,7 @@ contains
 
   double precision function hydrogenNetworkHminus_Electron_to_H_2Electron_RateCoefficient(temperature)
     !!{RST
-    Computes the rate coefficient (in units of cm\ :math:`^3` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \hbox{H} \rightarrow \hbox{H}_2 + \hbox{H}^+`.
+    Computes the rate coefficient (in units of cm\ :math:`^3` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{e}^- \rightarrow \hbox{H} + 2 \hbox{e}^-`.
     !!}
     use :: Numerical_Constants_Physical, only : boltzmannsConstant
     use :: Numerical_Constants_Units   , only : electronVolt
@@ -1018,7 +1018,7 @@ contains
     if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp critical(hydrogenNetworkRateHminus_H_to_2H_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenChemicalIndex     =Chemicals_Index("AtomicHydrogen"     )
@@ -1029,7 +1029,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH_Electron_to_Hminus_Photon_Init)
+       !$omp end critical(hydrogenNetworkRateHminus_H_to_2H_Electron_Init)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
@@ -1072,7 +1072,7 @@ contains
 
   subroutine hydrogenNetworkRateHminus_Hplus_to_2H(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \hbox{H} \rightarrow \hbox{H}_2 + \hbox{H}^+`.
+    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{H}^+ \rightarrow 2 \hbox{H}`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -1130,7 +1130,7 @@ contains
 
   double precision function hydrogenNetworkHminus_Hplus_to_2H_RateCoefficient(temperature)
     !!{RST
-    Compute the rate coefficient (in units of c\ :math:`^3` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \hbox{H} \rightarrow \hbox{H}_2 + \hbox{H}^+`.
+    Compute the rate coefficient (in units of c\ :math:`^3` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{H}^+ \rightarrow 2 \hbox{H}`.
     !!}
     implicit none
     double precision, intent(in   ) :: temperature
@@ -2059,7 +2059,7 @@ contains
 
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateH_Gamma_to_H_Electron)
+       !$omp critical(hydrogenNetworkRateH_Gamma_to_Hplus_Electron)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenChemicalIndex      =Chemicals_Index("AtomicHydrogen"      )
@@ -2072,7 +2072,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH_Gamma_to_H_Electron)
+       !$omp end critical(hydrogenNetworkRateH_Gamma_to_Hplus_Electron)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.

--- a/source/chemical/reaction_rates/hydrogen.F90
+++ b/source/chemical/reaction_rates/hydrogen.F90
@@ -275,7 +275,7 @@ contains
 
   subroutine hydrogenNetworkRateH_Electron_to_Hplus_2Electron(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H} + \hbox{e}^- \rightarrow \hbox{H}^+ + 2\hbox{e}^-`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H} + \hbox{e}^- \rightarrow \hbox{H}^+ + 2\hbox{e}^-`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -331,7 +331,7 @@ contains
 
   subroutine hydrogenNetworkRateHplus_Electron_to_H_Photon(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^+ + \hbox{e}^- \rightarrow \hbox{H} + \gamma`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^+ + \hbox{e}^- \rightarrow \hbox{H} + \gamma`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -540,7 +540,7 @@ contains
 
   double precision function hydrogenNetworkH_Hminus_to_H2_Electron_RateCoefficient(temperature)
     !!{RST
-    Computes the rate coefficient (in units of c\ :math:`^3` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H} + \hbox{H}^- \rightarrow \hbox{H}_2 + \hbox{e}^-`.
+    Computes the rate coefficient (in units of cm\ :math:`^3` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H} + \hbox{H}^- \rightarrow \hbox{H}_2 + \hbox{e}^-`.
     !!}
     use :: Numerical_Constants_Physical, only : boltzmannsConstant
     use :: Numerical_Constants_Units   , only : electronVolt
@@ -640,7 +640,7 @@ contains
 
   subroutine hydrogenNetworkRateH2plus_H_to_H2_Hplus(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \hbox{H} \rightarrow \hbox{H}_2 + \hbox{H}^+`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \hbox{H} \rightarrow \hbox{H}_2 + \hbox{H}^+`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -702,7 +702,7 @@ contains
 
   subroutine hydrogenNetworkRateH2_Hplus_to_H2plus_H(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2 + \hbox{H}^+ \rightarrow \hbox{H}_2^+ + \hbox{H}`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2 + \hbox{H}^+ \rightarrow \hbox{H}_2^+ + \hbox{H}`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Numerical_Constants_Physical , only : boltzmannsConstant
@@ -785,7 +785,7 @@ contains
 
   subroutine hydrogenNetworkRateH2_Electron_to_2H_Electron(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2 + \hbox{e}^- \rightarrow 2\hbox{H} + \hbox{e}^-`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2 + \hbox{e}^- \rightarrow 2\hbox{H} + \hbox{e}^-`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -842,7 +842,7 @@ contains
 
   subroutine hydrogenNetworkRateH2_H_to_3H(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2 + \hbox{H} \rightarrow 3\hbox{H}`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2 + \hbox{H} \rightarrow 3\hbox{H}`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Numerical_Constants_Physical , only : boltzmannsConstant
@@ -993,7 +993,7 @@ contains
 
   subroutine hydrogenNetworkRateHminus_H_to_2H_Electron(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{H} \rightarrow 2 \hbox{H} + \hbox{e}^-`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{H} \rightarrow 2 \hbox{H} + \hbox{e}^-`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Numerical_Constants_Physical , only : boltzmannsConstant
@@ -1072,7 +1072,7 @@ contains
 
   subroutine hydrogenNetworkRateHminus_Hplus_to_2H(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{H}^+ \rightarrow 2 \hbox{H}`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{H}^+ \rightarrow 2 \hbox{H}`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -1130,7 +1130,7 @@ contains
 
   double precision function hydrogenNetworkHminus_Hplus_to_2H_RateCoefficient(temperature)
     !!{RST
-    Compute the rate coefficient (in units of c\ :math:`^3` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{H}^+ \rightarrow 2 \hbox{H}`.
+    Compute the rate coefficient (in units of cm\ :math:`^3` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}^- + \hbox{H}^+ \rightarrow 2 \hbox{H}`.
     !!}
     implicit none
     double precision, intent(in   ) :: temperature
@@ -1221,7 +1221,7 @@ contains
 
   subroutine hydrogenNetworkRateH2plus_Electron_to_2H(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \hbox{e}^- \rightarrow 2\hbox{H}`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \hbox{e}^- \rightarrow 2\hbox{H}`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -1282,7 +1282,7 @@ contains
 
   subroutine hydrogenNetworkRateH2plus_Hminus_to_H2_H(self,temperature,radiation,chemicalDensity,factorClumping,chemicalRates)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \hbox{H}^- \rightarrow \hbox{H}_2 + \hbox{H}`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \hbox{H}^- \rightarrow \hbox{H}_2 + \hbox{H}`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Radiation_Fields             , only : radiationFieldClass
@@ -1376,7 +1376,7 @@ contains
 
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateHminus_Gamma_to_H_Electron)
+       !$omp critical(hydrogenNetworkRateHminus_Gamma_to_H_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenAnionChemicalIndex=Chemicals_Index("AtomicHydrogenAnion",status)
@@ -1387,7 +1387,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateHminus_Gamma_to_H_Electron)
+       !$omp end critical(hydrogenNetworkRateHminus_Gamma_to_H_Electron_Init)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
@@ -1459,7 +1459,7 @@ contains
 
   subroutine hydrogenNetworkRateH2plus_Gamma_to_H_Hplus(self,temperature,radiation,chemicalDensity,chemicalRates,node)
     !!{RST
-    Computes the rate (in units of c\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \gamma \rightarrow \hbox{H} + \hbox{H}^+`.
+    Computes the rate (in units of cm\ :math:`^{-3}` s\ :math:`^{-1}`) for the reaction :math:`\hbox{H}_2^+ + \gamma \rightarrow \hbox{H} + \hbox{H}^+`.
     !!}
     use :: Chemical_Abundances_Structure, only : Chemicals_Index
     use :: Numerical_Constants_Physical , only : plancksConstant    , speedLight
@@ -1490,7 +1490,7 @@ contains
     if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateH2plus_Gamma_to_H_Hplus)
+       !$omp critical(hydrogenNetworkRateH2plus_Gamma_to_H_Hplus_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           chemicalHydrogenCationChemicalIndex=Chemicals_Index("MolecularHydrogenCation")
@@ -1501,7 +1501,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH2plus_Gamma_to_H_Hplus)
+       !$omp end critical(hydrogenNetworkRateH2plus_Gamma_to_H_Hplus_Init)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
@@ -1612,7 +1612,7 @@ contains
 
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateH2_Gamma_to_H2star_to_2H)
+       !$omp critical(hydrogenNetworkRateH2_Gamma_to_H2star_to_2H_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           chemicalHydrogenChemicalIndex=Chemicals_Index("MolecularHydrogen")
@@ -1622,7 +1622,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH2_Gamma_to_H2star_to_2H)
+       !$omp end critical(hydrogenNetworkRateH2_Gamma_to_H2star_to_2H_Init)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
@@ -1705,7 +1705,7 @@ contains
     if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateH2_Gamma_to_H2plus_Electron)
+       !$omp critical(hydrogenNetworkRateH2_Gamma_to_H2plus_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           chemicalHydrogenChemicalIndex      =Chemicals_Index("MolecularHydrogen"      )
@@ -1718,7 +1718,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH2_Gamma_to_H2plus_Electron)
+       !$omp end critical(hydrogenNetworkRateH2_Gamma_to_H2plus_Electron_Init)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
@@ -1820,7 +1820,7 @@ contains
     if (self%fast) return
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateH2plus_Gamma_to_2Hplus_Electron)
+       !$omp critical(hydrogenNetworkRateH2plus_Gamma_to_2Hplus_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenCationChemicalIndex  =Chemicals_Index("AtomicHydrogenCation"   )
@@ -1833,7 +1833,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH2plus_Gamma_to_2Hplus_Electron)
+       !$omp end critical(hydrogenNetworkRateH2plus_Gamma_to_2Hplus_Electron_Init)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
@@ -1930,7 +1930,7 @@ contains
 
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateH2_Gamma_to_2H)
+       !$omp critical(hydrogenNetworkRateH2_Gamma_to_2H_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenChemicalIndex  =Chemicals_Index("AtomicHydrogen"   )
@@ -1941,7 +1941,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH2_Gamma_to_2H)
+       !$omp end critical(hydrogenNetworkRateH2_Gamma_to_2H_Init)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.
@@ -2059,7 +2059,7 @@ contains
 
     ! Check if this reaction needs initializing.
     if (.not.reactionInitializedThread) then
-       !$omp critical(hydrogenNetworkRateH_Gamma_to_Hplus_Electron)
+       !$omp critical(hydrogenNetworkRateH_Gamma_to_Hplus_Electron_Init)
        if (.not.reactionInitialized) then
           ! Find the chemicals in this reaction.
           atomicHydrogenChemicalIndex      =Chemicals_Index("AtomicHydrogen"      )
@@ -2072,7 +2072,7 @@ contains
           ! Flag that the reaction is now initialized.
           reactionInitialized=.true.
        end if
-       !$omp end critical(hydrogenNetworkRateH_Gamma_to_Hplus_Electron)
+       !$omp end critical(hydrogenNetworkRateH_Gamma_to_Hplus_Electron_Init)
        reactionInitializedThread=.true.
     end if
     ! Do calculation if this reaction is active.

--- a/source/objects/chemical_structure.F90
+++ b/source/objects/chemical_structure.F90
@@ -86,6 +86,11 @@ module Chemical_Structures
   ! Flag indicating if the database has been initialized.
   logical                                               :: chemicalDatabaseInitialized=.false.
 
+  ! Per-thread flag recording that this thread has already passed through the initialization critical section (see
+  ! `Chemical_Structure_Initialize`), and so is guaranteed to see the fully-initialized database.
+  logical                                               :: chemicalDatabaseInitializedThread=.false.
+  !$omp threadprivate(chemicalDatabaseInitializedThread)
+
 contains
 
   subroutine Chemical_Structure_Initialize
@@ -104,7 +109,13 @@ contains
     character(len=128       )                            :: name
     type     (varying_string)                           :: fileName
 
-    ! Check if the chemical database is initialized.
+    ! Check if the chemical database is initialized. See the "Once-Only Initialization Under OpenMP" section of the developer
+    ! guide for the rationale behind this pattern. Note that the test of "chemicalDatabaseInitialized" *must* be made while
+    ! holding the lock: previously it was made only outside of any critical section, so two threads could both find the
+    ! database uninitialized and both proceed to initialize it, the second then aborting when it attempted to allocate the
+    ! already-allocated "chemicals" array.
+    if (chemicalDatabaseInitializedThread) return
+    !$omp critical (chemicalDatabaseInitialize)
     if (.not.chemicalDatabaseInitialized) then
        fileName=char(inputPath(pathTypeDataStatic))//'abundances/Chemical_Database.cml'
        !$omp critical (FoX_DOM_Access)
@@ -170,6 +181,9 @@ contains
        ! Flag that the database is now initialized.
        chemicalDatabaseInitialized=.true.
     end if
+    !$omp end critical (chemicalDatabaseInitialize)
+    ! This thread has now synchronized with the initialization, so need never take the lock again.
+    chemicalDatabaseInitializedThread=.true.
     return
   end subroutine Chemical_Structure_Initialize
 

--- a/source/objects/chemical_structure.F90
+++ b/source/objects/chemical_structure.F90
@@ -75,16 +75,16 @@ module Chemical_Structures
   end type chemicalStructure
 
   ! Atoms (we include an electron here for convenience).
-  type(atomicStructure),   parameter                 :: atoms(2)=[                                                             &
-       &                                                          atomicStructure("electron","e",electronMass/atomicMassUnit), &
-       &                                                          atomicStructure("hydrogen","H",atomicMassHydrogen         )  &
-       &                                                         ]
+  type   (atomicStructure  ),   parameter               :: atoms(2)=[                                                             &
+       &                                                             atomicStructure("electron","e",electronMass/atomicMassUnit), &
+       &                                                             atomicStructure("hydrogen","H",atomicMassHydrogen         )  &
+       &                                                            ]
 
   ! Chemicals.
   type   (chemicalStructure), allocatable, dimension(:) :: chemicals
 
   ! Flag indicating if the database has been initialized.
-  logical                                               :: chemicalDatabaseInitialized=.false.
+  logical                                               :: chemicalDatabaseInitialized      =.false.
 
   ! Per-thread flag recording that this thread has already passed through the initialization critical section (see
   ! `Chemical_Structure_Initialize`), and so is guaranteed to see the fully-initialized database.


### PR DESCRIPTION
## Motivation

`Atomic_Data_Initialize` is called from every public entry point of the `Atomic_Data` module, several of which are reached for every element for every derivative evaluation during ODE evolution. It guarded its initialization check with a named critical section — a *global* lock — so the lock was acquired on every call even though the data are loaded exactly once. With large numbers of OpenMP threads (~300) the resulting contention is severe.

Investigating that turned up several related defects, which are separated into their own commits below.

## Changes

### `fix: avoid lock contention in once-only OpenMP initializers`

Guards the fast path with a `threadprivate` flag recording that the calling thread has already passed through the critical section. Ordering is supplied by the flush implied on exit from that section, so a thread which has left it is guaranteed to see the fully-initialized data and need never enter it again. **Each thread now acquires the lock exactly once for the lifetime of the run.**

Note that the *naive* form of this double-checked lock — simply testing the shared flag before taking the lock — would be a data race under the OpenMP memory model: an unsynchronized read of the flag establishes no happens-before relationship with the initializing thread's writes. An alternative using `!$omp atomic read seq_cst` is also correct but pays a full memory fence on every call, so the `threadprivate` form is preferred on hot paths.

The same pattern is applied to the 22 reaction initializers in the hydrogen chemical network, which are on the same hot path and which published their chemical indices through an unsynchronized read of a shared flag.

`Chemical_Structure_Initialize` tested its flag only *outside* any critical section with no re-test inside, so two threads could both find the database uninitialized and both initialize it — the second aborting when it attempted to allocate the already-allocated `chemicals` array. It now uses the same pattern.

Documented in a new "Once-Only Initialization Under OpenMP" section of the developer guide.

### `fix: test for all species in hydrogen network reaction rates`

**This is the only commit that changes behaviour.**

Five reactions looked up `electronChemicalIndex` but omitted it from the `reactionActive` test while still using it to subscript the chemical abundances arrays. `Chemicals_Index` returns `-1` when a species is not tracked, and neither `abundance` nor `abundanceSet` bounds checks, so a run which activated one of these reactions without tracking `Electron` would **read and write out of bounds** rather than fail cleanly.

Reachable by configuration: tracking `AtomicHydrogen AtomicHydrogenCation MolecularHydrogen` without `Electron` is sufficient to activate `hydrogenNetworkRateH2_Electron_to_2H_Electron`. No parameter file in the test suite omits `Electron`, so the defect was latent.

All five carried a stale "both species were found" comment, indicating they were copied from a two-species reaction.

### `docs: correct copy-paste errors in hydrogen network reactions`

Three subroutines shared one critical-section name, having been copied from the subroutine it belongs to. Each has its own initialization flag so this was not a correctness problem, but it serialized three unrelated initializations against one another. Also corrects four docstrings which described an entirely different reaction.

### `docs: correct rate units and normalize critical section names`

Thirteen docstrings gave their units as `c` rather than `cm`. Seven photo-reaction initializers omitted the `_Init` suffix used by the other fifteen; all twenty-two now follow the convention and all remain unique.

## Verification

- Full build (`make Galacticus.exe`) completes with **zero errors**; the linked executable runs.
- All modified files, including the `chemical/reaction_rates` submodule, compile at `-O3 -Wall`.
- A programmatic audit comparing each reaction's `reactionActive` test against the species it actually uses reports **0 gaps across 22 reactions** after the fix.
- The critical-section enumerator confirms every hydrogen critical name is unique.
- The two reactions using `(... > 0 .or. self%fast)` were checked individually and are sound — the anion subscript is guarded by `if (.not.self%fast)`.

## Note for reviewers

Adding and renaming critical sections shifts IDs in `openMPCriticalSections.xml`, so the next build after merging will re-preprocess broadly rather than incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)