### PR TITLE
feat(virialOrbits): pin and reuse the lossCone orbit tabulation

### DIFF
--- a/source/satellites/merging/virial_orbits/loss_cone.F90
+++ b/source/satellites/merging/virial_orbits/loss_cone.F90
@@ -17,8 +17,9 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The fixes for issue #1321 were diagnosed and drafted with
-!+    assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson. The fixes for issue #1321, and the pinning of the mass tabulation to an
+!+    absolute lattice for issue #1317, were diagnosed and drafted with assistance from Claude, and reviewed and verified by
+!+    Andrew Benson.
 
   !!{RST
   An implementation of virial orbits using a loss cone model.
@@ -36,6 +37,7 @@
   use :: Linear_Growth                  , only : linearGrowthClass
   use :: Virial_Density_Contrast        , only : virialDensityContrastClass
   use :: Numerical_Interpolation        , only : interpolator
+  use :: Numerical_Ranges               , only : rangeLattice
   use :: Correlation_Functions_Two_Point, only : correlationFunctionTwoPointClass
   use :: Galacticus_Nodes               , only : treeNode
   use :: Merger_Tree_Branching          , only : mergerTreeBranchingProbabilityClass
@@ -65,9 +67,9 @@
      class           (correlationFunctionTwoPointClass   ), pointer                         :: correlationFunctionTwoPoint_    => null()
      class           (mergerTreeBranchingProbabilityClass), pointer                         :: mergerTreeBranchingProbability_ => null()
      double precision                                                                       :: velocityMinimum                          , velocityMaximum                     , &
-          &                                                                                    massMinimum                              , massMaximum                         , &
           &                                                                                    time                                     , velocityDispersionMultiplier
      integer                                                                                :: countMassesPerDecade                     , countVelocitiesPerUnit
+     type            (rangeLattice                       )                                  :: latticeMass
      logical                                                                                :: includeInFlightGrowth
      double precision                                     , allocatable, dimension(:      ) :: mass                                     , velocity
      double precision                                     , allocatable, dimension(:,:    ) :: velocityRadialMeanVirial                 , velocityRadialDispersionVirial      , &
@@ -112,6 +114,12 @@
      module procedure lossConeConstructorParameters
      module procedure lossConeConstructorInternal
   end interface virialOrbitLossCone
+
+  ! Default range of halo masses over which to tabulate. This seeds the pinned range: any tabulation, whatever masses prompted
+  ! it, spans at least this range, which guarantees that any two tabulations overlap and so that one can always be extended to
+  ! cover the other. These are whole decades, and so are themselves anchor points of the lattice for any density of points per
+  ! decade.
+  double precision, parameter :: massTableMinimum=1.0d06, massTableMaximum=1.0d15
 
   ! Submodule-scope objects used for OpenMP parallelism.
   class(cosmologyFunctionsClass                    ), pointer :: cosmologyFunctions_
@@ -295,10 +303,9 @@ contains
     <constructorAssign variables="velocityMinimum, velocityMaximum, countVelocitiesPerUnit, countMassesPerDecade, includeInFlightGrowth, haloMassFunctionA, haloMassFunctionP, haloMassFunctionNormalization, velocityDispersionMultiplier, *cosmologyFunctions_, *cosmologyParameters_, *cosmologicalVelocityField_, *linearGrowth_, *darkMatterHaloBias_, *darkMatterHaloScale_, *virialDensityContrast_, *correlationFunctionTwoPoint_, *cosmologicalMassVariance_, *criticalOverdensity_, *mergerTreeBranchingProbability_, *darkMatterProfileDMO_"/>
     !!]
 
-    ! Set an initial mass range, along with an unphysical initial time (so that retabulation will be forced on the first call).
-    self%time       =-huge(0.0d0)
-    self%massMinimum=1.0d06
-    self%massMaximum=1.0d15
+    ! Set an unphysical initial time, so that tabulation is forced on the first call. The range of masses is left undefined here:
+    ! it is established on that first call, seeded with the default range of "massTableMinimum" to "massTableMaximum".
+    self%time=-huge(0.0d0)
     ! Build the velocity array and interpolator.
     countVelocities=int((self%velocityMaximum-self%velocityMinimum)*dble(self%countVelocitiesPerUnit))+1    
     allocate(self%velocity            (countVelocities))
