### PR TITLE
feat(promptCusps): assign no cusp where the collapse epoch postdates the halo

### DIFF
--- a/parameters/reference/warmDarkMatter.xml
+++ b/parameters/reference/warmDarkMatter.xml
@@ -61,7 +61,25 @@
       <kappa                 value=" 4.500"/>
       <coefficientScatter    value=" 0.195"/>
       <nonConvergenceIsFatal value="false" />
+      <!-- Halos in which no prompt cusp can form can not themselves have formed, and are pruned (below). This is the default,   -->
+      <!-- but is set explicitly here so that the parameter migration which pins the original behavior for existing user      -->
+      <!-- parameter files leaves these reference models on the new, more realistic, physics.                                 -->
+      <requireCollapseBeforeHalo value="true" />
     </nodeOperator>
+  </change>
+
+  <!-- Prune halos in which no prompt cusp can form. Prompt cusp formation is, by definition, the formation event of a halo, so a
+       halo for which the cusp collapse epoch would lie in its own future can not have formed. Such halos are labeled by the
+       `darkMatterProfilePromptCusps` node operator during tree initialization, and are removed from the tree here. Primary
+       progenitor status is not preserved: where the primary progenitor is pruned it is precisely because it could not have
+       formed, so the surviving progenitor is the true primary progenitor. -->
+  <change type="append" path="">
+    <mergerTreeOperator value="pruneByFilter">
+      <preservePrimaryProgenitor value="false"/>
+      <galacticFilter value="labelled">
+	<label value="promptCuspUnformed"/>
+      </galacticFilter>
+    </mergerTreeOperator>
   </change>
 
 </changes>

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -2132,6 +2132,7 @@
           <xs:enumeration value="pruneBaryons"/>
           <xs:enumeration value="pruneBranchComplement"/>
           <xs:enumeration value="pruneBranchTips"/>
+          <xs:enumeration value="pruneByFilter"/>
           <xs:enumeration value="pruneByMass"/>
           <xs:enumeration value="pruneByMassAndTime"/>
           <xs:enumeration value="pruneByTime"/>

--- a/scripts/aux/migrations.xml
+++ b/scripts/aux/migrations.xml
@@ -326,6 +326,15 @@
     <translation function="splashback_radius_accretion_flow"/>
   </migration>
 
+  <migration commit="ece0d28426e2797fbd0042eadab736710304dec1">
+    <!-- The `darkMatterProfilePromptCusps` node operator now follows the reference implementation of Delos & White (2025) in  -->
+    <!-- assigning no cusp to halos for which the cusp collapse epoch postdates the halo itself - such halos can not have      -->
+    <!-- formed, and are pruned from the merger tree. This changes the physics of existing models, so pin the original         -->
+    <!-- behavior here. Models which want the new behavior should set `requireCollapseBeforeHalo` to true and add a merger     -->
+    <!-- tree operator to prune the labeled halos.                                                                            -->
+    <translation function="prompt_cusp_require_collapse_before_halo"/>
+  </migration>
+
   <!-- Known default values for parameters -->
   <default parameter="componentBlackHole"             value="standard"        />
   <default parameter="componentDisk"                  value="standard"        />

--- a/scripts/aux/parametersMigrate.py
+++ b/scripts/aux/parametersMigrate.py
@@ -1517,7 +1517,46 @@ def splashback_radius_accretion_flow(input_doc, parameters, is_grid):
         node.append(splashback_node)
 
 
+def prompt_cusp_require_collapse_before_halo(input_doc, parameters, is_grid):
+    """Special handling for the introduction of the `requireCollapseBeforeHalo` parameter.
+
+    The `darkMatterProfilePromptCusps` node operator previously assigned a prompt cusp to every
+    halo, accepting collapse epochs which postdate the halo itself and, where no collapse epoch
+    existed at all, taking the collapse to occur at the limiting time of the search. It now follows
+    the reference implementation of Delos & White (2025) instead: since prompt cusp formation is,
+    by definition, the formation event of a halo, halos failing that condition can not have formed,
+    and are labeled so that they may be pruned from the merger tree.
+
+    This changes the physics of existing models, so we pin the original behavior here. Users who
+    want the new (more realistic) behavior should set `requireCollapseBeforeHalo` to true and add a
+    merger tree operator which prunes the labeled halos - see the documentation for the
+    `nodeOperatorDarkMatterProfilePromptCusps` class.
+    """
+    for node in parameters.xpath(".//nodeOperator[@value='darkMatterProfilePromptCusps']"):
+        # Do not override a choice which has already been made explicitly.
+        if len(node.xpath("./requireCollapseBeforeHalo[@value]")) > 0:
+            continue
+        print("   insert special 'requireCollapseBeforeHalo' into 'darkMatterProfilePromptCusps'")
+        require_node = etree.Element("requireCollapseBeforeHalo")
+        require_node.set("value", "false")
+        if is_grid:
+            require_node.set("iterable", "no")
+        # Append as the final child, preserving the indentation of the existing children.
+        children = list(node)
+        if children:
+            require_node.tail = children[-1].tail
+            children[-1].tail = node.text
+        else:
+            # The indentation of this node is carried by the whitespace which precedes it.
+            previous = node.getprevious()
+            indentation = (previous.tail if previous is not None else node.getparent().text) or "\n  "
+            require_node.tail = indentation
+            node.text = indentation + "  "
+        node.append(require_node)
+
+
 SPECIAL_FUNCTIONS = {
+    "prompt_cusp_require_collapse_before_halo": prompt_cusp_require_collapse_before_halo,
     "radiation_field_intergalactic_background_cmb": radiation_field_intergalactic_background_cmb,
     "black_hole_seed_mass": black_hole_seed_mass,
     "black_hole_physics": black_hole_physics,

--- a/source/merger_trees/operators/prune_by_filter.F90
+++ b/source/merger_trees/operators/prune_by_filter.F90
@@ -1,0 +1,196 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{RST
+Implements a pruning-by-filter operator on merger trees.
+!!}
+
+!+ Contributions to this file made by: Andrew Benson
+!+ This file was generated with assistance from Claude, and reviewed and tested by Andrew Benson.
+
+  use :: Galactic_Filters, only : galacticFilterClass
+
+  !![
+  <mergerTreeOperator name="mergerTreeOperatorPruneByFilter" docformat="rst">
+   <description>
+   A merger tree operator class which prunes branches of merger trees prior to any evolution. Note that the sense of the filter is
+   that nodes which *pass* ``[galacticFilter]`` are those which are *removed* from the tree, along with all of their
+   progenitors. (To prune the complement---i.e. to retain only those nodes which pass some filter---wrap that filter in a
+   :galacticus-class:`galacticFilterNot`.) This is intended for cases in which some earlier stage of tree initialization has
+   identified nodes which should not be present in the tree, for example by labeling them (see
+   :galacticus-class:`galacticFilterLabelled`).
+   </description>
+  </mergerTreeOperator>
+  !!]
+  type, extends(mergerTreeOperatorClass) :: mergerTreeOperatorPruneByFilter
+     !!{RST
+     A pruning-by-filter merger tree operator class.
+     !!}
+     private
+     class  (galacticFilterClass), pointer :: galacticFilter_           => null()
+     logical                               :: preservePrimaryProgenitor
+   contains
+     final     ::                        pruneByFilterDestructor
+     procedure :: operatePreEvolution => pruneByFilterOperatePreEvolution
+  end type mergerTreeOperatorPruneByFilter
+
+  interface mergerTreeOperatorPruneByFilter
+     !!{RST
+     Constructors for the prune-by-filter merger tree operator class.
+     !!}
+     module procedure pruneByFilterConstructorParameters
+     module procedure pruneByFilterConstructorInternal
+  end interface mergerTreeOperatorPruneByFilter
+
+contains
+
+  function pruneByFilterConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the prune-by-filter merger tree operator class which takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type   (mergerTreeOperatorPruneByFilter)                :: self
+    type   (inputParameters                ), intent(inout) :: parameters
+    class  (galacticFilterClass            ), pointer       :: galacticFilter_
+    logical                                                 :: preservePrimaryProgenitor
+
+    !![
+    <inputParameter docformat="rst">
+      <name>preservePrimaryProgenitor</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, primary progenitor status is preserved even if the primary progenitor is pruned from the tree.
+      </description>
+    </inputParameter>
+    <objectBuilder class="galacticFilter" name="galacticFilter_" source="parameters"/>
+    !!]
+    self=mergerTreeOperatorPruneByFilter(preservePrimaryProgenitor,galacticFilter_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="galacticFilter_"/>
+    !!]
+    return
+  end function pruneByFilterConstructorParameters
+
+  function pruneByFilterConstructorInternal(preservePrimaryProgenitor,galacticFilter_) result(self)
+    !!{RST
+    Internal constructor for the prune-by-filter merger tree operator class.
+    !!}
+    implicit none
+    type   (mergerTreeOperatorPruneByFilter)                        :: self
+    class  (galacticFilterClass            ), intent(in   ), target :: galacticFilter_
+    logical                                 , intent(in   )         :: preservePrimaryProgenitor
+    !![
+    <constructorAssign variables="preservePrimaryProgenitor, *galacticFilter_"/>
+    !!]
+
+    return
+  end function pruneByFilterConstructorInternal
+
+  subroutine pruneByFilterDestructor(self)
+    !!{RST
+    Destructor for the prune-by-filter merger tree operator class.
+    !!}
+    implicit none
+    type(mergerTreeOperatorPruneByFilter), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%galacticFilter_"/>
+    !!]
+    return
+  end subroutine pruneByFilterDestructor
+
+  subroutine pruneByFilterOperatePreEvolution(self,tree)
+    !!{RST
+    Perform a prune-by-filter operation on a merger tree.
+    !!}
+    use :: Galacticus_Nodes              , only : mergerTree                    , treeNode
+    use :: Merger_Tree_Walkers           , only : mergerTreeWalkerIsolatedNodes
+    use :: Merger_Trees_Pruning_Utilities, only : Merger_Tree_Prune_Clean_Branch, Merger_Tree_Prune_Uniqueify_IDs, Merger_Tree_Prune_Unlink_Parent
+    implicit none
+    class  (mergerTreeOperatorPruneByFilter), intent(inout), target :: self
+    type   (mergerTree                     ), intent(inout), target :: tree
+    type   (treeNode                       ), pointer               :: nodeNext   , nodeWork, &
+         &                                                             node
+    type   (mergerTree                     ), pointer               :: currentTree
+    type   (mergerTreeWalkerIsolatedNodes  )                        :: treeWalker
+    logical                                                         :: didPruning , parentWillBePruned
+
+    ! Iterate over trees.
+    currentTree => tree
+    do while (associated(currentTree))
+       didPruning=.true.
+       do while (didPruning)
+          didPruning=.false.
+          ! Get the root node of the tree.
+          node => currentTree%nodeBase
+          if (self%galacticFilter_%passes(node)) then
+             ! The base node itself is to be pruned. As we can not remove the base node, destroy all but this base node instead -
+             ! leaving just the base node makes the tree inert (i.e. it can not do anything).
+             call Merger_Tree_Prune_Clean_Branch(node)
+             nodeWork => node%firstChild
+             do while (associated(nodeWork))
+                nodeNext => nodeWork%sibling
+                call Merger_Tree_Prune_Clean_Branch(nodeWork)
+                call nodeWork%destroyBranch()
+                deallocate(nodeWork)
+                nodeWork => nodeNext
+             end do
+             nullify(node%firstChild)
+             nodeWork => node%firstSatellite
+             do while (associated(nodeWork))
+                nodeNext => nodeWork%sibling
+                call Merger_Tree_Prune_Clean_Branch(nodeWork)
+                call nodeWork%destroyBranch()
+                deallocate(nodeWork)
+                nodeWork => nodeNext
+             end do
+             nullify(node%firstSatellite)
+          else
+             ! Walk the tree, pruning branches.
+             treeWalker=mergerTreeWalkerIsolatedNodes(currentTree)
+             do while (treeWalker%next(node))
+                if (self%galacticFilter_%passes(node)) then
+                   didPruning=.true.
+                   ! Set the tree walker back to the base node so that it exits - we've changed the tree structure so need to
+                   ! begin the walk again.
+                   call treeWalker%setNode(currentTree%nodeBase)
+                   ! Determine whether the parent will also be pruned - if it will, there is no need to preserve primary
+                   ! progenitor status within it.
+                   parentWillBePruned=self%galacticFilter_%passes(node%parent)
+                   ! Decouple from other nodes.
+                   call Merger_Tree_Prune_Unlink_Parent(node,node%parent,parentWillBePruned,self%preservePrimaryProgenitor)
+                   ! Clean the branch.
+                   call Merger_Tree_Prune_Clean_Branch (node)
+                   ! Destroy the branch.
+                   call node%destroyBranch()
+                   deallocate(node)
+                end if
+             end do
+          end if
+       end do
+       ! Move to the next tree.
+       currentTree => currentTree%nextTree
+    end do
+    ! Uniqueify nodes.
+    call Merger_Tree_Prune_Uniqueify_IDs(tree)
+    return
+  end subroutine pruneByFilterOperatePreEvolution

