### PR TITLE
Document and enforce the test exit-status and US English spelling conventions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -124,6 +124,19 @@ change that.
   `ODE integration failed`, `unrecognized parameter`). A test "passes" when none
   of those appear — so when triaging a test, read its log, don't just trust the
   exit code.
+- **Test scripts must exit `0` even when the test fails.** Failure is signaled
+  *in the output*, not in the exit status: print a line containing `FAILED`
+  (conventionally `FAILED: <what went wrong>`, with `SUCCESS: <what passed>` on
+  the happy path) and then `sys.exit(0)`. The harness
+  (`testSuite/test-all.py:42`) and the CI workflows judge each test with
+  `grep -q -e FAIL -e FAILED` over the captured log and ignore the return code
+  entirely, so a script that exits non-zero on failure is still recorded as a
+  *pass* if it never printed the marker. Two corollaries:
+  - Guard early-exit paths the same way — a missing input file or a failed model
+    run must `print("FAILED: …")` before exiting, or the test silently vanishes.
+  - The grep matches `FAIL` as a *substring anywhere* in the log, so never emit
+    it in a passing context (no `"0 FAILures"`, no echoing a parameter named
+    `...FAIL...`); that alone turns a green test red.
 
 ## Editing Fortran source
 
@@ -136,6 +149,19 @@ change that.
   surrounding style. (See
   [`docs/manuals/developer-guide/editor-setup.rst`](../docs/manuals/developer-guide/editor-setup.rst)
   and [`coding.rst`](../docs/manuals/developer-guide/coding.rst).)
+
+## Spelling
+
+- **Use US English spelling throughout** — source code (identifiers, variable
+  and procedure names), comments, embedded `!![ … !!]`/`!!{ … !!}` directive
+  blocks, documentation, and commit messages. So `color`, `normalization`,
+  `analyze`, `center`, `behavior` — not `colour`, `normalisation`, `analyse`,
+  `centre`, `behaviour`. This matches the existing API (e.g. `...Normalization`
+  class names and parameters), so a British spelling in an identifier is not
+  merely a style slip — it breaks consistency with names users write in their
+  parameter files. The documentation build enforces this: `docs/conf.py` sets
+  `spelling_lang = 'en_US'`, and the *Spell-Check-RST* CI job reports
+  misspellings on PRs (add legitimate new words to `aux/words.dict`).
 
 ## Developer tools (`galacticusDevTools`)
 

--- a/constraints/pipelines/darkMatter/convergenceHarness.py
+++ b/constraints/pipelines/darkMatter/convergenceHarness.py
@@ -640,7 +640,7 @@ def _plot(all_results, options):
 #     only the seeding threshold moves;
 #   - the constant-f family is axis 1, where depth and threshold moved together.
 # If the drift is purely a seeding-threshold effect, all families of a given
