### PR TITLE
perf(massDistributions): hold the isothermal SIDM tabulation per thread, not per halo

### DIFF
--- a/source/mass_distributions/spherical/SIDM/isothermal/_class.F90
+++ b/source/mass_distributions/spherical/SIDM/isothermal/_class.F90
@@ -76,25 +76,25 @@
      A mass distribution implementing the "isothermal" approximation to the effects of SIDM based on the model of :cite:t:`jiang_semi-analytic_2023`.
      !!}
      private
-     double precision                                              :: velocityDispersionCentral     , radiusInteraction_                    , &
-          &                                                           densityInteraction            , massInteraction                       , &
+     double precision                                              :: velocityDispersionCentral     , radiusInteraction_      , &
+          &                                                           densityInteraction            , massInteraction         , &
           &                                                           velocityDispersionInteraction
-     type            (interpolator), allocatable                   :: densityCentralDimensionless   , velocityDispersionCentralDimensionless, &
-          &                                                           interpolatorRadiiDimensionless, interpolatorXi
-     double precision                                              :: xiTabulatedMinimum            , xiTabulatedMaximum
-     type            (rangeLattice)                                :: latticeXi
+     type            (interpolator), allocatable                   :: interpolatorRadiiDimensionless
+     ! The dimensionless profiles are held only for the two values of ξ which bracket that of this halo - the trailing dimension
+     ! of each runs over just those two values. ξ is fixed once the solution has been computed, so no other part of the shared
+     ! tabulation (see below) is ever used by this object. Keeping just this slab leaves each object a few tens of kilobytes in
+     ! size, instead of the few tens of megabytes of the full tabulation.
      double precision              , allocatable, dimension( : ,:) :: densityProfileDimensionless   , massProfileDimensionless
      double precision              , allocatable, dimension( :   ) :: radiiDimensionless
-     integer         (c_size_t    )                                :: indexXi
      double precision                           , dimension(0:1  ) :: factorsXi
    contains
      !![
      <methods docformat="rst">
-       <method method="tabulateSolutions" description="Tabulate solutions for the isothermal core of a SIDM halo."/>
+       <method method="tabulateSolutions" description="Ensure that the shared tabulation of solutions for the isothermal core of a SIDM halo spans the required value of ξ, and extract from it the part needed by this object."/>
        <method method="computeSolution"   description="Compute a solution for the isothermal core of a SIDM halo."/>
      </methods>
      !!]
-     final     ::                           sphericalSIDMIsothermalDestructor
+     final     ::                                   sphericalSIDMIsothermalDestructor
      procedure :: computeSolution                => sphericalSIDMIsothermalComputeSolution
      procedure :: tabulateSolutions              => sphericalSIDMIsothermalTabulateSolutions
      procedure :: density                        => sphericalSIDMIsothermalDensity
@@ -121,6 +121,26 @@
        &                                      z0_
   type            (odeSolver), allocatable :: odeSolver_
   !$omp threadprivate(xi_,y0_,z0_,odeSolver_)
+
+  ! The tabulation of the dimensionless solutions, held once per thread. The solutions y₀(ξ) and z₀(ξ), and the dimensionless
+  ! density and mass profiles, depend on ξ alone and so are common to every halo. Objects of this class are constructed once per
+  ! halo, so holding the tabulation per object had every halo read the entire (multi-megabyte) cache file from disk only to
+  ! discover that it already contained everything that halo needed - which dominated the run time of SIDM models. Held here
+  ! instead, each thread reads the file at most once, and only when its tabulation must actually be extended.
+  !
+  ! These are threadprivate rather than shared so that looking a solution up requires no lock at all. A single shared copy would
+  ! need every construction to be serialized - extending the tabulation reallocates these arrays, and the interpolators carry
+  ! mutable look-up caches - and with the hundreds of threads that these models are run with, and a mass distribution
+  ! constructed per halo, that lock would itself become the bottleneck. The cost is one copy of the tabulation per thread.
+  type            (rangeLattice)                              :: sidmIsothermalLatticeXi
+  double precision              , allocatable, dimension(:  ) :: sidmIsothermalXi            , sidmIsothermalY0                       , &
+       &                                                         sidmIsothermalZ0            , sidmIsothermalRadii
+  double precision              , allocatable, dimension(:,:) :: sidmIsothermalDensityProfile, sidmIsothermalMassProfile
+  type            (interpolator), allocatable                 :: sidmIsothermalDensityCentral, sidmIsothermalVelocityDispersionCentral, &
+       &                                                         sidmIsothermalInterpolatorXi
+  !$omp threadprivate(sidmIsothermalLatticeXi,sidmIsothermalXi,sidmIsothermalY0,sidmIsothermalZ0,sidmIsothermalRadii)
+  !$omp threadprivate(sidmIsothermalDensityProfile,sidmIsothermalMassProfile,sidmIsothermalDensityCentral)
+  !$omp threadprivate(sidmIsothermalVelocityDispersionCentral,sidmIsothermalInterpolatorXi)
 
 contains
 