--- a/source/nodes/operators/physics/dark_matter_profile/prompt_cusp.F90
+++ b/source/nodes/operators/physics/dark_matter_profile/prompt_cusp.F90
@@ -32,7 +32,25 @@
   !![
   <nodeOperator name="nodeOperatorDarkMatterProfilePromptCusps" docformat="rst">
    <description>
-   A node operator class that evaluates the properties of prompt cusps following the model of :cite:t:`delos_cusp-halo_2025`, with a log-normal scatter of :math:`\mu \exp(-1/\sigma_0)` dex added to the cusp amplitude, where :math:`\mu=`\ ``[coefficientScatter]``.
+   A node operator class that evaluates the properties of prompt cusps following the model of :cite:t:`delos_cusp-halo_2025`, with
+   a log-normal scatter of :math:`\mu \exp(-1/\sigma_0)` dex added to the cusp amplitude, where :math:`\mu=`\
+   ``[coefficientScatter]``.
+
+   Prompt cusp formation is, by definition, the formation event of a halo. A halo for which the cusp collapse epoch would lie in
+   its own future can therefore not have formed: such halos are assigned no cusp and are labeled ``promptCuspUnformed``. **This
+   class must be used together with a merger tree operator which prunes those labeled halos from the tree**, for example
+
+   .. code-block:: xml
+
+      &lt;mergerTreeOperator value="pruneByFilter"&gt;
+        &lt;preservePrimaryProgenitor value="false"/&gt;
+        &lt;galacticFilter value="labelled"&gt;
+          &lt;label value="promptCuspUnformed"/&gt;
+        &lt;/galacticFilter&gt;
+      &lt;/mergerTreeOperator&gt;
+
+   placed ahead of any other merger tree operator which depends on tree structure. Without it, halos which can not have formed are
+   retained and evolved, and the branches above them are assigned cusp properties inconsistent with those halos.
    </description>
   </nodeOperator>
   !!]
@@ -49,13 +67,15 @@
      class           (darkMatterProfileDMOClass ), pointer                   :: darkMatterProfileDMO_       => null()
      class           (virialDensityContrastClass), pointer                   :: virialDensityContrast_      => null()
      double precision                            , allocatable, dimension(:) :: sigma_
-     logical                                                                 :: growthIsWavenumberDependent          , nonConvergenceIsFatal
+     logical                                                                 :: growthIsWavenumberDependent          , nonConvergenceIsFatal , &
+          &                                                                     requireCollapseBeforeHalo
      double precision                                                        :: alpha                                , beta                  , &
           &                                                                     kappa                                , C                     , &
           &                                                                     p                                    , coefficientScatter
      integer                                                                 :: promptCuspMassID                     , promptCuspAmplitudeID , &
           &                                                                     promptCuspNFWYID                     , promptCuspNFWScaleID  , &
