### PR TITLE
Report zero-valued radius specifiers as an error rather than trapping

### DIFF
--- a/docs/manuals/physics/definitions.rst
+++ b/docs/manuals/physics/definitions.rst
@@ -104,6 +104,19 @@ The elements of this colon-separated specifier determine the radius at which a p
 ``massType``
    specifies which types of mass should be counted---allowed values are ``all``, ``dark``, ``baryonic``, ``galactic``, ``gaseous``, ``stellar``, and ``blackHole``.
 
+Zero radii
+^^^^^^^^^^
+
+A radius specifier can evaluate to zero---for example ``diskRadius:all:all:1.0`` in a node whose disk has zero radius. This is common: it happens whenever the component on which the radius is based is absent or empty in the node in question, and is quite distinct from an *undefined* radius (see ``solitonRadiusCore`` above), which is reported with a sentinel value instead.
+
+Such a radius is perfectly well defined, but not every property can be evaluated there:
+
+* enclosed masses (:galacticus-class:`nodePropertyExtractorMassProfile`), projected masses (:galacticus-class:`nodePropertyExtractorProjectedMass`), rotation curves, and velocity dispersions all exist at zero radius, and are reported there---note that the enclosed and projected masses are the mass of any central point mass, such as a black hole, and not necessarily zero;
+* densities (:galacticus-class:`nodePropertyExtractorDensityProfile`, :galacticus-class:`nodePropertyExtractorDensityDMOProfile`) exist only if the mass distribution being evaluated has a finite central density---which is true of a disk, but not of an :term:`NFW` halo;
+* projected densities (:galacticus-class:`nodePropertyExtractorProjectedDensity`) are never evaluated at zero radius, as the line of sight integral is performed in the logarithm of radius.
+
+Where the property does not exist, the model stops with an error naming the offending specifier and the node in which it was evaluated. To carry on regardless, set ``zeroRadiusIsFatal`` to ``false`` in the property extractor concerned: the undefined-value sentinel is then written in place of the property, and should be filtered out before analysis. The radius itself is still reported (as zero), since---unlike an undefined radius---it is perfectly well defined.
+
 Half-mode and quarter-mode masses
 ---------------------------------
 

--- a/source/galactic_structure/radius_definition.F90
+++ b/source/galactic_structure/radius_definition.F90
@@ -43,6 +43,11 @@ module Galactic_Structure_Radii_Definitions
   !!}
   double precision, parameter, public :: radiusUndefined=-huge(0.0d0)
 
