### PR TITLE
fix(IO): round chunk dimensions up so that chunks tile the dataset extent

### DIFF
--- a/source/tests/IO/HDF5.F90
+++ b/source/tests/IO/HDF5.F90
@@ -26,7 +26,7 @@ program Tests_IO_HDF5
   use :: HDF5              , only : HSIZE_T
   use :: IO_HDF5           , only : IO_HDF5_Is_HDF5    , hdf5File              , hdf5VarDouble       , hdf5VarInteger8  , &
        &                            hdf5VarDouble2D    , hdf5DataTypeDouble    , hdf5File            , hdf5Group        , &
-       &                            hdf5Dataset
+       &                            hdf5Dataset        , hdf5DataTypeInteger
   use :: ISO_Varying_String, only : assignment(=)      , trim                  , varying_string      , var_str          , &
        &                            char
   use :: Kind_Numbers      , only : kind_int8
@@ -38,7 +38,8 @@ program Tests_IO_HDF5
        &                                                                       integerValueReread               , i                             , &
        &                                                                       j                                , k
   logical                                                                   :: appendableOK
-  integer                                                                   :: unitsStatus                      , attributesStatus
+  integer                                                                   :: unitsStatus                      , attributesStatus              , &
+       &                                                                       chunkingStatus
   type            (unitType       )                                         :: unitsValue
   integer                                       , dimension(10)             :: integerValueArray
   integer                                       , dimension(10)             :: integerValueArrayRereadStatic
@@ -1004,15 +1005,26 @@ program Tests_IO_HDF5
           end block
        end if
        
-       ! Write a very large (>4GB) dataset to test that chunking limits
-       ! the chunksize to less than the maximum allowed.
+       ! Create very large (>4GB) datasets to test that chunking limits the chunk size to less than the maximum allowed. No
+       ! data are written to these datasets, so they occupy no space in the file - only their chunk shapes are of interest,
+       ! and those are checked (via h5py) after the file is closed. The chunk chosen must also continue to tile the extent of
+       ! the dataset - otherwise HDF5 allocates an extra, almost entirely unused, chunk along the affected dimension.
        if (iPass == 2) then
           block
-            type(hdf5Dataset) :: datasetObject
-            datasetObject=fileObject%openDataset('bigDataset','A dataset larger than 4GB.',hdf5DataTypeDouble,[600_hsize_t,100_hsize_t,100_hsize_t,100_hsize_t],chunkSize=1024_hsize_t)
+            type(hdf5Dataset) :: datasetBigEven, datasetBigOdd, datasetBigOdd2D, datasetBigInteger
+            ! Extents which are exactly halved - the reduced chunk tiles the extent trivially.
+            datasetBigEven   =fileObject%openDataset('bigDataset'           ,'A dataset larger than 4GB.'                     ,hdf5DataTypeDouble ,[600_hsize_t,100_hsize_t,100_hsize_t,100_hsize_t],chunkSize=1024_hsize_t)
+            ! An odd extent in the fastest-varying dimension - halving with rounding down would give a chunk which no longer
+            ! tiles the extent.
+            datasetBigOdd    =fileObject%openDataset('bigDatasetOdd'        ,'A dataset larger than 4GB with an odd extent.'  ,hdf5DataTypeDouble ,[601_hsize_t,100_hsize_t,100_hsize_t,100_hsize_t],chunkSize=1024_hsize_t)
+            ! Odd extents in two dimensions - two reductions are needed, so both dimensions must be handled.
+            datasetBigOdd2D  =fileObject%openDataset('bigDatasetOdd2D'      ,'A dataset larger than 4GB with two odd extents.',hdf5DataTypeDouble ,[601_hsize_t,201_hsize_t,100_hsize_t,100_hsize_t],chunkSize=1024_hsize_t)
+            ! A 4-byte datatype - the chunk size limit must be evaluated using the actual size of the datatype, so these
+            ! extents need no reduction at all, even though they do for an 8-byte datatype.
+            datasetBigInteger=fileObject%openDataset('bigDatasetInteger'    ,'An integer dataset which fits in one chunk.'    ,hdf5DataTypeInteger,[600_hsize_t,100_hsize_t,100_hsize_t,100_hsize_t],chunkSize=1024_hsize_t)
           end block
        end if
