### PR TITLE
docs: fix assorted defects found while auditing the component documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,8 +120,10 @@ templates_path = ['_templates']
 html_static_path = ['_static']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-# The physics pages are generated; do not fail the build on the occasional
-# duplicate label that can arise from auto-generated cross-reference anchors.
+# ``epub.unknown_project_files``: the epub builder warns about the generated
+# ``_figures`` assets it does not know how to package.  ``misc.highlighting_failure``:
+# some embedded snippets are pseudo-code that Pygments cannot lex.  Neither is
+# actionable, and neither should fail the build.
 suppress_warnings = ['epub.unknown_project_files', 'misc.highlighting_failure']
 
 

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -1107,7 +1107,7 @@ Parameterized Derived Types
 Fortran *parameterized derived types* (PDTs)---derived types carrying ``kind`` and/or ``len`` type parameters, for example ``type :: tensor(rank, dimension)`` instantiated as ``type(tensor(2, 3)) :: t``---are **not supported** in the Galacticus source code. The build parser detects both PDT definitions (``type :: name(...)``) and parameterized declarations (``type(name(...)) :: ...``) and aborts the build with an explicit error. This is a deliberate design decision, not an oversight; the reasoning and the (narrow) conditions under which it might be revisited are recorded here so the question has a durable answer.
 
 Why PDTs are not used
-'''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^^
 
 * **The build toolchain cannot represent them.** Every source file is parsed by the in-house preprocessor (:galacticus-ref:`sourceTreePreprocessor`), whose type-definition and declaration recognizers do not understand type-parameter lists. A PDT would fail to be recognized as a type and would be *silently* dropped from the generated state-store, deep-copy, source-digest, and module-dependency code---a wrong-behavior failure rather than a compile error. Rather than leave that trap open, the parser rejects PDT syntax loudly (see issue `#114 <https://github.com/galacticusorg/galacticus/issues/114>`_).
 
@@ -1116,12 +1116,12 @@ Why PDTs are not used
 * **Compiler maturity and language direction.** PDTs are among the least-mature features of the supported compiler, and the Fortran standards committee's chosen direction for generic programming is the templates facility of Fortran 2028, not PDTs. Investing in PDTs would be a detour rather than a step along that path; the generic-programming directives are, in effect, a home-grown template mechanism that native templates could eventually replace.
 
 Adding new fixed-size numeric types
-'''''''''''''''''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If a family of fixed-size numeric types is ever needed (for example, tensor shapes beyond the existing rank-2, dimension-3, symmetric tensor used for tidal fields), implement it with the generic-programming preprocessor directives (:galacticus-ref:`genericProgramming`), supplying any per-shape packing or contraction conventions as instance attributes---**not** as a PDT.
 
 When to revisit