+  !!{RST
+  Location of the documentation of radius specifier syntax, to which error messages refer the user.
+  !!}
+  character(len=*), parameter :: urlRadiusSpecifiers='https://galacticus.readthedocs.io/en/latest/manuals/physics/definitions.html#manual-sec-radiusspecifiers'
+
   !![
   <enumeration docformat="rst">
    <name>radiusType</name>
@@ -143,10 +148,12 @@ module Galactic_Structure_Radii_Definitions
    contains
      !![
      <methods docformat="rst">
-       <method method="evaluate" description="Evaluate the radius corresponding to a given radius definition in the node to which this resolver is attached, optionally also returning the scale radius on which that radius is based. Returns ``radiusUndefined`` if the radius is undefined in this node."/>
+       <method method="evaluate"         description="Evaluate the radius corresponding to a given radius definition in the node to which this resolver is attached, optionally also returning the scale radius on which that radius is based. Returns ``radiusUndefined`` if the radius is undefined in this node."/>
+       <method method="reportZeroRadius" description="Report a fatal error for a radius definition which evaluates to zero in a node in which the consumer is unable to evaluate its property at zero radius."                                                                                                      />
      </methods>
      !!]
-     procedure :: evaluate => radiusResolverEvaluate
+     procedure :: evaluate         => radiusResolverEvaluate
+     procedure :: reportZeroRadius => radiusResolverReportZeroRadius
   end type radiusResolver
 
   interface radiusResolver
@@ -623,6 +630,46 @@ contains
     return
   end subroutine radiusResolverEvaluate
 
+  subroutine radiusResolverReportZeroRadius(self,indexRadius,consumer,reason)
+    !!{RST
+    Report a fatal error for the ``indexRadius``\ :sup:`th` radius definition, which has evaluated to zero in a node in which
+    the calling ``consumer`` is unable to evaluate its property at zero radius---because the density of the mass distribution
+    being evaluated diverges at the center, for example, as explained by ``reason``. The error names the offending specifier,
+    highlighting the element which gives the radius its scale, along with the node and tree in which it was evaluated.
+
+    A radius of zero is perfectly well defined---it is not reported as ``radiusUndefined``---but a consumer which traps on it
+    would otherwise raise an uninformative floating point exception deep inside the mass distribution.
+    !!}
+    use :: Display           , only : displayGreen, displayReset
+    use :: Error             , only : Error_Report
+    use :: ISO_Varying_String, only : operator(//), var_str     , assignment(=)
+    use :: String_Handling   , only : operator(//)
+    implicit none
+    class    (radiusResolver ), intent(inout) :: self
+    integer                   , intent(in   ) :: indexRadius
+    character(len=*          ), intent(in   ) :: consumer   , reason
+    type     (radiusSpecifier), pointer       :: specifier_
+    type     (varying_string )                :: message    , cause
+
+    specifier_ => self%definitions_%specifiers(indexRadius)
+    if (specifier_%value <= 0.0d0) then
+       cause=var_str('The multiplier in this specifier is itself zero.')
+    else
+       cause=var_str('The quantity on which this radius is based is zero in this node, which usually means that the corresponding component is absent or empty there.')
+    end if
+    message=var_str('Radius specifier evaluates to a radius of zero:'                                                                                      )//char(10)//char(10)// &
+         &          '   '//specifierHighlighted(specifier_%name,highlight=1)                                                                                //char(10)//char(10)// &
+         &          'The `'//consumer//'` property extractor can not evaluate its property at zero radius here: '//reason//'.'                              //char(10)//char(10)// &
+         &          cause                                                                                                                                   //char(10)//char(10)// &
+         &          'The radius was evaluated in node '//self%node_%index()//' of tree '//self%node_%hostTree%index//'.'                                    //char(10)//char(10)// &
+         &          displayGreen()//'HELP:'//displayReset()//' use a radius which is non-zero in every node---one specified as a fraction of the virial'                        // &
+         &          ' radius, for example---or filter such nodes out of the output. Alternatively, set <zeroRadiusIsFatal value="false"/> in this property'                     // &
+         &          ' extractor to write the undefined-value sentinel in place of the property. See '//urlRadiusSpecifiers//' for an explanation of radius'                     // &
+         &          ' specifier syntax.'
+    call Error_Report(message//{introspection:location})
+    return
+  end subroutine radiusResolverReportZeroRadius
+
   subroutine extractFraction(specifier,radiusDefinition,openAt,fractionDefinition)
     !!{RST
     Parse a fractional radius definition.
@@ -649,22 +696,38 @@ contains
     !!{RST
     Report an error in parsing a radius specifier.
     !!}
-    use :: Display           , only : displayGreen      , displayRed        , displayReset
+    use :: Display           , only : displayGreen, displayReset
     use :: Error             , only : Error_Report
-    use :: ISO_Varying_String, only : operator(//)      , var_str           , char        , extract, &
-         &                            index
+    use :: ISO_Varying_String, only : operator(//), var_str
+    implicit none
+    type   (varying_string), intent(in   )           :: specifier, message
+    integer                , intent(in   ), optional :: highlight
+    logical                , intent(in   ), optional :: bracketed
+
+    call Error_Report(var_str('Failed to parse radius specifier:')//char(10)//char(10)//'   '//specifierHighlighted(specifier,highlight,bracketed)//char(10)//char(10)//message//char(10)//char(10)//displayGreen()//'HELP:'//displayReset()//' See '//urlRadiusSpecifiers//' for an explanation of radius specifier syntax'//{introspection:location})
+    return
+  end subroutine reportSpecifierError
+
+  function specifierHighlighted(specifier,highlight,bracketed) result(specifier_)
+    !!{RST
+    Return a radius specifier with the ``highlight``\ :sup:`th` of its colon-separated elements colorized, for use in error
+    messages which must draw attention to one element of the specifier. If ``highlight`` is not given the specifier is
+    returned unchanged.
+    !!}
+    use :: Display           , only : displayRed        , displayReset
+    use :: ISO_Varying_String, only : operator(//)      , char              , extract    , index
     use :: String_Handling   , only : String_Count_Words, String_Split_Words, String_Join
     implicit none
-    type   (varying_string), intent(in   )               :: specifier       , message
-    integer                , intent(in   ), optional     :: highlight
-    logical                , intent(in   ), optional     ::  bracketed
-    type   (varying_string)               , dimension(5) :: radiusDefinition
     type   (varying_string)                              :: specifier_
+    type   (varying_string), intent(in   )               :: specifier
+    integer                , intent(in   ), optional     :: highlight
+    logical                , intent(in   ), optional     :: bracketed
+    type   (varying_string)               , dimension(5) :: radiusDefinition
     integer                                              :: countComponents , indexBracket
     !![
     <optionalArgument name="bracketed" defaultsTo=".false."/>
     !!]
-    
+
     if (present(highlight)) then
        countComponents=String_Count_Words(char(specifier),':',bracketing="{}")
        call String_Split_Words(radiusDefinition,char(specifier),':',bracketing="{}")
@@ -682,8 +745,7 @@ contains
     else
        specifier_=specifier
     end if
-    call Error_Report(var_str('Failed to parse radius specifier:')//char(10)//char(10)//'   '//specifier_//char(10)//char(10)//message//char(10)//char(10)//displayGreen()//'HELP:'//displayReset()//' See https://galacticus.readthedocs.io/en/latest/manuals/physics/definitions.html#manual-sec-radiusspecifiers for an explanation of radius specifier syntax'//{introspection:location})    
     return
-  end subroutine reportSpecifierError
-  
+  end function specifierHighlighted
+
 end module Galactic_Structure_Radii_Definitions

--- a/source/mass_distributions/Gaussian_ellipsoid.F90
+++ b/source/mass_distributions/Gaussian_ellipsoid.F90
@@ -60,12 +60,13 @@
        <method description="(Re)initialize the structural properties of the Gaussian ellispoid."                    method="initialize"             />
      </methods>
      !!]
-     procedure :: density                 => gaussianEllipsoidDensity
-     procedure :: densityEllipsoidal      => gaussianEllipsoidDensityEllipsoidal
-     procedure :: acceleration            => gaussianEllipsoidAcceleration
-     procedure :: accelerationTabulate    => gaussianEllipsoidAccelerationTabulate
-     procedure :: accelerationInterpolate => gaussianEllipsoidAccelerationInterpolate
-     procedure :: initialize              => gaussianEllipsoidInitialize
+     procedure :: density                        => gaussianEllipsoidDensity
+     procedure :: densitySlopeLogarithmicCentral => gaussianEllipsoidDensitySlopeLogarithmicCentral
+     procedure :: densityEllipsoidal             => gaussianEllipsoidDensityEllipsoidal
+     procedure :: acceleration                   => gaussianEllipsoidAcceleration
+     procedure :: accelerationTabulate           => gaussianEllipsoidAccelerationTabulate
+     procedure :: accelerationInterpolate        => gaussianEllipsoidAccelerationInterpolate
+     procedure :: initialize                     => gaussianEllipsoidInitialize
   end type massDistributionGaussianEllipsoid
 
   interface massDistributionGaussianEllipsoid
@@ -311,6 +312,19 @@ contains
     gaussianEllipsoidDensity=+self%densityEllipsoidal(mSquared)
     return
   end function gaussianEllipsoidDensity
+
+  double precision function gaussianEllipsoidDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a Gaussian ellipsoid mass distribution. The density is
+    finite at the center of the ellipsoid, and so is evaluable there.
+    !!}
+    implicit none
+    class(massDistributionGaussianEllipsoid), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=0.0d0
+    return
+  end function gaussianEllipsoidDensitySlopeLogarithmicCentral
 
   double precision function gaussianEllipsoidDensityEllipsoidal(self,mSquared)
     !!{RST

--- a/source/mass_distributions/_class.F90
+++ b/source/mass_distributions/_class.F90
@@ -212,6 +212,25 @@ module Mass_Distributions
     <argument>class  (coordinate), intent(in   )           :: coordinates</argument>
     <argument>logical            , intent(in   ), optional :: logarithmic</argument>
    </method>
+   <method name="densitySlopeLogarithmicCentral" >
+    <description>
+    Return the logarithmic slope of the density profile, :math:`\mathrm{d}\ln\rho/\mathrm{d}\ln r`, in the limit :math:`r
+    \rightarrow 0`. The sign convention matches that of the ``densityGradientRadial`` method---an :term:`NFW` profile returns
+    :math:`-1`, a profile with a constant density core returns :math:`0`.
+
+    The default implementation returns ``-huge(0.0d0)``, indicating that the central slope is *unknown* for this
+    distribution. Since the slope is used to decide whether a quantity can be evaluated at zero radius---the density is finite
+    there only if the slope is non-negative, and the surface density only if it exceeds :math:`-1`---an unknown slope behaves
+    as an infinitely steep one, and so is rejected by any such test. Consumers must therefore only *compare* the returned
+    value, never perform arithmetic on it.
+    </description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <code>
+     !$GLC attributes unused :: self
+     massDistributionDensitySlopeLogarithmicCentral=-huge(0.0d0)
+    </code>
+   </method>
    <method name="potential" >
     <description>
     Return the gravitational potential of the distribution at the given coordinates.

--- a/source/mass_distributions/composite.F90
+++ b/source/mass_distributions/composite.F90
@@ -63,6 +63,7 @@
      procedure :: density                                 => compositeDensity
      procedure :: surfaceDensity                          => compositeSurfaceDensity
      procedure :: densityGradientRadial                   => compositeDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral          => compositeDensitySlopeLogarithmicCentral
      procedure :: densityRadialMoment                     => compositeDensityRadialMoment
      procedure :: densitySphericalAverage                 => compositeDensitySphericalAverage
      procedure :: densitySquareIntegral                   => compositeDensitySquareIntegral
@@ -643,6 +644,32 @@ contains
     end if
     return
   end function compositeDensityGradientRadial
+
+  double precision function compositeDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a composite mass distribution. Since the density of the
+    composite is the sum of the densities of its components, the steepest---that is, the most negative---central slope of any
+    component determines that of the composite. An unknown slope in any component therefore renders that of the composite
+    unknown too, which the minimum gives automatically since the unknown sentinel is the most negative representable value.
+    !!}
+    implicit none
+    class(massDistributionComposite   ), intent(inout) :: self
+    type (massDistributionList        ), pointer       :: massDistribution_
+
+    slope=+0.0d0
+    if (associated(self%massDistributions)) then
+       slope             =  +huge(0.0d0)
+       massDistribution_ =>  self%massDistributions
+       do while (associated(massDistribution_))
+          slope             =  min(                                                                          &
+               &                   +                 slope                                                 , &
+               &                   +massDistribution_%massDistribution_%densitySlopeLogarithmicCentral()     &
+               &                  )
+          massDistribution_ =>  massDistribution_%next
+       end do
+    end if
+    return
+  end function compositeDensitySlopeLogarithmicCentral
 
   double precision function compositeDensityRadialMoment(self,moment,radiusMinimum,radiusMaximum,isInfinite)
     !!{RST

--- a/source/mass_distributions/cylindrical/Gaussian_slab.F90
+++ b/source/mass_distributions/cylindrical/Gaussian_slab.F90
@@ -35,13 +35,14 @@
      private
      double precision :: scaleHeight, densityCentral
    contains
-     procedure :: density                    => gaussianSlabDensity
-     procedure :: densitySphericalAverage    => gaussianSlabDensitySphericalAverage
-     procedure :: rotationCurve              => gaussianSlabRotationCurve
-     procedure :: rotationCurveGradient      => gaussianSlabRotationCurveGradient
-     procedure :: surfaceDensity             => gaussianSlabSurfaceDensity
-     procedure :: surfaceDensityRadialMoment => gaussianSlabSurfaceDensityRadialMoment
-     procedure :: radiusHalfMass             => gaussianSlabRadiusHalfMass
+     procedure :: density                        => gaussianSlabDensity
+     procedure :: densitySlopeLogarithmicCentral => gaussianSlabDensitySlopeLogarithmicCentral
+     procedure :: densitySphericalAverage        => gaussianSlabDensitySphericalAverage
+     procedure :: rotationCurve                  => gaussianSlabRotationCurve
+     procedure :: rotationCurveGradient          => gaussianSlabRotationCurveGradient
+     procedure :: surfaceDensity                 => gaussianSlabSurfaceDensity
+     procedure :: surfaceDensityRadialMoment     => gaussianSlabSurfaceDensityRadialMoment
+     procedure :: radiusHalfMass                 => gaussianSlabRadiusHalfMass
    end type massDistributionGaussianSlab
 
   interface massDistributionGaussianSlab
@@ -185,6 +186,19 @@ contains
     gaussianSlabDensity=self%densityCentral*exp(-0.5d0*z**2)
     return
   end function gaussianSlabDensity
+
+  double precision function gaussianSlabDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a Gaussian slab mass distribution. The density is finite
+    at the center of the slab, and so is evaluable there.
+    !!}
+    implicit none
+    class(massDistributionGaussianSlab), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=0.0d0
+    return
+  end function gaussianSlabDensitySlopeLogarithmicCentral
 
   double precision function gaussianSlabDensitySphericalAverage(self,radius)
     !!{RST

--- a/source/mass_distributions/cylindrical/Miyamoto_Nagai.F90
+++ b/source/mass_distributions/cylindrical/Miyamoto_Nagai.F90
@@ -47,18 +47,19 @@
        <method description="Initialize the enclosed mass tabulation."   method="massEnclosedTabulate"  />
      </methods>
      !!]
-     procedure :: density                    => miyamotoNagaiDensity
-     procedure :: densitySphericalAverage    => miyamotoNagaiDensitySphericalAverage
-     procedure :: surfaceDensity             => miyamotoNagaiSurfaceDensity
-     procedure :: surfaceDensityTabulate     => miyamotoNagaiSurfaceDensityTabulate
-     procedure :: surfaceDensityRadialMoment => miyamotoNagaiSurfaceDensityRadialMoment
-     procedure :: massEnclosedBySphere       => miyamotoNagaiMassEnclosedBySphere
-     procedure :: massEnclosedTabulate       => miyamotoNagaiMassEnclosedTabulate
-     procedure :: potentialIsAnalytic        => miyamotoNagaiPotentialIsAnalytic
-     procedure :: potential                  => miyamotoNagaiPotential
-     procedure :: rotationCurve              => miyamotoNagaiRotationCurve
-     procedure :: rotationCurveGradient      => miyamotoNagaiRotationCurveGradient
-     procedure :: radiusHalfMass             => miyamotoNagaiRadiusHalfMass
+     procedure :: density                        => miyamotoNagaiDensity
+     procedure :: densitySlopeLogarithmicCentral => miyamotoNagaiDensitySlopeLogarithmicCentral
+     procedure :: densitySphericalAverage        => miyamotoNagaiDensitySphericalAverage
+     procedure :: surfaceDensity                 => miyamotoNagaiSurfaceDensity
+     procedure :: surfaceDensityTabulate         => miyamotoNagaiSurfaceDensityTabulate
+     procedure :: surfaceDensityRadialMoment     => miyamotoNagaiSurfaceDensityRadialMoment
+     procedure :: massEnclosedBySphere           => miyamotoNagaiMassEnclosedBySphere
+     procedure :: massEnclosedTabulate           => miyamotoNagaiMassEnclosedTabulate
+     procedure :: potentialIsAnalytic            => miyamotoNagaiPotentialIsAnalytic
+     procedure :: potential                      => miyamotoNagaiPotential
+     procedure :: rotationCurve                  => miyamotoNagaiRotationCurve
+     procedure :: rotationCurveGradient          => miyamotoNagaiRotationCurveGradient
+     procedure :: radiusHalfMass                 => miyamotoNagaiRadiusHalfMass
   end type massDistributionMiyamotoNagai
 
   interface massDistributionMiyamotoNagai
@@ -258,6 +259,19 @@ contains
          &                )**1.5d0
     return
   end function miyamotoNagaiDensity
+
+  double precision function miyamotoNagaiDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a :cite:p:`miyamoto_three-dimensional_1975` disk mass
+    distribution. The density is finite at the center of the disk, and so is evaluable there.
+    !!}
+    implicit none
+    class(massDistributionMiyamotoNagai), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=0.0d0
+    return
+  end function miyamotoNagaiDensitySlopeLogarithmicCentral
 
   double precision function miyamotoNagaiDensitySphericalAverage(self,radius)
     !!{RST

--- a/source/mass_distributions/cylindrical/exponential_disk.F90
+++ b/source/mass_distributions/cylindrical/exponential_disk.F90
@@ -74,6 +74,7 @@
      procedure :: massTotal                               => exponentialDiskMassTotal
      procedure :: density                                 => exponentialDiskDensity
      procedure :: densityGradientRadial                   => exponentialDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral          => exponentialDiskDensitySlopeLogarithmicCentral
      procedure :: densitySphericalAverage                 => exponentialDiskDensitySphericalAverage
      procedure :: surfaceDensity                          => exponentialDiskSurfaceDensity
      procedure :: massEnclosedBySphere                    => exponentialDiskMassEnclosedBySphere
@@ -410,6 +411,19 @@ contains
          &                                  /position%rSpherical                      (           )
     return
   end function exponentialDensityGradientRadial
+
+  double precision function exponentialDiskDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in an exponential disk mass distribution. The density is
+    finite at the center of the disk, and so is evaluable there.
+    !!}
+    implicit none
+    class(massDistributionExponentialDisk), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=0.0d0
+    return
+  end function exponentialDiskDensitySlopeLogarithmicCentral
   
   double precision function exponentialDiskDensitySphericalAverage(self,radius)
     !!{RST

--- a/source/mass_distributions/cylindrical/scaler.F90
+++ b/source/mass_distributions/cylindrical/scaler.F90
@@ -54,6 +54,7 @@
      procedure :: assumeMonotonicDecreasingSurfaceDensity => cylindricalScalerAssumeMonotonicDecreasingSurfaceDensity
      procedure :: massTotal                               => cylindricalScalerMassTotal
      procedure :: density                                 => cylindricalScalerDensity
+     procedure :: densitySlopeLogarithmicCentral          => cylindricalScalerDensitySlopeLogarithmicCentral
      procedure :: densitySphericalAverage                 => cylindricalScalerDensitySphericalAverage
      procedure :: densityGradientRadial                   => cylindricalScalerDensityGradientRadial
      procedure :: surfaceDensity                          => cylindricalScalerSurfaceDensity
@@ -231,6 +232,18 @@ contains
          &                   /self                  %factorScalingLength**3
     return
   end function cylindricalScalerDensity
+
+  double precision function cylindricalScalerDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a scaled cylindrical mass distribution. Scaling the length
+    and mass of a distribution leaves its logarithmic slope unchanged.
+    !!}
+    implicit none
+    class(massDistributionCylindricalScaler), intent(inout) :: self
+
+    slope=self%massDistribution_%densitySlopeLogarithmicCentral()
+    return
+  end function cylindricalScalerDensitySlopeLogarithmicCentral
 
   double precision function cylindricalScalerDensityGradientRadial(self,coordinates,logarithmic)
     !!{RST

--- a/source/mass_distributions/spherical/Burkert.F90
+++ b/source/mass_distributions/spherical/Burkert.F90
@@ -85,6 +85,7 @@
      procedure :: massTotal                         => burkertMassTotal
      procedure :: density                           => burkertDensity
      procedure :: densityGradientRadial             => burkertDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral    => burkertDensitySlopeLogarithmicCentral
      procedure :: densityRadialMoment               => burkertDensityRadialMoment
      procedure :: massEnclosedBySphere              => burkertMassEnclosedBySphere
      procedure :: velocityRotationCurveMaximum      => burkertVelocityRotationCurveMaximum
@@ -310,6 +311,19 @@ contains
          &                                       /coordinates%rSpherical           (           )
     return
   end function burkertDensityGradientRadial
+
+  double precision function burkertDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a Burkert :cite:p:`burkert_structure_1995` mass
+    distribution. The profile has a constant density core, so the density is evaluable at zero radius.
+    !!}
+    implicit none
+    class(massDistributionBurkert), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=0.0d0
+    return
+  end function burkertDensitySlopeLogarithmicCentral
 
   double precision function burkertDensityRadialMoment(self,moment,radiusMinimum,radiusMaximum,isInfinite) result(densityRadialMoment)
     !!{RST

--- a/source/mass_distributions/spherical/Einasto.F90
+++ b/source/mass_distributions/spherical/Einasto.F90
@@ -65,6 +65,7 @@
      procedure :: massTotal                         => einastoMassTotal
      procedure :: density                           => einastoDensity
      procedure :: densityGradientRadial             => einastoDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral    => einastoDensitySlopeLogarithmicCentral
      procedure :: densityRadialMoment               => einastoDensityRadialMoment
      procedure :: massEnclosedBySphere              => einastoMassEnclosedBySphere
      procedure :: radiusEnclosingMass               => einastoRadiusEnclosingMass
@@ -335,6 +336,21 @@ contains
     end if
     return
   end function einastoDensityGradientRadial
+
+  double precision function einastoDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in an Einasto mass distribution. The profile has a finite
+    central density, so the density is evaluable at zero radius.
+    !!}
+    use :: Coordinates, only : coordinateSpherical, assignment(=)
+    implicit none
+    class(massDistributionEinasto), intent(inout) :: self
+    type (coordinateSpherical    )                :: coordinates
+
+    coordinates=[0.0d0,0.0d0,0.0d0]
+    slope      =self%densityGradientRadial(coordinates,logarithmic=.true.)
+    return
+  end function einastoDensitySlopeLogarithmicCentral
 
   double precision function einastoDensityRadialMoment(self,moment,radiusMinimum,radiusMaximum,isInfinite) result(densityRadialMoment)
     !!{RST

--- a/source/mass_distributions/spherical/Hernquist.F90
+++ b/source/mass_distributions/spherical/Hernquist.F90
@@ -36,15 +36,16 @@
      double precision :: densityNormalization, mass, &
           &              scaleLength
    contains
-     procedure :: massTotal              => hernquistMassTotal
-     procedure :: density                => hernquistDensity
-     procedure :: densityGradientRadial  => hernquistDensityGradientRadial
-     procedure :: densityRadialMoment    => hernquistDensityRadialMoment
-     procedure :: massEnclosedBySphere   => hernquistMassEnclosedBySphere
-     procedure :: massEnclosedByCylinder => hernquistMassEnclosedByCylinder
-     procedure :: potentialIsAnalytic    => hernquistPotentialIsAnalytic
-     procedure :: potential              => hernquistPotential
-     procedure :: radiusHalfMass         => hernquistRadiusHalfMass
+     procedure :: massTotal                      => hernquistMassTotal
+     procedure :: density                        => hernquistDensity
+     procedure :: densityGradientRadial          => hernquistDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral => hernquistDensitySlopeLogarithmicCentral
+     procedure :: densityRadialMoment            => hernquistDensityRadialMoment
+     procedure :: massEnclosedBySphere           => hernquistMassEnclosedBySphere
+     procedure :: massEnclosedByCylinder         => hernquistMassEnclosedByCylinder
+     procedure :: potentialIsAnalytic            => hernquistPotentialIsAnalytic
+     procedure :: potential                      => hernquistPotential
+     procedure :: radiusHalfMass                 => hernquistRadiusHalfMass
   end type massDistributionHernquist
 
   interface massDistributionHernquist
@@ -248,6 +249,20 @@ contains
     end if
     return
   end function hernquistDensityGradientRadial
+
+  double precision function hernquistDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a Hernquist :cite:p:`hernquist_analytical_1990` mass
+    distribution. The profile is cuspy, :math:`\rho \propto r^{-1}` as :math:`r \rightarrow 0`, so the density is not
+    evaluable at zero radius.
+    !!}
+    implicit none
+    class(massDistributionHernquist), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=-1.0d0
+    return
+  end function hernquistDensitySlopeLogarithmicCentral
   
   double precision function hernquistDensityRadialMoment(self,moment,radiusMinimum,radiusMaximum,isInfinite)
     !!{RST

--- a/source/mass_distributions/spherical/NFW.F90
+++ b/source/mass_distributions/spherical/NFW.F90
@@ -55,6 +55,7 @@
      procedure :: massTotal                         => nfwMassTotal
      procedure :: density                           => nfwDensity
      procedure :: densityGradientRadial             => nfwDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral    => nfwDensitySlopeLogarithmicCentral
      procedure :: densityRadialMoment               => nfwDensityRadialMoment
      procedure :: massEnclosedBySphere              => nfwMassEnclosedBySphere
      procedure :: velocityRotationCurveMaximum      => nfwVelocityRotationCurveMaximum
@@ -346,6 +347,21 @@ contains
     end if
     return
   end function nfwDensityGradientRadial
+
+  double precision function nfwDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in an NFW :cite:p:`navarro_structure_1996` mass
+    distribution. The profile is cuspy, so the density is not evaluable at zero radius.
+    !!}
+    use :: Coordinates, only : coordinateSpherical, assignment(=)
+    implicit none
+    class(massDistributionNFW ), intent(inout) :: self
+    type (coordinateSpherical)                 :: coordinates
+
+    coordinates=[0.0d0,0.0d0,0.0d0]
+    slope      =self%densityGradientRadial(coordinates,logarithmic=.true.)
+    return
+  end function nfwDensitySlopeLogarithmicCentral
 
   double precision function nfwDensityRadialMoment(self,moment,radiusMinimum,radiusMaximum,isInfinite) result(densityRadialMoment)
     !!{RST

--- a/source/mass_distributions/spherical/SIDM/isothermal/_class.F90
+++ b/source/mass_distributions/spherical/SIDM/isothermal/_class.F90
@@ -93,13 +93,14 @@
      </methods>
      !!]
      final     ::                           sphericalSIDMIsothermalDestructor
-     procedure :: computeSolution        => sphericalSIDMIsothermalComputeSolution
-     procedure :: tabulateSolutions      => sphericalSIDMIsothermalTabulateSolutions
-     procedure :: density                => sphericalSIDMIsothermalDensity
-     procedure :: densityGradientRadial  => sphericalSIDMIsothermalDensityGradientRadial
-     procedure :: massEnclosedBySphere   => sphericalSIDMIsothermalMassEnclosedBySphere
-     procedure :: potential              => sphericalSIDMIsothermalPotential
-     procedure :: potentialIsAnalytic    => sphericalSIDMIsothermalPotentialIsAnalytic
+     procedure :: computeSolution                => sphericalSIDMIsothermalComputeSolution
+     procedure :: tabulateSolutions              => sphericalSIDMIsothermalTabulateSolutions
+     procedure :: density                        => sphericalSIDMIsothermalDensity
+     procedure :: densitySlopeLogarithmicCentral => sphericalSIDMIsothermalDensitySlopeLogarithmicCentral
+     procedure :: densityGradientRadial          => sphericalSIDMIsothermalDensityGradientRadial
+     procedure :: massEnclosedBySphere           => sphericalSIDMIsothermalMassEnclosedBySphere
+     procedure :: potential                      => sphericalSIDMIsothermalPotential
+     procedure :: potentialIsAnalytic            => sphericalSIDMIsothermalPotentialIsAnalytic
   end type massDistributionSphericalSIDMIsothermal
 
   interface massDistributionSphericalSIDMIsothermal
@@ -565,6 +566,20 @@ contains
     end if
     return
   end function sphericalSIDMIsothermalDensity
+
+  double precision function sphericalSIDMIsothermalDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in an isothermal Jeans solution self-interacting dark matter
+    mass distribution. Self-interactions establish an isothermal core within the interaction radius, so the density is finite
+    at zero radius.
+    !!}
+    implicit none
+    class(massDistributionSphericalSIDMIsothermal), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=0.0d0
+    return
+  end function sphericalSIDMIsothermalDensitySlopeLogarithmicCentral
 
   double precision function sphericalSIDMIsothermalDensityGradientRadial(self,coordinates,logarithmic) result(densityGradient)
     !!{RST

--- a/source/mass_distributions/spherical/SIDM_parametric_profile.F90
+++ b/source/mass_distributions/spherical/SIDM_parametric_profile.F90
@@ -46,6 +46,7 @@
    contains
      procedure :: density                         => SIDMParametricProfileDensity
      procedure :: densityGradientRadial           => SIDMParametricProfileDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral  => SIDMParametricProfileDensitySlopeLogarithmicCentral
      procedure :: radiusEnclosingDensity          => SIDMParametricProfileRadiusEnclosingDensity
      procedure :: radiusEnclosingDensityNumerical => SIDMParametricProfileRadiusEnclosingDensityNumerical
      procedure :: parameters                      => SIDMParametricProfileParameters
@@ -239,6 +240,23 @@ contains
     end if
     return
   end function SIDMParametricProfileDensityGradientRadial
+
+  double precision function SIDMParametricProfileDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a self-interacting dark matter parametric mass
+    distribution. A non-zero core radius gives a finite central density; with a zero core radius the profile is cuspy,
+    :math:`\rho \propto r^{-1}`.
+    !!}
+    implicit none
+    class(massDistributionSIDMParametricProfile), intent(inout) :: self
+
+    if (self%radiusCore > 0.0d0) then
+       slope=+0.0d0
+    else
+       slope=-1.0d0
+    end if
+    return
+  end function SIDMParametricProfileDensitySlopeLogarithmicCentral
   
   double precision function SIDMParametricProfileRadiusEnclosingDensity(self,density,radiusGuess) result(radius)
     !!{RST

--- a/source/mass_distributions/spherical/Zhao1996.F90
+++ b/source/mass_distributions/spherical/Zhao1996.F90
@@ -90,6 +90,7 @@
      procedure :: massTotal                         => zhao1996MassTotal
      procedure :: density                           => zhao1996Density
      procedure :: densityGradientRadial             => zhao1996DensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral    => zhao1996DensitySlopeLogarithmicCentral
      procedure :: densityRadialMoment               => zhao1996DensityRadialMoment
      procedure :: massEnclosedBySphere              => zhao1996MassEnclosedBySphere
      procedure :: velocityRotationCurveMaximum      => zhao1996VelocityRotationCurveMaximum
@@ -443,6 +444,18 @@ contains
          &                                       /coordinates%rSpherical           (           )
     return
   end function zhao1996DensityGradientRadial
+
+  double precision function zhao1996DensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a :cite:t:`zhao_analytical_1996` mass distribution, which
+    is simply :math:`-\gamma`. The density is evaluable at zero radius only for :math:`\gamma=0`.
+    !!}
+    implicit none
+    class(massDistributionZhao1996), intent(inout) :: self
+
+    slope=-self%gamma
+    return
+  end function zhao1996DensitySlopeLogarithmicCentral
 
   double precision function zhao1996DensityRadialMoment(self,moment,radiusMinimum,radiusMaximum,isInfinite) result(densityRadialMoment)
     !!{RST

--- a/source/mass_distributions/spherical/accelerator.F90
+++ b/source/mass_distributions/spherical/accelerator.F90
@@ -39,9 +39,10 @@
      double precision             :: toleranceRelative, factorRadiusMaximum, factorRadiusLogarithmicMaximum
    contains
      final     ::                         sphericalAcceleratorDestructor
-     procedure :: density              => sphericalAcceleratorDensity
-     procedure :: massEnclosedBySphere => sphericalAcceleratorMassEnclosedBySphere
-     procedure :: useUndecorated       => sphericalAcceleratorUseUndecorated
+     procedure :: density                        => sphericalAcceleratorDensity
+     procedure :: densitySlopeLogarithmicCentral => sphericalAcceleratorDensitySlopeLogarithmicCentral
+     procedure :: massEnclosedBySphere           => sphericalAcceleratorMassEnclosedBySphere
+     procedure :: useUndecorated                 => sphericalAcceleratorUseUndecorated
   end type massDistributionSphericalAccelerator
 
   interface massDistributionSphericalAccelerator
@@ -179,6 +180,18 @@ contains
     density=self%massDistribution_%density(coordinates)
     return
   end function sphericalAcceleratorDensity
+
+  double precision function sphericalAcceleratorDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in an accelerated mass distribution. Acceleration tabulates
+    the results of the undecorated distribution without changing them, so its central slope is unchanged.
+    !!}
+    implicit none
+    class(massDistributionSphericalAccelerator), intent(inout) :: self
+
+    slope=self%massDistribution_%densitySlopeLogarithmicCentral()
+    return
+  end function sphericalAcceleratorDensitySlopeLogarithmicCentral
 
   double precision function sphericalAcceleratorMassEnclosedBySphere(self,radius) result(mass)
     !!{RST

--- a/source/mass_distributions/spherical/beta_profile.F90
+++ b/source/mass_distributions/spherical/beta_profile.F90
@@ -42,15 +42,16 @@
        <method method="initialize" description="(Re)initialize the parameters of the :math:`\beta`-profile mass distribution."/>
      </methods>
      !!]
-     procedure :: initialize            => betaProfileInitialize
-     procedure :: density               => betaProfileDensity
-     procedure :: densityGradientRadial => betaProfileDensityGradientRadial
-     procedure :: densityRadialMoment   => betaProfileDensityRadialMoment
-     procedure :: densitySquareIntegral => betaProfileDensitySquareIntegral
-     procedure :: massEnclosedBySphere  => betaProfileMassEnclosedBySphere
-     procedure :: potentialIsAnalytic   => betaProfilePotentialIsAnalytic
-     procedure :: potential             => betaProfilePotential
-     procedure :: descriptor            => betaProfileDescriptor
+     procedure :: initialize                     => betaProfileInitialize
+     procedure :: density                        => betaProfileDensity
+     procedure :: densityGradientRadial          => betaProfileDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral => betaProfileDensitySlopeLogarithmicCentral
+     procedure :: densityRadialMoment            => betaProfileDensityRadialMoment
+     procedure :: densitySquareIntegral          => betaProfileDensitySquareIntegral
+     procedure :: massEnclosedBySphere           => betaProfileMassEnclosedBySphere
+     procedure :: potentialIsAnalytic            => betaProfilePotentialIsAnalytic
+     procedure :: potential                      => betaProfilePotential
+     procedure :: descriptor                     => betaProfileDescriptor
   end type massDistributionBetaProfile
 
   interface massDistributionBetaProfile
@@ -359,6 +360,19 @@ contains
     end if
     return
   end function betaProfileDensityGradientRadial
+
+  double precision function betaProfileDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a :math:`\beta`-profile mass distribution. The profile has
+    a constant density core, so the density is evaluable at zero radius.
+    !!}
+    implicit none
+    class(massDistributionBetaProfile), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=0.0d0
+    return
+  end function betaProfileDensitySlopeLogarithmicCentral
 
   double precision function betaProfileMassEnclosedBySphere(self,radius)
     !!{RST

--- a/source/mass_distributions/spherical/constant_density_cloud.F90
+++ b/source/mass_distributions/spherical/constant_density_cloud.F90
@@ -35,12 +35,13 @@
      double precision :: mass    , radius       , &
           &              density_, radiusSquared
    contains
-     procedure :: density               => constantDensityCloudDensity
-     procedure :: densityGradientRadial => constantDensityCloudDensityGradientRadial
-     procedure :: densityRadialMoment   => constantDensityCloudDensityRadialMoment
-     procedure :: massEnclosedBySphere  => constantDensityCloudMassEnclosedBySphere
-     procedure :: potentialIsAnalytic   => constantDensityCloudPotentialIsAnalytic
-    procedure :: potential              => constantDensityCloudPotential
+     procedure :: density                        => constantDensityCloudDensity
+     procedure :: densityGradientRadial          => constantDensityCloudDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral => constantDensityCloudDensitySlopeLogarithmicCentral
+     procedure :: densityRadialMoment            => constantDensityCloudDensityRadialMoment
+     procedure :: massEnclosedBySphere           => constantDensityCloudMassEnclosedBySphere
+     procedure :: potentialIsAnalytic            => constantDensityCloudPotentialIsAnalytic
+     procedure :: potential                      => constantDensityCloudPotential
   end type massDistributionConstantDensityCloud
 
   interface massDistributionConstantDensityCloud
@@ -157,6 +158,19 @@ contains
     constantDensityCloudDensityGradientRadial=0.0d0
     return
   end function constantDensityCloudDensityGradientRadial
+
+  double precision function constantDensityCloudDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a constant density cloud mass distribution. The density is
+    uniform, and so is evaluable at zero radius.
+    !!}
+    implicit none
+    class(massDistributionConstantDensityCloud), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=0.0d0
+    return
+  end function constantDensityCloudDensitySlopeLogarithmicCentral
 
   double precision function constantDensityCloudMassEnclosedBySphere(self,radius)
     !!{RST

--- a/source/mass_distributions/spherical/cored_NFW.F90
+++ b/source/mass_distributions/spherical/cored_NFW.F90
@@ -41,12 +41,13 @@
      double precision :: densityNormalization, radiusScale        , &
           &              radiusCore          , radiusCoreScaleFree
    contains
-     procedure :: density               => coredNFWDensity
-     procedure :: densityGradientRadial => coredNFWDensityGradientRadial
-     procedure :: parameters            => coredNFWParameters
-     procedure :: factoryTabulation     => coredNFWFactoryTabulation
-     procedure :: descriptor            => coredNFWDescriptor
-     procedure :: suffix                => coredNFWSuffix
+     procedure :: density                        => coredNFWDensity
+     procedure :: densityGradientRadial          => coredNFWDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral => coredNFWDensitySlopeLogarithmicCentral
+     procedure :: parameters                     => coredNFWParameters
+     procedure :: factoryTabulation              => coredNFWFactoryTabulation
+     procedure :: descriptor                     => coredNFWDescriptor
+     procedure :: suffix                         => coredNFWSuffix
   end type massDistributionCoredNFW
   
   interface massDistributionCoredNFW
@@ -326,6 +327,22 @@ contains
     end if
     return
   end function coredNFWDensityGradientRadial
+
+  double precision function coredNFWDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a cored NFW mass distribution. A non-zero core radius
+    gives a finite central density; with a zero core radius the profile reduces to the (cuspy) :term:`NFW` form.
+    !!}
+    implicit none
+    class(massDistributionCoredNFW), intent(inout) :: self
+
+    if (self%radiusCoreScaleFree > 0.0d0) then
+       slope=+0.0d0
+    else
+       slope=-1.0d0
+    end if
+    return
+  end function coredNFWDensitySlopeLogarithmicCentral
 
   subroutine coredNFWParameters(self,densityNormalization,radiusNormalization,parameters,container)
     !!{RST

--- a/source/mass_distributions/spherical/cusp-NFW.F90
+++ b/source/mass_distributions/spherical/cusp-NFW.F90
@@ -42,14 +42,15 @@
      double precision :: densityNormalization, radiusScale, &
           &              y
    contains
-     procedure :: describe              => cuspNFWDescribe
-     procedure :: density               => cuspNFWDensity
-     procedure :: densityGradientRadial => cuspNFWDensityGradientRadial
-     procedure :: massEnclosedBySphere  => cuspNFWMassEnclosedBySphere
-     procedure :: parameters            => cuspNFWParameters
-     procedure :: factoryTabulation     => cuspNFWFactoryTabulation
-     procedure :: descriptor            => cuspNFWDescriptor
-     procedure :: suffix                => cuspNFWSuffix
+     procedure :: describe                       => cuspNFWDescribe
+     procedure :: density                        => cuspNFWDensity
+     procedure :: densityGradientRadial          => cuspNFWDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral => cuspNFWDensitySlopeLogarithmicCentral
+     procedure :: massEnclosedBySphere           => cuspNFWMassEnclosedBySphere
+     procedure :: parameters                     => cuspNFWParameters
+     procedure :: factoryTabulation              => cuspNFWFactoryTabulation
+     procedure :: descriptor                     => cuspNFWDescriptor
+     procedure :: suffix                         => cuspNFWSuffix
   end type massDistributionCuspNFW
   
   interface massDistributionCuspNFW
@@ -322,6 +323,24 @@ contains
          &                 /     radiusScaleFree
     return
   end function cuspNFWDensityGradientRadial
+
+  double precision function cuspNFWDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a cusp-NFW mass distribution. The profile scales as
+    :math:`\rho \propto \sqrt{y^2+r/r_\mathrm{s}}\, (r/r_\mathrm{s})^{-3/2}` at small radii, giving a slope of :math:`-3/2`
+    for a non-zero cusp parameter, :math:`y`, and :math:`-1` (the :term:`NFW` limit) when it is zero. The profile is cuspy in
+    either case, so the density is not evaluable at zero radius.
+    !!}
+    implicit none
+    class(massDistributionCuspNFW), intent(inout) :: self
+
+    if (self%y > 0.0d0) then
+       slope=-1.5d0
+    else
+       slope=-1.0d0
+    end if
+    return
+  end function cuspNFWDensitySlopeLogarithmicCentral
 
   double precision function cuspNFWMassEnclosedBySphere(self,radius) result(mass)
     !!{RST

--- a/source/mass_distributions/spherical/decaying.F90
+++ b/source/mass_distributions/spherical/decaying.F90
@@ -48,11 +48,12 @@
      </methods>
      !!]
      final     ::                         sphericalDecayingDestructor
-     procedure :: decayingFactor       => sphericalDecayingDecayingFactor
-     procedure :: density              => sphericalDecayingDensity
-     procedure :: massEnclosedBySphere => sphericalDecayingMassEnclosedBySphere
-     procedure :: radiusEnclosingMass  => sphericalDecayingRadiusEnclosingMass
-     procedure :: useUndecorated       => sphericalDecayingUseUndecorated
+     procedure :: decayingFactor                 => sphericalDecayingDecayingFactor
+     procedure :: density                        => sphericalDecayingDensity
+     procedure :: densitySlopeLogarithmicCentral => sphericalDecayingDensitySlopeLogarithmicCentral
+     procedure :: massEnclosedBySphere           => sphericalDecayingMassEnclosedBySphere
+     procedure :: radiusEnclosingMass            => sphericalDecayingRadiusEnclosingMass
+     procedure :: useUndecorated                 => sphericalDecayingUseUndecorated
   end type massDistributionSphericalDecaying
 
   interface massDistributionSphericalDecaying
@@ -308,6 +309,19 @@ contains
          &  *self                  %decayingFactor(coordinates%rSpherical())
     return
   end function sphericalDecayingDensity
+
+  double precision function sphericalDecayingDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a decaying dark matter mass distribution. The depletion
+    factor tends to a constant as :math:`r \rightarrow 0`---it is unity throughout the undepleted region at the center of the
+    halo---so the central slope is that of the undecayed distribution.
+    !!}
+    implicit none
+    class(massDistributionSphericalDecaying), intent(inout) :: self
+
+    slope=self%massDistribution_%densitySlopeLogarithmicCentral()
+    return
+  end function sphericalDecayingDensitySlopeLogarithmicCentral
 
   double precision function sphericalDecayingMassEnclosedBySphere(self,radius) result(mass)
     !!{RST

--- a/source/mass_distributions/spherical/decorator.F90
+++ b/source/mass_distributions/spherical/decorator.F90
@@ -57,12 +57,13 @@
      procedure :: massEnclosedBySphere                         => sphericalDecoratorMassEnclosedBySphere
      procedure :: radiusEnclosingMass                          => sphericalDecoratorRadiusEnclosingMass
      procedure :: densityGradientRadial                        => sphericalDecoratorDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral               => sphericalDecoratorDensitySlopeLogarithmicCentral
      procedure :: densityRadialMoment                          => sphericalDecoratorDensityRadialMoment
      procedure :: radiusEnclosingDensity                       => sphericalDecoratorRadiusEnclosingDensity
      procedure :: radiusFromSpecificAngularMomentum            => sphericalDecoratorRadiusFromSpecificAngularMomentum
      procedure :: fourierTransform                             => sphericalDecoratorFourierTransform
      procedure :: radiusFreefall                               => sphericalDecoratorRadiusFreefall
-     procedure :: radiusFreefallIncreaseRate                   => sphericalDecoratorRadiusFreefallIncreaseRate 
+     procedure :: radiusFreefallIncreaseRate                   => sphericalDecoratorRadiusFreefallIncreaseRate
      procedure :: potentialIsAnalytic                          => sphericalDecoratorPotentialIsAnalytic
      procedure :: potential                                    => sphericalDecoratorPotential
      procedure :: energy                                       => sphericalDecoratorEnergy
@@ -76,7 +77,7 @@
      procedure :: radiusFromSpecificAngularMomentumNonAnalytic => sphericalDecoratorRadiusFromSpecificAngularMomentumNonAnalytic
      procedure :: fourierTransformNonAnalytic                  => sphericalDecoratorFourierTransformNonAnalytic
      procedure :: radiusFreefallNonAnalytic                    => sphericalDecoratorRadiusFreefallNonAnalytic
-     procedure :: radiusFreefallIncreaseRateNonAnalytic        => sphericalDecoratorRadiusFreefallIncreaseRateNonAnalytic 
+     procedure :: radiusFreefallIncreaseRateNonAnalytic        => sphericalDecoratorRadiusFreefallIncreaseRateNonAnalytic
      procedure :: potentialNonAnalytic                         => sphericalDecoratorPotentialNonAnalytic
      procedure :: energyNonAnalytic                            => sphericalDecoratorEnergyNonAnalytic
      procedure :: energyPotentialNonAnalytic                   => sphericalDecoratorEnergyPotentialNonAnalytic
@@ -154,6 +155,24 @@ contains
     end if 
     return
   end function sphericalDecoratorDensityGradientRadialNonAnalytic
+
+  double precision function sphericalDecoratorDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a decorator spherical mass distribution. The decoration
+    may reshape the profile at the center, so the slope of the undecorated distribution can be used only where the decoration
+    is not applied. Decorators which are known to leave the central slope unchanged should override this method to always
+    delegate to the undecorated distribution.
+    !!}
+    implicit none
+    class(massDistributionSphericalDecorator), intent(inout) :: self
+
+    if (self%useUndecorated()) then
+       slope=self%massDistribution_%densitySlopeLogarithmicCentral()
+    else
+       slope=-huge(0.0d0)
+    end if
+    return
+  end function sphericalDecoratorDensitySlopeLogarithmicCentral
   
   double precision function sphericalDecoratorRadiusEnclosingDensity(self,density,radiusGuess) result(radius)
     !!{RST

--- a/source/mass_distributions/spherical/isothermal.F90
+++ b/source/mass_distributions/spherical/isothermal.F90
@@ -43,6 +43,7 @@
      procedure :: massTotal                         => isothermalMassTotal
      procedure :: density                           => isothermalDensity
      procedure :: densityGradientRadial             => isothermalDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral    => isothermalDensitySlopeLogarithmicCentral
      procedure :: densityRadialMoment               => isothermalDensityRadialMoment
      procedure :: massEnclosedBySphere              => isothermalMassEnclosedBySphere
      procedure :: rotationCurve                     => isothermalRotationCurve
@@ -269,6 +270,19 @@ contains
     end if
     return
   end function isothermalDensityGradientRadial
+
+  double precision function isothermalDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in an isothermal mass distribution. The profile is cuspy,
+    :math:`\rho \propto r^{-2}`, so the density is not evaluable at zero radius.
+    !!}
+    implicit none
+    class(massDistributionIsothermal), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=-2.0d0
+    return
+  end function isothermalDensitySlopeLogarithmicCentral
 
   double precision function isothermalMassEnclosedBySphere(self,radius)
     !!{RST

--- a/source/mass_distributions/spherical/null.F90
+++ b/source/mass_distributions/spherical/null.F90
@@ -33,16 +33,17 @@
      A zero mass distribution.
      !!}
    contains
-     procedure :: massTotal             => zeroMassTotal
-     procedure :: density               => zeroDensity
-     procedure :: densityGradientRadial => zeroDensityGradientRadial
-     procedure :: densityRadialMoment   => zeroDensityRadialMoment
-     procedure :: massEnclosedBySphere  => zeroMassEnclosedBySphere
-     procedure :: surfaceDensity        => zeroSurfaceDensity
-     procedure :: rotationCurve         => zeroRotationCurve
-     procedure :: rotationCurveGradient => zeroRotationCurveGradient
-     procedure :: potentialIsAnalytic   => zeroPotentialIsAnalytic
-     procedure :: potential             => zeroPotential
+     procedure :: massTotal                      => zeroMassTotal
+     procedure :: density                        => zeroDensity
+     procedure :: densityGradientRadial          => zeroDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral => zeroDensitySlopeLogarithmicCentral
+     procedure :: densityRadialMoment            => zeroDensityRadialMoment
+     procedure :: massEnclosedBySphere           => zeroMassEnclosedBySphere
+     procedure :: surfaceDensity                 => zeroSurfaceDensity
+     procedure :: rotationCurve                  => zeroRotationCurve
+     procedure :: rotationCurveGradient          => zeroRotationCurveGradient
+     procedure :: potentialIsAnalytic            => zeroPotentialIsAnalytic
+     procedure :: potential                      => zeroPotential
   end type massDistributionZero
 
   interface massDistributionZero
@@ -137,6 +138,19 @@ contains
     zeroDensityGradientRadial=0.0d0
     return
   end function zeroDensityGradientRadial
+
+  double precision function zeroDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a zero mass distribution. The density is zero everywhere,
+    and so is evaluable at zero radius.
+    !!}
+    implicit none
+    class(massDistributionZero), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    slope=0.0d0
+    return
+  end function zeroDensitySlopeLogarithmicCentral
 
   double precision function zeroMassEnclosedBySphere(self,radius)
     !!{RST

--- a/source/mass_distributions/spherical/scaler.F90
+++ b/source/mass_distributions/spherical/scaler.F90
@@ -54,6 +54,7 @@
      procedure :: massTotal                         => sphericalScalerMassTotal
      procedure :: density                           => sphericalScalerDensity
      procedure :: densityGradientRadial             => sphericalScalerDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral    => sphericalScalerDensitySlopeLogarithmicCentral
      procedure :: densityRadialMoment               => sphericalScalerDensityRadialMoment
      procedure :: massEnclosedBySphere              => sphericalScalerMassEnclosedBySphere
      procedure :: massEnclosedByCylinder            => sphericalScalerMassEnclosedByCylinder
@@ -243,6 +244,23 @@ contains
          &                                      /self%factorScalingLength**4
     return
   end function sphericalScalerDensityGradientRadial
+
+  double precision function sphericalScalerDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a scaled spherical mass distribution. Scaling the length
+    and mass of a distribution leaves its logarithmic slope unchanged.
+    !!}
+    implicit none
+    class(massDistributionSphericalScaler), intent(inout) :: self
+
+    if (self%factorScalingMass > 0.0d0) then
+       slope=self%massDistribution_%densitySlopeLogarithmicCentral()
+    else
+       ! The distribution has zero mass, and so zero density everywhere.
+       slope=0.0d0
+    end if
+    return
+  end function sphericalScalerDensitySlopeLogarithmicCentral
 
   double precision function sphericalScalerMassEnclosedBySphere(self,radius)
     !!{RST

--- a/source/mass_distributions/spherical/soliton/_class.F90
+++ b/source/mass_distributions/spherical/soliton/_class.F90
@@ -40,6 +40,7 @@
      procedure :: massEnclosedBySphere            => solitonMassEnclosedBySphere
      procedure :: density                         => solitonDensity
      procedure :: densityGradientRadial           => solitonDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral  => solitonDensitySlopeLogarithmicCentral
      procedure :: radiusEnclosingDensity          => solitonRadiusEnclosingDensity
      procedure :: radiusEnclosingDensityNumerical => solitonRadiusEnclosingDensityNumerical
      procedure :: parameters                      => solitonParameters
@@ -304,7 +305,22 @@
      end if
      return
    end function solitonDensityGradientRadial
-   
+
+   double precision function solitonDensitySlopeLogarithmicCentral(self) result(slope)
+     !!{RST
+     Return the central logarithmic slope of the density profile in a soliton mass distribution. The soliton has a flat core,
+     so the density is evaluable at zero radius.
+     !!}
+     use :: Coordinates, only : coordinateSpherical, assignment(=)
+     implicit none
+     class(massDistributionSoliton), intent(inout) :: self
+     type (coordinateSpherical    )                :: coordinates
+
+     coordinates=[0.0d0,0.0d0,0.0d0]
+     slope      =self%densityGradientRadial(coordinates,logarithmic=.true.)
+     return
+   end function solitonDensitySlopeLogarithmicCentral
+
    double precision function solitonRadiusEnclosingDensity(self,density,radiusGuess) result(radius)
      !!{RST
      Computes the radius enclosing a given mean density for soliton mass distributions.

--- a/source/mass_distributions/spherical/soliton_NFW.F90
+++ b/source/mass_distributions/spherical/soliton_NFW.F90
@@ -46,6 +46,7 @@
      procedure :: massEnclosedBySphere            => solitonNFWMassEnclosedBySphere
      procedure :: density                         => solitonNFWDensity
      procedure :: densityGradientRadial           => solitonNFWDensityGradientRadial
+     procedure :: densitySlopeLogarithmicCentral  => solitonNFWDensitySlopeLogarithmicCentral
      procedure :: radiusEnclosingDensity          => solitonNFWRadiusEnclosingDensity
      procedure :: radiusEnclosingDensityNumerical => solitonNFWRadiusEnclosingDensityNumerical
      procedure :: parameters                      => solitonNFWParameters
@@ -458,7 +459,22 @@
      end if
      return
    end function solitonNFWDensityGradientRadial
-   
+
+   double precision function solitonNFWDensitySlopeLogarithmicCentral(self) result(slope)
+     !!{RST
+     Return the central logarithmic slope of the density profile in a soliton and NFW mass distribution. The soliton core
+     occupies the center of the profile, so the density is evaluable at zero radius.
+     !!}
+     use :: Coordinates, only : coordinateSpherical, assignment(=)
+     implicit none
+     class(massDistributionSolitonNFW), intent(inout) :: self
+     type (coordinateSpherical       )                :: coordinates
+
+     coordinates=[0.0d0,0.0d0,0.0d0]
+     slope      =self%densityGradientRadial(coordinates,logarithmic=.true.)
+     return
+   end function solitonNFWDensitySlopeLogarithmicCentral
+
    double precision function solitonNFWRadiusEnclosingDensity(self,density,radiusGuess) result(radius)
      !!{RST
      Computes the radius enclosing a given mean density for soliton NFW mass distributions.

--- a/source/mass_distributions/spherical/truncated.F90
+++ b/source/mass_distributions/spherical/truncated.F90
@@ -54,12 +54,13 @@
      </methods>
      !!]
      final     ::                           sphericalTruncatedDestructor
-     procedure :: density                => sphericalTruncatedDensity
-     procedure :: densityGradientRadial  => sphericalTruncatedDensityGradientRadial
-     procedure :: massTotal              => sphericalTruncatedMassTotal
-     procedure :: massEnclosedBySphere   => sphericalTruncatedMassEnclosedBySphere
-     procedure :: radiusEnclosingMass    => sphericalTruncatedRadiusEnclosingMass
-     procedure :: truncationFunction     => sphericalTruncatedTruncationFunction
+     procedure :: density                        => sphericalTruncatedDensity
+     procedure :: densitySlopeLogarithmicCentral => sphericalTruncatedDensitySlopeLogarithmicCentral
+     procedure :: densityGradientRadial          => sphericalTruncatedDensityGradientRadial
+     procedure :: massTotal                      => sphericalTruncatedMassTotal
+     procedure :: massEnclosedBySphere           => sphericalTruncatedMassEnclosedBySphere
+     procedure :: radiusEnclosingMass            => sphericalTruncatedRadiusEnclosingMass
+     procedure :: truncationFunction             => sphericalTruncatedTruncationFunction
   end type massDistributionSphericalTruncated
 
   interface massDistributionSphericalTruncated
@@ -223,6 +224,18 @@ contains
          &  *                       multiplier
     return
   end function sphericalTruncatedDensity
+
+  double precision function sphericalTruncatedDensitySlopeLogarithmicCentral(self) result(slope)
+    !!{RST
+    Return the central logarithmic slope of the density profile in a truncated spherical mass distribution. Truncation
+    affects only the outer regions of the profile, leaving the central slope that of the untruncated distribution.
+    !!}
+    implicit none
+    class(massDistributionSphericalTruncated), intent(inout) :: self
+
+    slope=self%massDistribution_%densitySlopeLogarithmicCentral()
+    return
+  end function sphericalTruncatedDensitySlopeLogarithmicCentral
 
   double precision function sphericalTruncatedDensityGradientRadial(self,coordinates,logarithmic) result(densityGradient)
     !!{RST

--- a/source/nodes/property_extractor/CGM_cooling_function.F90
+++ b/source/nodes/property_extractor/CGM_cooling_function.F90
@@ -29,6 +29,8 @@
   <nodePropertyExtractor name="nodePropertyExtractorCGMCoolingFunction" docformat="rst">
    <description>
    A property extractor that returns the radiative cooling function :math:`\Lambda(T,n_\mathrm{H},Z)` (in erg cm\ :math:`^3` s\ :math:`^{-1}`) of the circumgalactic medium at a user-specified set of radii in the hot halo, evaluated using the supplied :galacticus-class:`coolingFunctionClass` object with local density, temperature, and metallicity. The ``radiusSpecifiers`` parameter defines the radii; ``includeRadii`` and ``includeDensity`` optionally add the radius (Mpc) and hydrogen number density (cm\ :math:`^{-3}`) columns to the output. The ``label`` suffix distinguishes multiple instances of this extractor.
+
+   A radius specifier can evaluate to zero---most often because the component on which it is based is absent or empty in the node in question. The cooling function is then evaluable only if the hot halo mass distribution has a finite central density. By default a radius of zero at which it does not is reported as a fatal error naming the offending specifier; setting ``zeroRadiusIsFatal`` to ``false`` instead writes the undefined-value sentinel in place of the cooling function.
    </description>
    <deepCopy>
     <functionClass variables="radiation"/>
@@ -50,7 +52,8 @@
      integer                                                                     :: radiiCount                    , elementCount_ , &
           &                                                                         abundancesCount               , chemicalsCount, &
           &                                                                         indexRadii                    , indexDensity
-     logical                                                                     :: includeRadii                  , includeDensity
+     logical                                                                     :: includeRadii                  , includeDensity, &
+          &                                                                         zeroRadiusIsFatal
      type   (varying_string                         ), allocatable, dimension(:) :: radiusSpecifiers
      type   (radiusDefinitions                      )                            :: radii
      type   (varying_string                         )                            :: label
@@ -88,7 +91,8 @@ contains
     class  (darkMatterHaloScaleClass               ), pointer                     :: darkMatterHaloScale_
     class  (coolingFunctionClass                   ), pointer                     :: coolingFunction_
     class  (cosmologyFunctionsClass                ), pointer                     :: cosmologyFunctions_
-    logical                                                                       :: includeRadii        , includeDensity
+    logical                                                                       :: includeRadii        , includeDensity, &
+         &                                                                           zeroRadiusIsFatal
     type   (varying_string                         )                              :: label
     
     allocate(radiusSpecifiers(parameters%count('radiusSpecifiers')))
@@ -117,6 +121,16 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
+      <name>zeroRadiusIsFatal</name>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      Specifies whether a radius specifier which evaluates to zero, in a node in which the density of the hot halo diverges at
+      zero radius, should be reported as a fatal error. If ``false``, the undefined-value sentinel is written in place of the
+      cooling function instead.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
       <name>label</name>
       <defaultValue>var_str('')</defaultValue>
       <description>
@@ -128,7 +142,7 @@ contains
     <objectBuilder class="darkMatterHaloScale" name="darkMatterHaloScale_" source="parameters"/>
     <objectBuilder class="coolingFunction"     name="coolingFunction_"     source="parameters"/>
     !!]
-    self=nodePropertyExtractorCGMCoolingFunction(radiusSpecifiers,includeRadii,includeDensity,label,cosmologyFunctions_,darkMatterHaloScale_,coolingFunction_)
+    self=nodePropertyExtractorCGMCoolingFunction(radiusSpecifiers,includeRadii,includeDensity,zeroRadiusIsFatal,label,cosmologyFunctions_,darkMatterHaloScale_,coolingFunction_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_" />
@@ -138,7 +152,7 @@ contains
     return
   end function cgmCoolingFunctionConstructorParameters
 
-  function cgmCoolingFunctionConstructorInternal(radiusSpecifiers,includeRadii,includeDensity,label,cosmologyFunctions_,darkMatterHaloScale_,coolingFunction_) result(self)
+  function cgmCoolingFunctionConstructorInternal(radiusSpecifiers,includeRadii,includeDensity,zeroRadiusIsFatal,label,cosmologyFunctions_,darkMatterHaloScale_,coolingFunction_) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`nodePropertyExtractorCGMCoolingFunction` property extractor class.
     !!}
@@ -151,10 +165,11 @@ contains
     class  (cosmologyFunctionsClass                ), intent(in   ), target       :: cosmologyFunctions_
     class  (darkMatterHaloScaleClass               ), intent(in   ), target       :: darkMatterHaloScale_
     class  (coolingFunctionClass                   ), intent(in   ), target       :: coolingFunction_
-    logical                                         , intent(in   )               :: includeRadii        , includeDensity
+    logical                                         , intent(in   )               :: includeRadii        , includeDensity, &
+         &                                                                           zeroRadiusIsFatal
     type   (varying_string                         ), intent(in   )               :: label
     !![
-    <constructorAssign variables="radiusSpecifiers, includeRadii, includeDensity, *cosmologyFunctions_, *darkMatterHaloScale_, *coolingFunction_"/>
+    <constructorAssign variables="radiusSpecifiers, includeRadii, includeDensity, zeroRadiusIsFatal, *cosmologyFunctions_, *darkMatterHaloScale_, *coolingFunction_"/>
     !!]
 
     ! Decode radii specifiers.
@@ -299,7 +314,26 @@ contains
        end if
        ! Get density and temperature.
        coordinates             =  [radius,0.0d0,0.0d0]
-       massDistribution_       => node                   %massDistribution      (componentTypeHotHalo,massTypeGaseous)
+       massDistribution_       => node%massDistribution(componentTypeHotHalo,massTypeGaseous)
+       if     (                                                             &
+            &   radius                                             <= 0.0d0 &
+            &  .and.                                                        &
+            &   massDistribution_%densitySlopeLogarithmicCentral() <  0.0d0 &
+            & ) then
+          ! The radius is zero, but the density of the hot halo diverges at the center (or its central slope is unknown), so
+          ! the cooling function can not be evaluated here.
+          if (self%zeroRadiusIsFatal)                                                                                         &
+               & call resolver%reportZeroRadius(i,'cgmCoolingFunction','the density of the hot halo diverges at zero radius')
+          cgmCoolingFunctionExtract       (i,                1)=radiusUndefined
+          if (self%includeRadii  )                                              &
+               & cgmCoolingFunctionExtract(i,self%indexRadii  )=radius
+          if (self%includeDensity)                                              &
+               & cgmCoolingFunctionExtract(i,self%indexDensity)=radiusUndefined
+          !![
+          <objectDestructor name="massDistribution_"/>
+          !!]
+          cycle
+       end if
        kinematicsDistribution_ => massDistribution_      %kinematicsDistribution(                                    )
        density                 =  massDistribution_      %density               (coordinates                         )
        temperature             =  kinematicsDistribution_%temperature           (coordinates                         )
@@ -328,9 +362,9 @@ contains
        else
           cgmCoolingFunctionExtract    (i,                1)=+0.0d0
        end if
-       if (self%includeRadii  )                                                                                              &
+       if (self%includeRadii  )                                                                                                   &
             & cgmCoolingFunctionExtract(i,self%indexRadii  )=                                       radius
-       if (self%includeDensity)                                                                                              &
+       if (self%includeDensity)                                                                                                   &
             & cgmCoolingFunctionExtract(i,self%indexDensity)=                                       numberDensityHydrogen       
     end do
     return

--- a/source/nodes/property_extractor/density.F90
+++ b/source/nodes/property_extractor/density.F90
@@ -27,6 +27,8 @@
   <nodePropertyExtractor name="nodePropertyExtractorDensityProfile" docformat="rst">
    <description>
    A property extractor that returns the mass density profile (in :math:`\mathrm{M}_\odot \, \mathrm{Mpc}^{-3}`) of a galaxy or halo component at a user-specified set of radii. The ``radiusSpecifiers`` parameter provides a list of radius definitions (e.g. multiples of the virial radius, disk radius, or half-mass radius), supporting both galactic structural radii and fixed physical radii. If ``includeRadii`` is ``true``, the corresponding radii (in Mpc) are also written to the output file as a second column alongside the density values.
+
+   A radius specifier can evaluate to zero---most often because the component on which it is based is absent or empty in the node in question. The density is then finite only if the mass distribution being evaluated has a finite central density; where it does not, the requested property does not exist. By default this is reported as a fatal error naming the offending specifier; setting ``zeroRadiusIsFatal`` to ``false`` instead writes the undefined-value sentinel in place of the density.
    </description>
   </nodePropertyExtractor>
   !!]
@@ -37,7 +39,7 @@
      private
      class  (darkMatterHaloScaleClass), pointer                   :: darkMatterHaloScale_ => null()
      integer                                                      :: radiiCount                    , elementCount_
-     logical                                                      :: includeRadii
+     logical                                                      :: includeRadii                  , zeroRadiusIsFatal
      type   (varying_string          ), allocatable, dimension(:) :: radiusSpecifiers
      type   (radiusDefinitions       )                            :: radii
    contains
@@ -72,7 +74,7 @@ contains
     type   (inputParameters                    ), intent(inout)               :: parameters
     type   (varying_string                     ), allocatable  , dimension(:) :: radiusSpecifiers
     class  (darkMatterHaloScaleClass           ), pointer                     :: darkMatterHaloScale_
-    logical                                                                   :: includeRadii
+    logical                                                                   :: includeRadii        , zeroRadiusIsFatal
 
     allocate(radiusSpecifiers(parameters%count('radiusSpecifiers')))
     !![
@@ -91,9 +93,19 @@ contains
       </description>
       <source>parameters</source>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>zeroRadiusIsFatal</name>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      Specifies whether a radius specifier which evaluates to zero, in a node in which the density diverges at zero radius,
+      should be reported as a fatal error. If ``false``, the undefined-value sentinel is written in place of the density
+      instead.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
     <objectBuilder class="darkMatterHaloScale" name="darkMatterHaloScale_" source="parameters"/>
     !!]
-    self=nodePropertyExtractorDensityProfile(radiusSpecifiers,includeRadii,darkMatterHaloScale_)
+    self=nodePropertyExtractorDensityProfile(radiusSpecifiers,includeRadii,zeroRadiusIsFatal,darkMatterHaloScale_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="darkMatterHaloScale_"/>
@@ -101,7 +113,7 @@ contains
     return
   end function densityProfileConstructorParameters
 
-  function densityProfileConstructorInternal(radiusSpecifiers,includeRadii,darkMatterHaloScale_) result(self)
+  function densityProfileConstructorInternal(radiusSpecifiers,includeRadii,zeroRadiusIsFatal,darkMatterHaloScale_) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`nodePropertyExtractorDensityProfile` property extractor class.
     !!}
@@ -109,9 +121,9 @@ contains
     type   (nodePropertyExtractorDensityProfile)                              :: self
     type   (varying_string                     ), intent(in   ), dimension(:) :: radiusSpecifiers
     class  (darkMatterHaloScaleClass           ), intent(in   ), target       :: darkMatterHaloScale_
-    logical                                     , intent(in   )               :: includeRadii
+    logical                                     , intent(in   )               :: includeRadii        , zeroRadiusIsFatal
     !![
-    <constructorAssign variables="radiusSpecifiers, includeRadii, *darkMatterHaloScale_"/>
+    <constructorAssign variables="radiusSpecifiers, includeRadii, zeroRadiusIsFatal, *darkMatterHaloScale_"/>
     !!]
 
     if (includeRadii) then
@@ -197,16 +209,33 @@ contains
                & densityProfileExtract(i,2)=radiusUndefined
           cycle
        end if
+       massDistribution_ => node%massDistribution(                                                  &
+            &                                     componentType=self%radii%specifiers(i)%component, &
+            &                                     massType     =self%radii%specifiers(i)%mass       &
+            &                                    )
+       if     (                                                             &
+            &   radius                                             <= 0.0d0 &
+            &  .and.                                                        &
+            &   massDistribution_%densitySlopeLogarithmicCentral() <  0.0d0 &
+            & ) then
+          ! The radius is zero, but the density of this mass distribution diverges at the center (or its central slope is
+          ! unknown), so the density can not be evaluated here.
+          if (self%zeroRadiusIsFatal)                                                                                               &
+               & call resolver%reportZeroRadius(i,'densityProfile','the density of this mass distribution diverges at zero radius')
+          densityProfileExtract       (i,1)=radiusUndefined
+          if (self%includeRadii)                            &
+               & densityProfileExtract(i,2)=radius
+          !![
+          <objectDestructor name="massDistribution_"/>
+          !!]
+          cycle
+       end if
        coordinates                       =  [radius,Pi/2.0d0,0.0d0]
-       massDistribution_                 => node             %massDistribution(                                                  &
-            &                                                                  componentType=self%radii%specifiers(i)%component, &
-            &                                                                  massType     =self%radii%specifiers(i)%mass       &
-            &                                                                 )
-       densityProfileExtract       (i,1) =  massDistribution_%density         (                                                  &
-            &                                                                  coordinates=                coordinates           &
-            &                                                                 )
-       if (self%includeRadii)                                                                                                    &
-            & densityProfileExtract(i,2) =                                                                 radius
+       densityProfileExtract       (i,1) =  massDistribution_%density(                        &
+            &                                                         coordinates=coordinates &
+            &                                                        )
+       if (self%includeRadii)                                                                 &
+            & densityProfileExtract(i,2) =                                        radius
        !![
        <objectDestructor name="massDistribution_"/>
        !!]

--- a/source/nodes/property_extractor/density_DMO.F90
+++ b/source/nodes/property_extractor/density_DMO.F90
@@ -28,6 +28,8 @@
   <nodePropertyExtractor name="nodePropertyExtractorDensityDMOProfile" docformat="rst">
    <description>
    A property extractor class for the dark matter only density at a set of radii.
+
+   A radius specifier can evaluate to zero---most often because the component on which it is based is absent or empty in the node in question. The density is then finite only if the dark matter profile has a finite central density, which is not the case for the cuspy profiles typically used. By default this is reported as a fatal error naming the offending specifier; setting ``zeroRadiusIsFatal`` to ``false`` instead writes the undefined-value sentinel in place of the density.
    </description>
   </nodePropertyExtractor>
   !!]
@@ -36,10 +38,10 @@
      A property extractor class for the dark matter only density at a set of radii.
      !!}
      private
-     class  (darkMatterHaloScaleClass ), pointer                   :: darkMatterHaloScale_          => null()
-     class  (darkMatterProfileDMOClass), pointer                   :: darkMatterProfileDMO_         => null()
-     integer                                                       :: radiiCount                             , elementCount_
-     logical                                                       :: includeRadii
+     class  (darkMatterHaloScaleClass ), pointer                   :: darkMatterHaloScale_  => null()
+     class  (darkMatterProfileDMOClass), pointer                   :: darkMatterProfileDMO_ => null()
+     integer                                                       :: radiiCount                     , elementCount_
+     logical                                                       :: includeRadii                   , zeroRadiusIsFatal
      type   (varying_string           ), allocatable, dimension(:) :: radiusSpecifiers
      type   (radiusDefinitions        )                            :: radii
    contains
@@ -75,7 +77,7 @@ contains
     type   (varying_string                        ), allocatable  , dimension(:) :: radiusSpecifiers
     class  (darkMatterHaloScaleClass              ), pointer                     :: darkMatterHaloScale_
     class  (darkMatterProfileDMOClass             ), pointer                     :: darkMatterProfileDMO_
-    logical                                                                      :: includeRadii
+    logical                                                                      :: includeRadii         , zeroRadiusIsFatal
 
     allocate(radiusSpecifiers(parameters%count('radiusSpecifiers')))
     !![
@@ -94,10 +96,20 @@ contains
       </description>
       <source>parameters</source>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>zeroRadiusIsFatal</name>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      Specifies whether a radius specifier which evaluates to zero, in a node in which the density diverges at zero radius,
+      should be reported as a fatal error. If ``false``, the undefined-value sentinel is written in place of the density
+      instead.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
     <objectBuilder class="darkMatterHaloScale"  name="darkMatterHaloScale_"  source="parameters"/>
     <objectBuilder class="darkMatterProfileDMO" name="darkMatterProfileDMO_" source="parameters"/>
     !!]
-    self=nodePropertyExtractorDensityDMOProfile(radiusSpecifiers,includeRadii,darkMatterHaloScale_,darkMatterProfileDMO_)
+    self=nodePropertyExtractorDensityDMOProfile(radiusSpecifiers,includeRadii,zeroRadiusIsFatal,darkMatterHaloScale_,darkMatterProfileDMO_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="darkMatterHaloScale_" />
@@ -106,7 +118,7 @@ contains
     return
   end function densityDMOProfileConstructorParameters
 
-  function densityDMOProfileConstructorInternal(radiusSpecifiers,includeRadii,darkMatterHaloScale_,darkMatterProfileDMO_) result(self)
+  function densityDMOProfileConstructorInternal(radiusSpecifiers,includeRadii,zeroRadiusIsFatal,darkMatterHaloScale_,darkMatterProfileDMO_) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`nodePropertyExtractorDensityDMOProfile` property extractor class.
     !!}
@@ -117,9 +129,9 @@ contains
     type   (varying_string                        ), intent(in   ), dimension(:) :: radiusSpecifiers
     class  (darkMatterHaloScaleClass              ), intent(in   ), target       :: darkMatterHaloScale_
     class  (darkMatterProfileDMOClass             ), intent(in   ), target       :: darkMatterProfileDMO_
-    logical                                        , intent(in   )               :: includeRadii
+    logical                                        , intent(in   )               :: includeRadii         , zeroRadiusIsFatal
     !![
-    <constructorAssign variables="radiusSpecifiers, includeRadii, *darkMatterHaloScale_, *darkMatterProfileDMO_"/>
+    <constructorAssign variables="radiusSpecifiers, includeRadii, zeroRadiusIsFatal, *darkMatterHaloScale_, *darkMatterProfileDMO_"/>
     !!]
 
     if (includeRadii) then
@@ -208,11 +220,28 @@ contains
                & densityDMOProfileExtract(i,2)=radiusUndefined
           cycle
        end if
+       massDistribution_ => self%darkMatterProfileDMO_%get(node)
+       if     (                                                             &
+            &   radius                                             <= 0.0d0 &
+            &  .and.                                                        &
+            &   massDistribution_%densitySlopeLogarithmicCentral() <  0.0d0 &
+            & ) then
+          ! The radius is zero, but the density of this dark matter profile diverges at the center (or its central slope is
+          ! unknown), so the density can not be evaluated here.
+          if (self%zeroRadiusIsFatal)                                                                                                    &
+               & call resolver%reportZeroRadius(i,'densityDMOProfile','the density of this dark matter profile diverges at zero radius')
+          densityDMOProfileExtract       (i,1)=radiusUndefined
+          if (self%includeRadii)                               &
+               & densityDMOProfileExtract(i,2)=radius
+          !![
+          <objectDestructor name="massDistribution_"/>
+          !!]
+          cycle
+       end if
        coordinates                          =  [radius,Pi/2.0d0,0.0d0]
-       massDistribution_                    => self             %darkMatterProfileDMO_%get    (node       )
-       densityDMOProfileExtract       (i,1) =  massDistribution_                      %density(coordinates)
-       if (self%includeRadii)                                                                               &
-            & densityDMOProfileExtract(i,2) =                                                  radius
+       densityDMOProfileExtract       (i,1) =  massDistribution_%density(coordinates)
+       if (self%includeRadii)                                                         &
+            & densityDMOProfileExtract(i,2) =                            radius
        !![
        <objectDestructor name="massDistribution_"/>
        !!]

--- a/source/nodes/property_extractor/projected_density.F90
+++ b/source/nodes/property_extractor/projected_density.F90
@@ -27,6 +27,8 @@
   <nodePropertyExtractor name="nodePropertyExtractorProjectedDensity" docformat="rst">
    <description>
    A property extractor class for the projected density at a set of radii. The radii and types of projected density to output is specified by the ``radiusSpecifiers`` parameter. This parameter's value can contain multiple entries, each of which should be a valid :ref:`radius specifier &lt;manual-sec-radiusspecifiers&gt;`.
+
+   A radius specifier can evaluate to zero---most often because the component on which it is based is absent or empty in the node in question. The projected density is not evaluated there: it is finite only if the central logarithmic slope of the density profile exceeds :math:`-1` (an :term:`NFW` profile, for example, gives a logarithmically divergent integral), and even then the Abel integral used here is performed in the logarithm of radius, and so can not begin at zero radius. By default a radius of zero is reported as a fatal error naming the offending specifier; setting ``zeroRadiusIsFatal`` to ``false`` instead writes the undefined-value sentinel in place of the projected density.
    </description>
   </nodePropertyExtractor>
   !!]