@@ -702,13 +709,14 @@ contains
     !!}
     use :: Cosmological_Density_Field          , only : haloEnvironmentNormal
     use :: Dark_Matter_Profile_Mass_Definitions, only : Dark_Matter_Profile_Mass_Definition
-    use :: Display                             , only : displayCounter                     , displayCounterClear , displayIndent, displayUnindent, &
+    use :: Display                             , only : displayCounter                     , displayCounterClear , displayIndent, displayUnindent     , &
           &                                             verbosityLevelWorking
     use :: Error                               , only : errorStatusSuccess
     use :: Galacticus_Nodes                    , only : mergerTree                         , nodeComponentBasic  , treeNode
     use :: Calculations_Resets                 , only : Calculations_Reset
     use :: Numerical_Constants_Math            , only : Pi
-    use :: Numerical_Ranges                    , only : Make_Range                         , rangeTypeLogarithmic
+    use :: Numerical_Ranges                    , only : Make_Range                         , rangeTypeLogarithmic, Range_Pinned , Range_Lattice_Offset, &
+          &                                             gridSchemePerDecade
     use :: Table_Labels                        , only : extrapolationTypeFix
     use :: Numerical_Integration               , only : integrator
     use :: OMP_Lib                             , only : OMP_Get_Thread_Num
@@ -724,6 +732,10 @@ contains
          &                                                                               velocityDistributionPeak                       , velocityTotalRMS
     double precision                                , dimension(:,:,:  ), allocatable :: velocityRadialDistributionOrbits               , velocityTangentialDistributionOrbits
     double precision                                , dimension(:,:,:,:), allocatable :: velocityDistributionOrbits
+    logical                                         , dimension(:,:    ), allocatable :: isComputed
+    type            (rangeLattice                  )                                  :: latticeMass
+    integer                                                                           :: offsetMass                                     , countMassesPrevious
+    logical                                                                           :: reuseSolutions
     double precision                                , dimension(2      )              :: radiiEvaluation
     double precision                                , parameter                       :: velocityRadialInfallMaximum           =6.0000d0
     double precision                                , parameter                       :: velocityRadialInfallStep              =0.0001d0
@@ -784,44 +796,57 @@ contains
          &                                                cosmologyFunctions_   =self%cosmologyFunctions_                                                                            , &
          &                                                virialDensityContrast_=self%virialDensityContrast_                                                                           &
          & )
