### PR TITLE
fix(ci): exclude unsigned Cloudy build helper from the MacOS tool archives

### DIFF
--- a/.github/actions/verifySignedMacOS/action.yml
+++ b/.github/actions/verifySignedMacOS/action.yml
@@ -1,0 +1,64 @@
+name: Verify code signing of a MacOS archive
+
+description: >
+  Check that every Mach-O binary packaged into an archive destined for Apple notarization carries a
+  valid Developer ID signature with the hardened runtime enabled. Apple rejects the entire archive if
+  even one binary is unsigned, so catching this at packaging time avoids a rejection that only becomes
+  visible hours later when the notarization poll runs.
+
+inputs:
+  archive:
+    description: 'Name of the archive to verify'
+    required: true
+  working_directory:
+    description: 'Directory containing the archive; the archive entries are resolved relative to it'
+    required: true
+  macos_certificate:
+    description: 'Base-64 encoded signing certificate; if empty, verification is skipped'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Verify code signing
+      shell: bash
+      env:
+        ARCHIVE: ${{ inputs.archive }}
+        WORKING_DIRECTORY: ${{ inputs.working_directory }}
+        MACOS_CERTIFICATE: ${{ inputs.macos_certificate }}
+      run: |
+        # Code-signing is skipped when the certificate is unavailable (e.g. a Dependabot or fork pull
+        # request), so skip verification too rather than failing on unsigned binaries we never signed.
+        if [ -z "${MACOS_CERTIFICATE}" ]; then
+          echo "macOS signing certificate is unavailable -- skipping code-signing verification."
+          exit 0
+        fi
+        cd "${WORKING_DIRECTORY}"
+        # List the archive entries (dropping directories) and identify which of them are Mach-O binaries.
+        # The entries are resolved against the files on disk from which the archive was just built, which
+        # avoids unpacking an archive that can be over a gigabyte in size. A tab is used as the separator
+        # in the `file` output since a colon (the default) also appears in the descriptions it emits.
+        unzip -Z1 "${ARCHIVE}" | grep -v '/$' > entriesToVerify.txt
+        file -F $'\t' -f entriesToVerify.txt | awk -F $'\t' '$2 ~ /Mach-O/ {print $1}' > binariesToVerify.txt
+        status=0
+        while IFS= read -r binary; do
+          if ! codesign --verify --strict "${binary}" > /dev/null 2>&1; then
+            echo "::error::${ARCHIVE} contains a binary which is not validly code-signed: ${binary}"
+            status=1
+            continue
+          fi
+          signature=$(codesign --display --verbose=2 "${binary}" 2>&1)
+          # An ad-hoc signature (which the linker applies to arm64 binaries by default) passes
+          # `codesign --verify`, so require a Developer ID authority explicitly.
+          if ! echo "${signature}" | grep -q -E '^Authority=Developer ID Application'; then
+            echo "::error::${ARCHIVE} contains a binary not signed with a Developer ID certificate: ${binary}"
+            status=1
+          fi
+          if ! echo "${signature}" | grep -q -E '^CodeDirectory .*flags=.*runtime'; then
+            echo "::error::${ARCHIVE} contains a binary without the hardened runtime enabled: ${binary}"
+            status=1
+          fi
+        done < binariesToVerify.txt
+        echo "Verified $(wc -l < binariesToVerify.txt) Mach-O binaries in ${ARCHIVE}."
+        rm -f entriesToVerify.txt binariesToVerify.txt
+        exit $status

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -596,22 +596,47 @@ jobs:
         run: |
           # Package the zip with the signed executables
           cd $GALACTICUS_DATA_PATH