@@ -35,9 +37,10 @@
      A property extractor class for the projected density at a set of radii.
      !!}
      private
-     class  (darkMatterHaloScaleClass), pointer                   :: darkMatterHaloScale_          => null()
-     integer                                                      :: radiiCount                  , elementCount_
-     logical                                                      :: includeRadii                , tolerateIntegrationFailures
+     class  (darkMatterHaloScaleClass), pointer                   :: darkMatterHaloScale_ => null()
+     integer                                                      :: radiiCount                    , elementCount_
+     logical                                                      :: includeRadii                  , tolerateIntegrationFailures, &
+          &                                                          zeroRadiusIsFatal
      type   (varying_string          ), allocatable, dimension(:) :: radiusSpecifiers
      type   (radiusDefinitions       )                            :: radii
    contains
@@ -76,7 +79,8 @@ contains
     type   (inputParameters                      ), intent(inout)               :: parameters
     type   (varying_string                       ), allocatable  , dimension(:) :: radiusSpecifiers
     class  (darkMatterHaloScaleClass             ), pointer                     :: darkMatterHaloScale_
-    logical                                                                     :: includeRadii        , tolerateIntegrationFailures
+    logical                                                                     :: includeRadii        , tolerateIntegrationFailures, &
+         &                                                                         zeroRadiusIsFatal
 
     allocate(radiusSpecifiers(parameters%count('radiusSpecifiers')))
     !![
@@ -103,9 +107,19 @@ contains
       </description>
       <source>parameters</source>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>zeroRadiusIsFatal</name>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      Specifies whether a radius specifier which evaluates to zero, in a node in which the projected density diverges at zero
+      radius, should be reported as a fatal error. If ``false``, the undefined-value sentinel is written in place of the
+      projected density instead.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
     <objectBuilder class="darkMatterHaloScale" name="darkMatterHaloScale_" source="parameters"/>
     !!]
