### PR TITLE
fix(virialOrbits): make the lossCone class runnable (issue #1321)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1537,7 +1537,8 @@ jobs:
                 test-objectBuilder-recursion-success.py,
                 test-library-interfaces.py,
                 test-merger-tree-read-ties.py,
-                test-node-trajectory.py ]
+                test-node-trajectory.py,
+                test-virial-orbit-loss-cone.py ]
     uses: ./.github/workflows/testModel.yml
     with:
       file: ${{ matrix.file }}

--- a/source/satellites/merging/virial_orbits/loss_cone.F90
+++ b/source/satellites/merging/virial_orbits/loss_cone.F90
@@ -17,6 +17,9 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson. The fixes for issue #1321 were diagnosed and drafted with
+!+    assistance from Claude, and reviewed and verified by Andrew Benson.
+
   !!{RST
   An implementation of virial orbits using a loss cone model.
   !!}
@@ -727,7 +730,13 @@ contains
     double precision                                , parameter                       :: radiusTableMinimum                    =1.0d-2
     double precision                                , parameter                       :: radiusTableMaximum                    =1.0d+3
     integer                                         , parameter                       :: radiusTablePointsPerDecade            =20
-    integer                                         , parameter                       :: overdensityLimitLower                 =-10.0d0
+    double precision                                , parameter                       :: overdensityLimitLower                 =-10.0d0
+    ! The lower limit of the environmental overdensity integrals below is nominally "overdensityLimitLower" standard deviations
+    ! of the environmental density field. That can reach beyond the range over which the halo environment class is able to map
+    ! linear to nonlinear overdensity (which is tabulated by its spherical collapse solver over a fixed range of linear
+    ! overdensity), so the limit is clamped to the minimum of that range. Since the integrands are weighted by the (Gaussian)
+    ! environmental PDF, the truncated tail contributes negligibly, and the same factor appears in the normalizing integral.
+    double precision                                , parameter                       :: overdensityLinearMinimumMap           = -5.0d0
     integer                                                                           :: iHost                                          , iSatellite                                , &
          &                                                                               countProgress                                  , countTotal                                , &
          &                                                                               countMasses                                    , countVelocities                           , &
@@ -750,9 +759,10 @@ contains
          &                                                                               radiusInfallTerm2                              , factorEnvironmental                       , &
          &                                                                               massEnvironment                                , radiusEnvironment                         , &
          &                                                                               jacobianFactor                                 , jacobianSign                              , &
-         &                                                                               radiusEvaluateLagrangian
-    type            (interpolator                  )                                  :: interpolatorVelocityDispersionLinear
-    type            (integrator                    )                                  :: integratorEnvironment                          , integratorEnvironmentNormalizer
+         &                                                                               radiusEvaluateLagrangian                       , overdensityEnvironmentMinimum             , &
+         &                                                                               energyOrbitDoubled
+    type            (interpolator                  )                    , allocatable :: interpolatorVelocityDispersionLinear
+    type            (integrator                    )                    , allocatable :: integratorEnvironment                          , integratorEnvironmentNormalizer
     
     ! Read in any existing tabulation from file.
     call self%restoreTable()
@@ -785,10 +795,11 @@ contains
          &  .and.                                      &
          &   basicSatellite%mass() <= self%massMaximum &
          & ) return
-    ! Free existing tabulations.
+    ! Free existing tabulations. Note that "velocity" and "interpolatorVelocity" are *not* freed here---they are built once, by
+    ! the constructor, from parameters that do not change between tabulations, and are used (via "countVelocities" below, and by
+    ! the interpolants) throughout this and subsequent tabulations.
     if (allocated(self%mass)) then
        deallocate(self%mass                                )
-       deallocate(self%velocity                            )
        deallocate(self%velocityRadialMeanVirial            )
        deallocate(self%velocityRadialDispersionVirial      )
        deallocate(self%velocityTangentialMeanVirial        )
@@ -799,7 +810,6 @@ contains
        deallocate(self%velocityTotalRMS                    )
        deallocate(self%velocityDistributionPeak            )
        deallocate(self%interpolatorMass                    )
-       deallocate(self%interpolatorVelocity                )
     end if
     ! Set time for this tabulation.
     self%time=basicHost%time()
@@ -835,7 +845,7 @@ contains
     ! Iterate over host masses.
     countTotal   =(countMasses*(countMasses+1))/2
     countProgress=0
