### PR TITLE
feat(tables): support extension of cubic-spline tables onto an absolute lattice

### DIFF
--- a/source/objects/tables/_module.F90
+++ b/source/objects/tables/_module.F90
@@ -287,6 +287,7 @@ module Tables
      </methods>
      !!]
      procedure :: create              => Table_Linear_CSpline_1D_Create
+     procedure :: extend              => Table_Linear_CSpline_1D_Extend
      procedure :: destroy             => Table_Linear_CSpline_1D_Destroy
      procedure :: populateArray       => Table_Linear_CSpline_1D_Populate
      procedure :: populateScalar      => Table_Linear_CSpline_1D_Populate_Single
@@ -305,6 +306,7 @@ module Tables
      double precision :: xMinimum       , xMaximum
    contains
      procedure :: create              => Table_Logarithmic_CSpline_1D_Create
+     procedure :: extend              => Table_Logarithmic_CSpline_1D_Extend
      procedure :: interpolate         => Table_Logarithmic_CSpline_1D_Interpolate
      procedure :: interpolateGradient => Table_Logarithmic_CSpline_1D_Interpolate_Gradient
      procedure :: x                   => Table_Logarithmic_CSpline_1D_X
@@ -317,6 +319,7 @@ module Tables
      !!}
    contains
      procedure :: create              => Table_Linear_Monotone_CSpline_1D_Create
+     procedure :: extend              => Table_Linear_Monotone_CSpline_1D_Extend
      procedure :: destroy             => Table_Linear_Monotone_CSpline_1D_Destroy
      procedure :: populateArray       => Table_Linear_Monotone_CSpline_1D_Populate
      procedure :: populateScalar      => Table_Linear_Monotone_CSpline_1D_Populate_Single
@@ -334,6 +337,7 @@ module Tables
      double precision :: xMinimum       , xMaximum
    contains
      procedure :: create              => Table_Logarithmic_Monotone_CSpline_1D_Create
+     procedure :: extend              => Table_Logarithmic_Monotone_CSpline_1D_Extend
      procedure :: interpolate         => Table_Logarithmic_Monotone_CSpline_1D_Interpolate
      procedure :: interpolateGradient => Table_Logarithmic_Monotone_CSpline_1D_Interpolate_Gradient
      procedure :: x                   => Table_Logarithmic_Monotone_CSpline_1D_X
@@ -496,16 +500,19 @@ contains
     return
   end subroutine Table_1D_Extend
 