-          &                                                                     promptCuspNFWGrowthRateID            , promptCuspNFWDensityID
+          &                                                                     promptCuspNFWGrowthRateID            , promptCuspNFWDensityID, &
+          &                                                                     labelUnformedID
    contains
      !![
      <methods docformat="rst">
@@ -90,7 +110,25 @@
   ! Maximum allowed value of the y-parameter in the cusp-NFW profile. Values of 1 or greater are not valid. We limit here to a
   ! value close to 1.
   double precision                                          , parameter :: yMaximum        =0.99999d0
-  
+
+  ! Minimum value of the y-parameter for which the cusp-NFW expressions are evaluated; below this the NFW limit is used instead,
+  ! and y is stored as zero so that the cusp-NFW mass distribution class (which contains the same expressions, and so the same
+  ! problems) likewise takes its NFW branch.
+  !
+  ! The asinh and atanh terms of the enclosed mass each diverge logarithmically as y→0. Their divergences cancel, so the enclosed
+  ! mass remains finite - but the cancellation is increasingly ill-conditioned as y decreases, because the argument of the atanh
+  ! approaches 1 and so loses precision. Two limits follow:
+  !
+  !  * Once y ≲ 10⁻⁹ that argument rounds to exactly 1 in double precision, giving atanh(1) = ∞ and hence a floating point
+  !    exception.
+  !  * Well before that, the evaluation is simply inaccurate: the relative error grows as 1/y², reaching ~10⁻⁴ by y = 10⁻⁶.
+  !
+  ! Meanwhile the cusp itself contributes to the enclosed mass only at order y², so the error incurred by taking the NFW limit
+  ! *falls* as y². The two curves cross at y ≈ 10⁻⁴, where each is of order 10⁻⁸ - far below the tolerance to which the density
+  ! normalization is solved, and so the point at which the switch is least visible. Note that this is also far below the y of any
+  ! halo with a real cusp (values of order 10⁻² and above), so the threshold is never approached in practice.
+  double precision                                          , parameter :: yMinimum        =1.00000d-4
+
 contains
   
   function darkMatterProfilePromptCuspsConstructorParameters(parameters) result(self)
@@ -108,9 +146,9 @@ contains
     class           (darkMatterHaloScaleClass                ), pointer       :: darkMatterHaloScale_
     class           (darkMatterProfileDMOClass               ), pointer       :: darkMatterProfileDMO_
     class           (virialDensityContrastClass              ), pointer       :: virialDensityContrast_
-    logical                                                                   :: nonConvergenceIsFatal
-    double precision                                                          :: alpha                 , beta              , &
-         &                                                                       kappa                 , C                 , &
+    logical                                                                   :: nonConvergenceIsFatal , requireCollapseBeforeHalo
+    double precision                                                          :: alpha                 , beta                     , &
+         &                                                                       kappa                 , C                        , &
          &                                                                       p                     , coefficientScatter
 
     !![
@@ -120,6 +158,23 @@ contains
       <defaultValue>.true.</defaultValue>
       <description>
       If true, failure to converge on a solution for the scale radius, :math:`r_\mathrm{s}`, will result in a fatal error. Otherwise, only warnings are issued.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>requireCollapseBeforeHalo</name>
+      <source>parameters</source>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, a prompt cusp is assigned only to halos for which the cusp collapse epoch precedes the epoch of the halo itself, as
+      in the reference implementation of :cite:t:`delos_cusp-halo_2025`. Since prompt cusp formation is, by definition, the
+      formation event of a halo, halos failing this condition can not have formed: they are assigned no cusp and are labeled
+      ``promptCuspUnformed`` so that they may be pruned from the merger tree (see the class description above). Halos for which no
+      collapse epoch exists at all are treated identically, again matching the reference implementation.
+
+      If false, the original behavior of this class is used instead: any collapse epoch found is accepted, even where it postdates
+      the halo, and halos with no solution are assigned a collapse epoch at the limiting time of the search. No halo is labeled,
+      and so none is pruned. This is provided only to allow existing models to reproduce their previous results; it is not
+      physically preferable.
       </description>
     </inputParameter>
     <inputParameter docformat="rst">
@@ -196,7 +251,7 @@ contains
     <objectBuilder class="cosmologyParameters"   name="cosmologyParameters_"   source="parameters"/>
     <objectBuilder class="virialDensityContrast" name="virialDensityContrast_" source="parameters"/>
     !!]
-    self=nodeOperatorDarkMatterProfilePromptCusps(nonConvergenceIsFatal,alpha,beta,kappa,C,p,coefficientScatter,linearGrowth_,powerSpectrum_,cosmologyParameters_,cosmologyFunctions_,virialDensityContrast_,darkMatterHaloScale_,darkMatterProfileDMO_)
+    self=nodeOperatorDarkMatterProfilePromptCusps(nonConvergenceIsFatal,requireCollapseBeforeHalo,alpha,beta,kappa,C,p,coefficientScatter,linearGrowth_,powerSpectrum_,cosmologyParameters_,cosmologyFunctions_,virialDensityContrast_,darkMatterHaloScale_,darkMatterProfileDMO_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="linearGrowth_"         />
@@ -210,11 +265,12 @@ contains
     return
   end function darkMatterProfilePromptCuspsConstructorParameters
 
-  function darkMatterProfilePromptCuspsConstructorInternal(nonConvergenceIsFatal,alpha,beta,kappa,C,p,coefficientScatter,linearGrowth_,powerSpectrum_,cosmologyParameters_,cosmologyFunctions_,virialDensityContrast_,darkMatterHaloScale_,darkMatterProfileDMO_) result(self)
+  function darkMatterProfilePromptCuspsConstructorInternal(nonConvergenceIsFatal,requireCollapseBeforeHalo,alpha,beta,kappa,C,p,coefficientScatter,linearGrowth_,powerSpectrum_,cosmologyParameters_,cosmologyFunctions_,virialDensityContrast_,darkMatterHaloScale_,darkMatterProfileDMO_) result(self)
     !!{RST
     Constructor for the :galacticus-class:`nodeOperatorDarkMatterProfilePromptCusps` node operator class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameters
+    use :: Nodes_Labels    , only : nodeLabelRegister
     implicit none
     type            (nodeOperatorDarkMatterProfilePromptCusps)                        :: self
     class           (linearGrowthClass                       ), intent(in   ), target :: linearGrowth_
@@ -224,12 +280,12 @@ contains
     class           (darkMatterHaloScaleClass                ), intent(in   ), target :: darkMatterHaloScale_
     class           (darkMatterProfileDMOClass               ), intent(in   ), target :: darkMatterProfileDMO_
     class           (virialDensityContrastClass              ), intent(in   ), target :: virialDensityContrast_
-    logical                                                   , intent(in   )         :: nonConvergenceIsFatal
-    double precision                                          , intent(in   )         :: alpha                 , beta              , &
-         &                                                                               kappa                 , C                 , &
+    logical                                                   , intent(in   )         :: nonConvergenceIsFatal , requireCollapseBeforeHalo
+    double precision                                          , intent(in   )         :: alpha                 , beta                     , &
+         &                                                                               kappa                 , C                        , &
          &                                                                               p                     , coefficientScatter
     !![
-    <constructorAssign variables="nonConvergenceIsFatal, alpha, beta, kappa, C, p, coefficientScatter, *linearGrowth_, *powerSpectrum_, *cosmologyParameters_, *cosmologyFunctions_, *darkMatterHaloScale_, *darkMatterProfileDMO_, *virialDensityContrast_"/>
+    <constructorAssign variables="nonConvergenceIsFatal, requireCollapseBeforeHalo, alpha, beta, kappa, C, p, coefficientScatter, *linearGrowth_, *powerSpectrum_, *cosmologyParameters_, *cosmologyFunctions_, *darkMatterHaloScale_, *darkMatterProfileDMO_, *virialDensityContrast_"/>
     !!]
 
     !![
@@ -241,6 +297,14 @@ contains
     <addMetaProperty component="darkMatterProfile" name="promptCuspNFWGrowthRateID" id="self%promptCuspNFWGrowthRateID" isEvolvable="no" isCreator="yes"/>
     !!]
     self%growthIsWavenumberDependent=self%linearGrowth_%isWavenumberDependent()
+    ! Register the label used to identify halos in which no prompt cusp can form and which, therefore, can not themselves have
+    ! formed. Such nodes are expected to be pruned from the tree prior to evolution - see
+    ! `darkMatterProfilePromptCuspsNodeTreeInitialize()` for details.
+    self%labelUnformedID=nodeLabelRegister(                                                                                                         &
+         &                                 'promptCuspUnformed'                                                                                   , &
+         &                                 'Halos for which the prompt cusp collapse epoch is later than the epoch of the halo itself, and which'// &
+         &                                 ' therefore can not have formed.'                                                                        &
+         &                                )
     return
   end function darkMatterProfilePromptCuspsConstructorInternal
 
@@ -274,13 +338,14 @@ contains
     use :: Lambert_Ws                          , only : Lambert_W0
     use :: Numerical_Constants_Math            , only : Pi
     use :: Numerical_Comparison                , only : Values_Agree
+    use :: Nodes_Labels                        , only : nodeLabelSet
     use :: Root_Finder                         , only : rootFinder                         , rangeExpandMultiplicative     , rangeExpandSignExpectPositive, rangeExpandSignExpectNegative
     use :: ISO_Varying_String                  , only : var_str
     use :: String_Handling                     , only : operator(//)
     implicit none
     class           (nodeOperatorDarkMatterProfilePromptCusps), intent(inout), target  :: self
     type            (treeNode                                ), intent(inout), target  :: node
-    type            (treeNode                                )               , pointer :: nodeChild
+    type            (treeNode                                )               , pointer :: nodeChild                        , nodeTip
     class           (nodeComponentBasic                      )               , pointer :: basic
     class           (nodeComponentDarkMatterProfile          )               , pointer :: darkMatterProfile
     integer                                                   , parameter              :: iterationCountMaximum    =10000
@@ -288,15 +353,13 @@ contains
     type            (rootFinder                              )               , save    :: finderCollapse                   , finderRadius
     logical                                                                  , save    :: finderCollapseInitialized=.false., finderRadiusInitialized=.false.
     !$omp threadprivate(finderCollapse,finderRadius,finderCollapseInitialized,finderRadiusInitialized)
-    integer                                                                  , save    :: countNoCollapse          =0
-    !$omp threadprivate(countNoCollapse)
     ! Factor by which the collapse time is allowed to exceed the present age of the Universe before the search is abandoned. σ₀(t)
     ! grows only until the Universe becomes Λ-dominated and is then constant to far better than double precision by this epoch, so
     ! no root can exist beyond it.
     double precision                                          , parameter              :: factorTimeCollapseMaximum=1.0d1
     double precision                                                                   :: timeCollapseMaximum
-    double precision                                                         , save    :: errorFractionalMaximum=  0.0d+0
-    logical                                                                            :: computeCusp
+    double precision                                                         , save    :: errorFractionalMaximum   =0.0d+0
+    logical                                                                            :: computeCusp                      , cuspCanForm
     integer                                                                            :: iterationCount                   , statusCollapse
     double precision                                                                   :: sigma0                           , sigma2                         , &
          &                                                                                densityMean                      , densityMeanCollapse            , &
@@ -310,20 +373,25 @@ contains
          &                                                                                scatterRandom                    , errorFractional                , &
          &                                                                                densityScalePrevious             , massPrevious
     
-    ! Compute cusp properties for leaf nodes.
-    computeCusp=.not.associated(node%firstChild)
+    ! Compute cusp properties for branch tip nodes. Note that "branch tip" here means a node with no progenitors *which remain
+    ! after pruning* - i.e. progenitors which have themselves been identified as unable to form are ignored. Since the tree is
+    ! walked depth-first, all progenitors of this node have already been processed, so their status is known.
+    nodeChild   =>      progenitorPrimary(self%labelUnformedID,node     )
+    computeCusp = .not.associated        (                     nodeChild)
     if (.not.computeCusp) then
-       ! For non-leaf nodes, use the cusp properties from the leaf node.
-       nodeChild => node
-       do while (associated(nodeChild%firstChild))
-          nodeChild => nodeChild%firstChild
+       ! For non-branch tip nodes, use the cusp properties from the branch tip node.
+       nodeTip   => nodeChild
+       nodeChild => progenitorPrimary(self%labelUnformedID,nodeTip)
+       do while (associated(nodeChild))
+          nodeTip   => nodeChild
+          nodeChild => progenitorPrimary(self%labelUnformedID,nodeTip)
        end do
-       darkMatterProfile =>  nodeChild        %darkMatterProfile        (                          )
+       darkMatterProfile =>  nodeTip          %darkMatterProfile        (                          )
        amplitude         =   darkMatterProfile%floatRank0MetaPropertyGet(self%promptCuspAmplitudeID)
        mass              =   darkMatterProfile%floatRank0MetaPropertyGet(self%promptCuspMassID     )
        y                 =   darkMatterProfile%floatRank0MetaPropertyGet(self%promptCuspNFWYID     )
     else
-       ! For leaf nodes, assume no cusp on the initial iteration.
+       ! For branch tip nodes, assume no cusp on the initial iteration.
        y                 =   0.0d0
     end if
     ! Initialize the root finder.
@@ -348,7 +416,7 @@ contains
     ! out to ever later times, and the cosmological functions eventually raise a floating point exception when a³ overflows -
     ! which is diagnosed far from its cause. The limit is placed well beyond any epoch at which σ₀ is still growing, so it does
     ! not alter any collapse time that is found; it only converts the runaway into a clean out-of-range status here.
-    timeCollapseMaximum=+factorTimeCollapseMaximum                                &
+    timeCollapseMaximum=+factorTimeCollapseMaximum                                  &
          &              *self%cosmologyFunctions_%cosmicTime(expansionFactor=1.0d0)
     call finderCollapse%rangeExpand(                                                             &
          &                          rangeExpandUpward            =2.0d+0                       , &
@@ -367,10 +435,19 @@ contains
     radiusMinus2        =darkMatterProfile%scale()
     radiusScale         =radiusMinus2
     radiusScalePrevious =huge(0.0d0)
+    densityScale        =     0.0d0
     densityScalePrevious=huge(0.0d0)
     massPrevious        =huge(0.0d0)
     iterationCount      =0
-    scatterRandom       =0.0d0
+    cuspCanForm         =.true.
+    ! Draw the deviate used to scatter the cusp amplitude. This is drawn here, prior to any test of whether a prompt cusp can form
+    ! in this halo, so that the sequence of random numbers consumed from the tree's generator does not depend on the outcome of
+    ! that test.
+    if (computeCusp .and. self%coefficientScatter > 0.0d0) then
+       scatterRandom=node%hostTree%randomNumberGenerator_%standardNormalSample()
+    else
+       scatterRandom=0.0d0
+    end if
     ! Begin iteration.
     do while (                                                                                 &
          &     (                                                                               &
@@ -415,29 +492,34 @@ contains
                &                           )**((2.0d0*self%p-1.0d0)/3.0d0)                    &
                &                         )
           timeCollapse       =finderCollapse            %find(                  rootGuess=basic%time        (),status=statusCollapse)
-          if (statusCollapse /= errorStatusSuccess) then
-             ! No collapse time exists for this halo - σ₀Collapse exceeds σ₀(t) at every epoch. Take the collapse to occur at the
-             ! limiting time, which is the continuous limit of the solution as σ₀Collapse approaches the asymptotic value of σ₀.
-             timeCollapse   =timeCollapseMaximum
-             countNoCollapse=countNoCollapse+1
-             ! Report on the first occurrence and then at each decade, so that the incidence is visible without the reporting
-             ! itself dominating the run.
-             if (countNoCollapse == 10**int(log10(dble(countNoCollapse))+0.5d0)) then
-                block
-                  character(len=256) :: labelDiagnostic
-                  write (labelDiagnostic,'(a,i9,a,e12.6,a,e12.6,a,e12.6,a,e12.6,a,e12.6)') "prompt cusp: no collapse time solution (occurrence ",countNoCollapse," on this thread): t=",basic%time(),", M=",basic%mass(),", M200c=",mass200Critical,", sigma0=",sigma0,", sigma0Collapse=",sigma0Collapse
-                  call Warn(trim(labelDiagnostic))
-                end block
+          ! Test whether a prompt cusp can form in this halo. Following Delos (2025), a cusp exists only if the collapse epoch
+          ! precedes that of the halo itself - `CuspHalo.collapse_a()` in the reference implementation
+          ! (https://github.com/galacticusorg/cusp-halo-relation) returns NaN otherwise. Since prompt cusp formation is, by
+          ! definition, the formation event of a halo, a halo in which no cusp can form is one which can not itself exist. Such
+          ! nodes are assigned no cusp and are labeled, so that they may subsequently be pruned from the tree (for example by a
+          ! `mergerTreeOperatorPruneByFilter` operator using a `galacticFilterLabelled` filter). The case in which no solution
+          ! exists at all (σ₀Collapse exceeds σ₀(t) at every epoch, which occurs for sufficiently low mass halos, since σ₀(t)
+          ! grows only until the Universe becomes Λ-dominated and is constant thereafter) is treated identically - just as in the
+          ! reference implementation, where such halos fall off the end of the interpolating table and are likewise assigned no
+          ! cusp.
+          if (statusCollapse /= errorStatusSuccess .or. timeCollapse > basic%time()) then
+             if (self%requireCollapseBeforeHalo) then
+                cuspCanForm=.false.
+                exit
+             else if (statusCollapse /= errorStatusSuccess) then
+                ! Original behavior: no collapse time exists for this halo, so take the collapse to occur at the limiting time,
+                ! which is the continuous limit of the solution as σ₀Collapse approaches the asymptotic value of σ₀. Where a
+                ! solution does exist it is accepted unchanged, even though it postdates the halo.
+                timeCollapse=timeCollapseMaximum
              end if
           end if
-          sigma2Collapse     =self                      %sigma               (2,time     =      timeCollapse  )
-          densityMeanCollapse=self  %cosmologyFunctions_%matterDensityEpochal(  time     =      timeCollapse  )
+          sigma2Collapse     =self                      %sigma               (2,time=timeCollapse)
+          densityMeanCollapse=self  %cosmologyFunctions_%matterDensityEpochal(  time=timeCollapse)
           ! Evaluate the prompt cusp parameters.
           amplitude=self%alpha*(self%alpha/self%C/self%beta**self%p)**(1.0d0/(2.0d0*self%p-1.0d0))*densityMeanCollapse*sigma0Collapse**((9.0d0-6.0d0*self%p)/(4.0d0-8.0d0*self%p))/sigma2Collapse**0.75d0
           mass     =self%beta *(self%alpha/self%C/self%beta**self%p)**(2.0d0/(2.0d0*self%p-1.0d0))*densityMeanCollapse*sigma0Collapse**((9.0d0-6.0d0*self%p)/(2.0d0-4.0d0*self%p))/sigma2Collapse**1.50d0
           ! Add scatter to the cusp amplitude.
           if (self%coefficientScatter > 0.0d0) then
-             if (iterationCount == 1) scatterRandom=node%hostTree%randomNumberGenerator_%standardNormalSample()
              amplitude=+amplitude                         &
                   &    *10.0d0**(                         &
                   &              +self%coefficientScatter &
@@ -486,31 +568,15 @@ contains
           densityScalePrevious=      densityScale
           massPrevious        =basic%mass        ()
        else
-          ! Compute the normalization of the cusp-NFW profile. Handle the case of y=0 here (which is assumed on the first iteration).
+          ! Compute the normalization of the cusp-NFW profile. The y=0 case (which is assumed on the first iteration) is handled
+          ! by `factorMassCuspNFW()`, which takes the NFW limit for negligible y.
           concentration=+self%darkMatterHaloScale_%radiusVirial(node) &
                &        /                          radiusScale
-          if (y > 0.0d0) then
-             ! Cusp-NFW (y>0) case.
-             densityScale=+basic%mass()                                                                                 &
-                  &       /radiusScale**3                                                                               &
-                  &       /4.0d0                                                                                        &
-                  &       /Pi                                                                                           &
-                  &       /(                                                                                            &
-                  &         + 2.0d0                       *asinh(sqrt(concentration            )/               y     ) &
-                  &         -(2.0d0-y**2)/sqrt(1.0d0-y**2)*atanh(sqrt(concentration*(1.0d0-y**2)/(concentration+y**2))) &
-                  &         -sqrt(concentration*(concentration+y**2))/(1.0d0+concentration)                             &
-                  &        )
-          else
-             ! NFW (y=0) case.
-             densityScale=+basic%mass()                             &
-                  &       /4.0d0                                    &
-                  &       /Pi                                       &                                 
-                  &       /radiusScale**3                           &
-                  &       /(                                        &
-                  &         +              log(1.0d0+concentration) &
-                  &         -concentration/   (1.0d0+concentration) &
-                  &        )
-          end if
+          densityScale =+basic            %mass(               ) &
+               &        /radiusScale**3                          &
+               &        /4.0d0                                   &
+               &        /Pi                                      &
+               &        /factorMassCuspNFW     (concentration,y)
           ! Compute a new scale radius to obtain the target r₋₂, using equations (23) from Delos (2025).
           gamma      =+amplitude           &
                &      /densityScale        &
@@ -532,20 +598,18 @@ contains
                &      *radiusMinus2
           ! Enforce a maximum scale radius (minimum concentration) as required to ensure that y<1 in the cusp-NFW profile.
           radiusScale=max(radiusScale,(amplitude/densityScale/yMaximum)**(2.0d0/3.0d0))
-          ! Evaluate the prompt cusp y-parameter.
+          ! Evaluate the prompt cusp y-parameter. Values below `yMinimum` are indistinguishable from a cuspless (i.e. NFW) profile
+          ! and are set to zero, so that no negligible - but non-zero - y is stored for use by the cusp-NFW mass distribution.
           y          =+amplitude           &
                &      /densityScale        &
                &      /radiusScale **1.5d0
+          if (y < yMinimum) y=0.0d0
           ! Evaluate the mass to use in convergence checks.
-          massPrevious=+4.0d0                                                                                        &
-               &       *Pi                                                                                           &
-               &       *radiusScale**3                                                                               &
-               &       *densityScale                                                                                 &
-               &       *(                                                                                            &
-               &         + 2.0d0                       *asinh(sqrt(concentration            )/               y     ) &
-               &         -(2.0d0-y**2)/sqrt(1.0d0-y**2)*atanh(sqrt(concentration*(1.0d0-y**2)/(concentration+y**2))) &
-               &         -sqrt(concentration*(concentration+y**2))/(1.0d0+concentration)                             &
-               &        )
+          massPrevious=+4.0d0                              &
+               &       *Pi                                 &
+               &       *radiusScale**3                     &
+               &       *densityScale                       &
+               &       *factorMassCuspNFW(concentration,y)
        end if
        ! Store prompt cusp parameters.
        call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspAmplitudeID ,amplitude   )
@@ -554,6 +618,42 @@ contains
        call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWScaleID  ,radiusScale )
        call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWDensityID,densityScale)
     end do
+    ! Handle halos in which no prompt cusp can form, and which therefore can not themselves have formed. Such nodes are given a
+    ! cusp-free (i.e. NFW) profile - for which r₋₂ is simply the scale radius - and are labeled so that they may be pruned from
+    ! the tree prior to evolution.
+    if (.not.cuspCanForm) then
+       amplitude    =+0.0d0
+       mass         =+0.0d0
+       y            =+0.0d0
+       radiusScale  =+radiusMinus2
+       concentration=+self %darkMatterHaloScale_%radiusVirial(node) &
+            &        /                           radiusScale
+       densityScale =+basic%mass       ()                           &
+            &        /4.0d0                                         &
+            &        /Pi                                            &
+            &        /radiusScale**3                                &
+            &        /(                                             &
+            &          +              log(1.0d0+concentration)      &
+            &          -concentration/   (1.0d0+concentration)      &
+            &         )
+       call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspAmplitudeID ,amplitude   )
+       call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspMassID      ,mass        )
+       call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWYID      ,y           )
+       call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWScaleID  ,radiusScale )
+       call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWDensityID,densityScale)
+       call nodeLabelSet                              (self%labelUnformedID        ,node        )
+       ! If this is the base node of the tree then no halo in the tree could have formed. The base node can not be pruned, so warn
+       ! that this tree will be reduced to an inert base node.
+       if (.not.associated(node%parent)) then
+          block
+            type(varying_string) :: message
+            message=var_str('no prompt cusp can form in the base node of a tree {node index = ')//node%index()//'}'//char(10)// &
+                 &  '  no halo in this tree can have formed - the tree will be reduced to an inert base node'
+            call Warn(message)
+          end block
+       end if
+       return
+    end if
     ! Check for convergence.
     if     (                                                                               &
          &   .not.Values_Agree(radiusScale ,radiusScalePrevious ,relTol=toleranceRelative) &
@@ -604,6 +704,49 @@ contains
     return
   end subroutine darkMatterProfilePromptCuspsNodeTreeInitialize
 
+  function progenitorPrimary(labelUnformedID,node) result(nodeProgenitor)
+    !!{RST
+    Return a pointer to the primary progenitor which ``node`` will have once all halos identified as unable to form have been
+    pruned from the merger tree, or a ``null()`` pointer if ``node`` will have no progenitors. Pruning unlinks such nodes without
+    preserving primary progenitor status (i.e. ``firstChild`` is replaced by ``sibling``), so the primary progenitor after pruning
+    is simply the first progenitor which is not labeled as being unable to form.
+    !!}
+    use :: Nodes_Labels, only : nodeLabelIsPresent
+    implicit none
+    type   (treeNode), pointer                :: nodeProgenitor
+    integer          , intent(in   )          :: labelUnformedID
+    type   (treeNode), intent(inout), target  :: node
+
+    nodeProgenitor => node%firstChild
+    do while (associated(nodeProgenitor))
+       if (.not.nodeLabelIsPresent(labelUnformedID,nodeProgenitor)) return
+       nodeProgenitor => nodeProgenitor%sibling
+    end do
+    return
+  end function progenitorPrimary
+
+  double precision function factorMassCuspNFW(concentration,y)
+    !!{RST
+    Evaluate the dimensionless factor :math:`M/4 \pi \rho_\mathrm{s} r_\mathrm{s}^3` giving the mass enclosed within a radius
+    :math:`c r_\mathrm{s}` of a cusp-NFW density profile of parameter :math:`y`. For :math:`y` below ``yMinimum`` the NFW limit
+    of this expression is used instead---see the discussion accompanying that parameter.
+    !!}
+    implicit none
+    double precision, intent(in   ) :: concentration, y
+
+    if (y > yMinimum) then
+       ! Cusp-NFW case.
+       factorMassCuspNFW=+ 2.0d0                       *asinh(sqrt(concentration            )/               y     ) &
+            &            -(2.0d0-y**2)/sqrt(1.0d0-y**2)*atanh(sqrt(concentration*(1.0d0-y**2)/(concentration+y**2))) &
+            &            -sqrt(concentration*(concentration+y**2))/(1.0d0+concentration)
+    else
+       ! NFW limit.
+       factorMassCuspNFW=+              log(1.0d0+concentration) &
+            &            -concentration/   (1.0d0+concentration)
+    end if
+    return
+  end function factorMassCuspNFW
+
   double precision function timeCollapseRoot(timeCollapse)
     !!{RST
     Root function used to find the time of collapse.
@@ -650,7 +793,7 @@ contains
     logical                                                   , save                        :: integratorInitialized               =.false.
     !$omp threadprivate(integrator_,integratorInitialized)
     double precision                                          , allocatable  , dimension(:) :: sigmaTmp
-    double precision                                                                        :: wavenumberPhysicalLogarithmicMinimum        , wavenumberPhysicalLogarithmicMaximum, &
+    double precision                                                                        :: wavenumberPhysicalLogarithmicMinimum        , wavenumberPhysicalLogarithmicMaximum       , &
          &                                                                                     sigmaPrevious
 
     ! Initialize an integrator if necessary.
@@ -791,6 +934,12 @@ contains
 
     darkMatterProfile       => node       %darkMatterProfile()
     darkMatterProfileParent => node%parent%darkMatterProfile()
+    ! Note that the cusp amplitude and mass must be copied along with the remaining cusp properties. Along any branch which
+    ! remains after halos unable to form have been pruned these are constant, so copying them is a no-op. They are not constant if
+    ! such halos are left in the tree, however, in which case failing to copy them leaves the promoted node with the zero
+    ! amplitude of an unformed halo alongside the non-zero y-parameter of its parent - a state which is not self-consistent.
+    call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspAmplitudeID    ,darkMatterProfileParent%floatRank0MetaPropertyGet(self%promptCuspAmplitudeID    ))
+    call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspMassID         ,darkMatterProfileParent%floatRank0MetaPropertyGet(self%promptCuspMassID         ))
     call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWYID         ,darkMatterProfileParent%floatRank0MetaPropertyGet(self%promptCuspNFWYID         ))
     call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWGrowthRateID,darkMatterProfileParent%floatRank0MetaPropertyGet(self%promptCuspNFWGrowthRateID))
     call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWScaleID     ,darkMatterProfileParent%floatRank0MetaPropertyGet(self%promptCuspNFWScaleID     ))