-    if     (                                           &
-         &   basicHost     %time() == self%time        &
-         &  .and.                                      &
-         &   basicHost     %mass() >= self%massMinimum &
-         &  .and.                                      &
-         &   basicHost     %mass() <= self%massMaximum &
-         &  .and.                                      &
-         &   basicSatellite%mass() >= self%massMinimum &
-         &  .and.                                      &
-         &   basicSatellite%mass() <= self%massMaximum &
+    ! Find the range of masses required, pinned to an absolute lattice so that the tabulation---and hence every value
+    ! interpolated from it---is independent of the masses at which it happened to be first requested, and so that it can be
+    ! extended without recomputing any solution already found. Only the mass axis is pinned: the velocity axis is fixed by the
+    ! parameters of this object and never changes, while the epoch is a key rather than an axis---the tabulation is discarded
+    ! wholesale when it changes, since every tabulated quantity depends on it.
+    !
+    ! Both the raw node masses and those same masses under our own definition of the virial density contrast are covered. The
+    ! latter are the coordinates at which the tables are actually interpolated (see "lossConeInterpolants"), while the former are
+    ! what the range of the tabulation was historically tested against here; the two differ by the mass-definition conversion, so
+    ! covering both leaves the tabulation no narrower than it was before being pinned. The interpolator built below aborts on
+    ! extrapolation, so a mass falling outside the tabulated range is fatal rather than merely inaccurate.
+    latticeMass=Range_Pinned(                                                                                 &
+         &                                   [basicHost%mass(),basicSatellite%mass(),massHost,massSatellite], &
+         &                                    self%countMassesPerDecade                                     , &
+         &                                    gridSchemePerDecade                                           , &
+         &                    rangeCurrent  =[massTableMinimum,massTableMaximum]                            , &
+         &                    latticeCurrent=self%latticeMass                                                 &
+         &                   )
+    if     (                                                   &
+         &   basicHost       %time  (           ) == self%time &
+         &  .and.                                              &
+         &   self%latticeMass%covers(latticeMass)              &
          & ) return
-    ! Free existing tabulations. Note that "velocity" and "interpolatorVelocity" are *not* freed here---they are built once, by
-    ! the constructor, from parameters that do not change between tabulations, and are used (via "countVelocities" below, and by
-    ! the interpolants) throughout this and subsequent tabulations.
-    if (allocated(self%mass)) then
-       deallocate(self%mass                                )
-       deallocate(self%velocityRadialMeanVirial            )
-       deallocate(self%velocityRadialDispersionVirial      )
-       deallocate(self%velocityTangentialMeanVirial        )
-       deallocate(self%velocityTangentialDispersionVirial  )
-       deallocate(self%velocityRadialDistributionOrbits    )
-       deallocate(self%velocityTangentialDistributionOrbits)
-       deallocate(self%velocityDistributionOrbits          )
-       deallocate(self%velocityTotalRMS                    )
-       deallocate(self%velocityDistributionPeak            )
-       deallocate(self%interpolatorMass                    )
+    ! Determine whether the solutions already found can be carried over into the new tabulation. They can only if the epoch is
+    ! unchanged---every tabulated quantity depends on it---and if there is an existing tabulation, on a known lattice, to carry
+    ! over. Where they can, they occupy a block of the new arrays offset by the difference in the lattices.
+    reuseSolutions=  basicHost       %time     () == self%time &
+         &         .and.                                       &
+         &           self%latticeMass%isDefined()              &
+         &         .and.                                       &
+         &           allocated(self%velocityRadialMeanVirial)
+    countMassesPrevious=0
+    offsetMass         =0
+    if (reuseSolutions) then
+       countMassesPrevious=self%latticeMass%count
+       offsetMass         =Range_Lattice_Offset(self%latticeMass,latticeMass)
     end if
     ! Set time for this tabulation.
     self%time=basicHost%time()
-    ! Get number of velocities to tabulate.
+    ! Get number of velocities to tabulate. Note that "velocity" and "interpolatorVelocity" are built once, by the constructor,
+    ! from parameters that do not change between tabulations, and are deliberately left alone here---they are used below, and by
+    ! the interpolants, throughout this and subsequent tabulations.
     countVelocities=size(self%velocity)
-    ! Build range of masses.
-    self%massMinimum=min(self%massMinimum,0.5d0*min(basicHost%mass(),basicSatellite%mass()))
-    self%massMaximum=max(self%massMaximum,2.0d0*max(basicHost%mass(),basicSatellite%mass()))
-    countMasses     =int(log10(self%massMaximum/self%massMinimum)*dble(self%countMassesPerDecade))+1    
+    ! Build the range of masses. The abscissae are taken from the lattice, rather than by subdividing the range, so that they are
+    ! bit-identical to those of any other tabulation built on the same lattice.
+    countMasses=latticeMass%count
+    if (allocated(self%mass            )) deallocate(self%mass            )
+    if (allocated(self%interpolatorMass)) deallocate(self%interpolatorMass)
     allocate(self%mass            (countMasses))
     allocate(self%interpolatorMass             )
-    self%mass            =Make_Range(self%massMinimum,self%massMaximum,countMasses,rangeTypeLogarithmic)
+    self%mass            =latticeMass%values()
     self%interpolatorMass=interpolator(log(self%mass))
     ! Allocate arrays for results and initialize.
     allocate(velocityRadialMeanVirial            (countMasses,countMasses                                ))
@@ -833,6 +858,7 @@ contains
     allocate(velocityDistributionOrbits          (countMasses,countMasses,countVelocities,countVelocities))
     allocate(velocityTotalRMS                    (countMasses,countMasses                                ))
     allocate(velocityDistributionPeak            (countMasses,countMasses                                ))
+    allocate(isComputed                          (countMasses,countMasses                                ))
     velocityRadialMeanVirial                     =0.0d0
     velocityRadialDispersionVirial               =0.0d0
     velocityTangentialMeanVirial                 =0.0d0
@@ -842,8 +868,29 @@ contains
     velocityDistributionOrbits                   =0.0d0
     velocityTotalRMS                             =0.0d0
     velocityDistributionPeak                     =0.0d0
-    ! Iterate over host masses.
-    countTotal   =(countMasses*(countMasses+1))/2
+    isComputed                                   =.false.
+    ! Carry over the solutions already found. Both mass dimensions of every array are indexed on the same lattice, so the
+    ! surviving solutions form a square block offset equally along both.
+    if (reuseSolutions) then
+       velocityRadialMeanVirial            (offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious    )=self%velocityRadialMeanVirial
+       velocityRadialDispersionVirial      (offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious    )=self%velocityRadialDispersionVirial
+       velocityTangentialMeanVirial        (offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious    )=self%velocityTangentialMeanVirial
+       velocityTangentialDispersionVirial  (offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious    )=self%velocityTangentialDispersionVirial
+       velocityRadialDistributionOrbits    (offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious,:  )=self%velocityRadialDistributionOrbits
+       velocityTangentialDistributionOrbits(offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious,:  )=self%velocityTangentialDistributionOrbits
+       velocityDistributionOrbits          (offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious,:,:)=self%velocityDistributionOrbits
+       velocityTotalRMS                    (offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious    )=self%velocityTotalRMS
+       velocityDistributionPeak            (offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious    )=self%velocityDistributionPeak
+       isComputed                          (offsetMass+1:offsetMass+countMassesPrevious,offsetMass+1:offsetMass+countMassesPrevious    )=.true.
+    end if
+    ! Record the lattice on which this tabulation is built.
+    self%latticeMass=latticeMass
+    ! Iterate over host masses. Only those solutions not carried over need be found, and then only for satellites no more massive
+    ! than their host.
+    countTotal=0
+    do iHost=1,countMasses
+       countTotal=countTotal+count(.not.isComputed(iHost,1:iHost))
+    end do
     countProgress=0
     !$omp parallel private(iHost,iSatellite,massHost,massSatellite,tree,nodeHost,nodeSatellite,basicHost,basicSatellite,radiusVirialHost,velocityVirialHost,velocityDispersionLinear,indexVelocityRadial,indexVelocityTangential,velocityRadialVirial,velocityTangentialVirial,countVelocityRadialInfall,indexVelocityRadialInfall,velocityRadialInfall,radiusInfallTerm1,radiusInfallTerm2,radiiEvaluation,iEvaluate,radiusEvaluateVirial,timeEvaluate,radiusApocenterVirial,radiusPericenterVirial,timeOfFlightVirial,timeOfFlight,radiusEvaluate,radiusEvaluateComoving,velocityDispersionEvaluate,velocityRadialMeanEvaluate,velocityDispersionRadialEvaluateVirial,velocityDispersionTangentialEvaluateVirial,velocityMeanRadialEvaluateVirial,velocityTangentialInfall,jacobianFactor,jacobianDeterminant,distributionFunction,interpolatorVelocityDispersionLinear,integratorEnvironment,integratorEnvironmentNormalizer,factorEnvironmental,massEnvironment,radiusEnvironment,overdensityEnvironmentMinimum,energyOrbitDoubled)
     allocate(tree                                                                          )
@@ -956,6 +1003,11 @@ contains
          &                            +overdensityLinearMinimumMap                                                  &
          &                           )
     do iHost=1,countMasses
