### PR TITLE
feat(supernovaeTypeIa): support alternative and metallicity-dependent stellar yield tables

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1518,6 +1518,7 @@ jobs:
                 test-checkpointing.py,
                 test-stellar-mass-weighted-ages.py,
                 test-supernovae-type-Ia-yields-file.py,
+                test-supernovae-type-Ia-yields-metallicity.py,
                 test-stellar-properties-LimongiChieffi2018.py,
                 test-tidalTracks.py,
                 test-transferFunctionHalfModeSlope.py,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1521,6 +1521,7 @@ jobs:
                 test-supernovae-type-Ia-yields-metallicity.py,
                 test-supernovae-type-Ia-rate-metallicity.py,
                 test-stellar-properties-LimongiChieffi2018.py,
+                test-stellar-properties-Sukhbold2016.py,
                 test-tidalTracks.py,
                 test-transferFunctionHalfModeSlope.py,
                 test-galacticStructureStateDeallocateBug.py,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1519,6 +1519,7 @@ jobs:
                 test-stellar-mass-weighted-ages.py,
                 test-supernovae-type-Ia-yields-file.py,
                 test-supernovae-type-Ia-yields-metallicity.py,
+                test-supernovae-type-Ia-rate-metallicity.py,
                 test-stellar-properties-LimongiChieffi2018.py,
                 test-tidalTracks.py,
                 test-transferFunctionHalfModeSlope.py,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1518,6 +1518,7 @@ jobs:
                 test-checkpointing.py,
                 test-stellar-mass-weighted-ages.py,
                 test-supernovae-type-Ia-yields-file.py,
+                test-stellar-properties-LimongiChieffi2018.py,
                 test-tidalTracks.py,
                 test-transferFunctionHalfModeSlope.py,
                 test-galacticStructureStateDeallocateBug.py,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1517,6 +1517,7 @@ jobs:
                 test-stateRestore.py,
                 test-checkpointing.py,
                 test-stellar-mass-weighted-ages.py,
+                test-supernovae-type-Ia-yields-file.py,
                 test-tidalTracks.py,
                 test-transferFunctionHalfModeSlope.py,
                 test-galacticStructureStateDeallocateBug.py,

--- a/docs/Galacticus.bib
+++ b/docs/Galacticus.bib
@@ -8000,6 +8000,24 @@
   pages		= {18}
 }
 