-    self=nodePropertyExtractorProjectedDensity(radiusSpecifiers,includeRadii,tolerateIntegrationFailures,darkMatterHaloScale_)
+    self=nodePropertyExtractorProjectedDensity(radiusSpecifiers,includeRadii,tolerateIntegrationFailures,zeroRadiusIsFatal,darkMatterHaloScale_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="darkMatterHaloScale_"/>
@@ -113,7 +127,7 @@ contains
     return
   end function projectedDensityConstructorParameters
 
-  function projectedDensityConstructorInternal(radiusSpecifiers,includeRadii,tolerateIntegrationFailures,darkMatterHaloScale_) result(self)
+  function projectedDensityConstructorInternal(radiusSpecifiers,includeRadii,tolerateIntegrationFailures,zeroRadiusIsFatal,darkMatterHaloScale_) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`nodePropertyExtractorProjectedDensity` property extractor class.
     !!}
@@ -121,9 +135,10 @@ contains
     type   (nodePropertyExtractorProjectedDensity)                              :: self
     type   (varying_string                       ), intent(in   ), dimension(:) :: radiusSpecifiers
     class  (darkMatterHaloScaleClass             ), intent(in   ), target       :: darkMatterHaloScale_
-    logical                                       , intent(in   )               :: includeRadii        , tolerateIntegrationFailures
+    logical                                       , intent(in   )               :: includeRadii        , tolerateIntegrationFailures, &
+         &                                                                         zeroRadiusIsFatal
     !![
-    <constructorAssign variables="radiusSpecifiers, includeRadii, tolerateIntegrationFailures, *darkMatterHaloScale_"/>
+    <constructorAssign variables="radiusSpecifiers, includeRadii, tolerateIntegrationFailures, zeroRadiusIsFatal, *darkMatterHaloScale_"/>
     !!]
 
     if (includeRadii) then