@@ -847,23 +996,31 @@ contains
          &                     *darkMatterProfile                           %floatRank0MetaPropertyGet(self%promptCuspNFWGrowthRateID)
     concentration_          =  +self                   %darkMatterHaloScale_%radiusVirial             (node                          ) &
          &                     /                                             radiusScale_
-    densityScale            =  +massHalo_                                                                                      &
-         &                     /radiusScale_**3                                                                                &
-         &                     /4.0d0                                                                                          &
-         &                     /Pi                                                                                             &
-         &                     /(                                                                                              &
-         &                       + 2.0d0                       *asinh(sqrt(concentration_            )/                y     ) &
-         &                       -(2.0d0-y**2)/sqrt(1.0d0-y**2)*atanh(sqrt(concentration_*(1.0d0-y**2)/(concentration_+y**2))) &
-         &                       -sqrt(concentration_*(concentration_+y**2))/(1.0d0+concentration_)                            &
-         &                      )
-    densityScale            =   finder%find(rootGuess=densityScale)
-    ! Compute the cusp y parameter.
-    y                     =min(                      &
-         &                     +amplitudeCusp_       &
-         &                     /densityScale         &
-         &                     /radiusScale_**1.5d0, &
-         &                     +yMaximum             &
-         &                    )
+    if (amplitudeCusp_ > 0.0d0) then
+       ! Cusp-NFW (y>0) case - the density normalization must be found by solving for a self-consistent y.
+       densityScale         =  +massHalo_                           &
+            &                  /radiusScale_**3                     &
+            &                  /4.0d0                               &
+            &                  /Pi                                  &
+            &                  /factorMassCuspNFW(concentration_,y)
+       densityScale         =   finder%find(rootGuess=densityScale)
+       ! Compute the cusp y parameter, treating negligible values as zero - see the discussion accompanying `yMinimum`.
+       y                    =min(                      &
+            &                    +amplitudeCusp_       &
+            &                    /densityScale         &
+            &                    /radiusScale_**1.5d0, &
+            &                    +yMaximum             &
+            &                   )
+       if (y < yMinimum) y=0.0d0
+    else
+       ! NFW (y=0) case - the profile has no cusp, so the density normalization follows directly and no root find is needed.
+       densityScale         =  +massHalo_                               &
+            &                  /4.0d0                                   &
+            &                  /Pi                                      &
+            &                  /radiusScale_**3                         &
+            &                  /factorMassCuspNFW(concentration_,0.0d0)
+       y                    =  +0.0d0
+    end if
     call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWYID      ,y           )
     call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWScaleID  ,radiusScale_)    
     call darkMatterProfile%floatRank0MetaPropertySet(self%promptCuspNFWDensityID,densityScale)    
