### PR TITLE
fix(scripts): resolve version placeholders in names containing digits

### DIFF
--- a/scripts/aux/archive.py
+++ b/scripts/aux/archive.py
@@ -46,19 +46,22 @@ def resolve_versions(link):
     A placeholder is the name of the local variable holding the version, embedded in the URL by string concatenation. It
     appears either wrapped in `char()` (where the URL is assembled from `character` variables) or bare (where it is assembled
     from `varying_string` variables) - normalize to the bare form first so that a single set of patterns handles both.
+
+    The variable name may contain digits after its first character (e.g. `euclidEmulator2Version`), so match it as a full
+    Fortran identifier - a letters-only pattern would silently leave such placeholders unresolved.
     """
-    link = re.sub(r'char\s*\(\s*([a-zA-Z]+Version(?:Major)?)\s*\)', r'\1', link)
+    link = re.sub(r'char\s*\(\s*([a-zA-Z]\w*Version(?:Major)?)\s*\)', r'\1', link)
     def replace_major(match):
         name = match.group(1).lower()
         return dependencies.get(name, {}).get("versionMajor", match.group(0))
-    link = re.sub(r'//([a-zA-Z]+)VersionMajor//', replace_major, link)
+    link = re.sub(r'//([a-zA-Z]\w*)VersionMajor//', replace_major, link)
     # Cloudy tarballs are named for the version prefixed by "c".
     cloudy_version = dependencies.get('cloudy', {}).get('version', '')
     link = re.sub(r'//cloudyVersion//', 'c' + cloudy_version, link)
     def replace_version(match):
         name = match.group(1).lower()
         return dependencies.get(name, {}).get("version", match.group(0))
-    link = re.sub(r'//([a-zA-Z]+)Version//', replace_version, link)
+    link = re.sub(r'//([a-zA-Z]\w*)Version//', replace_version, link)
     return link
 
 # Top-level domains and second-level names reserved by RFC 2606 and RFC 6761 for documentation and testing. These never


### PR DESCRIPTION
## Problem

`scripts/aux/archive.py` reported:

```
UNRESOLVED: https://github.com/miknab/EuclidEmulator2/archive/v//char(euclidEmulator2Version)//.zip
```

## Cause

`resolve_versions()` matched the name of the Fortran variable holding a dependency version as `[a-zA-Z]+`. That cannot match `euclidEmulator2Version` (the digit `2` ends the match), so neither the `char()` unwrapping nor the `//<name>Version//` substitution fired, and the raw Fortran concatenation from `source/structure_formation/power_spectrum/nonlinear/EuclidEmulator2.F90:386` fell through to the unresolved-placeholder check. Since that check makes the script exit non-zero, the archiving run failed. `euclidemulator2` is currently the only dependency whose name contains a digit, which is why nothing else was affected.

## Fix

Match the name as a full Fortran identifier (`[a-zA-Z]\w*`) in all three placeholder patterns, plus a docstring note on why a letters-only pattern is wrong here.

## Verification

Ran the script's extraction stage over the full source tree: 0 unresolved links (was 1), all 14 links resolve as expected, and the other 13 are byte-identical to before the change. The EuclidEmulator2 link now resolves to `https://github.com/miknab/EuclidEmulator2/archive/v1.0.1.zip`, which matches the tag published upstream.

Developed with assistance from Claude Code, and reviewed and verified by @abensonca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)