### PR TITLE
feat(nodes): evaluate the projected density at zero radius where it converges

### DIFF
--- a/docs/manuals/physics/definitions.rst
+++ b/docs/manuals/physics/definitions.rst
@@ -166,7 +166,7 @@ Such a radius is perfectly well defined, but not every property can be evaluated
 
 * enclosed masses (:galacticus-class:`nodePropertyExtractorMassProfile`), projected masses (:galacticus-class:`nodePropertyExtractorProjectedMass`), rotation curves, and velocity dispersions all exist at zero radius, and are reported there---note that the enclosed and projected masses are the mass of any central point mass, such as a black hole, and not necessarily zero;
 * densities (:galacticus-class:`nodePropertyExtractorDensityProfile`, :galacticus-class:`nodePropertyExtractorDensityDMOProfile`) exist only if the mass distribution being evaluated has a finite central density---which is true of a disk, but not of an :term:`NFW` halo;
-* projected densities (:galacticus-class:`nodePropertyExtractorProjectedDensity`) are never evaluated at zero radius, as the line of sight integral is performed in the logarithm of radius.
+* projected densities (:galacticus-class:`nodePropertyExtractorProjectedDensity`) exist only if the central logarithmic slope of the density profile exceeds :math:`-1`---the line of sight integral through the center of an :term:`NFW` halo diverges logarithmically, while that through a cored profile, or through a shallower cusp, converges and is evaluated.
 
 Where the property does not exist, the model stops with an error naming the offending specifier and the node in which it was evaluated. To carry on regardless, set ``zeroRadiusIsFatal`` to ``false`` in the property extractor concerned: the undefined-value sentinel is then written in place of the property, and should be filtered out before analysis. The radius itself is still reported (as zero), since---unlike an undefined radius---it is perfectly well defined.
 

--- a/source/nodes/property_extractor/projected_density.F90
+++ b/source/nodes/property_extractor/projected_density.F90
@@ -28,7 +28,7 @@
    <description>
    A property extractor class for the projected density at a set of radii. The radii and types of projected density to output is specified by the ``radiusSpecifiers`` parameter. This parameter's value can contain multiple entries, each of which should be a valid :ref:`radius specifier &lt;manual-sec-radiusspecifiers&gt;`.
 
-   A radius specifier can evaluate to zero---most often because the component on which it is based is absent or empty in the node in question. The projected density is not evaluated there: it is finite only if the central logarithmic slope of the density profile exceeds :math:`-1` (an :term:`NFW` profile, for example, gives a logarithmically divergent integral), and even then the Abel integral used here is performed in the logarithm of radius, and so can not begin at zero radius. By default a radius of zero is reported as a fatal error naming the offending specifier; setting ``zeroRadiusIsFatal`` to ``false`` instead writes the undefined-value sentinel in place of the projected density.
+   A radius specifier can evaluate to zero---most often because the component on which it is based is absent or empty in the node in question. The line of sight then passes through the center of the mass distribution, where the projected density is finite only if the central logarithmic slope of the density profile exceeds :math:`-1` (an :term:`NFW` profile, for example, gives a logarithmically divergent integral). Where it is finite it is evaluated, by adding to the numerical integral an analytic estimate of the contribution from within some small radius, assuming that the density there follows the asymptotic central power law, and reducing that radius until the result no longer depends on it. Where it is not finite, a radius of zero is by default reported as a fatal error naming the offending specifier; setting ``zeroRadiusIsFatal`` to ``false`` instead writes the undefined-value sentinel in place of the projected density.
    </description>
   </nodePropertyExtractor>
   !!]
@@ -112,8 +112,10 @@ contains
       <defaultValue>.true.</defaultValue>
       <description>
       Specifies whether a radius specifier which evaluates to zero, in a node in which the projected density diverges at zero