-    !$omp parallel private(iHost,iSatellite,massHost,massSatellite,tree,nodeHost,nodeSatellite,basicHost,basicSatellite,radiusVirialHost,velocityVirialHost,velocityDispersionLinear,indexVelocityRadial,indexVelocityTangential,velocityRadialVirial,velocityTangentialVirial,countVelocityRadialInfall,indexVelocityRadialInfall,velocityRadialInfall,radiusInfallTerm1,radiusInfallTerm2,radiiEvaluation,iEvaluate,radiusEvaluateVirial,timeEvaluate,radiusApocenterVirial,radiusPericenterVirial,timeOfFlightVirial,timeOfFlight,radiusEvaluate,radiusEvaluateComoving,velocityDispersionEvaluate,velocityRadialMeanEvaluate,velocityDispersionRadialEvaluateVirial,velocityDispersionTangentialEvaluateVirial,velocityMeanRadialEvaluateVirial,velocityTangentialInfall,jacobianFactor,jacobianDeterminant,distributionFunction,interpolatorVelocityDispersionLinear,integratorEnvironment,integratorEnvironmentNormalizer,factorEnvironmental,massEnvironment,radiusEnvironment)
+    !$omp parallel private(iHost,iSatellite,massHost,massSatellite,tree,nodeHost,nodeSatellite,basicHost,basicSatellite,radiusVirialHost,velocityVirialHost,velocityDispersionLinear,indexVelocityRadial,indexVelocityTangential,velocityRadialVirial,velocityTangentialVirial,countVelocityRadialInfall,indexVelocityRadialInfall,velocityRadialInfall,radiusInfallTerm1,radiusInfallTerm2,radiiEvaluation,iEvaluate,radiusEvaluateVirial,timeEvaluate,radiusApocenterVirial,radiusPericenterVirial,timeOfFlightVirial,timeOfFlight,radiusEvaluate,radiusEvaluateComoving,velocityDispersionEvaluate,velocityRadialMeanEvaluate,velocityDispersionRadialEvaluateVirial,velocityDispersionTangentialEvaluateVirial,velocityMeanRadialEvaluateVirial,velocityTangentialInfall,jacobianFactor,jacobianDeterminant,distributionFunction,interpolatorVelocityDispersionLinear,integratorEnvironment,integratorEnvironmentNormalizer,factorEnvironmental,massEnvironment,radiusEnvironment,overdensityEnvironmentMinimum,energyOrbitDoubled)
     allocate(tree                                                                          )
     allocate(     cosmologyFunctions_            ,mold=self%cosmologyFunctions_            )
     allocate(     cosmologyParameters_           ,mold=self%cosmologyParameters_           )
@@ -925,8 +935,26 @@ contains
      </constructor>
     </referenceConstruct>
     !!]
