### PR TITLE
fix(numerical): Reset the GSL abort handler on all root finder exits

### DIFF
--- a/source/error/_module.F90
+++ b/source/error/_module.F90
@@ -17,6 +17,9 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson. The "GSL_Error_Handler_Aborting" function added for issue #1360 was
+!+    drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+
 !!{RST
 Contains a module which implements error reporting for the  Galacticus package.
 !!}
@@ -36,7 +39,9 @@ module Error
        &    GSL_Error_Handler_Abort_Off, GSL_Error_Status          , &
        &    Warn                       , Error_Wait_Set            , &
        &    GSL_Error_Details          , signalHandlerDeregister   , &
-       &    signalHandlerRegister      , signalHandlerInterface
+       &    signalHandlerRegister      , signalHandlerInterface    , &
+       &    GSL_Error_Handler_Aborting
+
   interface Error_Report
      module procedure Error_Report_Char
      module procedure Error_Report_VarStr
@@ -741,6 +746,19 @@ contains
     abortOnErrorGSL=abortOnErrorGSL-1
     return
   end subroutine GSL_Error_Handler_Abort_Off
+
+  logical function GSL_Error_Handler_Aborting()
+    !!{RST
+    Return true if GSL errors will currently cause an abort, false otherwise.
+
+    Intended for assertions and debugging: calls to ``GSL_Error_Handler_Abort_Off()`` and ``GSL_Error_Handler_Abort_On()`` must
+    balance, so any routine which disables aborting should find this restored to true once it has re-enabled it.
+    !!}
+    implicit none
+
+    GSL_Error_Handler_Aborting=(abortOnErrorGSL == 0)
+    return
+  end function GSL_Error_Handler_Aborting
 
   integer function GSL_Error_Status()
     !!{RST

--- a/source/numerical/root_finder.F90
+++ b/source/numerical/root_finder.F90
@@ -17,6 +17,9 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson. The routing of all exits through a common finalization for issue #1360
+!+    was drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+
 ! Specify an explicit dependence on the interface.GSL.C.root_finding.o object file.
 !: $(BUILDPATH)/interface/GSL/C/root_finding.o
 
@@ -601,7 +604,8 @@ contains
     class           (*                   ), pointer                               :: dummyPointer_
     integer                               , parameter                             :: iterationMaximum =1000
     integer                               , parameter                             :: findersIncrement =   3
-    logical                                                                       :: rangeChanged          , rangeLowerAsExpected, rangeUpperAsExpected
+    logical                                                                       :: rangeChanged          , rangeLowerAsExpected, rangeUpperAsExpected, &
+         &                                                                           errorHandlerDisabled
     integer                                                                       :: iteration             , statusActual
     double precision                                                              :: xHigh                 , xLow                , xRoot               , &
          &                                                                           xRootPrevious         , fLow                , fHigh               , &
@@ -615,6 +619,8 @@ contains
 
     ! Begin reporting.
     if (report_) call displayIndent("Root finder report:")
+    ! Record that this invocation has not (yet) disabled GSL's abort-on-error handler.
+    errorHandlerDisabled=.false.
     ! Add the current finder to the list of finders. This allows us to track back to the previously used finder if this function is called recursively.
     currentFinderIndex=currentFinderIndex+1
     if (allocated(currentFinders)) then
@@ -741,8 +747,8 @@ contains
        if (.not.rangeLowerAsExpected) then
           if (present(status)) then
              status        =errorStatusOutOfRange
-             call popCurrentFinder()
              rootFinderFind=self%rangeDownwardLimit
+             call finalizeFind()
              return
           else
              message='root function has incorrect sign at downward limit'
@@ -772,8 +778,8 @@ contains
        if (.not.rangeUpperAsExpected) then
           if (present(status)) then
              status        =errorStatusOutOfRange
-             call popCurrentFinder()
              rootFinderFind=self%rangeUpwardLimit
+             call finalizeFind()
              return
           else
              message='root function has incorrect sign at upward limit'
@@ -787,10 +793,13 @@ contains
           call displayMessage(message)
        end if
     end if
-    ! Set error handler if necessary.
+    ! Set error handler if necessary. Note that 'errorHandlerDisabled' records that this invocation is responsible for
+    ! re-enabling the handler - it must not be re-enabled by any invocation which did not disable it, as the handler state is
+    ! tracked by a counter which disables aborts whenever it is non-zero.
     if (present(status)) then
        call GSL_Error_Handler_Abort_Off()
-       statusActual=errorStatusSuccess
+       errorHandlerDisabled=.true.
+       statusActual        =errorStatusSuccess
     end if
     ! Expand the range as necessary.
     if (self%useDerivative) then
@@ -950,7 +959,7 @@ contains
              end if
              if (present(status)) then
                 status=errorStatusOutOfRange
-                call popCurrentFinder()
+                call finalizeFind()
                 return
              else
                 fLow =self%finderFunction(xLow )
@@ -1063,15 +1072,28 @@ contains
        end if
        if (report_) call displayUnindent("done")
     end if
-    ! Reset error handler.
-    if (present(status)) call GSL_Error_Handler_Abort_On()
-    ! Restore state.
-    call popCurrentFinder()
-    ! Finish reporting.
-    if (report_) call displayUnindent("done")
+    ! Reset error handler, restore state, and finish reporting.
+    call finalizeFind()
     return
 
   contains
+
+    subroutine finalizeFind()
+      !!{RST
+      Perform all clean up necessary before returning from ``rootFinderFind``: re-enable GSL's abort-on-error handler if this invocation disabled it, unwind the active-finder stack, and close the report indent.
+
+      Every exit from ``rootFinderFind`` - including the early returns taken when the root is out of range - must pass through this routine. Returning directly would leave the (thread-local) abort handler disabled for the remainder of the run, so that later GSL errors anywhere in the code - including in callers which pass no ``status`` and so rely on GSL aborting - would fail silently instead of aborting.
+      !!}
+      implicit none
+
+      if (errorHandlerDisabled) then
+         call GSL_Error_Handler_Abort_On()
+         errorHandlerDisabled=.false.
+      end if
+      call popCurrentFinder()
+      if (report_) call displayUnindent("done")
+      return
+    end subroutine finalizeFind
 
     subroutine popCurrentFinder()
       !!{RST

--- a/source/tests/root_finding.F90
+++ b/source/tests/root_finding.F90
@@ -17,6 +17,9 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson. The tests of the GSL abort-on-error handler state added for issue #1360
+!+    were drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+
 !!{RST
 Contains a program to test root finding routines.
 !!}
@@ -25,16 +28,16 @@ program Test_Root_Finding
   !!{RST
   Tests that routine finding routines work.
   !!}
-  use :: Display                    , only : displayVerbositySet    , verbosityLevelStandard
-  use :: Error                      , only : errorStatusDivideByZero, Error_Handler_Register
-  use :: Root_Finder                , only : rangeExpandAdditive    , rangeExpandMultiplicative, rangeExpandSignExpectPositive, rootFinder                , &
+  use :: Display                    , only : displayVerbositySet       , verbosityLevelStandard
+  use :: Error                      , only : errorStatusDivideByZero   , Error_Handler_Register   , errorStatusOutOfRange        , GSL_Error_Handler_Aborting
+  use :: Root_Finder                , only : rangeExpandAdditive       , rangeExpandMultiplicative, rangeExpandSignExpectPositive, rootFinder                , &
        &                                     stoppingCriterionDelta
-  use :: Test_Root_Finding_Functions, only : Root_Function_1        , Root_Function_2          , Root_Function_2_Both         , Root_Function_2_Derivative, &
-          &                                  Root_Function_3        , Root_Function_4          , Root_Function_4_Both         , Root_Function_4_Derivative
-  use :: Unit_Tests                 , only : Assert                 , Unit_Tests_Begin_Group   , Unit_Tests_End_Group         , Unit_Tests_Finish
+  use :: Test_Root_Finding_Functions, only : Root_Function_1           , Root_Function_2          , Root_Function_2_Both         , Root_Function_2_Derivative, &
+          &                                  Root_Function_3           , Root_Function_4          , Root_Function_4_Both         , Root_Function_4_Derivative
+  use :: Unit_Tests                 , only : Assert                    , Unit_Tests_Begin_Group   , Unit_Tests_End_Group         , Unit_Tests_Finish
   implicit none
   type            (rootFinder)               :: finder1, finder2, &
-       &                                        finder3
+       &                                        finder3, finder4
   double precision                           :: xGuess , xRoot
   double precision            , dimension(2) :: xRange
   integer                                    :: status
@@ -110,6 +113,72 @@ program Test_Root_Finding
   xRange=[+2.0d0,+4.0d0]
   xRoot=finder3%find(rootRange=xRange)
   call Assert('root of f(x)=x² - 5x + 1 in range  2 < x < 10 expand range upward only',xRoot,0.5d0*(5.0d0+sqrt(21.0d0)),absTol=1.0d-6,relTol=1.0d-6)
+
+  ! Test that out-of-range exits restore GSL's abort-on-error handler. Each of the following cases causes the root finder to
+  ! return early with an out-of-range status. Prior to the fix for issue #1360, the exit taken when the range could not be
+  ! expanded to bracket the root left the (thread-local) abort-on-error handler disabled for the remainder of the run, so that
+  ! subsequent GSL errors - including in callers which pass no "status" argument - failed silently instead of aborting. A single
+  ! root finder is used for all of these cases, reconfigured between them - each call to "rangeExpand" resets all range
+  ! expansion options, including those not explicitly specified.
+  call Assert('GSL abort-on-error handler is initially enabled',GSL_Error_Handler_Aborting(),.true.)
+  finder4=rootFinder(rootFunction=Root_Function_2,toleranceAbsolute=1.0d-6,toleranceRelative=1.0d-6)
+
+  !! Wrong sign at the downward limit. f(x)=x² - 5x + 1 is negative at the downward limit of x=1, but a positive value is
+  !! expected there.
+  call finder4%rangeExpand(                                                             &
+       &                   rangeExpandDownward          =0.5d0                        , &
+       &                   rangeExpandType              =rangeExpandMultiplicative    , &
+       &                   rangeDownwardLimit           =1.0d0                        , &
+       &                   rangeExpandDownwardSignExpect=rangeExpandSignExpectPositive, &
+       &                   testLimits                   =.true.                         &
+       &                  )
+  xRange=[1.0d0,2.0d0]
+  xRoot=finder4%find(rootRange=xRange,status=status)
+  call Assert('out of range status returned for incorrect sign at downward limit'         ,status                     ,errorStatusOutOfRange)
+  call Assert('GSL abort-on-error handler restored after incorrect sign at downward limit',GSL_Error_Handler_Aborting(),.true.               )
+
+  !! Wrong sign at the upward limit. f(x)=x² - 5x + 1 is negative at the upward limit of x=4, but a positive value is expected
+  !! there.
+  call finder4%rangeExpand(                                                             &
+       &                   rangeExpandUpward            =2.0d0                        , &
+       &                   rangeExpandType              =rangeExpandMultiplicative    , &
+       &                   rangeUpwardLimit             =4.0d0                        , &
+       &                   rangeExpandUpwardSignExpect  =rangeExpandSignExpectPositive, &
+       &                   testLimits                   =.true.                         &
+       &                  )
+  xRange=[1.0d0,2.0d0]
+  xRoot=finder4%find(rootRange=xRange,status=status)
+  call Assert('out of range status returned for incorrect sign at upward limit'         ,status                     ,errorStatusOutOfRange)
+  call Assert('GSL abort-on-error handler restored after incorrect sign at upward limit',GSL_Error_Handler_Aborting(),.true.               )
+
+  !! Range expansion unable to bracket the root. Expansion upward is limited to x=4, below the root of f(x)=x² - 5x + 1 at
+  !! x=(5+√21)/2 ≈ 4.79, so the root can never be bracketed. Limit testing is switched off here so that this case is reached
+  !! instead of the incorrect-sign-at-the-upward-limit case above.
+  call finder4%rangeExpand(                                                             &
+       &                   rangeExpandUpward            =2.0d0                        , &
+       &                   rangeExpandType              =rangeExpandMultiplicative    , &
+       &                   rangeUpwardLimit             =4.0d0                        , &
+       &                   rangeExpandUpwardSignExpect  =rangeExpandSignExpectPositive, &
+       &                   testLimits                   =.false.                        &
+       &                  )
+  xRange=[1.0d0,2.0d0]
+  xRoot=finder4%find(rootRange=xRange,status=status)
+  call Assert('out of range status returned when root can not be bracketed'         ,status                     ,errorStatusOutOfRange)
+  call Assert('GSL abort-on-error handler restored after root can not be bracketed' ,GSL_Error_Handler_Aborting(),.true.               )
+
+  !! Finally, check that a root can still be found once the range limit is relaxed sufficiently to allow the root to be
+  !! bracketed.
+  call finder4%rangeExpand(                                                             &
+       &                   rangeExpandUpward            =2.0d0                        , &
+       &                   rangeExpandType              =rangeExpandMultiplicative    , &
+       &                   rangeUpwardLimit             =8.0d0                        , &
+       &                   rangeExpandUpwardSignExpect  =rangeExpandSignExpectPositive, &
+       &                   testLimits                   =.true.                         &
+       &                  )
+  xRange=[1.0d0,2.0d0]
+  xRoot=finder4%find(rootRange=xRange,status=status)
+  call Assert('root of f(x)=x² - 5x + 1 found once upward limit is relaxed'      ,xRoot                      ,0.5d0*(5.0d0+sqrt(21.0d0)),absTol=1.0d-6,relTol=1.0d-6)
+  call Assert('GSL abort-on-error handler restored after successful root finding',GSL_Error_Handler_Aborting(),.true.                                              )
 
   ! End unit tests.
   call Unit_Tests_End_Group()


### PR DESCRIPTION
Closes #1360.

## The bug

When `status` is present, `rootFinderFind` disables GSL's abort-on-error handler before solving and re-enables it in its tail. The early return taken when range expansion could not bracket the root (`root_finder.F90:951`) bypassed that tail, so the first out-of-range exit left the handler disabled for the remainder of the run on that thread. Subsequent GSL errors anywhere in the code — including in callers which pass no `status` and therefore rely on GSL aborting — then failed silently instead of aborting.

One refinement to the issue's analysis: of the three early returns it lists, only the range-expansion one actually leaked the handler. The two incorrect-sign-at-the-limit returns (`:742`, `:773`) happen *before* `GSL_Error_Handler_Abort_Off()` is called, so they were never able to leak it — but they did leave the report indent unbalanced.

The leaking path is the one `nodeOperatorDarkMatterProfilePromptCusps` takes: it sets `rangeUpwardLimit` and passes `status`, but leaves `testLimits` at its default of false, so the bug was live in the COZMIC WDM models rather than never reached.

## The fix

All exits from `rootFinderFind` now pass through a new contained `finalizeFind` routine, which re-enables the handler, unwinds the active-finder stack, and closes the report indent — as the issue suggests, so a fourth instance of this bug cannot appear.

A local `errorHandlerDisabled` flag records whether *this* invocation disabled the handler. This matters: the handler state is a counter which disables aborts whenever it is non-zero, so unconditionally re-enabling on the two paths that never disabled it would have driven the counter to +1 and disabled aborts just as effectively as the original bug.

## Tests

`Error` gains `GSL_Error_Handler_Aborting()` to query the handler state, and `tests.root_finding` gains four cases — one per out-of-range exit, plus a success path once the range limit is relaxed — each asserting that the handler is restored. All 18 tests in that program pass.

Also verified: `tests.prompt_cusps` (12/12), and `parameters/quickTest.xml` runs to completion with no failure markers.

## Attribution

Drafted with assistance from Claude, and reviewed and verified by Andrew Benson, per the AI-assisted contribution policy in `CONTRIBUTING.md`. `!+` markers recording this were added to each modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)