@@ -885,15 +1042,11 @@ contains
          &                 /radiusScale_**1.5d0, &
          &                 +yMaximum             &
          &                )
-    densityNormalizationRoot=+massHalo_                                                                                      &
-         &                   /radiusScale_**3                                                                                &
-         &                   /4.0d0                                                                                          &
-         &                   /Pi                                                                                             &
-         &                   /(                                                                                              &
-         &                     + 2.0d0                       *asinh(sqrt(concentration_            )/                y     ) &
-         &                     -(2.0d0-y**2)/sqrt(1.0d0-y**2)*atanh(sqrt(concentration_*(1.0d0-y**2)/(concentration_+y**2))) &
-         &                     -sqrt(concentration_*(concentration_+y**2))/(1.0d0+concentration_)                            &
-         &                    )                                                                                              &
+    densityNormalizationRoot=+massHalo_                           &
+         &                   /radiusScale_**3                     &
+         &                   /4.0d0                               &
+         &                   /Pi                                  &
+         &                   /factorMassCuspNFW(concentration_,y) &
          &                   -densityScale
     return
   end function densityNormalizationRoot

--- a/source/tests/prompt_cusps.F90
+++ b/source/tests/prompt_cusps.F90
@@ -43,6 +43,7 @@ program Test_Prompt_Cusps
   use :: Node_Components                     , only : Node_Components_Initialize                                    , Node_Components_Thread_Initialize, Node_Components_Thread_Uninitialize, Node_Components_Uninitialize
   use :: Nodes_Operators                     , only : nodeOperatorDarkMatterProfilePromptCusps
   use :: Node_Property_Extractors            , only : nodePropertyExtractorPromptCusps