-      radius, should be reported as a fatal error. If ``false``, the undefined-value sentinel is written in place of the
-      projected density instead.
+      radius---that is, one in which the central logarithmic slope of the density profile is :math:`-1` or steeper---should be
+      reported as a fatal error. If ``false``, the undefined-value sentinel is written in place of the projected density
+      instead. A zero radius in a node in which the projected density is finite is always evaluated, and is unaffected by this
+      parameter.
       </description>
       <source>parameters</source>
     </inputParameter>
@@ -209,13 +211,20 @@ contains
     double precision                                       , intent(in   )               :: time
     type            (multiCounter                         ), intent(inout) , optional    :: instance
     class           (massDistributionClass                ), pointer                     :: massDistribution_
-    double precision                                       , parameter                   :: toleranceRelative      =1.0d-2, epsilonSingularity      =1.0d-3
+    double precision                                       , parameter                   :: toleranceRelative        =1.0d-2, epsilonSingularity   =1.0d-3
+    ! Parameters controlling the line of sight integral through the center of the distribution: the radius at which that
+    ! integral begins, as a fraction of the outer radius, the factor by which that radius is reduced at each refinement, and the
+    ! maximum number of such refinements permitted before convergence is declared to have failed.
+    double precision                                       , parameter                   :: radiusInnerFractional    =1.0d-3, factorRadiusInner    =1.0d+1
+    integer                                                , parameter                   :: refinementCountMaximum   =20
     type            (radiusResolver                       )                              :: resolver
     type            (integrator                           )                              :: integrator_
-    integer                                                                              :: i                             , status
-    double precision                                                                     :: radiusVirial                  , radiusOuter                    , &
-         &                                                                                  radiusSingularity             , densityProjectedPrevious       , &
-         &                                                                                  densityProjectedCurrent       , toleranceAbsolute
+    integer                                                                              :: i                               , status                      , &
+         &                                                                                  countRefinements                , countAgreements
+    double precision                                                                     :: radiusVirial                    , radiusOuter                 , &
+         &                                                                                  radiusInner                     , radiusInnerPrevious         , &
+         &                                                                                  densityProjectedPrevious        , densityProjectedInner       , &
+         &                                                                                  densityProjectedNumerical       , toleranceAbsolute
     logical                                                                              :: converged
     type            (coordinateSpherical                  )                              :: coordinates
     !$GLC attributes unused :: time, instance
@@ -230,58 +239,100 @@ contains
           ! The radius is undefined in this node - report the sentinel. Note that this test must precede any arithmetic on the
           ! radius, since the sentinel would overflow (and so trap) under multiplication.
           densityProjected       (i,1)=radiusUndefined
-          if (self%includeRadii)                      &
+          if (self%includeRadii)                       &
                & densityProjected(i,2)=radiusUndefined
           cycle
        end if
-       massDistribution_        => node%massDistribution(self%radii%specifiers(i)%component,self%radii%specifiers(i)%mass)
-       if (radius_ <= 0.0d0) then
-          ! The radius is zero. The projected density along a line of sight through the center is finite only if the central
-          ! logarithmic slope of the density profile exceeds -1, but even then it can not be evaluated here: the Abel integral
-          ! below is performed in the logarithm of radius, and so can not begin at zero radius.
+       massDistribution_ => node%massDistribution(self%radii%specifiers(i)%component,self%radii%specifiers(i)%mass)
+       if     (                                                              &
+            &   radius_                                            <=  0.0d0 &
+            &  .and.                                                         &
+            &   massDistribution_%densitySlopeLogarithmicCentral() <= -1.0d0 &
+            & ) then
+          ! The radius is zero, so the line of sight passes through the center of the mass distribution. The integral along that
+          ! line of sight converges only if the central logarithmic slope of the density profile exceeds -1, which it does not
+          ! here - an unknown central slope, being the most negative representable value, is rejected by the same test - so the
+          ! projected density does not exist in this node.
           if (self%zeroRadiusIsFatal) &
-               & call resolver%reportZeroRadius(i,'projectedDensity','the line of sight integral is evaluated in the logarithm of radius, which can not begin at zero radius')
+               & call resolver%reportZeroRadius(i,'projectedDensity','the line of sight integral through the center of this mass distribution diverges')
           densityProjected       (i,1)=radiusUndefined