@@ -220,8 +235,22 @@ contains
           cycle
        end if
        massDistribution_        => node%massDistribution(self%radii%specifiers(i)%component,self%radii%specifiers(i)%mass)
+       if (radius_ <= 0.0d0) then
+          ! The radius is zero. The projected density along a line of sight through the center is finite only if the central
+          ! logarithmic slope of the density profile exceeds -1, but even then it can not be evaluated here: the Abel integral
+          ! below is performed in the logarithm of radius, and so can not begin at zero radius.
+          if (self%zeroRadiusIsFatal) &
+               & call resolver%reportZeroRadius(i,'projectedDensity','the line of sight integral is evaluated in the logarithm of radius, which can not begin at zero radius')
+          densityProjected       (i,1)=radiusUndefined
+          if (self%includeRadii)                      &
+               & densityProjected(i,2)=radius_
+          !![
+          <objectDestructor name="massDistribution_"/>
+          !!]
+          cycle
+       end if
        densityProjectedPrevious =  0.0d0
-       radiusOuter              =  max(radius_* 2.0d0                    ,radiusVirial)
+       radiusOuter              =  max(radius_*2.0d0,radiusVirial)
        ! Cut out a small region round the coordinate singularity at the inner radius. This region will be integrated analytically
        ! assuming a constant density over this region. The region outside of this cut-out will be integrated numerically.
        radiusSingularity       =min(radius_*(1.0d0+epsilonSingularity),radiusOuter )