+  use :: Nodes_Labels                        , only : nodeLabelIsPresent                                            , nodeLabelRegister
   use :: Mass_Distributions                  , only : massDistributionClass
   use :: Power_Spectra                       , only : powerSpectrumStandard
   use :: Power_Spectra_Primordial            , only : powerSpectrumPrimordialPowerLaw
@@ -52,7 +53,7 @@ program Test_Prompt_Cusps
   use :: Transfer_Functions                  , only : transferFunctionCAMB                                          , transferFunctionBode2001         , scaleCutOffModelVogel23SpinHalf    , transferFunctionTypeTotal
   use :: Unit_Tests                          , only : Assert                                                        , Unit_Tests_Begin_Group                                                , Unit_Tests_End_Group        , Unit_Tests_Finish
   implicit none
-  type            (treeNode                                                      ), pointer     :: node
+  type            (treeNode                                                      ), pointer     :: node                                          , nodeUnformed
   class           (nodeComponentBasic                                            ), pointer     :: basic
   class           (nodeComponentDarkMatterProfile                                ), pointer     :: darkMatterProfile
   class           (massDistributionClass                                         ), pointer     :: massDistribution_
@@ -78,6 +79,9 @@ program Test_Prompt_Cusps
   type            (coordinateSpherical                                           )              :: coordinates
   double precision                                                               , parameter    :: massHalo                           =3.15057d+8, redshiftHalo            =1.50000d+00, &
        &                                                                                           radiusSlopeMinus2                  =1.08798d-3, densityVirial200Critical=1.38923d+14