+    ! Allocate the per-thread integrators and interpolator. These are declared "allocatable" and allocated here---rather than
+    ! being plain (non-allocatable) variables in the "private" clause above---because gfortran does not apply default
+    ! initialization to the private copy of a derived type, contrary to OpenMP, which requires the new list item to be
+    ! initialized as if it had been locally declared without an initializer. Their reference-counting "resourceManager"
+    ! components would therefore start filled with stack garbage, and the first assignment to them (which finalizes the
+    ! left-hand side) would release that garbage: either blocking forever in OMP_Set_Lock() on a bogus lock pointer, or
+    ! writing through a bogus counter pointer (issue #1321). OpenMP *does* guarantee that private copies of allocatables begin
+    ! unallocated, and ALLOCATE applies default initialization, so this route is safe.
+    allocate(integratorEnvironment               )
+    allocate(integratorEnvironmentNormalizer     )
+    allocate(interpolatorVelocityDispersionLinear)
     integratorEnvironment          =integrator(integrand=integrandEnvironment             ,toleranceRelative=1.0d-3)
     integratorEnvironmentNormalizer=integrator(integrand=integrandEnvironmentNormalization,toleranceRelative=1.0d-3)
+    ! Find the lower limit for the integrals over environmental overdensity, clamped to the range over which the halo environment
+    ! is able to map linear to nonlinear overdensity (see "overdensityLinearMinimumMap" above).
+    overdensityEnvironmentMinimum=max(                                                                              &
+         &                            +overdensityLimitLower                                                        &
+         &                            *cosmologicalMassVariance_%rootVariance(mass=massEnvironment,time=self%time), &
+         &                            +overdensityLinearMinimumMap                                                  &
+         &                           )
     do iHost=1,countMasses
        ! Build host node.
        massHost           =  self%mass     (            iHost)
@@ -944,9 +972,9 @@ contains
        radiusVirialHost  =darkMatterHaloScale_%radiusVirial  (nodeHost)
        velocityVirialHost=darkMatterHaloScale_%velocityVirial(nodeHost)
        ! Compute the environmental boost factor for velocity dispersion.
-       timeEvaluate_      =+                                                                                                                                 self%time
-       factorEnvironmental=+integratorEnvironment          %integrate(overdensityLimitLower*cosmologicalMassVariance_%rootVariance(mass=massEnvironment,time=self%time),haloEnvironment_%overdensityLinearMaximum()) &
-            &              /integratorEnvironmentNormalizer%integrate(overdensityLimitLower*cosmologicalMassVariance_%rootVariance(mass=massEnvironment,time=self%time),haloEnvironment_%overdensityLinearMaximum())
+       timeEvaluate_      =+self                           %time
+       factorEnvironmental=+integratorEnvironment          %integrate(overdensityEnvironmentMinimum,haloEnvironment_%overdensityLinearMaximum()) &
+            &              /integratorEnvironmentNormalizer%integrate(overdensityEnvironmentMinimum,haloEnvironment_%overdensityLinearMaximum())
        ! Iterate over satellite masses.
        do iSatellite=1,countMasses          
           ! Only consider satellites less (or equally) massive than their host.
@@ -1015,10 +1043,15 @@ contains
                         &            +  velocityRadialVirial    **2 &
                         &            +  velocityTangentialVirial**2 &
                         &            -  velocityRadialInfall    **2
+                   !! Skip cases where the roots are complex, or where the quadratic is degenerate. Note that
+                   !! "radiusInfallTerm1" must be excluded when it is exactly zero (not merely when it is negative): that is the
+                   !! tangency at which the two roots coincide, and the determinant of the Jacobian evaluated below diverges
+                   !! there as 1/√(radiusInfallTerm1). This is an integrable singularity of measure zero in the integral over
+                   !! infall radial velocity, so neighboring steps of that integral capture its contribution.
                     if     (                            &
-                        &   radiusInfallTerm1 <  0.0d0 &
-                        &  .or.                        &
-                        &   radiusInfallTerm2 == 0.0d0 &
+                        &    radiusInfallTerm1 <= 0.0d0 &
+                        &   .or.                        &
+                        &    radiusInfallTerm2 == 0.0d0 &
                         & ) cycle
                    !! Evaluate both roots of the equation to give the radii at which the current radial velocity is achieved.
                    radiiEvaluation(1)=(-2.0d0-sqrt(radiusInfallTerm1))/2.0d0/radiusInfallTerm2
@@ -1032,21 +1065,32 @@ contains
                       ! field at that lookback time.                         
                       !! Compute the apocenter of the orbit. For unbound orbits the apocentric radius will be negative - this
                       !! is acceptable and is handled correctly by the function which evaluates the time of flight.
-                      radiusApocenterVirial =+(                                                                                                            &
-                           &                   -2.0d0                                                                                                      &
-                           &                   -sqrt(4.0d0+4.0d0*velocityTangentialVirial**2*(-2.0d0+velocityRadialVirial**2+velocityTangentialVirial**2)) &
-                           &                  )                                                                                                            &
-                           &                 /  2.0d0                                                                                                      &
-                           &                 /                                               (-2.0d0+velocityRadialVirial**2+velocityTangentialVirial**2)
-                      radiusPericenterVirial=+(                                                                                                            &
-                           &                   -2.0d0                                                                                                      &
-                           &                   +sqrt(4.0d0+4.0d0*velocityTangentialVirial**2*(-2.0d0+velocityRadialVirial**2+velocityTangentialVirial**2)) &
-                           &                  )                                                                                                            &
-                           &                 /  2.0d0                                                                                                      &
-                           &                 /                                               (-2.0d0+velocityRadialVirial**2+velocityTangentialVirial**2)
-                      timeOfFlightVirial   =+abs(                                                                                                            &
-                           &                     +timeAlongOrbit(radiusEvaluateVirial,radiusApocenterVirial,radiusPericenterVirial,velocityTangentialVirial) &
-                           &                     -timeAlongOrbit(1.0d0               ,radiusApocenterVirial,radiusPericenterVirial,velocityTangentialVirial) &
+                      !! Twice the specific energy of the orbit. The turning points are the roots of "2 E r² + 2 r - v_θ² = 0",
+                      !! so this is also the coefficient which vanishes for a marginally bound (parabolic) orbit, for which the
+                      !! quadratic degenerates to a linear equation with the single root r = v_θ²/2 and no apocenter.
+                      energyOrbitDoubled=-2.0d0+velocityRadialVirial**2+velocityTangentialVirial**2
+                      if (energyOrbitDoubled == 0.0d0) then
+                         radiusPericenterVirial=+0.5d0*velocityTangentialVirial**2
+                         !! There is no apocenter; retain the convention that a negative apocentric radius denotes an unbound
+                         !! orbit. The value is never used, as timeAlongOrbit() branches on the energy before reaching it.
+                         radiusApocenterVirial =-huge(0.0d0)
+                      else
+                         radiusApocenterVirial =+(                                                                  &
+                              &                   -2.0d0                                                            &
+                              &                   -sqrt(4.0d0+4.0d0*velocityTangentialVirial**2*energyOrbitDoubled) &
+                              &                  )                                                                  &
+                              &                 /  2.0d0                                                            &
+                              &                 /                                               energyOrbitDoubled
+                         radiusPericenterVirial=+(                                                                  &
+                              &                   -2.0d0                                                            &
+                              &                   +sqrt(4.0d0+4.0d0*velocityTangentialVirial**2*energyOrbitDoubled) &
+                              &                  )                                                                  &
+                              &                 /  2.0d0                                                            &
+                              &                 /                                               energyOrbitDoubled
+                      end if
+                      timeOfFlightVirial   =+abs(                                                                                                                               &
+                           &                     +timeAlongOrbit(radiusEvaluateVirial,radiusApocenterVirial,radiusPericenterVirial,velocityTangentialVirial,energyOrbitDoubled) &
+                           &                     -timeAlongOrbit(1.0d0               ,radiusApocenterVirial,radiusPericenterVirial,velocityTangentialVirial,energyOrbitDoubled) &
                            &                    )
                       timeOfFlight=+                     timeOfFlightVirial           &
                            &       *darkMatterHaloScale_%timescaleDynamical(nodeHost)
@@ -1349,9 +1393,35 @@ contains
     
   end subroutine lossConeTabulate
 
-  double precision function timeAlongOrbit(radius,radiusApocenter,radiusPericenter,velocityTangentialVirial)
+  double precision function timeAlongOrbit(radius,radiusApocenter,radiusPericenter,velocityTangentialVirial,energyDoubled)
     !!{RST
-    Compute the time taken along the orbit specified by the pericenter radius, ``radiusPericenter``, and the tangential velocity at the virial radius, ``velocityTangentialVirial``, to travel from the pericenter to the given radius, ``radius``. All quantities are in virial units. Writing
+    Compute the time taken along the orbit specified by the pericenter radius, ``radiusPericenter``, and the tangential velocity at the virial radius, ``velocityTangentialVirial``, to travel from the pericenter to the given radius, ``radius``. All quantities are in virial units. The argument ``energyDoubled`` is twice the specific orbital energy, :math:`2 E = -2 + v_\mathrm{r}^2 + v_\theta^2`, which selects between the bound, marginally bound, and unbound forms below.
+
+    The general expression given below is singular in two limits which are, in general, sampled by the tabulation grid, and which are therefore treated separately using their (elementary) closed forms:
+
+    * **Radial orbits** (:math:`v_\theta=0`). The pericentric radius is then zero---the orbit plunges to the origin---and the general expression diverges since it divides by :math:`r_\mathrm{p}`. The radial Kepler problem instead gives, for :math:`a` the semi-major axis,
+
+      .. math::
+
+         r = a (1-\cos \eta),  \,\,\, t = a^{3/2} (\eta - \sin \eta)
+
+      when bound (:math:`a = -1/2E`), and
+
+      .. math::
+
+         r = a (\cosh \eta - 1),  \,\,\, t = a^{3/2} (\sinh \eta - \eta)
+
+      when unbound (:math:`a = +1/2E`).
+
+    * **Marginally bound (parabolic) orbits** (:math:`E=0`). Here :math:`2 r_\mathrm{p} - v_\theta^2 = -2 E r_\mathrm{p}^2 = 0`, so the general expression divides by zero. Barker's equation instead gives
+
+      .. math::
+
+         t(r) = \sqrt{2 r_\mathrm{p}^3} \left( D + D^3/3 \right), \,\,\, D = \sqrt{r/r_\mathrm{p} - 1},
+
+      which reduces to the radial, marginally bound result :math:`t = \sqrt{2} r^{3/2}/3` as :math:`r_\mathrm{p} \rightarrow 0`.
+
+    Writing
 
     .. math::
 
@@ -1378,12 +1448,38 @@ contains
     use :: Numerical_Constants_Math, only : Pi
     implicit none
     double precision, intent(in   ) :: radiusApocenter          , velocityTangentialVirial , &
-         &                             radiusPericenter         , radius
+         &                             radiusPericenter         , radius                   , &
+         &                             energyDoubled
     double precision, parameter     :: timeInfinite     =1.0d100
+    double precision                :: semiMajorAxis            , anomaly
     double complex                  :: radiusPericenter_        , velocityTangentialVirial_, &
          &                             timeAlongOrbit_          , radius_
-    
-    if (radius == radiusPericenter) then
+
+    if      (velocityTangentialVirial == 0.0d0) then
+       ! A purely radial orbit. The pericentric radius is zero, so the general expression below---which divides by it---is
+       ! singular. Use instead the elementary solution of the radial Kepler problem.
+       if      (energyDoubled <  0.0d0) then
+          ! Bound.
+          semiMajorAxis =-1.0d0/energyDoubled
+          !! Clamp the argument of the arccosine, which can exceed unity in magnitude by a rounding error when the radius
+          !! reaches the apocenter.
+          anomaly       =acos(max(-1.0d0,min(+1.0d0,1.0d0-radius/semiMajorAxis)))
+          timeAlongOrbit=semiMajorAxis**1.5d0*(anomaly-sin(anomaly))
+       else if (energyDoubled         == 0.0d0) then
+          ! Marginally bound.
+          timeAlongOrbit=sqrt(2.0d0)*radius**1.5d0/3.0d0
+       else
+          ! Unbound.
+          semiMajorAxis =+1.0d0/energyDoubled
+          anomaly       =acosh(1.0d0+radius/semiMajorAxis)
+          timeAlongOrbit=semiMajorAxis**1.5d0*(sinh(anomaly)-anomaly)
+       end if
+    else if (energyDoubled            == 0.0d0) then
+       ! A marginally bound (parabolic) orbit with non-zero angular momentum. Here 2 rₚ - v_θ² = -2 E rₚ² vanishes, so the general
+       ! expression below divides by zero. Use Barker's equation instead.
+       anomaly       =sqrt(max(0.0d0,radius/radiusPericenter-1.0d0))
+       timeAlongOrbit=sqrt(2.0d0*radiusPericenter**3)*(anomaly+anomaly**3/3.0d0)
+    else if (radius == radiusPericenter) then
        ! The time at the pericenter is zero by construction.
        timeAlongOrbit=0.0d0
     else if (radiusApocenter > 0.0d0 .and. radius >= radiusApocenter) then
@@ -1442,9 +1538,10 @@ contains
     if (.not.self%fileRead.and.File_Exists(self%fileName)) then
        ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
        call File_Lock(char(self%fileName),fileLock,lockIsShared=.true.)
+       ! As in tabulate(), "velocity" and "interpolatorVelocity" are constructor-built and are not restored from file, so they
+       ! must not be freed here.
        if (allocated(self%mass)) then
           deallocate(self%mass                                )
-          deallocate(self%velocity                            )
           deallocate(self%velocityRadialMeanVirial            )
           deallocate(self%velocityRadialDispersionVirial      )
           deallocate(self%velocityTangentialMeanVirial        )
@@ -1472,7 +1569,11 @@ contains
        !$ call hdf5Access%unset()
        call File_Unlock(fileLock)
        self%fileRead=.true.
-       ! Rebuild interpolator.
+       ! Rebuild interpolator. It must be allocated first: "interpolator" has a defined assignment, so assigning to it does not
+       ! cause automatic allocation, and its assignment finalizes the left-hand side---which, if unallocated, means finalizing
+       ! garbage. On this path the interpolator is always unallocated: it is either freed above, or was never built, since it is
+       ! constructed only by tabulate().
+       if (.not.allocated(self%interpolatorMass)) allocate(self%interpolatorMass)
        self%interpolatorMass=interpolator(log(self%mass))
     end if
     return

--- a/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
@@ -17,6 +17,9 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson. The fix for issue #1321 was diagnosed and drafted with
+!+    assistance from Claude, and reviewed and verified by Andrew Benson.
+
   !!{RST
   A spherical collapse solver class for universes consisting of collisionless matter and a cosmological constant.
   !!}
@@ -686,7 +689,6 @@ contains
          &                                                                                             iOverdensityLinear                    , iOverdensity                      , &
          &                                                                                             iTime
     type            (lockDescriptor                                  )                              :: fileLock
-    type            (hdf5File                                        )                              :: file
 
     ! Check that we have a linear growth object.
     if (.not.associated(self%linearGrowth_)) call Error_Report('no linearGrowth object was supplied'//{introspection:location})
@@ -704,12 +706,18 @@ contains
           ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
           call File_Lock(self%fileNameNonLinearMap,fileLock,lockIsShared=.true.)
           !$ call hdf5Access%set()
-          file=hdf5File(self%fileNameNonLinearMap)
-          call file%readDataset('time'               ,times               )
-          call file%readDataset('overdensitiesLinear',overdensitiesLinear )
-          call file%readDataset('linearNonlinearMap' ,linearNonlinearMap__)
+          ! The file object is scoped to this block so that it is finalized---and so the file closed---before the file lock is
+          ! released. Otherwise the file remains open within this process after the lock is dropped, and a subsequent attempt to
+          ! (re)create it, here or in another thread, fails with "unable to truncate a file which is already open".
+          hdf5ReadScope: block
+            type(hdf5File) :: file
+            file=hdf5File(self%fileNameNonLinearMap)
+            call file%readDataset('time'               ,times               )
+            call file%readDataset('overdensitiesLinear',overdensitiesLinear )
+            call file%readDataset('linearNonlinearMap' ,linearNonlinearMap__)
+          end block hdf5ReadScope
           !$ call hdf5Access%unset()
-          call File_Unlock(fileLock)       
+          call File_Unlock(fileLock)
           ! Test if map has sufficient extent.
           if     (                           &
                &   time < times(         1 ) &
@@ -915,12 +923,16 @@ contains
           ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
           call File_Lock(self%fileNameNonLinearMap,fileLock,lockIsShared=.false.)
           !$ call hdf5Access%set()
-          file=hdf5File(self%fileNameNonLinearMap,overWrite=.true.,readOnly=.false.)
-          call file%writeDataset(times               ,'time'               )
-          call file%writeDataset(overdensitiesLinear ,'overdensitiesLinear')
-          call file%writeDataset(linearNonlinearMap__,'linearNonlinearMap' )
+          ! As for the read above, the file object is scoped to this block so that the file is closed before the lock is released.
+          hdf5WriteScope: block
+            type(hdf5File) :: file
+            file=hdf5File(self%fileNameNonLinearMap,overWrite=.true.,readOnly=.false.)
+            call file%writeDataset(times               ,'time'               )
+            call file%writeDataset(overdensitiesLinear ,'overdensitiesLinear')
+            call file%writeDataset(linearNonlinearMap__,'linearNonlinearMap' )
+          end block hdf5WriteScope
           !$ call hdf5Access%unset()
-          call File_Unlock(fileLock)       
+          call File_Unlock(fileLock)
        end if
        ! Cache a copy of the map.
        !$omp critical(sphrclCllpsCllsnlssMttrCsmlgclCnstntNonLinCache)

--- a/source/tasks/mass_function_covariance.F90
+++ b/source/tasks/mass_function_covariance.F90
@@ -17,6 +17,9 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson. The fix for issue #1321 was diagnosed and drafted with
+!+    assistance from Claude, and reviewed and verified by Andrew Benson.
+
   use :: Conditional_Mass_Functions, only : conditionalMassFunction, conditionalMassFunctionClass
   use :: Cosmology_Functions       , only : cosmologyFunctions     , cosmologyFunctionsClass
   use :: Dark_Matter_Halo_Biases   , only : darkMatterHaloBias     , darkMatterHaloBiasClass
@@ -1199,7 +1202,7 @@ contains
          &                                                                           taskCount                    , taskTotal
     double precision                                                              :: wavenumberMinimum            , wavenumberMaximum, &
          &                                                                           distanceMaximum
-    type            (integrator                )                                  :: integrator_
+    type            (integrator                )                , allocatable     :: integrator_
 
     countFields=self_%surveyGeometry_%fieldCount()
     !$ call OMP_Set_Max_Active_Levels(OMP_Get_Supported_Active_Levels())
@@ -1221,6 +1224,12 @@ contains
     allocate(selfCopy%timeMinimumJ        (countFields))
     allocate(selfCopy%timeMaximumI        (countFields))
     allocate(selfCopy%timeMaximumJ        (countFields))
+    ! The integrator is declared "allocatable" and allocated here, rather than being a plain variable in the "private" clause
+    ! above, because gfortran does not apply default initialization to the private copy of a derived type which has no
+    ! allocatable components. Its reference-counting "resourceManager" components would therefore start filled with stack
+    ! garbage, and the assignment below (which finalizes the left-hand side) would release that garbage, either blocking forever
+    ! in OMP_Set_Lock() on a bogus lock pointer or writing through a bogus counter pointer (see issue #1321).
+    allocate(integrator_)
     integrator_=integrator(massFunctionCovarianceAngularPowerIntegrand,toleranceRelative=1.0d-2)
     !$omp do schedule (dynamic)
     do i=1,massBinCount

--- a/testSuite/parameters/test-virial-orbit-loss-cone.xml
+++ b/testSuite/parameters/test-virial-orbit-loss-cone.xml
@@ -1,0 +1,333 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Regression test for the "lossCone" virial orbit class (issue #1321).                      -->
+
+<!-- This class deadlocked and could not be run at all. The defects were only reachable once a -->
+<!-- model actually drove a tabulation, so this test simply runs a small model which uses the  -->
+<!-- class, with the tabulation grid chosen (see below) to sample the degenerate cases which   -->
+<!-- must be special-cased.                                                                    -->
+
+<!-- Andrew Benson                                                                             -->
+
+<!-- 03-August-2026                                                                            -->
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard">
+    <starveSatellites value="false"/>
+  </componentHotHalo>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <ratioAngularMomentumScaleRadius value="0.5"/>
+    <efficiencyEnergeticOutflow value="1.0e-2"/>
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeSeeds value="random"/>
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMinimum value="1.0e10"/>
+    <massTreeMaximum value="1.0e13"/>
+    <treesPerDecade value="2"/>
+  </mergerTreeBuildMasses>
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="gao2008"/>
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="simple">
+    <redshiftReionization value="10.5"/>
+    <velocitySuppressionReionization value="35.0"/>
+  </accretionHalo>
+
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="5.0"/>
+  </hotHaloOutflowReincorporation>
+  <hotHaloOutflowStripping value="standard">
+     <efficiency value="0.1"/>
+  </hotHaloOutflowStripping>
+  <coolingInfallTorque value="fixed">
+     <fractionLossAngularMomentum value="0.3"/>
+  </coolingInfallTorque>
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0"/>
+  </coolingTimeAvailable>
+  <circumgalacticMediumHeating value="AGNFeedback"/>
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <!-- Galactic structure solver options -->
+  <galacticStructureSolver value="equilibrium"/>
+  <darkMatterProfile value="adiabaticGnedin2004">
+    <A value="0.73"/>
+    <omega value="0.7"/>
+  </darkMatterProfile>
+  <!-- Star formation rate options -->
+  <starFormationRateDisks value="intgrtdSurfaceDensity"/>
+  <starFormationRateSurfaceDensityDisks value="krumholz2009">
+    <frequencyStarFormation value="0.385"/>
+    <clumpingFactorMolecularComplex value="5.000"/>
+    <molecularFractionFast value="true"/>
+  </starFormationRateSurfaceDensityDisks>
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.04"/>
+      <exponentVelocity value="2.0"/>
+      <timescaleMinimum value="0.001"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="instantaneous"/>
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+
+  <initialMassFunction value="chabrier2001"/>
+  <stellarPopulation value="standard">
+    <recycledFraction value="0.46"/>
+    <metalYield value="0.035"/>
+  </stellarPopulation>
+
+  <!-- AGN feedback options -->
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
+  <!-- Accretion disk properties -->
+  <accretionDisks value="switched">
+    <accretionRateThinDiskMaximum value="0.30"/>
+    <accretionRateThinDiskMinimum value="0.01"/>
+    <scaleADAFRadiativeEfficiency value="true"/>
+    <accretionDisksShakuraSunyaev value="shakuraSunyaev"/>
+    <accretionDisksADAF value="ADAF">
+      <efficiencyRadiationType value="thinDisk"/>
+      <adiabaticIndex value="1.444"/>
+      <energyOption value="pureADAF"/>
+      <efficiencyRadiation value="0.01"/>
+      <viscosityOption value="fit"/>
+    </accretionDisksADAF>
+  </accretionDisks>
+
+  <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+  </blackHoleAccretionRate>
+  <blackHoleBinaryMerger value="rezzolla2008"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="lossCone">
+    <!-- A deliberately coarse tabulation: this test exercises the code paths of this class, it does not aim  -->
+    <!-- to produce a converged orbital distribution. The velocity grid (0, 0.5, 1, 1.5, 2) is chosen to      -->
+    <!-- include both degenerate cases which the class must special-case: purely radial orbits (v_theta=0),   -->
+    <!-- for which the pericentric radius vanishes, and marginally bound orbits (v_r^2+v_theta^2=2, i.e.      -->
+    <!-- v_r=v_theta=1), for which the turning-point quadratic degenerates. Both were division-by-zero        -->
+    <!-- floating point exceptions prior to the fixes for issue #1321.                                        -->
+    <velocityMinimum value="0.0"/>
+    <velocityMaximum value="2.0"/>
+    <countVelocitiesPerUnit value="2"/>
+    <countMassesPerDecade value="1"/>
+    <correlationFunctionTwoPoint value="powerSpectrumTransform">
+      <powerSpectrum value="standard"/>
+    </correlationFunctionTwoPoint>
+    <cosmologicalVelocityField value="filteredPower">
+      <correlationFunctionTwoPoint value="powerSpectrumTransform">
+        <powerSpectrum value="standard"/>
+      </correlationFunctionTwoPoint>
+    </cosmologicalVelocityField>
+  </virialOrbit>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"/>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+    <nodeOperator value="starFormationSpheroids"/>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="250.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="100.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <!-- Bar instability in galactic disks -->
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="0.7"/>
+	<stabilityThresholdStellar value="1.1"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <!-- Black hole physics -->
+    <nodeOperator value="blackHolesSeed">
+      <blackHoleSeeds value="fixed">
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
+    </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <!-- CGM physics -->
+    <nodeOperator value="CGMAccretion">
+      <allowNegativeCGMMass value="true"/>
+      <angularMomentumAlwaysGrows value="false"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOutflowReincorporation">
+      <includeSatellites value="true"/>
+    </nodeOperator>
+    <nodeOperator value="CGMCoolingHeating">
+      <component value="disk"/>
+      <coolingFrom value="currentNode"/>
+      <excessHeatDrivesOutflow value="true"/>
+      <rateMaximumExpulsion value="1.0"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <outputFileName value="testSuite/outputs/test-virial-orbit-loss-cone.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+
+</parameters>

--- a/testSuite/test-virial-orbit-loss-cone.py
+++ b/testSuite/test-virial-orbit-loss-cone.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Regression test for the ``lossCone`` virial orbit class (issue #1321).
+
+The class deadlocked and could not be run at all. The defects it carried were
+reachable only once a model actually drove a tabulation, and they failed in
+three distinct ways---an unbreakable hang, a segmentation fault, and floating
+point exceptions---so this test runs a small model which uses the class and
+checks for all three:
+
+* the run is given a wall-clock timeout, so a re-introduced deadlock fails the
+  test promptly rather than hanging the CI job until its own (multi-hour)
+  timeout;
+* the run must exit cleanly, with no error markers in its log;
+* the resulting galaxy properties must all be finite, so that a re-introduced
+  divide-by-zero which is *not* trapped cannot pass silently as a NaN.
+
+The model is run multi-threaded because the class tabulates inside a nested
+OpenMP parallel region, and that nesting is what surfaced both the original
+deadlock and a cache-file collision between threads.
+
+Andrew Benson (03-August-2026)
+"""
+
+import os
+import subprocess
+import sys
+
+import h5py
+import numpy as np
+
+# The tabulation is coarse (see the parameter file), but it is still by far the dominant cost of this model, which takes
+# around 15s locally. Allow ample headroom over that so that a slow runner does not produce a spurious failure, while still
+# failing far sooner than the CI job timeout if the class deadlocks.
+timeoutSeconds = 900
+
+pathParameters      = os.path.abspath("parameters/test-virial-orbit-loss-cone.xml" )
+pathOutputDirectory = os.path.abspath("outputs"                                    )
+pathOutputLog       = os.path.abspath("outputs/test-virial-orbit-loss-cone.log"     )
+pathOutputModel     = os.path.abspath("outputs/test-virial-orbit-loss-cone.hdf5"    )
+
+os.makedirs(pathOutputDirectory,exist_ok=True)
+if os.path.exists(pathOutputModel):
+    os.remove(pathOutputModel)
+
+# Run the model, under a timeout so that a deadlock is reported as a failure.
+print("Running model...")
+environment                    = os.environ.copy()
+environment["OMP_NUM_THREADS"] = environment.get("OMP_NUM_THREADS","4")
+with open(pathOutputLog,"w") as log:
+    try:
+        status = subprocess.run(
+            f"cd ..; ./Galacticus.exe {pathParameters}",
+            stdout  = log,
+            stderr  = log,
+            shell   = True,
+            env     = environment,
+            timeout = timeoutSeconds,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"FAILED: model run did not complete within {timeoutSeconds}s - the lossCone class may be deadlocked")
+        sys.exit(0)
+print("...done ("+str(status)+")")
+if status.returncode != 0:
+    print("FAILED: model run:")
+    subprocess.run(f"cat {pathOutputLog}",shell=True)
+    sys.exit(0)
+
+# Check the log for errors. A floating point exception (which is how several of the defects in this class manifested) is
+# reported through this path.
+print("Checking for errors...")
+status = subprocess.run(
+    "grep -q -i"
+    " -e fatal"
+    " -e aborted"
+    " -e \"floating point exception\""
+    " -e \"Galacticus experienced an error in the GSL library\""
+    f" {pathOutputLog}",
+    shell=True,
+)
+if status.returncode == 0:
+    print("FAILED: model run (errors):")
+    subprocess.run(f"cat {pathOutputLog}",shell=True)
+    sys.exit(0)
+print("SUCCESS: model run")
+
+# Validate the output. The orbital parameters drawn from this class feed the merging satellite calculations, so a
+# non-finite orbit propagates into the galaxy properties. Checking for finiteness catches a re-introduced division by
+# zero which happens not to be trapped.
+countNodes = 0
+countBad   = 0
+with h5py.File(pathOutputModel,"r") as model:
+    for outputName, output in model["Outputs"].items():
+        if "nodeData" not in output:
+            continue
+        for propertyName, property_ in output["nodeData"].items():
+            values = property_[:]
+            if not np.issubdtype(values.dtype,np.floating):
+                continue
+            if propertyName == "nodeIndex":
+                continue
+            countNodes = max(countNodes,values.size)
+            if not np.all(np.isfinite(values)):
+                countBad += 1
+                print(f"FAILED: non-finite values in {outputName}/nodeData/{propertyName}")
+
+if countNodes == 0:
+    print("FAILED: model produced no galaxies - the test is not exercising the lossCone class")
+    sys.exit(0)
+if countBad > 0:
+    sys.exit(0)
+
+print(f"SUCCESS: virial orbit lossCone ({countNodes} galaxies, all properties finite)")


### PR DESCRIPTION
## Summary
- Fixes #1321. The `lossCone` virial orbit class deadlocked and could not be run at all; it is registered and selectable but referenced nowhere in the repository, so every one of its failure modes had gone unnoticed.
- **Root cause of the deadlock** (not the `virialOrbitLossConeDeepCopy` re-entry suggested in the issue, which is ruled out): three reference-counted, finalizable objects were listed in the `!$omp parallel private(...)` clause of `lossConeTabulate`. gfortran does not apply default initialization to the private copy of a derived type which has **no allocatable components**, so each thread's copy began as stack garbage. The first assignment finalizes the left-hand side, so `resourceManagerRelease` ran on garbage: it cleared its `associated(counter)` guard on a non-null garbage pointer and then either blocked forever in `OMP_Set_Lock()` on a bogus lock pointer — an unbreakable self-deadlock, even single-threaded — or wrote through a bogus counter pointer. The reported hang and a segfault are the same defect, decided by whatever occupied the stack slot. Fixed by declaring the objects `allocatable` and allocating them inside the region; OpenMP *does* guarantee private copies of allocatables begin unallocated, and `ALLOCATE` applies default initialization.
- Clearing the deadlock exposed **five further defects** in the class, all on paths which had never executed: the two retabulation defects noted in the issue; the environmental overdensity integral running beyond the range over which the halo environment can map linear to nonlinear overdensity; a divide-by-zero at the turning-point tangency; `timeAlongOrbit` being singular for radial and marginally bound orbits (both sampled by the tabulation grid), now handled with their elementary closed forms — radial Kepler and Barker's equation; and an assignment to an unallocated `interpolatorMass`.
- Two defects **outside the class** were also involved: `cllsnlssMttCsmlgclCnstntLinearNonlinearMap` released its file lock while the HDF5 file was still open (so a later create-with-truncate failed with *"unable to truncate a file which is already open"*), and `massFunctionCovarianceLSSAngularSpectrum` carried the same uninitialized-`private` hazard.
- Full diagnosis, including the `gdb` evidence, is in https://github.com/galacticusorg/galacticus/issues/1321#issuecomment-5172678023.

The gfortran behaviour appears to be non-conforming — OpenMP requires the new list item to be initialized "as if it had been locally declared without an initializer" — and will be reported upstream (reproduced at `-O0` and `-O3` on 16.0.1 20260322, trunk r16-8246). Once a PR number exists it is worth attaching a `<workaround type="gfortran" PR="…">` directive at the two fixed sites. Note that types which *do* have allocatable components are unaffected, as gfortran zeroes those copies — which is why this had gone unnoticed elsewhere.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
```bash
export GALACTICUS_EXEC_PATH=`pwd`
make -j2 Galacticus.exe
./Galacticus.exe parameters/quickTest.xml          # unaffected
cd testSuite && ./test-virial-orbit-loss-cone.py   # new regression test, ~15s
```

The class now runs and produces a physically sensible distribution: mean tangential velocity 0.846 in virial units, against the 0.842 used by the `fixed` class. Verified single- and multi-threaded, and on both the cold and warm (cache-restore) paths — these differ, since a cold run always takes the tabulate-and-store path and never exercises the restore path.

## Checklist
- [x] I ran relevant tests (or explain why not): `quickTest` passes; the new `test-virial-orbit-loss-cone.py` passes cold and warm. The new test is registered in the CI `Miscellaneous` matrix. It runs the model multi-threaded so the nested parallel region is exercised, under a wall-clock timeout so a re-introduced deadlock fails promptly rather than hanging the CI job for its own multi-hour timeout, and checks for a clean exit, error markers in the log, and that all output properties are finite. It caught the unallocated `interpolatorMass` defect before it was committed.
- [x] I updated documentation/comments if needed: the new `timeAlongOrbit` branches are documented in its RST docstring, and each fix carries a comment explaining the failure it prevents.
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

Diagnosed and drafted with assistance from Claude; reviewed and verified by Andrew Benson.