-       
+
        ! Write an attribute of length >64KB by forcing dense storage of
        ! attributes in s group.
        block
@@ -1088,6 +1100,13 @@ program Tests_IO_HDF5
   call Unit_Tests_Begin_Group("2-D double attribute")
   call System_Command_Do("./testSuite/scripts/verify_attributes.py",attributesStatus)
   call Assert("re-read 2-D double attribute (via h5py)",attributesStatus,0)
+  call Unit_Tests_End_Group()
+
+  ! Verify the chunk shapes chosen for the large datasets created above by reading them back with h5py (there is no Fortran
+  ! reader for chunk dimensions). The verifier script exits with non-zero status on any mismatch.
+  call Unit_Tests_Begin_Group("chunk dimensions of large datasets")
+  call System_Command_Do("./testSuite/scripts/verify_chunking.py",chunkingStatus)
+  call Assert("chunks of large datasets fit within, and tile, their extents (via h5py)",chunkingStatus,0)
   call Unit_Tests_End_Group()
 
   ! End unit tests.

--- a/source/utility/IO/HDF5/_module.F90
+++ b/source/utility/IO/HDF5/_module.F90
@@ -3620,7 +3620,8 @@ attributeValue=trim(attributeValue)
           &                           H5T_NATIVE_INTEGER  , h5screate_simple_f   , HID_T               , HSIZE_T           , &
           &                           h5dcreate_f         , h5dget_create_plist_f, h5dopen_f           , h5eset_auto_f     , &
           &                           hsize_t             , h5pclose_f           , h5pcreate_f         , h5pget_chunk_f    , &