--- a/source/nodes/property_extractor/projected_mass.F90
+++ b/source/nodes/property_extractor/projected_mass.F90
@@ -27,6 +27,8 @@
   <nodePropertyExtractor name="nodePropertyExtractorProjectedMass" docformat="rst">
    <description>
    A property extractor class for the projected mass at a set of radii. The radii and types of projected mass to output is specified by the ``radiusSpecifiers`` parameter. This parameter's value can contain multiple entries, each of which should be a valid :ref:`radius specifier &lt;manual-sec-radiusspecifiers&gt;`.
+
+   A radius specifier can evaluate to zero---most often because the component on which it is based is absent or empty in the node in question. The projected mass is well defined there: the fraction of each spherical shell lying inside the cylinder vanishes in that limit, leaving only the mass of any central point mass, such as a black hole.
    </description>
   </nodePropertyExtractor>
   !!]
@@ -211,6 +213,18 @@ contains
        radiusOuter          =max(radius_*2.0d0,radiusVirial)
        ! Evaluate the integral, then add on the mass of the sphere entirely enclosed inside the cylinder.
        massDistribution_ => node%massDistribution(componentType=self%radii%specifiers(i)%component,massType=self%radii%specifiers(i)%mass)
+       if (radius_ <= 0.0d0) then
+          ! The radius is zero. The fraction of each spherical shell lying inside the cylinder vanishes in this limit, so only
+          ! the mass enclosed by a sphere of zero radius - that of any central point mass - remains. (The integral below can
+          ! not be evaluated here in any case, since it begins at log(radius_).)
+          massProjected       (i,1)=massDistribution_%massEnclosedBySphere(0.0d0)
+          if (self%includeRadii)                                                  &
+               & massProjected(i,2)=                  radius_
+          !![
+          <objectDestructor name="massDistribution_"/>
+          !!]
+          cycle
+       end if
        converged         =  .false.
        do while (.not.converged)
           massProjectedCurrent=integrator_%integrate(log(radius_),log(radiusOuter))