+       ! Skip this host mass entirely if the solution for every satellite mass paired with it was carried over---this avoids
+       ! rebuilding the host node and re-evaluating its environmental boost factor, as well as the orbit distributions
+       ! themselves. Note that "isComputed" is shared, and is not modified anywhere within this parallel region, so every thread
+       ! takes this branch identically and the work-sharing constructs below remain matched across the team.
+       if (all(isComputed(iHost,1:iHost))) cycle
        ! Build host node.
        massHost           =  self%mass     (            iHost)
        massHost_          =  massHost
@@ -978,7 +1030,9 @@ contains
        ! Iterate over satellite masses.
        do iSatellite=1,countMasses          
           ! Only consider satellites less (or equally) massive than their host.
-          if (iSatellite > iHost) cycle
+          if (iSatellite > iHost         ) cycle
+          ! Skip solutions carried over from a previous tabulation.
+          if (isComputed(iHost,iSatellite)) cycle
           if (OMP_Get_Thread_Num() == 0) then
              call displayCounter(int(100.0d0*dble(countProgress)/dble(countTotal)),isNew=countProgress==0,verbosity=verbosityLevelWorking)
              countProgress=countProgress+1             
@@ -1525,15 +1579,18 @@ contains
     !!{RST
     Attempt to restore a table from file.
     !!}
