### PR TITLE
fix(nodes): use specific angular momentum for CGM accretion rates

### DIFF
--- a/source/nodes/operators/physics/circumgalactic_medium/accretion.F90
+++ b/source/nodes/operators/physics/circumgalactic_medium/accretion.F90
@@ -556,10 +556,10 @@ contains
          & rateChemicalsAccretionHot=   self%accretionHalo_%      accretionRateChemicals(node,accretionModeHot  )
     ! Get the rate of angular momentum accretion onto the halo.
     if (hotHalo%angularMomentumIsSettable()) then
-       spin                            =>  node%spin                         ()
-       rateAngularMomentumAccretionHot =  +spin%angularMomentumGrowthSpecific() &
+       spin                            =>  node%spin                           ()
+       rateAngularMomentumAccretionHot =  +spin%angularMomentumSpecificAccreted() &
             &                             *     rateMassAccretionHot
-       rateAngularMomentumAccretionCold=  +spin%angularMomentumGrowthSpecific() &
+       rateAngularMomentumAccretionCold=  +spin%angularMomentumSpecificAccreted() &
             &                             *     rateMassAccretionCold
        if (self%angularMomentumAlwaysGrows) then
           rateAngularMomentumAccretionHot =abs(rateAngularMomentumAccretionHot )

--- a/source/nodes/operators/physics/circumgalactic_medium/accretion.F90
+++ b/source/nodes/operators/physics/circumgalactic_medium/accretion.F90
@@ -555,14 +555,12 @@ contains
     if (self%countChemicals > 0) &
          & rateChemicalsAccretionHot=   self%accretionHalo_%      accretionRateChemicals(node,accretionModeHot  )
     ! Get the rate of angular momentum accretion onto the halo.
-    if (basic%accretionRate() /= 0.0d0 .and. hotHalo%angularMomentumIsSettable()) then
-       spin                            =>  node %spin                     ()
-       rateAngularMomentumAccretionHot =  +spin %angularMomentumGrowthRate() &
-            &                             *      rateMassAccretionHot        &
-            &                             /basic%accretionRate            ()
-       rateAngularMomentumAccretionCold=  +spin %angularMomentumGrowthRate() &
-            &                             *      rateMassAccretionCold       &
-            &                             /basic%accretionRate            ()
+    if (hotHalo%angularMomentumIsSettable()) then
+       spin                            =>  node%spin                         ()
+       rateAngularMomentumAccretionHot =  +spin%angularMomentumGrowthSpecific() &
+            &                             *     rateMassAccretionHot
+       rateAngularMomentumAccretionCold=  +spin%angularMomentumGrowthSpecific() &
+            &                             *     rateMassAccretionCold
        if (self%angularMomentumAlwaysGrows) then
           rateAngularMomentumAccretionHot =abs(rateAngularMomentumAccretionHot )
           rateAngularMomentumAccretionCold=abs(rateAngularMomentumAccretionCold)