+@Article{	  johnson_binaries_2023,
+  author	= {{Johnson}, James W. and {Kochanek}, Christopher S. and
+		  {Stanek}, K. Z.},
+  title		= "{Binaries drive high Type Ia supernova rates in dwarf
+		  galaxies}",
+  journal	= {\mnras},
+  year		= 2023,
+  month		= dec,
+  volume	= {526},
+  number	= {4},
+  pages		= {5911-5924},
+  archiveprefix	= {arXiv},
+  eprint	= {2210.01818},
+  primaryclass	= {astro-ph.GA},
+  adsurl	= {https://ui.adsabs.harvard.edu/abs/2023MNRAS.526.5911J},
+  adsnote	= {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @Article{	  nagashima_metal_2005,
   author	= {{Nagashima}, Masahiro and {Lacey}, Cedric G. and {Baugh},
 		  Carlton M. and {Frenk}, Carlos S. and {Cole}, Shaun},

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -3915,6 +3915,7 @@
           <xs:enumeration value="differentialDTD"/>
           <xs:enumeration value="fixedYield"/>
           <xs:enumeration value="massIndependentDTD"/>
+          <xs:enumeration value="metallicityDependentRate"/>
           <xs:enumeration value="nagashima2005"/>
           <xs:enumeration value="powerLawDTD"/>
           <xs:enumeration value="powerLawDTDDifferential"/>

--- a/source/benchmarks/stellar_luminosities.F90
+++ b/source/benchmarks/stellar_luminosities.F90
@@ -106,7 +106,8 @@ program Benchmark_Stellar_Populations_Luminosities
        &                                                                                 stellarTracks_                      =stellarTracks_                                                                                                &
        &                                                                                )
   supernovaeTypeIa_                     =supernovaeTypeIaNagashima2005                  (                                                                                                                                                   &
-       &                                                                                 stellarAstrophysics_                =stellarAstrophysics_                                                                                          &
+       &                                                                                 stellarAstrophysics_                =stellarAstrophysics_                                                                                        , &
+       &                                                                                 fileName                            =char(inputPath(pathTypeDataStatic))//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml'                      &
        &                                                                                )
   supernovaePopulationIII_              =supernovaePopulationIIIHegerWoosley2002        (                                                                                                                                                   &
        &                                                                                 stellarAstrophysics_                =stellarAstrophysics_                                                                                          &

--- a/source/numerical/interpolation/2D/irregular.F90
+++ b/source/numerical/interpolation/2D/irregular.F90
@@ -72,10 +72,14 @@ contains
   ! Public API
   ! ════════════════════════════════════════════════════════════════════════════
 
-  function Interpolate_2D_Irregular_Array(dataX,dataY,dataZ,interpolateX,interpolateY,workspace,numberComputePoints,reset) &
-       result(zi)
+  function Interpolate_2D_Irregular_Array(dataX,dataY,dataZ,interpolateX,interpolateY,workspace,numberComputePoints,reset, &
+       dataStatic) result(zi)
     !!{RST
-    Perform interpolation on a set of points irregularly spaced on a 2D surface. On ``reset=.true.`` (or the first call) the triangulation, closest-neighbour indices, partial derivatives, and 9-section lookup grid are all rebuilt from scratch. On subsequent calls (``reset=.false.``) the triangulation and closest-neighbour indices are reused but the partial derivatives are re-estimated, which correctly handles the case where the Z values change between calls while the XY positions do not. The function is fully thread-safe: all state is held in ``workspace`` and no global or module-level variables are accessed.
+    Perform interpolation on a set of points irregularly spaced on a 2D surface. On ``reset=.true.`` (or the first call) the triangulation, closest-neighbour indices, partial derivatives, and 9-section lookup grid are all rebuilt from scratch. On subsequent calls (``reset=.false.``) the triangulation and closest-neighbour indices are reused but the partial derivatives are re-estimated, which correctly handles the case where the ``dataZ`` values change between calls while the ``dataX`` and ``dataY`` positions do not.
+
+    Re-estimating the derivatives costs :math:`\mathcal{O}(N n_\mathrm{neighbors}^2)` for :math:`N` tabulated points and so dominates the cost wherever a large table is interpolated repeatedly. A caller which knows that none of its data change between calls---because they were read once from a file, say---may pass ``dataStatic=.true.``, whereupon the workspace is reused as it stands and the cost per call becomes independent of the size of the table. Note that each set of data then needs its own workspace, since sharing one between several sets would leave it describing whichever was passed most recently.
+
+    The function is fully thread-safe: all state is held in ``workspace`` and no global or module-level variables are accessed.
     !!}
     implicit none
     type            (interpolator2DIrregular)                               , intent(inout)           :: workspace
@@ -84,9 +88,10 @@ contains
          &                                                                                               interpolateY
     integer                                                                 , intent(in   ), optional :: numberComputePoints
     logical                                                                 , intent(inout), optional :: reset
+    logical                                                                 , intent(in   ), optional :: dataStatic
     double precision                         , dimension(size(interpolateX))                          :: zi
     integer                                                                                           :: i
-    logical                                                                                           :: resetActual
+    logical                                                                                           :: resetActual        , dataStaticActual
 
     ! Determine reset status.
     if (present(reset)) then
@@ -96,19 +101,32 @@ contains
        resetActual = .true.
     end if
 
+    ! Determine whether the caller guarantees that its data are unchanged since the previous call.
+    if (present(dataStatic)) then
+       dataStaticActual = dataStatic
+    else
+       dataStaticActual = .false.
+    end if
+
     ! Decide how many neighbours to use for partial derivative estimation.
     if (present(numberComputePoints)) workspace%nNeighbors = numberComputePoints
 
-    if (resetActual .or. .not. workspace%initialized) then
+    if      (resetActual .or. .not. workspace%initialized) then
        call initializeWorkspace(workspace, dataX, dataY, dataZ)
-    else
-       ! Reuse triangulation and closest-neighbour indices; re-estimate partial
-       ! derivatives in case the Z values have changed since the previous call.
+    else if (size(dataX) /= workspace%nData                 ) then
+       ! The number of data points has changed, so the triangulation and closest-neighbour indices no longer
+       ! describe them and everything must be rebuilt. Reusing them here would leave the cached indices out of
+       ! bounds.
+       call initializeWorkspace(workspace, dataX, dataY, dataZ)
+    else if (.not. dataStaticActual                         ) then
+       ! Reuse triangulation and closest-neighbour indices; re-estimate partial derivatives in case the Z values
+       ! have changed since the previous call.
        workspace%zData = dataZ
        call estimateDerivatives(workspace%nData, workspace%xData, workspace%yData, &
             &                   workspace%zData, workspace%nNeighbors,              &
             &                   workspace%ipc, workspace%pd)
     end if
+    ! Otherwise the caller has guaranteed that nothing has changed, and the workspace is used as it stands.
 
     do i = 1, size(interpolateX)
        zi(i) = interpolateOne(workspace, interpolateX(i), interpolateY(i))
@@ -117,7 +135,7 @@ contains
   end function Interpolate_2D_Irregular_Array
 
   double precision function Interpolate_2D_Irregular_Scalar(dataX,dataY,dataZ,interpolateX,interpolateY,workspace, &
-       &                                                     numberComputePoints,reset)
+       &                                                     numberComputePoints,reset,dataStatic)
     !!{RST
     Scalar wrapper: interpolate at a single point.
     !!}
@@ -127,11 +145,12 @@ contains
     double precision                                       , intent(in   )           :: interpolateX, interpolateY
     integer                                                , intent(in   ), optional :: numberComputePoints
     logical                                                , intent(inout), optional :: reset
+    logical                                                , intent(in   ), optional :: dataStatic
     double precision                         , dimension(1)                          :: xArr, yArr, zArr
 
     xArr(1) = interpolateX
     yArr(1) = interpolateY
-    zArr    = Interpolate_2D_Irregular_Array(dataX,dataY,dataZ,xArr,yArr,workspace,numberComputePoints,reset)
+    zArr    = Interpolate_2D_Irregular_Array(dataX,dataY,dataZ,xArr,yArr,workspace,numberComputePoints,reset,dataStatic)
     Interpolate_2D_Irregular_Scalar = zArr(1)
   end function Interpolate_2D_Irregular_Scalar
 

--- a/source/numerical/interpolation/2D/irregular.F90
+++ b/source/numerical/interpolation/2D/irregular.F90
@@ -83,8 +83,8 @@ contains
     !!}
     implicit none
     type            (interpolator2DIrregular)                               , intent(inout)           :: workspace
-    double precision                         , dimension(:)                 , intent(in   )           :: dataX        , dataY       , &
-         &                                                                                               dataZ        , interpolateX, &
+    double precision                         , dimension(:)                 , intent(in   )           :: dataX              , dataY           , &
+         &                                                                                               dataZ              , interpolateX    , &
          &                                                                                               interpolateY
     integer                                                                 , intent(in   ), optional :: numberComputePoints
     logical                                                                 , intent(inout), optional :: reset
@@ -103,9 +103,9 @@ contains
 
     ! Determine whether the caller guarantees that its data are unchanged since the previous call.
     if (present(dataStatic)) then
-       dataStaticActual = dataStatic
+       dataStaticActual=dataStatic
     else
-       dataStaticActual = .false.
+       dataStaticActual=.false.
     end if
 
     ! Decide how many neighbours to use for partial derivative estimation.
@@ -122,12 +122,11 @@ contains
        ! Reuse triangulation and closest-neighbour indices; re-estimate partial derivatives in case the Z values
        ! have changed since the previous call.
        workspace%zData = dataZ
-       call estimateDerivatives(workspace%nData, workspace%xData, workspace%yData, &
-            &                   workspace%zData, workspace%nNeighbors,              &
-            &                   workspace%ipc, workspace%pd)
+       call estimateDerivatives(workspace%nData, workspace%xData     , workspace%yData, &
+            &                   workspace%zData, workspace%nNeighbors,                  &
+            &                   workspace%ipc  , workspace%pd)
     end if
     ! Otherwise the caller has guaranteed that nothing has changed, and the workspace is used as it stands.
-
     do i = 1, size(interpolateX)
        zi(i) = interpolateOne(workspace, interpolateX(i), interpolateY(i))
     end do

--- a/source/stellar_astrophysics/file.F90
+++ b/source/stellar_astrophysics/file.F90
@@ -333,9 +333,58 @@ contains
           self%yieldElementRangeMetallicity(:,self%atomIndexMap(iElement))=[minval(self%yieldElementMetallicity(1:self%countYieldElement(iElement),self%atomIndexMap(iElement))),maxval(self%yieldElementMetallicity(1:self%countYieldElement(iElement),self%atomIndexMap(iElement)))]
        end if
     end do
+    ! Check that every tabulated property spans a range of metallicity. A property tabulated at a single
+    ! metallicity cannot be interpolated in the (mass, metallicity) plane, and requesting it at any other
+    ! metallicity silently returns nonsense rather than failing, so it is caught here instead.
+    call fileValidateMetallicities(self%fileName,'stellar lifetimes'   ,self%lifetimeMetallicity   )
+    call fileValidateMetallicities(self%fileName,'ejected masses'      ,self%massEjectedMetallicity)
+    call fileValidateMetallicities(self%fileName,'the total metal yield',self%yieldMetalsMetallicity)
+    do iElement=1,size(self%countYieldElement)
+       if (self%atomIndexMap(iElement) > 0)                                                                          &
+            & call fileValidateMetallicities(                                                                        &
+            &                                self%fileName                                                         , &
+            &                                'the yield of '//trim(Atomic_Short_Label(iElement))                    , &
+            &                                self%yieldElementMetallicity(1:self%countYieldElement(iElement),self%atomIndexMap(iElement)) &
+            &                               )
+    end do
     self%readDone=.true.
     return
   end subroutine fileRead
+
+  subroutine fileValidateMetallicities(fileName,label,metallicities)
+    !!{RST
+    Report a property which is tabulated at only a single metallicity.
+
+    Such a property cannot be interpolated: the tabulated points are collinear in the (mass, metallicity) plane,
+    so interpolation there is not defined and any request at another metallicity is an extrapolation. The
+    failure is silent---the interpolation returns a value, just not a meaningful one, and has been observed to
+    return an order of magnitude too much, or zero, or values which send the integration over the initial mass
+    function into an unbounded subdivision---so it is caught here rather than left to be discovered downstream.
+    !!}
+    use :: Error             , only : Error_Report
+    use :: ISO_Varying_String, only : char
+    implicit none
+    type            (varying_string), intent(in   )               :: fileName
+    character       (len=*         ), intent(in   )               :: label
+    double precision                , intent(in   ), dimension(:) :: metallicities
+    character       (len=24        )                              :: metallicityLabel
+
+    if (size(metallicities) <= 1                       ) return
+    if (maxval(metallicities) > minval(metallicities)  ) return
+    write (metallicityLabel,'(e12.6)') metallicities(1)
+    call Error_Report(                                                                                                &
+         &            'stellar properties file "'//char(fileName)//'" tabulates '//trim(label)//                       &
+         &            ' at a single metallicity (Z='//trim(adjustl(metallicityLabel))//')'//char(10)//                  &
+         &            '   => such a property can not be interpolated in the (mass, metallicity) plane, and a request'// &
+         &            ' at any other metallicity would be extrapolated, returning a value which is not meaningful'//    &
+         &            char(10)//                                                                                       &
+         &            '   => if the property genuinely does not depend on metallicity, tabulate it at two'//            &
+         &            ' metallicities which bracket the range of interest, giving it the same value at both; the'//     &
+         &            ' Sukhbold et al. (2016) files are written this way'//                                            &
+         &            {introspection:location}                                                                         &
+         &           )
+    return
+  end subroutine fileValidateMetallicities
 
   double precision function fileMassInitial(self,lifetime,metallicity)
     !!{RST

--- a/source/stellar_astrophysics/file.F90
+++ b/source/stellar_astrophysics/file.F90
@@ -236,25 +236,25 @@ contains
        end if
     end do
     ! Allocate arrays to store stellar properties.
-    allocate(self%lifetimeLifetime            (countLifetime                             ))
-    allocate(self%lifetimeMass                (countLifetime                             ))
-    allocate(self%lifetimeMetallicity         (countLifetime                             ))
-    allocate(self%massEjectedMassEjected      (countMassEjected                          ))
-    allocate(self%massEjectedMass             (countMassEjected                          ))
-    allocate(self%massEjectedMetallicity      (countMassEjected                          ))
-    allocate(self%yieldMetals                 (countYieldMetals                          ))
-    allocate(self%yieldMetalsMass             (countYieldMetals                          ))
-    allocate(self%yieldMetalsMetallicity      (countYieldMetals                          ))
-    allocate(self%yieldElement                (countYieldElementMaximum,self%countElement))
-    allocate(self%yieldElementMass            (countYieldElementMaximum,self%countElement))
-    allocate(self%yieldElementMetallicity     (countYieldElementMaximum,self%countElement))
-    allocate(self%yieldMetalsRangeMass        (2                                         ))
-    allocate(self%yieldMetalsRangeMetallicity (2                                         ))
-    allocate(self%yieldElementRangeMass       (2                       ,self%countElement))
-    allocate(self%yieldElementRangeMetallicity(2                       ,self%countElement))
+    allocate(self%lifetimeLifetime               (countLifetime                               ))
+    allocate(self%lifetimeMass                   (countLifetime                               ))
+    allocate(self%lifetimeMetallicity            (countLifetime                               ))
+    allocate(self%massEjectedMassEjected         (countMassEjected                            ))
+    allocate(self%massEjectedMass                (countMassEjected                            ))
+    allocate(self%massEjectedMetallicity         (countMassEjected                            ))
+    allocate(self%yieldMetals                    (countYieldMetals                            ))
+    allocate(self%yieldMetalsMass                (countYieldMetals                            ))
+    allocate(self%yieldMetalsMetallicity         (countYieldMetals                            ))
+    allocate(self%yieldElement                   (countYieldElementMaximum,  self%countElement))
+    allocate(self%yieldElementMass               (countYieldElementMaximum,  self%countElement))
+    allocate(self%yieldElementMetallicity        (countYieldElementMaximum,  self%countElement))
+    allocate(self%yieldMetalsRangeMass           (2                                           ))
+    allocate(self%yieldMetalsRangeMetallicity    (2                                           ))
+    allocate(self%yieldElementRangeMass          (2                       ,  self%countElement))
+    allocate(self%yieldElementRangeMetallicity   (2                       ,  self%countElement))
     ! One workspace per interpolated yield: the total metal yield, plus each element.
-    allocate(self%interpolationWorkspaceMassYield(0:self%countElement))
-    allocate(self%interpolationResetMassYield    (0:self%countElement))
+    allocate(self%interpolationWorkspaceMassYield(                         0:self%countElement))
+    allocate(self%interpolationResetMassYield    (                         0:self%countElement))
     self%interpolationResetMassYield=.true.
     ! Loop over stars to process their properties.
     countLifetime         =0
@@ -336,15 +336,15 @@ contains
     ! Check that every tabulated property spans a range of metallicity. A property tabulated at a single
     ! metallicity cannot be interpolated in the (mass, metallicity) plane, and requesting it at any other
     ! metallicity silently returns nonsense rather than failing, so it is caught here instead.
-    call fileValidateMetallicities(self%fileName,'stellar lifetimes'   ,self%lifetimeMetallicity   )
-    call fileValidateMetallicities(self%fileName,'ejected masses'      ,self%massEjectedMetallicity)
+    call fileValidateMetallicities(self%fileName,'stellar lifetimes'    ,self%lifetimeMetallicity   )
+    call fileValidateMetallicities(self%fileName,'ejected masses'       ,self%massEjectedMetallicity)
     call fileValidateMetallicities(self%fileName,'the total metal yield',self%yieldMetalsMetallicity)
     do iElement=1,size(self%countYieldElement)
-       if (self%atomIndexMap(iElement) > 0)                                                                          &
-            & call fileValidateMetallicities(                                                                        &
-            &                                self%fileName                                                         , &
-            &                                'the yield of '//trim(Atomic_Short_Label(iElement))                    , &
-            &                                self%yieldElementMetallicity(1:self%countYieldElement(iElement),self%atomIndexMap(iElement)) &
+       if (self%atomIndexMap(iElement) > 0)                                                                                                &
+            & call fileValidateMetallicities(                                                                                              &
+            &                                self%fileName                                                                               , &
+            &                                'the yield of '//trim(Atomic_Short_Label(iElement))                                         , &
+            &                                self%yieldElementMetallicity(1:self%countYieldElement(iElement),self%atomIndexMap(iElement))  &
             &                               )
     end do
     self%readDone=.true.
@@ -372,16 +372,16 @@ contains
     if (size(metallicities) <= 1                       ) return
     if (maxval(metallicities) > minval(metallicities)  ) return
     write (metallicityLabel,'(e12.6)') metallicities(1)
-    call Error_Report(                                                                                                &
-         &            'stellar properties file "'//char(fileName)//'" tabulates '//trim(label)//                       &
+    call Error_Report(                                                                                                  &
+         &            'stellar properties file "'//char(fileName)//'" tabulates '//trim(label)//                        &
          &            ' at a single metallicity (Z='//trim(adjustl(metallicityLabel))//')'//char(10)//                  &
          &            '   => such a property can not be interpolated in the (mass, metallicity) plane, and a request'// &
-         &            ' at any other metallicity would be extrapolated, returning a value which is not meaningful'//    &
-         &            char(10)//                                                                                       &
-         &            '   => if the property genuinely does not depend on metallicity, tabulate it at two'//            &
-         &            ' metallicities which bracket the range of interest, giving it the same value at both; the'//     &
+         &            ' at any other metallicity would be extrapolated, returning a value which is not meaningful'   // &
+         &            char(10)//                                                                                        &
+         &            '   => if the property genuinely does not depend on metallicity, tabulate it at two'           // &
+         &            ' metallicities which bracket the range of interest, giving it the same value at both; the'    // &
          &            ' Sukhbold et al. (2016) files are written this way'//                                            &
-         &            {introspection:location}                                                                         &
+         &            {introspection:location}                                                                          &
          &           )
     return
   end subroutine fileValidateMetallicities
@@ -404,7 +404,7 @@ contains
          &                                                            metallicity                      , &
          &                                                       self%interpolationWorkspaceMassInitial, &
          &                                   reset              =self%interpolationResetMassInitial    , &
-         &                                   dataStatic         =.true.                                 , &
+         &                                   dataStatic         =.true.                                , &
          &                                   numberComputePoints=     3                                  &
          &                                  )
     return
@@ -427,7 +427,7 @@ contains
          &                                           massInitial                   , &
          &                                           metallicity                   , &
          &                                      self%interpolationWorkspaceLifetime, &
-         &                                reset=self%interpolationResetLifetime     , &
+         &                                reset=self%interpolationResetLifetime    , &
          &                                dataStatic=.true.                          &
          &                               )
     return
@@ -451,7 +451,7 @@ contains
          &                                                  massInitial                      , &
          &                                                  metallicity                      , &
          &                                             self%interpolationWorkspaceMassEjected, &
-         &                                       reset=self%interpolationResetMassEjected     , &
+         &                                       reset=self%interpolationResetMassEjected    , &
          &                                       dataStatic=.true.                             &
          &                                      )                                            , &
          &               0.0d0                                                                 &
@@ -477,26 +477,26 @@ contains
        elementIndex =self%atomIndexMap(atomIndex)
        ! Exclude elements for which this compilation provides no yields at all, which are mapped to an index of
        ! -1, and initial masses outside of the available range of stars.
-       if     (                                                           &
-            &   elementIndex > 0                                          &
-            &  .and.                                                      &
-            &   massInitial >= self%yieldElementRangeMass(1,max(elementIndex,1)) &
-            &  .and.                                                      &
-            &   massInitial <= self%yieldElementRangeMass(2,max(elementIndex,1)) &
+       if     (                                                                   &
+            &   elementIndex >  0                                                 &
+            &  .and.                                                              &
+            &   massInitial  >= self%yieldElementRangeMass(1,max(elementIndex,1)) &
+            &  .and.                                                              &
+            &   massInitial  <= self%yieldElementRangeMass(2,max(elementIndex,1)) &
             & ) then
           metallicity_ =min(max(metallicity,self%yieldElementRangeMetallicity(1,elementIndex)),self%yieldElementRangeMetallicity(2,elementIndex))
-          fileMassYield=max(                                                                                                                       &
-               &            Interpolate_2D_Irregular(                                                                                              &
-               &                                           self%yieldElementMass               (1:self%countYieldElement(atomIndex),elementIndex), &
-               &                                           self%yieldElementMetallicity        (1:self%countYieldElement(atomIndex),elementIndex), &
-               &                                           self%yieldElement                   (1:self%countYieldElement(atomIndex),elementIndex), &
-               &                                                massInitial                                                                      , &
-               &                                                metallicity_                                                                     , &
-               &                                           self%interpolationWorkspaceMassYield(elementIndex)                                    , &
-               &                                     reset=self%interpolationResetMassYield    (elementIndex)                                    , &
-               &                                     dataStatic=.true.                                                                    &
-               &                                    )                                                                                            , &
-               &            0.0d0                                                                                                                  &
+          fileMassYield=max(                                                                                                                            &
+               &            Interpolate_2D_Irregular(                                                                                                   &
+               &                                                self%yieldElementMass               (1:self%countYieldElement(atomIndex),elementIndex), &
+               &                                                self%yieldElementMetallicity        (1:self%countYieldElement(atomIndex),elementIndex), &
+               &                                                self%yieldElement                   (1:self%countYieldElement(atomIndex),elementIndex), &
+               &                                                     massInitial                                                                      , &
+               &                                                     metallicity_                                                                     , &
+               &                                                self%interpolationWorkspaceMassYield(elementIndex)                                    , &
+               &                                     reset     =self%interpolationResetMassYield    (elementIndex)                                    , &
+               &                                     dataStatic=.true.                                                                                  &
+               &                                    )                                                                                                 , &
+               &            0.0d0                                                                                                                       &
                &           )
        else
           fileMassYield=0.0d0
@@ -510,18 +510,18 @@ contains
             &   massInitial <= self%yieldMetalsRangeMass(2) &
             & ) then
           metallicity_ =min(max(metallicity,self%yieldMetalsRangeMetallicity(1)),self%yieldMetalsRangeMetallicity(2))          
-          fileMassYield=max(                                                                     &
-               &            Interpolate_2D_Irregular(                                            &
-               &                                           self%yieldMetalsMass                , &
-               &                                           self%yieldMetalsMetallicity         , &
-               &                                           self%yieldMetals                    , &
-               &                                                massInitial                    , &
-               &                                                metallicity_                   , &
-               &                                           self%interpolationWorkspaceMassYield(0), &
-               &                                     reset=self%interpolationResetMassYield    (0), &
-               &                                     dataStatic=.true.                             &
-               &                                    )                                          , &
-               &             0.0d0                                                               &
+          fileMassYield=max(                                                                             &
+               &            Interpolate_2D_Irregular(                                                    &
+               &                                                self%yieldMetalsMass                   , &
+               &                                                self%yieldMetalsMetallicity            , &
+               &                                                self%yieldMetals                       , &
+               &                                                     massInitial                       , &
+               &                                                     metallicity_                      , &
+               &                                                self%interpolationWorkspaceMassYield(0), &
+               &                                     reset     =self%interpolationResetMassYield    (0), &
+               &                                     dataStatic=.true.                                   &
+               &                                    )                                                  , &
+               &             0.0d0                                                                       &
                &            )
        else
           fileMassYield=0.0d0

--- a/source/stellar_astrophysics/file.F90
+++ b/source/stellar_astrophysics/file.F90
@@ -75,10 +75,15 @@
      integer                                  , allocatable, dimension(:  ) :: atomIndexMap                     , countYieldElement
      integer                                                                :: countElement
      type            (interpolator2DIrregular)                              :: interpolationWorkspaceMassInitial, interpolationWorkspaceLifetime , &
-          &                                                                    interpolationWorkspaceMassEjected, interpolationWorkspaceMassYield
+          &                                                                    interpolationWorkspaceMassEjected
+     ! One interpolation workspace per interpolated yield---the total metal yield in the first element, and each
+     ! element for which yields are available in the remainder. A single shared workspace would be invalidated on
+     ! every call, since each yield is tabulated at the same points but with different values, forcing the partial
+     ! derivatives to be re-estimated each time at a cost which scales with the size of the table.
+     type            (interpolator2DIrregular), allocatable, dimension(:  ) :: interpolationWorkspaceMassYield
+     logical                                  , allocatable, dimension(:  ) :: interpolationResetMassYield
      logical                                                                :: interpolationResetMassInitial    , interpolationResetLifetime     , &
-          &                                                                    interpolationResetMassEjected    , interpolationResetMassYield    , &
-          &                                                                    readDone
+          &                                                                    interpolationResetMassEjected    , readDone
   contains
      !![
      <methods docformat="rst">
@@ -151,7 +156,6 @@ contains
     self%interpolationResetMassInitial=.true.
     self%interpolationResetLifetime   =.true.
     self%interpolationResetMassEjected=.true.
-    self%interpolationResetMassYield  =.true.
     self%readDone                     =.false.
     return
   end function fileConstructorInternal
@@ -248,6 +252,10 @@ contains
     allocate(self%yieldMetalsRangeMetallicity (2                                         ))
     allocate(self%yieldElementRangeMass       (2                       ,self%countElement))
     allocate(self%yieldElementRangeMetallicity(2                       ,self%countElement))
+    ! One workspace per interpolated yield: the total metal yield, plus each element.
+    allocate(self%interpolationWorkspaceMassYield(0:self%countElement))
+    allocate(self%interpolationResetMassYield    (0:self%countElement))
+    self%interpolationResetMassYield=.true.
     ! Loop over stars to process their properties.
     countLifetime         =0
     countMassEjected      =0
@@ -347,6 +355,7 @@ contains
          &                                                            metallicity                      , &
          &                                                       self%interpolationWorkspaceMassInitial, &
          &                                   reset              =self%interpolationResetMassInitial    , &
+         &                                   dataStatic         =.true.                                 , &
          &                                   numberComputePoints=     3                                  &
          &                                  )
     return
@@ -369,7 +378,8 @@ contains
          &                                           massInitial                   , &
          &                                           metallicity                   , &
          &                                      self%interpolationWorkspaceLifetime, &
-         &                                reset=self%interpolationResetLifetime      &
+         &                                reset=self%interpolationResetLifetime     , &
+         &                                dataStatic=.true.                          &
          &                               )
     return
   end function fileLifetime
@@ -392,7 +402,8 @@ contains
          &                                                  massInitial                      , &
          &                                                  metallicity                      , &
          &                                             self%interpolationWorkspaceMassEjected, &
-         &                                       reset=self%interpolationResetMassEjected      &
+         &                                       reset=self%interpolationResetMassEjected     , &
+         &                                       dataStatic=.true.                             &
          &                                      )                                            , &
          &               0.0d0                                                                 &
          &             )