+  ! A halo far below the free-streaming cutoff scale, in which no prompt cusp can form.
+  double precision                                                               , parameter    :: massHaloUnformed                   =1.00000d+4, redshiftHaloUnformed    =0.00000d+00, &
+       &                                                                                           radiusSlopeMinus2Unformed          =1.00000d-5
   double precision                                                               , dimension(6) :: propertiesPromptCusp
   double precision                                                                              :: radiusScale                                   , densityScale                        , &
        &                                                                                           radiusVirial                                  , massVirial                          , &
@@ -254,6 +258,7 @@ program Test_Prompt_Cusps
    <constructor>
     nodeOperatorDarkMatterProfilePromptCusps                      (                                                                                                              &amp;
      &amp;                                                         nonConvergenceIsFatal                     =.true.                                                           , &amp;
+     &amp;                                                         requireCollapseBeforeHalo                 =.true.                                                           , &amp;
      &amp;                                                         alpha                                     =24.0d0                                                           , &amp;
      &amp;                                                         beta                                      = 7.3d0                                                           , &amp;
      &amp;                                                         kappa                                     = 4.5d0                                                           , &amp;
@@ -325,6 +330,24 @@ program Test_Prompt_Cusps
   call Assert("α₋₂",densitySlopeLogarithmic,-2.00000d+00,relTol=1.0d-3)
   call Assert("rᵥ" ,radiusVirial           ,+8.01838d-03,relTol=1.0d-3)
   call Assert("mᵥ" ,massVirial             ,+3.00000d+08,relTol=1.0d-3)
+  ! Test a halo far below the free-streaming cutoff scale of the power spectrum. For such a halo σ₀,collapse exceeds σ₀(t) at
+  ! every epoch, so no prompt cusp can form in it. Since prompt cusp formation is, by definition, the formation event of a halo,
+  ! such a halo can not itself have formed: it must be assigned no cusp, and labeled so that it may subsequently be pruned from
+  ! the merger tree. (This matches the reference implementation, in which `CuspHalo.collapse_a()` returns NaN both for halos with
+  ! no solution and for those whose collapse epoch would postdate the halo.)
+  nodeUnformed      => treeNode                      (                 )
+  basic             => nodeUnformed%basic            (autoCreate=.true.)
+  darkMatterProfile => nodeUnformed%darkMatterProfile(autoCreate=.true.)
+  call basic            %massSet            (                                                                               massHaloUnformed         )
+  call basic            %timeSet            (cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(redshiftHaloUnformed     )))
+  call basic            %timeLastIsolatedSet(cosmologyFunctions_%cosmicTime(cosmologyFunctions_%expansionFactorFromRedshift(redshiftHaloUnformed     )))
+  call darkMatterProfile%scaleSet           (                                                                               radiusSlopeMinus2Unformed)
+  call nodeOperator_%nodeTreeInitialize(nodeUnformed)
+  propertiesPromptCusp    =   nodePropertyExtractor_%extract(nodeUnformed,basic%time())
+  call Assert("A {no cusp}"        ,propertiesPromptCusp(1)                                                 ,+0.0d0,absTol=0.0d0)
+  call Assert("m {no cusp}"        ,propertiesPromptCusp(2)                                                 ,+0.0d0,absTol=0.0d0)
+  call Assert("y {no cusp}"        ,propertiesPromptCusp(3)                                                 ,+0.0d0,absTol=0.0d0)
+  call Assert("labeled as unformed",nodeLabelIsPresent(nodeLabelRegister('promptCuspUnformed'),nodeUnformed),.true.             )
   ! End unit tests.
   call Unit_Tests_End_Group               ()
   call Unit_Tests_Finish                  ()

--- a/testSuite/parameters/promptCuspsUnformed.xml
+++ b/testSuite/parameters/promptCuspsUnformed.xml
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Compute prompt cusp parameters - used in testing the calculation again Sten Delos' implementation. -->
+<!-- Test that halos in which no prompt cusp can form are pruned from merger trees. A 3 keV thermal warm dark matter particle
+     with a merger tree mass resolution of 5e6 Msun places this model in the regime where such halos arise. See
+     https://github.com/galacticusorg/galacticus/issues/1362 -->
 
 <parameters>
   <lastModified revision="f62df0c3b1d868c052eedef79c20488955a738c9" time="2026-08-12T22:48:39"/>
@@ -36,7 +38,7 @@
   <!-- Dark matter particle type -->  
   <darkMatterParticle value="WDMThermal">
     <degreesOfFreedomEffective value="1.5"/>
-    <mass value="10.0"/>
+    <mass value="3.0"/>
   </darkMatterParticle>  
 
   <!-- Cosmological parameters and options -->
@@ -141,8 +143,8 @@
   </mergerTreeBranchingProbability>
 
   <mergerTreeBuildMasses value="fixedMass">
-    <massTree value="1.0e12"/>
-    <treeCount value="1"/>
+    <massTree value="1.0e11"/>
+    <treeCount value="2"/>
   </mergerTreeBuildMasses>
   <mergerTreeBuildMassDistribution value="haloMassFunction">
     <abundanceMinimum value="1.0e-6"/>
@@ -152,7 +154,7 @@
   <!-- Halo mass resolution -->
   <mergerTreeMassResolution value="fixed">
     <!-- All trees are set to have the same halo mass resolution. -->
-    <massResolution value="1.0e8"/>
+    <massResolution value="5.0e6"/>
   </mergerTreeMassResolution>
   
   <!-- Dark matter only halo structure options -->
@@ -448,7 +450,7 @@
   </mergerTreeOperator>
 
   <!-- Output file -->
-  <outputFileName value="testSuite/outputs/testPromptCuspNFW.hdf5"/>
+  <outputFileName value="testSuite/outputs/promptCuspsUnformed.hdf5"/>
 
   <!-- Output properties -->
   <nodePropertyExtractor value="multi">
@@ -460,6 +462,7 @@
     <nodePropertyExtractor value="uniqueIDBranchTip"/>
     <nodePropertyExtractor value="promptCusps"/>
     <nodePropertyExtractor value="radiusVirialLastDefined"/>
+    <nodePropertyExtractor value="labels"/>
   </nodePropertyExtractor>
 
   <powerSpectrumWindowFunction value="sharpKSpace">