-          if (self%includeRadii)                      &
+          if (self%includeRadii)                       &
                & densityProjected(i,2)=radius_
           !![
           <objectDestructor name="massDistribution_"/>
           !!]
           cycle
        end if
-       densityProjectedPrevious =  0.0d0
        radiusOuter              =  max(radius_*2.0d0,radiusVirial)
-       ! Cut out a small region round the coordinate singularity at the inner radius. This region will be integrated analytically
-       ! assuming a constant density over this region. The region outside of this cut-out will be integrated numerically.
-       radiusSingularity       =min(radius_*(1.0d0+epsilonSingularity),radiusOuter )
-       !! Analytic integral within the cut-out.
-       coordinates=[radius_,0.0d0,0.0d0]
-       densityProjected(i,1)=+2.0d0                                  &
-            &                *sqrt(                                  &
-            &                      +radiusSingularity**2             &
-            &                      -radius_          **2             &
-            &                     )                                  &
-            &                *massDistribution_%density(coordinates)
-       !! Numerical integral outside of the cut-out.
-       if (radiusSingularity < radiusOuter) then
-          ! Set an absolute tolerance scale for projected density convergence that is a small fraction of the mean halo density,
-          ! integrated over a path length of 1 Mpc.
-          toleranceAbsolute=+toleranceRelative                          &
-               &            *self%darkMatterHaloScale_%densityMean(node)
-          converged        =.false.
+       ! Set an absolute tolerance scale for projected density convergence that is a small fraction of the mean halo density,
+       ! integrated over a path length of 1 Mpc.
+       toleranceAbsolute        =  +toleranceRelative                           &
+            &                      *self%darkMatterHaloScale_%densityMean(node)
+       if (radius_ > 0.0d0) then
+          ! Cut out a small region round the coordinate singularity at the inner radius. This region will be integrated
+          ! analytically assuming a constant density over this region. The region outside of this cut-out will be integrated
+          ! numerically.
+          radiusInner=min(radius_*(1.0d0+epsilonSingularity),radiusOuter)
+       else
+          ! The line of sight passes through the center of the distribution. There is no coordinate singularity in this case,
+          ! but the integral is performed in the logarithm of radius and so can not begin at zero radius. Begin it instead at a
+          ! small radius, and add an analytic estimate of the contribution from within that radius. As that radius is
+          ! subsequently reduced until the result no longer depends on it, this initial choice need not resolve the scale radii
+          ! of the distribution---it need only provide a starting point.
+          radiusInner=radiusOuter*radiusInnerFractional
+       end if
+       !! Analytic integral within the innermost radius.
+       densityProjectedInner    =  projectedDensityInner(radiusInner)
+       !! Numerical integral outside of the innermost radius.
+       densityProjectedNumerical  =0.0d0
+       if (radiusInner < radiusOuter) then
+          densityProjectedPrevious=0.0d0
+          converged               =.false.
           do while (.not.converged)