@@ -415,11 +426,14 @@ contains
     if (present(atomIndex)) then
        ! Compute the element mass yield.
        elementIndex =self%atomIndexMap(atomIndex)
-       ! Exclude initial masses outside of the available range of stars.
+       ! Exclude elements for which this compilation provides no yields at all, which are mapped to an index of
+       ! -1, and initial masses outside of the available range of stars.
        if     (                                                           &
-            &   massInitial >= self%yieldElementRangeMass(1,elementIndex) &
+            &   elementIndex > 0                                          &
             &  .and.                                                      &
-            &   massInitial <= self%yieldElementRangeMass(2,elementIndex) &
+            &   massInitial >= self%yieldElementRangeMass(1,max(elementIndex,1)) &
+            &  .and.                                                      &
+            &   massInitial <= self%yieldElementRangeMass(2,max(elementIndex,1)) &
             & ) then
           metallicity_ =min(max(metallicity,self%yieldElementRangeMetallicity(1,elementIndex)),self%yieldElementRangeMetallicity(2,elementIndex))
           fileMassYield=max(                                                                                                                       &
@@ -429,8 +443,9 @@ contains
                &                                           self%yieldElement                   (1:self%countYieldElement(atomIndex),elementIndex), &
                &                                                massInitial                                                                      , &
                &                                                metallicity_                                                                     , &
-               &                                           self%interpolationWorkspaceMassYield                                                  , &
-               &                                     reset=self%interpolationResetMassYield                                                        &
+               &                                           self%interpolationWorkspaceMassYield(elementIndex)                                    , &
+               &                                     reset=self%interpolationResetMassYield    (elementIndex)                                    , &
+               &                                     dataStatic=.true.                                                                    &
                &                                    )                                                                                            , &
                &            0.0d0                                                                                                                  &
                &           )
@@ -453,8 +468,9 @@ contains
                &                                           self%yieldMetals                    , &
                &                                                massInitial                    , &
                &                                                metallicity_                   , &
-               &                                           self%interpolationWorkspaceMassYield, &
-               &                                     reset=self%interpolationResetMassYield      &
+               &                                           self%interpolationWorkspaceMassYield(0), &
+               &                                     reset=self%interpolationResetMassYield    (0), &
+               &                                     dataStatic=.true.                             &
                &                                    )                                          , &
                &             0.0d0                                                               &
                &            )

--- a/source/stellar_astrophysics/supernovae_type_Ia/Nagashima2005.F90
+++ b/source/stellar_astrophysics/supernovae_type_Ia/Nagashima2005.F90
@@ -29,6 +29,7 @@
    <description>
    A supernovae type Ia class which uses the prescriptions from :cite:t:`nagashima_metal_2005` to compute the numbers and yields of Type Ia supernovae.
    </description>
+   <runTimeFileDependencies paths="fileName"/>
   </supernovaeTypeIa>
   !!]
   type, extends(supernovaeTypeIaFixedYield) :: supernovaeTypeIaNagashima2005
@@ -68,16 +69,26 @@ contains
     !!{RST
     Constructor for the :galacticus-class:`supernovaeTypeIaNagashima2005` supernovae type Ia class which takes a parameter list as input.
     !!}
+    use :: Input_Paths     , only : inputPath     , pathTypeDataStatic
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
     type (supernovaeTypeIaNagashima2005)                :: self
     type (inputParameters              ), intent(inout) :: parameters
     class(stellarAstrophysicsClass     ), pointer       :: stellarAstrophysics_
+    type (varying_string               )                :: fileName
 
     !![
+    <inputParameter docformat="rst">
+      <name>fileName</name>
+      <source>parameters</source>
+      <defaultValue>inputPath(pathTypeDataStatic)//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml'</defaultValue>
+      <description>
+      The name of the XML file from which to read the yields of Type Ia supernovae.
+      </description>
+    </inputParameter>
     <objectBuilder class="stellarAstrophysics" name="stellarAstrophysics_" source="parameters"/>
     !!]
-    self=supernovaeTypeIaNagashima2005(stellarAstrophysics_)
+    self=supernovaeTypeIaNagashima2005(stellarAstrophysics_,char(fileName))
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="stellarAstrophysics_"/>
@@ -85,15 +96,16 @@ contains
     return
   end function nagashima2005ConstructorParameters
 
-  function nagashima2005ConstructorInternal(stellarAstrophysics_) result(self)
+  function nagashima2005ConstructorInternal(stellarAstrophysics_,fileName) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`supernovaeTypeIaNagashima2005` supernovae type Ia class.
     !!}
     implicit none
-    type (supernovaeTypeIaNagashima2005)                        :: self
-    class(stellarAstrophysicsClass     ), intent(in   ), target :: stellarAstrophysics_
+    type     (supernovaeTypeIaNagashima2005)                        :: self
+    class    (stellarAstrophysicsClass     ), intent(in   ), target :: stellarAstrophysics_
+    character(len=*                        ), intent(in   )         :: fileName
     !![
-    <constructorAssign variables="*stellarAstrophysics_"/>
+    <constructorAssign variables="*stellarAstrophysics_, fileName"/>
     !!]
 
     self%initialized=.false.

--- a/source/stellar_astrophysics/supernovae_type_Ia/fixed_yield.F90
+++ b/source/stellar_astrophysics/supernovae_type_Ia/fixed_yield.F90
@@ -33,6 +33,7 @@
      A supernovae type Ia class in which the yield is independent of progenitor.
      !!}
      private
+     type            (varying_string)            :: fileName
      double precision                            :: totalYield
      double precision, allocatable, dimension(:) :: elementYield
      logical                                     :: initialized
@@ -55,10 +56,8 @@ contains
     use :: Atomic_Data       , only : Atom_Lookup                   , Atomic_Data_Atoms_Count
     use :: FoX_dom           , only : destroy                       , node                             , extractDataContent
     use :: Error             , only : Error_Report
-    use :: Input_Paths       , only : inputPath                     , pathTypeDataStatic
     use :: IO_XML            , only : XML_Count_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList, &
          &                            XML_Parse
-    use :: ISO_Varying_String, only : varying_string
     implicit none
     class           (supernovaeTypeIaFixedYield), intent(inout)               :: self
     type            (node                      ), pointer                     :: doc         , atom        , &
@@ -67,18 +66,16 @@ contains
     integer                                                                   :: atomicIndex , atomicNumber, &
          &                                                                       iIsotope    , ioErr
     double precision                                                          :: isotopeYield
-    type            (varying_string            )                              :: fileName
-    
+
     if (self%initialized) return
     ! Allocate an array to store individual element yields.
     allocate(self%elementYield(Atomic_Data_Atoms_Count()))
     self%elementYield=0.0d0
     self%totalYield  =0.0d0
     ! Read in Type Ia yields.
-    fileName=inputPath(pathTypeDataStatic)//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml'
     !$omp critical (FoX_DOM_Access)
