### PR TITLE
Correct the sign of published log-likelihood values

### DIFF
--- a/python/validate.py
+++ b/python/validate.py
@@ -60,7 +60,8 @@ def extract(fileName, name, suffix, parameterFileName):
 
         *likelihoods* is a list of dicts, one per analysis, each with keys
         ``"name"``, ``"unit"`` (always ``"-logℒ"``), and ``"value"`` (the
-        string representation of ``|-log ℒ|``).
+        string representation of ``-log ℒ``, so that smaller is better, as the
+        ``customSmallerIsBetter`` benchmark tool expects).
 
         *results* is a list of dicts containing plot-ready x/y data, error
         estimates, and metadata for each analysis that defines a supported
@@ -89,7 +90,7 @@ def extract(fileName, name, suffix, parameterFileName):
             {
         	"name" : name+" - Likelihood - "+analysisName,
         	"unit" : "-logℒ"                            ,
-        	"value": str(np.abs(logLikelihood))
+        	"value": str(-logLikelihood)
             }
             )
         # Skip cases for which we have no "type" specified.
@@ -176,7 +177,7 @@ def write(likelihoods, results, suffix, parameterFileName):
     likelihoods : list[dict]
         A list of dicts, one per analysis, each with keys ``"name"``, ``"unit"``
         (always ``"-logℒ"``), and ``"value"`` (the string representation of
-        ``|-log ℒ|``).
+        ``-log ℒ``).
     results : list[dict]
         A list of dicts containing plot-ready x/y data, error estimates, and
         metadata for each analysis.

--- a/testSuite/validate-darkMatterOnlySubhalos-decayingDarkMatter.py
+++ b/testSuite/validate-darkMatterOnlySubhalos-decayingDarkMatter.py
@@ -116,7 +116,7 @@ for model in dataTarget.keys():
                 "targetLabel": "Mau et al. (DES), 2022",
                 "comment": "Analysis of subhalo bound mass cumulative distribution function",
                 "description": f'Subhalo bound mass cumulative distribution function (τ={lifetime} Gyr; vₖ={velocityKick} km/s)',
-                "logLikelihood": str(np.abs(logLikelihoodMass  )),
+                "logLikelihood": str(logLikelihoodMass  ),
                 "type": "function1D"
         },
         "data": {
@@ -136,7 +136,7 @@ for model in dataTarget.keys():
                 "targetLabel": "Mau et al. (DES), 2022",
                 "comment": "Analysis of subhalo orbital radius cumulative distribution function",
                 "description": f'Subhalo orbital radius cumulative distribution function (τ={lifetime} Gyr; vₖ={velocityKick} km/s)',
-                "logLikelihood": str(np.abs(logLikelihoodRadius)),
+                "logLikelihood": str(logLikelihoodRadius),
                 "type": "function1D"
         },
         "data": {

--- a/testSuite/validate-darkMatterOnlySubhalos-decayingDarkMatter.py
+++ b/testSuite/validate-darkMatterOnlySubhalos-decayingDarkMatter.py
@@ -151,12 +151,12 @@ for model in dataTarget.keys():
     likelihoodMass   = {
         "name" : f' (τ={lifetime} Gyr; vₖ={velocityKick} km/s) - Likelihood - mass function',
         "unit" : "-logℒ"                                                                   ,
-        "value": str(np.abs(logLikelihoodMass  ))
+        "value": str(-logLikelihoodMass  )
     }
     likelihoodRadius = {
         "name" : f' (τ={lifetime} Gyr; vₖ={velocityKick} km/s) - Likelihood - orbital radius function',
         "unit" : "-logℒ"                                                                             ,
-        "value": str(np.abs(logLikelihoodRadius))
+        "value": str(-logLikelihoodRadius)
     }
     likelihoods.append(likelihoodMass  )
     likelihoods.append(likelihoodRadius)

--- a/testSuite/validate-haloMassFunction.py
+++ b/testSuite/validate-haloMassFunction.py
@@ -136,7 +136,7 @@ for key in sorted(aggregates.keys()):
         {
             "name" : "Halo mass function - Likelihood - "+name,
             "unit" : "-logℒ"                                   ,
-            "value": str(np.abs(negativeLogLikelihood))
+            "value": str(negativeLogLikelihood)
         }
     )
     # Stack mass functions over realizations on a common mass grid.