--- a/testSuite/test-prompt-cusps-unformed.py
+++ b/testSuite/test-prompt-cusps-unformed.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import h5py
+import numpy as np
+import lxml.etree as ET
+
+# Test that halos in which no prompt cusp can form are pruned from merger trees.
+#
+# Prompt cusp formation is, by definition, the formation event of a halo. A halo for which the cusp collapse epoch would lie in
+# its own future can therefore not have formed at all: the `darkMatterProfilePromptCusps` node operator assigns no cusp to such
+# halos and labels them `promptCuspUnformed`, and a `pruneByFilter` merger tree operator removes them from the tree prior to
+# evolution. See https://github.com/galacticusorg/galacticus/issues/1362.
+#
+# The model used here has a 3 keV thermal warm dark matter particle and a merger tree mass resolution of 5e6 M☉ - conditions
+# under which such halos do arise. The model is run twice: once with the pruning operator removed, to establish that the
+# condition is actually triggered under these conditions, and once with it in place, to establish that no halo lacking a cusp
+# survives into the evolved tree.
+# Andrew Benson
+
+# Ensure the output directory exists.
+subprocess.run("mkdir -p outputs", shell=True)
+
+parameterFileBase = "parameters/promptCuspsUnformed.xml"
+
+
+def runModel(label, prune):
+    """Run the model with pruning enabled or disabled, and return the cusp amplitudes of all output halos."""
+    tree = ET.parse(parameterFileBase)
+    root = tree.getroot()
+    root.find("outputFileName").set("value", "testSuite/outputs/promptCuspsUnformed_" + label + ".hdf5")
+    if not prune:
+        # Remove the pruning operator, leaving the remainder of the operator sequence intact.
+        operator = root.find(".//mergerTreeOperator[@value='pruneByFilter']")
+        if operator is None:
+            print("FAILED: could not find the `pruneByFilter` operator in " + parameterFileBase)
+            sys.exit(0)
+        operator.getparent().remove(operator)
+    parameterFile = "outputs/promptCuspsUnformed_" + label + ".xml"
+    logFile = "outputs/promptCuspsUnformed_" + label + ".log"
+    tree.write(parameterFile)
+    status = subprocess.run(
+        "cd ..; ./Galacticus.exe testSuite/" + parameterFile + " > testSuite/" + logFile + " 2>&1",
+        shell=True
+    )
+    if status.returncode != 0:
+        print("FAILED: model '" + label + "' failed to run - see " + logFile)
+        sys.exit(0)
+    # Check the model log for failure markers.
+    with open(logFile, "r") as log:
+        logText = log.read()
+    for marker in ("fatal", "aborted", "ODE integration failed", "unrecognized parameter"):
+        if marker in logText:
+            print("FAILED: model '" + label + "' reported '" + marker + "' - see " + logFile)
+            sys.exit(0)
+    # Extract, for every output halo, whether it carries the `promptCuspUnformed` label. The label is used in preference to the
+    # cusp amplitude because labels persist through node promotion, whereas the cusp properties of a promoted node are overwritten
+    # with those of its parent.
+    labels = []
+    counts = 0
+    with h5py.File("outputs/promptCuspsUnformed_" + label + ".hdf5", "r") as model:
+        outputs = model["Outputs"]
+        for outputName in outputs:
+            nodeData = outputs[outputName]["nodeData"]
+            if "nodeLabelPromptCuspUnformed" not in nodeData:
+                print("FAILED: model '" + label + "' output contains no `nodeLabelPromptCuspUnformed` dataset")
+                sys.exit(0)
+            labels.append(nodeData["nodeLabelPromptCuspUnformed"][:])
+            counts += nodeData["nodeLabelPromptCuspUnformed"].shape[0]
+    return np.concatenate(labels), counts
+
+
+# Run the model with pruning disabled, and with it enabled.
+labelsUnpruned, countUnpruned = runModel("unpruned", prune=False)
+labelsPruned  , countPruned   = runModel("pruned"  , prune=True )
+
+# With pruning disabled, halos in which no cusp can form remain in the tree and so must appear in the output carrying the label.
+# If none appear then the model is not probing the regime in which this occurs, and the test below would be vacuous.
+countUnformedUnpruned = int(np.count_nonzero(labelsUnpruned != 0))
+if countUnformedUnpruned == 0:
+    print("FAILED: no halo lacking a prompt cusp arose with pruning disabled - the model does not probe the relevant regime")
+    sys.exit(0)
+
+# With pruning enabled, no such halo may survive into the evolved tree.
+countUnformedPruned = int(np.count_nonzero(labelsPruned != 0))
+if countUnformedPruned > 0:
+    print("FAILED: " + str(countUnformedPruned) + " halos lacking a prompt cusp survived pruning")
+    sys.exit(0)
+
+print("SUCCESS: halos in which no prompt cusp can form are pruned from merger trees")
+print("  halos labeled as unable to form, pruning disabled: " + str(countUnformedUnpruned))
+print("  halos in output, pruning disabled/enabled: " + str(countUnpruned) + "/" + str(countPruned))


### PR DESCRIPTION
## Summary
- Closes the remaining divergence from the reference implementation described in #1362: a prompt cusp is now assigned only where the cusp collapse epoch precedes the epoch of the halo itself. Since prompt cusp formation is, by definition, the formation event of a halo, halos failing that condition can not have formed — following discussion with Sten Delos, they are assigned no cusp, labeled `promptCuspUnformed`, and pruned from the merger tree. Halos with no collapse epoch at all take the same path, as they do in the reference (`CuspHalo.collapse_a()` returns NaN for both).
- The decision is made in `nodeOperatorDarkMatterProfilePromptCusps`, which owns the iteration the collapse epoch is coupled to; the pruning is done by a new `mergerTreeOperatorPruneByFilter` at `operatePreEvolution`. It can not be done in the node operator, which is invoked from inside a live `mergerTreeWalkerAllNodes` loop at three call sites and so can not reset the walker after modifying the tree (see [this comment](https://github.com/galacticusorg/galacticus/issues/1362#issuecomment-5283908145) for the full reasoning).
- The original behavior is retained under `requireCollapseBeforeHalo=false`, and a parameter migration pins that value in existing parameter files so their results are unchanged. The reference and test models set it explicitly to `true`, so the migration leaves them on the new physics.

Three further defects were found and fixed along the way:

- **`nodePromote` did not copy the cusp amplitude or mass.** Harmless while the amplitude was constant along a branch — which this change ends — it left promoted nodes holding the zero amplitude of an unformed halo alongside the non-zero `y` of their parent. Caught by the new test.
- **The cusp-NFW enclosed mass raised an FPE for small `y`.** The `asinh` and `atanh` terms each diverge as `y → 0`; their divergences cancel, but the cancellation is ill-conditioned, and below `y ~ 1e-9` the `atanh` argument rounds to exactly 1, giving `atanh(1) = ∞`. The four duplicated copies of that expression are now a single `factorMassCuspNFW()` which takes the NFW limit below `y = 1e-4`. **This is likely the FPE in `densitynormalizationroot()` seen in CI for #1368**, since the collapse-time clamp added in 9da49a81a evaluates the amplitude at 10 × t₀, where `A ∝ a^-1.5` drives `y` down by orders of magnitude. That inference is *not* verified — see below.
- **`differentialEvolutionSolveAnalytics` divided by a zero `y`** for cusp-free halos, and `densityScale` was read before assignment in the scale radius iteration (the "incidental" item in #1362).

The threshold `y = 1e-4` was chosen by measuring against a 60-digit reference: the cusp's physical contribution to the enclosed mass falls as `y²` while the double-precision error grows as `1/y²`, and they cross at `1e-4` where both are `~1e-8` — two orders below the tolerance to which the density normalization is solved. Real halos have `y ≳ 1e-2`, so the threshold is never approached in practice.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Docs / tooling
- [x] Other: changes model physics (migration provided)

## How to test
```bash
export GALACTICUS_EXEC_PATH=`pwd`
make -j8 Galacticus.exe tests.prompt_cusps.exe
./tests.prompt_cusps.exe                              # 16/16
./Galacticus.exe parameters/quickTest.xml
./Galacticus.exe testSuite/parameters/testPromptCuspNFW.xml
cd testSuite && python3 test-prompt-cusps-unformed.py  # new
```

`test-prompt-cusps-unformed.py` runs a 3 keV WDM model at a 5e6 M☉ resolution twice — once with the pruning operator stripped out, to establish that the condition actually triggers under those conditions, and once with it in place — asserting that labeled halos appear in the first and none survives in the second.

## Checklist
- [x] I ran relevant tests (or explain why not): all of the above pass. See the caveats below for what is *not* covered.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

## Not yet done / caveats

- **No COZMIC validation deltas.** #1362 asks for these and they are the actual justification for the physics change. The test model here sits far deeper in the rejection regime than COZMIC (it prunes ~17% of z=0 halos), so it says nothing about the magnitude to expect there.
- **The CI FPE from #1368 has not been reproduced.** The singularity is characterised and guarded, and the default path avoids reaching it, but the claim that the clamp is the route in is inference from the `A ∝ a^-1.5` scaling rather than a demonstration. Running COZMIC WDM X8 3 keV on this branch would settle it and produce the validation deltas in the same job.
- **`nodeOperatorDarkMatterProfilePromptCusps` and the pruning operator are configured independently**, so a parameter file can use the first without the second and get halos which can not have formed left in the tree. The class documentation says so prominently, but nothing enforces it — an instance of the broader problem that Galacticus can not detect inconsistent physics in a parameter file.
- **`massDistributionCuspNFW` contains the same singular expression** (`cusp-NFW.F90:247`, `:408`) with no `y`-based guard of its own; its `fractionSmall` branches key on radius. Storing sub-threshold `y` as zero keeps it out of that regime for now, but the class itself remains exposed if anything else hands it a small `y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