-    use :: File_Utilities    , only : File_Exists, File_Lock, File_Unlock, lockDescriptor
+    use :: File_Utilities    , only : File_Exists              , File_Lock          , File_Unlock, lockDescriptor
     use :: HDF5_Access       , only : hdf5Access
     use :: IO_HDF5           , only : hdf5File
     use :: ISO_Varying_String, only : char
+    use :: Numerical_Ranges  , only : enumerationGridSchemeType, gridSchemePerDecade
     implicit none
-    class           (virialOrbitLossCone)             , intent(inout) :: self
-    type            (hdf5File                                        )                             :: file
-    type            (lockDescriptor                                  )                             :: fileLock
-    !$GLC attributes unused :: self
+    class  (virialOrbitLossCone), intent(inout) :: self
+    type   (hdf5File           )                :: file
+    type   (lockDescriptor     )                :: fileLock
+    type   (rangeLattice       )                :: latticeCached
+    integer                                     :: schemeCached      , pointsPerCached, &
+         &                                         indexMinimumCached, countCached
 
     if (.not.self%fileRead.and.File_Exists(self%fileName)) then
        ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
@@ -1549,32 +1606,73 @@ contains
           deallocate(self%velocityRadialDistributionOrbits    )
           deallocate(self%velocityTangentialDistributionOrbits)
           deallocate(self%velocityDistributionOrbits          )
+          deallocate(self%velocityTotalRMS                    )
+          deallocate(self%velocityDistributionPeak            )
           deallocate(self%interpolatorMass                    )
        end if
        !$ call hdf5Access%set()
-       file=hdf5File(self%fileName)
-       call file%readAttribute('time'                                ,     self%time                                 )
-       call file%readAttribute('massMinimum'                         ,     self%massMinimum                          )
-       call file%readAttribute('massMaximum'                         ,     self%massMaximum                          )
-       call file%readDataset  ('mass'                                ,     self%mass                                 )
-       call file%readDataset  ('velocityRadialMeanVirial'            ,     self%velocityRadialMeanVirial             )
-       call file%readDataset  ('velocityRadialDispersionVirial'      ,     self%velocityRadialDispersionVirial       )
-       call file%readDataset  ('velocityTangentialMeanVirial'        ,     self%velocityTangentialMeanVirial         )
-       call file%readDataset  ('velocityTangentialDispersionVirial'  ,     self%velocityTangentialDispersionVirial   )
-       call file%readDataset  ('velocityRadialDistributionOrbits'    ,     self%velocityRadialDistributionOrbits     )
-       call file%readDataset  ('velocityTangentialDistributionOrbits',     self%velocityTangentialDistributionOrbits )
-       call file%readDataset  ('velocityDistributionOrbits'          ,     self%velocityDistributionOrbits           )
-       call file%readDataset  ('velocityTotalRMS'                    ,     self%velocityTotalRMS                     )
-       call file%readDataset  ('velocityDistributionPeak'            ,     self%velocityDistributionPeak             )
+       ! Open read-only: opening read-write would have HDF5 take an exclusive lock on the file, so that another process reading
+       ! it concurrently---which the shared file lock taken above explicitly permits---would fail to open it at all.
+       file=hdf5File(self%fileName,overWrite=.false.,readOnly=.true.)
+       call file%readAttribute('time'                                ,     self%time                                )
+       call file%readAttribute('massGridScheme'                      ,     schemeCached                             )
+       call file%readAttribute('massPointsPer'                       ,     pointsPerCached                          )
+       call file%readAttribute('massIndexMinimum'                    ,     indexMinimumCached                       )
+       call file%readAttribute('massCount'                           ,     countCached                              )
+       call file%readDataset  ('mass'                                ,     self%mass                                )
+       call file%readDataset  ('velocityRadialMeanVirial'            ,     self%velocityRadialMeanVirial            )
+       call file%readDataset  ('velocityRadialDispersionVirial'      ,     self%velocityRadialDispersionVirial      )
+       call file%readDataset  ('velocityTangentialMeanVirial'        ,     self%velocityTangentialMeanVirial        )
+       call file%readDataset  ('velocityTangentialDispersionVirial'  ,     self%velocityTangentialDispersionVirial  )
+       call file%readDataset  ('velocityRadialDistributionOrbits'    ,     self%velocityRadialDistributionOrbits    )
+       call file%readDataset  ('velocityTangentialDistributionOrbits',     self%velocityTangentialDistributionOrbits)
+       call file%readDataset  ('velocityDistributionOrbits'          ,     self%velocityDistributionOrbits          )
+       call file%readDataset  ('velocityTotalRMS'                    ,     self%velocityTotalRMS                    )
+       call file%readDataset  ('velocityDistributionPeak'            ,     self%velocityDistributionPeak            )
        !$ call hdf5Access%unset()
        call File_Unlock(fileLock)
        self%fileRead=.true.