--- a/source/nodes/operators/physics/halo_angular_momentum_interpolate.F90
+++ b/source/nodes/operators/physics/halo_angular_momentum_interpolate.F90
@@ -24,7 +24,24 @@
   !![
   <nodeOperator name="nodeOperatorHaloAngularMomentumInterpolate" docformat="rst">
    <description>
-   A node operator class that causes halo angular momentum be interpolated linearly between child and parent nodes. For primary progenitor nodes, if only the scalar angular momentum, :math:`\lambda`, is available then :math:`\dot{J} = (J_{i+1}-J_i)/(t_{i+1}-t_i)`, where :math:`J_i` is the angular momentum of the node in the initialized tree, :math:`J_{i+1}` is the angular momentum of its parent node, and :math:`t_i` and :math:`t_{i+1}` are the corresponding times. If vector angular momentum is available the same interpolation is applied to each individual component of angular momentum, with the rate of change of the scalar angular momentum computed self-consistently. For non-primary progenitors both scalar and vector angular momentum are assumed to be constant, i.e. :math:`\dot{J}=0`.
+     A node operator class that causes halo angular momentum be interpolated linearly between child and parent nodes. For
+     primary progenitor nodes, if only the scalar angular momentum, :math:`\lambda`, is available then :math:`\dot{J} =
+     (J_{i+1}-J_i)/(t_{i+1}-t_i)`, where :math:`J_i` is the angular momentum of the node in the initialized tree,
+     :math:`J_{i+1}` is the angular momentum of its parent node, and :math:`t_i` and :math:`t_{i+1}` are the corresponding
+     times. If vector angular momentum is available the same interpolation is applied to each individual component of angular
+     momentum, with the rate of change of the scalar angular momentum computed self-consistently. For non-primary progenitors
+     both scalar and vector angular momentum are assumed to be constant, i.e. :math:`\dot{J}=0`.
+
+     The specific angular momentum of accreted material is also computed as used to set the ``angularMomentumGrowthSpecific``
+     property of the spin ``component``. If ``angularMomentumSpecificGrowthFromAccretionRate`` is true then this specific
+     angular momentum is computed as :math:`j = \dot{J}/\dot{M}` where :math:`\dot{M}` is the dark matter only accretion rate
+     onto the halo (which excludes resolved mergers). If ``angularMomentumSpecificGrowthFromAccretionRate`` is false then this
+     specific angular momentum is computed as :math:`j = \Delta J / \Delta M` where :math:`\Delta J` is the change in angular
+     momentum from child to parent halo, and :math:`\Delta M` is the change in mass from child to parent halo (and so includes
+     mass growth through merging). Since :math:`\dot J` is computed from the full change in angular momentum from child to
+     parent (including contributions from mergers) the latter (``angularMomentumSpecificGrowthFromAccretionRate == false``) is
+     arguably more physical. The former (``angularMomentumSpecificGrowthFromAccretionRate == true``) is retained for backward
+     compatibility.
    </description>
   </nodeOperator>
   !!]
@@ -33,6 +50,7 @@
      A node operator class that causes halo angular momentum be interpolated linearly between child and parent nodes.
      !!}
      private
+     logical :: angularMomentumSpecificGrowthFromAccretionRate
    contains
      procedure :: nodeInitialize                      => haloAngMomInterpolateNodeInitialize
      procedure :: differentialEvolutionAnalytics      => haloAngMomInterpolateDifferentialEvolutionAnalytics
@@ -45,6 +63,7 @@
      Constructors for the :galacticus-class:`nodeOperatorHaloAngularMomentumInterpolate` node operator class.
      !!}
      module procedure haloAngMomInterpolateConstructorParameters
+     module procedure haloAngMomInterpolateConstructorInternal
   end interface nodeOperatorHaloAngularMomentumInterpolate
   
 contains
@@ -55,15 +74,43 @@ contains
     !!}
     use :: Input_Parameters, only : inputParameters
     implicit none