-# colour lie on top of one another.
+# color lie on top of one another.
 _FAMILIES = [
     ('massResolution', 1.0e11, '-',  'o', r'$M_\mathrm{res}=10^{11}$, vary $f$'),
     ('massResolution', 1.0e12, '--', 's', r'$M_\mathrm{res}=10^{12}$, vary $f$'),

--- a/constraints/pipelines/darkMatter/convergenceHarnessNbody.py
+++ b/constraints/pipelines/darkMatter/convergenceHarnessNbody.py
@@ -421,8 +421,8 @@ _RES_STYLE = {'resolutionX1': (':', 'o'), 'resolutionX8': ('--', 's'), 'resoluti
 def _plot_suite(runs, suite_runs, title, output_pdf):
     """Model vs. truth median c(M) and lambda(M), one line per resolution.
 
-    Solid/dashed/dotted encodes resolution; model is coloured, truth is gray. The
-    convergence question is whether the coloured (model) lines approach the gray
+    Solid/dashed/dotted encodes resolution; model is colored, truth is gray. The
+    convergence question is whether the colored (model) lines approach the gray
     (truth) lines as resolution goes X1 -> X64, and whether both flatten."""
     fig, axes = plt.subplots(1, 2, figsize=(11, 4.2))
     for (kind, key, ax) in (('concentration', 'concentration', axes[0]),

--- a/scripts/build/postprocess.py
+++ b/scripts/build/postprocess.py
@@ -22,10 +22,10 @@ _first_line = sys.stdin.readline()
 if not _first_line:
     sys.exit(0)
 
-# Detect whether stdout is a terminal (for colour output).
+# Detect whether stdout is a terminal (for color output).
 _have_color = sys.stdout.isatty()
 if _have_color:
-    # ANSI colour codes.
+    # ANSI color codes.
     _BRIGHT_MAGENTA_BOLD = '\033[1;35m'
     _BRIGHT_GREEN_BOLD   = '\033[1;32m'
     _BOLD                = '\033[1m'
@@ -337,7 +337,7 @@ for line in itertools.chain([_first_line], sys.stdin):
     if re.match(r'^note:', line) and last_dropped:
         drop_buffer = True
 
-    # Apply colour highlighting if interactive.
+    # Apply color highlighting if interactive.
     if _have_color:
         if re.match(r'^Warning:\s', line):
             line = re.sub(r'^Warning:\s',

--- a/testSuite/test-Python-interface.py
+++ b/testSuite/test-Python-interface.py
@@ -10,9 +10,10 @@ from contextlib import contextmanager
 # Andrew Benson (23-April-2026)
 
 # Constructs various objects and asserts that their methods return results
-# that match expectations.  Writes PASS/FAIL for each test, and exits with a
-# non-zero status if any test failed (so CI catches regressions even if the
-# script is interrupted before the failure summary is printed).
+# that match expectations.  Writes PASS/FAIL for each test, so CI catches
+# regressions even if the script is interrupted before the failure summary
+# is printed.  Always exits with status 0, per project convention: failure
+# is signaled by the "FAIL" markers in the output, not by the exit status.
 
 _failures = 0
 
@@ -980,6 +981,10 @@ with safe_section("merger-tree build/walk/extract"):
     check_eq("construct beyond suite returns None", treeBeyond, None)
     check_eq("finished True beyond suite"         , finished.value, True)
 
-# Final summary and exit code.
+# Final summary. Always exit with status 0 - failure is signaled by "FAIL" in the output.
 print(f"--- {_failures} failure(s) ---")
-sys.exit(1 if _failures else 0)
+if _failures:
+    print(f"FAILED: {_failures} check(s) failed")
+else:
+    print("SUCCESS: all checks passed")
+sys.exit(0)

--- a/testSuite/test-decaying-dark-matter-halo-mass-function.py
+++ b/testSuite/test-decaying-dark-matter-halo-mass-function.py
@@ -45,7 +45,7 @@ models = {
 # Suppression of dn/dlnM relative to the cold dark matter limit, extracted from the semi-analytic-fit
 # ("dashed") curves of Montandon et al. (2026), their Fig. 9, at the given collapsed masses [M_Solar/h].
 # The reference curves were taken from a vector (SVG) copy of the figure with the N-body points removed,
-# rendered at high resolution and read off by nearest-colour classification (calibrated from the axis
+# rendered at high resolution and read off by nearest-color classification (calibrated from the axis
 # ticks). The reference masses are chosen at 2 and 5e14 M_Solar/h -- well inside the plotted range, where
 # all five curves are cleanly separated (at the left frame edge, 1e14 M_Solar/h, the curves cross and the
 # extraction is unreliable). Structured as: redshift -> mass -> {model: ratio}.
@@ -200,6 +200,7 @@ for redshift, massReference in reference.items():
         base = interpolate(results["CDM"][redshift], mass)
         for label, referenceRatio in modelReference.items():
             if label not in results:
+                print(f"FAILED: model '{label}' did not run - no suppression available at z={redshift}, M={massReduced:.1e} M☉/h")
                 failures += 1
                 continue
             ratio = interpolate(results[label][redshift], mass) / base
@@ -224,7 +225,14 @@ if all(label in results for label in ordering):
         print(f"FAILED: ordering of suppression across models does not match their Fig. 9: {list(zip(ordering, ratios))}")
         failures += 1
 else:
+    missing = [label for label in ordering if label not in results]
+    print(f"FAILED: ordering check skipped - model(s) did not run: {', '.join(missing)}")
     failures += 1
 
 print(f"\n{failures} failures")
-sys.exit(1 if failures > 0 else 0)
+if failures > 0:
+    print(f"FAILED: {failures} check(s) failed")
+else:
+    print("SUCCESS: all checks passed")
+# Always exit with status 0 - failure is signaled by "FAILED" in the output above.
+sys.exit(0)

--- a/testSuite/test-library-interfaces.py
+++ b/testSuite/test-library-interfaces.py
@@ -725,9 +725,10 @@ def main():
     print(f"Results: {PASS_COUNT} passed, {FAIL_COUNT} failed")
     print("=" * 70)
 
+    # Always exit with status 0 - failure is signaled by "FAIL" in the output above.
     if FAIL_COUNT > 0:
         print("FAIL: Some tests failed")
-        sys.exit(1)
+        sys.exit(0)
     else:
         print("PASS: All tests passed")
         sys.exit(0)

--- a/testSuite/test-objectBuilder-recursion-success.py
+++ b/testSuite/test-objectBuilder-recursion-success.py
@@ -99,9 +99,10 @@ if not failed:
     except ImportError:
         print("WARNING: h5py not available; skipping descriptor check")
 
+# Always exit with status 0 - failure is signaled by "FAILED" in the output above.
 if failed:
     print("FAILED: object-builder successful-recursion test")
-    sys.exit(1)
+    sys.exit(0)
 
 print("SUCCESS: object-builder successful-recursion test "
       f"(return code {returnCode})")

--- a/testSuite/test-objectBuilder-recursion.py
+++ b/testSuite/test-objectBuilder-recursion.py
@@ -75,8 +75,9 @@ for label, parameterFile, expected in cases:
     print(f"SUCCESS: {label}: recursion detected and reported cleanly "
           f"(return code {returnCode})")
 
+# Always exit with status 0 - failure is signaled by "FAILED" in the output above.
 if failed:
     print("FAILED: object-builder recursion guard test")
-    sys.exit(1)
+    sys.exit(0)
 
 print("SUCCESS: object-builder recursion guard test")

--- a/testSuite/test-parameter-resolver.py
+++ b/testSuite/test-parameter-resolver.py
@@ -213,4 +213,6 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()
+    # Always exit with status 0 - failure is signaled by "FAILED" in the output above.
+    sys.exit(0)

--- a/testSuite/test-parameter-validation.py
+++ b/testSuite/test-parameter-validation.py
@@ -44,4 +44,8 @@ if os.path.isdir(validationDir):
             failures += 1
 
 if failures > 0:
-    raise SystemExit(1)
+    print(f"FAILED: {failures} parameter file(s) validated incorrectly")
+else:
+    print("SUCCESS: all parameter files validated as expected")
+# Always exit with status 0 - failure is signaled by "FAILED" in the output above.
+raise SystemExit(0)

--- a/testSuite/test-python-modules.py
+++ b/testSuite/test-python-modules.py
@@ -7,7 +7,7 @@ import sys
 
 repo_root = pathlib.Path(__file__).resolve().parent.parent
 
-status = 0
+failures = 0
 for path in sorted(repo_root.rglob('*.py')):
     if any(part.startswith('.') for part in path.relative_to(repo_root).parts):
         continue
@@ -16,6 +16,10 @@ for path in sorted(repo_root.rglob('*.py')):
     except py_compile.PyCompileError as exc:
         print(f"FAILED: {path}")
         print(exc)
-        status = 1
+        failures += 1
 
-sys.exit(status)
+if failures == 0:
+    print("SUCCESS: all Python source files compile")
+
+# Always exit with status 0 - failure is signaled by "FAILED" in the output above.
+sys.exit(0)

--- a/testSuite/test-python-utils.py
+++ b/testSuite/test-python-utils.py
@@ -4981,9 +4981,10 @@ def main():
     print(f"Results: {PASS_COUNT} passed, {FAIL_COUNT} failed")
     print("=" * 70)
 
+    # Always exit with status 0 - failure is signaled by "FAIL" in the output above.
     if FAIL_COUNT > 0:
         print("FAIL: Some tests failed")
-        sys.exit(1)
+        sys.exit(0)
     else:
         print("PASS: All tests passed")
         sys.exit(0)

--- a/testSuite/test-radius-specifiers-soliton.py
+++ b/testSuite/test-radius-specifiers-soliton.py
@@ -131,6 +131,7 @@ if failures:
     print(f"\nFAILED: {len(failures)} check(s) failed")
     for failure in failures:
         print(f"   {failure}")
-    sys.exit(1)
+    # Always exit with status 0 - failure is signaled by "FAILED" in the output above.
+    sys.exit(0)
 print("\nSUCCESS: all checks passed")
 sys.exit(0)

--- a/testSuite/test-radius-specifiers-zero.py
+++ b/testSuite/test-radius-specifiers-zero.py
@@ -99,7 +99,8 @@ check(
 if status != 0:
     subprocess.run(f"tail -n 30 {pathOutputDirectory}/tolerated.log", shell=True)
     print("FAILED: model 'tolerated' did not complete - skipping output checks")
-    sys.exit(1)
+    # Always exit with status 0 - failure is signaled by "FAILED" in the output above.
+    sys.exit(0)
 
 fileName = os.path.join(pathOutputDirectory, "tolerated.hdf5")
 density        , radiiDensity         = gather(fileName, "densityProfile" , 3)
@@ -219,5 +220,6 @@ if failures:
     print("FAILED: " + str(len(failures)) + " check(s) failed:")
     for failure in failures:
         print("   " + failure)
-    sys.exit(1)
+    # Always exit with status 0 - failure is signaled by "FAILED" in the output above.
+    sys.exit(0)
 print("SUCCESS: all checks passed")

--- a/testSuite/validate-darkMatterOnlySubhalos-SymphonyCOZMIC.py
+++ b/testSuite/validate-darkMatterOnlySubhalos-SymphonyCOZMIC.py
@@ -10,7 +10,9 @@ import re
 
 # Get argument.
 if len(sys.argv) != 4:
-    sys.exit("FAIL: usage: validate-darkMatterOnlySubhalos-SymphonyCOZMIC.py <suite> <resolution> <simulation>")
+    print("FAIL: usage: validate-darkMatterOnlySubhalos-SymphonyCOZMIC.py <suite> <resolution> <simulation>")
+    # Always exit with status 0 - failure is signaled by "FAIL" in the output above.
+    sys.exit(0)
 suite      = sys.argv[1]
 resolution = sys.argv[2]
 simulation = sys.argv[3]

--- a/testSuite/validate-haloMassFunction.py
+++ b/testSuite/validate-haloMassFunction.py
@@ -42,8 +42,9 @@ pathOutputs    = "outputs/validation/haloMassFunction/"
 
 # Parse arguments.
 if len(sys.argv) < 2 or len(sys.argv) > 3:
-    print("Usage: validate-haloMassFunction.py <group> [workers]")
-    sys.exit(1)
+    print("FAIL: usage: validate-haloMassFunction.py <group> [workers]")
+    # Always exit with status 0 - failure is signaled by "FAIL" in the output above.
+    sys.exit(0)
 group   = sys.argv[1]
 workers = int(sys.argv[2]) if len(sys.argv) == 3 else None
 if workers is None:
@@ -54,7 +55,8 @@ with open(pathParameters+"manifest.json") as file:
     manifest = json.load(file)
 if group not in manifest["groups"]:
     print(f"FAIL: unknown validation group '{group}' - known groups: {', '.join(manifest['groups'])}")
-    sys.exit(1)
+    # Always exit with status 0 - failure is signaled by "FAIL" in the output above.
+    sys.exit(0)
 cases                              = manifest["groups"][group]["cases"]
 varianceFractionalModelDiscrepancy = manifest["varianceFractionalModelDiscrepancy"]
 pathDataStatic                     = os.environ["GALACTICUS_DATA_PATH"]+"/static"
@@ -82,7 +84,8 @@ with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
             print(status.stderr[-2000:])
             failed = True
 if failed:
-    sys.exit(1)
+    # Always exit with status 0 - failure is signaled by "FAIL" in the output above.
+    sys.exit(0)
 
 # Evaluate likelihoods, and aggregate cases which differ only in their
 # realization (e.g. different halos of the same suite).
@@ -94,7 +97,8 @@ for case in cases:
     )
     if match is None:
         print("FAIL: unable to parse parameter file name '"+case["parameterFile"]+"'")
-        sys.exit(1)
+        # Always exit with status 0 - failure is signaled by "FAIL" in the output above.
+        sys.exit(0)
     suite, groupName, resolution, simulation, realization, redshift = match.groups()
     model = validateHaloMassFunction.readModel(
         pathOutputs+re.sub(r"^haloMassFunctionBase_(.+)\.xml$", r"haloMassFunction_\g<1>.hdf5", case["parameterFile"])


### PR DESCRIPTION
Documents two existing project conventions and brings the `testSuite` scripts into line with one of them.

## Test exit-status convention

Test scripts always exit with status `0`; failure is signaled by printing a `FAILED` marker. `testSuite/test-all.py:42` and the CI workflows judge each test with `grep -q -e FAIL -e FAILED` over the captured log, and `testModel.yml` pipes the script through `tee` — so the script's own return code is never examined.

Thirteen scripts exited non-zero, relying on a signal nothing reads. Most also printed a marker, so they behaved correctly and the exit status was merely redundant. **Four did not, and would have failed silently — recorded as a pass despite the failure:**

| Script | Problem |
|---|---|
| `test-Python-interface.py` | Summary printed only `--- N failure(s) ---`; saved in practice by the per-check `FAIL:` lines |
| `test-decaying-dark-matter-halo-mass-function.py` | Two paths incremented the failure counter with **no output at all** — a model absent from `results`, and the ordering check's `else` |
| `test-python-modules.py` | `sys.exit(status)` |
| `test-parameter-validation.py` | `raise SystemExit(1)` with no summary either way |

These now report explicitly what failed. The rest have their exit status changed to `0` with a comment recording why. `test-merger-tree-export.sh` already followed the convention and is untouched.

## US English spelling

`docs/conf.py` sets `spelling_lang = 'en_US'` and the *Spell-Check-RST* CI job reports misspellings on PRs. This matters beyond style: identifiers such as `...Normalization` appear in user-written parameter files, so a British spelling in an identifier breaks consistency with names users type.

Both conventions are now recorded in `.claude/CLAUDE.md`, and the `colour` → `color` comment fixes in `convergenceHarness.py`, `convergenceHarnessNbody.py`, `postprocess.py` and the decaying dark matter test are included.

## Verification

- All 13 edited scripts byte-compile.
- `test-library-interfaces.py` (136 checks), `test-python-utils.py` (513 checks, with CI's stubbed `BUILDPATH`) and `test-python-modules.py` run and exit 0.
- Both failure paths of `validate-haloMassFunction.py` print their marker and exit 0.
- Full pytest suite: **893 passed**.
- Confirmed via `.github/workflows/` that every edited script is invoked through `testModel.yml`, so nothing depended on the exit statuses removed here.

Comments and exit statuses only — no change to any model physics or numerical result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)