### PR TITLE
fix(darkMatterProfiles): only report Johnson2021 energy model stats when used

### DIFF
--- a/source/dark_matter_profiles/structure/scale/Johnson2021.F90
+++ b/source/dark_matter_profiles/structure/scale/Johnson2021.F90
@@ -369,6 +369,7 @@ contains
     !!{RST
     Internal constructor for the :galacticus-class:`darkMatterProfileScaleRadiusJohnson2021` dark matter halo profile scale radius class.
     !!}
+    use :: Johnson2021_Statistics, only : johnson2021EnergyModelInitialized
     implicit none
     type            (darkMatterProfileScaleRadiusJohnson2021)                        :: self
     class           (cosmologyFunctionsClass                ), intent(in   ), target :: cosmologyFunctions_
@@ -391,6 +392,7 @@ contains
     <constructorAssign variables="massExponent, peakHeightExponent, energyBoost, unresolvedEnergy, factorMassResolution, scatter, scatterExcess, correlationRateDecay, correlationExponent, massFunctionSlopeLogarithmic, countSampleEnergyUnresolved, mainBranchOnly, applySubsamplingWeights, acceptUnboundOrbits, includeUnresolvedVariance, *cosmologyFunctions_, *darkMatterProfileScaleRadius_, *darkMatterHaloScale_, *darkMatterProfileDMO_, *virialOrbit_, *mergerTreeMassResolution_, *criticalOverdensity_, *cosmologicalMassVariance_"/>
     !!]
 
+    johnson2021EnergyModelInitialized=.true.
     return
   end function darkMatterProfileScaleJohnson2021ConstructorInternal
 

--- a/source/dark_matter_profiles/structure/scale/Johnson2021_statistics.F90
+++ b/source/dark_matter_profiles/structure/scale/Johnson2021_statistics.F90
@@ -45,11 +45,12 @@ module Johnson2021_Statistics
   use, intrinsic :: ISO_C_Binding, only : c_size_t
   implicit none
   private
-  public :: johnson2021EnergyModelApplied, johnson2021EnergyModelFailed
+  public :: johnson2021EnergyModelApplied, johnson2021EnergyModelFailed, johnson2021EnergyModelInitialized
 
   ! Counts of the nodes to which the energy model was applied, and of those for which it failed. Deliberately not
   ! threadprivate: they accumulate across all threads, and are updated atomically by the caller.
-  integer(c_size_t) :: johnson2021EnergyModelApplied=0_c_size_t, johnson2021EnergyModelFailed=0_c_size_t
+  logical           :: johnson2021EnergyModelInitialized=.false.
+  integer(c_size_t) :: johnson2021EnergyModelApplied    =0_c_size_t, johnson2021EnergyModelFailed=0_c_size_t
 
 contains
 
@@ -67,6 +68,8 @@ contains
     implicit none
     type(varying_string) :: message
 
+    ! The energy model was never initialized - no need to report anything.
+    if (.not.johnson2021EnergyModelInitialized) return
     ! The energy model was never applied to any node. Report this rather than passing over it in silence: "applied but never
     ! failed" must not look identical to "never applied at all". Note that no rate can be formed here - computing one would
     ! divide by zero, which this build traps.


### PR DESCRIPTION
## Summary
- The "energy model never applied" warning was emitted even in runs that never construct the `Johnson2021` scale radius class, since the counters live in a module that is always linked. Track whether the class was actually instantiated and stay silent otherwise.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- Run a model that does not use the `Johnson2021` scale radius class - verify that it does not report "energy model never applied" at the end of the run.

## Checklist
- [x] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'