-          zip -r toolsMacOS.zip \
-            dynamic/CAMB-${cambVersion}/fortran/camb \
-            dynamic/axionCAMB-${axioncambVersion}/camb \
-            dynamic/class_public-${classVersion}/class \
-            dynamic/RecFast/recfast.exe \
-            dynamic/RecFast/currentVersion \
-            dynamic/c${cloudyVersion}/source/cloudy.exe \
-            dynamic/c${cloudyVersion}/data \
-            dynamic/fsps-${fspsVersion}/src/autosps.exe \
-            dynamic/fsps-${fspsVersion}/dust \
-            dynamic/fsps-${fspsVersion}/data \
-            dynamic/fsps-${fspsVersion}/nebular \
-            dynamic/fsps-${fspsVersion}/SPECTRA \
-            dynamic/fsps-${fspsVersion}/OUTPUTS \
-            dynamic/fsps-${fspsVersion}/ISOCHRONES \
+          # `convert_calpgm` is a helper that Cloudy compiles inside its own data directory to convert the
+          # CDMS/JPL catalogs at data-build time. It is never run by Galacticus, and it is not code-signed
+          # above, so leaving it in the archive causes notarization to reject the whole archive ("the binary
+          # is not signed", "no secure timestamp", "no hardened runtime"). Exclude it and its debug symbols.
+          toolProducts=(
+            dynamic/CAMB-${cambVersion}/fortran/camb
+            dynamic/axionCAMB-${axioncambVersion}/camb
+            dynamic/class_public-${classVersion}/class
+            dynamic/RecFast/recfast.exe
+            dynamic/RecFast/currentVersion
+            dynamic/c${cloudyVersion}/source/cloudy.exe
+            dynamic/c${cloudyVersion}/data
+            dynamic/fsps-${fspsVersion}/src/autosps.exe
+            dynamic/fsps-${fspsVersion}/dust
+            dynamic/fsps-${fspsVersion}/data
+            dynamic/fsps-${fspsVersion}/nebular
+            dynamic/fsps-${fspsVersion}/SPECTRA
+            dynamic/fsps-${fspsVersion}/OUTPUTS
+            dynamic/fsps-${fspsVersion}/ISOCHRONES
             dynamic/mangle-${mangleVersion}/bin/harmonize
+          )
+          # `zip` only warns (and still exits successfully) when a named path does not exist, so any error in
+          # the paths above -- for example an unset version variable -- would silently produce an archive
+          # missing most of the tools. Require every path to be present before packaging.
+          missingProducts=0
+          for toolProduct in "${toolProducts[@]}"; do
+            if [ ! -e "${toolProduct}" ]; then
+              echo "::error::tool product to be packaged does not exist: ${toolProduct}"
+              missingProducts=1
+            fi
+          done
+          [ ${missingProducts} -eq 0 ] || exit 1
+          zip -r toolsMacOS.zip "${toolProducts[@]}" \
+            -x "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm" \
+               "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm.dSYM/*"
+      - name: Verify all packaged binaries are code-signed
+        uses: ./.github/actions/verifySignedMacOS
+        with:
+          archive: toolsMacOS.zip
+          working_directory: ${{ env.GALACTICUS_DATA_PATH }}
+          macos_certificate: ${{ secrets.MACOS_CERTIFICATE }}
       - name: Upload tool executables
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -729,22 +754,47 @@ jobs:
         run: |
           # Package the zip with the signed executables
           cd $GALACTICUS_DATA_PATH
-          zip -r toolsMacOSM1.zip \
-            dynamic/CAMB-${cambVersion}/fortran/camb \
-            dynamic/axionCAMB-${axioncambVersion}/camb \
-            dynamic/class_public-${classVersion}/class \
-            dynamic/RecFast/recfast.exe \
-            dynamic/RecFast/currentVersion \
-            dynamic/c${cloudyVersion}/source/cloudy.exe \
-            dynamic/c${cloudyVersion}/data \
-            dynamic/fsps-${fspsVersion}/src/autosps.exe \
-            dynamic/fsps-${fspsVersion}/dust \
-            dynamic/fsps-${fspsVersion}/data \
-            dynamic/fsps-${fspsVersion}/nebular \
-            dynamic/fsps-${fspsVersion}/SPECTRA \
-            dynamic/fsps-${fspsVersion}/OUTPUTS \
-            dynamic/fsps-${fspsVersion}/ISOCHRONES \
+          # `convert_calpgm` is a helper that Cloudy compiles inside its own data directory to convert the
+          # CDMS/JPL catalogs at data-build time. It is never run by Galacticus, and it is not code-signed
+          # above, so leaving it in the archive causes notarization to reject the whole archive ("the binary
+          # is not signed", "no secure timestamp", "no hardened runtime"). Exclude it and its debug symbols.
+          toolProducts=(
+            dynamic/CAMB-${cambVersion}/fortran/camb
+            dynamic/axionCAMB-${axioncambVersion}/camb
+            dynamic/class_public-${classVersion}/class
+            dynamic/RecFast/recfast.exe
+            dynamic/RecFast/currentVersion
+            dynamic/c${cloudyVersion}/source/cloudy.exe
+            dynamic/c${cloudyVersion}/data
+            dynamic/fsps-${fspsVersion}/src/autosps.exe
+            dynamic/fsps-${fspsVersion}/dust
+            dynamic/fsps-${fspsVersion}/data
+            dynamic/fsps-${fspsVersion}/nebular
+            dynamic/fsps-${fspsVersion}/SPECTRA
+            dynamic/fsps-${fspsVersion}/OUTPUTS
+            dynamic/fsps-${fspsVersion}/ISOCHRONES
             dynamic/mangle-${mangleVersion}/bin/harmonize
+          )
+          # `zip` only warns (and still exits successfully) when a named path does not exist, so any error in
+          # the paths above -- for example an unset version variable -- would silently produce an archive
+          # missing most of the tools. Require every path to be present before packaging.
+          missingProducts=0
+          for toolProduct in "${toolProducts[@]}"; do
+            if [ ! -e "${toolProduct}" ]; then
+              echo "::error::tool product to be packaged does not exist: ${toolProduct}"
+              missingProducts=1
+            fi
+          done
+          [ ${missingProducts} -eq 0 ] || exit 1
+          zip -r toolsMacOSM1.zip "${toolProducts[@]}" \
+            -x "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm" \
+               "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm.dSYM/*"
+      - name: Verify all packaged binaries are code-signed
+        uses: ./.github/actions/verifySignedMacOS
+        with:
+          archive: toolsMacOSM1.zip
+          working_directory: ${{ env.GALACTICUS_DATA_PATH }}
+          macos_certificate: ${{ secrets.MACOS_CERTIFICATE }}
       - name: Upload tool executables
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/scripts/aux/notarizationRetrieve.py
+++ b/scripts/aux/notarizationRetrieve.py
@@ -72,10 +72,15 @@ for request in requests:
         )
         if log_result.returncode == 0:
             log_data = json.loads(log_result.stdout)