--- a/source/tests/dark_matter_profiles/projected.F90
+++ b/source/tests/dark_matter_profiles/projected.F90
@@ -153,6 +153,7 @@ program Test_Dark_Matter_Profiles_Projected
      &amp;                                radiusSpecifiers                    =radiusSpecifiers     , &amp;
      &amp;                                includeRadii                        =.false.              , &amp;
      &amp;                                tolerateIntegrationFailures         =.false.              , &amp;
+     &amp;                                zeroRadiusIsFatal                   =.true.               , &amp;
      &amp;                                darkMatterHaloScale_                =darkMatterHaloScale_   &amp;
      &amp;                               )
    </constructor>

--- a/testSuite/parameters/checkpointingCheckpoints.xml
+++ b/testSuite/parameters/checkpointingCheckpoints.xml
@@ -560,6 +560,11 @@
       <darkMatterOnly            value="true"    />
     </nodePropertyExtractor>
     <nodePropertyExtractor value="densityProfile">
+      <!-- Radii given as a fraction of the stellar half-mass radius vanish in nodes with no
+           stars. The galactic mass distribution there can be a bare black hole point mass,
+           whose density at zero radius does not exist, so report the undefined-value sentinel
+           rather than stopping. -->
+      <zeroRadiusIsFatal value="false"/>
       <radiusSpecifiers value="virialRadius:darkHalo:dark:0.001 virialRadius:darkHalo:dark:0.003 virialRadius:darkHalo:dark:0.005 virialRadius:darkHalo:dark:0.007 virialRadius:darkHalo:dark:0.009 virialRadius:darkHalo:dark:0.01 virialRadius:darkHalo:dark:0.03 virialRadius:darkHalo:dark:0.05 virialRadius:darkHalo:dark:0.07 virialRadius:darkHalo:dark:0.09 virialRadius:darkHalo:dark:0.1 virialRadius:darkHalo:dark:0.3 virialRadius:darkHalo:dark:0.5 virialRadius:darkHalo:dark:0.7 virialRadius:darkHalo:dark:0.9 virialRadius:darkHalo:dark:1.0 stellarMassFraction{0.5}:all:galactic:0.3 stellarMassFraction{0.5}:all:galactic:0.5 stellarMassFraction{0.5}:all:galactic:0.7 stellarMassFraction{0.5}:all:galactic:1.0 stellarMassFraction{0.5}:all:galactic:2.0 stellarMassFraction{0.5}:all:galactic:3.0"/>
       <includeRadii value="true"/>
     </nodePropertyExtractor>

--- a/testSuite/parameters/checkpointingNoCheckpoints.xml
+++ b/testSuite/parameters/checkpointingNoCheckpoints.xml
@@ -557,6 +557,11 @@
       <darkMatterOnly            value="true"    />
     </nodePropertyExtractor>
     <nodePropertyExtractor value="densityProfile">
+      <!-- Radii given as a fraction of the stellar half-mass radius vanish in nodes with no
+           stars. The galactic mass distribution there can be a bare black hole point mass,
+           whose density at zero radius does not exist, so report the undefined-value sentinel
+           rather than stopping. -->
+      <zeroRadiusIsFatal value="false"/>
       <radiusSpecifiers value="virialRadius:darkHalo:dark:0.001 virialRadius:darkHalo:dark:0.003 virialRadius:darkHalo:dark:0.005 virialRadius:darkHalo:dark:0.007 virialRadius:darkHalo:dark:0.009 virialRadius:darkHalo:dark:0.01 virialRadius:darkHalo:dark:0.03 virialRadius:darkHalo:dark:0.05 virialRadius:darkHalo:dark:0.07 virialRadius:darkHalo:dark:0.09 virialRadius:darkHalo:dark:0.1 virialRadius:darkHalo:dark:0.3 virialRadius:darkHalo:dark:0.5 virialRadius:darkHalo:dark:0.7 virialRadius:darkHalo:dark:0.9 virialRadius:darkHalo:dark:1.0 stellarMassFraction{0.5}:all:galactic:0.3 stellarMassFraction{0.5}:all:galactic:0.5 stellarMassFraction{0.5}:all:galactic:0.7 stellarMassFraction{0.5}:all:galactic:1.0 stellarMassFraction{0.5}:all:galactic:2.0 stellarMassFraction{0.5}:all:galactic:3.0"/>
       <includeRadii value="true"/>
     </nodePropertyExtractor>

--- a/testSuite/parameters/checkpointingResume.xml
+++ b/testSuite/parameters/checkpointingResume.xml
@@ -560,6 +560,11 @@
       <darkMatterOnly            value="true"    />
     </nodePropertyExtractor>
     <nodePropertyExtractor value="densityProfile">
+      <!-- Radii given as a fraction of the stellar half-mass radius vanish in nodes with no
+           stars. The galactic mass distribution there can be a bare black hole point mass,
+           whose density at zero radius does not exist, so report the undefined-value sentinel
+           rather than stopping. -->
+      <zeroRadiusIsFatal value="false"/>
       <radiusSpecifiers value="virialRadius:darkHalo:dark:0.001 virialRadius:darkHalo:dark:0.003 virialRadius:darkHalo:dark:0.005 virialRadius:darkHalo:dark:0.007 virialRadius:darkHalo:dark:0.009 virialRadius:darkHalo:dark:0.01 virialRadius:darkHalo:dark:0.03 virialRadius:darkHalo:dark:0.05 virialRadius:darkHalo:dark:0.07 virialRadius:darkHalo:dark:0.09 virialRadius:darkHalo:dark:0.1 virialRadius:darkHalo:dark:0.3 virialRadius:darkHalo:dark:0.5 virialRadius:darkHalo:dark:0.7 virialRadius:darkHalo:dark:0.9 virialRadius:darkHalo:dark:1.0 stellarMassFraction{0.5}:all:galactic:0.3 stellarMassFraction{0.5}:all:galactic:0.5 stellarMassFraction{0.5}:all:galactic:0.7 stellarMassFraction{0.5}:all:galactic:1.0 stellarMassFraction{0.5}:all:galactic:2.0 stellarMassFraction{0.5}:all:galactic:3.0"/>
       <includeRadii value="true"/>
     </nodePropertyExtractor>

--- a/testSuite/parameters/radiusSpecifiersZeroFatal.xml
+++ b/testSuite/parameters/radiusSpecifiersZeroFatal.xml
@@ -1,0 +1,321 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard">
+    <starveSatellites value="false"/>
+  </componentHotHalo>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <ratioAngularMomentumScaleRadius value="0.5"/>
+    <efficiencyEnergeticOutflow value="1.0e-2"/>
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeSeeds value="random"/>
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMinimum value="1.0e10"/>
+    <massTreeMaximum value="1.0e13"/>
+    <treesPerDecade value="2"/>
+  </mergerTreeBuildMasses>
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="gao2008"/>
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="simple">
+    <redshiftReionization value="10.5"/>
+    <velocitySuppressionReionization value="35.0"/>
+  </accretionHalo>
+
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="5.0"/>
+  </hotHaloOutflowReincorporation>
+  <hotHaloOutflowStripping value="standard">
+     <efficiency value="0.1"/>
+  </hotHaloOutflowStripping>
+  <coolingInfallTorque value="fixed">
+     <fractionLossAngularMomentum value="0.3"/>
+  </coolingInfallTorque>
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0"/>
+  </coolingTimeAvailable>
+  <circumgalacticMediumHeating value="AGNFeedback"/>
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <!-- Galactic structure solver options -->
+  <galacticStructureSolver value="equilibrium"/>
+  <darkMatterProfile value="adiabaticGnedin2004">
+    <A value="0.73"/>
+    <omega value="0.7"/>
+  </darkMatterProfile>
+  <!-- Star formation rate options -->
+  <starFormationRateDisks value="intgrtdSurfaceDensity"/>
+  <starFormationRateSurfaceDensityDisks value="krumholz2009">
+    <frequencyStarFormation value="0.385"/>
+    <clumpingFactorMolecularComplex value="5.000"/>
+    <molecularFractionFast value="true"/>
+  </starFormationRateSurfaceDensityDisks>
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.04"/>
+      <exponentVelocity value="2.0"/>
+      <timescaleMinimum value="0.001"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="instantaneous"/>
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+
+  <initialMassFunction value="chabrier2001"/>
+  <stellarPopulation value="standard">
+    <recycledFraction value="0.46"/>
+    <metalYield value="0.035"/>
+  </stellarPopulation>
+
+  <!-- AGN feedback options -->
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
+  <!-- Accretion disk properties -->
+  <accretionDisks value="switched">
+    <accretionRateThinDiskMaximum value="0.30"/>
+    <accretionRateThinDiskMinimum value="0.01"/>
+    <scaleADAFRadiativeEfficiency value="true"/>
+    <accretionDisksShakuraSunyaev value="shakuraSunyaev"/>
+    <accretionDisksADAF value="ADAF">
+      <efficiencyRadiationType value="thinDisk"/>
+      <adiabaticIndex value="1.444"/>
+      <energyOption value="pureADAF"/>
+      <efficiencyRadiation value="0.01"/>
+      <viscosityOption value="fit"/>
+    </accretionDisksADAF>
+  </accretionDisks>
+
+  <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+  </blackHoleAccretionRate>
+  <blackHoleBinaryMerger value="rezzolla2008"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="benson2005"/>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"/>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+    <nodeOperator value="starFormationSpheroids"/>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="250.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="100.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <!-- Bar instability in galactic disks -->
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="0.7"/>
+	<stabilityThresholdStellar value="1.1"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <!-- Black hole physics -->
+    <nodeOperator value="blackHolesSeed">
+      <blackHoleSeeds value="fixed">
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
+    </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <!-- CGM physics -->
+    <nodeOperator value="CGMAccretion">
+      <allowNegativeCGMMass value="true"/>
+      <angularMomentumAlwaysGrows value="false"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOutflowReincorporation">
+      <includeSatellites value="true"/>
+    </nodeOperator>
+    <nodeOperator value="CGMCoolingHeating">
+      <component value="disk"/>
+      <coolingFrom value="currentNode"/>
+      <excessHeatDrivesOutflow value="true"/>
+      <rateMaximumExpulsion value="1.0"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+
+  <!-- A radius specifier which evaluates to zero in nodes whose disk is absent or empty. The
+       dark matter profile here is NFW, whose density diverges at the center, so the density can
+       not be evaluated at zero radius: the model must abort with an error naming the specifier
+       rather than raising a floating point exception. -->
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="nodeIndices"/>
+    <nodePropertyExtractor value="densityProfile">
+      <includeRadii value="true"/>
+      <radiusSpecifiers value="diskRadius:all:all:1.0  virialRadius:all:all:1.0"/>
+    </nodePropertyExtractor>
+  </nodePropertyExtractor>
+
+  <outputFileName value="testSuite/outputs/radiusSpecifiersZero/fatal.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/radiusSpecifiersZeroTolerated.xml
+++ b/testSuite/parameters/radiusSpecifiersZeroTolerated.xml
@@ -1,0 +1,336 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard">
+    <starveSatellites value="false"/>
+  </componentHotHalo>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <ratioAngularMomentumScaleRadius value="0.5"/>
+    <efficiencyEnergeticOutflow value="1.0e-2"/>
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeSeeds value="random"/>
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMinimum value="1.0e10"/>
+    <massTreeMaximum value="1.0e13"/>
+    <treesPerDecade value="2"/>
+  </mergerTreeBuildMasses>
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="gao2008"/>
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="simple">
+    <redshiftReionization value="10.5"/>
+    <velocitySuppressionReionization value="35.0"/>
+  </accretionHalo>
+
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="5.0"/>
+  </hotHaloOutflowReincorporation>
+  <hotHaloOutflowStripping value="standard">
+     <efficiency value="0.1"/>
+  </hotHaloOutflowStripping>
+  <coolingInfallTorque value="fixed">
+     <fractionLossAngularMomentum value="0.3"/>
+  </coolingInfallTorque>
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0"/>
+  </coolingTimeAvailable>
+  <circumgalacticMediumHeating value="AGNFeedback"/>
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <!-- Galactic structure solver options -->
+  <galacticStructureSolver value="equilibrium"/>
+  <darkMatterProfile value="adiabaticGnedin2004">
+    <A value="0.73"/>
+    <omega value="0.7"/>
+  </darkMatterProfile>
+  <!-- Star formation rate options -->
+  <starFormationRateDisks value="intgrtdSurfaceDensity"/>
+  <starFormationRateSurfaceDensityDisks value="krumholz2009">
+    <frequencyStarFormation value="0.385"/>
+    <clumpingFactorMolecularComplex value="5.000"/>
+    <molecularFractionFast value="true"/>
+  </starFormationRateSurfaceDensityDisks>
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.04"/>
+      <exponentVelocity value="2.0"/>
+      <timescaleMinimum value="0.001"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="instantaneous"/>
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+
+  <initialMassFunction value="chabrier2001"/>
+  <stellarPopulation value="standard">
+    <recycledFraction value="0.46"/>
+    <metalYield value="0.035"/>
+  </stellarPopulation>
+
+  <!-- AGN feedback options -->
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
+  <!-- Accretion disk properties -->
+  <accretionDisks value="switched">
+    <accretionRateThinDiskMaximum value="0.30"/>
+    <accretionRateThinDiskMinimum value="0.01"/>
+    <scaleADAFRadiativeEfficiency value="true"/>
+    <accretionDisksShakuraSunyaev value="shakuraSunyaev"/>
+    <accretionDisksADAF value="ADAF">
+      <efficiencyRadiationType value="thinDisk"/>
+      <adiabaticIndex value="1.444"/>
+      <energyOption value="pureADAF"/>
+      <efficiencyRadiation value="0.01"/>
+      <viscosityOption value="fit"/>
+    </accretionDisksADAF>
+  </accretionDisks>
+
+  <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+  </blackHoleAccretionRate>
+  <blackHoleBinaryMerger value="rezzolla2008"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="benson2005"/>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"/>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+    <nodeOperator value="starFormationSpheroids"/>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="250.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="100.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <!-- Bar instability in galactic disks -->
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="0.7"/>
+	<stabilityThresholdStellar value="1.1"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <!-- Black hole physics -->
+    <nodeOperator value="blackHolesSeed">
+      <blackHoleSeeds value="fixed">
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
+    </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <!-- CGM physics -->
+    <nodeOperator value="CGMAccretion">
+      <allowNegativeCGMMass value="true"/>
+      <angularMomentumAlwaysGrows value="false"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOutflowReincorporation">
+      <includeSatellites value="true"/>
+    </nodeOperator>
+    <nodeOperator value="CGMCoolingHeating">
+      <component value="disk"/>
+      <coolingFrom value="currentNode"/>
+      <excessHeatDrivesOutflow value="true"/>
+      <rateMaximumExpulsion value="1.0"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+
+  <!-- The same zero-valued radius specifier, with the error suppressed. Densities and projected
+       densities at zero radius are reported as the undefined-value sentinel, while enclosed and
+       projected masses - which are simply zero at zero radius - are reported as such. The third
+       density specifier evaluates the density of the hot halo, a beta-profile with a finite
+       central density, at exactly zero radius: that is well defined, and must not be rejected. -->
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="nodeIndices"/>
+    <nodePropertyExtractor value="densityProfile">
+      <includeRadii      value="true"/>
+      <zeroRadiusIsFatal value="false"/>
+      <radiusSpecifiers  value="diskRadius:all:all:1.0  virialRadius:all:all:1.0  radius:hotHalo:gaseous:0.0"/>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="projectedDensity">
+      <includeRadii      value="true"/>
+      <zeroRadiusIsFatal value="false"/>
+      <radiusSpecifiers  value="diskRadius:all:all:1.0  virialRadius:all:all:1.0"/>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="massProfile">
+      <includeRadii value="true"/>
+      <radiusSpecifiers value="diskRadius:all:all:1.0  virialRadius:all:all:1.0"/>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="projectedMass">
+      <includeRadii value="true"/>
+      <radiusSpecifiers value="diskRadius:all:all:1.0  virialRadius:all:all:1.0"/>
+    </nodePropertyExtractor>
+  </nodePropertyExtractor>
+
+  <outputFileName value="testSuite/outputs/radiusSpecifiersZero/tolerated.hdf5"/>
+
+</parameters>

