### PR TITLE
docs(powerSpectra): correct the smoothed power spectrum integral

### DIFF
--- a/source/structure_formation/power_spectrum/variance/window_function/ETHOS/extended.F90
+++ b/source/structure_formation/power_spectrum/variance/window_function/ETHOS/extended.F90
@@ -43,7 +43,7 @@
 
    .. math::
 
-      \tilde{P}(k) = \int_0^\infty \frac{1}{\sqrt{2 \pi} \sigma} \exp\left[-\frac{1}{2} \left(\frac{\log k - \log k^\prime}{\sigma}\right)^2\right] P(k^\prime) \mathrm{d}k^\prime,
+      \tilde{P}(k) = \int_{-\infty}^\infty \frac{1}{\sqrt{2 \pi} \sigma} \exp\left[-\frac{1}{2} \left(\frac{\log k - \log k^\prime}{\sigma}\right)^2\right] P(k^\prime) \mathrm{d} \log k^\prime,
 
    with the :math:`\log k` terms using natural logarithms, and :math:`\sigma=` ``[powerSpectrumSmoothingWidth]``.
    </description>
@@ -272,7 +272,7 @@ contains
   
   double precision function ETHOSExtendedPowerSpectrumSlopeSmoothed(self,wavenumber,time) result(slope)
     !!{RST
-    Compute the logarithmic derivate of the power spectrum after smoothing.
+    Compute the logarithmic derivative of the power spectrum after smoothing.
     !!}
     use :: Numerical_Ranges     , only : Make_Range, rangeTypeLinear
     use :: Numerical_Integration, only : integrator


### PR DESCRIPTION
## Summary
- The description of the log-normal smoothing kernel gave the integration limits as 0 to ∞ over dk′, but the kernel is expressed in log-wavenumber, so the integral runs from -∞ to ∞ over d log k′. Also fix a typo in a function description.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Docs / tooling
- [ ] Other:

## How to test
- Check that the reaedthedocs build succeeds.

## Checklist
- [ ] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'