-             densityProjectedCurrent=integrator_%integrate(log(radiusSingularity),log(radiusOuter),status=status)
+             densityProjectedNumerical=integrator_%integrate(log(radiusInner),log(radiusOuter),status=status)
              if (status /= errorStatusSuccess .and. .not.self%tolerateIntegrationFailures) &
                   & call Error_Report('integration of projected density failed'//{introspection:location})
-             converged              =Values_Agree(densityProjectedCurrent,densityProjectedPrevious,relTol=toleranceRelative,absTol=toleranceAbsolute)
+             converged                =Values_Agree(densityProjectedNumerical,densityProjectedPrevious,relTol=toleranceRelative,absTol=toleranceAbsolute)
              if (.not.converged) then
                 radiusOuter             =2.0d0*radiusOuter
-                densityProjectedPrevious=      densityProjectedCurrent
+                densityProjectedPrevious=      densityProjectedNumerical
              end if
           end do
        end if
-       densityProjected(i,1)=+densityProjected       (i,1) &
-            &                +densityProjectedCurrent
+       densityProjected(i,1)=+densityProjectedInner     &
+            &                +densityProjectedNumerical
+       if (radius_ <= 0.0d0 .and. radiusInner > 0.0d0) then
+          ! Reduce the radius at which the numerical integral begins, integrating each newly-exposed shell and re-estimating the
+          ! contribution from within the new innermost radius, until the total is insensitive to that radius. This tests the
+          ! accuracy of the analytic estimate directly, and so requires no knowledge of the scale radii of the distribution: the
+          ! estimate becomes exact as the radius approaches zero, but converges as soon as the density has reached its
+          ! asymptotic, central power law form. Two successive agreements are required, so that the slow variation of a poor
+          ! estimate is not mistaken for convergence.
+          countAgreements =0
+          countRefinements=0
+          do while (countAgreements < 2)
+             radiusInnerPrevious      =                           radiusInner
+             radiusInner              =                           radiusInner/factorRadiusInner
+             densityProjectedNumerical=+densityProjectedNumerical                                                      &
+                  &                    +integrator_%integrate(log(radiusInner),log(radiusInnerPrevious),status=status)
+             if (status /= errorStatusSuccess .and. .not.self%tolerateIntegrationFailures) &
+                  & call Error_Report('integration of projected density failed'//{introspection:location})
+             densityProjectedPrevious =+densityProjected     (i          ,1)
+             densityProjected(i,1)    =+projectedDensityInner(radiusInner   ) &
+                  &                    +densityProjectedNumerical
+             if (Values_Agree(densityProjected(i,1),densityProjectedPrevious,relTol=toleranceRelative,absTol=toleranceAbsolute)) then
+                countAgreements=countAgreements+1
+             else
+                countAgreements=0
+             end if
+             countRefinements=countRefinements+1
+             if (countRefinements >= refinementCountMaximum .and. countAgreements < 2) then
+                if (.not.self%tolerateIntegrationFailures) &
+                     & call Error_Report('projected density at zero radius failed to converge'//{introspection:location})
+                exit
+             end if
+          end do
+       end if
        if (self%includeRadii) densityProjected(i,2)=radius_
        !![
        <objectDestructor name="massDistribution_"/>
@@ -290,6 +341,52 @@ contains
     return
 
   contains
+
+    double precision function projectedDensityInner(radius)
+      !!{RST
+      Return the contribution to the projected density from within the given ``radius``---that is, the part of the line of sight
+      integral which is not evaluated numerically.
+
+      For a line of sight which passes to one side of the center the density is assumed to be constant, at its value at the
+      radius of closest approach, over the small region cut out around the coordinate singularity there.
+
+      For a line of sight which passes through the center there is no singularity to cut out, but the integral can not begin at
+      zero radius. The contribution from within ``radius`` is instead estimated by assuming that the density follows its
+      asymptotic, central power law, :math:`\rho \propto r^\gamma`, there:
+
+      .. math::
+
+         2 \int_0^r \rho(r^\prime) \mathrm{d}r^\prime = \frac{2 r \rho(r)}{1+\gamma},
+
+      which is finite for :math:`\gamma > -1`---precisely the condition under which the full integral converges, and which is
+      guaranteed to hold here as any distribution failing it has already been rejected.
+      !!}
+      implicit none
+      double precision, intent(in   ) :: radius
+
+      if (radius_ > 0.0d0) then
+         coordinates          =[radius_,0.0d0,0.0d0]
+         projectedDensityInner=+2.0d0                                  &
+              &                *sqrt(                                  &
+              &                      +radius **2                       &
+              &                      -radius_**2                       &
+              &                     )                                  &
+              &                *massDistribution_%density(coordinates)
+      else if (radius <= 0.0d0) then
+         ! The distribution has no extent, so there is nothing to integrate.
+         projectedDensityInner=+0.0d0
+      else
+         coordinates          =[radius ,0.0d0,0.0d0]
+         projectedDensityInner=+2.0d0                                                           &
+              &                *radius                                                          &
+              &                *  massDistribution_%density                       (coordinates) &
+              &                /(                                                               &
+              &                  +1.0d0                                                         &
+              &                  +massDistribution_%densitySlopeLogarithmicCentral(           ) &
+              &                 )
+      end if
+      return
+    end function projectedDensityInner
 
     double precision function projectedDensityIntegrand(radiusLogarithmic)
       !!{RST

--- a/testSuite/parameters/radiusSpecifiersZeroTolerated.xml
+++ b/testSuite/parameters/radiusSpecifiersZeroTolerated.xml
@@ -305,10 +305,14 @@
   </mergerTreeOutputter>
 
   <!-- The same zero-valued radius specifier, with the error suppressed. Densities and projected
-       densities at zero radius are reported as the undefined-value sentinel, while enclosed and
-       projected masses - which are simply zero at zero radius - are reported as such. The third
-       density specifier evaluates the density of the hot halo, a beta-profile with a finite
-       central density, at exactly zero radius: that is well defined, and must not be rejected. -->
+       densities of the total mass distribution at zero radius are reported as the undefined-value
+       sentinel - it contains an NFW halo, for which neither exists there - while enclosed and
+       projected masses - which are simply zero at zero radius - are reported as such. The
+       remaining specifiers evaluate the hot halo, a beta-profile with a finite central density,
+       for which both the density and the projected density at zero radius are well defined and
+       must not be rejected. The projected density there is checked against the projected mass
+       within a small, non-zero radius, which must approach the product of the central projected
+       density and the area of the cylinder. -->
   <nodePropertyExtractor value="multi">
     <nodePropertyExtractor value="nodeIndices"/>
     <nodePropertyExtractor value="densityProfile">
@@ -319,7 +323,7 @@
     <nodePropertyExtractor value="projectedDensity">
       <includeRadii      value="true"/>
       <zeroRadiusIsFatal value="false"/>
-      <radiusSpecifiers  value="diskRadius:all:all:1.0  virialRadius:all:all:1.0"/>
+      <radiusSpecifiers  value="diskRadius:all:all:1.0  virialRadius:all:all:1.0  radius:hotHalo:gaseous:0.0  radius:hotHalo:gaseous:1.0e-4"/>
     </nodePropertyExtractor>
     <nodePropertyExtractor value="massProfile">
       <includeRadii value="true"/>
@@ -327,7 +331,7 @@
     </nodePropertyExtractor>
     <nodePropertyExtractor value="projectedMass">
       <includeRadii value="true"/>
-      <radiusSpecifiers value="diskRadius:all:all:1.0  virialRadius:all:all:1.0"/>
+      <radiusSpecifiers value="diskRadius:all:all:1.0  virialRadius:all:all:1.0  radius:hotHalo:gaseous:1.0e-4"/>
     </nodePropertyExtractor>
   </nodePropertyExtractor>
 

--- a/testSuite/test-radius-specifiers-zero.py
+++ b/testSuite/test-radius-specifiers-zero.py
@@ -15,8 +15,12 @@ Two models are run:
     the sentinel appears in the density and projected density exactly where the
     radius is zero (while the radius itself is still reported as zero), that the
     enclosed and projected masses are defined and agree there, and that the
-    density of the beta-profile hot halo - which has a finite central density -
-    is still evaluated at exactly zero radius.
+    density and projected density of the beta-profile hot halo - which has a
+    finite central density, and so also a finite projected density along a line
+    of sight through its center - are still evaluated at exactly zero radius. The
+    central projected density is checked against the projected mass within a
+    small, non-zero radius, which must approach the product of that projected
+    density and the area of the cylinder.
 
 Andrew Benson (03-August-2026)
 """
@@ -99,9 +103,9 @@ if status != 0:
 
 fileName = os.path.join(pathOutputDirectory, "tolerated.hdf5")
 density        , radiiDensity         = gather(fileName, "densityProfile" , 3)
-densityProjected, radiiDensityProjected = gather(fileName, "projectedDensity", 2)
+densityProjected, radiiDensityProjected = gather(fileName, "projectedDensity", 4)
 mass           , radiiMass            = gather(fileName, "massProfile"   , 2)
-massProjected  , radiiMassProjected   = gather(fileName, "projectedMass" , 2)
+massProjected  , radiiMassProjected   = gather(fileName, "projectedMass" , 3)
 
 # The first two radii of the `densityProfile` extractor are the disk radius and the virial radius;
 # the third is the fixed, zero radius in the hot halo.
@@ -121,7 +125,7 @@ check(
 )
 check(
     np.all(densityProjected[radiiDensityProjected[:, 0] == 0.0, 0] == radiusUndefined),
-    "projected density is the sentinel where the radius is zero",
+    "projected density is the sentinel where the radius is zero in a cusped profile",
 )
 
 # Enclosed and projected masses exist at zero radius: both reduce to the mass of any central point
@@ -149,6 +153,65 @@ check(
 check(
     np.all(density[:, 2] >= 0.0) and np.any(density[:, 2] > 0.0),
     "the central density of the hot halo is evaluated at zero radius",
+)
+
+# The line of sight integral through the center of the hot halo converges for the same reason - the
+# central logarithmic slope of a beta-profile is zero, which exceeds the -1 that the integral requires
+# - and so must also be evaluated, rather than rejected as it is for the NFW halo above.
+densityProjectedCentral = densityProjected[:, 2]
+check(
+    np.all(radiiDensityProjected[:, 2] == 0.0),
+    "the fixed hot halo radius is zero in the projected density",
+)
+check(
+    np.all(densityProjectedCentral != radiusUndefined),
+    "the central projected density of the hot halo is evaluated at zero radius",
+)
+check(
+    np.all(densityProjectedCentral >= 0.0) and np.any(densityProjectedCentral > 0.0),
+    "the central projected density of the hot halo is positive",
+)
+
+# The projected mass within a cylinder of radius R approaches pi R^2 times the central projected
+# density as R goes to zero. Evaluated at a radius far inside the core radius of the beta-profile
+# (0.3 of the virial radius), this is an independent check on the value of the central projected
+# density - the two are computed by different extractors, with only the density profile in common.
+# Nodes in which the hot halo is empty, or in which it has been stripped back to inside this radius
+# (so that the projected density has already fallen away there), are excluded.
+inCore = (densityProjectedCentral > 0.0) & (densityProjected[:, 3] > 0.9*densityProjectedCentral)
+check(np.any(inCore), "some node has a hot halo resolved well inside its core radius")
+densityProjectedImplied = (
+    massProjected[inCore, 2]/np.pi/radiiMassProjected[inCore, 2]**2
+)
+check(
+    np.all(np.abs(densityProjectedImplied/densityProjectedCentral[inCore]-1.0) < 5.0e-2),
+    "the central projected density of the hot halo matches the projected mass within a small radius",
+)
+
+# The central projected density of the beta-profile hot halo is also known analytically. With
+# beta = 2/3 (the default), rho(r) = rho_0/[1+(r/r_c)^2], truncated at the outer radius r_o, and
+# normalized such that the mass within that radius is the hot halo mass, M:
+#
+#   Sigma(0) = 2 rho_0 r_c atan(x) = M atan(x)/[2 pi r_c^2 (x - atan x)],   x = r_o/r_c,
+#
+# where the core radius, r_c, is 0.3 of the virial radius here (see `hotHaloMassDistributionCoreRadius`
+# above), and the virial radius is reported as the second radius of the `densityProfile` extractor.
+with h5py.File(fileName, "r") as model:
+    massHotHalo, radiusOuterHotHalo = [], []
+    for output in sorted(model["Outputs"].keys()):
+        nodes = model["Outputs"][output]["nodeData"]
+        massHotHalo       .append(nodes["hotHaloMass"       ][:])
+        radiusOuterHotHalo.append(nodes["hotHaloOuterRadius"][:])
+    massHotHalo        = np.concatenate(massHotHalo       )
+    radiusOuterHotHalo = np.concatenate(radiusOuterHotHalo)
+radiusCore = 0.3*radiiDensity[:, 1]
+x          = radiusOuterHotHalo/radiusCore
+densityProjectedAnalytic = (
+    massHotHalo*np.arctan(x)/(2.0*np.pi*radiusCore**2*(x-np.arctan(x)))
+)
+check(
+    np.all(np.abs(densityProjectedAnalytic[inCore]/densityProjectedCentral[inCore]-1.0) < 1.0e-2),
+    "the central projected density of the hot halo matches the analytic beta-profile result",
 )
 
 print()


### PR DESCRIPTION
Fixes #1322.

`projectedDensity` refused a radius specifier which resolved to zero for every mass distribution. That is more restrictive than the physics requires: the line of sight integral through the center,

$$\Sigma(0) = 2 \int_0^\infty \rho(z) \mathrm{d}z,$$

converges whenever the central logarithmic slope of the density profile exceeds $-1$. A cored profile, or a $\gamma=0.5$ Zhao1996 cusp, has a perfectly finite projected density there; only a slope of $-1$ or steeper — an NFW halo, say — diverges. The restriction was an artifact of how the integral was evaluated, not of the quantity being asked for.

## What this does

A zero radius is now evaluated wherever the integral converges. The numerical integral begins at a small radius, with the contribution from within it estimated by assuming that the density there follows its asymptotic central power law:

$$2 \int_0^r \rho(r^\prime) \mathrm{d}r^\prime = \frac{2 r \rho(r)}{1+\gamma},$$

which is finite under exactly the condition the full integral requires. That radius is then reduced by factors of ten — each newly-exposed shell added to the numerical integral — until the total is insensitive to it.

This is what settles the question raised in the issue of how the inner radius should be chosen relative to the scale radii of the distribution: **it need not be**. The refinement measures the accuracy of the analytic estimate directly, so the initial radius need only provide a starting point. Two successive agreements are required, so that the slow variation of a poor estimate is not mistaken for convergence; failure to converge within twenty refinements is reported as an error.

The guard added in #1314 now tests `densitySlopeLogarithmicCentral() > -1` rather than rejecting every zero radius, matching `densityProfile` and `densityDMOProfile`, which already used the finite-central-density criterion. An unknown central slope — the most negative representable value — is rejected by the same comparison. Where the integral does diverge the behavior is unchanged.

Also initializes the numerical part of the integral explicitly, rather than leaving it undefined in the (unreachable) case of a cut-out which extends to the outer radius.

## Verification

The scheme was checked against exact analytic central projected densities before being trusted:

| profile | error | refinements |
|---|---|---|
| Zhao1996 $(\alpha,\beta,\gamma) = (1,3,0.5)$ | $-8.7\times10^{-4}$ | 2 |
| Zhao1996 $(1,4,0.9)$ | $-1.5\times10^{-5}$ | 3 |
| Zhao1996 $(1,3,0.99)$ | $-3.0\times10^{-5}$ | 3 |
| Burkert | $-1.5\times10^{-3}$ | 2 |
| $r^{-1}$ cusp cored at $10^{-6} r_\mathrm{out}$ | $-9.1\times10^{-5}$ | 7 |

The last case matters: there the initial estimate begins badly wrong — the starting radius is a thousand core radii out, where the profile still follows the outer cusp — and must be recovered entirely by the refinement. The residual errors are dominated by the pre-existing outer-radius convergence tolerance, not by the inner estimate.

In the model, the central projected density of the $\beta$-profile hot halo agrees with the exact analytic value to $3\times10^{-5}$, and with $\pi R^2 \Sigma(0)$ inferred from `projectedMass` to $3\times10^{-4}$.

## Tests

`testSuite/test-radius-specifiers-zero.py` now also checks that the central projected density of the $\beta$-profile hot halo is evaluated rather than rejected, that it matches the analytic $\beta$-profile result, and that it matches the projected mass within a small radius. The NFW halo at zero radius must still report the sentinel.

Also run: `tests.dark_matter_profiles.projected.exe` (the NFW $R>0$ anchor, unchanged), `test-outputs.py`, and `quickTest.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