@@ -223,7 +223,7 @@ if group == "SymphonyMilkyWayZ0":
         {
             "name" : "Halo mass function - Likelihood - "+name,
             "unit" : "-logℒ"                                   ,
-            "value": str(np.abs(negativeLogLikelihood))
+            "value": str(negativeLogLikelihood)
         }
     ]
     results     = [


### PR DESCRIPTION
Two related fixes, both from a spurious `np.abs()` applied to log-likelihood values. Split into one commit each, since the consequences differ a lot.

Found while tuning the dashboard thresholds in #1342; independent of that PR.

## 1. `results.json` sign for decaying dark matter (the real bug)

`testSuite/validate-darkMatterOnlySubhalos-decayingDarkMatter.py` wrote `np.abs(logLikelihood)` into the `logLikelihood` attribute of `results.json`, not just into the benchmark series. Both likelihoods are built as

```python
logLikelihood = -0.5*np.sum((cdf - cdfTarget)**2/cdfTarget)
```

and so are **≤ 0 by construction** — meaning `results.json` carried `+χ²/2`, where bigger is worse.

`buildGhPagesIndex.py:226` treats `logLikelihood` as bigger-is-better, so the dashboard status has been **inverted for all six decaying dark matter metrics**. A better fit lowers the published value and reads as a regression; a worse fit raises it and reads as passing. The bootstrapped thresholds sit below the recorded value and encode that inversion.

Concretely, for `lifetime40.0_velocityKick20.0` / `massCumulativeDistribution` (current 2.8589, warn 2.573, fail 2.2871): χ²/2 improving to 2.0 reports **fail**, while degrading to 50 reports **ok**.

The other two emitters are unaffected — `python/validate.py` passes the HDF5 attribute through unmodified, and `validate-haloMassFunction.py:164` already negates `negativeLogLikelihood` when writing `results.json`.

## 2. Benchmark series publish `-logL` instead of `|logL|`

The series published to `dev/bench/*/data.js` carried `np.abs(logLikelihood)` under a `-logℒ` unit label, discarding the sign. Positive log-likelihoods are normal here — several analyses deliberately de-normalize the likelihood (see the comment at `source/output/analyses/subhalo_mass_function.F90:650`) — and **47 of the 111 published analyses currently have one**, including all 24 idealized-subhalo and all 12 decaying-DM entries. For those, `abs()` inverts the trend: an improving model publishes a growing `-logℒ`.

Switching to `-logL` costs nothing for alerting. At the pinned action SHA, `dist/src/write.js` decides alerts from

```js
return biggerIsBetter(tool)
    ? prev.value / current.value
    : current.value / prev.value;   // customSmallerIsBetter
// findAlerts: if (ratio > threshold) → alert
```

An overall sign cancels in that ratio, so `|logL|` and `-logL` give **algebraically identical ratios** whenever consecutive runs share a sign. They differ only at a sign crossing, where `|logL|` yields a ratio that fires on a large improvement just as readily as on a large degradation, and `-logL` yields a negative ratio that never fires. Neither is meaningful there, and no alert is the better default. 25 of the 111 series come within one scatter of zero, so crossings are plausible for them.

`extract.js:430` does no unit normalization and no positivity check for the custom tools, so negative values pass through fine.

Note the correct replacement differs by call site: `python/validate.py` holds `logL`, while `validate-haloMassFunction.py` already holds `-logL` in `negativeLogLikelihood` and so only sheds the wrapper.

## Consequences

- **The 12 decaying dark matter entries in `ghPagesAnalysisThresholds.yml` need re-bootstrapping** once a corrected run is published, and will read as failing until then.
- The 47 positive-logL series will show a **one-time sign flip** in their gh-pages charts at the changeover. Historical points stay as `|logL|`; only new points are signed.
- `fail-on-alert` is not set in `.github/actions/benchmark/action.yml`, so benchmark alerts only produce a PR comment — no build behavior changes either way.

## Testing

`python -m pytest` — 892 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)