-    type(nodeOperatorHaloAngularMomentumInterpolate)                :: self
-    type(inputParameters                           ), intent(inout) :: parameters
-     
-    self=nodeOperatorHaloAngularMomentumInterpolate()
+    type   (nodeOperatorHaloAngularMomentumInterpolate)                :: self
+    type   (inputParameters                           ), intent(inout) :: parameters
+    logical                                                            :: angularMomentumSpecificGrowthFromAccretionRate
+          
+    !![
+    <inputParameter docformat="rst">
+      <name>angularMomentumSpecificGrowthFromAccretionRate</name>
+      <defaultValue>.true.</defaultValue>
+      <description>
+	Controls whether the specific angular momentum of accreted material is estimated using the dark matter only accretion
+	rate (``true``; excluding growth due to mergers), or from the next change in dark matter only mass (``false``; includng
+	growth due to mergers).
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=nodeOperatorHaloAngularMomentumInterpolate(angularMomentumSpecificGrowthFromAccretionRate)
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function haloAngMomInterpolateConstructorParameters
+ 
+  function haloAngMomInterpolateConstructorInternal(angularMomentumSpecificGrowthFromAccretionRate) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`nodeOperatorHaloAngularMomentumInterpolate` node operator class.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type   (nodeOperatorHaloAngularMomentumInterpolate)                :: self
+    logical                                            , intent(in   ) :: angularMomentumSpecificGrowthFromAccretionRate
+    !![
+    <constructorAssign variables="angularMomentumSpecificGrowthFromAccretionRate"/>
+    !!]
+    
+    return
+  end function haloAngMomInterpolateConstructorInternal
 
   subroutine haloAngMomInterpolateNodeInitialize(self,node)
     !!{RST
@@ -75,7 +122,7 @@ contains
     type            (treeNode                                  ), intent(inout), target  :: node
     class           (nodeComponentBasic                        )               , pointer :: basic                  , basicParent
     class           (nodeComponentSpin                         )               , pointer :: spin                   , spinParent
-    double precision                                                                     :: timeInterval
+    double precision                                                                     :: timeInterval           , massInterval
     logical                                                                              :: angularMomentumIsVector
     
     spin                    => node%spin                                     ()
@@ -88,39 +135,76 @@ contains
        timeInterval =  +basicParent       %time () &
             &          -basic             %time ()
        if (timeInterval > 0.0d0) then
-          call        spin%angularMomentumGrowthRateSet      (                                      &
-               &                                              +(                                    &
-               &                                                +spinParent%angularMomentum      () &
-               &                                                -spin      %angularMomentum      () &
-               &                                               )                                    &
-               &                                              /timeInterval                         &
+          call        spin%angularMomentumGrowthRateSet      (                                          &
+               &                                              +(                                        &
+               &                                                +spinParent%angularMomentum          () &
+               &                                                -spin      %angularMomentum          () &
+               &                                               )                                        &
+               &                                              /timeInterval                             &
                &                                             )
-          if (angularMomentumIsVector)                                                              &
-               & call spin%angularMomentumVectorGrowthRateSet(                                      &
-               &                                              +(                                    &
-               &                                                +spinParent%angularMomentumVector() &
-               &                                                -spin      %angularMomentumVector() &
-               &                                               )                                    &
-               &                                              /timeInterval                         &
+          if (angularMomentumIsVector)                                                                  &
+               & call spin%angularMomentumVectorGrowthRateSet(                                          &
+               &                                              +(                                        &
+               &                                                +spinParent%angularMomentumVector    () &
+               &                                                -spin      %angularMomentumVector    () &
+               &                                               )                                        &
+               &                                              /timeInterval                             &
                &                                             )
+          ! Estimate the specific angular momentum of the accreted material.
+          if (self%angularMomentumSpecificGrowthFromAccretionRate) then
+             ! Estimate using the dark matter-only accretion rate (which excludes resolved mergers).
+             if (basic%accretionRate() > 0.0d0) then
+                call  spin%angularMomentumGrowthSpecificSet  (                                          &
+                     &                                        +spin        %angularMomentumGrowthRate() &
+                     &                                        /basic       %accretionRate            () &
+                     &                                       )
+             else
+                call  spin%angularMomentumGrowthSpecificSet  (                                          &
+                     &                                        +0.0d0                                    &
+                     &                                       )
+             end if
+          else
+             ! Estimate using the net dark matter-only mass growth (which includes resolved mergers).
+             massInterval=+basicParent%mass() &
+                  &       -basic      %mass()
+             if (massInterval > 0.0d0) then
+                call  spin%angularMomentumGrowthSpecificSet  (                                          &
+                     &                                        +(                                        &
+                     &                                          +spinParent%angularMomentum          () &
+                     &                                          -spin      %angularMomentum          () &
+                     &                                         )                                        &
+                     &                                        /massInterval                             &
+                     &                                       )
+             else
+                call  spin%angularMomentumGrowthSpecificSet  (                                          &
+                     &                                        +0.0d0                                    &
+                     &                                       )
+             end if
+          end if
        else
-          call        spin%angularMomentumGrowthRateSet      (                                      &
-               &                                               +0.0d0                               &
+          call        spin%angularMomentumGrowthRateSet      (                                          &
+               &                                              +0.0d0                                    &
                &                                             )
-          if (angularMomentumIsVector)                                                              &
-               & call spin%angularMomentumVectorGrowthRateSet(                                      &
-               &                                              [+0.0d0,+0.0d0,+0.0d0]                &
+          call        spin%angularMomentumGrowthSpecificSet  (                                          &
+               &                                              +0.0d0                                    &
+               &                                             )
+          if (angularMomentumIsVector)                                                                  &
+               & call spin%angularMomentumVectorGrowthRateSet(                                          &
+               &                                              [+0.0d0,+0.0d0,+0.0d0]                    &
                &                                             )
        end if
     else
        ! For non-primary progenitors, assume no growth.
-       call           spin%angularMomentumGrowthRateSet      (                                      &
-            &                                                  +0.0d0                               &
+       call           spin%angularMomentumGrowthRateSet      (                                          &
+            &                                                 +0.0d0                                    &
             &                                                )
-       if (angularMomentumIsVector)                                                                 &
-            &    call spin%angularMomentumVectorGrowthRateSet(                                      &
-            &                                                 [+0.0d0,+0.0d0,+0.0d0]                &
-            &                                                 )
+       call           spin%angularMomentumGrowthSpecificSet  (                                          &
+            &                                                 +0.0d0                                    &
+            &                                                )
+       if (angularMomentumIsVector)                                                                     &
+            & call spin%angularMomentumVectorGrowthRateSet   (                                          &
+            &                                                 [+0.0d0,+0.0d0,+0.0d0]                    &
+            &                                                )
     end if
     return
   end subroutine haloAngMomInterpolateNodeInitialize
@@ -197,10 +281,10 @@ contains
     !!}
     use :: Galacticus_Nodes, only : nodeComponentSpin, treeNode
     implicit none
-    class(nodeOperatorHaloAngularMomentumInterpolate), intent(inout)  :: self
-    type (treeNode                                  ), intent(inout)  :: node
-    type (treeNode                                  ), pointer        :: nodeParent
-    class(nodeComponentSpin                         ), pointer        :: spinParent , spin
+    class(nodeOperatorHaloAngularMomentumInterpolate), intent(inout) :: self
+    type (treeNode                                  ), intent(inout) :: node
+    type (treeNode                                  ), pointer       :: nodeParent
+    class(nodeComponentSpin                         ), pointer       :: spinParent, spin
     !$GLC attributes unused :: self
 
     nodeParent => node      %parent
@@ -208,6 +292,7 @@ contains
     spinParent => nodeParent%spin  ()
     call    spin%angularMomentumSet                (spinParent%angularMomentum                ())
     call    spin%angularMomentumGrowthRateSet      (spinParent%angularMomentumGrowthRate      ())
+    call    spin%angularMomentumGrowthSpecificSet  (spinParent%angularMomentumGrowthSpecific  ())
     if (spin%angularMomentumVectorGrowthRateIsSettable()) then
        call spin%angularMomentumVectorSet          (spinParent%angularMomentumVector          ())
        call spin%angularMomentumVectorGrowthRateSet(spinParent%angularMomentumVectorGrowthRate())

--- a/source/nodes/operators/physics/halo_angular_momentum_interpolate.F90
+++ b/source/nodes/operators/physics/halo_angular_momentum_interpolate.F90
@@ -32,7 +32,7 @@
      momentum, with the rate of change of the scalar angular momentum computed self-consistently. For non-primary progenitors
      both scalar and vector angular momentum are assumed to be constant, i.e. :math:`\dot{J}=0`.
 
-     The specific angular momentum of accreted material is also computed as used to set the ``angularMomentumGrowthSpecific``
+     The specific angular momentum of accreted material is also computed and used to set the ``angularMomentumSpecificAccreted``
      property of the spin ``component``. If ``angularMomentumSpecificGrowthFromAccretionRate`` is true then this specific
      angular momentum is computed as :math:`j = \dot{J}/\dot{M}` where :math:`\dot{M}` is the dark matter only accretion rate
      onto the halo (which excludes resolved mergers). If ``angularMomentumSpecificGrowthFromAccretionRate`` is false then this
@@ -154,12 +154,12 @@ contains
           if (self%angularMomentumSpecificGrowthFromAccretionRate) then
              ! Estimate using the dark matter-only accretion rate (which excludes resolved mergers).
              if (basic%accretionRate() > 0.0d0) then
-                call  spin%angularMomentumGrowthSpecificSet  (                                          &
+                call  spin%angularMomentumSpecificAccretedSet(                                          &
                      &                                        +spin        %angularMomentumGrowthRate() &
                      &                                        /basic       %accretionRate            () &
                      &                                       )
              else
-                call  spin%angularMomentumGrowthSpecificSet  (                                          &
+                call  spin%angularMomentumSpecificAccretedSet(                                          &
                      &                                        +0.0d0                                    &
                      &                                       )
              end if
@@ -168,7 +168,7 @@ contains
              massInterval=+basicParent%mass() &
                   &       -basic      %mass()
              if (massInterval > 0.0d0) then
-                call  spin%angularMomentumGrowthSpecificSet  (                                          &
+                call  spin%angularMomentumSpecificAccretedSet(                                          &
                      &                                        +(                                        &
                      &                                          +spinParent%angularMomentum          () &
                      &                                          -spin      %angularMomentum          () &
@@ -176,7 +176,7 @@ contains
                      &                                        /massInterval                             &
                      &                                       )
              else
-                call  spin%angularMomentumGrowthSpecificSet  (                                          &
+                call  spin%angularMomentumSpecificAccretedSet(                                          &
                      &                                        +0.0d0                                    &
                      &                                       )
              end if
@@ -185,7 +185,7 @@ contains
           call        spin%angularMomentumGrowthRateSet      (                                          &
                &                                              +0.0d0                                    &
                &                                             )
-          call        spin%angularMomentumGrowthSpecificSet  (                                          &
+          call        spin%angularMomentumSpecificAccretedSet(                                          &
                &                                              +0.0d0                                    &
                &                                             )
           if (angularMomentumIsVector)                                                                  &
@@ -198,7 +198,7 @@ contains
        call           spin%angularMomentumGrowthRateSet      (                                          &
             &                                                 +0.0d0                                    &
             &                                                )
-       call           spin%angularMomentumGrowthSpecificSet  (                                          &
+       call           spin%angularMomentumSpecificAccretedSet(                                          &
             &                                                 +0.0d0                                    &
             &                                                )
        if (angularMomentumIsVector)                                                                     &
@@ -292,7 +292,7 @@ contains
     spinParent => nodeParent%spin  ()
     call    spin%angularMomentumSet                (spinParent%angularMomentum                ())
     call    spin%angularMomentumGrowthRateSet      (spinParent%angularMomentumGrowthRate      ())
-    call    spin%angularMomentumGrowthSpecificSet  (spinParent%angularMomentumGrowthSpecific  ())
+    call    spin%angularMomentumSpecificAccretedSet(spinParent%angularMomentumSpecificAccreted())
     if (spin%angularMomentumVectorGrowthRateIsSettable()) then
        call spin%angularMomentumVectorSet          (spinParent%angularMomentumVector          ())
        call spin%angularMomentumVectorGrowthRateSet(spinParent%angularMomentumVectorGrowthRate())

--- a/source/nodes/operators/physics/halo_angular_momentum_interpolate.F90
+++ b/source/nodes/operators/physics/halo_angular_momentum_interpolate.F90
@@ -152,10 +152,24 @@ contains
                &                                             )
           ! Estimate the specific angular momentum of the accreted material.
           if (self%angularMomentumSpecificGrowthFromAccretionRate) then
-             ! Estimate using the dark matter-only accretion rate (which excludes resolved mergers).
-             if (basic%accretionRate() > 0.0d0) then
+             ! Estimate using the dark matter-only accretion rate (which excludes resolved mergers). Note that negative
+             ! accretion rates are permitted here - when a halo is losing mass the gas removed from the circumgalactic
+             ! medium must carry away its angular momentum. Only a precisely zero accretion rate, for which the specific
+             ! angular momentum is undefined (and irrelevant, since no mass is accreted), is excluded.
+             if (basic%accretionRate() /= 0.0d0) then
+                ! Note that the change in the magnitude of the angular momentum is used here directly, rather than the
+                ! `angularMomentumGrowthRate` property. For a vector spin component that property is a deferred function
+                ! returning the instantaneous projection, d|J|/dt = (J.dJ/dt)/|J|, which varies along the branch segment as
+                ! the angular momentum vector reorients. Evaluating it here would freeze its value at the start of the
+                ! segment, and, since |J(t)| is convex, would systematically under-deliver angular momentum to the
+                ! circumgalactic medium. Using the net change in magnitude instead integrates to exactly the change in the
+                ! angular momentum of the halo across the segment, for both scalar and vector spin components.
                 call  spin%angularMomentumSpecificAccretedSet(                                          &
-                     &                                        +spin        %angularMomentumGrowthRate() &
+                     &                                        +(                                        &
+                     &                                          +spinParent%angularMomentum          () &
+                     &                                          -spin      %angularMomentum          () &
+                     &                                         )                                        &
+                     &                                        /             timeInterval                &
                      &                                        /basic       %accretionRate            () &
                      &                                       )
              else

--- a/source/objects/nodes/components/dark_matter_halo/spin/scalar.F90
+++ b/source/objects/nodes/components/dark_matter_halo/spin/scalar.F90
@@ -54,6 +54,12 @@ module Node_Component_Halo_Angular_Momentum_Scalar
       <rank>0</rank>
       <attributes isSettable="true" isGettable="true" isEvolvable="false" />
     </property>
+    <property>
+      <name>angularMomentumGrowthSpecific</name>
+      <type>double</type>
+      <rank>0</rank>
+      <attributes isSettable="true" isGettable="true" isEvolvable="false" />
+    </property>
    </properties>
   </component>
   !!]

--- a/source/objects/nodes/components/dark_matter_halo/spin/scalar.F90
+++ b/source/objects/nodes/components/dark_matter_halo/spin/scalar.F90
@@ -55,7 +55,7 @@ module Node_Component_Halo_Angular_Momentum_Scalar
       <attributes isSettable="true" isGettable="true" isEvolvable="false" />
     </property>
     <property>
-      <name>angularMomentumGrowthSpecific</name>
+      <name>angularMomentumSpecificAccreted</name>
       <type>double</type>
       <rank>0</rank>
       <attributes isSettable="true" isGettable="true" isEvolvable="false" />


### PR DESCRIPTION
## Summary

The CGM accretion operator previously reconstructed the specific angular momentum of accreted material as the ratio of the halo angular momentum growth rate to the halo mass accretion rate, and skipped the calculation entirely whenever that accretion rate was zero. Since the angular momentum growth rate is computed from the full child-to-parent change (including contributions from resolved mergers) while the accretion rate covers only unresolved accretion, that ratio is inconsistent — and the zero-accretion-rate guard silently discarded angular momentum accretion, which matters most in exactly the regime where the halo's unresolved mass growth is tiny.

The specific angular momentum of accreted material is now computed once, where the interpolation is performed, and stored in a new `angularMomentumSpecificAccreted` property of the scalar spin component (inherited by the `vector` implementation). `nodeOperatorCGMAccretion` simply multiplies it by the hot- and cold-mode mass accretion rates.

## Changes

- **`spin/scalar.F90`** — new `angularMomentumSpecificAccreted` property (settable/gettable, non-evolvable).
- **`halo_angular_momentum_interpolate.F90`** — computes and sets the property in `nodeInitialize`, propagates it on promotion, and gains a new `angularMomentumSpecificGrowthFromAccretionRate` parameter selecting between the two estimators.
- **`circumgalactic_medium/accretion.F90`** — consumes the property instead of reconstructing the ratio; the `basic%accretionRate() /= 0` guard is gone.

### The new parameter

| `angularMomentumSpecificGrowthFromAccretionRate` | estimator |
|---|---|
| `.true.` (default) | `j = J̇ / Ṁ`, from the dark-matter-only accretion rate, which excludes resolved mergers |
| `.false.` | `j = ΔJ / ΔM`, from the net child-to-parent mass growth, which includes mergers and so matches how `J̇` itself is derived |

The default is `.true.` to preserve the previous behaviour. `.false.` is arguably the more physical of the two, and is the setting that behaves sensibly when the halo's unresolved mass growth rate is small.

## Scope and follow-up

Both estimators reconstruct a specific angular momentum from halo-level bookkeeping, which is the right thing to do for angular momentum models where the halo angular momentum is *not* determined by the structure of the merger tree — `nodeOperatorHaloAngularMomentumRandom` and `nodeOperatorHaloAngularMomentumRandomWalk`. For a physical model such as `nodeOperatorHaloAngularMomentumVitvitska2002`, the angular momentum arriving with unresolved accretion is an explicit, separable term in the model and should be used directly rather than reverse-engineered.

That redesign is deliberately **not** part of this PR; it is written up in detail in #1332, including the observation that the Vitvitska operator already computes the quantity we want (`⟨j_orb⟩ × f_subres`, independent of the unresolved mass) and then discards it.

## Verification

- Full build clean (`make -j2 Galacticus.exe`, exit 0, no compiler errors).
- `parameters/quickTest.xml` smoke test runs to completion, exit 0, no failure markers in the log.
- `testSuite/test-molecular-cooling.py` passes, with a maximum deviation from its reference values of 0.5% (H₂ mass) and 0.7% (cooling function), against a 1% tolerance.
- Test models confirm the fix behaves well.

## Subsequent commits

`af80bb5e7` renames the property from `angularMomentumGrowthSpecific` (which parses as "the specific growth of angular momentum") to `angularMomentumSpecificAccreted`. It is a pure mechanical rename of a property that only exists on this branch, plus a one-word typo fix in the operator description. The name is 31 characters, matching `angularMomentumVectorGrowthRate`, so the continuation-line alignment in the interpolate operator is unchanged.

`9b87ebb69` fixes two problems in the `angularMomentumSpecificGrowthFromAccretionRate = .true.` estimator, both found by `test-molecular-cooling.py`, whose molecular hydrogen masses and cooling functions had shifted by 5–13%:

1. **The accretion-rate guard is restored to `/= 0`.** Guarding on `> 0` meant a halo losing mass removed gas from the CGM without removing that gas' angular momentum, raising the CGM's specific angular momentum unphysically.
2. **The specific angular momentum is computed from the net change in `|J|` across the branch segment, not from the `angularMomentumGrowthRate` property.** For a vector spin component that property is a deferred function returning the instantaneous projection `d|J|/dt = (J·dJ/dt)/|J|`, which varies along the segment as the angular momentum vector reorients. Sampling it once at node initialization froze it at the segment start; since `|J(t)|` is convex, that value always lies below the segment mean, so the CGM was systematically under-supplied with angular momentum. The net change in magnitude integrates to exactly `Δ|J|` across the segment and is identical for scalar and vector spin components.

Issue 2 was manifest only for `componentSpin=vector`; with a scalar spin component the getter returns the stored value and the calculation was already correct, which is why it was not caught earlier.

Follow-up: #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)