-  subroutine Table_1D_Extend_Uniform(self,lattice,xValues,deltaX,isComputed,tableCount,extrapolationType)
+  subroutine Table_1D_Extend_Uniform(self,lattice,xValues,isComputed,tableCount,extrapolationType)
     !!{RST
     Worker used to extend 1-D tables which have uniformly-spaced *internal* abscissae. ``xValues`` must be the internal-coordinate
     abscissae of the points of ``lattice``---for example, for a logarithmically-spaced table these are the natural logarithms of
-    the lattice points---and ``deltaX`` their spacing.
+    the lattice points.
 
-    Note that ``deltaX`` is supplied by the caller (from the lattice) rather than evaluated here as ``xValues(2)-xValues(1)``.
-    The difference of two neighbouring lattice points varies in its final bits with position along the lattice, so deriving the
-    interpolation factor from it would change every interpolated value by of order one unit in the last place whenever the lower
-    bound of the table moved - defeating the very reuse which extension exists to provide.
+    This handles only the state held by ``table1D`` itself---the abscissae, the values, the lattice, and the extrapolation
+    type. Each concrete table type must, on return, set its own spacing and reset any cached interpolation state.
+
+    **The spacing must be taken from the lattice**, never evaluated as ``xValues(2)-xValues(1)``: the difference of two
+    neighbouring lattice points varies in its final bits with position along the lattice, so deriving the interpolation factor
+    from it would change every interpolated value by of order one unit in the last place whenever the lower bound of the table
+    moved---defeating the very reuse which extension exists to provide.
 
     Previously computed values are preserved by copying them into the index window which they occupy in the new table---the
     index offset is computed from the integer lattice indices, so no searching or floating-point comparison of abscissae is
@@ -515,10 +522,9 @@ contains
     use :: Numerical_Ranges, only : rangeLattice
     use :: Table_Labels    , only : extrapolationTypeExtrapolate
     implicit none
-    class           (table1DLinearLinear             ), intent(inout)                            :: self
+    class           (table1D                         ), intent(inout)                            :: self
     type            (rangeLattice                    ), intent(in   )                            :: lattice
     double precision                                  , intent(in   )             , dimension(:) :: xValues
-    double precision                                  , intent(in   )                            :: deltaX
     logical                                           , intent(  out), allocatable, dimension(:) :: isComputed
     integer                                           , intent(in   ), optional                  :: tableCount
     type            (enumerationExtrapolationTypeType), intent(in   ), optional   , dimension(2) :: extrapolationType
@@ -565,11 +571,6 @@ contains
     if (allocated(yvPrevious)) self%yv(offset+1:offset+size(yvPrevious,dim=1),:)=yvPrevious
     self%xCount        =lattice%count
     self%lattice       =lattice
-    self%inverseDeltaX =1.0d0/deltaX
-    self%tablePrevious =-1
-    self%dTablePrevious=-1
-    self%xPrevious     =-1.0d0
-    self%dxPrevious    =-1.0d0
     ! Set the extrapolation type if one was specified.
     if (present(extrapolationType)) self%extrapolationType=extrapolationType
     return
@@ -1289,7 +1290,13 @@ contains
     type   (enumerationExtrapolationTypeType), intent(in   ), optional  , dimension(2)  :: extrapolationType
 
     if (lattice%scheme /= gridSchemePerUnit) call Error_Report('a linearly-spaced table requires a `perUnit` gridding scheme'//{introspection:location})
-    call Table_1D_Extend_Uniform(self,lattice,lattice%values(),lattice%step(),isComputed,tableCount,extrapolationType)
+    call Table_1D_Extend_Uniform(self,lattice,lattice%values(),isComputed,tableCount,extrapolationType)
+    ! The spacing comes from the lattice - see `Table_1D_Extend_Uniform`.
+    self%inverseDeltaX =1.0d0/lattice%step()
+    self%tablePrevious =-1
+    self%dTablePrevious=-1
+    self%xPrevious     =-1.0d0
+    self%dxPrevious    =-1.0d0
     return
   end subroutine Table_Linear_1D_Extend
 
@@ -1480,7 +1487,13 @@ contains
          &   lattice%scheme /= gridSchemePerOctave &
          & ) call Error_Report('a logarithmically-spaced table requires a `perDecade` or `perOctave` gridding scheme'//{introspection:location})
     ! The internal abscissae of this table type are the natural logarithms of the tabulation points.
-    call Table_1D_Extend_Uniform(self,lattice,lattice%valuesLogarithmic(),lattice%stepLogarithmic(),isComputed,tableCount,extrapolationType)
+    call Table_1D_Extend_Uniform(self,lattice,lattice%valuesLogarithmic(),isComputed,tableCount,extrapolationType)
+    ! The spacing comes from the lattice - see `Table_1D_Extend_Uniform`.
+    self%inverseDeltaX       =1.0d0/lattice%stepLogarithmic()
+    self%tablePrevious       =-1
+    self%dTablePrevious      =-1
+    self%xPrevious           =-1.0d0
+    self%dxPrevious          =-1.0d0
     self%previousSet         =.false.
     self%xLinearPrevious     =-1.0d0
     self%xLogarithmicPrevious=-1.0d0
@@ -1725,6 +1738,193 @@ contains
     end if
     return
   end subroutine Table_Linear_CSpline_1D_Create
+
+  subroutine Table_1D_CSpline_Extend_Uniform(self,lattice,xValues,deltaX,isComputed,tableCount,extrapolationType)
+    !!{RST
+    Worker used to extend cubic-spline 1-D tables which have uniformly-spaced *internal* abscissae, onto an absolute lattice.
+
+    Note what is and is not preserved here. The tabulated values *are* preserved, and they are the expensive part---this is what
+    makes extension worthwhile. The spline coefficients are **not**: a cubic spline is not local, so every coefficient depends on
+    every tabulated value, and adding points at either end changes the interpolant everywhere. They are therefore discarded and
+    reallocated, to be rebuilt when the table is next populated. The consequence, which callers must accept, is that extending a
+    cubic-spline table preserves its tabulated values exactly but *not* the values it interpolates between them---unlike a
+    linearly-interpolated table, where interpolation is local and extension changes nothing on the overlap.
+    !!}
+    use :: Numerical_Ranges, only : rangeLattice
+    implicit none
+    class           (table1DLinearCSpline            ), intent(inout)                            :: self
+    type            (rangeLattice                    ), intent(in   )                            :: lattice
+    double precision                                  , intent(in   )             , dimension(:) :: xValues
+    double precision                                  , intent(in   )                            :: deltaX
+    logical                                           , intent(  out), allocatable, dimension(:) :: isComputed
+    integer                                           , intent(in   ), optional                  :: tableCount
+    type            (enumerationExtrapolationTypeType), intent(in   ), optional   , dimension(2) :: extrapolationType
+
+    call Table_1D_Extend_Uniform(self,lattice,xValues,isComputed,tableCount,extrapolationType)
+    ! The spacing comes from the lattice - see `Table_1D_Extend_Uniform`. Note that the creator for this type takes it as
+    ! `xv(2)-xv(1)`, which is exactly what must not be done here.
+    self%       deltaX =      deltaX
+    self%inverseDeltaX =1.0d0/deltaX
+    self%tablePrevious =-1
+    self%dTablePrevious=-1
+    self%iPrevious     =-1
+    self%xPrevious     =-1.0d0
+    self%dxPrevious    =-1.0d0
+    return
+  end subroutine Table_1D_CSpline_Extend_Uniform
+
+  subroutine Table_1D_CSpline_Coefficients(self)
+    !!{RST
+    Discard and reallocate the spline coefficients of a cubic-spline table after its range has changed---see
+    ``Table_1D_CSpline_Extend_Uniform`` for why they are not preserved. The shapes here must match those used by the creator of
+    the corresponding table type exactly: ``Table_Linear_Monotone_CSpline_1D_Compute_Spline`` writes to ``av`` one element
+    beyond the number of intervals, so a monotonic table allocates ``av`` with one row *more* than the others, and uses neither
+    ``sv`` nor ``dv``. This is why the monotonic variants have their own allocator below rather than sharing this one.
+    !!}
+    implicit none
+    class  (table1DLinearCSpline), intent(inout) :: self
+    integer                                      :: countPoints, countTables
+
+    countPoints=size(self%yv,dim=1)
+    countTables=size(self%yv,dim=2)
+    if (allocated(self%sv)) deallocate(self%sv)
+    if (allocated(self%av)) deallocate(self%av)
+    if (allocated(self%bv)) deallocate(self%bv)
+    if (allocated(self%cv)) deallocate(self%cv)
+    if (allocated(self%dv)) deallocate(self%dv)
+    allocate(self%sv(countPoints  ,countTables))
+    allocate(self%av(countPoints-1,countTables))
+    allocate(self%bv(countPoints-1,countTables))
+    allocate(self%cv(countPoints-1,countTables))
+    allocate(self%dv(countPoints-1,countTables))
+    return
+  end subroutine Table_1D_CSpline_Coefficients
+
+  subroutine Table_1D_Monotone_CSpline_Coefficients(self)
+    !!{RST
+    As ``Table_1D_CSpline_Coefficients``, but using the array shapes of the monotonic cubic-spline creator: ``av`` carries one
+    entry per point rather than per interval, and ``sv`` and ``dv`` are unused.
+    !!}
+    implicit none
+    class  (table1DLinearMonotoneCSpline), intent(inout) :: self
+    integer                                              :: countPoints, countTables
+
+    countPoints=size(self%yv,dim=1)
+    countTables=size(self%yv,dim=2)
+    if (allocated(self%av)) deallocate(self%av)
+    if (allocated(self%bv)) deallocate(self%bv)
+    if (allocated(self%cv)) deallocate(self%cv)
+    allocate(self%av(countPoints  ,countTables))
+    allocate(self%bv(countPoints-1,countTables))
+    allocate(self%cv(countPoints-1,countTables))
+    return
+  end subroutine Table_1D_Monotone_CSpline_Coefficients
+
+  subroutine Table_Linear_CSpline_1D_Extend(self,lattice,isComputed,tableCount,extrapolationType)
+    !!{RST
+    Extend a 1-D linearly-spaced cubic-spline table onto an absolute lattice. Since the abscissae of such a table are uniformly
+    spaced in :math:`x`, only the ``perUnit`` gridding scheme is applicable.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Numerical_Ranges, only : rangeLattice, gridSchemePerUnit
+    implicit none
+    class  (table1DLinearCSpline            ), intent(inout)                            :: self
+    type   (rangeLattice                    ), intent(in   )                            :: lattice
+    logical                                  , intent(  out), allocatable, dimension(:) :: isComputed
+    integer                                  , intent(in   ), optional                  :: tableCount
+    type   (enumerationExtrapolationTypeType), intent(in   ), optional  , dimension(2)  :: extrapolationType
+
+    if (lattice%scheme /= gridSchemePerUnit) call Error_Report('a linearly-spaced table requires a `perUnit` gridding scheme'//{introspection:location})
+    call Table_1D_CSpline_Extend_Uniform(self,lattice,lattice%values(),lattice%step(),isComputed,tableCount,extrapolationType)
+    call Table_1D_CSpline_Coefficients   (self)
+    return
+  end subroutine Table_Linear_CSpline_1D_Extend
+
+  subroutine Table_Linear_Monotone_CSpline_1D_Extend(self,lattice,isComputed,tableCount,extrapolationType)
+    !!{RST
+    Extend a 1-D linearly-spaced monotonic cubic-spline table onto an absolute lattice. This differs from
+    ``Table_Linear_CSpline_1D_Extend`` only in the shapes of the spline coefficient arrays.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Numerical_Ranges, only : rangeLattice, gridSchemePerUnit
+    implicit none
+    class  (table1DLinearMonotoneCSpline    ), intent(inout)                            :: self
+    type   (rangeLattice                    ), intent(in   )                            :: lattice
+    logical                                  , intent(  out), allocatable, dimension(:) :: isComputed
+    integer                                  , intent(in   ), optional                  :: tableCount
+    type   (enumerationExtrapolationTypeType), intent(in   ), optional  , dimension(2)  :: extrapolationType
+
+    if (lattice%scheme /= gridSchemePerUnit) call Error_Report('a linearly-spaced table requires a `perUnit` gridding scheme'//{introspection:location})
+    call Table_1D_CSpline_Extend_Uniform      (self,lattice,lattice%values(),lattice%step(),isComputed,tableCount,extrapolationType)
+    call Table_1D_Monotone_CSpline_Coefficients(self)
+    return
+  end subroutine Table_Linear_Monotone_CSpline_1D_Extend
+
+  subroutine Table_Logarithmic_CSpline_1D_Extend(self,lattice,isComputed,tableCount,extrapolationType)
+    !!{RST
+    Extend a 1-D logarithmically-spaced cubic-spline table onto an absolute lattice.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Numerical_Ranges, only : rangeLattice, gridSchemePerDecade, gridSchemePerOctave
+    implicit none
+    class  (table1DLogarithmicCSpline       ), intent(inout)                            :: self
+    type   (rangeLattice                    ), intent(in   )                            :: lattice
+    logical                                  , intent(  out), allocatable, dimension(:) :: isComputed
+    integer                                  , intent(in   ), optional                  :: tableCount
+    type   (enumerationExtrapolationTypeType), intent(in   ), optional  , dimension(2)  :: extrapolationType
+
+    if     (                                       &
+         &   lattice%scheme /= gridSchemePerDecade &
+         &  .and.                                  &
+         &   lattice%scheme /= gridSchemePerOctave &
+         & ) call Error_Report('a logarithmically-spaced table requires a `perDecade` or `perOctave` gridding scheme'//{introspection:location})
+    ! The internal abscissae of this table type are the natural logarithms of the tabulation points.
+    call Table_1D_CSpline_Extend_Uniform(self,lattice,lattice%valuesLogarithmic(),lattice%stepLogarithmic(),isComputed,tableCount,extrapolationType)
+    call Table_1D_CSpline_Coefficients   (self)
+    self%previousSet         =.false.
+    self%xLinearPrevious     =-1.0d0
+    self%xLogarithmicPrevious=-1.0d0
+    ! The end points are cached for rapid look-up. They are evaluated from the stored internal abscissae, exactly as the creator
+    ! does, and deliberately *not* from `lattice%minimum()`/`%maximum()`: the internal abscissae of this table type are the
+    ! natural logarithms of the lattice points, so `x(i)` returns exp(xv(i)) for every interior point, and 2**(k/N) is not
+    ! bit-identical to exp((k/N)ln2). Taking the end points from the lattice would make them disagree with the same points seen
+    ! from a table whose range extends past them - which is precisely the invariance extension exists to provide.
+    self%xMinimum            =exp(self%xv(          1))
+    self%xMaximum            =exp(self%xv(self%xCount))
+    return
+  end subroutine Table_Logarithmic_CSpline_1D_Extend
+
+  subroutine Table_Logarithmic_Monotone_CSpline_1D_Extend(self,lattice,isComputed,tableCount,extrapolationType)
+    !!{RST
+    Extend a 1-D logarithmically-spaced monotonic cubic-spline table onto an absolute lattice. This duplicates
+    ``Table_Logarithmic_CSpline_1D_Extend`` because the monotonic variant descends from ``table1DLinearMonotoneCSpline`` rather
+    than from ``table1DLogarithmicCSpline``, exactly as their creators are duplicated for the same reason.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Numerical_Ranges, only : rangeLattice, gridSchemePerDecade, gridSchemePerOctave
+    implicit none
+    class  (table1DLogarithmicMonotoneCSpline), intent(inout)                            :: self
+    type   (rangeLattice                     ), intent(in   )                            :: lattice
+    logical                                   , intent(  out), allocatable, dimension(:) :: isComputed
+    integer                                   , intent(in   ), optional                  :: tableCount
+    type   (enumerationExtrapolationTypeType ), intent(in   ), optional  , dimension(2)  :: extrapolationType
+
+    if     (                                       &
+         &   lattice%scheme /= gridSchemePerDecade &
+         &  .and.                                  &
+         &   lattice%scheme /= gridSchemePerOctave &
+         & ) call Error_Report('a logarithmically-spaced table requires a `perDecade` or `perOctave` gridding scheme'//{introspection:location})
+    ! The internal abscissae of this table type are the natural logarithms of the tabulation points.
+    call Table_1D_CSpline_Extend_Uniform       (self,lattice,lattice%valuesLogarithmic(),lattice%stepLogarithmic(),isComputed,tableCount,extrapolationType)
+    call Table_1D_Monotone_CSpline_Coefficients(self)
+    self%previousSet         =.false.
+    self%xLinearPrevious     =-1.0d0
+    self%xLogarithmicPrevious=-1.0d0
+    ! See `Table_Logarithmic_CSpline_1D_Extend` for why the end points come from the stored abscissae, not from the lattice.
+    self%xMinimum            =exp(self%xv(          1))
+    self%xMaximum            =exp(self%xv(self%xCount))
+    return
+  end subroutine Table_Logarithmic_Monotone_CSpline_1D_Extend
 
   subroutine Table_Linear_CSpline_1D_Destroy(self)
     !!{RST

--- a/source/tests/tables.F90
+++ b/source/tests/tables.F90
@@ -27,10 +27,12 @@ program Test_Tables
   !!}
   use :: Array_Utilities , only : directionDecreasing         , directionIncreasing
   use :: Display         , only : displayVerbositySet         , verbosityLevelStandard
-  use :: Numerical_Ranges, only : Range_Pinned                , rangeLattice            , gridSchemePerOctave               , gridSchemePerDecade
-  use :: Tables          , only : table                       , table1D                 , table1DLinearCSpline              , table1DLinearLinear, &
-          &                       table1DLinearMonotoneCSpline, table1DLogarithmicLinear, table1DNonUniformLinearLogarithmic, table2DLogLogLin
-  use :: Unit_Tests      , only : Assert                      , Unit_Tests_Begin_Group  , Unit_Tests_End_Group              , Unit_Tests_Finish
+  use :: Numerical_Ranges, only : Range_Pinned                , rangeLattice                     , gridSchemePerOctave               , gridSchemePerDecade, &
+          &                       gridSchemePerUnit
+  use :: Tables          , only : table                       , table1D                          , table1DLinearCSpline              , table1DLinearLinear, &
+          &                       table1DLinearMonotoneCSpline, table1DLogarithmicLinear         , table1DNonUniformLinearLogarithmic, table2DLogLogLin   , &
+          &                       table1DLogarithmicCSpline   , table1DLogarithmicMonotoneCSpline
+  use :: Unit_Tests      , only : Assert                      , Unit_Tests_Begin_Group           , Unit_Tests_End_Group              , Unit_Tests_Finish
   implicit none
   class           (table           ), allocatable                 :: myTable
   class           (table1D         ), allocatable                 :: myReversedTable
@@ -50,6 +52,9 @@ program Test_Tables
   type            (rangeLattice    )                              :: latticeX2D     , latticeY2D
   logical                           , allocatable, dimension(:,:) :: isComputed2D
   double precision                  , allocatable, dimension(:,:) :: zValuesNarrow2D, zValuesWide2D
+  double precision                  , allocatable, dimension(:  ) :: xValuesSpline  , interpolatedExtended, &
+       &                                                             interpolatedDirect
+  double precision                  , allocatable, dimension(:,:) :: yValuesSpline
 
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
@@ -470,6 +475,99 @@ program Test_Tables
        &      .true.                                                                                              &
        &     )
   call myTable2DExtend%destroy()
+
+  ! Test extension of a cubic-spline table. A cubic spline is not local - every coefficient depends on every tabulated value -
+  ! so extension preserves the tabulated values but not the interpolant between them. What it must guarantee is that an extended
+  ! table is indistinguishable from one built directly on the wider lattice, including in what it interpolates.
+  allocate(table1DLogarithmicMonotoneCSpline :: myTable)
+  select type (myTable)
+  type is (table1DLogarithmicMonotoneCSpline)
+     latticeNarrow=Range_Pinned(3.0d0,4,gridSchemePerOctave)
+     call myTable%extend(latticeNarrow,isComputed)
+     call Assert('spline extension of an empty table requires every point to be computed',count(isComputed),0                  )
+     call Assert('spline extension of an empty table gives the lattice point count'      ,myTable%size()   ,latticeNarrow%count)
+     do i=1,myTable%size()
+        call myTable%populate(myTable%x(i)**2,i)
+     end do
+     xValuesSpline=myTable%xs()
+     yValuesSpline=myTable%ys()
+     ! Extend to a wider range on the same lattice.
+     latticeWide=Range_Pinned(30.0d0,4,gridSchemePerOctave,latticeCurrent=myTable%lattice)
+     call myTable%extend(latticeWide,isComputed)
+     offset=latticeNarrow%indexMinimum-latticeWide%indexMinimum
+     call Assert('spline extension marks precisely the previously computed points as computed',count(isComputed)                                   ,latticeNarrow%count)
+     call Assert('spline extension marks the correct window as computed'                      ,all(isComputed(offset+1:offset+latticeNarrow%count)),.true.             )
+     xValuesWide=myTable%xs()
+     yValuesWide=myTable%ys()
+     call Assert('spline extension preserves abscissae bit-for-bit'                            , &
+          &      all(xValuesWide(offset+1:offset+latticeNarrow%count  ) == xValuesSpline      ), &
+          &      .true.                                                                          &
+          &     )
+     call Assert('spline extension preserves tabulated values bit-for-bit'                     , &
+          &      all(yValuesWide(offset+1:offset+latticeNarrow%count,1) == yValuesSpline(:,1) ), &
+          &      .true.                                                                          &
+          &     )
+     ! Compute the newly added points, then record what the extended table holds and interpolates.
+     do i=1,myTable%size()
+        if (.not.isComputed(i)) call myTable%populate(myTable%x(i)**2,i)
+     end do
+     xValuesWide=myTable%xs()
+     yValuesWide=myTable%ys()
+     allocate(interpolatedExtended(latticeWide%count-1))
+     do i=1,latticeWide%count-1
+        interpolatedExtended(i)=myTable%interpolate(sqrt(myTable%x(i)*myTable%x(i+1)))
+     end do
+     call myTable%destroy()
+  end select
+  deallocate(myTable)
+
+  ! Build the same table directly on the wider lattice. It must agree with the extended table not only in its tabulated values
+  ! but in what it interpolates - the spline coefficients having been rebuilt over the whole range by both routes.
+  allocate(table1DLogarithmicMonotoneCSpline :: myTable)
+  select type (myTable)
+  type is (table1DLogarithmicMonotoneCSpline)
+     call myTable%extend(latticeWide,isComputed)
+     do i=1,myTable%size()
+        call myTable%populate(myTable%x(i)**2,i)
+     end do
+     xValuesDirect=myTable%xs()
+     yValuesDirect=myTable%ys()
+     call Assert('a spline table built directly has abscissae identical to one built by extension'       ,all(xValuesDirect      == xValuesWide     ),.true.)
+     call Assert('a spline table built directly has tabulated values identical to one built by extension',all(yValuesDirect(:,1) == yValuesWide(:,1)),.true.)
+     allocate(interpolatedDirect(latticeWide%count-1))
+     do i=1,latticeWide%count-1
+        interpolatedDirect(i)=myTable%interpolate(sqrt(myTable%x(i)*myTable%x(i+1)))
+     end do
+     call Assert('a spline table built directly interpolates identically to one built by extension'      ,all(interpolatedDirect == interpolatedExtended),.true.)
+     call myTable%destroy()
+  end select
+  deallocate(myTable)
+
+  ! A linearly-spaced cubic-spline table extends onto a `perUnit` lattice in the same way.
+  allocate(table1DLinearCSpline :: myTable)
+  select type (myTable)
+  type is (table1DLinearCSpline)
+     latticeNarrow=Range_Pinned(3.0d0,4,gridSchemePerUnit)
+     call myTable%extend(latticeNarrow,isComputed)
+     do i=1,myTable%size()
+        call myTable%populate(myTable%x(i)**2,i)
+     end do
+     yValuesSpline=myTable%ys()
+     latticeWide=Range_Pinned(9.0d0,4,gridSchemePerUnit,latticeCurrent=myTable%lattice)
+     call myTable%extend(latticeWide,isComputed)
+     offset=latticeNarrow%indexMinimum-latticeWide%indexMinimum
+     yValuesWide=myTable%ys()
+     call Assert('a linearly-spaced spline table preserves tabulated values bit-for-bit on extension'    , &
+          &      all(yValuesWide(offset+1:offset+latticeNarrow%count,1) == yValuesSpline(:,1)          ), &
+          &      .true.                                                                                   &
+          &     )
+     call Assert('a linearly-spaced spline table takes its spacing from the lattice'                     , &
+          &      myTable%x(2)-myTable%x(1) == latticeWide%step()                                        , &
+          &      .true.                                                                                   &
+          &     )
+     call myTable%destroy()
+  end select
+  deallocate(myTable)
 
   ! End unit tests.
   call Unit_Tests_End_Group()

--- a/testSuite/test-merger-tree-builder.py
+++ b/testSuite/test-merger-tree-builder.py
@@ -5,6 +5,7 @@ import os
 import glob
 import argparse
 import shutil
+import xml.etree.ElementTree as ET
 import h5py
 import numpy as np
 
@@ -76,24 +77,30 @@ launchOptions = f"--launchMethod {args.launchMethod} --threadMaximum {args.threa
 if args.instance:
     launchOptions += f" --instance {args.instance}"
 
-# Build parameterGrid XML and run via launch.py.
-with open("outputs/test-merger-tree-builder.xml", "w") as f:
-    f.write("<parameterGrid>\n")
-    f.write("  <emailReport>no</emailReport>\n")
-    f.write("  <doAnalysis>no</doAnalysis>\n")
-    f.write("  <modelRootDirectory>testSuite/outputs/test-merger-tree-builder</modelRootDirectory>\n")
-    f.write("  <baseParameters>testSuite/parameters/mergerTreeBuilderCole2000_intervalStepTrue.xml</baseParameters>\n")
-    for paramFile in paramFiles:
-        with open(paramFile) as pf:
-            f.write(pf.read())
-    f.write("</parameterGrid>\n")
+# Build the parameterGrid XML and run via launch.py. The parameter files are parsed and their root elements grafted into the
+# document, rather than their text being concatenated into it: each is a document in its own right and so begins with an XML
+# declaration, which is well formed only at the very start of a document. Concatenating them produced a document which
+# launch.py could not parse, so no model ran at all.
+grid = ET.Element("parameterGrid")
+for name, text in (
+        ("emailReport",        "no"                                                                  ),
+        ("doAnalysis",         "no"                                                                  ),
+        ("modelRootDirectory", "testSuite/outputs/test-merger-tree-builder"                          ),
+        ("baseParameters",     "testSuite/parameters/mergerTreeBuilderCole2000_intervalStepTrue.xml" ),
+):
+    ET.SubElement(grid, name).text = text
+for paramFile in paramFiles:
+    grid.append(ET.parse(paramFile).getroot())
+ET.indent(grid)
+ET.ElementTree(grid).write("outputs/test-merger-tree-builder.xml", encoding="UTF-8", xml_declaration=True)
 
 subprocess.run(
     f"cd ..; mkdir -p testSuite/outputs/test-merger-tree-builder; ./scripts/aux/launch.py testSuite/outputs/test-merger-tree-builder.xml {launchOptions}",
     shell=True
 )
 
-# Check for failed models.
+# Check for failed models. Note that a model which never ran leaves no log to grep, so the number of logs found must be checked
+# against the number of models launched - otherwise a failure to launch any model at all reports as a success.
 logFiles = glob.glob("outputs/test-merger-tree-builder/galacticus_*/galacticus.log")
 failures = []
 for logFile in logFiles:
@@ -104,7 +111,9 @@ for logFile in logFiles:
     if result.returncode == 0:
         failures.append(logFile)
 
-if failures:
+if len(logFiles) < len(paramFiles):
+    print(f"FAILED: {len(paramFiles)} models were launched but only {len(logFiles)} produced a log - they did not run")
+elif failures:
     for failure in failures:
         print(f"FAILED: log from {failure}:")
         with open(failure) as f:
@@ -123,6 +132,9 @@ for model in models:
             shutil.copy(tmpName, model["fileName"])
             model["exists"] = True
         else:
+            # Report this: a model which produced no output is silently dropped from the comparisons below, so without this the
+            # remaining models are compared and the run reports as a success.
+            print(f"FAILED: model '{model['type']}' produced no output at {tmpName}")
             model["exists"] = False
             continue
     else:

--- a/testSuite/test-merger-tree-builder.py
+++ b/testSuite/test-merger-tree-builder.py
@@ -2,7 +2,6 @@
 import subprocess
 import sys
 import os
-import glob
 import argparse
 import shutil
 import xml.etree.ElementTree as ET
@@ -99,42 +98,61 @@ subprocess.run(
     shell=True
 )
 
-# Check for failed models. Note that a model which never ran leaves no log to grep, so the number of logs found must be checked
-# against the number of models launched - otherwise a failure to launch any model at all reports as a success.
-logFiles = glob.glob("outputs/test-merger-tree-builder/galacticus_*/galacticus.log")
-failures = []
-for logFile in logFiles:
-    result = subprocess.run(
-        f'grep -q -i -e fatal -e aborted -e "Galacticus experienced an error in the GSL library" {logFile}',
-        shell=True
-    )
-    if result.returncode == 0:
-        failures.append(logFile)
+# Identify which models this invocation actually ran. `launch.py` distributes models over instances - CI runs this script four
+# times with `--instance N:4`, so each run launches only one of the four models - and it creates an output directory only for
+# those models it runs. The presence of that directory, not of a log, is therefore what separates a model which ran from one
+# belonging to another instance; a model which ran but died leaves the directory behind, with no log or no output in it.
+modelIndex = -1
+for model in models:
+    if "parameterFile" not in model:
+        continue
+    modelIndex              += 1
+    model["outputDirectory"] = f"outputs/test-merger-tree-builder/galacticus_{modelIndex}:1"
+    model["launched"       ] = os.path.isdir(model["outputDirectory"])
 
-if len(logFiles) < len(paramFiles):
-    print(f"FAILED: {len(paramFiles)} models were launched but only {len(logFiles)} produced a log - they did not run")
-elif failures:
-    for failure in failures:
-        print(f"FAILED: log from {failure}:")
-        with open(failure) as f:
-            print(f.read())
+launched = [model for model in models if model.get("launched")]
+
+# Check for failed models. A model which never ran leaves no log to grep, so an empty set of logs would otherwise yield an empty
+# set of failures and report as a success - hence the check that this invocation ran something at all, and that everything it did
+# run left a log.
+failures = []
+if not launched:
+    print(f"FAILED: none of the {len(paramFiles)} models was launched - no output directory was created")
 else:
-    print("SUCCESS: model run")
+    for model in launched:
+        logFile = f"{model['outputDirectory']}/galacticus.log"
+        if not os.path.exists(logFile):
+            print(f"FAILED: model '{model['type']}' was launched but produced no log at {logFile}")
+            failures.append(logFile)
+            continue
+        result = subprocess.run(
+            f'grep -q -i -e fatal -e aborted -e "Galacticus experienced an error in the GSL library" {logFile}',
+            shell=True
+        )
+        if result.returncode == 0:
+            print(f"FAILED: log from {logFile}:")
+            with open(logFile) as f:
+                print(f.read())
+            failures.append(logFile)
+    if not failures:
+        print(f"SUCCESS: model run ({len(launched)} of {len(paramFiles)} models in this instance)")
 
 # Read test and reference data.
 modelData = {}
-i = -1
 for model in models:
     if "parameterFile" in model:
-        i += 1
-        tmpName = f"outputs/test-merger-tree-builder/galacticus_{i}:1/galacticus.hdf5"
+        if not model["launched"]:
+            # This model belongs to another instance - it is not expected to have run here, and is simply not compared.
+            model["exists"] = False
+            continue
+        tmpName = f"{model['outputDirectory']}/galacticus.hdf5"
         if os.path.exists(tmpName):
             shutil.copy(tmpName, model["fileName"])
             model["exists"] = True
         else:
-            # Report this: a model which produced no output is silently dropped from the comparisons below, so without this the
-            # remaining models are compared and the run reports as a success.
-            print(f"FAILED: model '{model['type']}' produced no output at {tmpName}")
+            # Report this: a model which ran but produced no output would otherwise be silently dropped from the comparisons
+            # below, leaving the run to report as a success.
+            print(f"FAILED: model '{model['type']}' was launched but produced no output at {tmpName}")
             model["exists"] = False
             continue
     else:


### PR DESCRIPTION
Two independent changes, both prerequisites for the next conversion under #1317.

### `extend` for cubic-spline tables

Adds `extend` to the cubic-spline 1-D table types, so that sites tabulating on a cubic spline can be pinned to an absolute lattice as the linearly-interpolated sites already are. This is the infrastructure `cosmological_mass_variance/filtered_power_spectrum.F90` requires; no site is converted here.

What extension preserves is weaker than for a linearly-interpolated table, deliberately: a cubic spline is not local, so adding points at either end changes the interpolant everywhere. The tabulated values are preserved - they are the expensive part, and what makes extension worth having - while the coefficients are discarded and rebuilt when the table is next populated.

The state common to every 1-D table now lives on `table1D` rather than on `table1DLinearLinear`, so the cubic-spline types share it rather than duplicating it.

Two subtleties, both caught by the new unit tests rather than by inspection:

- The **monotonic** variants need their own extension despite deriving from `table1DLinearCSpline`, because they allocate their coefficients differently - `Table_Linear_Monotone_CSpline_1D_Compute_Spline` writes to `av` one element beyond the number of intervals, so a monotonic table carries one row more in `av` and uses neither `sv` nor `dv`. Sharing the base allocation made that an out-of-bounds write.
- The cached end points of a logarithmic table must be evaluated from the stored abscissae, exactly as its creator does, and **not** from the lattice bounds: the internal abscissae are natural logarithms of the lattice points, and `2**(k/N)` is not bit-identical to `exp((k/N)ln2)`, so taking the end points from the lattice made the first point of a table disagree with the same point seen from a table extending past it.

### `testSuite/test-merger-tree-builder.py`

The script built its `parameterGrid` launch document by concatenating the *text* of each model's parameter file into it. Each of those is a document in its own right beginning with an XML declaration, which is well formed only at the very start of a document, so `launch.py` could not parse what it wrote and no model ran at all.

It reported `SUCCESS: model run` throughout, because it detects failure by grepping each model's log and a model which never ran leaves no log. The log count is now checked against the number of models launched, and a model producing no output is reported rather than dropped silently.

### Verification

`tests.tables` 38/38 (eleven new), `tests.make_ranges` 32/32, `tests.table_caches` 17/17, `tests.spherical_collapse.determinism` 30/30 and `tests.mass_distributions` 157/157 - the last four covering the linear and logarithmic extension paths which this refactors. All four merger-tree-builder models now run and agree with their stored references.

Part of #1317.