--- a/testSuite/test-radius-specifiers-zero.py
+++ b/testSuite/test-radius-specifiers-zero.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Test radius specifiers which evaluate to zero.
+
+A radius specifier can resolve to zero - `diskRadius:all:all:1.0` in a node whose
+disk is absent or empty, for example. The radius is perfectly well defined, but
+not every property exists there: the density of an NFW halo does not, while the
+mass enclosed by a sphere or cylinder of zero radius is simply zero.
+
+Two models are run:
+
+  * one which asks for the density at such a radius, checking that it aborts with
+    an error naming the offending specifier rather than raising a floating point
+    exception;
+  * one which sets `zeroRadiusIsFatal` to false, checking that it completes, that
+    the sentinel appears in the density and projected density exactly where the
+    radius is zero (while the radius itself is still reported as zero), that the
+    enclosed and projected masses are defined and agree there, and that the
+    density of the beta-profile hot halo - which has a finite central density -
+    is still evaluated at exactly zero radius.
+
+Andrew Benson (03-August-2026)
+"""
+
+import os
+import subprocess
+import sys
+
+import h5py
+import numpy as np
+
+# The `radiusUndefined` sentinel from `Galactic_Structure_Radii_Definitions`.
+radiusUndefined = -np.finfo('f8').max
+
+pathOutputDirectory = os.path.abspath("outputs/radiusSpecifiersZero")
+subprocess.run(f"mkdir -p {pathOutputDirectory}", shell=True)
+
+failures = []
+
+
+def runModel(name, pathParameters):
+    """Run a model, returning its exit status and the text of its log."""
+    pathLog = os.path.join(pathOutputDirectory, f"{name}.log")
+    print(f"Running model '{name}'...")
+    with open(pathLog, "w") as log:
+        status = subprocess.run(
+            f"cd ..; ./Galacticus.exe {pathParameters}",
+            stdout=log, stderr=log, shell=True,
+        )
+    print(f"...done ({status.returncode})")
+    with open(pathLog) as log:
+        return status.returncode, log.read()
+
+
+def check(condition, description):
+    print(("SUCCESS: " if condition else "FAILED: ") + description)
+    if not condition:
+        failures.append(description)
+
+
+def gather(fileName, name, countRadii):
+    """Concatenate the per-output node data of the given property across all outputs."""
+    values, radii = [], []
+    with h5py.File(fileName, "r") as model:
+        for output in sorted(model["Outputs"].keys()):
+            nodes = model["Outputs"][output]["nodeData"]
+            values.append(nodes[name          ][:].reshape(-1, countRadii))
+            radii .append(nodes[name+"Radius" ][:].reshape(-1, countRadii))
+    return np.concatenate(values), np.concatenate(radii)
+
+
+# Model 1: the error must be reported, and must name the specifier.
+status, log = runModel("fatal", "testSuite/parameters/radiusSpecifiersZeroFatal.xml")
+check(status != 0, "model 'fatal' exits with non-zero status")
+check(
+    "floating point exception" not in log.lower(),
+    "model 'fatal' does not raise a floating point exception",
+)
+check(
+    "Radius specifier evaluates to a radius of zero" in log,
+    "model 'fatal' reports a zero radius error",
+)
+check("diskRadius" in log, "model 'fatal' names the offending radius specifier")
+check("densityProfile" in log, "model 'fatal' names the property extractor")
+if failures:
+    # Show the tail of the log to aid diagnosis of any of the above failures.
+    subprocess.run(f"tail -n 30 {pathOutputDirectory}/fatal.log", shell=True)
+
+# Model 2: with the error suppressed the model must run to completion.
+status, log = runModel("tolerated", "testSuite/parameters/radiusSpecifiersZeroTolerated.xml")
+check(status == 0, "model 'tolerated' runs to completion")
+check(
+    "floating point exception" not in log.lower(),
+    "model 'tolerated' does not raise a floating point exception",
+)
+if status != 0:
+    subprocess.run(f"tail -n 30 {pathOutputDirectory}/tolerated.log", shell=True)
+    print("FAILED: model 'tolerated' did not complete - skipping output checks")
+    sys.exit(1)
+
+fileName = os.path.join(pathOutputDirectory, "tolerated.hdf5")
+density        , radiiDensity         = gather(fileName, "densityProfile" , 3)
+densityProjected, radiiDensityProjected = gather(fileName, "projectedDensity", 2)
+mass           , radiiMass            = gather(fileName, "massProfile"   , 2)
+massProjected  , radiiMassProjected   = gather(fileName, "projectedMass" , 2)
+
+# The first two radii of the `densityProfile` extractor are the disk radius and the virial radius;
+# the third is the fixed, zero radius in the hot halo.
+isZero = radiiDensity[:, 0] == 0.0
+check(np.any(isZero), "some node has a zero disk radius")
+check(
+    np.all(density[isZero, 0] == radiusUndefined),
+    "density is the sentinel where the radius is zero",
+)
+check(
+    np.all(density[~isZero, 0] > 0.0),
+    "density is evaluated where the disk radius is non-zero",
+)
+check(
+    np.all(density[:, 1] > 0.0),
+    "density is evaluated at the virial radius in every node",
+)
+check(
+    np.all(densityProjected[radiiDensityProjected[:, 0] == 0.0, 0] == radiusUndefined),
+    "projected density is the sentinel where the radius is zero",
+)
+
+# Enclosed and projected masses exist at zero radius: both reduce to the mass of any central point
+# mass - here the black hole seed - and so must agree with each other, and must never be the
+# sentinel.
+massZero          = mass         [radiiMass         [:, 0] == 0.0, 0]
+massProjectedZero = massProjected[radiiMassProjected[:, 0] == 0.0, 0]
+check(massZero.size > 0, "some node has a zero disk radius in the mass profile")
+check(
+    np.all(massZero >= 0.0),
+    "enclosed mass is defined where the radius is zero",
+)
+check(
+    np.all(massProjectedZero == massZero),
+    "projected mass at zero radius equals the enclosed mass of the central point mass",
+)
+
+# The beta-profile hot halo has a finite central density, so evaluating it at exactly zero radius
+# is well defined and must not be rejected - even though this extractor leaves `zeroRadiusIsFatal`
+# at its default of true.
+check(
+    np.all(radiiDensity[:, 2] == 0.0),
+    "the fixed hot halo radius is zero",
+)
+check(
+    np.all(density[:, 2] >= 0.0) and np.any(density[:, 2] > 0.0),
+    "the central density of the hot halo is evaluated at zero radius",
+)
+
+print()
+if failures:
+    print("FAILED: " + str(len(failures)) + " check(s) failed:")
+    for failure in failures:
+        print("   " + failure)
+    sys.exit(1)
+print("SUCCESS: all checks passed")


### PR DESCRIPTION
Fixes #1314.

A radius specifier which resolves to zero — `diskRadius:all:all:1.0` in a node whose disk
is absent or empty, say — used to raise a floating point exception deep inside the mass
distribution, with nothing to indicate which specifier was responsible. Zero radii are
routine: 40 of 175 resolved radii were zero in a `quickTest.xml`-based model with 25
specifiers.

The radius is well defined in these cases; it is the *property* which may not exist there,
and whether it does depends on the quantity being asked for as much as on the mass
distribution. The density of an NFW halo has no value at r=0, while the mass it encloses
is perfectly well defined.

## The central density slope

`massDistributionClass` gains a `densitySlopeLogarithmicCentral` method returning
dln ρ/dln r as r → 0, in the same sign convention as `densityGradientRadial`. Each consumer
then applies its own threshold — density needs a slope ≥ 0, projected density > −1,
enclosed mass > −3 — rather than the distribution trying to decide for them.

The default is `-huge(0.0d0)`, meaning *unknown*. Being the most negative representable
value, it behaves as an infinitely steep cusp and so fails every such test by ordinary
comparison, with no special case in consumers. A class whose central behavior has not been
established therefore produces an informative error rather than an exception — the safe
direction in which to be wrong.

Classes which already handle r=0 in `densityGradientRadial` delegate to it, so the limit is
stated once. Composites report the minimum over their components (their densities add, so
the steepest cusp wins, and an unknown slope propagates correctly); decorators delegate
where they use the undecorated solution, and truncation, acceleration, scaling and decay
delegate always. Tabulated profiles, accretion flows, heated and adiabatically contracted
profiles, Sérsic, and the finite-resolution profiles are deliberately left unknown.

## Consumers

| extractor | behavior at r=0 |
|---|---|
| `densityProfile`, `densityDMOProfile`, `cgmCoolingFunction` | refused unless the central density is finite |
| `projectedDensity` | refused for every distribution — see below |
| `projectedMass` | **now evaluated**: the shell solid-angle fraction vanishes, leaving the mass of any central point mass, matching what `massProfile` reports |
| `massProfile`, `rotationCurve`, `velocityDispersion` | already correct; untouched |

Where the property does not exist the model stops with an error naming the specifier (with
the element setting the radius scale highlighted, reusing the existing parse-error
formatting), the node and tree, why it could not be computed, and how to avoid it:

```
Radius specifier evaluates to a radius of zero:

   diskRadius:all:all:1.0

The `densityProfile` property extractor can not evaluate its property at zero radius here:
the density of this mass distribution diverges at zero radius.

The quantity on which this radius is based is zero in this node, which usually means that
the corresponding component is absent or empty there.

The radius was evaluated in node 3 of tree 6.

HELP: use a radius which is non-zero in every node---one specified as a fraction of the
virial radius, for example---or filter such nodes out of the output. Alternatively, set
<zeroRadiusIsFatal value="false"/> in this property extractor to write the undefined-value
sentinel in place of the property. See <docs URL> for an explanation of radius specifier
syntax.
```

Setting `zeroRadiusIsFatal` to `false` writes the undefined-value sentinel in place of the
property instead, for models where aborting at the first output is too costly. The radius
itself is still reported — unlike an undefined radius it is well defined, and reporting it
keeps the two conditions distinguishable in the output.

## Known limitation

`projectedDensity` refuses r=0 for *every* profile, which is more conservative than the
physics requires: Σ(0) converges for any slope exceeding −1. The obstruction is in the
implementation — the Abel integral runs in the logarithm of radius, and the analytic
cut-out evaluates the density at the radius itself — so relaxing it needs an inner cutoff
and an analytic core term. Split out as #1322.

## Testing

* `testSuite/test-radius-specifiers-zero.py` (new): the error is raised and names the
  specifier; the sentinel appears exactly where expected when suppressed; enclosed and
  projected masses agree at zero radius; and the finite central density of a β-profile hot
  halo is still evaluated at exactly zero radius.
* `test-radius-specifiers-soliton.py` (the undefined-radius path from #1313) passes.
* `test-decayingDM-profile.py` passes — exercises Zhao1996 γ=0 and γ=0.5 profiles and the
  decaying decorator.
* `tests.dark_matter_profiles.projected.exe` passes.
* `parameters/quickTest.xml` completes cleanly.

## Note for reviewers

Adding a method to a `functionClass` changes the vtable layout, and
`Makefile_Use_Dependencies` does not record `use` statements injected by the code
generator, so an incremental build fails with a derived-type mismatch until stale objects
are removed. Deleting the affected `.o` files (not the `.mod` files) and re-running
`make -k` converges. This is a pre-existing build-system gap, not something introduced
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