-            issues = log_data.get("issues", [])
-            issue_messages = [issue.get("message") for issue in issues if issue.get("message")]
-            for message in issue_messages:
-                failure_details.append(f"{asset}: {message}")
+            issues = log_data.get("issues", []) or []
+            for issue in issues:
+                message = issue.get("message")
+                if not message:
+                    continue
+                # Include the path reported by Apple -- without it the message (e.g. "The binary is not
+                # signed.") does not identify which of the many binaries in the archive was rejected.
+                path = issue.get("path")
+                failure_details.append(f"{asset}: {message}" + (f" [{path}]" if path else ""))
 
 if "failure" in statuses:
     overall = "failure"


### PR DESCRIPTION
## Problem

The `Notarize-MacOS` job failed on [run 30501360131](https://github.com/galacticusorg/galacticus/actions/runs/30501360131):

```
toolsMacOS.zip: Invalid; toolsMacOS.zip: The binary is not signed.;
toolsMacOS.zip: The signature does not include a secure timestamp.;
toolsMacOS.zip: The executable does not have the hardened runtime enabled.;
toolsMacOSM1.zip: Invalid; toolsMacOSM1.zip: The binary is not signed with a valid Developer ID certificate.; ...
```

Code-signing itself is **not** broken. All seven tool executables are signed with a Developer ID certificate and the hardened runtime; `codesign --verify` confirms each one in the build log. Scanning the two published artifacts shows the rejected binaries are:

- `dynamic/c25.00/data/cdms+jpl/convert_calpgm`
- `dynamic/c25.00/data/cdms+jpl/convert_calpgm.dSYM/Contents/Resources/DWARF/convert_calpgm`

`convert_calpgm` is a helper Cloudy compiles inside its own data directory to convert the CDMS/JPL catalogs at data-build time. Galacticus never invokes it and it is not in the signing list, but `zip -r ... dynamic/c${cloudyVersion}/data` sweeps it in. On arm64 the linker gives it an ad-hoc signature, which is why Apple's message differs between the two archives.

## Why it surfaced now

This was latent, not new. Before #1282 merged the tool builds into the executable build jobs, the dependency version variables were shell locals in the "Build tools" step and empty in the separate "Package" step, so `zip` reported:

```
zip warning: name not matched: dynamic/c/data
zip warning: name not matched: dynamic/fsps-/SPECTRA
... (12 of 15 paths)
  adding: dynamic/AxionCAMB/camb
  adding: dynamic/RecFast/recfast.exe
  adding: dynamic/RecFast/currentVersion
```

`zip` exits successfully on unmatched names, so the step passed and the truncated archive notarized cleanly — it held no unsigned binaries because it held almost nothing. Fixing the variable scoping made the archive complete and exposed the helper.

> [!NOTE]
> A consequence worth flagging separately: the macOS tool archives published to the `bleeding-edge` release have been near-empty (RecFast and AxionCAMB only) since at least April 2026.

## Changes

1. **`cicd.yml`** — exclude `convert_calpgm` and its `.dSYM` from both archives.
2. **`cicd.yml`** — move the path list into a `toolProducts` array and require every path to exist before packaging, so a silent truncation cannot recur. The Linux job needs no equivalent: it uses `tar`, which already fails on a missing path.
3. **`.github/actions/verifySignedMacOS`** (new) — after packaging, check that every Mach-O binary in the archive has a Developer ID signature *and* the hardened runtime, failing the build instead of surfacing hours later as a notarization rejection. An ad-hoc signature passes `codesign --verify`, so the signing authority is checked explicitly. Entries are resolved against the on-disk files rather than unpacking the >1 GB archive, and verification is skipped when the certificate is unavailable (fork/Dependabot PRs), matching `codeSignMacOS`.
4. **`notarizationRetrieve.py`** — include the path Apple reports with each issue. Its absence is what made this need artifact archaeology.

## Testing

Both `Package` scripts were extracted from the workflow and run locally against a mock tool tree:

| Scenario | Result |
|---|---|
| All paths present | exits 0, 24 entries, helper + `.dSYM` excluded, `.cpp` and other Cloudy data retained |
| Version variables unset (the original bug) | exits 1, all 13 broken paths reported, no archive produced |
| Single tool missing (`harmonize`) | exits 1, names that path, no archive |
| M1 variant | identical |

The `unzip -Z1 | file -F | awk` pipeline in the new action was checked against a real Mach-O binary taken from the published artifact.

Not verifiable off-runner: the `codesign --display` grep patterns (`^Authority=Developer ID Application`, `^CodeDirectory .*flags=.*runtime`). These come from the documented output format rather than observed output — worth confirming the `Build-Executable-MacOS{,-M1}` jobs pass here before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)