-       ! Rebuild interpolator. It must be allocated first: "interpolator" has a defined assignment, so assigning to it does not
-       ! cause automatic allocation, and its assignment finalizes the left-hand side---which, if unallocated, means finalizing
-       ! garbage. On this path the interpolator is always unallocated: it is either freed above, or was never built, since it is
-       ! constructed only by tabulate().
-       if (.not.allocated(self%interpolatorMass)) allocate(self%interpolatorMass)
-       self%interpolatorMass=interpolator(log(self%mass))
+       ! Place the restored tabulation on its lattice. If the file is not self-consistent---the datasets not matching the lattice
+       ! recorded alongside them, or that lattice not one which this object could have built---then discard everything read from
+       ! it and retabulate from scratch, rather than leave a partially-restored tabulation behind.
+       latticeCached=rangeLattice(enumerationGridSchemeType(schemeCached),pointsPerCached,indexMinimumCached,countCached)
+       if     (                                                        &
+            &   latticeCached%isDefined  (                 )           &
+            &  .and.                                                   &
+            &   latticeCached%scheme      ==      gridSchemePerDecade  &
+            &  .and.                                                   &
+            &   pointsPerCached           == self%countMassesPerDecade &
+            &  .and.                                                   &
+            &   size(self%mass                      ) == countCached   &
+            &  .and.                                                   &
+            &   size(self%velocityRadialMeanVirial,1) == countCached   &
+            &  .and.                                                   &
+            &   size(self%velocityRadialMeanVirial,2) == countCached   &
+            & ) then
+          self%latticeMass=latticeCached
+          ! Take the abscissae from the lattice rather than from the file, so that they are bit-identical to those of any other
+          ! tabulation built on the same lattice.
+          self%mass       =latticeCached%values()
+          ! Rebuild interpolator. It must be allocated first: "interpolator" has a defined assignment, so assigning to it does
+          ! not cause automatic allocation, and its assignment finalizes the left-hand side---which, if unallocated, means
+          ! finalizing garbage. On this path the interpolator is always unallocated: it is either freed above, or was never
+          ! built, since it is constructed only by tabulate().
+          if (.not.allocated(self%interpolatorMass)) allocate(self%interpolatorMass)
+          self%interpolatorMass=interpolator(log(self%mass))
+       else
+          self%time       =-huge(0.0d0)
+          self%latticeMass= rangeLattice()
+          deallocate(self%mass                                )
+          deallocate(self%velocityRadialMeanVirial            )
+          deallocate(self%velocityRadialDispersionVirial      )
+          deallocate(self%velocityTangentialMeanVirial        )
+          deallocate(self%velocityTangentialDispersionVirial  )
+          deallocate(self%velocityRadialDistributionOrbits    )
+          deallocate(self%velocityTangentialDistributionOrbits)
+          deallocate(self%velocityDistributionOrbits          )
+          deallocate(self%velocityTotalRMS                    )
+          deallocate(self%velocityDistributionPeak            )
+       end if
     end if
     return
   end subroutine lossConeRestoreTable
@@ -1599,8 +1697,12 @@ contains
     !$ call hdf5Access%set()
     file=hdf5File(self%fileName,overWrite=.true.,readOnly=.false.)
     call file%writeAttribute(self%time                                ,'time'                                )
