### PR TITLE
feat(dust): Phase 0 infrastructure for the unified dust framework

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1229,6 +1229,8 @@ jobs:
                       tests.table_caches.exe,
                       tests.interpolation.exe,
                       tests.interpolation.2D.exe,
+                      tests.interpolation.multiD.exe,
+                      tests.dust.attenuation_descriptors.exe,
                       tests.make_ranges.exe,
                       tests.mass_distributions.exe,
                       tests.mass_distributions.tabulated.exe,

--- a/python/LibraryInterfaces/Pipeline.py
+++ b/python/LibraryInterfaces/Pipeline.py
@@ -211,6 +211,41 @@ _CALLBACK_PROCEDURE_INTERFACES = {
 }
 
 
+def _resolve_type_module(type_name, implementation, module_uses_impls,
+                         extensions, func_class):
+    """Return the module from which *type_name* should be imported.
+
+    Resolution order:
+
+      0. an explicit override in :data:`_SHARED_TYPE_MODULES` (wins outright —
+         used when the type's home module isn't imported by name anywhere in
+         the class's own ``use``-blocks, e.g. because it is defined in the very
+         module the implementation is included into),
+      1. the implementation's ``use``-blocks, walking up the ``extends`` chain,
+      2. the functionClass file's own ``use``-blocks,
+      3. last resort: the functionClass's own module.
+
+    Step 2 matters for a type which the functionClass merely *use-associates*
+    from elsewhere: falling straight through to step 3 would emit
+    ``use :: <functionClass module>, only : <type>``, which fails to compile
+    whenever that module does not itself re-export the type (the usual case,
+    since functionClass modules are ``private`` by default).
+    """
+    import_module = _SHARED_TYPE_MODULES.get(type_name)
+    if implementation:
+        cls = implementation['name']
+        while cls and not import_module:
+            import_module = _module_for_symbol(
+                module_uses_impls.get(cls, []), type_name)
+            cls = extensions.get(cls)
+    if not import_module:
+        import_module = _module_for_symbol(
+            func_class.get('moduleUses', []), type_name)
+    if not import_module:
+        import_module = func_class.get('module')
+    return import_module
+
+
 def _module_for_symbol(use_blocks, symbol):
     """Return the name of the module whose `use ..., only :` list includes
     `symbol`, or None.
@@ -1722,21 +1757,9 @@ def build_fortran_reassignments(argument_list, func_class, implementation,
                 #    type explicitly (e.g. when the enum is defined in the same
                 #    module the impl is included into) so the walk below would
                 #    otherwise miss it.
-                import_module = _SHARED_TYPE_MODULES.get(type_spec_val)
-                # 1. walk implementation's module uses, following the extends chain.
-                if implementation:
-                    cls = implementation['name']
-                    while cls and not import_module:
-                        import_module = _module_for_symbol(
-                            module_uses_impls.get(cls, []), type_spec_val)
-                        cls = extensions.get(cls)
-                # 2. fall back to the functionClass file's own module uses.
-                if not import_module:
-                    import_module = _module_for_symbol(
-                        func_class.get('moduleUses', []), type_spec_val)
-                # 3. last resort: the functionClass's own module.
-                if not import_module:
-                    import_module = func_class.get('module')
+                import_module = _resolve_type_module(
+                    type_spec_val, implementation, module_uses_impls,
+                    extensions, func_class)
                 if import_module:
                     arg.fort_modules.setdefault(import_module, {})[type_spec_val] = 1
 
@@ -1765,7 +1788,13 @@ def build_fortran_reassignments(argument_list, func_class, implementation,
                 if type_spec_val == 'inputParameters':
                     arg.fort_modules.setdefault('Input_Parameters', {})['inputParameters'] = 1
                 else:
-                    mod = func_class.get('module', '')
+                    # Resolve the type's home module rather than assuming it is
+                    # the functionClass's own: a type which the functionClass
+                    # only use-associates (and so does not re-export) would
+                    # otherwise produce an uncompilable `use` statement.
+                    mod = _resolve_type_module(
+                        type_spec_val, implementation, module_uses_impls,
+                        extensions, func_class)
                     if mod:
                         arg.fort_modules.setdefault(mod, {})[type_spec_val] = 1
 

--- a/python/LibraryInterfaces/tests/test_pipeline.py
+++ b/python/LibraryInterfaces/tests/test_pipeline.py
@@ -1246,3 +1246,58 @@ def test_fortran_reassignments_list_array_loops_via_get_ptr():
     # because the host only `use`s the List type, not the Class.
     assert 'modelParameterList'  in out[0].fort_modules.get('Model_Parameters', {})
     assert 'modelParameterClass' in out[0].fort_modules.get('Model_Parameters', {})
+
+
+# ---------------------------------------------------------------------------
+# build_fortran_reassignments — home-module resolution for plain derived types
+# ---------------------------------------------------------------------------
+
+def test_fortran_reassignments_derived_type_resolves_use_associated_module():
+    """A plain derived-type argument which the functionClass merely
+    *use-associates* from another module must have its `use ::` line point at
+    that other module.
+
+    Assuming the functionClass's own module instead emits
+    `use :: <functionClass module>, only : <type>`, which fails to compile
+    whenever that module does not re-export the type — and functionClass
+    modules are `private` by default, so it usually does not.  This is what
+    broke `nodePropertyExtractor%recompose`, whose `type(luminosityDecomposition)`
+    argument lives in `Dust_Attenuation_Descriptors`."""
+    arg = ArgSpec(name='decomposition', intrinsic='type',
+                  type_spec='luminosityDecomposition',
+                  ctype='c_void_p', fort_type='type(c_ptr)')
+    out = build_fortran_reassignments(
+        [arg],
+        func_class={
+            'module':     'Node_Property_Extractors',
+            'moduleUses': [{'Dust_Attenuation_Descriptors':
+                            [{'only': {'luminosityDecomposition': 1,
+                                       'decompositionRequest':   1}}]}],
+        },
+        implementation=None, extensions={}, module_uses_impls={},
+        lib_function_classes={},
+    )
+    assert 'type(luminosityDecomposition), pointer :: decomposition_' \
+        in out[0].fort_declarations
+    assert 'call c_f_pointer(decomposition,decomposition_)' \
+        in out[0].fort_reassignment
+    assert 'luminosityDecomposition' \
+        in out[0].fort_modules.get('Dust_Attenuation_Descriptors', {})
+    # The functionClass's own module must NOT be used as the source of the type.
+    assert 'luminosityDecomposition' \
+        not in out[0].fort_modules.get('Node_Property_Extractors', {})
+
+
+def test_fortran_reassignments_derived_type_falls_back_to_own_module():
+    """A derived type which is defined in the functionClass's own module — and
+    so appears in none of its `use`-blocks — still resolves to that module.
+    This is the pre-existing behaviour, preserved."""
+    arg = ArgSpec(name='thing', intrinsic='type', type_spec='localThing',
+                  ctype='c_void_p', fort_type='type(c_ptr)')
+    out = build_fortran_reassignments(
+        [arg],
+        func_class={'module': 'Some_Class_Module', 'moduleUses': []},
+        implementation=None, extensions={}, module_uses_impls={},
+        lib_function_classes={},
+    )
+    assert 'localThing' in out[0].fort_modules.get('Some_Class_Module', {})

--- a/source/dust/attenuation_descriptors.F90
+++ b/source/dust/attenuation_descriptors.F90
@@ -1,0 +1,305 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson
+!+    Implemented with assistance from Claude (Anthropic).
+
+!!{RST
+Contains a module which provides the data structures used to describe emission to be attenuated by dust.
+!!}
+
+module Dust_Attenuation_Descriptors
+  !!{RST
+  Provides the data structures which mediate between objects that *produce* luminosity (typically
+  :galacticus-class:`nodePropertyExtractorClass` objects) and objects that *attenuate* it (``dustAttenuation``
+  objects).
+
+  Dust attenuation is not, in general, a single multiplicative factor applied to a galaxy's total luminosity: it
+  depends on the wavelength of the emission, on which component the emission comes from, and---where birth clouds are
+  modelled---on the age of the emitting stellar population. A luminosity-producing object must therefore be able to
+  hand over its luminosity *split* along whichever of those axes matter, have each piece attenuated, and then
+  recombine the pieces.
+
+  Three types cooperate to make that possible:
+
+  ``emissionDescriptor``
+     Describes a single, homogeneous parcel of emission---one wavelength, one component, one source type, one age
+     range. This is what a ``dustAttenuation`` object is asked to attenuate.
+
+  ``luminosityDecomposition``
+     A set of such parcels together with their luminosities, plus a map recording which output element each parcel
+     contributes to. This is what a luminosity-producing object hands over.
+
+  ``decompositionRequest``
+     Describes how finely the decomposition must be split. A ``dustAttenuation`` object builds this to declare which
+     axes it actually depends upon, so that a producer can collapse the axes which are irrelevant. This matters for
+     performance: an unnegotiated decomposition of a spectrum would have one term per (wavelength, age, metallicity)
+     triple, while an age-independent screen applied to a broad-band luminosity needs only one term per component.
+  !!}
+  use :: Galactic_Structure_Options, only : enumerationComponentTypeType, componentTypeUnknown
+  implicit none
+  private
+  public :: emissionDescriptor, luminosityDecomposition, decompositionRequest
+
+  !![
+  <enumeration docformat="rst">
+   <name>emissionSource</name>
+   <description>
+   Specifies the physical origin of a parcel of emission which is to be attenuated by dust. Dust attenuation models may
+   treat these differently---for example, nebular emission arises from H II regions which are embedded in their birth
+   clouds and so may be more heavily obscured than the stellar continuum of the same age, while emission from an
+   accretion disk originates at the very centre of the galaxy and so is seen through the full column of the galaxy's
+   dust.
+   </description>
+   <encodeFunction>yes</encodeFunction>
+   <decodeFunction>yes</decodeFunction>
+   <validator>yes</validator>
+   <visibility>public</visibility>
+   <entry label="stellar"       description="Stellar continuum emission"               />
+   <entry label="nebular"       description="Nebular continuum and line emission"      />
+   <entry label="accretionDisk" description="Emission from a black hole accretion disk"/>
+   <entry label="dust"          description="Thermal re-emission from dust grains"     />
+   <entry label="unknown"       description="Emission of unknown or unspecified origin"/>
+  </enumeration>
+  !!]
+
+  type :: emissionDescriptor
+     !!{RST
+     Describes a single, homogeneous parcel of emission to be attenuated by dust.
+
+     The fields are:
+
+     ``wavelength``
+        Rest-frame wavelength of the emission, in Å.
+     ``componentType``
+        The galactic component from which the emission originates.
+     ``sourceType``
+        The physical origin of the emission.
+     ``ageMinimum``, ``ageMaximum``
+        The range of stellar population ages contributing to this parcel, in Gyr. A parcel whose age is unresolved
+        ---because the attenuation model does not depend on age, or because the producer cannot resolve it---spans
+        the full range, from zero to ``huge(0.0d0)``. Attenuators which distinguish young from old populations should
+        therefore test ``ageMaximum`` against their birth cloud lifetime, so that an unresolved parcel is treated as
+        old rather than young.
+     ``metallicity``
+        Metallicity of the emitting material (linear, by mass); negative if unresolved.
+     ``radius``
+        Galactocentric radius at which the emission originates, in Mpc; negative if unresolved.
+     !!}
+     double precision                                :: wavelength   =-1.0d0
+     type            (enumerationComponentTypeType ) :: componentType= componentTypeUnknown
+     type            (enumerationEmissionSourceType) :: sourceType   = emissionSourceUnknown
+     double precision                                :: ageMinimum   = 0.0d0
+     double precision                                :: ageMaximum   = huge(0.0d0)
+     double precision                                :: metallicity  =-1.0d0
+     double precision                                :: radius       =-1.0d0
+  end type emissionDescriptor
+
+  type :: luminosityDecomposition
+     !!{RST
+     A luminosity, split into parcels which may each be attenuated differently, together with a map recording which
+     output element each parcel contributes to.
+
+     ``elementIndex(i)`` gives the (1-based) index of the output element to which parcel ``i`` contributes, and must
+     lie in the range :math:`[1,` ``countElements`` :math:`]`. Several parcels may share an output element---indeed
+     that is the usual case, since the whole point of the decomposition is that a single output luminosity is built
+     from parcels which attenuate differently.
+     !!}
+     type            (emissionDescriptor), allocatable, dimension(:) :: descriptors
+     double precision                    , allocatable, dimension(:) :: luminosities
+     integer                             , allocatable, dimension(:) :: elementIndex
+     integer                                                         :: countElements=0
+   contains
+     !![
+     <methods docformat="rst">
+       <method method="initialize" description="Allocate storage for the given numbers of parcels and output elements."/>
+       <method method="countTerms" description="Return the number of parcels in the decomposition."                    />
+       <method method="reduce"     description="Sum attenuated parcel luminosities into their output elements."        />
+     </methods>
+     !!]
+     procedure :: initialize => luminosityDecompositionInitialize
+     procedure :: countTerms => luminosityDecompositionCountTerms
+     procedure :: reduce     => luminosityDecompositionReduce
+  end type luminosityDecomposition
+
+  type :: decompositionRequest
+     !!{RST
+     Declares how finely a ``luminosityDecomposition`` must be split for a given dust attenuation model.
+
+     ``ageBoundaries`` holds the *internal* boundaries of the age bins required, in Gyr, in increasing order. An empty
+     (or unallocated) array requests no age resolution at all; a single boundary at the birth cloud lifetime requests
+     a young/old split; and so on. A producer should return parcels which do not straddle any of these boundaries.
+
+     The ``resolve*`` flags request splitting along the remaining axes. Producers are permitted to return a *finer*
+     decomposition than requested---the request is a lower bound on resolution, not an upper one---but returning a
+     coarser one will give wrong answers.
+     !!}
+     double precision, allocatable, dimension(:) :: ageBoundaries
+     logical                                     :: resolveComponents =.true.
+     logical                                     :: resolveMetallicity=.false.
+     logical                                     :: resolveRadius     =.false.
+   contains
+     !![
+     <methods docformat="rst">
+       <method method="countAgeBins" description="Return the number of age bins requested."                       />
+       <method method="ageBinIndex"  description="Return the index of the age bin containing the given age."       />
+       <method method="ageBinRange"  description="Return the age range spanned by the age bin of the given index."/>
+     </methods>
+     !!]
+     procedure :: countAgeBins => decompositionRequestCountAgeBins
+     procedure :: ageBinIndex  => decompositionRequestAgeBinIndex
+     procedure :: ageBinRange  => decompositionRequestAgeBinRange
+  end type decompositionRequest
+
+contains
+
+  subroutine luminosityDecompositionInitialize(self,countTerms,countElements)
+    !!{RST
+    Allocate storage in a ``luminosityDecomposition`` for ``countTerms`` parcels contributing to ``countElements``
+    output elements. Luminosities are initialized to zero and element indices to one, so that a producer need only
+    fill in the parcels which are actually non-zero.
+    !!}
+    implicit none
+    class  (luminosityDecomposition), intent(inout) :: self
+    integer                         , intent(in   ) :: countTerms, countElements
+
+    if (allocated(self%descriptors )) deallocate(self%descriptors )
+    if (allocated(self%luminosities)) deallocate(self%luminosities)
+    if (allocated(self%elementIndex)) deallocate(self%elementIndex)
+    allocate(self%descriptors (countTerms))
+    allocate(self%luminosities(countTerms))
+    allocate(self%elementIndex(countTerms))
+    self%luminosities =0.0d0
+    self%elementIndex =1
+    self%countElements=countElements
+    return
+  end subroutine luminosityDecompositionInitialize
+
+  integer function luminosityDecompositionCountTerms(self) result(countTerms)
+    !!{RST
+    Return the number of parcels in a ``luminosityDecomposition``.
+    !!}
+    implicit none
+    class(luminosityDecomposition), intent(in   ) :: self
+
+    if (allocated(self%luminosities)) then
+       countTerms=size(self%luminosities)
+    else
+       countTerms=0
+    end if
+    return
+  end function luminosityDecompositionCountTerms
+
+  subroutine luminosityDecompositionReduce(self,transmission,values)
+    !!{RST
+    Sum the parcel luminosities of a ``luminosityDecomposition``, each multiplied by the corresponding
+    ``transmission`` factor, into the output elements to which they contribute. This is the default reduction, and is
+    correct for any output which is linear in luminosity. Producers whose output is *not* linear in luminosity---
+    magnitudes, colours, or ratios, for example---must reduce their decomposition themselves.
+
+    ``values`` is allocated to ``countElements`` and zeroed before accumulation.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    class           (luminosityDecomposition), intent(in   )                            :: self
+    double precision                         , intent(in   ), dimension(:)              :: transmission
+    double precision                         , intent(inout), dimension(:), allocatable :: values
+    integer                                                                             :: i
+
+    if (size(transmission) /= self%countTerms())                                                                      &
+         & call Error_Report('number of transmission factors does not match number of terms'//{introspection:location})
+    if (allocated(values)) deallocate(values)
+    allocate(values(self%countElements))
+    values=0.0d0
+    do i=1,self%countTerms()
+       if (self%elementIndex(i) < 1 .or. self%elementIndex(i) > self%countElements)                                   &
+            & call Error_Report('element index out of range'                             //{introspection:location})
+       values(self%elementIndex(i))=+values      (self%elementIndex(i)) &
+            &                       +self        %luminosities    (i)   &
+            &                       *transmission                 (i)
+    end do
+    return
+  end subroutine luminosityDecompositionReduce
+
+  integer function decompositionRequestCountAgeBins(self) result(countAgeBins)
+    !!{RST
+    Return the number of age bins requested by a ``decompositionRequest``. This is one more than the number of
+    internal boundaries, and is always at least one.
+    !!}
+    implicit none
+    class(decompositionRequest), intent(in   ) :: self
+
+    if (allocated(self%ageBoundaries)) then
+       countAgeBins=size(self%ageBoundaries)+1
+    else
+       countAgeBins=1
+    end if
+    return
+  end function decompositionRequestCountAgeBins
+
+  integer function decompositionRequestAgeBinIndex(self,age) result(indexBin)
+    !!{RST
+    Return the index of the age bin of a ``decompositionRequest`` which contains the given ``age`` (in Gyr). Bins are
+    closed at their lower boundary and open at their upper boundary, so an age exactly equal to a boundary falls in
+    the *older* bin.
+    !!}
+    implicit none
+    class           (decompositionRequest), intent(in   ) :: self
+    double precision                      , intent(in   ) :: age
+
+    indexBin=1
+    if (.not.allocated(self%ageBoundaries)) return
+    do while (indexBin <= size(self%ageBoundaries))
+       if (age < self%ageBoundaries(indexBin)) exit
+       indexBin=indexBin+1
+    end do
+    return
+  end function decompositionRequestAgeBinIndex
+
+  subroutine decompositionRequestAgeBinRange(self,indexBin,ageMinimum,ageMaximum)
+    !!{RST
+    Return the range of ages (in Gyr) spanned by the age bin of a ``decompositionRequest`` with the given index. The
+    lowest bin begins at zero age, and the highest extends to ``huge(0.0d0)``.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    class           (decompositionRequest), intent(in   ) :: self
+    integer                               , intent(in   ) :: indexBin
+    double precision                      , intent(  out) :: ageMinimum, ageMaximum
+
+    if (indexBin < 1 .or. indexBin > self%countAgeBins()) then
+       ageMinimum=0.0d0
+       ageMaximum=0.0d0
+       call Error_Report('age bin index out of range'//{introspection:location})
+       return
+    end if
+    if (indexBin == 1                   ) then
+       ageMinimum=0.0d0
+    else
+       ageMinimum=self%ageBoundaries(indexBin-1)
+    end if
+    if (indexBin == self%countAgeBins()) then
+       ageMaximum=huge(0.0d0)
+    else
+       ageMaximum=self%ageBoundaries(indexBin  )
+    end if
+    return
+  end subroutine decompositionRequestAgeBinRange
+
+end module Dust_Attenuation_Descriptors

--- a/source/dust/attenuation_descriptors.F90
+++ b/source/dust/attenuation_descriptors.F90
@@ -158,7 +158,7 @@ module Dust_Attenuation_Descriptors
      !![
      <methods docformat="rst">
        <method method="countAgeBins" description="Return the number of age bins requested."                       />
-       <method method="ageBinIndex"  description="Return the index of the age bin containing the given age."       />
+       <method method="ageBinIndex"  description="Return the index of the age bin containing the given age."      />
        <method method="ageBinRange"  description="Return the age range spanned by the age bin of the given index."/>
      </methods>
      !!]
@@ -211,7 +211,7 @@ contains
     Sum the parcel luminosities of a ``luminosityDecomposition``, each multiplied by the corresponding
     ``transmission`` factor, into the output elements to which they contribute. This is the default reduction, and is
     correct for any output which is linear in luminosity. Producers whose output is *not* linear in luminosity---
-    magnitudes, colours, or ratios, for example---must reduce their decomposition themselves.
+    magnitudes, colors, or ratios, for example---must reduce their decomposition themselves.
 
     ``values`` is allocated to ``countElements`` and zeroed before accumulation.
     !!}
@@ -222,17 +222,17 @@ contains
     double precision                         , intent(inout), dimension(:), allocatable :: values
     integer                                                                             :: i
 
-    if (size(transmission) /= self%countTerms())                                                                      &
+    if (size(transmission) /= self%countTerms())                                                                       &
          & call Error_Report('number of transmission factors does not match number of terms'//{introspection:location})
     if (allocated(values)) deallocate(values)
     allocate(values(self%countElements))
     values=0.0d0
     do i=1,self%countTerms()
-       if (self%elementIndex(i) < 1 .or. self%elementIndex(i) > self%countElements)                                   &
-            & call Error_Report('element index out of range'                             //{introspection:location})
+       if (self%elementIndex(i) < 1 .or. self%elementIndex(i) > self%countElements)                                    &
+            & call Error_Report('element index out of range'                               //{introspection:location})
        values(self%elementIndex(i))=+values      (self%elementIndex(i)) &
-            &                       +self        %luminosities    (i)   &
-            &                       *transmission                 (i)
+            &                       +self        %luminosities     (i)  &
+            &                       *transmission                  (i)
     end do
     return
   end subroutine luminosityDecompositionReduce
@@ -289,7 +289,7 @@ contains
        call Error_Report('age bin index out of range'//{introspection:location})
        return
     end if
-    if (indexBin == 1                   ) then
+    if (indexBin == 1                  ) then
        ageMinimum=0.0d0
     else
        ageMinimum=self%ageBoundaries(indexBin-1)

--- a/source/nodes/property_extractor/_class.F90
+++ b/source/nodes/property_extractor/_class.F90
@@ -25,6 +25,7 @@ module Node_Property_Extractors
   !!{RST
   Provides a class that implements extraction of properties from nodes.
   !!}
+  use :: Dust_Attenuation_Descriptors, only : decompositionRequest, luminosityDecomposition
   use :: Galacticus_Nodes       , only : treeNode
   use :: Multi_Counters         , only : multiCounter
   use :: Output_Analyses_Options, only : enumerationOutputAnalysisPropertyQuantityType, enumerationOutputAnalysisPropertyTypeType, outputAnalysisPropertyQuantityUnknown, outputAnalysisPropertyTypeLinear
@@ -93,6 +94,65 @@ module Node_Property_Extractors
         nodePropertyExtractorExtractScalar=0.0d0
         call Error_Report('extractScalar requires an extractor of the scalar class'//{introspection:location})
      end select
+    </code>
+   </method>
+   <method name="supportsAttenuation" >
+    <description>
+    Return true if this extractor is able to decompose its output into parcels of emission which can be attenuated by
+    dust---that is, if it implements the ``decompose`` method. Extractors which do not produce a luminosity, and
+    luminosity-producing extractors for which no decomposition has yet been implemented, return false. The
+    ``dustAttenuation`` property extractor uses this to reject unusable children at construction time, rather than
+    failing part way through a run.
+    </description>
+    <type>logical</type>
+    <pass>yes</pass>
+    <code>
+     !$GLC attributes unused :: self
+     nodePropertyExtractorSupportsAttenuation=.false.
+    </code>
+   </method>
+   <method name="decompose" >
+    <description>
+    Return the luminosity extracted from the given ``node`` at the given ``time``, split into parcels of emission which
+    may each be attenuated differently by dust, at a resolution at least as fine as that specified by ``request``. Each
+    parcel records the output element to which it contributes, so that the parcels can be recombined by the
+    ``recompose`` method once they have been attenuated.
+
+    The default implementation reports an error: only extractors whose ``supportsAttenuation`` method returns true
+    override it. This mirrors the treatment of ``extractScalar``, and is used because Fortran provides no way to mix a
+    decomposition interface into the several rank-specific extractor classes independently.
+    </description>
+    <type>type(luminosityDecomposition)</type>
+    <pass>yes</pass>
+    <selfTarget>yes</selfTarget>
+    <modules>Error</modules>
+    <argument>type            (treeNode            ), intent(inout), target :: node</argument>
+    <argument>double precision                      , intent(in   )         :: time</argument>
+    <argument>type            (decompositionRequest), intent(in   )         :: request</argument>
+    <code>
+     !$GLC attributes unused :: self, node, time, request
+     call nodePropertyExtractorDecompose%initialize(0,0)
+     call Error_Report('this property extractor does not support dust attenuation'//{introspection:location})
+    </code>
+   </method>
+   <method name="recompose" >
+    <description>
+    Recombine the parcels of a ``luminosityDecomposition``, each multiplied by the corresponding ``transmission``
+    factor, into the output element values of this extractor. On return ``values`` has one element per output element
+    of the decomposition, in the same order as the extractor's own ``extract`` method would return them.
+
+    The default implementation simply sums each parcel into the output element which it contributes to, which is
+    correct for any output that is linear in luminosity. Extractors whose output is not linear in luminosity---
+    magnitudes, colours, or ratios, for example---must override this method.
+    </description>
+    <type>void</type>
+    <pass>yes</pass>
+    <argument>type            (luminosityDecomposition), intent(in   )                            :: decomposition</argument>
+    <argument>double precision                         , intent(in   ), dimension(:)              :: transmission</argument>
+    <argument>double precision                         , intent(inout), dimension(:), allocatable :: values</argument>
+    <code>
+     !$GLC attributes unused :: self
+     call decomposition%reduce(transmission,values)
     </code>
    </method>
   </functionClass>

--- a/source/nodes/property_extractor/_class.F90
+++ b/source/nodes/property_extractor/_class.F90
@@ -25,10 +25,10 @@ module Node_Property_Extractors
   !!{RST
   Provides a class that implements extraction of properties from nodes.
   !!}
-  use :: Dust_Attenuation_Descriptors, only : decompositionRequest, luminosityDecomposition
-  use :: Galacticus_Nodes       , only : treeNode
-  use :: Multi_Counters         , only : multiCounter
-  use :: Output_Analyses_Options, only : enumerationOutputAnalysisPropertyQuantityType, enumerationOutputAnalysisPropertyTypeType, outputAnalysisPropertyQuantityUnknown, outputAnalysisPropertyTypeLinear
+  use :: Dust_Attenuation_Descriptors, only : decompositionRequest                         , luminosityDecomposition
+  use :: Galacticus_Nodes            , only : treeNode
+  use :: Multi_Counters              , only : multiCounter
+  use :: Output_Analyses_Options     , only : enumerationOutputAnalysisPropertyQuantityType, enumerationOutputAnalysisPropertyTypeType, outputAnalysisPropertyQuantityUnknown, outputAnalysisPropertyTypeLinear
   private
 
   !![

--- a/source/nodes/property_extractor/luminosity_stellar/_class.F90
+++ b/source/nodes/property_extractor/luminosity_stellar/_class.F90
@@ -22,8 +22,8 @@ Implements a stellar mass output analysis property extractor class.
 !!}
 
   use :: Galactic_Structure_Options, only : enumerationComponentTypeType
-  use :: ISO_Varying_String, only : varying_string, var_str
-  use :: Output_Times      , only : outputTimesClass
+  use :: ISO_Varying_String        , only : varying_string              , var_str
+  use :: Output_Times              , only : outputTimesClass
 
   !![
   <nodePropertyExtractor name="nodePropertyExtractorLuminosityStellar" docformat="rst">
@@ -69,7 +69,7 @@ contains
     Constructor for the :galacticus-class:`nodePropertyExtractorLuminosityStellar` property extractor class which takes a parameter set as input.
     !!}
     use :: Galactic_Structure_Options, only : enumerationComponentTypeEncode
-    use :: Input_Parameters, only : inputParameter, inputParameters
+    use :: Input_Parameters          , only : inputParameter                , inputParameters
     implicit none
     type            (nodePropertyExtractorLuminosityStellar)                :: self
     type            (inputParameters                       ), intent(inout) :: parameters
@@ -158,8 +158,8 @@ contains
     !!}
     use, intrinsic :: ISO_C_Binding                 , only : c_size_t
     use            :: Error                         , only : Error_Report
-    use            :: Galactic_Structure_Options     , only : componentTypeAll               , componentTypeDisk    , componentTypeSpheroid, &
-         &                                                    componentTypeNuclearStarCluster, enumerationComponentTypeDecode
+    use            :: Galactic_Structure_Options    , only : componentTypeAll               , componentTypeDisk             , componentTypeSpheroid, &
+         &                                                   componentTypeNuclearStarCluster, enumerationComponentTypeDecode
     use            :: Stellar_Luminosities_Structure, only : unitStellarLuminosities
     implicit none
     type            (nodePropertyExtractorLuminosityStellar)                                        :: self
@@ -180,12 +180,12 @@ contains
     case (componentTypeAll%ID,componentTypeDisk%ID,componentTypeSpheroid%ID,componentTypeNuclearStarCluster%ID)
        ! These are supported.
     case default
-       call Error_Report(                                                                                          &
-            &            'component "'                                                                          // &
-            &            enumerationComponentTypeDecode(component,includePrefix=.false.)                        // &
-            &            '" can not host a stellar population - use "all", "disk", "spheroid", or'               // &
-            &            ' "nuclearStarCluster"'                                                                 // &
-            &            {introspection:location}                                                                  &
+       call Error_Report(                                                                            &
+            &            'component "'                                                            // &
+            &            enumerationComponentTypeDecode(component,includePrefix=.false.)          // &
+            &            '" can not host a stellar population - use "all", "disk", "spheroid", or'// &
+            &            ' "nuclearStarCluster"'                                                  // &
+            &            {introspection:location}                                                    &
             &           )
     end select
 
@@ -201,10 +201,10 @@ contains
     if (component == componentTypeAll) then
        self%description_="Total stellar luminosity in the "//filterType//"-frame "//filterName//" filter"
     else
-       self%name_       =self%name_       //":"                                                              // &
+       self%name_       =self%name_       //":"                                            // &
             &            enumerationComponentTypeDecode(component,includePrefix=.false.)
-       self%description_="Stellar luminosity of the "                                                        // &
-            &            enumerationComponentTypeDecode(component,includePrefix=.false.)                     // &
+       self%description_="Stellar luminosity of the "                                      // &
+            &            enumerationComponentTypeDecode(component,includePrefix=.false.)   // &
             &            " component in the "//filterType//"-frame "//filterName//" filter"
     end if
     if (present(redshiftBand)) then

--- a/source/nodes/property_extractor/luminosity_stellar/_class.F90
+++ b/source/nodes/property_extractor/luminosity_stellar/_class.F90
@@ -21,13 +21,14 @@
 Implements a stellar mass output analysis property extractor class.
 !!}
 
-  use :: ISO_Varying_String, only : varying_string
+  use :: Galactic_Structure_Options, only : enumerationComponentTypeType
+  use :: ISO_Varying_String, only : varying_string, var_str
   use :: Output_Times      , only : outputTimesClass
 
   !![
   <nodePropertyExtractor name="nodePropertyExtractorLuminosityStellar" docformat="rst">
    <description>
-   A property extractor that returns the total stellar luminosity of a node in a specified broadband filter, in units of the AB zero-point. The ``filterName`` and ``filterType`` parameters select the photometric band and whether to use rest-frame or observer-frame luminosities. The optional ``redshiftBand`` shifts the band to a fixed redshift (for K-corrections), and ``postprocessChain`` applies a named spectral postprocessing chain (e.g.\ :term:`IGM` attenuation) before the photometric integration. Luminosity indices are pre-computed per output time for efficiency.
+   A property extractor that returns the stellar luminosity of a node in a specified broadband filter, in units of the AB zero-point. The ``filterName`` and ``filterType`` parameters select the photometric band and whether to use rest-frame or observer-frame luminosities. The ``component`` parameter selects the galactic component whose luminosity is returned (``all``, the default, sums over all components; ``disk``, ``spheroid``, and ``nuclearStarCluster`` select an individual component---the latter are needed when applying dust attenuation, which cannot meaningfully be applied to a summed luminosity). The optional ``redshiftBand`` shifts the band to a fixed redshift (for K-corrections), and ``postprocessChain`` applies a named spectral postprocessing chain (e.g.\ :term:`IGM` attenuation) before the photometric integration. Luminosity indices are pre-computed per output time for efficiency.
    </description>
   </nodePropertyExtractor>
   !!]
@@ -36,12 +37,13 @@ Implements a stellar mass output analysis property extractor class.
      A stellar luminosity output analysis property extractor class.
      !!}
      private
-     type            (varying_string  )                            :: filterName                , filterType, &
-          &                                                           postprocessChain          , name_     , &
-          &                                                           description_
-     double precision                                              :: redshiftBand
-     integer                           , allocatable, dimension(:) :: luminosityIndex
-     class           (outputTimesClass), pointer                   :: outputTimes_     => null()
+     type            (varying_string              )                            :: filterName                , filterType, &
+          &                                                                       postprocessChain          , name_     , &
+          &                                                                       description_
+     type            (enumerationComponentTypeType)                            :: component
+     double precision                                                          :: redshiftBand
+     integer                                       , allocatable, dimension(:) :: luminosityIndex
+     class           (outputTimesClass            ), pointer                   :: outputTimes_     => null()
    contains
      final     ::                luminosityStellarDestructor
      procedure :: extract     => luminosityStellarExtract
@@ -66,13 +68,14 @@ contains
     !!{RST
     Constructor for the :galacticus-class:`nodePropertyExtractorLuminosityStellar` property extractor class which takes a parameter set as input.
     !!}
+    use :: Galactic_Structure_Options, only : enumerationComponentTypeEncode
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
     type            (nodePropertyExtractorLuminosityStellar)                :: self
     type            (inputParameters                       ), intent(inout) :: parameters
     class           (outputTimesClass                      ), pointer       :: outputTimes_
     type            (varying_string                        )                :: filterName           , filterType               , &
-         &                                                                     postprocessChain
+         &                                                                     postprocessChain     , component
     double precision                                                        :: redshiftBand
     logical                                                                 :: redshiftBandIsPresent, postprocessChainIsPresent
 
@@ -91,6 +94,16 @@ contains
       <source>parameters</source>
       <description>
       The filter type (rest or observed) to select.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>component</name>
+      <defaultValue>var_str('all')</defaultValue>
+      <source>parameters</source>
+      <description>
+      The galactic component whose luminosity is to be extracted---one of ``all``, ``disk``, ``spheroid``, or
+      ``nuclearStarCluster``. Note that dust attenuation can not be applied to the ``all`` case, since the components
+      are attenuated differently and so must be attenuated separately before being summed.
       </description>
     </inputParameter>
     !!]
@@ -121,15 +134,15 @@ contains
     !!]
     if (redshiftBandIsPresent) then
        if (postprocessChainIsPresent) then
-          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),outputTimes_,redshiftBand=redshiftBand,postprocessChain=char(postprocessChain))
+          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,redshiftBand=redshiftBand,postprocessChain=char(postprocessChain))
        else
-          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),outputTimes_,redshiftBand=redshiftBand                                        )
+          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,redshiftBand=redshiftBand                                        )
        end if
     else
        if (postprocessChainIsPresent) then
-          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),outputTimes_,                          postprocessChain=char(postprocessChain))
+          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,                          postprocessChain=char(postprocessChain))
        else
-          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),outputTimes_                                                                  )
+          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_                                                                  )
        end if
     end if
     !![
@@ -139,15 +152,19 @@ contains
     return
   end function luminosityStellarConstructorParameters
 
-  function luminosityStellarConstructorInternal(filterName,filterType,outputTimes_,redshiftBand,postprocessChain,outputMask) result(self)
+  function luminosityStellarConstructorInternal(filterName,filterType,component,outputTimes_,redshiftBand,postprocessChain,outputMask) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`nodePropertyExtractorLuminosityStellar` property extractor class.
     !!}
     use, intrinsic :: ISO_C_Binding                 , only : c_size_t
+    use            :: Error                         , only : Error_Report
+    use            :: Galactic_Structure_Options     , only : componentTypeAll               , componentTypeDisk    , componentTypeSpheroid, &
+         &                                                    componentTypeNuclearStarCluster, enumerationComponentTypeDecode
     use            :: Stellar_Luminosities_Structure, only : unitStellarLuminosities
     implicit none
     type            (nodePropertyExtractorLuminosityStellar)                                        :: self
     character       (len=*                                 ), intent(in   )                         :: filterName      , filterType
+    type            (enumerationComponentTypeType          ), intent(in   )                         :: component
     class           (outputTimesClass                      ), intent(in   ), target                 :: outputTimes_
     character       (len=*                                 ), intent(in   ), optional               :: postprocessChain
     double precision                                        , intent(in   ), optional               :: redshiftBand
@@ -155,8 +172,22 @@ contains
     integer         (c_size_t                              )                                        :: i
     character       (len=7                                 )                                        :: label
     !![
-    <constructorAssign variables="filterName, filterType, redshiftBand, postprocessChain, *outputTimes_"/>
+    <constructorAssign variables="filterName, filterType, component, redshiftBand, postprocessChain, *outputTimes_"/>
     !!]
+
+    ! Validate the component. Only components which can host a stellar population are meaningful here.
+    select case (component%ID)
+    case (componentTypeAll%ID,componentTypeDisk%ID,componentTypeSpheroid%ID,componentTypeNuclearStarCluster%ID)
+       ! These are supported.
+    case default
+       call Error_Report(                                                                                          &
+            &            'component "'                                                                          // &
+            &            enumerationComponentTypeDecode(component,includePrefix=.false.)                        // &
+            &            '" can not host a stellar population - use "all", "disk", "spheroid", or'               // &
+            &            ' "nuclearStarCluster"'                                                                 // &
+            &            {introspection:location}                                                                  &
+            &           )
+    end select
 
     allocate(self%luminosityIndex(self%outputTimes_%count()))
     do i=1,self%outputTimes_%count()
@@ -167,7 +198,15 @@ contains
        end if
     end do
     self%name_       ="luminosityStellar:"//filterName//":"//filterType
-    self%description_="Total stellar luminosity luminosity in the "//filterType//"-frame "//filterName//" filter"
+    if (component == componentTypeAll) then
+       self%description_="Total stellar luminosity in the "//filterType//"-frame "//filterName//" filter"
+    else
+       self%name_       =self%name_       //":"                                                              // &
+            &            enumerationComponentTypeDecode(component,includePrefix=.false.)
+       self%description_="Stellar luminosity of the "                                                        // &
+            &            enumerationComponentTypeDecode(component,includePrefix=.false.)                     // &
+            &            " component in the "//filterType//"-frame "//filterName//" filter"
+    end if
     if (present(redshiftBand)) then
        write (label,'(f7.3)') redshiftBand
        self%name_       =self%name_        //":z"            //trim(adjustl(label))
@@ -210,10 +249,10 @@ contains
     integer(c_size_t                              )                          :: i
     !$GLC attributes unused :: instance
 
-    basic                    => node             %basic           (                                                                                        )
-    i                        =  self%outputTimes_%index           (basic%time(),findClosest=.true.                                                         )
-    massDistribution_        => node             %massDistribution(massType=massTypeStellar,weightBy=weightByLuminosity,weightIndex=self%luminosityIndex(i))
-    luminosityStellarExtract =  massDistribution_%massTotal       (                                                                                        )
+    basic                    => node             %basic           (                                                                                                                     )
+    i                        =  self%outputTimes_%index           (basic%time(),findClosest=.true.                                                                                      )
+    massDistribution_        => node             %massDistribution(componentType=self%component,massType=massTypeStellar,weightBy=weightByLuminosity,weightIndex=self%luminosityIndex(i))
+    luminosityStellarExtract =  massDistribution_%massTotal       (                                                                                                                     )
     !![
     <objectDestructor name="massDistribution_"/>
     !!]

--- a/source/numerical/interpolation/1D.F90
+++ b/source/numerical/interpolation/1D.F90
@@ -208,18 +208,18 @@ module Numerical_Interpolation
    contains
      !![
      <methods docformat="rst">
-       <method description="Interpolate in the tabulated function."                                                 method="interpolate"         />
-       <method description="Interpolate the derivative in the tabulated function."                                  method="derivative"          />
-       <method description="Interpolate the second derivative in the tabulated function."                           method="secondDerivative"    />
-       <method description="Locate the position in the array corresponding to the given ``x``."                  method="locate"              />
-       <method description="Return factors required to perform a linear interpolation."                             method="linearFactors"       />
-       <method description="Return weights required to perform a linear interpolation."                             method="linearWeights"       />
-       <method description="Allocate GSL objects."                                                                  method="gslAllocate"         />
-       <method description="Reallocate GSL objects."                                                                method="gslReallocate"       />
-       <method description="Initialize GSL interpolator."                                                           method="gslInitialize"       />
-       <method description="Assert that the data is interpolatable."                                                method="assertInterpolatable"/>
-       <method description="Return the number of points in the tabulated function."                                 method="count"               />
-       <method description="Assign interpolator objects."                                                           method="assignment(=)"       />
+       <method description="Interpolate in the tabulated function."                             method="interpolate"         />
+       <method description="Interpolate the derivative in the tabulated function."              method="derivative"          />
+       <method description="Interpolate the second derivative in the tabulated function."       method="secondDerivative"    />
+       <method description="Locate the position in the array corresponding to the given ``x``." method="locate"              />
+       <method description="Return factors required to perform a linear interpolation."         method="linearFactors"       />
+       <method description="Return weights required to perform a linear interpolation."         method="linearWeights"       />
+       <method description="Allocate GSL objects."                                              method="gslAllocate"         />
+       <method description="Reallocate GSL objects."                                            method="gslReallocate"       />
+       <method description="Initialize GSL interpolator."                                       method="gslInitialize"       />
+       <method description="Assert that the data is interpolatable."                            method="assertInterpolatable"/>
+       <method description="Return the number of points in the tabulated function."             method="count"               />
+       <method description="Assign interpolator objects."                                       method="assignment(=)"       />
      </methods>
      !!]
      procedure ::                         interpolatorAssign

--- a/source/numerical/interpolation/1D.F90
+++ b/source/numerical/interpolation/1D.F90
@@ -218,6 +218,7 @@ module Numerical_Interpolation
        <method description="Reallocate GSL objects."                                                                method="gslReallocate"       />
        <method description="Initialize GSL interpolator."                                                           method="gslInitialize"       />
        <method description="Assert that the data is interpolatable."                                                method="assertInterpolatable"/>
+       <method description="Return the number of points in the tabulated function."                                 method="count"               />
        <method description="Assign interpolator objects."                                                           method="assignment(=)"       />
      </methods>
      !!]
@@ -242,6 +243,7 @@ module Numerical_Interpolation
      procedure :: gslReallocate        => interpolatorGSLReallocate
      procedure :: gslInitialize        => interpolatorGSLInitialize
      procedure :: assertInterpolatable => interpolatorAssertInterpolatable
+     procedure :: count                => interpolatorCount
   end type interpolator
 
   interface interpolator
@@ -514,6 +516,18 @@ contains
     return
   end subroutine interpolatorAssertInterpolatable
   
+  function interpolatorCount(self) result(count_)
+    !!{RST
+    Return the number of points in the tabulated function of an ``interpolator``.
+    !!}
+    implicit none
+    integer(c_size_t    )                :: count_
+    class  (interpolator), intent(in   ) :: self
+
+    count_=self%countArray
+    return
+  end function interpolatorCount
+
   subroutine interpolatorLinearFactors(self,x,i,h)
     !!{RST
     Return interpolating factors for linear interpolation in the array ``xArray()`` given ``x``.

--- a/source/numerical/interpolation/multiD.F90
+++ b/source/numerical/interpolation/multiD.F90
@@ -1,0 +1,274 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson
+!+    Implemented with assistance from Claude (Anthropic).
+
+!!{RST
+Contains a module which implements multilinear interpolation in tables of arbitrary dimensionality.
+!!}
+
+module Numerical_Interpolation_MultiD
+  !!{RST
+  Implements multilinear interpolation in tables of arbitrary dimensionality, on a grid which is separable---that is,
+  one specified by an independent array of abscissae along each dimension.
+
+  Several tabulations in Galacticus are functions of four or more variables. Interpolating in them means locating the
+  bracketing pair of abscissae along each dimension and then forming the weighted sum over the :math:`2^N` corners of
+  the enclosing hypercube. That pattern is mechanical but fiddly to write out by hand for each new table, and is easy
+  to get subtly wrong. This class factors it out.
+
+  Each dimension is described by an ordinary :galacticus-class:`interpolator` object, so extrapolation behaviour is
+  specified per-dimension in the usual way, and a dimension which should be interpolated logarithmically is handled
+  by constructing its interpolator on---and evaluating it at---the logarithm of the coordinate.
+
+  Table values are indexed in Fortran's usual column-major order, so that the value at grid point
+  :math:`(i_1,i_2,\ldots,i_N)` lies at position :math:`i_1 + n_1 (i_2-1) + n_1 n_2 (i_3-1) + \ldots` of the flattened
+  array, where :math:`n_d` is the number of abscissae along dimension :math:`d`. A contiguous rank-\ :math:`N` array
+  whose shape matches that returned by the ``shapeTable`` method may therefore be passed directly to the
+  ``interpolate`` method.
+  !!}
+  use, intrinsic :: ISO_C_Binding          , only : c_size_t
+  use            :: Numerical_Interpolation, only : interpolator
+  implicit none
+  private
+  public :: interpolatorMultiD
+
+  ! Maximum number of dimensions supported. The limit exists only to keep the number of hypercube corners, 2^N, within
+  ! a default integer; it is far above any plausible tabulation.
+  integer, parameter :: countDimensionsMaximum=16
+
+  type :: interpolatorMultiD
+     !!{RST
+     A multilinear interpolator over a separable grid of arbitrary dimensionality.
+     !!}
+     private
+     type   (interpolator), allocatable, dimension(:) :: dimensions
+     integer(c_size_t    ), allocatable, dimension(:) :: countPoints
+     integer(c_size_t    ), allocatable, dimension(:) :: stride
+     integer                                          :: countDimensions_=0
+     integer                                          :: countCorners_   =0
+   contains
+     !![
+     <methods docformat="rst">
+       <method method="countDimensions" description="Return the number of dimensions of the interpolator."                  />
+       <method method="countCorners"    description="Return the number of corners of the interpolating hypercube, i.e. 2^N."/>
+       <method method="countTable"      description="Return the total number of entries in the flattened table."            />
+       <method method="shapeTable"      description="Return the number of abscissae along each dimension."                  />
+       <method method="factors"         description="Return the bracketing index and linear weights along each dimension."  />
+       <method method="corners"         description="Return the flattened index of, and weight for, each hypercube corner." />
+       <method method="interpolate"     description="Interpolate in a flattened table of values at the given coordinates."  />
+     </methods>
+     !!]
+     procedure :: countDimensions => interpolatorMultiDCountDimensions
+     procedure :: countCorners    => interpolatorMultiDCountCorners
+     procedure :: countTable      => interpolatorMultiDCountTable
+     procedure :: shapeTable      => interpolatorMultiDShapeTable
+     procedure :: factors         => interpolatorMultiDFactors
+     procedure :: corners         => interpolatorMultiDCorners
+     procedure :: interpolate     => interpolatorMultiDInterpolate
+  end type interpolatorMultiD
+
+  interface interpolatorMultiD
+     !!{RST
+     Constructors for the ``interpolatorMultiD`` class.
+     !!}
+     module procedure interpolatorMultiDConstructor
+  end interface interpolatorMultiD
+
+contains
+
+  function interpolatorMultiDConstructor(interpolators) result(self)
+    !!{RST
+    Constructor for ``interpolatorMultiD`` objects. ``interpolators`` provides one :galacticus-class:`interpolator`
+    per dimension, in the order in which the dimensions are laid out in the table---that is, the first element
+    corresponds to the most rapidly varying index of the flattened table.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    type   (interpolatorMultiD)                              :: self
+    type   (interpolator      ), intent(in   ), dimension(:) :: interpolators
+    integer                                                  :: i
+
+    if (size(interpolators) < 1                     )                                                        &
+         & call Error_Report('at least one dimension is required'          //{introspection:location})
+    if (size(interpolators) > countDimensionsMaximum)                                                        &
+         & call Error_Report('too many dimensions'                         //{introspection:location})
+    self%countDimensions_=size(interpolators)
+    self%countCorners_   =2**self%countDimensions_
+    allocate(self%dimensions (self%countDimensions_))
+    allocate(self%countPoints(self%countDimensions_))
+    allocate(self%stride     (self%countDimensions_))
+    do i=1,self%countDimensions_
+       self%dimensions (i)=interpolators(i)
+       self%countPoints(i)=interpolators(i)%count()
+       if (self%countPoints(i) < 2_c_size_t)                                                                 &
+            & call Error_Report('each dimension requires at least 2 abscissae'//{introspection:location})
+    end do
+    ! Compute strides for column-major (Fortran) ordering of the flattened table.
+    self%stride(1)=1_c_size_t
+    do i=2,self%countDimensions_
+       self%stride(i)=self%stride(i-1)*self%countPoints(i-1)
+    end do
+    return
+  end function interpolatorMultiDConstructor
+
+  integer function interpolatorMultiDCountDimensions(self) result(countDimensions)
+    !!{RST
+    Return the number of dimensions of an ``interpolatorMultiD``.
+    !!}
+    implicit none
+    class(interpolatorMultiD), intent(in   ) :: self
+
+    countDimensions=self%countDimensions_
+    return
+  end function interpolatorMultiDCountDimensions
+
+  integer function interpolatorMultiDCountCorners(self) result(countCorners)
+    !!{RST
+    Return the number of corners, :math:`2^N`, of the hypercube in which an ``interpolatorMultiD`` interpolates.
+    !!}
+    implicit none
+    class(interpolatorMultiD), intent(in   ) :: self
+
+    countCorners=self%countCorners_
+    return
+  end function interpolatorMultiDCountCorners
+
+  function interpolatorMultiDCountTable(self) result(countTable)
+    !!{RST
+    Return the total number of entries in the flattened table of values expected by an ``interpolatorMultiD``.
+    !!}
+    implicit none
+    integer(c_size_t          )                :: countTable
+    class  (interpolatorMultiD), intent(in   ) :: self
+
+    countTable=product(self%countPoints)
+    return
+  end function interpolatorMultiDCountTable
+
+  function interpolatorMultiDShapeTable(self) result(shape_)
+    !!{RST
+    Return the number of abscissae along each dimension of an ``interpolatorMultiD``. The product of these is the
+    required size of the flattened table of values.
+    !!}
+    implicit none
+    integer(c_size_t          ), allocatable, dimension(:) :: shape_
+    class  (interpolatorMultiD), intent(in   )             :: self
+
+    allocate(shape_(self%countDimensions_))
+    shape_=self%countPoints
+    return
+  end function interpolatorMultiDShapeTable
+
+  subroutine interpolatorMultiDFactors(self,x,indices,weights)
+    !!{RST
+    Return, for each dimension of an ``interpolatorMultiD``, the index ``indices(d)`` of the lower of the pair of
+    abscissae bracketing ``x(d)``, together with the linear interpolating weights ``weights(0:1,d)`` to be applied at
+    that abscissa and the next.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    class           (interpolatorMultiD), intent(inout)                 :: self
+    double precision                    , intent(in   ), dimension(:  ) :: x
+    integer         (c_size_t          ), intent(  out), dimension(:  ) :: indices
+    double precision                    , intent(  out), dimension(:,:) :: weights
+    integer                                                             :: i
+
+    if (size(x                ) /= self%countDimensions_)                                                    &
+         & call Error_Report('coordinate vector has wrong size'//{introspection:location})
+    if (size(indices          ) /= self%countDimensions_)                                                    &
+         & call Error_Report('index array has wrong size'      //{introspection:location})
+    if (size(weights,dim=2) /= self%countDimensions_ .or. size(weights,dim=1) /= 2)                          &
+         & call Error_Report('weight array has wrong shape'    //{introspection:location})
+    do i=1,self%countDimensions_
+       call self%dimensions(i)%linearFactors(x(i),indices(i),weights(:,i))
+    end do
+    return
+  end subroutine interpolatorMultiDFactors
+
+  subroutine interpolatorMultiDCorners(self,x,indices,weights)
+    !!{RST
+    Return, for each of the :math:`2^N` corners of the hypercube of an ``interpolatorMultiD`` enclosing ``x``, the
+    index ``indices(c)`` of that corner in the flattened table of values, together with the multilinear weight
+    ``weights(c)`` to be applied to it. The weights sum to unity, except where a dimension is extrapolating under the
+    ``zero`` extrapolation type, in which case they sum to zero.
+
+    ``indices`` and ``weights`` must each be of size ``countCorners()``.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    class           (interpolatorMultiD), intent(inout)                                 :: self
+    double precision                    , intent(in   ), dimension(:)                   :: x
+    integer         (c_size_t          ), intent(  out), dimension(:)                   :: indices
+    double precision                    , intent(  out), dimension(:)                   :: weights
+    integer         (c_size_t          ), dimension(    self%countDimensions_)          :: indicesDimension
+    double precision                    , dimension(0:1,self%countDimensions_)          :: weightsDimension
+    integer                                                                             :: corner          , i, &
+         &                                                                                 offset
+
+    if (size(indices) /= self%countCorners_ .or. size(weights) /= self%countCorners_)                        &
+         & call Error_Report('corner arrays have wrong size'//{introspection:location})
+    call self%factors(x,indicesDimension,weightsDimension)
+    ! Enumerate the corners of the hypercube. Bit `i-1` of the corner number selects the lower (0) or upper (1)
+    ! abscissa along dimension `i`.
+    do corner=0,self%countCorners_-1
+       indices(corner+1)=1_c_size_t
+       weights(corner+1)=1.0d0
+       do i=1,self%countDimensions_
+          offset           =ibits(corner,i-1,1)
+          indices(corner+1)=+indices(corner+1)                    &
+               &            +(                                    &
+               &              +indicesDimension(i)                &
+               &              +int(offset,kind=c_size_t)          &
+               &              -1_c_size_t                         &
+               &             )                                    &
+               &            *self%stride     (i)
+          weights(corner+1)=+weights         (corner+1)           &
+               &            *weightsDimension(offset  ,i)
+       end do
+    end do
+    return
+  end subroutine interpolatorMultiDCorners
+
+  double precision function interpolatorMultiDInterpolate(self,values,x) result(y)
+    !!{RST
+    Interpolate in the table ``values`` at the coordinates ``x``. ``values`` holds the tabulated function in Fortran's
+    usual column-major ordering, so a contiguous rank-\ :math:`N` array whose shape matches that returned by the
+    ``shapeTable`` method may be passed directly.
+    !!}
+    implicit none
+    class           (interpolatorMultiD), intent(inout)                        :: self
+    double precision                    , intent(in   ), dimension(*)          :: values
+    double precision                    , intent(in   ), dimension(:)          :: x
+    integer         (c_size_t          ), dimension(self%countCorners_)        :: indices
+    double precision                    , dimension(self%countCorners_)        :: weights
+    integer                                                                    :: corner
+
+    call self%corners(x,indices,weights)
+    y=0.0d0
+    do corner=1,self%countCorners_
+       y=+y                        &
+         & +weights(corner )       &
+         & *values (indices(corner))
+    end do
+    return
+  end function interpolatorMultiDInterpolate
+
+end module Numerical_Interpolation_MultiD

--- a/source/numerical/interpolation/multiD.F90
+++ b/source/numerical/interpolation/multiD.F90
@@ -106,10 +106,10 @@ contains
     type   (interpolator      ), intent(in   ), dimension(:) :: interpolators
     integer                                                  :: i
 
-    if (size(interpolators) < 1                     )                                                        &
-         & call Error_Report('at least one dimension is required'          //{introspection:location})
-    if (size(interpolators) > countDimensionsMaximum)                                                        &
-         & call Error_Report('too many dimensions'                         //{introspection:location})
+    if (size(interpolators) < 1                     )                                                     &
+         & call Error_Report('at least one dimension is required'             //{introspection:location})
+    if (size(interpolators) > countDimensionsMaximum)                                                     &
+         & call Error_Report('too many dimensions'                            //{introspection:location})
     self%countDimensions_=size(interpolators)
     self%countCorners_   =2**self%countDimensions_
     allocate(self%dimensions (self%countDimensions_))
@@ -118,7 +118,7 @@ contains
     do i=1,self%countDimensions_
        self%dimensions (i)=interpolators(i)
        self%countPoints(i)=interpolators(i)%count()
-       if (self%countPoints(i) < 2_c_size_t)                                                                 &
+       if (self%countPoints(i) < 2_c_size_t)                                                              &
             & call Error_Report('each dimension requires at least 2 abscissae'//{introspection:location})
     end do
     ! Compute strides for column-major (Fortran) ordering of the flattened table.
@@ -191,11 +191,11 @@ contains
     double precision                    , intent(  out), dimension(:,:) :: weights
     integer                                                             :: i
 
-    if (size(x                ) /= self%countDimensions_)                                                    &
+    if (size(x                ) /= self%countDimensions_)                                  &
          & call Error_Report('coordinate vector has wrong size'//{introspection:location})
-    if (size(indices          ) /= self%countDimensions_)                                                    &
+    if (size(indices          ) /= self%countDimensions_)                                  &
          & call Error_Report('index array has wrong size'      //{introspection:location})
-    if (size(weights,dim=2) /= self%countDimensions_ .or. size(weights,dim=1) /= 2)                          &
+    if (size(weights,dim=2) /= self%countDimensions_ .or. size(weights,dim=1) /= 2)        &
          & call Error_Report('weight array has wrong shape'    //{introspection:location})
     do i=1,self%countDimensions_
        call self%dimensions(i)%linearFactors(x(i),indices(i),weights(:,i))
@@ -214,16 +214,16 @@ contains
     !!}
     use :: Error, only : Error_Report
     implicit none
-    class           (interpolatorMultiD), intent(inout)                                 :: self
-    double precision                    , intent(in   ), dimension(:)                   :: x
-    integer         (c_size_t          ), intent(  out), dimension(:)                   :: indices
-    double precision                    , intent(  out), dimension(:)                   :: weights
-    integer         (c_size_t          ), dimension(    self%countDimensions_)          :: indicesDimension
-    double precision                    , dimension(0:1,self%countDimensions_)          :: weightsDimension
-    integer                                                                             :: corner          , i, &
-         &                                                                                 offset
+    class           (interpolatorMultiD), intent(inout)                        :: self
+    double precision                    , intent(in   ), dimension(:)          :: x
+    integer         (c_size_t          ), intent(  out), dimension(:)          :: indices
+    double precision                    , intent(  out), dimension(:)          :: weights
+    integer         (c_size_t          ), dimension(    self%countDimensions_) :: indicesDimension
+    double precision                    , dimension(0:1,self%countDimensions_) :: weightsDimension
+    integer                                                                    :: corner          , i, &
+         &                                                                        offset
 
-    if (size(indices) /= self%countCorners_ .or. size(weights) /= self%countCorners_)                        &
+    if (size(indices) /= self%countCorners_ .or. size(weights) /= self%countCorners_)   &
          & call Error_Report('corner arrays have wrong size'//{introspection:location})
     call self%factors(x,indicesDimension,weightsDimension)
     ! Enumerate the corners of the hypercube. Bit `i-1` of the corner number selects the lower (0) or upper (1)
@@ -233,14 +233,14 @@ contains
        weights(corner+1)=1.0d0
        do i=1,self%countDimensions_
           offset           =ibits(corner,i-1,1)
-          indices(corner+1)=+indices(corner+1)                    &
-               &            +(                                    &
-               &              +indicesDimension(i)                &
-               &              +int(offset,kind=c_size_t)          &
-               &              -1_c_size_t                         &
-               &             )                                    &
+          indices(corner+1)=+indices(corner+1)            &
+               &            +(                            &
+               &              +indicesDimension(i)        &
+               &              +int(offset,kind=c_size_t)  &
+               &              -1_c_size_t                 &
+               &             )                            &
                &            *self%stride     (i)
-          weights(corner+1)=+weights         (corner+1)           &
+          weights(corner+1)=+weights         (corner+1  ) &
                &            *weightsDimension(offset  ,i)
        end do
     end do
@@ -254,19 +254,19 @@ contains
     ``shapeTable`` method may be passed directly.
     !!}
     implicit none
-    class           (interpolatorMultiD), intent(inout)                        :: self
-    double precision                    , intent(in   ), dimension(*)          :: values
-    double precision                    , intent(in   ), dimension(:)          :: x
-    integer         (c_size_t          ), dimension(self%countCorners_)        :: indices
-    double precision                    , dimension(self%countCorners_)        :: weights
-    integer                                                                    :: corner
+    class           (interpolatorMultiD), intent(inout)                 :: self
+    double precision                    , intent(in   ), dimension(*)   :: values
+    double precision                    , intent(in   ), dimension(:)   :: x
+    integer         (c_size_t          ), dimension(self%countCorners_) :: indices
+    double precision                    , dimension(self%countCorners_) :: weights
+    integer                                                             :: corner
 
     call self%corners(x,indices,weights)
     y=0.0d0
     do corner=1,self%countCorners_
-       y=+y                        &
-         & +weights(corner )       &
-         & *values (indices(corner))
+       y   =+y                        &
+         &  +weights(        corner ) &
+         &  *values (indices(corner))
     end do
     return
   end function interpolatorMultiDInterpolate

--- a/source/objects/stellar_luminosities/structure.F90
+++ b/source/objects/stellar_luminosities/structure.F90
@@ -107,6 +107,9 @@ module Stellar_Luminosities_Structure
        <method description="Return true if the indexed luminosity is to be output at the given time." method="isOutput" />
        <method description="Return the index to a luminosity specified by name or properties." method="index" />
        <method description="Return the name of a luminosity specified by index." method="name" />
+       <method description="Return the effective wavelength (in Å, in the frame of the filter) of a luminosity specified by index." method="wavelengthEffective" />
+       <method description="Return the redshift to which the filter of a luminosity specified by index is shifted (zero for rest-frame filters)." method="bandRedshift" />
+       <method description="Return the rest-frame effective wavelength (in Å) of a luminosity specified by index." method="wavelengthRestFrame" />
        <method description="Truncate the number of stellar luminosities stored to match that in the given ``templateLuminosities``." method="truncate" />
        <method description="Returns the size of any non-static components of the type." method="nonStaticSizeOf" />
      </methods>
@@ -146,6 +149,9 @@ module Stellar_Luminosities_Structure
      generic           :: index                 => Stellar_Luminosities_Index_From_Name      , &
           &                                        Stellar_Luminosities_Index_From_Properties
      procedure, nopass :: name                  => Stellar_Luminosities_Name
+     procedure, nopass :: wavelengthEffective   => Stellar_Luminosities_Wavelength_Effective
+     procedure, nopass :: bandRedshift          => Stellar_Luminosities_Band_Redshift
+     procedure, nopass :: wavelengthRestFrame   => Stellar_Luminosities_Wavelength_Rest_Frame
      procedure         :: truncate              => Stellar_Luminosities_Truncate
   end type stellarLuminosities
   
@@ -871,6 +877,63 @@ contains
     end if
     return
   end function Stellar_Luminosities_Name
+
+  double precision function Stellar_Luminosities_Wavelength_Effective(index)
+    !!{RST
+    Return the effective wavelength (in Å) of the filter used for the specified entry in the stellar luminosities
+    structure. Note that this is the wavelength in the frame of the filter---for an observed-frame filter the corresponding
+    rest-frame wavelength is smaller by a factor of :math:`1+z_\mathrm{band}`, where :math:`z_\mathrm{band}` is returned by
+    the ``bandRedshift`` method. Use the ``wavelengthRestFrame`` method to get the rest-frame wavelength directly.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    integer, intent(in   ) :: index
+
+    ! Check for index in range.
+    if (index > 0 .and. index <= luminosityCount) then
+       Stellar_Luminosities_Wavelength_Effective=luminosityWavelengthEffective(index)
+    else
+       Stellar_Luminosities_Wavelength_Effective=0.0d0
+       call Error_Report('index out of range'//{introspection:location})
+    end if
+    return
+  end function Stellar_Luminosities_Wavelength_Effective
+
+  double precision function Stellar_Luminosities_Band_Redshift(index)
+    !!{RST
+    Return the redshift to which the filter of the specified entry in the stellar luminosities structure is shifted. This is
+    zero for rest-frame filters, and equals the redshift at which the filter is applied for observed-frame filters.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    integer, intent(in   ) :: index
+
+    ! Check for index in range.
+    if (index > 0 .and. index <= luminosityCount) then
+       Stellar_Luminosities_Band_Redshift=luminosityBandRedshift(index)
+    else
+       Stellar_Luminosities_Band_Redshift=0.0d0
+       call Error_Report('index out of range'//{introspection:location})
+    end if
+    return
+  end function Stellar_Luminosities_Band_Redshift
+
+  double precision function Stellar_Luminosities_Wavelength_Rest_Frame(index)
+    !!{RST
+    Return the rest-frame effective wavelength (in Å) of the filter used for the specified entry in the stellar luminosities
+    structure, i.e. :math:`\lambda_\mathrm{eff}/(1+z_\mathrm{band})`. This is the wavelength at which any process acting in
+    the rest frame of the emitting galaxy---such as dust attenuation---should be evaluated.
+    !!}
+    implicit none
+    integer, intent(in   ) :: index
+
+    Stellar_Luminosities_Wavelength_Rest_Frame=+Stellar_Luminosities_Wavelength_Effective(index)  &
+         &                                     /(                                               &
+         &                                       +1.0d0                                         &
+         &                                       +Stellar_Luminosities_Band_Redshift     (index) &
+         &                                      )
+    return
+  end function Stellar_Luminosities_Wavelength_Rest_Frame
 
   subroutine Stellar_Luminosities_Create(self)
     !!{RST

--- a/source/objects/stellar_luminosities/structure.F90
+++ b/source/objects/stellar_luminosities/structure.F90
@@ -927,9 +927,9 @@ contains
     implicit none
     integer, intent(in   ) :: index
 
-    Stellar_Luminosities_Wavelength_Rest_Frame=+Stellar_Luminosities_Wavelength_Effective(index)  &
-         &                                     /(                                               &
-         &                                       +1.0d0                                         &
+    Stellar_Luminosities_Wavelength_Rest_Frame=+Stellar_Luminosities_Wavelength_Effective(index) &
+         &                                     /(                                                &
+         &                                       +1.0d0                                          &
          &                                       +Stellar_Luminosities_Band_Redshift     (index) &
          &                                      )
     return

--- a/source/tests/dust/attenuation_descriptors.F90
+++ b/source/tests/dust/attenuation_descriptors.F90
@@ -1,0 +1,118 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson
+!+    Implemented with assistance from Claude (Anthropic).
+
+!!{RST
+Contains a program to test the dust attenuation descriptor data structures.
+!!}
+
+program Test_Dust_Attenuation_Descriptors
+  !!{RST
+  Tests the data structures which mediate between luminosity-producing objects and dust attenuation objects: the age
+  binning negotiated through a ``decompositionRequest``, and the reduction of an attenuated
+  ``luminosityDecomposition`` back into output element values.
+  !!}
+  use :: Display                    , only : displayVerbositySet   , verbosityLevelStandard
+  use :: Dust_Attenuation_Descriptors, only : decompositionRequest  , emissionDescriptor  , luminosityDecomposition
+  use :: Galactic_Structure_Options , only : componentTypeUnknown
+  use :: Unit_Tests                 , only : Assert                , Unit_Tests_Begin_Group, Unit_Tests_End_Group   , Unit_Tests_Finish
+  implicit none
+  type            (decompositionRequest   )                            :: request
+  type            (luminosityDecomposition)                            :: decomposition
+  type            (emissionDescriptor     )                            :: descriptor
+  double precision                         , allocatable, dimension(:) :: values
+  double precision                                                     :: ageMinimum   , ageMaximum
+
+  ! Set verbosity level.
+  call displayVerbositySet(verbosityLevelStandard)
+
+  ! Begin unit tests.
+  call Unit_Tests_Begin_Group("Dust attenuation descriptors")
+
+  ! An emission descriptor which has not been filled in should describe emission of unknown origin spanning all ages.
+  call Unit_Tests_Begin_Group("default emission descriptor")
+  call Assert("wavelength unresolved" ,descriptor%wavelength  < 0.0d0      ,.true.)
+  call Assert("metallicity unresolved",descriptor%metallicity < 0.0d0      ,.true.)
+  call Assert("radius unresolved"     ,descriptor%radius      < 0.0d0      ,.true.)
+  call Assert("age spans all"         ,descriptor%ageMinimum             ,0.0d0     )
+  call Assert("age unbounded above"   ,descriptor%ageMaximum == huge(0.0d0),.true.)
+  call Assert("component unknown"     ,descriptor%componentType == componentTypeUnknown,.true.)
+  call Unit_Tests_End_Group()
+
+  ! A request with no age boundaries requests no age resolution at all.
+  call Unit_Tests_Begin_Group("age binning: unresolved")
+  call Assert("single bin"      ,request%countAgeBins(       ),1)
+  call Assert("all ages in bin 1 (young)",request%ageBinIndex(0.001d0),1)
+  call Assert("all ages in bin 1 (old)"  ,request%ageBinIndex(1.0d1  ),1)
+  call request%ageBinRange(1,ageMinimum,ageMaximum)
+  call Assert("bin starts at zero"  ,ageMinimum             ,0.0d0 )
+  call Assert("bin unbounded above" ,ageMaximum == huge(0.0d0),.true.)
+  call Unit_Tests_End_Group()
+
+  ! A request with two internal boundaries defines three bins. Bins are closed below and open above, so an age
+  ! exactly on a boundary falls into the older bin.
+  call Unit_Tests_Begin_Group("age binning: two boundaries")
+  request%ageBoundaries=[1.0d-2,1.0d-1]
+  call Assert("three bins"             ,request%countAgeBins(        ),3)
+  call Assert("below first boundary"   ,request%ageBinIndex (5.0d-3  ),1)
+  call Assert("on first boundary"      ,request%ageBinIndex (1.0d-2  ),2)
+  call Assert("between boundaries"     ,request%ageBinIndex (5.0d-2  ),2)
+  call Assert("on second boundary"     ,request%ageBinIndex (1.0d-1  ),3)
+  call Assert("above second boundary"  ,request%ageBinIndex (1.0d1   ),3)
+  call request%ageBinRange(2,ageMinimum,ageMaximum)
+  call Assert("middle bin lower bound" ,ageMinimum,1.0d-2)
+  call Assert("middle bin upper bound" ,ageMaximum,1.0d-1)
+  call request%ageBinRange(3,ageMinimum,ageMaximum)
+  call Assert("upper bin lower bound"  ,ageMinimum,1.0d-1)
+  call Assert("upper bin unbounded"    ,ageMaximum == huge(0.0d0),.true.)
+  call Unit_Tests_End_Group()
+
+  ! Reduction of a decomposition sums each parcel, weighted by its transmission, into the output element which it
+  ! contributes to.
+  call Unit_Tests_Begin_Group("reduction")
+  call decomposition%initialize(4,2)
+  call Assert("term count",decomposition%countTerms(),4)
+  decomposition%luminosities=[1.0d0,2.0d0,3.0d0,4.0d0]
+  decomposition%elementIndex=[1    ,1    ,2    ,2    ]
+  ! With unit transmission the reduction simply sums the parcels of each element.
+  call decomposition%reduce([1.0d0,1.0d0,1.0d0,1.0d0],values)
+  call Assert("unattenuated element 1",values(1),3.0d0,relTol=1.0d-12)
+  call Assert("unattenuated element 2",values(2),7.0d0,relTol=1.0d-12)
+  ! With a transmission which differs between parcels of the same element, the parcels are weighted individually.
+  call decomposition%reduce([1.0d0,5.0d-1,2.5d-1,0.0d0],values)
+  call Assert("attenuated element 1"  ,values(1),2.0d0 ,relTol=1.0d-12)
+  call Assert("attenuated element 2"  ,values(2),7.5d-1,relTol=1.0d-12)
+  ! Zero transmission extinguishes everything.
+  call decomposition%reduce([0.0d0,0.0d0,0.0d0,0.0d0],values)
+  call Assert("fully extinguished"    ,values   ,[0.0d0,0.0d0])
+  call Unit_Tests_End_Group()
+
+  ! An empty decomposition is legal, and reduces to no elements.
+  call Unit_Tests_Begin_Group("empty decomposition")
+  call decomposition%initialize(0,0)
+  call Assert("no terms",decomposition%countTerms(),0)
+  call Unit_Tests_End_Group()
+
+  ! End unit tests.
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Finish()
+
+end program Test_Dust_Attenuation_Descriptors

--- a/source/tests/dust/attenuation_descriptors.F90
+++ b/source/tests/dust/attenuation_descriptors.F90
@@ -30,10 +30,10 @@ program Test_Dust_Attenuation_Descriptors
   binning negotiated through a ``decompositionRequest``, and the reduction of an attenuated
   ``luminosityDecomposition`` back into output element values.
   !!}
-  use :: Display                    , only : displayVerbositySet   , verbosityLevelStandard
-  use :: Dust_Attenuation_Descriptors, only : decompositionRequest  , emissionDescriptor  , luminosityDecomposition
-  use :: Galactic_Structure_Options , only : componentTypeUnknown
-  use :: Unit_Tests                 , only : Assert                , Unit_Tests_Begin_Group, Unit_Tests_End_Group   , Unit_Tests_Finish
+  use :: Display                     , only : displayVerbositySet , verbosityLevelStandard
+  use :: Dust_Attenuation_Descriptors, only : decompositionRequest, emissionDescriptor    , luminosityDecomposition
+  use :: Galactic_Structure_Options  , only : componentTypeUnknown
+  use :: Unit_Tests                  , only : Assert              , Unit_Tests_Begin_Group, Unit_Tests_End_Group   , Unit_Tests_Finish
   implicit none
   type            (decompositionRequest   )                            :: request
   type            (luminosityDecomposition)                            :: decomposition
@@ -49,34 +49,34 @@ program Test_Dust_Attenuation_Descriptors
 
   ! An emission descriptor which has not been filled in should describe emission of unknown origin spanning all ages.
   call Unit_Tests_Begin_Group("default emission descriptor")
-  call Assert("wavelength unresolved" ,descriptor%wavelength  < 0.0d0      ,.true.)
-  call Assert("metallicity unresolved",descriptor%metallicity < 0.0d0      ,.true.)
-  call Assert("radius unresolved"     ,descriptor%radius      < 0.0d0      ,.true.)
-  call Assert("age spans all"         ,descriptor%ageMinimum             ,0.0d0     )
-  call Assert("age unbounded above"   ,descriptor%ageMaximum == huge(0.0d0),.true.)
+  call Assert("wavelength unresolved" ,descriptor%wavelength    < 0.0d0                ,.true.)
+  call Assert("metallicity unresolved",descriptor%metallicity   < 0.0d0                ,.true.)
+  call Assert("radius unresolved"     ,descriptor%radius        < 0.0d0                ,.true.)
+  call Assert("age spans all"         ,descriptor%ageMinimum                           ,0.0d0 )
+  call Assert("age unbounded above"   ,descriptor%ageMaximum    == huge(0.0d0)         ,.true.)
   call Assert("component unknown"     ,descriptor%componentType == componentTypeUnknown,.true.)
   call Unit_Tests_End_Group()
 
   ! A request with no age boundaries requests no age resolution at all.
   call Unit_Tests_Begin_Group("age binning: unresolved")
-  call Assert("single bin"      ,request%countAgeBins(       ),1)
-  call Assert("all ages in bin 1 (young)",request%ageBinIndex(0.001d0),1)
-  call Assert("all ages in bin 1 (old)"  ,request%ageBinIndex(1.0d1  ),1)
+  call Assert("single bin"               ,request%countAgeBins(       ),1     )
+  call Assert("all ages in bin 1 (young)",request%ageBinIndex (0.001d0),1     )
+  call Assert("all ages in bin 1 (old)"  ,request%ageBinIndex (1.000d1),1     )
   call request%ageBinRange(1,ageMinimum,ageMaximum)
-  call Assert("bin starts at zero"  ,ageMinimum             ,0.0d0 )
-  call Assert("bin unbounded above" ,ageMaximum == huge(0.0d0),.true.)
+  call Assert("bin starts at zero"       ,ageMinimum                   ,0.0d0 )
+  call Assert("bin unbounded above"      ,ageMaximum == huge(0.0d0)    ,.true.)
   call Unit_Tests_End_Group()
 
   ! A request with two internal boundaries defines three bins. Bins are closed below and open above, so an age
   ! exactly on a boundary falls into the older bin.
   call Unit_Tests_Begin_Group("age binning: two boundaries")
   request%ageBoundaries=[1.0d-2,1.0d-1]
-  call Assert("three bins"             ,request%countAgeBins(        ),3)
-  call Assert("below first boundary"   ,request%ageBinIndex (5.0d-3  ),1)
-  call Assert("on first boundary"      ,request%ageBinIndex (1.0d-2  ),2)
-  call Assert("between boundaries"     ,request%ageBinIndex (5.0d-2  ),2)
-  call Assert("on second boundary"     ,request%ageBinIndex (1.0d-1  ),3)
-  call Assert("above second boundary"  ,request%ageBinIndex (1.0d1   ),3)
+  call Assert("three bins"             ,request%countAgeBins(      ),3)
+  call Assert("below first boundary"   ,request%ageBinIndex (5.0d-3),1)
+  call Assert("on first boundary"      ,request%ageBinIndex (1.0d-2),2)
+  call Assert("between boundaries"     ,request%ageBinIndex (5.0d-2),2)
+  call Assert("on second boundary"     ,request%ageBinIndex (1.0d-1),3)
+  call Assert("above second boundary"  ,request%ageBinIndex (1.0d+1),3)
   call request%ageBinRange(2,ageMinimum,ageMaximum)
   call Assert("middle bin lower bound" ,ageMinimum,1.0d-2)
   call Assert("middle bin upper bound" ,ageMaximum,1.0d-1)
@@ -94,15 +94,15 @@ program Test_Dust_Attenuation_Descriptors
   decomposition%elementIndex=[1    ,1    ,2    ,2    ]
   ! With unit transmission the reduction simply sums the parcels of each element.
   call decomposition%reduce([1.0d0,1.0d0,1.0d0,1.0d0],values)
-  call Assert("unattenuated element 1",values(1),3.0d0,relTol=1.0d-12)
-  call Assert("unattenuated element 2",values(2),7.0d0,relTol=1.0d-12)
+  call Assert("unattenuated element 1",values(1),3.0d+0,relTol=1.0d-12)
+  call Assert("unattenuated element 2",values(2),7.0d+0,relTol=1.0d-12)
   ! With a transmission which differs between parcels of the same element, the parcels are weighted individually.
   call decomposition%reduce([1.0d0,5.0d-1,2.5d-1,0.0d0],values)
-  call Assert("attenuated element 1"  ,values(1),2.0d0 ,relTol=1.0d-12)
+  call Assert("attenuated element 1"  ,values(1),2.0d+0,relTol=1.0d-12)
   call Assert("attenuated element 2"  ,values(2),7.5d-1,relTol=1.0d-12)
   ! Zero transmission extinguishes everything.
   call decomposition%reduce([0.0d0,0.0d0,0.0d0,0.0d0],values)
-  call Assert("fully extinguished"    ,values   ,[0.0d0,0.0d0])
+  call Assert("fully extinguished",values,[0.0d0,0.0d0])
   call Unit_Tests_End_Group()
 
   ! An empty decomposition is legal, and reduces to no elements.

--- a/source/tests/interpolation/multiD.F90
+++ b/source/tests/interpolation/multiD.F90
@@ -1,0 +1,159 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson
+!+    Implemented with assistance from Claude (Anthropic).
+
+!!{RST
+Contains a program to test multi-dimensional interpolation.
+!!}
+
+program Test_Interpolation_MultiD
+  !!{RST
+  Tests that the multi-dimensional interpolation code works correctly.
+
+  Multilinear interpolation is exact for functions which are multilinear in the coordinates, so the primary tests
+  build such a function, tabulate it, and check that interpolation recovers it exactly. Interpolation at the grid
+  nodes of a function which is *not* multilinear is also checked, since that catches errors in the flattened
+  indexing which a smooth test function could mask.
+  !!}
+  use            :: Display                      , only : displayVerbositySet, verbosityLevelStandard
+  use, intrinsic :: ISO_C_Binding                , only : c_size_t
+  use            :: Numerical_Interpolation      , only : interpolator
+  use            :: Numerical_Interpolation_MultiD, only : interpolatorMultiD
+  use            :: Unit_Tests                   , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
+  implicit none
+  type            (interpolatorMultiD)                             :: interpolator2_        , interpolator3_
+  type            (interpolator      ), dimension(2)               :: interpolators2
+  type            (interpolator      ), dimension(3)               :: interpolators3
+  double precision                    , dimension(4)               :: x1            =[0.0d0,1.0d0,2.0d0,3.0d0]
+  double precision                    , dimension(3)               :: x2            =[0.0d0,2.0d0,4.0d0]
+  double precision                    , dimension(2)               :: y1            =[0.0d0,1.0d0]
+  double precision                    , dimension(2)               :: y2            =[0.0d0,1.0d0]
+  double precision                    , dimension(2)               :: y3            =[0.0d0,2.0d0]
+  double precision                    , dimension(4,3)             :: values2
+  double precision                    , dimension(2,2,2)           :: values3
+  double precision                    , dimension(4,3)             :: valuesLumpy
+  integer         (c_size_t          ), allocatable, dimension(:)  :: shape_
+  integer         (c_size_t          ), dimension(4)               :: indices2
+  double precision                    , dimension(4)               :: weights2
+  integer                                                          :: i             , j             , &
+       &                                                              k
+  double precision                                                 :: y
+
+  ! Set verbosity level.
+  call displayVerbositySet(verbosityLevelStandard)
+
+  ! Begin unit tests.
+  call Unit_Tests_Begin_Group("Multi-dimensional interpolation")
+
+  ! Build a 2-D interpolator over a (4,3) grid.
+  interpolators2(1)=interpolator(x1)
+  interpolators2(2)=interpolator(x2)
+  interpolator2_   =interpolatorMultiD(interpolators2)
+
+  ! Tabulate a bilinear function, for which bilinear interpolation is exact, plus a "lumpy" function which is not
+  ! bilinear and so only agrees at the grid nodes.
+  do i=1,size(x1)
+     do j=1,size(x2)
+        values2    (i,j)=+1.0d0            &
+             &           +2.0d0*x1(i)      &
+             &           +3.0d0*x2(j)      &
+             &           +4.0d0*x1(i)*x2(j)
+        valuesLumpy(i,j)=+dble(i)**3       &
+             &           -dble(j)**2       &
+             &           +dble(i*j)
+     end do
+  end do
+
+  ! Test the reported geometry of the interpolator.
+  call Unit_Tests_Begin_Group("geometry")
+  call Assert("dimension count",     interpolator2_%countDimensions(),2    )
+  call Assert("corner count"   ,     interpolator2_%countCorners   (),4    )
+  call Assert("table count"    ,int (interpolator2_%countTable     ()),12  )
+  shape_=interpolator2_%shapeTable()
+  call Assert("table shape"    ,int (shape_                          ),[4,3])
+  call Unit_Tests_End_Group()
+
+  ! Test that interpolation of a bilinear function is exact.
+  call Unit_Tests_Begin_Group("bilinear function")
+  y=interpolator2_%interpolate(values2,[1.5d0,3.0d0])
+  call Assert("interior point"      ,y,31.0d0,relTol=1.0d-12)
+  y=interpolator2_%interpolate(values2,[0.0d0,0.0d0])
+  call Assert("lower corner"        ,y, 1.0d0,relTol=1.0d-12)
+  y=interpolator2_%interpolate(values2,[3.0d0,4.0d0])
+  call Assert("upper corner"        ,y,+1.0d0+2.0d0*3.0d0+3.0d0*4.0d0+4.0d0*3.0d0*4.0d0,relTol=1.0d-12)
+  y=interpolator2_%interpolate(values2,[2.0d0,1.0d0])
+  call Assert("on a grid line"      ,y,+1.0d0+2.0d0*2.0d0+3.0d0*1.0d0+4.0d0*2.0d0*1.0d0,relTol=1.0d-12)
+  call Unit_Tests_End_Group()
+
+  ! Test that interpolation at grid nodes recovers the tabulated values even for a function which is not bilinear.
+  ! This verifies that the mapping from grid indices to positions in the flattened table is correct.
+  call Unit_Tests_Begin_Group("grid nodes")
+  do i=1,size(x1)
+     do j=1,size(x2)
+        y=interpolator2_%interpolate(valuesLumpy,[x1(i),x2(j)])
+        call Assert("node value",y,valuesLumpy(i,j),relTol=1.0d-12)
+     end do
+  end do
+  call Unit_Tests_End_Group()
+
+  ! Test that the corner weights form a partition of unity.
+  call Unit_Tests_Begin_Group("corner weights")
+  call interpolator2_%corners([1.5d0,3.0d0],indices2,weights2)
+  call Assert("weights sum to unity"       ,sum(weights2),1.0d0,relTol=1.0d-12)
+  call Assert("corner indices within table",all(indices2 >= 1_c_size_t .and. indices2 <= interpolator2_%countTable()),.true.)
+  call interpolator2_%corners([0.0d0,0.0d0],indices2,weights2)
+  call Assert("weights sum to unity at node",sum(weights2),1.0d0,relTol=1.0d-12)
+  call Unit_Tests_End_Group()
+
+  ! Build a 3-D interpolator and check that interpolation of a trilinear function is exact.
+  call Unit_Tests_Begin_Group("trilinear function")
+  interpolators3(1)=interpolator(y1)
+  interpolators3(2)=interpolator(y2)
+  interpolators3(3)=interpolator(y3)
+  interpolator3_   =interpolatorMultiD(interpolators3)
+  do i=1,size(y1)
+     do j=1,size(y2)
+        do k=1,size(y3)
+           values3(i,j,k)=+1.0d0                        &
+                &         +      y1(i)                  &
+                &         +2.0d0*y2(j)                  &
+                &         +3.0d0*y3(k)                  &
+                &         +      y1(i)*y2(j)            &
+                &         +      y1(i)*      y3(k)      &
+                &         +            y2(j)*y3(k)      &
+                &         +      y1(i)*y2(j)*y3(k)
+        end do
+     end do
+  end do
+  call Assert("corner count"  ,interpolator3_%countCorners(),8)
+  y=interpolator3_%interpolate(values3,[0.5d0,0.5d0,1.0d0])
+  call Assert("interior point",y,7.0d0,relTol=1.0d-12)
+  y=interpolator3_%interpolate(values3,[1.0d0,1.0d0,2.0d0])
+  call Assert("upper corner"  ,y,values3(2,2,2),relTol=1.0d-12)
+  y=interpolator3_%interpolate(values3,[0.0d0,1.0d0,0.0d0])
+  call Assert("mixed corner"  ,y,values3(1,2,1),relTol=1.0d-12)
+  call Unit_Tests_End_Group()
+
+  ! End unit tests.
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Finish()
+
+end program Test_Interpolation_MultiD

--- a/source/tests/interpolation/multiD.F90
+++ b/source/tests/interpolation/multiD.F90
@@ -33,13 +33,13 @@ program Test_Interpolation_MultiD
   nodes of a function which is *not* multilinear is also checked, since that catches errors in the flattened
   indexing which a smooth test function could mask.
   !!}
-  use            :: Display                      , only : displayVerbositySet, verbosityLevelStandard
-  use, intrinsic :: ISO_C_Binding                , only : c_size_t
-  use            :: Numerical_Interpolation      , only : interpolator
+  use            :: Display                       , only : displayVerbositySet, verbosityLevelStandard
+  use, intrinsic :: ISO_C_Binding                 , only : c_size_t
+  use            :: Numerical_Interpolation       , only : interpolator
   use            :: Numerical_Interpolation_MultiD, only : interpolatorMultiD
-  use            :: Unit_Tests                   , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
+  use            :: Unit_Tests                    , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
   implicit none
-  type            (interpolatorMultiD)                             :: interpolator2_        , interpolator3_
+  type            (interpolatorMultiD)                             :: interpolator2_                          , interpolator3_
   type            (interpolator      ), dimension(2)               :: interpolators2
   type            (interpolator      ), dimension(3)               :: interpolators3
   double precision                    , dimension(4)               :: x1            =[0.0d0,1.0d0,2.0d0,3.0d0]
@@ -53,7 +53,7 @@ program Test_Interpolation_MultiD
   integer         (c_size_t          ), allocatable, dimension(:)  :: shape_
   integer         (c_size_t          ), dimension(4)               :: indices2
   double precision                    , dimension(4)               :: weights2
-  integer                                                          :: i             , j             , &
+  integer                                                          :: i                                       , j             , &
        &                                                              k
   double precision                                                 :: y
 
@@ -72,21 +72,21 @@ program Test_Interpolation_MultiD
   ! bilinear and so only agrees at the grid nodes.
   do i=1,size(x1)
      do j=1,size(x2)
-        values2    (i,j)=+1.0d0            &
-             &           +2.0d0*x1(i)      &
-             &           +3.0d0*x2(j)      &
+        values2    (i,j)=+1.0d0             &
+             &           +2.0d0*x1(i)       &
+             &           +3.0d0      *x2(j) &
              &           +4.0d0*x1(i)*x2(j)
-        valuesLumpy(i,j)=+dble(i)**3       &
-             &           -dble(j)**2       &
+        valuesLumpy(i,j)=+dble(i  )**3      &
+             &           -dble(  j)**2      &
              &           +dble(i*j)
      end do
   end do
 
   ! Test the reported geometry of the interpolator.
   call Unit_Tests_Begin_Group("geometry")
-  call Assert("dimension count",     interpolator2_%countDimensions(),2    )
-  call Assert("corner count"   ,     interpolator2_%countCorners   (),4    )
-  call Assert("table count"    ,int (interpolator2_%countTable     ()),12  )
+  call Assert("dimension count",     interpolator2_%countDimensions() , 2   )
+  call Assert("corner count"   ,     interpolator2_%countCorners   () , 4   )
+  call Assert("table count"    ,int (interpolator2_%countTable     ()),12   )
   shape_=interpolator2_%shapeTable()
   call Assert("table shape"    ,int (shape_                          ),[4,3])
   call Unit_Tests_End_Group()
@@ -132,13 +132,13 @@ program Test_Interpolation_MultiD
   do i=1,size(y1)
      do j=1,size(y2)
         do k=1,size(y3)
-           values3(i,j,k)=+1.0d0                        &
-                &         +      y1(i)                  &
-                &         +2.0d0*y2(j)                  &
-                &         +3.0d0*y3(k)                  &
-                &         +      y1(i)*y2(j)            &
-                &         +      y1(i)*      y3(k)      &
-                &         +            y2(j)*y3(k)      &
+           values3(i,j,k)=+1.0d0                   &
+                &         +      y1(i)             &
+                &         +2.0d0*y2(j)             &
+                &         +3.0d0*y3(k)             &
+                &         +      y1(i)*y2(j)       &
+                &         +      y1(i)*      y3(k) &
+                &         +            y2(j)*y3(k) &
                 &         +      y1(i)*y2(j)*y3(k)
         end do
      end do


### PR DESCRIPTION
## Summary

Phase 0 of the dust attenuation and emission framework planned in #893. This is
**groundwork only** — no new physics, and no change to any result. It puts in
place the interfaces that the `dustAttenuation` class and the `dustAttenuation`
property extractor will build on in Phase 1.

Dust attenuation is not a single multiplicative factor on a galaxy's total
luminosity: it depends on wavelength, on which component the light comes from,
and — where birth clouds are modelled — on the age of the emitting population.
A luminosity-producing object therefore has to hand over its luminosity *split*
along whichever of those axes matter, have each piece attenuated, and recombine
the pieces. That is what this PR makes possible.

### The decomposition interface

* **`source/dust/attenuation_descriptors.F90`** (new) — `emissionDescriptor`
  (one homogeneous parcel of emission: wavelength, component, source type, age
  range, optionally metallicity and radius), `luminosityDecomposition` (a set of
  parcels plus a map from parcel to output element), and `decompositionRequest`
  (how finely the split must be made). Also an `emissionSource` enumeration
  (stellar / nebular / accretionDisk / dust / unknown).

* **`nodePropertyExtractor`** gains `supportsAttenuation`, `decompose`, and
  `recompose`. Two design points worth review:

  * Fortran has no multiple inheritance, so a decomposition interface cannot be
    mixed into `nodePropertyExtractorScalar` / `Tuple` / `Array` / `List`
    independently. These methods therefore go on the base class with defaults
    (`supportsAttenuation` false, `decompose` errors), following the existing
    `extractScalar` precedent in the same file.
  * `recompose` **defaults to a weighted sum** of each parcel into its output
    element, which is correct for any output linear in luminosity. Most
    producers will therefore only need to implement `decompose`; only outputs
    that are non-linear in luminosity (magnitudes, colours, ratios) override it.

* `decompositionRequest` carries explicit **age bin boundaries** rather than an
  `isAgeDependent` flag. An attenuator declares the birth cloud lifetime and a
  producer collapses its age axis to two bins. This is what keeps a
  decomposition of a spectrum affordable — without negotiation it would carry
  one term per (wavelength, age, metallicity) triple.

### Supporting changes

* **`stellarLuminosities`** gains `wavelengthEffective`, `bandRedshift`, and
  `wavelengthRestFrame` accessors. The underlying arrays were module-private,
  but attenuation must be evaluated at the rest-frame wavelength,
  `lambda_eff/(1+z_band)`.

* **`nodePropertyExtractorLuminosityStellar`** gains a `component` selector
  (`all` / `disk` / `spheroid` / `nuclearStarCluster`). It previously always
  returned the sum over components, and dust cannot meaningfully be applied to a
  sum. **The default is `all`, so existing parameter files and output dataset
  names are unchanged**; the name gains a `:disk`-style suffix only when a
  component is selected. The constructor rejects components that cannot host a
  stellar population.

* **`interpolatorMultiD`** (new) generalizes the nested-corner interpolation
  pattern currently hand-written in `Panuzzo2003.F90` to tables of arbitrary
  rank, ready for the 4–5 dimensional dust atlas and compendium tables of
  Phase 3. `interpolator` gains a `count` accessor to support it.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test

```bash
export GALACTICUS_EXEC_PATH=`pwd`
make -jN Galacticus.exe tests.interpolation.multiD.exe tests.dust.attenuation_descriptors.exe
./tests.interpolation.multiD.exe
./tests.dust.attenuation_descriptors.exe
./Galacticus.exe parameters/quickTest.xml
```

## Checklist
- [x] I ran relevant tests (or explain why not):
  - `make -j6 Galacticus.exe` — exit 0, no errors
  - `tests.interpolation.multiD.exe` — 27/27 passed
  - `tests.dust.attenuation_descriptors.exe` — 28/28 passed
  - `./Galacticus.exe parameters/quickTest.xml` — exit 0, no failure markers
  - `python -m pytest` — 892 passed, 1 skipped
  - `testSuite/test-inactive_luminosities.py` — SUCCESS
  - `scripts/build/libraryInterfaces.py` — exit 0; the regenerated wrapper is
    `__init__(self, filterName, filterType, component, outputTimes_, redshiftBand=None, postprocessChain=None, outputMask=None)`,
    with no cautions
  - **Not run:** `testSuite/test-Python-interface.py`, which needs a full
    `GALACTICUS_BUILD_OPTION=lib libgalacticus.so` rebuild. Instead the
    interface generator was run standalone (above), since that is the part this
    change could break. The pattern is also already exercised:
    `nodePropertyExtractorSED` — likewise an exposed extractor — already takes
    `type(enumerationComponentTypeType)` as its first constructor argument.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

## Note

One incidental metadata change: the default-case description string was
`"Total stellar luminosity luminosity in the ..."` (duplicated word); it now
reads `"Total stellar luminosity in the ..."`.

Both new units carry unit tests, registered in the CI matrix in `cicd.yml`.

Part of #893.