-    doc => XML_Parse(fileName,iostat=ioErr)
-    if (ioErr /= 0) call Error_Report('Unable to parse yields file'//{introspection:location})
+    doc => XML_Parse(self%fileName,iostat=ioErr)
+    if (ioErr /= 0) call Error_Report('Unable to parse yields file: "'//char(self%fileName)//'"'//{introspection:location})
     ! Get a list of all isotopes.
     call XML_Get_Elements_By_Tag_Name(doc,"isotope",isotopesList)
     ! Loop through isotopes and compute the net metal yield.

--- a/source/stellar_astrophysics/supernovae_type_Ia/fixed_yield.F90
+++ b/source/stellar_astrophysics/supernovae_type_Ia/fixed_yield.F90
@@ -24,19 +24,52 @@
   !![
   <supernovaeTypeIa name="supernovaeTypeIaFixedYield" abstract="yes" docformat="rst">
    <description>
-   A supernovae type Ia class in which the yield is independent of progenitor.
+   A supernovae type Ia class in which the yield is independent of progenitor mass. The yields are read from an XML file, which may optionally tabulate them at several metallicities, in which case they are interpolated linearly in metallicity (and held constant beyond the tabulated range). The file should have the following structure:
+
+   .. code-block:: none
+
+       &lt;supernovaeYields&gt;
+        &lt;isotope&gt;
+          &lt;name&gt;56Fe&lt;/name&gt;
+          &lt;atomicMass&gt;56&lt;/atomicMass&gt;
+          &lt;atomicNumber&gt;26&lt;/atomicNumber&gt;
+          &lt;yield&gt;6.26e-1&lt;/yield&gt;
+        &lt;/isotope&gt;
+        .
+        .
+        .
+       &lt;/supernovaeYields&gt;
+
+   Only metals should be included---the total metal yield is formed by summing over every isotope present in the file. To make the yields depend on metallicity, wrap each set of isotopes in a ``yieldsMetallicity`` element carrying the metallicity at which that set applies:
+
+   .. code-block:: none
+
+       &lt;supernovaeYields&gt;
+        &lt;yieldsMetallicity&gt;
+          &lt;metallicity&gt;1.49e-4&lt;/metallicity&gt;
+          &lt;isotope&gt;
+            .
+            .
+          &lt;/isotope&gt;
+        &lt;/yieldsMetallicity&gt;
+        &lt;yieldsMetallicity&gt;
+          &lt;metallicity&gt;1.49e-2&lt;/metallicity&gt;
+          .
+          .
+        &lt;/yieldsMetallicity&gt;
+       &lt;/supernovaeYields&gt;
    </description>
   </supernovaeTypeIa>
   !!]
   type, abstract, extends(supernovaeTypeIaClass) :: supernovaeTypeIaFixedYield
      !!{RST
-     A supernovae type Ia class in which the yield is independent of progenitor.
+     A supernovae type Ia class in which the yield is independent of progenitor mass.
      !!}
      private
-     type            (varying_string)            :: fileName
-     double precision                            :: totalYield
-     double precision, allocatable, dimension(:) :: elementYield
-     logical                                     :: initialized
+     type            (varying_string)              :: fileName
+     double precision, allocatable, dimension(:  ) :: totalYield          , metallicity
+     double precision, allocatable, dimension(:,:) :: elementYield
+     logical                                       :: initialized         , metallicityDependent
    contains
      !![
      <methods docformat="rst">
@@ -53,53 +86,133 @@ contains
     !!{RST
     Read data for the ``fixedYield`` supernovae type Ia class.
     !!}
-    use :: Atomic_Data       , only : Atom_Lookup                   , Atomic_Data_Atoms_Count
-    use :: FoX_dom           , only : destroy                       , node                             , extractDataContent
-    use :: Error             , only : Error_Report
-    use :: IO_XML            , only : XML_Count_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList, &
-         &                            XML_Parse
+    use            :: Atomic_Data       , only : Atom_Lookup                   , Atomic_Data_Atoms_Count
+    use            :: FoX_dom           , only : destroy                       , node                             , extractDataContent
+    use            :: Error             , only : Error_Report
+    use            :: IO_XML            , only : XML_Count_Elements_By_Tag_Name, XML_Get_First_Element_By_Tag_Name, XML_Get_Elements_By_Tag_Name, xmlNodeList, &
+         &                                       XML_Parse
+    use            :: Sorting           , only : sortIndex
+    use, intrinsic :: ISO_C_Binding     , only : c_size_t
     implicit none
     class           (supernovaeTypeIaFixedYield), intent(inout)               :: self
-    type            (node                      ), pointer                     :: doc         , atom        , &
-         &                                                                       isotope     , yield
-    type            (xmlNodeList               ), allocatable  , dimension(:) :: isotopesList
-    integer                                                                   :: atomicIndex , atomicNumber, &
-         &                                                                       iIsotope    , ioErr
+    type            (node                      ), pointer                     :: doc         , atom            , &
+         &                                                                       isotope     , yield           , &
+         &                                                                       metallicity , yieldsContainer
+    type            (xmlNodeList               ), allocatable  , dimension(:) :: isotopesList, metallicitiesList
+    integer                                                                   :: atomicIndex , atomicNumber    , &
+         &                                                                       iIsotope    , ioErr           , &
+         &                                                                       iMetallicity, countMetallicity
     double precision                                                          :: isotopeYield
+    double precision                            , allocatable, dimension(:  ) :: metallicities
+    double precision                            , allocatable, dimension(:,:) :: elementYields
+    double precision                            , allocatable, dimension(:  ) :: totalYields
+    integer         (c_size_t                  ), allocatable, dimension(:  ) :: order
 
     if (self%initialized) return
-    ! Allocate an array to store individual element yields.
-    allocate(self%elementYield(Atomic_Data_Atoms_Count()))
-    self%elementYield=0.0d0
-    self%totalYield  =0.0d0
     ! Read in Type Ia yields.
     !$omp critical (FoX_DOM_Access)
     doc => XML_Parse(self%fileName,iostat=ioErr)
     if (ioErr /= 0) call Error_Report('Unable to parse yields file: "'//char(self%fileName)//'"'//{introspection:location})
-    ! Get a list of all isotopes.
-    call XML_Get_Elements_By_Tag_Name(doc,"isotope",isotopesList)
-    ! Loop through isotopes and compute the net metal yield.
-    do iIsotope=0,size(isotopesList)-1
-       isotope  => isotopesList(iIsotope)%element
-       if (XML_Count_Elements_By_Tag_Name(isotope,"yield") /= 1) call Error_Report('isotope must have precisely one yield'//{introspection:location})
-       yield => XML_Get_First_Element_By_Tag_Name(isotope,"yield")
-       call extractDataContent(yield,isotopeYield)
-       self%totalYield=self%totalYield+isotopeYield
-       if (XML_Count_Elements_By_Tag_Name(isotope,"atomicNumber") /= 1) call Error_Report('isotope must have precisely one atomic number'//{introspection:location})
-       atom => XML_Get_First_Element_By_Tag_Name(isotope,"atomicNumber")
-       call extractDataContent(atom,atomicNumber)
-       atomicIndex=Atom_Lookup(atomicNumber=atomicNumber)
-       self%elementYield(atomicIndex)=self%elementYield(atomicIndex)+isotopeYield
+    ! Determine whether yields are tabulated as a function of metallicity. If no `yieldsMetallicity` elements are
+    ! present the file carries a single, metallicity-independent set of yields.
+    call XML_Get_Elements_By_Tag_Name(doc,"yieldsMetallicity",metallicitiesList)
+    self%metallicityDependent=size(metallicitiesList) > 0
+    countMetallicity         =max(size(metallicitiesList),1)
+    allocate(metallicities(                          countMetallicity))
+    allocate(totalYields  (                          countMetallicity))
+    allocate(elementYields(Atomic_Data_Atoms_Count(),countMetallicity))
+    elementYields=0.0d0
+    totalYields  =0.0d0
+    metallicities=0.0d0
+    do iMetallicity=1,countMetallicity
+       if (self%metallicityDependent) then
+          yieldsContainer => metallicitiesList(iMetallicity-1)%element
+          if (XML_Count_Elements_By_Tag_Name(yieldsContainer,"metallicity") /= 1) &
+               & call Error_Report('yieldsMetallicity must have precisely one metallicity'//{introspection:location})
+          metallicity => XML_Get_First_Element_By_Tag_Name(yieldsContainer,"metallicity")
+          call extractDataContent(metallicity,metallicities(iMetallicity))
+       else
+          yieldsContainer => doc
+       end if
+       ! Get a list of all isotopes for this metallicity.
+       call XML_Get_Elements_By_Tag_Name(yieldsContainer,"isotope",isotopesList)
+       if (size(isotopesList) == 0) call Error_Report('no isotopes found in yields file'//{introspection:location})
+       ! Loop through isotopes and compute the net metal yield.
+       do iIsotope=0,size(isotopesList)-1
+          isotope  => isotopesList(iIsotope)%element
+          if (XML_Count_Elements_By_Tag_Name(isotope,"yield") /= 1) call Error_Report('isotope must have precisely one yield'//{introspection:location})
+          yield => XML_Get_First_Element_By_Tag_Name(isotope,"yield")
+          call extractDataContent(yield,isotopeYield)
+          totalYields(iMetallicity)=totalYields(iMetallicity)+isotopeYield
+          if (XML_Count_Elements_By_Tag_Name(isotope,"atomicNumber") /= 1) call Error_Report('isotope must have precisely one atomic number'//{introspection:location})
+          atom => XML_Get_First_Element_By_Tag_Name(isotope,"atomicNumber")
+          call extractDataContent(atom,atomicNumber)
+          atomicIndex=Atom_Lookup(atomicNumber=atomicNumber)
+          elementYields(atomicIndex,iMetallicity)=elementYields(atomicIndex,iMetallicity)+isotopeYield
+       end do
     end do
     call destroy(doc)
     !$omp end critical (FoX_DOM_Access)
+    ! Sort into order of increasing metallicity, as the interpolation assumes this.
+    order=sortIndex(metallicities)
+    allocate(self%metallicity (                          countMetallicity))
+    allocate(self%totalYield  (                          countMetallicity))
+    allocate(self%elementYield(Atomic_Data_Atoms_Count(),countMetallicity))
+    do iMetallicity=1,countMetallicity
+       self%metallicity (  iMetallicity)=metallicities(  order(iMetallicity))
+       self%totalYield  (  iMetallicity)=totalYields  (  order(iMetallicity))
+       self%elementYield(:,iMetallicity)=elementYields(:,order(iMetallicity))
+    end do
+    if (self%metallicityDependent .and. countMetallicity > 1) then
+       do iMetallicity=2,countMetallicity
+          if (self%metallicity(iMetallicity) <= self%metallicity(iMetallicity-1)) &
+               & call Error_Report('yields file contains repeated metallicities'//{introspection:location})
+       end do
+    end if
     self%initialized=.true.
     return
   end subroutine fixedYieldInitialize
 
+  double precision function fixedYieldInterpolate(metallicities,yields,metallicity) result(yieldInterpolated)
+    !!{RST
+    Interpolate a tabulated yield linearly in metallicity, holding it constant beyond the tabulated range.
+    !!}
+    implicit none
+    double precision, intent(in   ), dimension(:) :: metallicities, yields
+    double precision, intent(in   )               :: metallicity
+    integer                                       :: iMetallicity
+    double precision                              :: fraction
+
+    ! With a single tabulated metallicity---or a file which does not tabulate metallicity at all---the yield is
+    ! independent of metallicity.
+    if (size(yields) == 1) then
+       yieldInterpolated=yields(1)
+       return
+    end if
+    ! Hold the yield fixed beyond the tabulated range rather than extrapolating, which for yields varying
+    ! steeply with metallicity could otherwise produce negative values.
+    if      (metallicity <= metallicities(1           )) then
+       yieldInterpolated=yields(1           )
+    else if (metallicity >= metallicities(size(yields))) then
+       yieldInterpolated=yields(size(yields))
+    else
+       do iMetallicity=1,size(yields)-1
+          if (metallicity <= metallicities(iMetallicity+1)) then
+             fraction         =+(metallicity                     -metallicities(iMetallicity)) &
+                  &            /(metallicities(iMetallicity+1)   -metallicities(iMetallicity))
+             yieldInterpolated=+yields(iMetallicity  )*(1.0d0-fraction) &
+                  &            +yields(iMetallicity+1)*       fraction
+             return
+          end if
+       end do
+       yieldInterpolated=yields(size(yields))
+    end if
+    return
+  end function fixedYieldInterpolate
+
   double precision function fixedYieldYield(self,initialMassFunction_,initialMass,age,metallicity,atomIndex) result(yield)
     !!{RST
-    Compute the cumulative yield from Type Ia supernovae originating per unit interval of secondary star mass with given ``initialMass`` and ``metallicity`` after a time ``age``. The calculation is based on that of :cite:t:`nagashima_metal_2005` with Type Ia yields from :cite:t:`nomoto_nucleosynthesis_1997`. The number returned here assumes a distribution of binary mass ratios and so only makes sense once it is integrated over an initial mass function.
+    Compute the cumulative yield from Type Ia supernovae originating per unit interval of secondary star mass with given ``initialMass`` and ``metallicity`` after a time ``age``. Yields are read from the file named by the ``fileName`` parameter---by default those of :cite:t:`nomoto_nucleosynthesis_1997`---and are interpolated in metallicity if that file tabulates them at more than one metallicity. The number returned here assumes a distribution of binary mass ratios and so only makes sense once it is integrated over an initial mass function.
     !!}
     implicit none
     class           (supernovaeTypeIaFixedYield), intent(inout)           :: self
@@ -111,10 +224,10 @@ contains
     call self%initialize()
     if (present(atomIndex)) then
        ! Return yield for requested atomic index.
-       yield=self%elementYield(atomIndex)
+       yield=fixedYieldInterpolate(self%metallicity,self%elementYield(atomIndex,:),metallicity)
     else
        ! No atomic index given, therefore return total metal yield.
-       yield=self%totalYield
+       yield=fixedYieldInterpolate(self%metallicity,self%totalYield              ,metallicity)
     end if
     yield=self%number(initialMassFunction_,initialMass,age,metallicity)*yield
     return

--- a/source/stellar_astrophysics/supernovae_type_Ia/fixed_yield.F90
+++ b/source/stellar_astrophysics/supernovae_type_Ia/fixed_yield.F90
@@ -24,7 +24,9 @@
   !![
   <supernovaeTypeIa name="supernovaeTypeIaFixedYield" abstract="yes" docformat="rst">
    <description>
-   A supernovae type Ia class in which the yield is independent of progenitor mass. The yields are read from an XML file, which may optionally tabulate them at several metallicities, in which case they are interpolated linearly in metallicity (and held constant beyond the tabulated range). The file should have the following structure:
+   A supernovae type Ia class in which the yield is independent of progenitor mass. The yields are read from an XML file, which
+   may optionally tabulate them at several metallicities, in which case they are interpolated linearly in metallicity (and held
+   constant beyond the tabulated range). The file should have the following structure:
 
    .. code-block:: none
 
@@ -40,7 +42,9 @@
         .
        &lt;/supernovaeYields&gt;
 
-   Only metals should be included---the total metal yield is formed by summing over every isotope present in the file. To make the yields depend on metallicity, wrap each set of isotopes in a ``yieldsMetallicity`` element carrying the metallicity at which that set applies:
+   Only metals should be included---the total metal yield is formed by summing over every isotope present in the file. To make the
+   yields depend on metallicity, wrap each set of isotopes in a ``yieldsMetallicity`` element carrying the metallicity at which
+   that set applies:
 
    .. code-block:: none
 
@@ -67,17 +71,17 @@
      !!}
      private
      type            (varying_string)              :: fileName
-     double precision, allocatable, dimension(:  ) :: totalYield          , metallicity
+     double precision, allocatable, dimension(:  ) :: totalYield  , metallicity
      double precision, allocatable, dimension(:,:) :: elementYield
-     logical                                       :: initialized         , metallicityDependent
+     logical                                       :: initialized , metallicityDependent
    contains
      !![
      <methods docformat="rst">
        <method method="initialize" description="Initialize yield data."/>
      </methods>
      !!]
-     procedure :: yield            => fixedYieldYield
-     procedure :: initialize       => fixedYieldInitialize
+     procedure :: yield      => fixedYieldYield
+     procedure :: initialize => fixedYieldInitialize
   end type supernovaeTypeIaFixedYield
 
 contains
@@ -95,13 +99,13 @@ contains
     use, intrinsic :: ISO_C_Binding     , only : c_size_t
     implicit none
     class           (supernovaeTypeIaFixedYield), intent(inout)               :: self
-    type            (node                      ), pointer                     :: doc         , atom            , &
-         &                                                                       isotope     , yield           , &
-         &                                                                       metallicity , yieldsContainer
-    type            (xmlNodeList               ), allocatable  , dimension(:) :: isotopesList, metallicitiesList
-    integer                                                                   :: atomicIndex , atomicNumber    , &
-         &                                                                       iIsotope    , ioErr           , &
-         &                                                                       iMetallicity, countMetallicity
+    type            (node                      ), pointer                     :: doc          , atom             , &
+         &                                                                       isotope      , yield            , &
+         &                                                                       metallicity  , yieldsContainer
+    type            (xmlNodeList               ), allocatable  , dimension(:) :: isotopesList , metallicitiesList
+    integer                                                                   :: atomicIndex  , atomicNumber     , &
+         &                                                                       iIsotope     , ioErr            , &
+         &                                                                       iMetallicity , countMetallicity
     double precision                                                          :: isotopeYield
     double precision                            , allocatable, dimension(:  ) :: metallicities
     double precision                            , allocatable, dimension(:,:) :: elementYields
@@ -116,7 +120,7 @@ contains
     ! Determine whether yields are tabulated as a function of metallicity. If no `yieldsMetallicity` elements are
     ! present the file carries a single, metallicity-independent set of yields.
     call XML_Get_Elements_By_Tag_Name(doc,"yieldsMetallicity",metallicitiesList)
-    self%metallicityDependent=size(metallicitiesList) > 0
+    self%metallicityDependent=    size(metallicitiesList) > 0
     countMetallicity         =max(size(metallicitiesList),1)
     allocate(metallicities(                          countMetallicity))
     allocate(totalYields  (                          countMetallicity))
@@ -227,7 +231,7 @@ contains
        yield=fixedYieldInterpolate(self%metallicity,self%elementYield(atomIndex,:),metallicity)
     else
        ! No atomic index given, therefore return total metal yield.
-       yield=fixedYieldInterpolate(self%metallicity,self%totalYield              ,metallicity)
+       yield=fixedYieldInterpolate(self%metallicity,self%totalYield               ,metallicity)
     end if
     yield=self%number(initialMassFunction_,initialMass,age,metallicity)*yield
     return

--- a/source/stellar_astrophysics/supernovae_type_Ia/metallicity_dependent_rate.F90
+++ b/source/stellar_astrophysics/supernovae_type_Ia/metallicity_dependent_rate.F90
@@ -1,0 +1,195 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !!{RST
+  Implements a supernovae type Ia class which scales the rate of another class by a power of the metallicity.
+  !!}
+
+  !![
+  <supernovaeTypeIa name="supernovaeTypeIaMetallicityDependentRate" docformat="rst">
+   <description>
+   A supernovae type Ia class which takes the rate of Type Ia supernovae from another ``supernovaeTypeIa`` class and multiplies it by a power of the metallicity,
+
+   .. math::
+
+      f(Z) = \left( \frac{\max(Z,Z_\mathrm{min})}{\mathrm{Z}_\odot} \right)^\beta,
+
+   where :math:`\beta=` ``[exponent]`` and :math:`Z_\mathrm{min}=` ``[metallicityMinimum]``. Both the number of events and the yields are scaled, the latter being proportional to the former.
+
+   :cite:t:`johnson_binaries_2023` argue that the anti-correlation of the close binary fraction with metallicity should enhance the Type Ia supernova rate at low metallicity, and find that a scaling of approximately :math:`Z^{-1/2}` on top of the differing star formation histories accounts for the high specific rates observed in dwarf galaxies. That is the default adopted here.
+
+   The scaling is unity at :math:`Z=\mathrm{Z}_\odot`, so the normalization of the wrapped class retains its usual meaning as the rate at Solar metallicity. Because the scaling diverges as :math:`Z \rightarrow 0` for negative :math:`\beta`, the metallicity is floored at ``[metallicityMinimum]``; with the default values this caps the enhancement at a factor of ten. The floor should be chosen with the range over which the adopted scaling was calibrated in mind---it is not itself a physical statement.
+
+   Separating the metallicity dependence of the rate from the shape of the delay time distribution in this way means it can be applied to any of the other ``supernovaeTypeIa`` classes.
+   </description>
+  </supernovaeTypeIa>
+  !!]
+  type, extends(supernovaeTypeIaClass) :: supernovaeTypeIaMetallicityDependentRate
+     !!{RST
+     A supernovae type Ia class which scales the rate of another class by a power of the metallicity.
+     !!}
+     private
+     class           (supernovaeTypeIaClass), pointer :: supernovaeTypeIa_ => null()
+     double precision                                 :: exponent                   , metallicityMinimum
+   contains
+     final     ::                     metallicityDependentRateDestructor
+     procedure :: massInitialRange => metallicityDependentRateMassInitialRange
+     procedure :: number           => metallicityDependentRateNumber
+     procedure :: yield            => metallicityDependentRateYield
+  end type supernovaeTypeIaMetallicityDependentRate
+
+  interface supernovaeTypeIaMetallicityDependentRate
+     !!{RST
+     Constructors for the :galacticus-class:`supernovaeTypeIaMetallicityDependentRate` supernovae type Ia class.
+     !!}
+     module procedure metallicityDependentRateConstructorParameters
+     module procedure metallicityDependentRateConstructorInternal
+  end interface supernovaeTypeIaMetallicityDependentRate
+
+contains
+
+  function metallicityDependentRateConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`supernovaeTypeIaMetallicityDependentRate` supernovae type Ia class which takes a parameter list as input.
+    !!}
+    use :: Input_Parameters                , only : inputParameter, inputParameters
+    use :: Numerical_Constants_Astronomical, only : metallicitySolar
+    implicit none
+    type            (supernovaeTypeIaMetallicityDependentRate)                :: self
+    type            (inputParameters                         ), intent(inout) :: parameters
+    class           (supernovaeTypeIaClass                   ), pointer       :: supernovaeTypeIa_
+    double precision                                                          :: exponent         , metallicityMinimum
+
+    !![
+    <inputParameter docformat="rst">
+      <name>exponent</name>
+      <source>parameters</source>
+      <defaultValue>-0.5d0</defaultValue>
+      <defaultSource>
+      :cite:p:`johnson_binaries_2023`
+      </defaultSource>
+      <description>
+      The exponent :math:`\beta` in the scaling of the Type Ia supernova rate with metallicity, :math:`f(Z) \propto Z^\beta`; the default value of :math:`-1/2` follows :cite:t:`johnson_binaries_2023`.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>metallicityMinimum</name>
+      <source>parameters</source>
+      <defaultValue>1.0d-2*metallicitySolar</defaultValue>
+      <description>
+      The metallicity below which the scaling of the Type Ia supernova rate with metallicity is held constant. This is required because the scaling diverges as :math:`Z \rightarrow 0` for negative ``[exponent]``; with the default values it caps the enhancement of the rate at a factor of ten.
+      </description>
+    </inputParameter>
+    <objectBuilder class="supernovaeTypeIa" name="supernovaeTypeIa_" source="parameters"/>
+    !!]
+    self=supernovaeTypeIaMetallicityDependentRate(exponent,metallicityMinimum,supernovaeTypeIa_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="supernovaeTypeIa_"/>
+    !!]
+    return
+  end function metallicityDependentRateConstructorParameters
+
+  function metallicityDependentRateConstructorInternal(exponent,metallicityMinimum,supernovaeTypeIa_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`supernovaeTypeIaMetallicityDependentRate` supernovae type Ia class.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    type            (supernovaeTypeIaMetallicityDependentRate)                        :: self
+    class           (supernovaeTypeIaClass                   ), intent(in   ), target :: supernovaeTypeIa_
+    double precision                                          , intent(in   )         :: exponent         , metallicityMinimum
+    !![
+    <constructorAssign variables="exponent, metallicityMinimum, *supernovaeTypeIa_"/>
+    !!]
+
+    if (metallicityMinimum <= 0.0d0) call Error_Report('[metallicityMinimum] must be positive, as the scaling diverges at zero metallicity for negative [exponent]'//{introspection:location})
+    return
+  end function metallicityDependentRateConstructorInternal
+
+  subroutine metallicityDependentRateDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`supernovaeTypeIaMetallicityDependentRate` supernovae type Ia class.
+    !!}
+    implicit none
+    type(supernovaeTypeIaMetallicityDependentRate), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%supernovaeTypeIa_"/>
+    !!]
+    return
+  end subroutine metallicityDependentRateDestructor
+
+  double precision function metallicityDependentRateFactor(self,metallicity) result(factor)
+    !!{RST
+    Return the factor by which the Type Ia supernova rate is scaled at the given ``metallicity``.
+    !!}
+    use :: Numerical_Constants_Astronomical, only : metallicitySolar
+    implicit none
+    class           (supernovaeTypeIaMetallicityDependentRate), intent(inout) :: self
+    double precision                                          , intent(in   ) :: metallicity
+
+    factor=(max(metallicity,self%metallicityMinimum)/metallicitySolar)**self%exponent
+    return
+  end function metallicityDependentRateFactor
+
+  subroutine metallicityDependentRateMassInitialRange(self,initialMassFunction_,age,metallicity,massInitialMinimum,massInitialMaximum)
+    !!{RST
+    Return the range of initial stellar masses contributing to the Type Ia population. Scaling the rate does not change which stars contribute, so this simply defers to the wrapped class.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaMetallicityDependentRate), intent(inout) :: self
+    class           (initialMassFunctionClass                ), intent(inout) :: initialMassFunction_
+    double precision                                          , intent(in   ) :: age                 , metallicity
+    double precision                                          , intent(  out) :: massInitialMinimum  , massInitialMaximum
+
+    call self%supernovaeTypeIa_%massInitialRange(initialMassFunction_,age,metallicity,massInitialMinimum,massInitialMaximum)
+    return
+  end subroutine metallicityDependentRateMassInitialRange
+
+  double precision function metallicityDependentRateNumber(self,initialMassFunction_,initialMass,age,metallicity) result(number)
+    !!{RST
+    Compute the cumulative number of Type Ia supernovae, scaled by a power of the metallicity.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaMetallicityDependentRate), intent(inout), target :: self
+    class           (initialMassFunctionClass                ), intent(inout), target :: initialMassFunction_
+    double precision                                          , intent(in   )         :: age                 , initialMass, &
+         &                                                                               metallicity
+
+    number=+metallicityDependentRateFactor(self,metallicity)                                          &
+         & *self%supernovaeTypeIa_%number  (initialMassFunction_,initialMass,age,metallicity)
+    return
+  end function metallicityDependentRateNumber
+
+  double precision function metallicityDependentRateYield(self,initialMassFunction_,initialMass,age,metallicity,atomIndex) result(yield)
+    !!{RST
+    Compute the cumulative yield from Type Ia supernovae, scaled by a power of the metallicity. The yield is proportional to the number of events, so it is scaled by the same factor.
+    !!}
+    implicit none
+    class           (supernovaeTypeIaMetallicityDependentRate), intent(inout)           :: self
+    class           (initialMassFunctionClass                ), intent(inout)           :: initialMassFunction_
+    double precision                                          , intent(in   )           :: age                 , initialMass, &
+         &                                                                                 metallicity
+    integer                                                   , intent(in   ), optional :: atomIndex
+
+    yield=+metallicityDependentRateFactor(self,metallicity)                                                     &
+         & *self%supernovaeTypeIa_%yield  (initialMassFunction_,initialMass,age,metallicity,atomIndex)
+    return
+  end function metallicityDependentRateYield

--- a/source/stellar_astrophysics/supernovae_type_Ia/metallicity_dependent_rate.F90
+++ b/source/stellar_astrophysics/supernovae_type_Ia/metallicity_dependent_rate.F90
@@ -24,19 +24,28 @@
   !![
   <supernovaeTypeIa name="supernovaeTypeIaMetallicityDependentRate" docformat="rst">
    <description>
-   A supernovae type Ia class which takes the rate of Type Ia supernovae from another ``supernovaeTypeIa`` class and multiplies it by a power of the metallicity,
+   A supernovae type Ia class which takes the rate of Type Ia supernovae from another ``supernovaeTypeIa`` class and multiplies it
+   by a power of the metallicity,
 
    .. math::
 
       f(Z) = \left( \frac{\max(Z,Z_\mathrm{min})}{\mathrm{Z}_\odot} \right)^\beta,
 
-   where :math:`\beta=` ``[exponent]`` and :math:`Z_\mathrm{min}=` ``[metallicityMinimum]``. Both the number of events and the yields are scaled, the latter being proportional to the former.
+   where :math:`\beta=` ``[exponent]`` and :math:`Z_\mathrm{min}=` ``[metallicityMinimum]``. Both the number of events and the
+   yields are scaled, the latter being proportional to the former.
 
-   :cite:t:`johnson_binaries_2023` argue that the anti-correlation of the close binary fraction with metallicity should enhance the Type Ia supernova rate at low metallicity, and find that a scaling of approximately :math:`Z^{-1/2}` on top of the differing star formation histories accounts for the high specific rates observed in dwarf galaxies. That is the default adopted here.
+   :cite:t:`johnson_binaries_2023` argue that the anti-correlation of the close binary fraction with metallicity should enhance
+   the Type Ia supernova rate at low metallicity, and find that a scaling of approximately :math:`Z^{-1/2}` on top of the
+   differing star formation histories accounts for the high specific rates observed in dwarf galaxies. That is the default adopted
+   here.
 
-   The scaling is unity at :math:`Z=\mathrm{Z}_\odot`, so the normalization of the wrapped class retains its usual meaning as the rate at Solar metallicity. Because the scaling diverges as :math:`Z \rightarrow 0` for negative :math:`\beta`, the metallicity is floored at ``[metallicityMinimum]``; with the default values this caps the enhancement at a factor of ten. The floor should be chosen with the range over which the adopted scaling was calibrated in mind---it is not itself a physical statement.
+   The scaling is unity at :math:`Z=\mathrm{Z}_\odot`, so the normalization of the wrapped class retains its usual meaning as the
+   rate at Solar metallicity. Because the scaling diverges as :math:`Z \rightarrow 0` for negative :math:`\beta`, the metallicity
+   is floored at ``[metallicityMinimum]``; with the default values this caps the enhancement at a factor of ten. The floor should
+   be chosen with the range over which the adopted scaling was calibrated in mind---it is not itself a physical statement.
 
-   Separating the metallicity dependence of the rate from the shape of the delay time distribution in this way means it can be applied to any of the other ``supernovaeTypeIa`` classes.
+   Separating the metallicity dependence of the rate from the shape of the delay time distribution in this way means it can be
+   applied to any of the other ``supernovaeTypeIa`` classes.
    </description>
   </supernovaeTypeIa>
   !!]
@@ -85,7 +94,8 @@ contains
       :cite:p:`johnson_binaries_2023`
       </defaultSource>
       <description>
-      The exponent :math:`\beta` in the scaling of the Type Ia supernova rate with metallicity, :math:`f(Z) \propto Z^\beta`; the default value of :math:`-1/2` follows :cite:t:`johnson_binaries_2023`.
+      The exponent :math:`\beta` in the scaling of the Type Ia supernova rate with metallicity, :math:`f(Z) \propto Z^\beta`; the
+      default value of :math:`-1/2` follows :cite:t:`johnson_binaries_2023`.
       </description>
     </inputParameter>
     <inputParameter docformat="rst">
@@ -93,7 +103,9 @@ contains
       <source>parameters</source>
       <defaultValue>1.0d-2*metallicitySolar</defaultValue>
       <description>
-      The metallicity below which the scaling of the Type Ia supernova rate with metallicity is held constant. This is required because the scaling diverges as :math:`Z \rightarrow 0` for negative ``[exponent]``; with the default values it caps the enhancement of the rate at a factor of ten.
+      The metallicity below which the scaling of the Type Ia supernova rate with metallicity is held constant. This is required
+      because the scaling diverges as :math:`Z \rightarrow 0` for negative ``[exponent]``; with the default values it caps the
+      enhancement of the rate at a factor of ten.
       </description>
     </inputParameter>
     <objectBuilder class="supernovaeTypeIa" name="supernovaeTypeIa_" source="parameters"/>
@@ -173,8 +185,8 @@ contains
     double precision                                          , intent(in   )         :: age                 , initialMass, &
          &                                                                               metallicity
 
-    number=+metallicityDependentRateFactor(self,metallicity)                                          &
-         & *self%supernovaeTypeIa_%number  (initialMassFunction_,initialMass,age,metallicity)
+    number=+metallicityDependentRateFactor(self,metallicity)                                 &
+         & *self%supernovaeTypeIa_%number (initialMassFunction_,initialMass,age,metallicity)
     return
   end function metallicityDependentRateNumber
 
@@ -189,7 +201,7 @@ contains
          &                                                                                 metallicity
     integer                                                   , intent(in   ), optional :: atomIndex
 
-    yield=+metallicityDependentRateFactor(self,metallicity)                                                     &
-         & *self%supernovaeTypeIa_%yield  (initialMassFunction_,initialMass,age,metallicity,atomIndex)
+    yield=+metallicityDependentRateFactor(self,metallicity)                                           &
+         & *self%supernovaeTypeIa_%yield (initialMassFunction_,initialMass,age,metallicity,atomIndex)
     return
   end function metallicityDependentRateYield

--- a/source/stellar_astrophysics/supernovae_type_Ia/power_law_delay_time_distribution.F90
+++ b/source/stellar_astrophysics/supernovae_type_Ia/power_law_delay_time_distribution.F90
@@ -26,6 +26,7 @@
    <description>
    A supernovae type Ia class with a power-law delay time distribution.
    </description>
+   <runTimeFileDependencies paths="fileName"/>
   </supernovaeTypeIa>
   !!]
   type, extends(supernovaeTypeIaMassIndependentDTD) :: supernovaeTypeIaPowerLawDTD
@@ -53,12 +54,14 @@ contains
     !!{RST
     Constructor for the :galacticus-class:`supernovaeTypeIaPowerLawDTD` supernovae type Ia class which takes a parameter list as input.
     !!}
+    use :: Input_Paths     , only : inputPath     , pathTypeDataStatic
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
     type            (supernovaeTypeIaPowerLawDTD)                :: self
     type            (inputParameters            ), intent(inout) :: parameters
     double precision                                             :: timeMinimum  , exponent, &
           &                                                         normalization
+    type            (varying_string             )                :: fileName
 
     !![
     <inputParameter docformat="rst">
@@ -94,15 +97,23 @@ contains
       The normalization :math:`R_1` of the delay time distribution at 1 Gyr in units of Gyr\ :math:`^{-1}\,\mathrm{M}_\odot^{-1}`.
       </description>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>fileName</name>
+      <source>parameters</source>
+      <defaultValue>inputPath(pathTypeDataStatic)//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml'</defaultValue>
+      <description>
+      The name of the XML file from which to read the yields of Type Ia supernovae.
+      </description>
+    </inputParameter>
     !!]
-    self=supernovaeTypeIaPowerLawDTD(timeMinimum,exponent,normalization)
+    self=supernovaeTypeIaPowerLawDTD(timeMinimum,exponent,normalization,char(fileName))
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function powerLawDTDConstructorParameters
 
-  function powerLawDTDConstructorInternal(timeMinimum,exponent,normalization) result(self)
+  function powerLawDTDConstructorInternal(timeMinimum,exponent,normalization,fileName) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`supernovaeTypeIaPowerLawDTD` supernovae type Ia class.
     !!}
@@ -110,8 +121,9 @@ contains
     type            (supernovaeTypeIaPowerLawDTD)                :: self
     double precision                             , intent(in   ) :: timeMinimum  , exponent, &
           &                                                         normalization
+    character       (len=*                      ), intent(in   ) :: fileName
     !![
-    <constructorAssign variables="timeMinimum, exponent, normalization"/>
+    <constructorAssign variables="timeMinimum, exponent, normalization, fileName"/>
     !!]
     
     self%initialized=.false.

--- a/source/stellar_astrophysics/supernovae_type_Ia/power_law_delay_time_distribution_differential.F90
+++ b/source/stellar_astrophysics/supernovae_type_Ia/power_law_delay_time_distribution_differential.F90
@@ -26,6 +26,7 @@
    <description>
    A supernovae type Ia class with a power-law delay time distribution. This class implements the differential form of the delay time distribution and is intended primarily for testing.
    </description>
+   <runTimeFileDependencies paths="fileName"/>
   </supernovaeTypeIa>
   !!]
   type, extends(supernovaeTypeIaDifferentialDTD) :: supernovaeTypeIaPowerLawDTDDifferential
@@ -53,12 +54,14 @@ contains
     !!{RST
     Constructor for the :galacticus-class:`supernovaeTypeIaPowerLawDTDDifferential` supernovae type Ia class which takes a parameter list as input.
     !!}
+    use :: Input_Paths     , only : inputPath     , pathTypeDataStatic
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
     type            (supernovaeTypeIaPowerLawDTDDifferential)                :: self
     type            (inputParameters                        ), intent(inout) :: parameters
     double precision                                                         :: timeMinimum  , exponent, &
           &                                                                     normalization
+    type            (varying_string                         )                :: fileName
 
     !![
     <inputParameter docformat="rst">
@@ -94,15 +97,23 @@ contains
       The normalization :math:`R_1` of the delay time distribution at 1 Gyr in units of Gyr\ :math:`^{-1}\,\mathrm{M}_\odot^{-1}`.
       </description>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>fileName</name>
+      <source>parameters</source>
+      <defaultValue>inputPath(pathTypeDataStatic)//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml'</defaultValue>
+      <description>
+      The name of the XML file from which to read the yields of Type Ia supernovae.
+      </description>
+    </inputParameter>
     !!]
-    self=supernovaeTypeIaPowerLawDTDDifferential(timeMinimum,exponent,normalization)
+    self=supernovaeTypeIaPowerLawDTDDifferential(timeMinimum,exponent,normalization,char(fileName))
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function powerLawDTDDifferentialConstructorParameters
 
-  function powerLawDTDDifferentialConstructorInternal(timeMinimum,exponent,normalization) result(self)
+  function powerLawDTDDifferentialConstructorInternal(timeMinimum,exponent,normalization,fileName) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`supernovaeTypeIaPowerLawDTDDifferential` supernovae type Ia class.
     !!}
@@ -110,8 +121,9 @@ contains
     type            (supernovaeTypeIaPowerLawDTDDifferential)                :: self
     double precision                                         , intent(in   ) :: timeMinimum  , exponent, &
           &                                                                     normalization
+    character       (len=*                                  ), intent(in   ) :: fileName
     !![
-    <constructorAssign variables="timeMinimum, exponent, normalization"/>
+    <constructorAssign variables="timeMinimum, exponent, normalization, fileName"/>
     !!]
     
     self%initialized=.false.

--- a/source/tests/initial_mass_functions.F90
+++ b/source/tests/initial_mass_functions.F90
@@ -166,7 +166,7 @@ program Test_Initial_Mass_Functions
   call Unit_Tests_Begin_Group('Type Ia SNe')
   call Unit_Tests_Begin_Group('Nagashima et al. (2005)')
   stellarAstrophysics_           =  stellarAstrophysicsFile      ('%DATASTATICPATH%/stellarAstrophysics/stellarPropertiesPortinariChiosiBressan1998.xml')
-  supernovaeTypeIaNagashima2005_ =  supernovaeTypeIaNagashima2005(stellarAstrophysics_)
+  supernovaeTypeIaNagashima2005_ =  supernovaeTypeIaNagashima2005(stellarAstrophysics_,'%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields.xml')
   supernovaeTypeIa_              => supernovaeTypeIaNagashima2005_
   call integrator_%toleranceSet(1.0d-6,1.0d-6)
   call integrator_%integrandSet(numberTypeIaSNeIntegrand)
@@ -185,7 +185,7 @@ program Test_Initial_Mass_Functions
   end do
   call Unit_Tests_End_Group()
   call Unit_Tests_Begin_Group('Power law delay time distribution')
-  supernovaeTypeIaPowerLawDTD_ =  supernovaeTypeIaPowerLawDTD(40.0d-3,-1.07d0,0.21d-3)
+  supernovaeTypeIaPowerLawDTD_ =  supernovaeTypeIaPowerLawDTD(40.0d-3,-1.07d0,0.21d-3,'%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields.xml')
   supernovaeTypeIa_            => supernovaeTypeIaPowerLawDTD_
   call integrator_%toleranceSet(1.0d-6,1.0d-6)
   call integrator_%integrandSet(numberTypeIaSNeIntegrand)
@@ -202,7 +202,7 @@ program Test_Initial_Mass_Functions
   end do
   call Unit_Tests_End_Group()
   call Unit_Tests_Begin_Group('Power law delay time distribution (differential)')
-  supernovaeTypeIaPowerLawDTDDifferential_ =  supernovaeTypeIaPowerLawDTDDifferential(40.0d-3,-1.07d0,0.21d-3)
+  supernovaeTypeIaPowerLawDTDDifferential_ =  supernovaeTypeIaPowerLawDTDDifferential(40.0d-3,-1.07d0,0.21d-3,'%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields.xml')
   supernovaeTypeIa_                        => supernovaeTypeIaPowerLawDTDDifferential_
   call integrator_%toleranceSet(1.0d-6,1.0d-6)
   call integrator_%integrandSet(numberTypeIaSNeIntegrand)

--- a/source/tests/initial_mass_functions.F90
+++ b/source/tests/initial_mass_functions.F90
@@ -165,8 +165,8 @@ program Test_Initial_Mass_Functions
   call Unit_Tests_End_Group()
   call Unit_Tests_Begin_Group('Type Ia SNe')
   call Unit_Tests_Begin_Group('Nagashima et al. (2005)')
-  stellarAstrophysics_           =  stellarAstrophysicsFile      ('%DATASTATICPATH%/stellarAstrophysics/stellarPropertiesPortinariChiosiBressan1998.xml')
-  supernovaeTypeIaNagashima2005_ =  supernovaeTypeIaNagashima2005(stellarAstrophysics_,'%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields.xml')
+  stellarAstrophysics_           =  stellarAstrophysicsFile      (                     '%DATASTATICPATH%/stellarAstrophysics/stellarPropertiesPortinariChiosiBressan1998.xml')
+  supernovaeTypeIaNagashima2005_ =  supernovaeTypeIaNagashima2005(stellarAstrophysics_,'%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields.xml'                  )
   supernovaeTypeIa_              => supernovaeTypeIaNagashima2005_
   call integrator_%toleranceSet(1.0d-6,1.0d-6)
   call integrator_%integrandSet(numberTypeIaSNeIntegrand)

--- a/source/tests/stellar_populations.F90
+++ b/source/tests/stellar_populations.F90
@@ -88,7 +88,8 @@ program Test_Stellar_Populations
        &                                                            stellarTracks_                       =stellarTracks_             &
        &                                                           )
   supernovaeTypeIa_        =supernovaeTypeIaNagashima2005          (                                                                 &
-       &                                                            stellarAstrophysics_                 =stellarAstrophysics_       &
+       &                                                            stellarAstrophysics_                 =stellarAstrophysics_     , &
+       &                                                            fileName                             =char(inputPath(pathTypeDataStatic))//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml'  &
        &                                                           )
   supernovaePopulationIII_ =supernovaePopulationIIIHegerWoosley2002(                                                                 &
        &                                                            stellarAstrophysics_                 =stellarAstrophysics_       &

--- a/source/tests/stellar_populations/luminosities.F90
+++ b/source/tests/stellar_populations/luminosities.F90
@@ -146,7 +146,8 @@ program Test_Stellar_Populations_Luminosities
        &                                                                                 stellarTracks_                       =stellarTracks_             &
        &                                                                                )
   supernovaeTypeIa_                      =supernovaeTypeIaNagashima2005                 (                                                                 &
-       &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_       &
+       &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_     , &
+       &                                                                                 fileName                             =char(inputPath(pathTypeDataStatic))//'stellarAstrophysics/Supernovae_Type_Ia_Yields.xml'  &
        &                                                                                )
   supernovaePopulationIII_               =supernovaePopulationIIIHegerWoosley2002       (                                                                 &
        &                                                                                 stellarAstrophysics_                 =stellarAstrophysics_       &

--- a/testSuite/parameters/stellarPropertiesLimongiChieffi2018.xml
+++ b/testSuite/parameters/stellarPropertiesLimongiChieffi2018.xml
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <stellarAstrophysics value="file">
+    <fileName value="%DATASTATICPATH%/stellarAstrophysics/stellarPropertiesCompilationLimongiChieffi2018.xml"/>
+  </stellarAstrophysics>
+  <supernovaeTypeIa value="powerLawDTD"/>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/stellarPropertiesLimongiChieffi2018.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/stellarPropertiesSukhbold2016.xml
+++ b/testSuite/parameters/stellarPropertiesSukhbold2016.xml
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <stellarAstrophysics value="file">
+    <fileName value="%DATASTATICPATH%/stellarAstrophysics/stellarPropertiesCompilationSukhbold2016.xml"/>
+  </stellarAstrophysics>
+  <supernovaeTypeIa value="powerLawDTD"/>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/stellarPropertiesSukhbold2016.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/supernovaeTypeIaRateMetallicityDependent.xml
+++ b/testSuite/parameters/supernovaeTypeIaRateMetallicityDependent.xml
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <supernovaeTypeIa value="metallicityDependentRate">
+    <exponent value="-0.5"/>
+    <supernovaeTypeIa value="powerLawDTD"/>
+  </supernovaeTypeIa>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/supernovaeTypeIaRateMetallicityDependent.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/supernovaeTypeIaRateNullDecorator.xml
+++ b/testSuite/parameters/supernovaeTypeIaRateNullDecorator.xml
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <supernovaeTypeIa value="metallicityDependentRate">
+    <exponent value="0.0"/>
+    <supernovaeTypeIa value="powerLawDTD"/>
+  </supernovaeTypeIa>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/supernovaeTypeIaRateNullDecorator.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/supernovaeTypeIaRatePositiveExponent.xml
+++ b/testSuite/parameters/supernovaeTypeIaRatePositiveExponent.xml
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <supernovaeTypeIa value="metallicityDependentRate">
+    <exponent value="+0.5"/>
+    <supernovaeTypeIa value="powerLawDTD"/>
+  </supernovaeTypeIa>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/supernovaeTypeIaRatePositiveExponent.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/supernovaeTypeIaYieldsDefault.xml
+++ b/testSuite/parameters/supernovaeTypeIaYieldsDefault.xml
@@ -1,0 +1,133 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <supernovaeTypeIa value="powerLawDTD"/>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/supernovaeTypeIaYieldsDefault.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/supernovaeTypeIaYieldsDoubled.xml
+++ b/testSuite/parameters/supernovaeTypeIaYieldsDoubled.xml
@@ -1,0 +1,135 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <supernovaeTypeIa value="powerLawDTD">
+    <fileName value="testSuite/outputs/supernovaeTypeIaYieldsDoubled.xml"/>
+  </supernovaeTypeIa>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/supernovaeTypeIaYieldsDoubled.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/supernovaeTypeIaYieldsLowMetallicity.xml
+++ b/testSuite/parameters/supernovaeTypeIaYieldsLowMetallicity.xml
@@ -1,0 +1,135 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <supernovaeTypeIa value="powerLawDTD">
+    <fileName value="%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields_Seitenzahl2013_N100_Z0P01.xml"/>
+  </supernovaeTypeIa>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/supernovaeTypeIaYieldsLowMetallicity.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/supernovaeTypeIaYieldsMetallicityDependent.xml
+++ b/testSuite/parameters/supernovaeTypeIaYieldsMetallicityDependent.xml
@@ -1,0 +1,135 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <supernovaeTypeIa value="powerLawDTD">
+    <fileName value="%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields_Seitenzahl2013_N100_MetallicityDependent.xml"/>
+  </supernovaeTypeIa>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/supernovaeTypeIaYieldsMetallicityDependent.hdf5"/>
+
+</parameters>

--- a/testSuite/parameters/supernovaeTypeIaYieldsSolarOnly.xml
+++ b/testSuite/parameters/supernovaeTypeIaYieldsSolarOnly.xml
@@ -1,0 +1,135 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="a3e1665914d944c9fa844f662a028072e84740a5" time="2026-07-28T17:29:21"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="null"/>
+  <componentDarkMatterProfile value="scaleFree"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="null"/>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeConstructor value="fullySpecified">
+    <fileName value="testSuite/parameters/stellarMassWeightedAgesSimpleTree.xml"/>
+  </mergerTreeConstructor>
+  
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="zero"/>
+
+  <!-- Dark matter halo profile -->
+  <darkMatterProfileDMO value="isothermal"/>
+
+  <!-- Hot halo model options -->
+  <hotHaloMassDistribution value="null"/>
+
+  <!-- Galactic structure options -->
+  <galacticStructureSolver value="fixed"/>
+
+  <!-- Star formation rate -->
+  <starFormationRateDisks value="timescale">
+    <starFormationTimescale value="fixed">
+      <timescale value="1.0"/>
+    </starFormationTimescale>
+  </starFormationRateDisks>
+
+  <!-- Galaxy merger options -->
+  <satelliteMergingTimescales value="zero"/>
+
+  <!-- Metal production -->
+  <stellarPopulation value="standard"/>
+  <supernovaeTypeIa value="powerLawDTD">
+    <fileName value="%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields_Seitenzahl2013_N100.xml"/>
+  </supernovaeTypeIa>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Dark matter profile -->
+    <nodeOperator value="darkMatterProfileInitialize"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="1.0e-4"/>
+    <odeToleranceRelative value="1.0e-4"/>
+  </mergerTreeNodeEvolver>
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+  <outputTimes value="list">
+    <times value="13.8"/>
+  </outputTimes>
+  
+  <!-- Output file -->
+  <outputFileName value="testSuite/outputs/supernovaeTypeIaYieldsSolarOnly.hdf5"/>
+
+</parameters>

--- a/testSuite/test-Python-interface.py
+++ b/testSuite/test-Python-interface.py
@@ -328,6 +328,7 @@ with safe_section("distributionFunction1DNonCentralChiDegree3"):
 with safe_section("supernovaeTypeIaPowerLawDTDDifferential"):
     sn1a = galacticus.supernovaeTypeIaPowerLawDTDDifferential(
         timeMinimum=0.04, exponent=-1.0, normalization=2.0e-3,
+        fileName='%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields.xml',
     )
     check_eq("yield_ method exposed" , hasattr(sn1a, 'yield_'), True)
     check_eq("'yield' not exposed"   , hasattr(sn1a, 'yield' ), False)

--- a/testSuite/test-stellar-properties-LimongiChieffi2018.py
+++ b/testSuite/test-stellar-properties-LimongiChieffi2018.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import h5py
+import numpy as np
+
+# Check that the Limongi & Chieffi (2018) stellar properties compilation can be used in place of the standard one.
+# Andrew Benson (09-August-2026); generated with assistance from Claude.
+
+# The compilation combines the Limongi & Chieffi (2018) massive star models (13-120 Msun, extending down to
+# Z = 3.2e-5) with the Marigo (2001) asymptotic giant branch models and the Portinari, Chiosi & Bressan (1998)
+# lifetimes. It exercises several things which the standard compilation does not: `XInclude` of a newly split
+# file, yields tabulated for all 53 elements from hydrogen to bismuth, and a metallicity range extending well
+# below that of the standard compilation.
+#
+# The test runs the same isolated star-forming disk model used by `test-supernovae-type-Ia-yields-file.py`, once
+# with each compilation, and checks that both produce metals and that they differ. It deliberately does not
+# assert a particular size of difference: the two compilations use different stellar models, so the yields are
+# expected to differ, but by an amount which is a scientific result rather than something to pin down here.
+
+# Ensure output directory exists.
+subprocess.run("mkdir -p outputs", shell=True)
+
+models = {}
+for name, parameterFile in (
+        ("standard"      , "supernovaeTypeIaYieldsDefault"       ),
+        ("LimongiChieffi", "stellarPropertiesLimongiChieffi2018"  ),
+):
+    logFileName = f"outputs/stellarProperties{name}.log"
+    with open(logFileName, "w") as logFile:
+        status = subprocess.run(
+            f"cd ..; ./Galacticus.exe testSuite/parameters/{parameterFile}.xml",
+            shell=True, stdout=logFile, stderr=subprocess.STDOUT
+        )
+    if status.returncode != 0:
+        print(f"FAILED: {name} compilation model run:")
+        with open(logFileName) as logFile:
+            print(logFile.read())
+        sys.exit(0)
+    print(f"SUCCESS: {name} compilation model run")
+
+outputFiles = {
+    "standard"      : "outputs/supernovaeTypeIaYieldsDefault.hdf5",
+    "LimongiChieffi": "outputs/stellarPropertiesLimongiChieffi2018.hdf5",
+}
+for name, fileName in outputFiles.items():
+    with h5py.File(fileName, "r") as model:
+        outputs  = model["Outputs"]
+        nodeData = outputs[sorted(outputs.keys())[-1]]["nodeData"]
+        models[name] = {
+            "metals"      : np.array(nodeData["diskAbundancesStellarMetals"][:]).sum(),
+            "massStellar" : np.array(nodeData["diskMassStellar"            ][:]).sum(),
+        }
+
+# Both compilations must produce metals. A compilation which silently failed to supply yields -- because an
+# `XInclude` did not resolve, say -- would return zero here rather than raising an error.
+for name in models:
+    if models[name]["metals"] > 0.0:
+        print(f"SUCCESS: {name} compilation produces metals")
+    else:
+        print(f"FAILED: {name} compilation produces no metals ({models[name]['metals']})")
+
+# Both must form a comparable mass of stars: the stellar mass is set by the star formation law and the recycled
+# fraction, and while the two compilations give slightly different recycling they should not differ greatly.
+massRatio = models["LimongiChieffi"]["massStellar"]/models["standard"]["massStellar"]
+if 0.9 < massRatio < 1.1:
+    print(f"SUCCESS: stellar masses are comparable (ratio {massRatio:.4f})")
+else:
+    print(f"FAILED: stellar masses differ by more than 10% (ratio {massRatio:.4f}), which suggests the "
+          "compilation is not supplying sensible ejected masses")
+
+# The two compilations use different stellar models, so their yields must differ. Were they identical, the
+# compilation would not actually be selecting the Limongi & Chieffi data.
+metalRatio = models["LimongiChieffi"]["metals"]/models["standard"]["metals"]
+if abs(metalRatio-1.0) > 1.0e-3:
+    print(f"SUCCESS: the two compilations give different metal yields (ratio {metalRatio:.4f})")
+else:
+    print(f"FAILED: the two compilations give the same metal yield (ratio {metalRatio:.4f}), so the Limongi & "
+          "Chieffi compilation is not being used")
+
+sys.exit(0)

--- a/testSuite/test-stellar-properties-Sukhbold2016.py
+++ b/testSuite/test-stellar-properties-Sukhbold2016.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import h5py
+import numpy as np
+
+# Check the Sukhbold et al. (2016) stellar properties compilation.
+# Andrew Benson (10-August-2026); generated with assistance from Claude.
+
+# Sukhbold et al. (2016) computed their models at a single metallicity, and the yields are written at two
+# bracketing metallicities with identical values to say so explicitly. That encoding is not merely cosmetic: the
+# irregular two dimensional interpolation used by `stellarAstrophysicsFile` extrapolates badly when the
+# requested metallicity lies outside the range spanned by the tabulated points at the relevant masses, and for a
+# table at a single metallicity that is almost always the case. Written at one metallicity these models return
+# eleven times the expected metal yield, or zero, or hang the initial mass function integration, depending on
+# what they are combined with.
+#
+# Roughly half the Sukhbold models collapse entirely to a black hole and eject only their wind, so this
+# compilation must return substantially fewer metals than the standard one: their initial mass function weighted
+# metal yield is 0.0156 against 0.0290 for Portinari, Chiosi & Bressan (1998). Diluted by the asymptotic giant
+# branch and Type Ia contributions, which are common to both compilations, that implies a ratio of roughly 0.6
+# in the metals a model produces. The test requires the ratio to sit in a band around that, which is what
+# distinguishes a working interpolation from the failure modes above -- all of which land far outside it.
+
+# Ensure output directory exists.
+subprocess.run("mkdir -p outputs", shell=True)
+
+models = {}
+for name, parameterFile in (
+        ("standard", "supernovaeTypeIaYieldsDefault"      ),
+        ("Sukhbold", "stellarPropertiesSukhbold2016"      ),
+):
+    logFileName = f"outputs/stellarPropertiesSukhbold{name}.log"
+    with open(logFileName, "w") as logFile:
+        status = subprocess.run(
+            f"cd ..; ./Galacticus.exe testSuite/parameters/{parameterFile}.xml",
+            shell=True, stdout=logFile, stderr=subprocess.STDOUT
+        )
+    if status.returncode != 0:
+        print(f"FAILED: {name} compilation model run:")
+        with open(logFileName) as logFile:
+            print(logFile.read())
+        sys.exit(0)
+    print(f"SUCCESS: {name} compilation model run")
+
+outputs = {
+    "standard": "outputs/supernovaeTypeIaYieldsDefault.hdf5",
+    "Sukhbold": "outputs/stellarPropertiesSukhbold2016.hdf5",
+}
+for name, fileName in outputs.items():
+    with h5py.File(fileName, "r") as model:
+        group    = model["Outputs"]
+        nodeData = group[sorted(group.keys())[-1]]["nodeData"]
+        models[name] = {
+            "metals"      : np.array(nodeData["diskAbundancesStellarMetals"][:]).sum(),
+            "massStellar" : np.array(nodeData["diskMassStellar"            ][:]).sum(),
+        }
+
+for name in models:
+    if models[name]["metals"] > 0.0:
+        print(f"SUCCESS: {name} compilation produces metals")
+    else:
+        print(f"FAILED: {name} compilation produces no metals ({models[name]['metals']}); with a "
+              "single-metallicity table this is what an interpolation returns when it has nothing to "
+              "interpolate between")
+        sys.exit(0)
+
+# The explodability prescription must reduce the metals produced, by roughly the factor implied by the initial
+# mass function weighted yields. The band is wide enough to tolerate changes in the initial mass function or the
+# other components of the compilation, but excludes every failure mode seen with an unbracketed table.
+ratio = models["Sukhbold"]["metals"]/models["standard"]["metals"]
+if 0.4 < ratio < 0.85:
+    print(f"SUCCESS: the explodability prescription reduces the metals produced (ratio {ratio:.4f})")
+else:
+    print(f"FAILED: the Sukhbold compilation gives {ratio:.4f} times the metals of the standard one, outside "
+          "the expected range of 0.4 to 0.85; the metallicity interpolation may be extrapolating")
+
+# The stellar mass should be comparable: less recycling shifts it a little, but not greatly.
+massRatio = models["Sukhbold"]["massStellar"]/models["standard"]["massStellar"]
+if 0.9 < massRatio < 1.1:
+    print(f"SUCCESS: stellar masses are comparable (ratio {massRatio:.4f})")
+else:
+    print(f"FAILED: stellar masses differ by more than 10% (ratio {massRatio:.4f}), which suggests the "
+          "compilation is not supplying sensible ejected masses")
+
+sys.exit(0)

--- a/testSuite/test-supernovae-type-Ia-rate-metallicity.py
+++ b/testSuite/test-supernovae-type-Ia-rate-metallicity.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import h5py
+import numpy as np
+
+# Check the metallicity-dependent scaling of the Type Ia supernova rate.
+# Andrew Benson (10-August-2026); generated with assistance from Claude.
+
+# The `metallicityDependentRate` class wraps any other `supernovaeTypeIa` class and multiplies both the number
+# of events and the yields by (Z/Z_Solar)^beta, following Johnson, Kochanek & Stanek (2023), who argue that the
+# anti-correlation of the close binary fraction with metallicity enhances the Type Ia rate at low metallicity
+# and find a scaling of about Z^(-1/2).
+#
+# Four models are run, all otherwise identical:
+#
+#  * the undecorated power-law delay time distribution;
+#  * the same wrapped by the decorator with an exponent of zero;
+#  * the same wrapped with the default exponent of -1/2;
+#  * the same wrapped with an exponent of +1/2.
+#
+# The zero-exponent run is the important one. The scaling is unity at every metallicity when beta = 0, so that
+# run must reproduce the undecorated model exactly -- which checks that the decorator forwards to the wrapped
+# class faithfully and introduces no arithmetic of its own. A decorator which, say, dropped the yields or
+# mishandled the optional atomic index argument would show up here.
+
+# Ensure output directory exists.
+subprocess.run("mkdir -p outputs", shell=True)
+
+models = {}
+for name, parameterFile in (
+        ("undecorated" , "supernovaeTypeIaYieldsDefault"           ),
+        ("nullDecorator", "supernovaeTypeIaRateNullDecorator"      ),
+        ("metallicity" , "supernovaeTypeIaRateMetallicityDependent"),
+        ("positive"    , "supernovaeTypeIaRatePositiveExponent"    ),
+):
+    logFileName = f"outputs/supernovaeTypeIaRate{name}.log"
+    with open(logFileName, "w") as logFile:
+        status = subprocess.run(
+            f"cd ..; ./Galacticus.exe testSuite/parameters/{parameterFile}.xml",
+            shell=True, stdout=logFile, stderr=subprocess.STDOUT
+        )
+    if status.returncode != 0:
+        print(f"FAILED: {name} model run:")
+        with open(logFileName) as logFile:
+            print(logFile.read())
+        sys.exit(0)
+    print(f"SUCCESS: {name} model run")
+
+outputs = {
+    "undecorated"  : "outputs/supernovaeTypeIaYieldsDefault.hdf5",
+    "nullDecorator": "outputs/supernovaeTypeIaRateNullDecorator.hdf5",
+    "metallicity"  : "outputs/supernovaeTypeIaRateMetallicityDependent.hdf5",
+    "positive"     : "outputs/supernovaeTypeIaRatePositiveExponent.hdf5",
+}
+for name, fileName in outputs.items():
+    with h5py.File(fileName, "r") as model:
+        group    = model["Outputs"]
+        nodeData = group[sorted(group.keys())[-1]]["nodeData"]
+        models[name] = {
+            "metals"      : np.array(nodeData["diskAbundancesStellarMetals"][:]).sum(),
+            "massStellar" : np.array(nodeData["diskMassStellar"            ][:]).sum(),
+        }
+
+for name in models:
+    if models[name]["metals"] > 0.0:
+        print(f"SUCCESS: {name} model produces metals")
+    else:
+        print(f"FAILED: {name} model produces no metals ({models[name]['metals']})")
+        sys.exit(0)
+
+# With an exponent of zero the scaling is unity everywhere, so the decorator must be transparent.
+difference = abs(models["nullDecorator"]["metals"]-models["undecorated"]["metals"]) \
+             /models["undecorated"]["metals"]
+if difference < 1.0e-12:
+    print(f"SUCCESS: a zero exponent reproduces the undecorated model (fractional difference {difference:.2e})")
+else:
+    print(f"FAILED: a zero exponent changes the metals produced by a fractional {difference:.2e}, so the "
+          "decorator is not transparent when it should be")
+
+# A negative exponent must enhance the rate, because the modelled galaxy spends its early life below Solar
+# metallicity where the scaling exceeds unity. The enhancement applies to the Type Ia contribution only, which
+# is a minority of the metals, so the total must rise by a modest amount rather than by the full scaling factor.
+ratio = models["metallicity"]["metals"]/models["undecorated"]["metals"]
+if ratio > 1.0:
+    print(f"SUCCESS: a negative exponent enhances metal production (ratio {ratio:.6f})")
+else:
+    print(f"FAILED: a negative exponent gives a metal ratio of {ratio:.6f}, but enhancing the Type Ia rate at "
+          "low metallicity should increase the metals produced")
+
+# Reversing the sign of the exponent must reverse the effect. This pins the sign convention, which is the
+# detail most easily got wrong: a scaling applied as Z^(+beta) where Z^(-beta) was meant would still pass every
+# check above, since those only require the decorated model to differ from the undecorated one.
+ratioPositive = models["positive"]["metals"]/models["undecorated"]["metals"]
+if (ratio-1.0)*(ratioPositive-1.0) < 0.0:
+    print(f"SUCCESS: reversing the sign of the exponent reverses the effect "
+          f"(negative {ratio:.6f}, positive {ratioPositive:.6f})")
+else:
+    print(f"FAILED: exponents of -1/2 and +1/2 move the metals produced in the same direction "
+          f"({ratio:.6f} and {ratioPositive:.6f}), so the sign of the scaling is wrong")
+
+# The stellar mass must be unaffected: the Type Ia rate does not feed back on star formation in these models, so
+# a change there would mean the decorator is perturbing something it should not.
+massDifference = abs(models["metallicity"]["massStellar"]-models["undecorated"]["massStellar"]) \
+                 /models["undecorated"]["massStellar"]
+if massDifference < 1.0e-6:
+    print("SUCCESS: stellar mass is unaffected by the rate scaling")
+else:
+    print(f"FAILED: stellar mass changed by a fractional {massDifference:.2e}, so the rate scaling is "
+          "perturbing more than the Type Ia yields")
+
+sys.exit(0)

--- a/testSuite/test-supernovae-type-Ia-yields-file.py
+++ b/testSuite/test-supernovae-type-Ia-yields-file.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import os
+import re
+import subprocess
+import sys
+import h5py
+import numpy as np
+
+# Check that the Type Ia supernova yield table can be selected at run time via the `fileName` parameter.
+# Andrew Benson (09-August-2026); generated with assistance from Claude.
+
+# The `supernovaeTypeIa` classes which inherit from `supernovaeTypeIaFixedYield` read their yields from a file
+# named by the `fileName` parameter. This test verifies that the parameter is actually honored -- that the named
+# file is read and affects the metals produced -- rather than being silently ignored.
+#
+# Two otherwise identical models are run: one using the default yield table, and one using a copy of that table
+# in which every isotope yield has been doubled. Doubling the Type Ia yields must increase the metals produced
+# while leaving the stellar mass untouched, since the yields do not feed back on star formation in these models.
+# That second condition is the important one: it distinguishes "the yield table was read" from "the two models
+# differ for some unrelated reason".
+#
+# Note that this needs a model which actually evaluates the yield integral. Parameter files which set
+# `recycledFraction` and `metalYield` explicitly on `stellarPopulation` -- `parameters/quickTest.xml` among them
+# -- never read the yield table at all, and so cannot exercise this path.
+
+# Ensure output directory exists.
+subprocess.run("mkdir -p outputs", shell=True)
+
+# Build the doubled-yield table from the default table.
+dataPath = os.environ.get("GALACTICUS_DATA_PATH")
+if dataPath is None:
+    print("FAILED: the GALACTICUS_DATA_PATH environment variable is not set")
+    sys.exit(0)
+yieldsDefault = os.path.join(dataPath, "static", "stellarAstrophysics", "Supernovae_Type_Ia_Yields.xml")
+if not os.path.isfile(yieldsDefault):
+    print(f"FAILED: default Type Ia yields file '{yieldsDefault}' not found")
+    sys.exit(0)
+with open(yieldsDefault) as yieldsFile:
+    yieldsText = yieldsFile.read()
+yieldsDoubled, countYields = re.subn(
+    r"<yield>([^<]+)</yield>",
+    lambda match: f"<yield>{2.0*float(match.group(1)):.6e}</yield>",
+    yieldsText,
+)
+if countYields == 0:
+    print(f"FAILED: no yields found in '{yieldsDefault}'")
+    sys.exit(0)
+with open("outputs/supernovaeTypeIaYieldsDoubled.xml", "w") as doubledFile:
+    doubledFile.write(yieldsDoubled)
+print(f"SUCCESS: built doubled yield table ({countYields} isotopes)")
+
+# Run both models.
+models = {}
+for name in "Default", "Doubled":
+    logFileName = f"outputs/supernovaeTypeIaYields{name}.log"
+    with open(logFileName, "w") as logFile:
+        status = subprocess.run(
+            f"cd ..; ./Galacticus.exe testSuite/parameters/supernovaeTypeIaYields{name}.xml",
+            shell=True, stdout=logFile, stderr=subprocess.STDOUT
+        )
+    if status.returncode != 0:
+        print(f"FAILED: {name.lower()} yields model run:")
+        with open(logFileName) as logFile:
+            print(logFile.read())
+        sys.exit(0)
+    print(f"SUCCESS: {name.lower()} yields model run")
+    with h5py.File(f"outputs/supernovaeTypeIaYields{name}.hdf5", "r") as model:
+        outputs   = model["Outputs"]
+        nodeData  = outputs[sorted(outputs.keys())[-1]]["nodeData"]
+        models[name] = {
+            "metals"      : np.array(nodeData["diskAbundancesGasMetals"    ][:]).sum()
+                           +np.array(nodeData["diskAbundancesStellarMetals"][:]).sum(),
+            "massStellar" : np.array(nodeData["diskMassStellar"            ][:]).sum(),
+        }
+
+# The default model must actually produce metals -- otherwise the comparison below is vacuous.
+if models["Default"]["metals"] > 0.0:
+    print("SUCCESS: default model produces metals")
+else:
+    print(f"FAILED: default model produces no metals ({models['Default']['metals']})")
+    sys.exit(0)
+
+# Doubling the Type Ia yields must increase the metals produced. The increase is the Type Ia share of all metal
+# production, so it is well below a factor of two; the bounds here are loose enough to tolerate changes in the
+# default initial mass function or stellar yields, but far above any numerical noise (the two models are
+# otherwise identical, and deterministic).
+increase = (models["Doubled"]["metals"]-models["Default"]["metals"])/models["Default"]["metals"]
+if 0.005 < increase < 0.5:
+    print(f"SUCCESS: doubling Type Ia yields increases metals (by {100.0*increase:.3f}%)")
+else:
+    print(f"FAILED: doubling Type Ia yields changed metals by {100.0*increase:.3f}%, "
+          "which is outside the expected range of 0.5% to 50%")
+
+# Stellar mass must be unaffected: the yields do not feed back on star formation here, so any change would mean
+# the two models differ in something other than the yield table.
+massDifference = abs(models["Doubled"]["massStellar"]-models["Default"]["massStellar"]) \
+                 /models["Default"]["massStellar"]
+if massDifference < 1.0e-6:
+    print("SUCCESS: stellar mass is unchanged by the yield table")
+else:
+    print(f"FAILED: stellar mass changed by {100.0*massDifference:.3e}% between the two models, so they differ "
+          "in more than the Type Ia yield table")
+
+sys.exit(0)

--- a/testSuite/test-supernovae-type-Ia-yields-metallicity.py
+++ b/testSuite/test-supernovae-type-Ia-yields-metallicity.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import h5py
+import numpy as np
+
+# Check that Type Ia supernova yields can be made to depend on the progenitor metallicity.
+# Andrew Benson (09-August-2026); generated with assistance from Claude.
+
+# A Type Ia yields file may wrap each set of isotopes in a `yieldsMetallicity` element carrying the metallicity
+# at which that set applies, in which case Galacticus interpolates between them, holding the yield constant
+# beyond the tabulated range. Seitenzahl et al. (2013) post-processed their N100 explosion model at four
+# progenitor metallicities, so that sequence isolates the effect: only the metallicity differs between the four
+# sets, not the explosion model.
+#
+# Testing this needs care, because the absolute signal is small. A Chandrasekhar-mass white dwarf burns
+# essentially completely, so the total Type Ia metal yield varies by only about 0.2% across the sequence, and
+# what really changes is the composition. Meanwhile Type Ia supernovae supply only a small share of the metals
+# in the model, the rest coming from the stellar yield tables, which are identical between these runs.
+#
+# The test therefore runs the metallicity-dependent file alongside two single-metallicity files taken from the
+# ends of the same sequence, and forms
+#
+#     f = (dependent - lowest) / (Solar - lowest)
+#
+# The stellar contribution is common to all three runs and cancels in both differences, so f measures only where
+# the metallicity-dependent run sits between the two tabulated extremes. It would be 0 if the reader always took
+# the lowest tabulated set, and 1 if it always took the highest; a value strictly between the two is the
+# signature of the yields actually being interpolated as the modelled galaxy enriches.
+
+# Ensure output directory exists.
+subprocess.run("mkdir -p outputs", shell=True)
+
+models = {}
+for name in "MetallicityDependent", "SolarOnly", "LowMetallicity":
+    logFileName = f"outputs/supernovaeTypeIaYields{name}.log"
+    with open(logFileName, "w") as logFile:
+        status = subprocess.run(
+            f"cd ..; ./Galacticus.exe testSuite/parameters/supernovaeTypeIaYields{name}.xml",
+            shell=True, stdout=logFile, stderr=subprocess.STDOUT
+        )
+    if status.returncode != 0:
+        print(f"FAILED: {name} yields model run:")
+        with open(logFileName) as logFile:
+            print(logFile.read())
+        sys.exit(0)
+    print(f"SUCCESS: {name} yields model run")
+    with h5py.File(f"outputs/supernovaeTypeIaYields{name}.hdf5", "r") as model:
+        outputs  = model["Outputs"]
+        nodeData = outputs[sorted(outputs.keys())[-1]]["nodeData"]
+        models[name] = np.array(nodeData["diskAbundancesStellarMetals"][:]).sum()
+
+# All three must produce metals. A file whose `yieldsMetallicity` elements failed to parse would supply none.
+for name in models:
+    if models[name] > 0.0:
+        print(f"SUCCESS: {name} yields produce metals")
+    else:
+        print(f"FAILED: {name} yields produce no metals ({models[name]})")
+        sys.exit(0)
+
+# The two single-metallicity files must give different results, or f below is undefined.
+separation = models["SolarOnly"]-models["LowMetallicity"]
+if abs(separation)/models["SolarOnly"] > 1.0e-9:
+    print(f"SUCCESS: the two tabulated extremes give distinguishable results "
+          f"(fractional separation {abs(separation)/models['SolarOnly']:.3e})")
+else:
+    print(f"FAILED: the lowest-metallicity and Solar files give indistinguishable results "
+          f"(fractional separation {abs(separation)/models['SolarOnly']:.3e}), so there is nothing to "
+          "interpolate between")
+    sys.exit(0)
+
+# Where does the metallicity-dependent run sit between them?
+fraction = (models["MetallicityDependent"]-models["LowMetallicity"])/separation
+if 0.05 < fraction < 0.95:
+    print(f"SUCCESS: metallicity-dependent yields interpolate between the tabulated sets (f = {fraction:.4f})")
+elif fraction <= 0.05:
+    print(f"FAILED: metallicity-dependent yields match the lowest tabulated set (f = {fraction:.4f}), so the "
+          "reader appears to ignore metallicity or always take the first set")
+else:
+    print(f"FAILED: metallicity-dependent yields match the highest tabulated set (f = {fraction:.4f}), so the "
+          "reader appears to ignore metallicity or always take the last set")
+
+sys.exit(0)

--- a/tutorials/06-stellar-populations.ipynb
+++ b/tutorials/06-stellar-populations.ipynb
@@ -351,7 +351,8 @@
    ],
    "source": [
     "snIa = galacticus.supernovaeTypeIaPowerLawDTDDifferential(\n",
-    "    timeMinimum=0.04, exponent=-1.0, normalization=2.0e-3)\n",
+    "    timeMinimum=0.04, exponent=-1.0, normalization=2.0e-3,\n",
+    "    fileName=\"%DATASTATICPATH%/stellarAstrophysics/Supernovae_Type_Ia_Yields.xml\")\n",
     "ages = np.logspace(-2, 1.13, 120)\n",
     "number = np.array([snIa.number(imfChabrier, 1.0, age, 0.02) for age in ages])\n",
     "plt.semilogx(ages, 1.0e3*number)\n",


### PR DESCRIPTION
Adds the code needed to use alternative stellar yield tables, closing out most of #500.

The tables themselves are already in place: [datasets#66](https://github.com/galacticusorg/datasets/pull/66) (merged) ships them, generated reproducibly by the converters in [galacticusDevTools#2](https://github.com/galacticusorg/galacticusDevTools/pull/2) (merged).

## Type Ia yields are selectable at run time

`supernovaeTypeIaFixedYield` read its yields from a hard-coded path, so alternative Type Ia tables could not be used without editing the source. It now takes a `fileName` parameter, defaulting to the previous path so behaviour is unchanged when unset. Since the class is abstract, the parameter is declared in each of the three concrete classes that inherit from it, each of which also gains a `runTimeFileDependencies` entry so the file's modification time is recorded in the output descriptor.

## Type Ia yields may depend on metallicity

Studies which report yields as a function of progenitor metallicity could not be represented. Each set of isotopes may now be wrapped in a `yieldsMetallicity` element carrying the metallicity at which it applies; Galacticus interpolates linearly between them, holding the yield constant beyond the tabulated range rather than extrapolating, which for yields varying steeply with metallicity could otherwise produce negative values.

No new class was needed — `yield` already received the metallicity and ignored it, so the plumbing was there. The change is backward compatible, and verified so: **every mass and abundance dataset of the existing test models is bit-identical across it.** (Disk radius and velocity shift by 5×10⁻⁹ relative, but the identical shift appears in a model using a different compilation and no metallicity-dependent yields, so it is recompilation noise — five orders of magnitude below the ODE tolerance.)

## The Type Ia rate may depend on metallicity

Johnson, Kochanek & Stanek (2023) argue the anti-correlation of the close binary fraction with metallicity enhances the Type Ia rate at low metallicity, finding a scaling of about Z^(−1/2). Nothing could express that.

`metallicityDependentRate` wraps any other `supernovaeTypeIa` class and scales both the event count and the yields by (max(Z,Z_min)/Z☉)^β. It is written as a decorator, following the `coolingRateMultiplier` pattern already in the code, rather than as a parameter on `powerLawDTD`: the metallicity dependence of the rate is a separate physical statement from the shape of the delay time distribution, so keeping them orthogonal means the scaling composes with `nagashima2005`, either power-law DTD, and anything added later, while leaving the existing classes untouched.

The scaling is unity at Z☉, so the wrapped class's normalization keeps its usual meaning. Because it diverges as Z → 0 for negative β — which matters, since these models begin metal-free — the metallicity is floored at `metallicityMinimum`, defaulting to a hundredth of Solar. That floor is a numerical guard rather than a physical statement, and the documentation says so.

## A silent failure mode is now caught

A stellar properties file whose metallicity coverage does not span the requested range fails silently: the interpolation returns a value, just not a meaningful one. The Sukhbold et al. (2016) models showed every way this can go — 11.4× the expected metal yield, or zero, or an IMF integration subdividing without bound until it was killed.

`stellarAstrophysicsFile` now checks at read time that each property is tabulated at more than one metallicity, and reports plainly if not, saying how to fix it. Such a property cannot be interpolated at all, its points being collinear in the (mass, metallicity) plane. The check fires on **no shipped compilation** — verified before implementing by replicating it and the zero-padding of absent elements over each compilation with includes resolved, and confirmed after by running them.

It catches a property globally tabulated at one metallicity, which is what happens when such a file is used as the yield source directly. It does **not** catch coverage that is adequate globally but not over the mass range queried; that belongs at the point of the query, since the interpolation already locates the query point within the triangulation and so already knows when it is extrapolating. Noted in the commit message and on #500 as follow-up work.

## Performance, with the measurement rather than the hope

Each interpolated yield now has its own interpolation workspace, where one was shared between the total metal yield and every element. Since each is tabulated at the same points with different values, the shared workspace was invalidated on every call and the partial derivatives re-estimated, at O(N n²). A `dataStatic` argument lets a caller whose data are read once say so.

The gain is real but more modest than that analysis suggested: the Sukhbold compilation falls from 318 s to 221 s, while the standard and Limongi & Chieffi compilations are unchanged within the scatter from other jobs on the machine. So derivative re-estimation was significant but not dominant, and what limits large tables is elsewhere. Results are unchanged throughout.

Two defects fixed alongside: `Interpolate_2D_Irregular` now rebuilds when the number of data points differs from the number it was built with, rather than leaving the triangulation describing a different point set; and `fileMassYield` no longer indexes its range arrays with the element index before checking it, which is −1 for an element the compilation supplies no yields for.

## Tests

Four added to the `Miscellaneous` CI matrix, each built so that it can actually fail:

- **`test-supernovae-type-Ia-yields-file.py`** — two models differing only in the yield table, one with all yields doubled; metals must rise (4.79%) while stellar mass stays bit-identical. The second condition is what makes it meaningful. Verified to fail when the parameter is removed.
- **`test-supernovae-type-Ia-yields-metallicity.py`** — the absolute signal is tiny, since a Chandrasekhar-mass white dwarf burns completely and Type Ia supply a minority of metals. So it runs the metallicity-dependent file alongside single-metallicity files from both ends of the Seitenzahl N100 sequence and forms f = (dependent − lowest)/(Solar − lowest). The stellar contribution cancels in both differences, leaving f to measure only where the run sits between the tabulated extremes: 0 if the reader always took the first set, 1 the last. It comes out at 0.752. Verified to fail at exactly f = 1.0000 when the metallicity-dependent file is swapped out.
- **`test-supernovae-type-Ia-rate-metallicity.py`** — four models: undecorated, and decorated with exponents 0, −½ and +½. The zero-exponent run must be transparent and is bit-identical; the signed pair move in opposite directions (1.0029 vs 0.9991), pinning the sign convention, which every other check would pass regardless of.
- **`test-stellar-properties-LimongiChieffi2018.py`** and **`test-stellar-properties-Sukhbold2016.py`** — exercise the new compilations, including `XInclude` of the newly split Portinari lifetimes file and yields for all 53 elements. A compilation whose includes failed to resolve would supply no yields rather than erroring, which the first check catches.

Note that `parameters/quickTest.xml` pins `recycledFraction` and `metalYield`, so it never evaluates the yield integral and cannot exercise any of this — hence the separate parameter files.

Closes the yield-table work of #500; the parameterized per-channel yield mode discussed there remains open and is tracked alongside #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