-'''''''''''''''
+^^^^^^^^^^^^^^^
 
 Reconsider PDT support only if *all* of the following hold: (a) a concrete need arises for a family of fixed-size numeric types differing *only* in a compile-time size or kind within a single intrinsic type; (b) the generic-programming directives are a demonstrably poor fit; (c) the supported ``gfortran`` release has carried mature, bug-quiet PDT support for several releases; and (d) the preprocessor's type-definition and declaration parsers (plus the state-store, deep-copy, and dependency generators) have been extended to represent type parameters. Even then, support should be restricted to ``kind`` parameters---``len``-parameterized PDTs should be considered permanently out of scope on performance and portability grounds.
 Allocations

--- a/docs/manuals/developer-guide/creating-a-new-class.rst
+++ b/docs/manuals/developer-guide/creating-a-new-class.rst
@@ -127,6 +127,8 @@ The next line:
 
 declares that all content of this module is private by default - it cannot be exported to other parts of the code unless explicitly made public. Setting this default is also good practice - it prevents the rest of the code from accessing module content that it shouldn't. Of course, our module needs to export *something* in order to be useful! Galacticus knows that it needs to exploit that class that we are about to create in this module, and will do so automatically.
 
+.. _new-class-the-class:
+
 The class!
 ^^^^^^^^^^
 
@@ -464,6 +466,8 @@ This is in XML format (because it's inside a ``!![`` ``!!]`` section). The openi
 
 The remainder of this section is a ``description`` element, which should give a detailed description of this implementation - the physics it implements, any relevant equations and references. This should be in reStructuredText format, as it will be incorporated into the ReadTheDocs documentation.
 
+.. _new-class-implementation-type:
+
 The implementation ``type``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -582,6 +586,8 @@ Last, we close the type:
 
      end type starFormationTimescaleHaloScaling
 
+.. _new-class-list-of-constructors:
+
 List of constructors
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -624,7 +630,7 @@ indicates that we've reached the end of this, and are ready to start the actual 
 Constructors
 ^^^^^^^^^^^^
 
-The first functions we define are constructors. `Above <#list-of-constructors>`_, in our list of constructors, we named two constructor functions. Each of these must return as its result an object of our implementation type, ``starFormationTimescaleHaloScaling``, fully initialized so that it is ready to use. Constructor functions are named by starting with the non-class part of our implementation name (so, take ``starFormationTimescaleHaloScaling``, remove the ``starFormationTimescale``, leaving just ``haloScaling``).
+The first functions we define are constructors. :ref:`Above <new-class-list-of-constructors>`, in our list of constructors, we named two constructor functions. Each of these must return as its result an object of our implementation type, ``starFormationTimescaleHaloScaling``, fully initialized so that it is ready to use. Constructor functions are named by starting with the non-class part of our implementation name (so, take ``starFormationTimescaleHaloScaling``, remove the ``starFormationTimescale``, leaving just ``haloScaling``).
 
 Two constructors is typical, but only the first is actually required. In our example, the two constructor functions are:
 
@@ -717,7 +723,7 @@ The ``implicit none`` just enforces that we must explicitly declare all variable
 
 The first of these lines defines our ``self`` object - the thing we will construct. It must be defined as a ``type()`` of our implementation type, ``starFormationTimescaleHaloScaling``. The second line defines the argument - for this constructor that is always the ``parameters`` argument and *must* have the form given above.
 
-After these, we typically have any variables that we need to get from the parameter file so that we can build our object. These will include any pointers to other classes (e.g. ``cosmologyFunctions_`` here), and parameters to be read from the parameter file. Note that the names of these should match the name of the corresponding entry in the `implementation type <#the-implementation-type>`_.
+After these, we typically have any variables that we need to get from the parameter file so that we can build our object. These will include any pointers to other classes (e.g. ``cosmologyFunctions_`` here), and parameters to be read from the parameter file. Note that the names of these should match the name of the corresponding entry in the :ref:`implementation type <new-class-implementation-type>`.
 
 .. note::
 
@@ -868,6 +874,8 @@ We then just return our constructed object and finish the function.
        return
      end function haloScalingConstructorInternal
 
+.. _new-class-autohook:
+
 The ``autoHook`` method
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -893,7 +901,7 @@ It takes a single argument, ``self``, which must be declared with:
 
        class(starFormationTimescaleHaloScaling), intent(inout) :: self
 
-This is the object that was created/copied. In this example, we're using the ``autoHook`` method to attach our object to the ``calculationReset`` event. We won't go into detail about this event (or events in general) here, but, briefly, the ``calculationReset`` event is called every time Galacticus updates a node in a merger tree. Since our implementation uses memoization to store and re-use results of its calculations it needs to know when those stored results are no longer valid. The ``calculationReset`` event lets it know that. We tell the ``calculationReset`` event to call our function `haloScalingCalculationReset <#other-functions>`_ as needed.
+This is the object that was created/copied. In this example, we're using the ``autoHook`` method to attach our object to the ``calculationReset`` event. We won't go into detail about this event (or events in general) here, but, briefly, the ``calculationReset`` event is called every time Galacticus updates a node in a merger tree. Since our implementation uses memoization to store and re-use results of its calculations it needs to know when those stored results are no longer valid. The ``calculationReset`` event lets it know that. We tell the ``calculationReset`` event to call our function :ref:`haloScalingCalculationReset <new-class-other-functions>` as needed.
 
 Destructor
 ^^^^^^^^^^
@@ -926,7 +934,7 @@ Destructors have a single ``self`` argument, declared as:
 
 In our example, there are two things we need to do in our destructor:
 
-#. Detach from the ``calculationReset`` event (that we attached to in via the `autoHook <#the-autohook-method>`_ method);
+#. Detach from the ``calculationReset`` event (that we attached to in via the :ref:`autoHook <new-class-autohook>` method);
 #. Destroy any objects that we kept pointers to in our object. This is done using the ``objectDestructor`` directive. For example:
 
 .. code-block:: xml
@@ -935,10 +943,12 @@ In our example, there are two things we need to do in our destructor:
 
 tells Galacticus that we are done with the object pointed to by ``self%cosmologyFunctions_``. It will update the reference count to this object, and, if it decides the object is no longer in use anywhere, it will destroy it.
 
+.. _new-class-other-functions:
+
 Other functions
 ^^^^^^^^^^^^^^^
 
-In our example implementation we also have a function ``haloScalingCalculationReset`` that will be called by the ``calculationReset`` event (see `above <#the-autohook-method>`_ for details). We won't go into details about this function, but note that it simply resets the state of our implementation's memoization variables, forcing them to be recomputed as needed.
+In our example implementation we also have a function ``haloScalingCalculationReset`` that will be called by the ``calculationReset`` event (see :ref:`above <new-class-autohook>` for details). We won't go into details about this function, but note that it simply resets the state of our implementation's memoization variables, forcing them to be recomputed as needed.
 
 The physics!
 ^^^^^^^^^^^^
@@ -997,13 +1007,13 @@ We start by opening the function:
 
      double precision function haloScalingTimescale(self,component) result(timescale)
 
-The type of the function (``double precision``) and the names of the arguments *must* match precisely with those defined in our `class <#the-class>`_. The name of the ``result`` can be whatever you want, but typically it makes sense to set this to match the method name, i.e. ``result(timescale)`` in this example. The declarations of the ``self`` argument must be:
+The type of the function (``double precision``) and the names of the arguments *must* match precisely with those defined in our :ref:`class <new-class-the-class>`. The name of the ``result`` can be whatever you want, but typically it makes sense to set this to match the method name, i.e. ``result(timescale)`` in this example. The declarations of the ``self`` argument must be:
 
 .. code-block:: fortran
 
        class           (starFormationTimescaleHaloScaling), intent(inout) :: self
 
-and other arguments must match their definitions in our `class <#the-class>`_:
+and other arguments must match their definitions in our :ref:`class <new-class-the-class>`:
 
 .. code-block:: fortran
 

--- a/docs/manuals/developer-guide/versions-and-releases.rst
+++ b/docs/manuals/developer-guide/versions-and-releases.rst
@@ -107,6 +107,7 @@ therefore lightweight:
    GitHub release, mirroring the current ``bleeding-edge`` binary and tools
    assets onto it (see `Publishing the Python Package to PyPI`_ below). This is
    what makes ``pip install galacticus`` resolve to the new version.
+
 The publish workflow also pins the run-time data: it records the current
 ``datasets`` ``master`` commit as a ``datasets.ref`` asset on the release and
 notes that commit in the release body, so every install of that version (whether

--- a/docs/manuals/user-guide/advanced.rst
+++ b/docs/manuals/user-guide/advanced.rst
@@ -548,21 +548,21 @@ Output is controlled by parameters given within the ``mergerTreeOutput`` section
 .. _manual-sec-nodeDataGroup:
 
 nodeData group
-^^^^^^^^^^^^^^
+""""""""""""""
 
 The ``nodeData`` group contains all data from nodes in all merger trees. The group consists of a collection of datasets each of which lists a property of all nodes in the trees which exist at the output time. Where relevant, each dataset contains an attribute, ``units``, which is a composite HDF5 data-type containing the units of the dataset in the SI system as ``unitsInSI``, a human-readable description of the units as ``description``, an ``astropy.units``-parseable description of the units as ``quantity``, and ``isComoving`` which is ``1`` if the units are in comoving coordinates, and ``0`` otherwise.
 
 .. _manual-sec-mergerTreeDatasets:
 
 mergerTree datasets
-^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""
 
 To allow locating of nodes belonging to a given merger tree in the datasets in the ``nodeData`` group, the ``mergerTreeStartIndex`` and ``mergerTreeCount`` datasets list the starting index of each tree's nodes in the ``nodeData`` datasets, and the number of nodes belonging to each tree respectively. Additionally, the ``mergerTreeWeight`` dataset lists the ``volumeWeight`` property for each tree (see Section :galacticus-ref:`mergerTreeSubgroups`) which gives the weight (in Mpc\ :math:`^{-3}`) which should be assigned to this tree (and all nodes in it) to create a volume-averaged sample (see Section :galacticus-ref:`volumeLimitedSamples`). The ``mergerTreeIndex`` dataset gives the index of each tree stored in the ``nodeData`` datasets. Finally, the ``mergerTreeSeed`` dataset gives the seed used by this tree when generating random numbers.
 
 .. _manual-sec-mergerTreeSubgroups:
 
 mergerTree subgroups
-^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""
 
 These subgroups will be present if the ``[mergerTreeOutputReferences]`` parameter is set to true. Each ``mergerTree`` subgroup contains HDF5 references to all data on a single merger tree. The group consists of a collection of scalar references each of which points to the appropriate region of the corresponding dataset in the ``nodeData`` group. Additionally, the ``volumeWeight`` attribute of this group gives the weight (in Mpc\ :math:`^{-3}`) which should be assigned to this tree (and all nodes in it) to create a volume-averaged sample. (A second attribute, ``units``, gives the units of ``volumeWeight`` in the SI system, along with human-readable, ``astropy.units``-parseable descriptions, and a boolean indicating that these are in comoving coordinates.)
 

--- a/docs/manuals/user-guide/tutorials/parameter-files.rst
+++ b/docs/manuals/user-guide/tutorials/parameter-files.rst
@@ -134,6 +134,8 @@ For deeper, catalog-aware checks (valid implementation selectors, accepted param
 
 informing you that a parameter appears multiple times in the file.
 
+.. _parameter-files-warnings:
+
 Warnings
 ~~~~~~~~
 
@@ -156,7 +158,7 @@ Warnings of the type:
 
    multiple copies of parameter [componentDisk] present - only the first will be utilized
 
-indicate that the named parameter ("``componentDisk``" in this case) appears more than once in a section of the parameter file. Most parameters are allowed to appear only once (see `here <#multiple-copies-1>`_ for an explanation of exceptions to this rule). The warning indicates that copies of the parameter after the first are simply being ignored. Often this means that you added a parameter to your file, but forgot to remove the old copy. If the old copy appears first in the file, your new copy will be ignored and you will get unexpected results. The solution is to remove additional copies of the parameter, retaining only the one that you want.
+indicate that the named parameter ("``componentDisk``" in this case) appears more than once in a section of the parameter file. Most parameters are allowed to appear only once (see :ref:`here <parameter-files-multiple-copies>` for an explanation of exceptions to this rule). The warning indicates that copies of the parameter after the first are simply being ignored. Often this means that you added a parameter to your file, but forgot to remove the old copy. If the old copy appears first in the file, your new copy will be ignored and you will get unexpected results. The solution is to remove additional copies of the parameter, retaining only the one that you want.
 
 Empty value
 ^^^^^^^^^^^
@@ -167,7 +169,7 @@ Warnings of the type:
 
    empty value for parameter [cosmologyFunctions]
 
-indicate that the ``value`` element of the named parameter ("``cosmologyFunctions``" in this case) is empty, which is invalid. Either enter a value for the parameter or, if you want the parameter to take its default value (see `here <#cardinality>`_) simply remove the parameter from the file entirely.
+indicate that the ``value`` element of the named parameter ("``cosmologyFunctions``" in this case) is empty, which is invalid. Either enter a value for the parameter or, if you want the parameter to take its default value (see :ref:`here <parameter-files-cardinality>`) simply remove the parameter from the file entirely.
 
 Ambiguous value
 ^^^^^^^^^^^^^^^
@@ -208,6 +210,8 @@ Where to find information about available parameters
 
 The best resource to get information about available parameters, their allowed values, etc. is the `Galacticus Physics <https://galacticus.readthedocs.io/en/latest/physics/index.html>`_ document. Specifically, the section on `Functions <https://galacticus.readthedocs.io/en/latest/physics/index.html>`_ section details the available parameters, their types, cardinality, and default values for all allowed classes.
 
+.. _parameter-files-types:
+
 Types
 ~~~~~
 
@@ -229,6 +233,8 @@ In the `Functions <https://galacticus.readthedocs.io/en/latest/physics/index.htm
    ``[normalization]`` (real; 0,1) {``0.3221836349e0``} The normalization parameter :math:`A` in the Sheth et al. [2001] halo mass function fit.
 
 The word "real" (in the "``(real; 0,1)``") in each of the above parameters indicates that a real type value is expected.
+
+.. _parameter-files-cardinality:
 
 Cardinality
 ~~~~~~~~~~~
@@ -322,10 +328,12 @@ the ``cosmologyFunctions`` object, not finding a helper ``cosmologyParameters`` 
 
 If no helper object is found, a default choice is adopted.
 
+.. _parameter-files-multiple-copies:
+
 Multiple copies
 ~~~~~~~~~~~~~~~
 
-Most parameters allow only one copy of the parameter to appear in any given section of the parameter file (and `warnings <#warnings>`_ will be issued if multiple copies appear). Some parameters, however, allow multiple copies. Most often, these correspond to classes which sum over the results of other classes (e.g. a cooling function class that sums the cooling rates from multiple other cooling function classes), or applies a sequence of multiple operators.
+Most parameters allow only one copy of the parameter to appear in any given section of the parameter file (and :ref:`warnings <parameter-files-warnings>` will be issued if multiple copies appear). Some parameters, however, allow multiple copies. Most often, these correspond to classes which sum over the results of other classes (e.g. a cooling function class that sums the cooling rates from multiple other cooling function classes), or applies a sequence of multiple operators.
 
 A common example of this is the ``nodePropertyExtractor`` class, which is used to determine which properties to output to the output file. Frequently we want to output many different properties. The ``nodePropertyExtractorMulti`` class allows this, for example:
 
@@ -434,7 +442,7 @@ Advanced topics
 Math evaluation
 ~~~~~~~~~~~~~~~
 
-Parameter values of type real and cardinality 1 can be written as equations using basic mathematical operations and referencing other (`type <#types>`_ real, `cardinality <#cardinality>`_ 1) parameters as variables.
+Parameter values of type real and cardinality 1 can be written as equations using basic mathematical operations and referencing other (:ref:`type <parameter-files-types>` real, :ref:`cardinality <parameter-files-cardinality>` 1) parameters as variables.
 
 This functionality is provided via `libmatheval <https://github.com/galacticusorg/libmatheval>`_. This library automatically compiled into the pre-compiled versions of Galacticus. If you compile your own Galacticus then you must have ``libmatheval`` available, otherwise math expressions in the parameter file will cause a run-time error.
 
@@ -516,7 +524,7 @@ Note that, internally in Galacticus, these three instances of the ``cosmological
 Ignoring warnings
 ~~~~~~~~~~~~~~~~~~
 
-As described in the `Warnings <#warnings>`_ section, Galacticus will emit warnings about any potential problems that it finds in a parameter file. In general, the recommendation is to fix these potential problems!
+As described in the :ref:`Warnings <parameter-files-warnings>` section, Galacticus will emit warnings about any potential problems that it finds in a parameter file. In general, the recommendation is to fix these potential problems!
 
 However, if you are 100% sure that the parameter file is correct and doing what you intended, you can silence the warning for any parameter by adding an attribute ``ignoreWarnings="true"``. For example:
 

--- a/source/hot_halo/outflow_stripping/_class.F90
+++ b/source/hot_halo/outflow_stripping/_class.F90
@@ -31,7 +31,7 @@ module Hot_Halo_Outflows_Stripping
   !![
   <functionClass docformat="rst">
    <name>hotHaloOutflowStripping</name>
-   <descriptiveName>Hot Halo Outflow Reincorporation</descriptiveName>
+   <descriptiveName>Hot Halo Outflow Stripping</descriptiveName>
    <description>
    Class providing models of the stripping of outflowed (ejected) gas from the hot halo of a satellite galaxy as it orbits within its host halo. When a galaxy becomes a satellite the ejected gas reservoir associated with it may be stripped by tidal or ram pressure forces from the host halo. The fraction of outflowed gas stripped (returned to the host halo's hot gas) depends on the orbital position and the relative pressures, affecting the satellite's subsequent star formation and stellar mass.
    </description>

--- a/source/nodes/operators/physics/black_holes/accretion.F90
+++ b/source/nodes/operators/physics/black_holes/accretion.F90
@@ -27,7 +27,11 @@
   !![
   <nodeOperator name="nodeOperatorBlackHolesAccretion" docformat="rst">
    <description>
-   Evolves supermassive black hole masses by computing gas accretion rates (including Bondi and feedback-regulated modes) and integrating them over each timestep, driving AGN feedback that regulates star formation in massive galaxies.
+   A node operator class that grows black holes by accretion. The rate at which gas is accreted from the spheroid, the :term:`CGM`, and any nuclear star cluster is computed by a :galacticus-class:`blackHoleAccretionRateClass` object, and is removed from each of those components. The radiative and jet efficiencies of the resulting accretion flow, together with the rate at which it spins the black hole up, are computed by a :galacticus-class:`accretionDisksClass` object; the black hole grows at the rest mass accretion rate reduced by those two efficiencies,
+
+   .. math::
+
+      \dot{M}_\bullet = (1-\epsilon_\mathrm{radiation}-\epsilon_\mathrm{jet}) \dot{M}_0.
    </description>
   </nodeOperator>
   !!]

--- a/source/nodes/operators/physics/satellite_dynamical_friction.F90
+++ b/source/nodes/operators/physics/satellite_dynamical_friction.F90
@@ -26,7 +26,7 @@
   !![
   <nodeOperator name="nodeOperatorSatelliteDynamicalFriction" docformat="rst">
    <description>
-   Applies the Chandrasekhar dynamical friction force to satellite halos orbiting in their host potential, decelerating satellites and driving orbital decay toward the halo center, ultimately leading to satellite merging on a dynamical friction timescale.
+   A node operator class that applies dynamical friction to orbiting satellite halos, decelerating them and so driving orbital decay toward the center of the host. The deceleration is computed by a :galacticus-class:`satelliteDynamicalFrictionClass` object and added to the rate of change of the satellite's velocity, alongside the gravitational acceleration applied by :galacticus-class:`nodeOperatorSatelliteOrbit`.
    </description>
   </nodeOperator>
   !!]

--- a/source/objects/nodes/components/nuclear_star_cluster/standard/_class.F90
+++ b/source/objects/nodes/components/nuclear_star_cluster/standard/_class.F90
@@ -302,7 +302,7 @@ contains
        class is (massDistributionSpherical)
           ! The NSC mass distribution must have spherical symmetry. So, this is acceptable.
        class default 
-          call Error_Report('only spehrically symmetric mass distributions are allowed'//{introspection:location})
+          call Error_Report('only spherically symmetric mass distributions are allowed'//{introspection:location})
        end select
        if (.not.massDistributionStellar_%isDimensionless()) call Error_Report('Nuclear star cluster mass distribution must be dimensionless'//{introspection:location})
        ! Duplicate the dimensionless mass distribution to use for the gas component, and set component and mass type in both.

--- a/source/objects/nodes/components/spheroid/standard/_class.F90
+++ b/source/objects/nodes/components/spheroid/standard/_class.F90
@@ -316,7 +316,7 @@ contains
        class is (massDistributionSpherical)
           ! The spheroid mass distribution must have spherical symmetry. So, this is acceptable.        
        class default
-          call Error_Report('only spehrically symmetric mass distributions are allowed'//{introspection:location})
+          call Error_Report('only spherically symmetric mass distributions are allowed'//{introspection:location})
        end select
        if (.not.massDistributionStellar_%isDimensionless()) call Error_Report('spheroid mass distribution must be dimensionless'//{introspection:location})
        ! Duplicate the dimensionless mass distribution to use for the gas component, and set component and mass types in both.


### PR DESCRIPTION
A collection of small, independent fixes turned up while working on the node
component documentation (#1327). Independent of that PR — no overlapping
changes — and together these take the Sphinx build **from 30 warnings/errors to
zero**.

### 1. Two generated physics pages shared one title

`source/hot_halo/outflow_stripping/_class.F90` declared
`<descriptiveName>Hot Halo Outflow Reincorporation</descriptiveName>`,
copy-pasted from the neighbouring class. Both `hotHaloOutflowStripping.rst` and
`hotHaloOutflowReincorporation.rst` rendered under that title and both appeared
under it in the physics index.

### 2. Descriptions asserting a specific model where the code is pluggable

`nodeOperatorSatelliteDynamicalFriction` claimed to apply "the **Chandrasekhar**
dynamical friction force" — but it delegates to `satelliteDynamicalFriction`,
which has seven implementations (`Chandrasekhar1943`, `Kaur2018`,
`Lancaster2020`, `Petts2015`, `MassRatioThreshold`, `Scale`, `Zero`), so the
description was wrong for six of them. `nodeOperatorBlackHolesAccretion` named
Bondi accretion in the same way.

Both now name the class they actually use, following the pattern of
`nodeOperatorSatelliteTidalMassLoss`; the black hole operator also gains the
expression by which the hole grows. This is the same defect class as the
"Gunn-Gott criterion" claim corrected in #1327 — a recognisable tier of
descriptions that invent specifics. The tell is a description naming a model
with no `:galacticus-class:` reference in a file that builds a pluggable object;
filtering on that across `nodes/operators/` leaves only these two.

*(A third candidate, `nodeOperatorSatelliteDestructionDensityProfileThreshold`,
was checked and is correct — it describes its own criterion.)*

### 3. Six `Inconsistent title style` errors

`developer-guide/coding.rst` and `user-guide/advanced.rst` each had three
sections skipping a heading level. Worth noting the two files establish
*different* ladders — `= - ~ ^` and `= - ~ "` — so the fix differs between them.

### 4. Thirteen hand-written fragment links, one already broken

`parameter-files.rst` and `creating-a-new-class.rst` contained links of the form
`` `text <#slug>`_ ``, leftovers from an HTML conversion.

`#multiple-copies-1` was already broken, and instructively so: "Multiple copies"
appears **twice** as a heading in that file, and Sphinx had given the second
section the positional id `id5` — which no hand-written fragment could reliably
target. The other twelve resolved only by coincidence and would break on any
heading rename or reorder.

All thirteen are now `:ref:` links to explicit labels added at the nine target
headings.

### 5. Smaller items

* An enumerated list in `versions-and-releases.rst` ran straight into a
  following paragraph with no blank line.
* `conf.py` justified `suppress_warnings` by reference to duplicate labels
  "from auto-generated cross-reference anchors". There are no duplicate
  `physics-*` anchors, and the suppression list never mentioned duplicate labels
  in the first place; the comment now describes what is actually suppressed.
* Typo in a user-facing error message, in two files: `spehrically` →
  `spherically`.

## Verification

* Regenerated the documentation and built it with Sphinx in a tree laid out the
  way ReadTheDocs builds it — including the notebook copy `conf.py` performs —
  giving **zero warnings**, down from 30.
* Every internal reference in the two converted files resolves in the rendered
  HTML (27 and 27).
* `pytest scripts/doc/tests` passes; `scripts/doc/residualLatex.py` clean; all
  five modified Fortran files preprocess cleanly.

## Note for reviewers

The `01-claude-review` pre-commit hook errored on its own turn limit, so this
commit did not receive its automated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)