@@ -219,9 +239,7 @@ contains
     class default
        call Error_Report('this class expects a self-interacting dark matter particle'//{introspection:location})
     end select
-    self%dimensionless     =.false.
-    self%xiTabulatedMinimum=+huge(0.0d0)
-    self%xiTabulatedMaximum=-huge(0.0d0)
+    self%dimensionless=.false.
     call self%computeSolution()
     return
   end function sphericalSIDMIsothermalConstructorInternal
@@ -240,9 +258,49 @@ contains
     return
   end subroutine sphericalSIDMIsothermalDestructor
 
-  subroutine sphericalSIDMIsothermalTabulateSolutions(self,xiRequired)
+  subroutine sphericalSIDMIsothermalTabulateSolutions(self,xiRequired,densityCentralDimensionless,velocityDispersionCentralDimensionless)
     !!{RST
-    Tabulate solutions for :math:`y_0(\xi)`, :math:`z_0(\xi)`.
+    Ensure that this thread's tabulation of :math:`y_0(\xi)`, :math:`z_0(\xi)`, and of the dimensionless density and mass
+    profiles, spans ``xiRequired``, extending it - and the copy of it cached on disk - if it does not. The dimensionless central
+    density and velocity dispersion at ``xiRequired`` are returned, and the part of the tabulation which this object will
+    subsequently need - the two columns in ξ which bracket ``xiRequired`` - is copied out of the tabulation into the object.
+    !!}
+    implicit none
+    class           (massDistributionSphericalSIDMIsothermal), intent(inout) :: self
+    double precision                                         , intent(in   ) :: xiRequired
+    double precision                                         , intent(  out) :: densityCentralDimensionless, velocityDispersionCentralDimensionless
+    integer         (c_size_t                               )                :: indexXi
+
+    ! Note that no locking is needed anywhere below: the tabulation and the interpolators built on it are threadprivate, so
+    ! nothing here is reachable from another thread.
+    call sphericalSIDMIsothermalTabulationExtend(self,xiRequired)
+    densityCentralDimensionless           =sidmIsothermalDensityCentral           %interpolate  (xiRequired                       )
+    velocityDispersionCentralDimensionless=sidmIsothermalVelocityDispersionCentral%interpolate  (xiRequired                       )
+    call                                   sidmIsothermalInterpolatorXi           %linearFactors(xiRequired,indexXi,self%factorsXi)
+    ! Copy out of the tabulation the two columns in ξ which bracket the value required by this object, together with the radial
+    ! abscissae. ξ is fixed once the solution has been computed, so this slab is all of the tabulation that this object will ever
+    ! use. Copying it, rather than referring back to the thread's tabulation, keeps the object valid if it is later used from
+    ! another thread, and unaffected if the tabulation is subsequently extended - and it keeps the object small enough that the
+    ! copy itself is inconsequential.
+    if (allocated(self%radiiDimensionless         )) deallocate(self%radiiDimensionless         )
+    if (allocated(self%densityProfileDimensionless)) deallocate(self%densityProfileDimensionless)
+    if (allocated(self%massProfileDimensionless   )) deallocate(self%massProfileDimensionless   )
+    allocate(self%radiiDimensionless         ,source=sidmIsothermalRadii  )
+    allocate(self%densityProfileDimensionless(size(sidmIsothermalRadii),2))
+    allocate(self%massProfileDimensionless   (size(sidmIsothermalRadii),2))
+    self%densityProfileDimensionless=sidmIsothermalDensityProfile(:,indexXi:indexXi+1)
+    self%massProfileDimensionless   =sidmIsothermalMassProfile   (:,indexXi:indexXi+1)
+    ! Build the interpolator in the radial abscissae. This is held per object as it caches the result of the most recent look-up.
+    if (allocated(self%interpolatorRadiiDimensionless)) deallocate(self%interpolatorRadiiDimensionless)
+    allocate(self%interpolatorRadiiDimensionless)
+    self%interpolatorRadiiDimensionless=interpolator(self%radiiDimensionless)
+    return
+  end subroutine sphericalSIDMIsothermalTabulateSolutions
+
+  subroutine sphericalSIDMIsothermalTabulationExtend(self,xiRequired)
+    !!{RST
+    Extend this thread's tabulation of :math:`y_0(\xi)`, :math:`z_0(\xi)`, and of the dimensionless density and mass profiles,
+    so that it spans ``xiRequired``, merging with - and writing back to - the copy of it cached on disk.
     !!}
     use :: Display                   , only : displayIndent    , displayUnindent     , displayMessage, verbosityLevelWorking, &
          &                                    displayCounter   , displayCounterClear
@@ -273,8 +331,11 @@ contains
     double precision                                         , dimension(propertyCount+1  )              :: properties                 , propertyScales
     double precision                                         , dimension(propertyCount    )              :: locationMinimum
     double precision                                         , dimension(              :  ), allocatable :: xi                         , y0                         , &
-         &                                                                                                  z0
-    double precision                                                                                     :: x
+         &                                                                                                  z0                         , radii
+    double precision                                         , dimension(              :,:), allocatable :: densityProfile             , massProfile
+    type            (rangeLattice                           )                                            :: latticeXi
+    double precision                                                                                     :: x                          , xiTabulatedMinimum         , &
+         &                                                                                                  xiTabulatedMaximum
     type            (multiDMinimizer                        ), save                        , allocatable :: minimizer_
     !$omp threadprivate(minimizer_)
     integer                                                                                              :: countXi                    , count
@@ -293,26 +354,34 @@ contains
     ! from it - is independent of the value of ξ at which it was first requested, and so that the tabulation can be extended
     ! without recomputing any solution already found. Note that the margin is applied at both ends: previously the lower bound
     ! was placed exactly at the requested value, leaving that value sitting on the edge of the table.
-    lattice=Range_Pinned(                                      &
-         &                              xiRequired           , &
-         &                              countXiPerUnit       , &
-         &                              gridSchemePerUnit    , &
-         &               marginOffset  =xiMargin             , &
-         &               rangeCurrent  =[xiMinimum,xiMaximum], &
-         &               latticeCurrent=self%latticeXi       , &
-         &               limitMinimum  =xiFloor                &
+    lattice=Range_Pinned(                                        &
+         &                              xiRequired             , &
+         &                              countXiPerUnit         , &
+         &                              gridSchemePerUnit      , &
+         &               marginOffset  =xiMargin               , &
+         &               rangeCurrent  =[xiMinimum,xiMaximum]  , &
+         &               latticeCurrent=sidmIsothermalLatticeXi, &
+         &               limitMinimum  =xiFloor                  &
          &              )
-    if (self%latticeXi%covers(lattice)) return
+    if (sidmIsothermalLatticeXi%covers(lattice)) return
+    ! Take this thread's tabulation into local arrays for the duration of this routine, publishing it back at the end. The
+    ! module-scope tabulation is threadprivate - which is what makes look-ups lock free - but that also makes it invisible to
+    ! the threads of the parallel region below, each of which would otherwise see its own, unallocated, copy of it.
+    latticeXi=sidmIsothermalLatticeXi
+    call Move_Alloc(sidmIsothermalXi            ,xi            )
+    call Move_Alloc(sidmIsothermalY0            ,y0            )
+    call Move_Alloc(sidmIsothermalZ0            ,z0            )
+    call Move_Alloc(sidmIsothermalRadii         ,radii         )
+    call Move_Alloc(sidmIsothermalDensityProfile,densityProfile)
+    call Move_Alloc(sidmIsothermalMassProfile   ,massProfile   )
     ! Discard the interpolators - they are rebuilt below once the tabulation is complete.
-    if (allocated(self%interpolatorXi                        )) deallocate(self%interpolatorXi                        )
-    if (allocated(self%interpolatorRadiiDimensionless        )) deallocate(self%interpolatorRadiiDimensionless        )
-    if (allocated(self%densityCentralDimensionless           )) deallocate(self%densityCentralDimensionless           )
-    if (allocated(self%velocityDispersionCentralDimensionless)) deallocate(self%velocityDispersionCentralDimensionless)
+    if (allocated(sidmIsothermalInterpolatorXi           )) deallocate(sidmIsothermalInterpolatorXi           )
+    if (allocated(sidmIsothermalDensityCentral           )) deallocate(sidmIsothermalDensityCentral           )
+    if (allocated(sidmIsothermalVelocityDispersionCentral)) deallocate(sidmIsothermalVelocityDispersionCentral)
     ! Construct a file name for the table. Note that this deliberately carries no descriptor of the parameters of this object:
     ! the tabulated solutions y₀(ξ) and z₀(ξ), and the dimensionless profiles, depend on ξ alone and so are common to every
-    ! halo. Objects of this class are constructed per halo, so including a descriptor here would give each halo its own
-    ! multi-megabyte copy of an identical tabulation. Only the extent in ξ differs between users, and that is handled by
-    ! extending and merging the tabulation rather than by separating it into distinct files.
+    ! halo. Only the extent in ξ differs between users, and that is handled by extending and merging the tabulation rather than
+    ! by separating it into distinct files.
     fileName=inputPath(pathTypeDataDynamic)// &
          &   'darkMatter/'                 // &
          &   self%objectType()             // &
@@ -320,7 +389,9 @@ contains
     call Directory_Make(File_Path(fileName))
     ! Merge in any tabulation already cached on disk. Since the tabulation lies on an absolute lattice the cached and in-memory
     ! solutions share abscissae wherever they overlap, so the cache is adopted when it spans everything we hold, rather than
-    ! being discarded - and, unlike previously, it never overwrites a wider range already held in memory.
+    ! being discarded - and it never overwrites a wider range already held in memory. Note that, as the tabulation is now held
+    ! per thread rather than per object, this is reached only when a thread's range in ξ must actually be extended - which
+    ! happens at most a handful of times per thread, instead of once per halo.
     if (File_Exists(fileName)) then
        ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
        call File_Lock(fileName,fileLock,lockIsShared=.true.)
@@ -337,37 +408,39 @@ contains
             call file%readAttribute('indexMinimum',indexMinimumCached)
             call file%readAttribute('count'       ,countCached       )
             latticeCached=rangeLattice(gridSchemePerUnit,pointsPerCached,indexMinimumCached,countCached)
-            ! Adopt the cached tabulation if we hold nothing yet, or if it spans everything we do hold. Note that the first of
-            ! these is the usual case: objects of this class are constructed per halo, and each therefore begins with no
-            ! tabulation at all - `covers` is false when either lattice is undefined, so testing it alone would reject the
-            ! cache on every first call and leave every halo to recompute and rewrite the entire tabulation.
-            if     (                                                 &
-                 &           latticeCached%isDefined(              ) &
-                 &  .and.                                            &
-                 &   (                                               &
-                 &     .not.                                         &
-                 &      self%latticeXi    %isDefined(              ) &
-                 &    .or.                                           &
-                 &           latticeCached%covers   (self%latticeXi) &
-                 &   )                                               &
+            ! Adopt the cached tabulation if we hold nothing yet, or if it spans everything we do hold. Note that `covers` is
+            ! false when either lattice is undefined, so testing it alone would reject the cache on the first call - when
+            ! nothing at all is held in memory - and leave the entire tabulation to be recomputed and rewritten.
+            if     (                                    &
+                 &   latticeCached%isDefined(         ) &
+                 &  .and.                               &
+                 &   (                                  &
+                 &     .not.                            &
+                 &    latticeXi   %isDefined(         ) &
+                 &    .or.                              &
+                 &   latticeCached%covers   (latticeXi) &
+                 &   )                                  &
                  & ) then
-               call file%readDataset('xi'                         ,     xi                         )
-               call file%readDataset('radii'                      ,self%radiiDimensionless         )
-               call file%readDataset('y0'                         ,     y0                         )
-               call file%readDataset('z0'                         ,     z0                         )
-               call file%readDataset('densityProfileDimensionless',self%densityProfileDimensionless)
-               call file%readDataset('massProfileDimensionless'   ,self%massProfileDimensionless   )
+               call file%readDataset('xi'                         ,xi            )
+               call file%readDataset('radii'                      ,radii         )
+               call file%readDataset('y0'                         ,y0            )
+               call file%readDataset('z0'                         ,z0            )
+               call file%readDataset('densityProfileDimensionless',densityProfile)
+               call file%readDataset('massProfileDimensionless'   ,massProfile   )
                if (size(xi) == latticeCached%count) then
-                  self%latticeXi=latticeCached
+                  latticeXi=latticeCached
                else
                   ! The datasets do not match the lattice recorded alongside them, so the file is not self-consistent. Discard
-                  ! everything read from it rather than leave a partially-restored tabulation behind, and retabulate.
-                  if (allocated(     xi                         )) deallocate(     xi                         )
-                  if (allocated(     y0                         )) deallocate(     y0                         )
-                  if (allocated(     z0                         )) deallocate(     z0                         )
-                  if (allocated(self%radiiDimensionless         )) deallocate(self%radiiDimensionless         )
-                  if (allocated(self%densityProfileDimensionless)) deallocate(self%densityProfileDimensionless)
-                  if (allocated(self%massProfileDimensionless   )) deallocate(self%massProfileDimensionless   )
+                  ! everything read from it rather than leave a partially-restored tabulation behind, and retabulate. The
+                  ! lattice is reset along with the arrays: the tabulation which it described has now been overwritten by the
+                  ! contents of the file, so leaving it defined would leave it describing arrays which no longer exist.
+                  latticeXi=rangeLattice()
+                  if (allocated(xi            )) deallocate(xi            )
+                  if (allocated(y0            )) deallocate(y0            )
+                  if (allocated(z0            )) deallocate(z0            )
+                  if (allocated(radii         )) deallocate(radii         )
+                  if (allocated(densityProfile)) deallocate(densityProfile)
+                  if (allocated(massProfile   )) deallocate(massProfile   )
                end if
             end if
          end if
@@ -383,36 +456,36 @@ contains
          &                              gridSchemePerUnit    , &
          &               marginOffset  =xiMargin             , &
          &               rangeCurrent  =[xiMinimum,xiMaximum], &
-         &               latticeCurrent=self%latticeXi       , &
+         &               latticeCurrent=latticeXi            , &
          &               limitMinimum  =xiFloor                &
          &              )
     countXi=lattice%count
-    if (.not.allocated(self%radiiDimensionless)) then
-       allocate(self%radiiDimensionless(countRadii))
-       self%radiiDimensionless=Make_Range(0.0d0,1.0d0,countRadii,rangeTypeLinear)
+    if (.not.allocated(radii)) then
+       allocate(radii(countRadii))
+       radii=Make_Range(0.0d0,1.0d0,countRadii,rangeTypeLinear)
     end if
     ! Extend the rank-1 tabulations, and the ξ dimension (the trailing one) of the profile tabulations.
-    call Range_Lattice_Extend(self%latticeXi,lattice,y0,isComputed)
-    call Range_Lattice_Extend(self%latticeXi,lattice,z0,isComputed)
+    call Range_Lattice_Extend(latticeXi,lattice,y0,isComputed)
+    call Range_Lattice_Extend(latticeXi,lattice,z0,isComputed)
     if (allocated(xi)) deallocate(xi)
     allocate(xi(countXi))
     xi=lattice%values()
     offset=0
-    if (self%latticeXi%isDefined()) offset=Range_Lattice_Offset(self%latticeXi,lattice)
-    if (allocated(self%densityProfileDimensionless)) call Move_Alloc(self%densityProfileDimensionless,densityPrevious)
-    if (allocated(self%massProfileDimensionless   )) call Move_Alloc(self%massProfileDimensionless   ,massPrevious   )
-    allocate(self%densityProfileDimensionless(countRadii,countXi))
-    allocate(self%massProfileDimensionless   (countRadii,countXi))
-    self%densityProfileDimensionless=0.0d0
-    self%massProfileDimensionless   =0.0d0
-    if (allocated(densityPrevious)) self%densityProfileDimensionless(:,offset+1:offset+size(densityPrevious,dim=2))=densityPrevious
-    if (allocated(massPrevious   )) self%massProfileDimensionless   (:,offset+1:offset+size(massPrevious   ,dim=2))=massPrevious
-    self%latticeXi         =lattice
-    self%xiTabulatedMinimum=lattice%minimum()
-    self%xiTabulatedMaximum=lattice%maximum()
+    if (latticeXi%isDefined()) offset=Range_Lattice_Offset(latticeXi,lattice)
+    if (allocated(densityProfile)) call Move_Alloc(densityProfile,densityPrevious)
+    if (allocated(massProfile   )) call Move_Alloc(massProfile   ,massPrevious   )
+    allocate(densityProfile(countRadii,countXi))
+    allocate(massProfile   (countRadii,countXi))
+    densityProfile=0.0d0
+    massProfile   =0.0d0
+    if (allocated(densityPrevious)) densityProfile(:,offset+1:offset+size(densityPrevious,dim=2))=densityPrevious
+    if (allocated(massPrevious   )) massProfile   (:,offset+1:offset+size(massPrevious   ,dim=2))=massPrevious
+    latticeXi         =lattice
+    xiTabulatedMinimum=lattice%minimum()
+    xiTabulatedMaximum=lattice%maximum()
     if (any(.not.isComputed)) then
-       write (labelXiMinimum,'(f5.2)') self%xiTabulatedMinimum
-       write (labelXiMaximum,'(f5.2)') self%xiTabulatedMaximum
+       write (labelXiMinimum,'(f5.2)') xiTabulatedMinimum
+       write (labelXiMaximum,'(f5.2)') xiTabulatedMaximum
        call displayIndent ('tabulating isothermal SIDM density profile solutions'                                ,verbosityLevelWorking)
        call displayMessage('range: '//trim(adjustl(labelXiMinimum))//' < ξ < '//trim(adjustl(labelXiMaximum))//'',verbosityLevelWorking)
        ! Set absolute property scales for ODE solving.
@@ -446,13 +519,13 @@ contains
           do j=1,countRadii
              x         =0.0d0
              properties=0.0d0
-             call odeSolver_%solve(x,self%radiiDimensionless(j),properties)
-             self%densityProfileDimensionless(j,i)=+y0(i)                 &
-                  &                                *exp(                  &
-                  &                                     -properties(1)    &
-                  &                                     /z0(i)        **2 &
-                  &                                    )
-             self%massProfileDimensionless   (j,i)=+     properties(3)
+             call odeSolver_%solve(x,radii(j),properties)
+             densityProfile(j,i)=+y0(i)                 &
+                  &              *exp(                  &
+                  &                   -properties(1)    &
+                  &                   /z0(i)        **2 &
+                  &                  )
+             massProfile   (j,i)=+     properties(3)
           end do
           !$omp atomic
           count=count+1
@@ -469,31 +542,36 @@ contains
        hdf5FileScopeWrite: block
          type(hdf5File  ) :: file
          file=hdf5File(fileName,overWrite=.true.,readOnly=.false.)
-         call file%writeDataset  (     xi                          ,'xi'                         )
-         call file%writeDataset  (self%radiiDimensionless          ,'radii'                      )
-         call file%writeDataset  (     y0                          ,'y0'                         )
-         call file%writeDataset  (     z0                          ,'z0'                         )
-         call file%writeDataset  (self%densityProfileDimensionless ,'densityProfileDimensionless')
-         call file%writeDataset  (self%massProfileDimensionless    ,'massProfileDimensionless'   )
-         call file%writeAttribute(self%latticeXi%pointsPer         ,'pointsPer'                  )
-         call file%writeAttribute(self%latticeXi%indexMinimum      ,'indexMinimum'               )
-         call file%writeAttribute(self%latticeXi%count             ,'count'                      )
+         call file%writeDataset  (xi                    ,'xi'                         )
+         call file%writeDataset  (radii                 ,'radii'                      )
+         call file%writeDataset  (y0                    ,'y0'                         )
+         call file%writeDataset  (z0                    ,'z0'                         )
+         call file%writeDataset  (densityProfile        ,'densityProfileDimensionless')
+         call file%writeDataset  (massProfile           ,'massProfileDimensionless'   )
+         call file%writeAttribute(latticeXi%pointsPer   ,'pointsPer'                  )
+         call file%writeAttribute(latticeXi%indexMinimum,'indexMinimum'               )
+         call file%writeAttribute(latticeXi%count       ,'count'                      )
        end block hdf5FileScopeWrite
        !$ call hdf5Access%unset()
        call File_Unlock(fileLock)
        call displayUnindent('done',verbosityLevelWorking)
     end if
-    ! Build the interpolators.
-    allocate(self%interpolatorXi                        )
-    allocate(self%interpolatorRadiiDimensionless        )
-    allocate(self%densityCentralDimensionless           )
-    allocate(self%velocityDispersionCentralDimensionless)
-    self%densityCentralDimensionless           =interpolator(     xi                ,y0)
-    self%velocityDispersionCentralDimensionless=interpolator(     xi                ,z0)
-    self%interpolatorXi                        =interpolator(     xi                   )
-    self%interpolatorRadiiDimensionless        =interpolator(self%radiiDimensionless   )
+    ! Publish the completed tabulation back to this thread's copy, and build the interpolators on it.
+    sidmIsothermalLatticeXi=latticeXi
+    call Move_Alloc(xi            ,sidmIsothermalXi            )
+    call Move_Alloc(y0            ,sidmIsothermalY0            )
+    call Move_Alloc(z0            ,sidmIsothermalZ0            )
+    call Move_Alloc(radii         ,sidmIsothermalRadii         )
+    call Move_Alloc(densityProfile,sidmIsothermalDensityProfile)
+    call Move_Alloc(massProfile   ,sidmIsothermalMassProfile   )
+    allocate(sidmIsothermalInterpolatorXi           )
+    allocate(sidmIsothermalDensityCentral           )
+    allocate(sidmIsothermalVelocityDispersionCentral)
+    sidmIsothermalDensityCentral           =interpolator(sidmIsothermalXi,sidmIsothermalY0)
+    sidmIsothermalVelocityDispersionCentral=interpolator(sidmIsothermalXi,sidmIsothermalZ0)
+    sidmIsothermalInterpolatorXi           =interpolator(sidmIsothermalXi                 )
     return
-  end subroutine sphericalSIDMIsothermalTabulateSolutions
+  end subroutine sphericalSIDMIsothermalTabulationExtend
   
   double precision function sphericalSIDMIsothermalDimensionlessFitMetric(propertiesCentral)
     !!{RST
@@ -522,7 +600,7 @@ contains
     m1     =+     properties(3)
     ! Evaluate the fit metric.
     sphericalSIDMIsothermalDimensionlessFitMetric=+(y1-1.0d0)**2 &
-         &                               +(m1-1.0d0)**2
+         &                                        +(m1-1.0d0)**2
     return
   end function sphericalSIDMIsothermalDimensionlessFitMetric
   
@@ -570,12 +648,13 @@ contains
     use :: Numerical_Constants_Astronomical, only : gravitationalConstant_internal
     implicit none
     class           (massDistributionSphericalSIDMIsothermal), intent(inout) :: self
-    integer                                                  , parameter     :: countTable                   =1000
-    double precision                                         , parameter     :: odeToleranceAbsolute         =1.0d-3, odeToleranceRelative     =1.0d-3
-    double precision                                                         :: densityCentral                      , velocityDispersionCentral       , &
-         &                                                                      densityInteraction                  , massInteraction                 , &
-         &                                                                      radiusInteraction                   , xi                              , &
-         &                                                                      velocityDispersionInteraction
+    integer                                                  , parameter     :: countTable                            =1000
+    double precision                                         , parameter     :: odeToleranceAbsolute                  =1.0d-3, odeToleranceRelative     =1.0d-3
+    double precision                                                         :: densityCentral                               , velocityDispersionCentral       , &
+         &                                                                      densityInteraction                           , massInteraction                 , &
+         &                                                                      radiusInteraction                            , xi                              , &
+         &                                                                      velocityDispersionInteraction                , densityCentralDimensionless     , &
+         &                                                                      velocityDispersionCentralDimensionless
     type            (coordinateSpherical                    )                :: coordinatesInteraction
     
     ! Find the interaction radius.
@@ -593,19 +672,18 @@ contains
          &                        /Pi                    &
          &                        /densityInteraction    &
          &                        /radiusInteraction **3
-    ! Ensure dimensionless solutions have been tabulated.
-    call self%tabulateSolutions(xi)
+    ! Ensure dimensionless solutions have been tabulated, and extract from the shared tabulation the dimensionless central
+    ! properties at this ξ, along with the interpolating factors in ξ and the profiles upon which they act.
+    call self%tabulateSolutions(xi,densityCentralDimensionless,velocityDispersionCentralDimensionless)
     ! Find the properties at the halo center.
-    densityCentral               =self%densityCentralDimensionless           %interpolate(xi)*densityInteraction
-    velocityDispersionCentral    =self%velocityDispersionCentralDimensionless%interpolate(xi)*velocityDispersionInteraction
+    densityCentral               =densityCentralDimensionless           *densityInteraction
+    velocityDispersionCentral    =velocityDispersionCentralDimensionless*velocityDispersionInteraction
     ! Store properties of current profile.
     self%radiusInteraction_           =radiusInteraction
     self%densityInteraction           =densityInteraction
     self%massInteraction              =massInteraction
     self%velocityDispersionInteraction=velocityDispersionInteraction
     self%velocityDispersionCentral    =velocityDispersionCentral
-    ! Compute interpolating factors in ξ.
-    call self%interpolatorXi%linearFactors(xi,self%indexXi,self%factorsXi)
     return
   end subroutine sphericalSIDMIsothermalComputeSolution
 
@@ -627,10 +705,10 @@ contains
        density=0.0d0
        do i=0,1
           do j=0,1
-             density=+     density                                                   &
-                  &  +self%densityProfileDimensionless(indexRadius+i,self%indexXi+j) &
-                  &  *     factorsRadius              (           i                ) &
-                  &  *self%factorsXi                  (                           j)
+             density=+     density                                        &
+                  &  +self%densityProfileDimensionless(indexRadius+i,j+1) &
+                  &  *     factorsRadius              (            i    ) &
+                  &  *self%factorsXi                  (              j  )
           end do
        end do
        density=+     density            &
@@ -672,8 +750,8 @@ contains
     else
        call self%interpolatorRadiiDimensionless%linearFactors(coordinates%rSpherical()/self%radiusInteraction_,indexRadius,factorsRadius)
        if (indexRadius > 1) then
-          densityGradient=+log(self%densityProfileDimensionless(indexRadius+1,self%indexXi+0)/self%densityProfileDimensionless(indexRadius+0,self%indexXi+0)) &
-               &          /log(self%radiiDimensionless         (indexRadius+1               )/self%radiiDimensionless         (indexRadius+0               ))
+          densityGradient=+log(self%densityProfileDimensionless(indexRadius+1,1)/self%densityProfileDimensionless(indexRadius+0,1)) &
+               &          /log(self%radiiDimensionless         (indexRadius+1  )/self%radiiDimensionless         (indexRadius+0  ))
           if (.not.logarithmic_)                                         &
                densityGradient=+            densityGradient              &
                &               *self       %density        (coordinates) &
@@ -703,10 +781,10 @@ contains
        mass=0.0d0
        do i=0,1
           do j=0,1
-             mass   =+     mass                                                   &
-                  &  +self%massProfileDimensionless(indexRadius+i,self%indexXi+j) &
-                  &  *     factorsRadius           (            i               ) &
-                  &  *self%factorsXi               (                           j)
+             mass   =+     mass                                        &
+                  &  +self%massProfileDimensionless(indexRadius+i,j+1) &
+                  &  *     factorsRadius           (            i    ) &
+                  &  *self%factorsXi               (              j  )
           end do
        end do
        mass   =+     mass            &


### PR DESCRIPTION
Closes #1333.

## Summary

`massDistributionSphericalSIDMIsothermal` is constructed once per halo, and each instance re-read the whole multi-megabyte cached tabulation from disk before discovering it already held everything that instance needed. Since #1323 made the tabulation get written exactly once, reading it was the single largest remaining cost at this site — visible as system time exceeding wall time.

The tabulation, its `rangeLattice`, and the interpolators built on it now live at module scope, `!$omp threadprivate`, so each thread reads the cache file at most once, and only when its own range in ξ must actually be extended.

## Why per thread rather than a single shared copy

The solutions depend on ξ alone, so one shared copy would suffice in principle. But every construction would then have to be serialized — extending the tabulation reallocates the arrays, and the interpolators carry mutable look-up caches. With a mass distribution constructed per halo and models run with hundreds of threads, that lock would itself become the bottleneck. The lookup path is now lock free; the cost is one copy of the tabulation per thread (~14.4 MB).

Two consequences of that choice, both handled:

- Threadprivate module variables are not visible to the threads of the inner parallel region which solves the ODEs — each would see its own, unallocated, copy. The extension routine therefore works on local arrays and publishes them back with `Move_Alloc` once that region has ended.
- Each object retains only the two columns in ξ bracketing its own value, rather than the whole tabulation: ξ is fixed once the solution has been computed, so no other part is ever used. That leaves each instance a few tens of kilobytes instead of a few tens of megabytes, and — unlike indexing back into the thread's tabulation — keeps the object valid if it is later used from another thread, or after that tabulation has been extended.

## Verification

| check | result |
|---|---|
| mass distribution vs. previous behaviour | **bit-identical** — interaction radius, and ρ(r) and M(r) at 21 radii spanning r₁ for the Jiang reference halo, to full printed precision |
| tabulation computed cold vs. cached reference | **bit-identical** — all six datasets and the recorded lattice |
| `tests.dark_matter_profiles.exe` | 100 / 100 pass |
| determinism controls | old and new each reproduce themselves bit-for-bit single threaded |

The profile comparison was made by instrumenting `source/tests/dark_matter_profiles.F90` with a full-precision dump and building it against both versions of the class file, so the class file was the only variable. The cold-start check pointed `GALACTICUS_DYNAMIC_DATA_PATH` at an empty directory, forcing every thread through the compute-and-write path.

## Performance

`benchmark_milkyWay_SIDM.xml`, cache present, 8 threads:

| | wall | user | system |
|---|---|---|---|
| before | 31:52 | 1004 s | 2039 s |
| after | **0:45** | 64 s | **1.4 s** |

Single tree, single thread: 15:49 / 697 s system → 18.6 s / 0.6 s. The "before" figures reproduce the measurement reported in #1333 (33m51s wall, 38m57s system).

## Things reviewers should know

**Full model outputs are not bit-identical to those from before this change.** The profile itself is unchanged, as measured above; but restructuring the module alters inlining and floating-point contraction in the callers which evaluate it, the adaptive ODE solver lifts that to its own tolerance, and chaotic evolution carries it to order unity by z=0. The growth is monotonic — median relative difference 8×10⁻⁹ at z=6, order unity at z=0 — and merger trees and dark matter structure (`nodeIndex`, `basicMass`, `darkMatterProfileScale`, `mergerTreeWeight`) remain bit-identical.

**Cold start is more expensive.** With no cache present, every thread computes the tabulation independently; measured at 25m22s wall for a single tree on 8 threads, versus 45s warm. This is a one-off. The obvious alternative — holding the file lock across the computation so only one thread performs it — would stall every other thread's file I/O for the duration, since `posixOpenMPFileLock` is held for as long as any thread holds any file lock. It remains available if cold-start redundancy ever becomes a real cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