-          &                           h5pset_chunk_f      , h5pset_deflate_f     , h5sclose_f
+          &                           h5pset_chunk_f      , h5pset_deflate_f     , h5sclose_f          , h5tget_size_f     , &
+          &                           SIZE_T
     use :: ISO_Varying_String, only : assignment(=)       , operator(//)         , operator(/=)
     implicit none
     type     (hdf5Dataset   )                                        :: self
@@ -3637,6 +3638,7 @@ attributeValue=trim(attributeValue)
     integer  (kind=HSIZE_T  ), dimension(7)                          :: chunkDimensions                            , datasetDimensionsActual, &
          &                                                              datasetDimensionsMaximum
     integer  (kind=HSIZE_T  )                                        :: chunkSizeActual
+    integer  (kind=SIZE_T   )                                        :: dataTypeSize
     integer                                                          :: compressionLevelActual                     , datasetRank            , &
          &                                                              errorCode                                  , appendDimensionActual  , &
          &                                                              iDimension
@@ -3789,51 +3791,6 @@ attributeValue=trim(attributeValue)
           end if
        end if
        self%compressionLevel=compressionLevelActual
-       ! Create a property list for the dataset.
-       call h5pcreate_f(H5P_DATASET_CREATE_F,propertyList,errorCode)
-       if (errorCode < 0) then
-          message="unable to create property list for dataset '"//trim(datasetName)//"'"
-          call Error_Report(message//inObject%locationReport()//{introspection:location})
-       end if
-       ! Check if chunk size needs to be set.
-       if (chunkSizeActual /= -1) then
-          ! It does - determine a suitable chunk size.
-          if (appendToActual) then
-             ! Extensible dataset, use selected chunk size.
-             chunkDimensions(1:datasetRank          )=datasetDimensions
-             chunkDimensions(  appendDimensionActual)=chunkSizeActual
-          else
-             ! Fixed dimension array, use smaller of chunk size and actual size.
-             chunkDimensions(1:datasetRank)=min(datasetDimensionsActual(1:datasetRank),chunkSizeActual)
-          end if
-          ! Reduce chunk size if needed to fit within HDF5's maximum chunk size.
-          iDimension=0
-          do while (product(chunkDimensions(1:datasetRank))*sizeof(0.0d0) > chunkSizeMaximum)
-             iDimension=iDimension+1
-             if (iDimension > datasetRank) iDimension=1
-             chunkDimensions(iDimension)=max(1_hsize_t,chunkDimensions(iDimension)/2_hsize_t)
-          end do
-          call h5pset_chunk_f(propertyList,datasetRank,chunkDimensions,errorCode)
-          if (errorCode < 0) then
-             message="unable to set chunk size for dataset '"//trim(datasetName)//"'"
-             call Error_Report(message//inObject%locationReport()//{introspection:location})
-          end if
-       else
-          ! No chunk size was specified. This is problematic if the dataset is appendable.
-          if (appendToActual) then
-             message="appendable dataset '"//trim(datasetName)//"' requires a chunk size"
-             call Error_Report(message//inObject%locationReport()//{introspection:location})
-          end if
-       end if
-
-       ! Check if compression level should be set.
-       if (compressionLevelActual >= 0) then
-          call h5pset_deflate_f(propertyList,compressionLevelActual,errorCode)
-          if (errorCode < 0) then
-             message="could not set compression level for dataset '"//trim(datasetName)//"'"
-             call Error_Report(message//inObject%locationReport()//{introspection:location})
-          end if
-       end if
        ! Ensure that a data type was specified.
        if (.not.present(datasetDataType)) then
           message="no datatype was specified for dataset '"//trim(datasetName)//"' at "//locationPath
@@ -3859,6 +3816,65 @@ attributeValue=trim(attributeValue)
           case (hdf5DataTypeVlenInteger8  )
              dataTypeID=H5T_VLEN_INTEGER8   (1)
           end select
+       end if
+       ! Determine the size (in bytes) of a single element of this datatype - this is needed to limit the chunk size below.
+       call h5tget_size_f(dataTypeID,dataTypeSize,errorCode)
+       if (errorCode < 0) then
+          message="unable to determine datatype size for dataset '"//trim(datasetName)//"'"
+          call Error_Report(message//inObject%locationReport()//{introspection:location})
+       end if
+       ! Create a property list for the dataset.
+       call h5pcreate_f(H5P_DATASET_CREATE_F,propertyList,errorCode)
+       if (errorCode < 0) then
+          message="unable to create property list for dataset '"//trim(datasetName)//"'"
+          call Error_Report(message//inObject%locationReport()//{introspection:location})
+       end if
+       ! Check if chunk size needs to be set.
+       if (chunkSizeActual /= -1) then
+          ! It does - determine a suitable chunk size.
+          if (appendToActual) then
+             ! Extensible dataset, use selected chunk size.
+             chunkDimensions(1:datasetRank          )=datasetDimensions
+             chunkDimensions(  appendDimensionActual)=chunkSizeActual
+          else
+             ! Fixed dimension array, use smaller of chunk size and actual size.
+             chunkDimensions(1:datasetRank)=min(datasetDimensionsActual(1:datasetRank),chunkSizeActual)
+          end if
+          ! Reduce chunk size if needed to fit within HDF5's maximum chunk size. Dimensions are halved with rounding *up*, so
+          ! that the reduced chunk continues to tile the extent that it tiled before. Rounding down instead leaves a chunk
+          ! which need not divide the extent, in which case HDF5 allocates an extra chunk along that dimension of which only a
+          ! small fraction is ever written - up to ~50% of the allocated space per dimension is then wasted.
+          iDimension=0
+          do while (product(chunkDimensions(1:datasetRank))*int(dataTypeSize,kind=hsize_t) > chunkSizeMaximum)
+             ! Guard against an infinite loop in the case that a single element exceeds the maximum chunk size.
+             if (all(chunkDimensions(1:datasetRank) == 1_hsize_t)) then
+                message="unable to reduce chunk size below HDF5's maximum for dataset '"//trim(datasetName)//"' - a single element of the datatype is too large"
+                call Error_Report(message//inObject%locationReport()//{introspection:location})
+             end if
+             iDimension=iDimension+1
+             if (iDimension > datasetRank) iDimension=1
+             chunkDimensions(iDimension)=max(1_hsize_t,(chunkDimensions(iDimension)+1_hsize_t)/2_hsize_t)
+          end do
+          call h5pset_chunk_f(propertyList,datasetRank,chunkDimensions,errorCode)
+          if (errorCode < 0) then
+             message="unable to set chunk size for dataset '"//trim(datasetName)//"'"
+             call Error_Report(message//inObject%locationReport()//{introspection:location})
+          end if
+       else
+          ! No chunk size was specified. This is problematic if the dataset is appendable.
+          if (appendToActual) then
+             message="appendable dataset '"//trim(datasetName)//"' requires a chunk size"
+             call Error_Report(message//inObject%locationReport()//{introspection:location})
+          end if
+       end if
+
+       ! Check if compression level should be set.
+       if (compressionLevelActual >= 0) then
+          call h5pset_deflate_f(propertyList,compressionLevelActual,errorCode)
+          if (errorCode < 0) then
+             message="could not set compression level for dataset '"//trim(datasetName)//"'"
+             call Error_Report(message//inObject%locationReport()//{introspection:location})
+          end if
        end if
        ! Create the dataset.
        call h5dcreate_f(locationID,trim(datasetName),dataTypeID,dataSpaceID,self%objectID,errorCode,propertyList)

--- a/testSuite/scripts/verify_chunking.py
+++ b/testSuite/scripts/verify_chunking.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Verify the chunk shapes chosen for large datasets written by tests.IO.HDF5.
+
+Datasets too large to be held in a single HDF5 chunk have their chunk
+dimensions reduced until the chunk fits within HDF5's 4GB limit. The reduced
+chunk must still tile the extent of the dataset - if it does not, HDF5
+allocates an extra chunk along the affected dimension of which only a small
+fraction is ever written, wasting up to ~50% of the allocated space per
+dimension (see https://github.com/galacticusorg/galacticus/issues/1365). The
+limit must also be evaluated using the size of the actual datatype, not an
+assumed 8 bytes.
+
+HDF5 stores dimensions in C order, so h5py sees each Fortran array transposed,
+with the Fortran first dimension varying fastest. Exits with status 0 on
+success and 1 on any mismatch, so that the Fortran test can assert on the exit
+status.
+"""
+import sys
+import h5py
+
+fileName = "testSuite/outputs/test.IO.HDF5.hdf5"
+
+# Maximum chunk size (in bytes) permitted by HDF5.
+chunkSizeMaximum = 4294967296
+
+# Expected shapes and chunk shapes, in h5py (C) order, i.e. reversed relative to the Fortran extents used to create them.
+expected = {
+    # Fortran (600,100,100,100) doubles: 4.80GB, halved once along the first dimension to give a chunk of 2.40GB.
+    "bigDataset"       : {"shape": (100, 100, 100, 600), "chunks": (100, 100, 100, 300)},
+    # Fortran (601,100,100,100) doubles: 4.81GB, halved once along the first dimension. Rounding down would give a chunk of
+    # 300, which tiles 601 only in three chunks (900 elements allocated for 601 held).
+    "bigDatasetOdd"    : {"shape": (100, 100, 100, 601), "chunks": (100, 100, 100, 301)},
+    # Fortran (601,201,100,100) doubles: 9.66GB, requiring a reduction along each of the first two dimensions.
+    "bigDatasetOdd2D"  : {"shape": (100, 100, 201, 601), "chunks": (100, 100, 101, 301)},
+    # Fortran (600,100,100,100) 4-byte integers: 2.40GB, which fits within a single chunk and so needs no reduction at all.
+    "bigDatasetInteger": {"shape": (100, 100, 100, 600), "chunks": (100, 100, 100, 600)},
+}
+
+failures = []
+try:
+    with h5py.File(fileName, "r") as fileObject:
+        for name, expectedValue in expected.items():
+            dataset = fileObject[name]
+            if dataset.shape != expectedValue["shape"]:
+                failures.append(f"{name}: shape: got {dataset.shape!r}, expected {expectedValue['shape']!r}")
+                continue
+            if dataset.chunks is None:
+                failures.append(f"{name}: dataset is not chunked")
+                continue
+            if dataset.chunks != expectedValue["chunks"]:
+                failures.append(f"{name}: chunks: got {dataset.chunks!r}, expected {expectedValue['chunks']!r}")
+                continue
+            # Check that the chunk is within HDF5's maximum chunk size, as measured using the actual datatype.
+            chunkSize = dataset.dtype.itemsize
+            for chunkDimension in dataset.chunks:
+                chunkSize *= chunkDimension
+            if chunkSize > chunkSizeMaximum:
+                failures.append(f"{name}: chunk of {chunkSize} bytes exceeds the maximum of {chunkSizeMaximum} bytes")
+                continue
+            # Check that the chunks tile the extent with no more than one chunk's worth of overshoot in total - i.e. that the
+            # space HDF5 would allocate exceeds that needed by less than the size of a single chunk.
+            elementsAllocated = 1
+            elementsHeld = 1
+            for extent, chunkDimension in zip(dataset.shape, dataset.chunks):
+                elementsAllocated *= -(-extent // chunkDimension) * chunkDimension
+                elementsHeld *= extent
+            elementsChunk = 1
+            for chunkDimension in dataset.chunks:
+                elementsChunk *= chunkDimension
+            if elementsAllocated - elementsHeld >= elementsChunk:
+                failures.append(
+                    f"{name}: chunks {dataset.chunks!r} do not tile extent {dataset.shape!r}:"
+                    f" {elementsAllocated} elements allocated for {elementsHeld} held"
+                )
+except (OSError, KeyError) as error:
+    sys.stderr.write(f"verify_chunking.py: unable to read dataset: {error}\n")
+    sys.exit(1)
+
+if failures:
+    for failure in failures:
+        sys.stderr.write(f"verify_chunking.py: mismatch: {failure}\n")
+    sys.exit(1)
+sys.exit(0)


### PR DESCRIPTION
Closes #1365.

## The problem

When a dataset is too large to be written as a single HDF5 chunk, `IO_HDF5_Open_Dataset` reduced the chunk dimensions by halving one dimension at a time with **integer division**. For an odd extent the chunk was rounded *down* and so no longer divided the extent; since HDF5 always allocates whole chunks, the edge chunk was allocated in full and its unused remainder left as dead space — up to ~50% per dimension, multiplying across dimensions. The waste is invisible to `h5stat`, being allocated raw data rather than tracked free space.

The issue measured this on a `massDistributionSolitonNFW` `radiusEnclosingDensity` cache: an extent of 247 (versus 244, which happens to tile) inflated the file from 6.75 GB to 10.08 GB — 49.4% waste, from a 1.2% change in extent and nothing else.

## The fix

Halve with rounding **up**: `(chunkDimensions(iDimension)+1_hsize_t)/2_hsize_t`.

Repeated ceiling-halving of an extent is `ceil(n/2^k)`, so the reduced chunk always tiles whatever it tiled before, and the overshoot is bounded by one slab per chunk rather than by one whole chunk. It is a no-op wherever the extents already tiled, so no existing well-behaved file changes.

I used this rather than the `chunkCounts` variant sketched in the issue because it also does the right thing in the two cases where `chunkDimensions` does not start at the extent: an explicit `chunkSize` smaller than the extent, and the append dimension of an extensible dataset, whose extent is `H5S_UNLIMITED`.

## Secondary observation, also addressed

The loop measured the chunk against `chunkSizeMaximum` using `sizeof(0.0d0)`, a fixed 8 bytes, while `IO_HDF5_Open_Dataset` is the shared path for all datatypes — under-estimating the chunk for larger elements (which could in principle allow a chunk past HDF5's 4 GB limit) and over-chunking for smaller ones. The datatype determination now happens before the chunk is sized, and the guard uses `h5tget_size_f` on the actual datatype. A check now reports an error rather than looping forever should a single element exceed the maximum chunk size — unreachable with a hardcoded 8 bytes, but no longer so with a genuine datatype size.

## Testing

`tests.IO.HDF5` gains three oversized datasets alongside the existing `bigDataset`: odd extents in one and in two dimensions, and a 4-byte datatype whose extents need no reduction at all. Nothing is written to them, so they cost no space (the test file stays at 1 MB) — only their chunk shapes matter. Those are checked by a new `testSuite/scripts/verify_chunking.py`, following the existing `verify_units.py` / `verify_attributes.py` pattern.

Reverting both changes and rebuilding, the new verifier catches all three regressions:

```
bigDatasetOdd:     chunks: got (100,100,100,300), expected (100,100,100,301)
bigDatasetOdd2D:   chunks: got (100,100,100,300), expected (100,100,101,301)
bigDatasetInteger: chunks: got (100,100,100,300), expected (100,100,100,600)
```

`bigDatasetOdd2D` is the compounding case: the old chunk `[300,100,100,100]` tiles Fortran extents `(601,201,100,100)` in 3×3 chunks, allocating 2.7e9 elements to hold 1.21e9 — 2.23× inflation. With the fix it is `[301,101,100,100]`, 2×2 chunks, 0.2% overshoot.

With the fix in place, `tests.IO.HDF5.exe` reports 211 passed, 0 failed.

---

*Developed with the assistance of Claude Code, and verified locally as described above.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