-    call file%writeAttribute(self%massMinimum                         ,'massMinimum'                         )
-    call file%writeAttribute(self%massMaximum                         ,'massMaximum'                         )
+    ! Record the lattice, not the bounds: the bounds follow from the lattice, but the converse does not, and it is the lattice
+    ! which determines whether a tabulation read back later can be extended to cover a new range without recomputation.
+    call file%writeAttribute(self%latticeMass%scheme%ID               ,'massGridScheme'                      )
+    call file%writeAttribute(self%latticeMass%pointsPer               ,'massPointsPer'                       )
+    call file%writeAttribute(self%latticeMass%indexMinimum            ,'massIndexMinimum'                    )
+    call file%writeAttribute(self%latticeMass%count                   ,'massCount'                           )
     call file%writeDataset  (self%mass                                ,'mass'                                )
     call file%writeDataset  (self%velocityRadialMeanVirial            ,'velocityRadialMeanVirial'            )
     call file%writeDataset  (self%velocityRadialDispersionVirial      ,'velocityRadialDispersionVirial'      )

--- a/source/satellites/merging/virial_orbits/loss_cone.F90
+++ b/source/satellites/merging/virial_orbits/loss_cone.F90
@@ -1339,11 +1339,11 @@ contains
                      &                               +self%velocity                  (                                     indexVelocityTangential)**2 &
                      &                              )
              end do
-             velocityTotalRMS(iHost,iSatellite)=sqrt(                                                       &
-                  &                                  +    velocityTotalRMS          (iHost,iSatellite    )  &
-                  &                                  /sum(velocityDistributionOrbits(iHost,iSatellite,:,:)) &
-                  &                                 )
           end do
+          velocityTotalRMS(iHost,iSatellite)=sqrt(                                                       &
+               &                                  +    velocityTotalRMS          (iHost,iSatellite    )  &
+               &                                  /sum(velocityDistributionOrbits(iHost,iSatellite,:,:)) &
+               &                                 )
           !$omp end single
           ! Clean up.
           deallocate(nodeSatellite)


### PR DESCRIPTION
Converts the `lossCone` virial orbit class to a pinned tabulation, continuing Phase 1 of #1317.

The mass axis becomes a single `rangeLattice` (`gridSchemePerDecade`, whole-decade anchors), seeded from the existing 1e6/1e15 defaults. Surviving solutions are carried over as a square block offset equally along both mass dimensions, tracked by a shared, read-only `isComputed` mask; the `iHost` and `iSatellite` loops skip cells carried over. Time remains a *key* rather than an axis - the tabulation is discarded wholesale when the epoch changes - per the multi-dimensional decision recorded on #1317.

Two defects at this site were fixed as part of the conversion, since pinning makes them reachable:

- `restoreTable` opened the cache read-write, so HDF5 took an exclusive lock and aborted concurrent readers - the same defect already fixed at the SIDM site.
- `restoreTable`'s deallocate block omitted `velocityTotalRMS` and `velocityDistributionPeak`, although both are read back.

A third, unrelated to pinning, is fixed in its own commit: `velocityTotalRMS` took its square root *inside* the `indexVelocityRadial` loop, so it square-rooted a partial sum once per radial velocity bin.

### Verification

- Clean build with no compiler warnings; `tests.make_ranges` 32/32, `tests.tables` 27/27, `tests.table_caches` 17/17, `tests.spherical_collapse.determinism` 30/30.
- `parameters/quickTest.xml`, and `testSuite/test-virial-orbit-loss-cone.py`.
- The lattice is exactly `(scheme=perDecade, pointsPer=1, indexMinimum=6, count=10)` - an identical grid to the pre-change tabulation.
- Extension was forced by cropping a stored tabulation and re-running: single-threaded, the extended table is bit-identical to one built in a single pass over the whole 10x10 lattice at a matched epoch. Reuse itself was then confirmed by scaling the cached block by 1.5 and checking that factor appears at exactly the expected offset, with every cell outside it recomputed bit-identically.

Note the extension check must be run single-threaded: this compute loop uses `!$omp do reduction(...) schedule(dynamic)`, so summation order varies and two runs of the same binary at the same epoch disagree by up to 1e-1 relative, which swamps the comparison.

Part of #1317.
