### PR TITLE
fix(starFormation): floor disk gas mass to avoid a Blitz2006 overflow FPE

### DIFF
--- a/source/star_formation/rate_surface_density/disks/Blitz2006.F90
+++ b/source/star_formation/rate_surface_density/disks/Blitz2006.F90
@@ -24,7 +24,24 @@
   use :: Kind_Numbers       , only : kind_int8
   use :: Root_Finder        , only : rootFinder
   use :: Math_Exponentiation, only : fastExponentiator
-  
+
+  ! Floor on the disk gas mass, below which the disk is treated as gas-free.
+  !
+  ! The stellar pressure-boost coefficient scales as factorBoostStellarCoefficient proportional to
+  ! 1/massGas, and is subsequently raised to the fourth power when locating the molecular/atomic
+  ! transition radius. A vanishingly small but strictly positive gas mass therefore drives the
+  ! coefficient (or its fourth power) past HUGE(0.0d0), raising an overflow floating point exception.
+  ! Writing the finite remainder of the coefficient as C = σ_gas*2*π*R²*√(M_star/[2*π²*G*
+  ! h_star*R³]) (C <~ 1e10 for any physical disk), the coefficient itself overflows for
+  ! massGas <~ C/HUGE ~ 1e-298, and its fourth power for the far less extreme
+  ! massGas <~ C/HUGE**(1/4) ~ 1e-68. A gas mass of ~1e-30 Msun is numerical residue rather than gas -
+  ! its star formation rate is already zero - so flooring here removes the exception with tens of orders
+  ! of margin above the binding (fourth-power) bound while remaining ~30 orders below any physical disk
+  ! gas mass. Note: this floor must be applied identically in blitz2006ComputeFactors, blitz2006Rate,
+  ! and blitz2006Intervals, since the coefficients are only *set* (in computeFactors) under
+  ! massGas > massGasFloor and must only be *used* (in Rate/Intervals) under the complementary condition.
+  double precision, parameter :: massGasFloor=1.0d-30
+
   !![
   <starFormationRateSurfaceDensityDisks name="starFormationRateSurfaceDensityDisksBlitz2006" docformat="rst">
    <description>
@@ -369,8 +386,8 @@ contains
     if (node%uniqueID() /= self%lastUniqueID) call self%calculationReset(node,node%uniqueID())
     ! Compute factors.
     call self%computeFactors(node)
-    ! Return zero rate for non-positive radius or mass.
-    if (self%massGas <= 0.0d0 .or. self%massStellar < 0.0d0 .or. self%radiusDisk <= 0.0d0) then
+    ! Return zero rate for non-positive radius or negligible mass.
+    if (self%massGas <= massGasFloor .or. self%massStellar < 0.0d0 .or. self%radiusDisk <= 0.0d0) then
        blitz2006Rate=0.0d0
        return
     end if
@@ -446,7 +463,7 @@ contains
        ! Get the disk properties.
        disk         => node%disk   ()
        self%massGas =  disk%massGas()
-       if (self%massGas > 0.0d0) then
+       if (self%massGas > massGasFloor) then
           self%massStellar=disk%massStellar()
           self%radiusDisk =disk%radius     ()
           ! Find the hydrogen fraction in the disk gas of the fuel supply.
@@ -565,8 +582,8 @@ contains
        self%radiusCritical=-huge(0.0d0)
        ! Compute factors.
        call self%computeFactors(node)
-       ! Set zero intervals for non-positive radius or mass.
-       if (self%massGas <= 0.0d0 .or. self%massStellar < 0.0d0 .or. self%radiusDisk <= 0.0d0) then
+       ! Set zero intervals for non-positive radius or negligible mass.
+       if (self%massGas <= massGasFloor .or. self%massStellar < 0.0d0 .or. self%radiusDisk <= 0.0d0) then
           allocate(blitz2006Intervals(2,0))
           self%radiusCritical=-huge(0.0d0)          
        else


### PR DESCRIPTION
## Summary

Fixes a latent floating-point overflow in the `blitz2006` star formation rate surface density calculation, triggered when a disk's gas mass becomes vanishingly small but still strictly positive.

## The bug

The stellar pressure-boost coefficient is

```
factorBoostStellarCoefficient ∝ 1 / massGas
```

and is subsequently raised to the **fourth power** when locating the molecular/atomic transition radius. A residual gas mass left by the ODE integrator — observed as small as `~2e-301 M☉` — therefore drives the coefficient (or its fourth power) past `HUGE(0.0d0)`, raising a **trapped overflow exception** (the build runs with `-ffpe-trap=...,overflow`).

Worked example from a node that actually tripped it:

| quantity | value |
|---|---|
| `radiusDisk`  | `3.9e-4` (fine) |
| `massStellar` | `1.5e7` (fine) |
| `massGas`     | `1.99e-301` ← pathological |

`/massGas = ×5.0e300`, giving `factorBoostStellarCoefficient ≈ 2.6e308 > 1.8e308` → overflow, right at the boundary. Note the companion `pressureRatioCoefficient` carries `massGas**2` in its *numerator*, so it underflows harmlessly to `0`; only the coefficient that is *linear in `1/massGas`* diverges.

## Why it looked intermittent

The overflow only fires when a node's gas mass lands in the narrow window near the boundary, so whether any given run hits it is decided by last-ULP rounding. It surfaced on CI in the `adaptiveSFHLengths` regression under the CI toolchain (`-O3 -ffinite-math-only`, static libm) but was not reproducible on other toolchains. It is **pre-existing on `master`** and independent of any other in-flight change — an unrelated ULP-level change elsewhere was merely enough to nudge one node across the boundary.

## The fix

Treat a disk with negligible gas (`< massGasFloor = 1e-30 M☉`) as gas-free, routing it through the **existing no-gas branch**, which yields the physically correct **zero** star formation rate — a disk with `1e-301 M☉` of gas forms no stars.

The floor is applied identically at all three sites:

- `blitz2006ComputeFactors` — the coefficient-*setting* guard (`massGas > massGasFloor`)
- `blitz2006Rate` — use-site early-out (`massGas <= massGasFloor`)
- `blitz2006Intervals` — use-site early-out (`massGas <= massGasFloor`)

These must move in lockstep: the coefficients are only *set* under `massGas > massGasFloor` and must only be *used* under the complementary condition, or an uninitialized-coefficient path reopens.

### Why `1e-30`

The binding constraint is the downstream fourth power, which overflows only for `massGas ≲ 1e-68` even for a generously large disk. `1e-30 M☉` sits tens of orders of magnitude above that bound and ~30 orders below any physical disk gas mass (`≫ 1 M☉`), so it removes the exception with enormous margin while diverting only numerically-dead nodes whose SF rate was already ~0.

## Validation

- The previously-overflowing model (adaptiveSFHLengths, CI toolchain, in a `buildenv:latest` container) now runs to completion.
- Results away from the overflow are expected to be unchanged — the floor only affects sub-`1e-30 M☉` disks, whose SF rate was already zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)