### PR TITLE
Pin dynamically-tabulated ranges to an absolute lattice: phase 3

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1249,6 +1249,7 @@ jobs:
                       tests.dust.attenuation_descriptors.exe,
                       tests.make_ranges.exe,
                       tests.tabulations_inverse.exe,
+                      tests.cosmology_functions.exe,
                       tests.mass_distributions.exe,
                       tests.mass_distributions.tabulated.exe,
                       tests.kinematic_distributions.NFW.exe,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1248,6 +1248,7 @@ jobs:
                       tests.interpolation.multiD.exe,
                       tests.dust.attenuation_descriptors.exe,
                       tests.make_ranges.exe,
+                      tests.tabulations_inverse.exe,
                       tests.mass_distributions.exe,
                       tests.mass_distributions.tabulated.exe,
                       tests.kinematic_distributions.NFW.exe,

--- a/source/accretion/halo/Naoz_Barkana_2007.F90
+++ b/source/accretion/halo/Naoz_Barkana_2007.F90
@@ -114,6 +114,13 @@
   ! Virial density contrast definition used by Gnedin (2000) to define halos, and therefore used in the filtering mass fitting functions.
   double precision, parameter :: densityContrastVirial=200.0d0
 
+  ! Minimum hot halo mass (in M☉) for which a metal mass fraction is formed. Below this the halo holds no mass worth speaking of,
+  ! and testing simply for a positive mass is not sufficient: as the ordinary differential equations carry the hot halo mass
+  ! toward zero it passes through denormal values - masses of order 10⁻³⁰⁶ M☉ have been observed here - at which dividing the
+  ! metal mass by it overflows, and the floating point overflow trap fires. Treating such a halo as empty gives the same answer
+  ! to any accuracy which means anything, since the fraction is immediately multiplied by that same negligible mass again.
+  double precision, parameter :: massHotHaloMinimum   =  1.0d-30
+
 contains
 
   function naozBarkana2007ConstructorParameters(parameters) result(self)
@@ -616,7 +623,7 @@ contains
        if (rateCorrection > 0.0d0) then
           ! Mass is being moved from the hot reservoir to the unaccreted reservoir. Find the mass fraction of metals in the hot
           ! halo.
-          if (hotHalo%mass() > 0.0d0) then
+          if (hotHalo%mass() > massHotHaloMinimum) then
              fractionMetals=+hotHalo%abundances() &
                   &         /hotHalo%mass      ()
           else
@@ -682,7 +689,7 @@ contains
        if (rateCorrection > 0.0d0) then
           ! Mass is being moved from the hot reservoir to the unaccreted reservoir. Find the mass fraction of metals in the hot
           ! halo.
-          if (hotHalo%mass() > 0.0d0) then
+          if (hotHalo%mass() > massHotHaloMinimum) then
              fractionMetals=+hotHalo%abundances() &
                   &         /hotHalo%mass      ()
           else
@@ -752,7 +759,7 @@ contains
        if (rateCorrection > 0.0d0) then
           ! Mass is being moved from the hot reservoir to the unaccreted reservoir. Find the mass fraction of chemicals in the hot
           ! halo.
-          if (hotHalo%mass() > 0.0d0) then
+          if (hotHalo%mass() > massHotHaloMinimum) then
              fractionChemicals= hotHalo%chemicals() &
                   &            /hotHalo%mass     ()
           else

--- a/source/cosmology/functions/matter_dark_energy.F90
+++ b/source/cosmology/functions/matter_dark_energy.F90
@@ -24,9 +24,6 @@
   use :: Root_Finder, only : rootFinder
 
   integer         , parameter :: ageTableNPointsPerDecade     =300
-  double precision, parameter :: ageTableNPointsPerOctave     =dble(ageTableNPointsPerDecade)*log(2.0d0)/log(10.0d0)
-  double precision, parameter :: ageTableIncrementFactor      =exp(int(ageTableNPointsPerOctave+1.0d0)*log(10.0d0)/dble(ageTableNPointsPerDecade))
-  integer         , parameter :: distanceTableNPointsPerDecade=100
 
   ! Factor by which one component of Universe must dominate others such that we can ignore the others.
   double precision, parameter :: factorDominate               =100.0d0
@@ -238,13 +235,13 @@ contains
        call Error_Report('non-collapsing universe assumed'//{introspection:location})
     else
        ! In expanding phase ensure that sufficiently small and large expansion factors have been reached.
+       ! Request a wider range rather than adjusting the bounds directly: the tabulation derives its range from the request
+       ! and from the lattice it already holds, so a bound assigned here would simply be overwritten and the loop never end.
        do while (self%ageTableExpansionFactor(                        1) > expansionFactor)
-          self%ageTableTimeMinimum=    self%ageTableTimeMinimum/ageTableIncrementFactor
-          call self%expansionFactorTabulate()
+          call self%expansionFactorTabulate(self%ageTableTimeMinimum/2.0d0)
        end do
        do while (self%ageTableExpansionFactor(self%ageTableNumberPoints) < expansionFactor)
-          self%ageTableTimeMaximum=max(self%ageTableTimeMaximum*ageTableIncrementFactor,self%timeTurnaround)
-          call self%expansionFactorTabulate()
+          call self%expansionFactorTabulate(self%ageTableTimeMaximum*2.0d0)
        end do
     end if
     ! Interpolate to get cosmic time.
@@ -488,14 +485,21 @@ contains
     Builds a table of expansion factor vs. time for dark energy universes.
     !!}
     use :: Cosmology_Parameters, only : hubbleUnitsTime
-    use :: Numerical_Ranges    , only : Make_Range     , rangeTypeLogarithmic
+    use :: Numerical_Ranges    , only : Range_Pinned   , Range_Lattice_Extend, rangeLattice, gridSchemePerDecade
     implicit none
     class           (cosmologyFunctionsMatterDarkEnergy)             , intent(inout), target   :: self
     double precision                                                 , intent(in   ), optional :: time
     double precision                                    , parameter                            :: turnaroundTimeTolerance         =1.0d-12
     double precision                                    , parameter                            :: odeToleranceAbsolute            =1.0d-9 , odeToleranceRelative    =1.0d-9
+    ! The bounds are pinned to single lattice steps rather than to whole decades: at three hundred points per decade, with an
+    ! ordinary differential equation integrated across each of them, rounding a bound out to a whole decade would add three
+    ! hundred epochs for the sake of reaching one.
+    integer                                             , parameter                            :: ageTableAnchorEvery             =1
     double precision                                    , allocatable, dimension(:)            :: ageTableExpansionFactorTemporary        , ageTableTimeTemporary
-    integer                                                                                    :: iTime                                   , prefixPointCount
+    logical                                             , allocatable, dimension(:)            :: isComputed
+    type            (rangeLattice                      )                                       :: latticeTime
+    integer                                                                                    :: iTime
+    logical                                                                                    :: carryOver
     double precision                                                                           :: OmegaDominant                           , deltaTime                      , &
          &                                                                                        densityPower                            , timeDominant                   , &
          &                                                                                        expansionFactorDominant                 , timeActual
@@ -505,65 +509,71 @@ contains
     call self%densityScalingEarlyTime(factorDominate,densityPower,expansionFactorDominant,OmegaDominant)
     ! Find the corresponding time.
     timeDominant=-2.0d0/densityPower/self%cosmologyParameters_%HubbleConstant(hubbleUnitsTime)/sqrt(OmegaDominant)/expansionFactorDominant**(0.5d0*densityPower)
-    ! Find minimum and maximum times to tabulate.
+    ! Assume initially that this Universe does not collapse; the tabulation below detects otherwise. Once found, the epoch of
+    ! turnaround is a property of the cosmology rather than of the tabulation, so it is determined on the first build and
+    ! retained thereafter. Redetermining it on every call, as was formerly attempted here, cannot work once previously computed
+    ! values are carried over, since the detection below examines only those points which are computed afresh.
+    if (.not.self%ageTableInitialized) then
+       self%collapsingUniverse    =.false.
+       self%expansionFactorMaximum=0.0d0
+       self%timeTurnaround        =0.0d0
+       self%timeMaximum           =0.0d0
+    end if
+    ! Find the range of epochs to tabulate, pinning it to an absolute lattice so that the epochs tabulated - and therefore every
+    ! expansion factor interpolated between them - depend only on which lattice points are spanned, and not on the sequence of
+    ! epochs which happened to be requested. The bounds formerly grew by repeated multiplication by a fixed factor from an origin
+    ! set by the first request, and the abscissae were then redistributed over the result by `Make_Range`, so that the previously
+    ! computed points pasted back into the new table carried the *old* spacing. The table thereby became a patchwork of spacings
+    ! which no single `ageTableInverseDeltaLogTime` could describe, and the index computed from it in `expansionFactor` drifted
+    ! further from the truth with every extension.
     if (present(time)) then
        timeActual=time
-       do while (self%ageTableTimeMinimum > min(timeActual,timeDominant)/2.0d0)
-          self%ageTableTimeMinimum=self%ageTableTimeMinimum/ageTableIncrementFactor
-       end do
-       do while (self%ageTableTimeMaximum < max(timeActual,timeDominant)*2.0d0)
-          self%ageTableTimeMaximum=self%ageTableTimeMaximum*ageTableIncrementFactor
-       end do
     else
-       do while (self%ageTableTimeMinimum > timeDominant/2.0d0)
-          self%ageTableTimeMinimum=self%ageTableTimeMinimum/ageTableIncrementFactor
-       end do
-       do while (self%ageTableTimeMaximum < timeDominant*2.0d0)
-          self%ageTableTimeMaximum=self%ageTableTimeMaximum*ageTableIncrementFactor
-       end do
+       timeActual=timeDominant
     end if
-    ! Determine number of points to tabulate.
-    self%ageTableNumberPoints=int(log10(self%ageTableTimeMaximum/self%ageTableTimeMinimum)     *dble(ageTableNPointsPerDecade))+1
-    self%ageTableTimeMaximum =self%ageTableTimeMinimum*10.0d0**(dble(self%ageTableNumberPoints)/dble(ageTableNPointsPerDecade))
-    ! Assume this Universe does not collapse initially.
-    self%collapsingUniverse    =.false.
-    self%expansionFactorMaximum=0.0d0
-    self%timeTurnaround        =0.0d0
-    self%timeMaximum           =0.0d0
-    ! Deallocate arrays if currently allocated.
-    if (allocated(self%ageTableTime)) then
-       ! Determine number of points that are being added at the start of the array.
-       prefixPointCount=int(log10(self%ageTableTime(1)/self%ageTableTimeMinimum)*dble(ageTableNPointsPerDecade)+0.5d0)
-       call Move_Alloc(self%ageTableTime           ,ageTableTimeTemporary           )
-       call Move_Alloc(self%ageTableExpansionFactor,ageTableExpansionFactorTemporary)
-       ! Allocate the arrays to current required size.
-       allocate(self%ageTableTime           (self%ageTableNumberPoints))
-       allocate(self%ageTableExpansionFactor(self%ageTableNumberPoints))
-       ! Create set of grid points in time variable.
-       self%ageTableTime=Make_Range(self%ageTableTimeMinimum,self%ageTableTimeMaximum,self%ageTableNumberPoints,rangeTypeLogarithmic)
-       ! Set the expansion factors to a negative value to indicate they are not yet computed.
-       self%ageTableExpansionFactor=-1.0d0
-       ! Paste in the previously computed regions.
-       self%ageTableTime           (prefixPointCount+1:prefixPointCount+size(ageTableTimeTemporary))=ageTableTimeTemporary
-       self%ageTableExpansionFactor(prefixPointCount+1:prefixPointCount+size(ageTableTimeTemporary))=ageTableExpansionFactorTemporary
-       ! Deallocate the temporary arrays.
-       deallocate(ageTableTimeTemporary           )
-       deallocate(ageTableExpansionFactorTemporary)
+    if (self%collapsingUniverse) then
+       latticeTime=Range_Pinned(                                          &
+            &                                  [timeActual,timeDominant], &
+            &                                   ageTableNPointsPerDecade, &
+            &                                   gridSchemePerDecade     , &
+            &                   marginFactor  = 2.0d0                   , &
+            &                   anchorEvery   = ageTableAnchorEvery     , &
+            &                   limitMaximum  = self%timeTurnaround     , &
+            &                   latticeCurrent= self%latticeAgeTable      &
+            &                  )
     else
-       ! Allocate the arrays to current required size.
-       allocate(self%ageTableTime           (self%ageTableNumberPoints))
-       allocate(self%ageTableExpansionFactor(self%ageTableNumberPoints))
-       ! Create set of grid points in time variable.
-       self%ageTableTime=Make_Range(self%ageTableTimeMinimum,self%ageTableTimeMaximum,self%ageTableNumberPoints,rangeTypeLogarithmic)
-       ! Set the expansion factors to a negative value to indicate they are not yet computed.
-       self%ageTableExpansionFactor=-1.0d0
+       latticeTime=Range_Pinned(                                          &
+            &                                  [timeActual,timeDominant], &
+            &                                   ageTableNPointsPerDecade, &
+            &                                   gridSchemePerDecade     , &
+            &                   marginFactor  = 2.0d0                   , &
+            &                   anchorEvery   = ageTableAnchorEvery     , &
+            &                   latticeCurrent= self%latticeAgeTable      &
+            &                  )
     end if
-    ! Compute quantities required for table interpolation.
+    ! The expansion factor is integrated forward from an initial condition imposed at the earliest tabulated epoch, so every
+    ! value depends on where that integration began. The tabulation can therefore be carried over only while the earliest epoch
+    ! is unchanged; where it moves, everything is discarded by presenting an undefined lattice to the extension.
+    carryOver=self%ageTableInitialized .and. self%latticeAgeTable%isDefined()
+    if (carryOver) carryOver=latticeTime%indexMinimum == self%latticeAgeTable%indexMinimum
+    if (.not.carryOver) then
+       if (allocated(self%ageTableExpansionFactor)) deallocate(self%ageTableExpansionFactor)
+       self%latticeAgeTable=rangeLattice()
+    end if
+    call Range_Lattice_Extend(self%latticeAgeTable,latticeTime,self%ageTableExpansionFactor,isComputed)
+    self%latticeAgeTable     =latticeTime
+    self%ageTableNumberPoints=latticeTime%count
+    if (allocated(self%ageTableTime)) deallocate(self%ageTableTime)
+    self%ageTableTime        =latticeTime%values()
+    self%ageTableTimeMinimum =self%ageTableTime(                        1)
+    self%ageTableTimeMaximum =self%ageTableTime(self%ageTableNumberPoints)
+    ! Compute quantities required for table interpolation. These are evaluated again after the tabulation below, so that they
+    ! describe the table actually held even where it is truncated at turnaround.
     self%ageTableTimeLogarithmicMinimum=log(self%ageTableTimeMinimum)
     self%ageTableInverseDeltaLogTime   =dble(self%ageTableNumberPoints-1)/log(self%ageTableTimeMaximum/self%ageTableTimeMinimum)
     ! For the initial time, we approximate that we are at sufficiently early times that a single component dominates the
     ! Universe and use the appropriate analytic solution.
-    if (self%ageTableExpansionFactor(1) < 0.0d0)                        &
+    if (.not.isComputed(1))                                             &
          &    self%ageTableExpansionFactor           (               1) &
          & =(                                                           &
          &   -0.5d0                                                     &
@@ -577,7 +587,7 @@ contains
     call self%targetSelf()
     do iTime=2,self%ageTableNumberPoints
        ! Compute the expansion factor if it is not already computed.
-       if (self%ageTableExpansionFactor(iTime) < 0.0d0) then
+       if (.not.isComputed(iTime)) then
           self%ageTableExpansionFactor(iTime)=matterDarkEnergyExpansionFactorChange(                                       &
                &                                                                    self%ageTableTime           (iTime-1), &
                &                                                                    self%ageTableTime           (iTime  ), &
@@ -617,19 +627,27 @@ contains
              end do
              self%enableRangeChecks=.true.
              self%timeMaximum      =2.0d0*self%timeTurnaround
-             ! Limit the tables to the expanding part of the evolution.
-             self%iTableTurnaround=iTime-2
+             ! Limit the tables to the expanding part of the evolution. The lattice held is shortened to match: its points are
+             ! unchanged, so the shortened table remains a set of points of the same absolute lattice and can be extended - or
+             ! carried over - exactly as before. Now that the epoch of turnaround is known it is imposed as a hard limit on the
+             ! range above, so this truncation happens only on the build which discovers it.
+             self%iTableTurnaround     =iTime-2
+             self%ageTableNumberPoints =self%iTableTurnaround
+             self%latticeAgeTable%count=self%ageTableNumberPoints
              call Move_Alloc(self%ageTableTime           ,ageTableTimeTemporary           )
              call Move_Alloc(self%ageTableExpansionFactor,ageTableExpansionFactorTemporary)
-             self%ageTableNumberPoints=self%iTableTurnaround
              allocate(self%ageTableTime           (self%ageTableNumberPoints))
              allocate(self%ageTableExpansionFactor(self%ageTableNumberPoints))
              self%ageTableTime           =ageTableTimeTemporary           (1:self%ageTableNumberPoints)
              self%ageTableExpansionFactor=ageTableExpansionFactorTemporary(1:self%ageTableNumberPoints)
+             self%ageTableTimeMaximum    =self%ageTableTime               (  self%ageTableNumberPoints)
              exit
           end if
        end if
     end do
+    ! Recompute the quantities required for table interpolation, so that they describe the table actually held even where it was
+    ! truncated at turnaround above.
+    self%ageTableInverseDeltaLogTime=dble(self%ageTableNumberPoints-1)/log(self%ageTableTimeMaximum/self%ageTableTimeMinimum)
     if (allocated(self%interpolatorTime)) deallocate(self%interpolatorTime)
     allocate(self%interpolatorTime)
     self%interpolatorTime=interpolator(self%ageTableExpansionFactor,self%ageTableTime)

--- a/source/cosmology/functions/matter_dark_energy.F90
+++ b/source/cosmology/functions/matter_dark_energy.F90
@@ -24,6 +24,10 @@
   use :: Root_Finder, only : rootFinder
 
   integer         , parameter :: ageTableNPointsPerDecade     =300
+  ! Factor by which the earliest epoch of the expansion factor tabulation is placed below the epoch of single component
+  ! domination - see the equivalent tabulation in the parent class for why that bound is seeded rather than left to follow
+  ! the request.
+  double precision, parameter :: ageTableTimeEarliestFactor   =100.0d0
 
   ! Factor by which one component of Universe must dominate others such that we can ignore the others.
   double precision, parameter :: factorDominate               =100.0d0
@@ -504,6 +508,7 @@ contains
          &                                                                                        densityPower                            , timeDominant                   , &
          &                                                                                        expansionFactorDominant                 , timeActual
     logical                                                                                    :: solutionFound                           , timeExceeded
+    double precision                                                 , dimension(3)            :: timesTarget
 
     ! Find expansion factor early enough that a single component dominates the evolution of the Universe.
     call self%densityScalingEarlyTime(factorDominate,densityPower,expansionFactorDominant,OmegaDominant)
@@ -531,9 +536,10 @@ contains
     else
        timeActual=timeDominant
     end if
+    timesTarget=[timeActual,timeDominant,timeDominant/ageTableTimeEarliestFactor]
     if (self%collapsingUniverse) then
        latticeTime=Range_Pinned(                                          &
-            &                                  [timeActual,timeDominant], &
+            &                                   timesTarget             , &
             &                                   ageTableNPointsPerDecade, &
             &                                   gridSchemePerDecade     , &
             &                   marginFactor  = 2.0d0                   , &
@@ -543,7 +549,7 @@ contains
             &                  )
     else
        latticeTime=Range_Pinned(                                          &
-            &                                  [timeActual,timeDominant], &
+            &                                   timesTarget             , &
             &                                   ageTableNPointsPerDecade, &
             &                                   gridSchemePerDecade     , &
             &                   marginFactor  = 2.0d0                   , &

--- a/source/cosmology/functions/matter_lambda.F90
+++ b/source/cosmology/functions/matter_lambda.F90
@@ -26,11 +26,7 @@
   use :: Numerical_Ranges       , only : rangeLattice
 
   integer         , parameter :: ageTableNPointsPerDecade     =300
-  double precision, parameter :: ageTableNPointsPerOctave     =dble(ageTableNPointsPerDecade)*log(2.0d0)/log(10.0d0)
-  double precision, parameter :: ageTableIncrementFactor      =exp(int(ageTableNPointsPerOctave+1.0d0)*log(10.0d0)/dble(ageTableNPointsPerDecade))
   integer         , parameter :: distanceTableNPointsPerDecade=100
-  double precision, parameter :: distanceTableNPointsPerOctave=dble(distanceTableNPointsPerDecade)*log(2.0d0)/log(10.0d0)
-  double precision, parameter :: distanceTableIncrementFactor =exp(int(distanceTableNPointsPerOctave+1.0d0)*log(10.0d0)/dble(distanceTableNPointsPerDecade))
 
   ! Factor by which one component of Universe must dominate others such that we can ignore the others.
   double precision, parameter :: matterLambdaDominateFactor               =100.0d0
@@ -64,7 +60,8 @@
           &                                                                   interpolatorDistanceInverse                              , interpolatorLuminosityDistance                             , &
           &                                                                   interpolatorLuminosityDistanceKCorrected
      logical                                                               :: distanceTableInitialized                        =.false.
-     integer                                                               :: distanceTableNumberPoints
+     type            (rangeLattice            )                            :: latticeDistanceTable
+     integer                                                               :: distanceTableNumberPoints                                , distanceTableAgeTableIndexMinimum
      double precision                                                      :: distanceTableTimeMaximum                                 , distanceTableTimeMinimum                            =1.0d+0
      double precision                          , allocatable, dimension(:) :: distanceTableComovingDistance                            , distanceTableComovingDistanceNegated                       , &
           &                                                                   distanceTableLuminosityDistanceNegated                   , distanceTableTime                                          , &
@@ -1283,74 +1280,66 @@ contains
     Builds a table of comoving distance vs. time.
     !!}
     use :: Numerical_Integration           , only : integrator
-    use :: Numerical_Ranges                , only : Make_Range   , rangeTypeLogarithmic
-    use :: Numerical_Constants_Astronomical, only : gigaYear  , megaParsec
+    use :: Numerical_Ranges                , only : Range_Pinned                                     , Range_Lattice_Extend, gridSchemePerDecade
+    use :: Numerical_Constants_Astronomical, only : gigaYear                                         , megaParsec
     use :: Numerical_Constants_Physical    , only : speedLight
     implicit none
     class           (cosmologyFunctionsMatterLambda), intent(inout), target       :: self
     double precision                                , intent(in   )               :: time
-    double precision                                , allocatable  , dimension(:) :: distanceTableTimeTemporary                                      , distanceTableComovingDistanceTemporary                , &
-         &                                                                           distanceTableComovingDistanceNegatedTemporary                   , distanceTableLuminosityDistanceNegatedTemporary       , &
-         &                                                                           distanceTableLuminosityDistanceKCorrectedNegatedTemporary
-    double precision                                , parameter                   :: toleranceAbsolute                                        =1.0d-5, toleranceRelative                              =1.0d-5
-    integer                                                                       :: iTime                                                           , prefixPointCount
+    double precision                                , parameter                   :: toleranceAbsolute       =1.0d-5, toleranceRelative=1.0d-5
+    ! The bounds are pinned to single lattice steps rather than to whole decades: every point of this table is a numerical
+    ! integral, so rounding a bound out to a whole decade would add a hundred of them for the sake of reaching one.
+    integer                                         , parameter                   :: distanceTableAnchorEvery=1
+    logical                                         , allocatable  , dimension(:) :: isComputed
+    type            (rangeLattice                  )                              :: latticeTime
+    integer                                                                       :: iTime                          , ageTableIndexMinimum
+    logical                                                                       :: carryOver
     type            (integrator                    )                              :: integrator_
 
-    ! Find minimum and maximum times to tabulate.
-    if (.not.self%distanceTableInitialized) then
-       self%distanceTableTimeMinimum=0.5d0*time
+    ! Find the range of epochs to tabulate, pinning it to an absolute lattice so that the epochs tabulated - and therefore every
+    ! distance interpolated between them - depend only on which lattice points are spanned, and not on the sequence of epochs
+    ! which happened to be requested.
+    !
+    ! The comoving distance to an epoch is an integral out to the present day, so this table must *end* exactly at the present
+    ! day - and no lattice point of an absolute lattice in cosmic time does. The axis is therefore tabulated in units of the
+    ! present day age of the universe, in which the present day is the lattice point of index zero, exactly, on any lattice. (The
+    ! same device is used for the electron scattering optical depth of the intergalactic medium state class.)
+    !
+    ! Both that unit and the limits of each integral are interpolated from the expansion factor table, so this tabulation is only
+    ! as stable as that one: extending the expansion factor table downward restarts its integration from a new earliest epoch,
+    ! and so changes every value in it. The loop below therefore establishes the expansion factor table across the whole range
+    ! about to be tabulated *before* any distance is computed, and repeats if doing so rebuilt it. The tabulation which follows
+    ! then cannot be undermined part way through, and previously computed distances are carried over only while that table has
+    ! not been rebuilt since they were computed.
+    do
        self%distanceTableTimeMaximum=self%cosmicTime(1.0d0)
-    else
-       do while (self%distanceTableTimeMinimum > time/2.0d0)
-          self%distanceTableTimeMinimum=self%distanceTableTimeMinimum/distanceTableIncrementFactor
-       end do
+       ageTableIndexMinimum         =self%latticeAgeTable%indexMinimum
+       latticeTime=Range_Pinned(                                                            &
+            &                                  [time/self%distanceTableTimeMaximum,1.0d0] , &
+            &                                   distanceTableNPointsPerDecade             , &
+            &                                   gridSchemePerDecade                       , &
+            &                   marginFactor  = 2.0d0                                     , &
+            &                   anchorEvery   = distanceTableAnchorEvery                  , &
+            &                   limitMaximum  = 1.0d0                                     , &
+            &                   latticeCurrent= self%latticeDistanceTable                   &
+            &                  )
+       call self%expansionFactorTabulate(latticeTime%minimum()*self%distanceTableTimeMaximum)
+       if (self%latticeAgeTable%indexMinimum == ageTableIndexMinimum) exit
+    end do
+    carryOver=self%distanceTableInitialized .and. self%latticeDistanceTable%isDefined()
+    if (carryOver) carryOver=self%distanceTableAgeTableIndexMinimum == ageTableIndexMinimum
+    if (.not.carryOver) then
+       if (allocated(self%distanceTableComovingDistance)) deallocate(self%distanceTableComovingDistance)
+       self%latticeDistanceTable=rangeLattice()
     end if
-    ! Determine number of points to tabulate.
-    self%distanceTableNumberPoints=int(log10(self%distanceTableTimeMaximum/self%distanceTableTimeMinimum)*dble(distanceTableNPointsPerDecade))+1
-    self%distanceTableTimeMinimum =self%distanceTableTimeMaximum/10.0d0**(dble(self%distanceTableNumberPoints)/dble(distanceTableNPointsPerDecade))
-    ! Deallocate arrays if currently allocated.
-    if (allocated(self%distanceTableTime)) then
-       prefixPointCount=int(log10(self%distanceTableTime(1)/self%distanceTableTimeMinimum)*dble(distanceTableNPointsPerDecade)+0.5d0)
-       call Move_Alloc(self%distanceTableTime                               ,distanceTableTimeTemporary                               )
-       call Move_Alloc(self%distanceTableComovingDistance                   ,distanceTableComovingDistanceTemporary                   )
-       call Move_Alloc(self%distanceTableComovingDistanceNegated            ,distanceTableComovingDistanceNegatedTemporary            )
-       call Move_Alloc(self%distanceTableLuminosityDistanceNegated          ,distanceTableLuminosityDistanceNegatedTemporary          )
-       call Move_Alloc(self%distanceTableLuminosityDistanceKCorrectedNegated,distanceTableLuminosityDistanceKCorrectedNegatedTemporary)
-       ! Allocate the arrays to current required size.
-       allocate(self%distanceTableTime                               (self%distanceTableNumberPoints))
-       allocate(self%distanceTableComovingDistance                   (self%distanceTableNumberPoints))
-       allocate(self%distanceTableComovingDistanceNegated            (self%distanceTableNumberPoints))
-       allocate(self%distanceTableLuminosityDistanceNegated          (self%distanceTableNumberPoints))
-       allocate(self%distanceTableLuminosityDistanceKCorrectedNegated(self%distanceTableNumberPoints))
-       ! Create the range of times.
-       self%distanceTableTime=Make_Range(self%distanceTableTimeMinimum,self%distanceTableTimeMaximum,self%distanceTableNumberPoints,rangeTypeLogarithmic)
-       ! Set the comoving distances to a negative value to indicate they are not yet computed.
-       self%distanceTableComovingDistance=-1.0d0
-       ! Paste in the previously computed regions.
-       self%distanceTableTime                               (prefixPointCount+1:prefixPointCount+size(distanceTableTimeTemporary))=+distanceTableTimeTemporary
-       self%distanceTableComovingDistance                   (prefixPointCount+1:prefixPointCount+size(distanceTableTimeTemporary))=+distanceTableComovingDistanceTemporary
-       self%distanceTableComovingDistanceNegated            (prefixPointCount+1:prefixPointCount+size(distanceTableTimeTemporary))=-distanceTableComovingDistanceNegatedTemporary
-       self%distanceTableLuminosityDistanceNegated          (prefixPointCount+1:prefixPointCount+size(distanceTableTimeTemporary))=-distanceTableLuminosityDistanceNegatedTemporary
-       self%distanceTableLuminosityDistanceKCorrectedNegated(prefixPointCount+1:prefixPointCount+size(distanceTableTimeTemporary))=-distanceTableLuminosityDistanceKCorrectedNegatedTemporary
-       ! Deallocate the temporary arrays.
-       deallocate(distanceTableTimeTemporary                               )
-       deallocate(distanceTableComovingDistanceTemporary                   )
-       deallocate(distanceTableComovingDistanceNegatedTemporary            )
-       deallocate(distanceTableLuminosityDistanceNegatedTemporary          )
-       deallocate(distanceTableLuminosityDistanceKCorrectedNegatedTemporary)
-    else
-       ! Allocate the arrays to current required size.
-       allocate(self%distanceTableTime                               (self%distanceTableNumberPoints))
-       allocate(self%distanceTableComovingDistance                   (self%distanceTableNumberPoints))
-       allocate(self%distanceTableComovingDistanceNegated            (self%distanceTableNumberPoints))
-       allocate(self%distanceTableLuminosityDistanceNegated          (self%distanceTableNumberPoints))
-       allocate(self%distanceTableLuminosityDistanceKCorrectedNegated(self%distanceTableNumberPoints))
-       ! Create set of grid points in time variable.
-       self%distanceTableTime=Make_Range(self%distanceTableTimeMinimum,self%distanceTableTimeMaximum,self%distanceTableNumberPoints,rangeTypeLogarithmic)
-       ! Set the expansion factors to a negative value to indicate they are not yet computed.
-       self%distanceTableComovingDistance=-1.0d0
-    end if
-        ! Integrate to get the comoving distance.
+    call Range_Lattice_Extend(self%latticeDistanceTable,latticeTime,self%distanceTableComovingDistance,isComputed)
+    self%latticeDistanceTable             =latticeTime
+    self%distanceTableAgeTableIndexMinimum=ageTableIndexMinimum
+    self%distanceTableNumberPoints        =latticeTime%count
+    if (allocated(self%distanceTableTime)) deallocate(self%distanceTableTime)
+    self%distanceTableTime                =latticeTime%values()*self%distanceTableTimeMaximum
+    self%distanceTableTimeMinimum         =self%distanceTableTime(1)
+    ! Integrate to get the comoving distance.
     integrator_ =  integrator(                                                         &
          &                                      matterLambdaComovingDistanceIntegrand, &
          &                    toleranceAbsolute=toleranceAbsolute                    , &
@@ -1359,25 +1348,34 @@ contains
     self_       => self
     do iTime=1,self%distanceTableNumberPoints
        ! Skip pre-computed entries.
-       if (self%distanceTableComovingDistance(iTime) >= 0.0d0) cycle
+       if (isComputed(iTime)) cycle
        self%distanceTableComovingDistance(iTime)=+integrator_%integrate(                                                                              &
             &                                                           self%expansionFactor(self%distanceTableTime(iTime                         )), &
             &                                                           self%expansionFactor(self%distanceTableTime(self%distanceTableNumberPoints))  &
             &                                                          )                                                                              &
             &                                    *speedLight                                                                                          &
             &                                    *gigaYear                                                                                            &
-            &                                    /megaParsec       
+            &                                    /megaParsec
+    end do
+    ! Make negated copies of the distances so that we have increasing arrays for use in interpolation routines. The luminosity
+    ! distances are simple functions of the comoving distance and of the expansion factor, so they are evaluated afresh at every
+    ! point rather than being carried over: the expansion factor is interpolated from a table which has not been rebuilt, so for
+    ! the points carried over this gives back exactly the values they had.
+    if (allocated(self%distanceTableComovingDistanceNegated            )) deallocate(self%distanceTableComovingDistanceNegated            )
+    if (allocated(self%distanceTableLuminosityDistanceNegated          )) deallocate(self%distanceTableLuminosityDistanceNegated          )
+    if (allocated(self%distanceTableLuminosityDistanceKCorrectedNegated)) deallocate(self%distanceTableLuminosityDistanceKCorrectedNegated)
+    allocate(self%distanceTableComovingDistanceNegated            (self%distanceTableNumberPoints))
+    allocate(self%distanceTableLuminosityDistanceNegated          (self%distanceTableNumberPoints))
+    allocate(self%distanceTableLuminosityDistanceKCorrectedNegated(self%distanceTableNumberPoints))
+    self%distanceTableComovingDistanceNegated=-self%distanceTableComovingDistance
+    do iTime=1,self%distanceTableNumberPoints
        self              %distanceTableLuminosityDistanceNegated              (iTime)   &
-            & =      self%distanceTableComovingDistance                       (iTime)   &
+            & =     -self%distanceTableComovingDistance                       (iTime)   &
             &       /self%expansionFactor              (self%distanceTableTime(iTime))
        self              %distanceTableLuminosityDistanceKCorrectedNegated    (iTime)   &
-            & =      self%distanceTableComovingDistance                       (iTime)   &
+            & =     -self%distanceTableComovingDistance                       (iTime)   &
             &  /sqrt(self%expansionFactor              (self%distanceTableTime(iTime)))
     end do
-    ! Make a negated copy of the distances so that we have an increasing array for use in interpolation routines.
-    self%distanceTableComovingDistanceNegated            =-self%distanceTableComovingDistance
-    self%distanceTableLuminosityDistanceNegated          =-self%distanceTableLuminosityDistanceNegated
-    self%distanceTableLuminosityDistanceKCorrectedNegated=-self%distanceTableLuminosityDistanceKCorrectedNegated
     ! Build interpolators.
     if (allocated(self%interpolatorDistance                    )) deallocate(self%interpolatorDistance                    )
     if (allocated(self%interpolatorDistanceInverse             )) deallocate(self%interpolatorDistanceInverse             )

--- a/source/cosmology/functions/matter_lambda.F90
+++ b/source/cosmology/functions/matter_lambda.F90
@@ -29,7 +29,7 @@
   integer         , parameter :: distanceTableNPointsPerDecade=100
 
   ! Factor by which one component of Universe must dominate others such that we can ignore the others.
-  double precision, parameter :: matterLambdaDominateFactor               =100.0d0
+  double precision, parameter :: matterLambdaDominateFactor   =100.0d0
 
   !![
   <cosmologyFunctions name="cosmologyFunctionsMatterLambda" docformat="rst">
@@ -1280,8 +1280,8 @@ contains
     Builds a table of comoving distance vs. time.
     !!}
     use :: Numerical_Integration           , only : integrator
-    use :: Numerical_Ranges                , only : Range_Pinned                                     , Range_Lattice_Extend, gridSchemePerDecade
-    use :: Numerical_Constants_Astronomical, only : gigaYear                                         , megaParsec
+    use :: Numerical_Ranges                , only : Range_Pinned, Range_Lattice_Extend, gridSchemePerDecade
+    use :: Numerical_Constants_Astronomical, only : gigaYear    , megaParsec
     use :: Numerical_Constants_Physical    , only : speedLight
     implicit none
     class           (cosmologyFunctionsMatterLambda), intent(inout), target       :: self

--- a/source/cosmology/functions/matter_lambda.F90
+++ b/source/cosmology/functions/matter_lambda.F90
@@ -23,6 +23,7 @@
 
   use :: Cosmology_Parameters   , only : cosmologyParameters, cosmologyParametersClass
   use :: Numerical_Interpolation, only : interpolator
+  use :: Numerical_Ranges       , only : rangeLattice
 
   integer         , parameter :: ageTableNPointsPerDecade     =300
   double precision, parameter :: ageTableNPointsPerOctave     =dble(ageTableNPointsPerDecade)*log(2.0d0)/log(10.0d0)
@@ -54,6 +55,7 @@
           &                                                                   timeTurnaround
      double precision                                       , dimension(2) :: expansionRatePrevious                                    , expansionRateExpansionFactorPrevious
      logical                                                               :: ageTableInitialized                             =.false.
+     type            (rangeLattice            )                            :: latticeAgeTable
      integer                                                               :: ageTableNumberPoints
      double precision                                                      :: ageTableTimeMaximum                             =20.0d0  , ageTableTimeMinimum                                 =1.0d-4
      double precision                                                      :: ageTableTimeLogarithmicMinimum                           , ageTableInverseDeltaLogTime
@@ -407,19 +409,18 @@ contains
     ! Ensure that the tabulation spans a sufficient range of expansion factors.
     if (collapsingPhaseActual) then
        ! In collapsing phase just ensure that a sufficiently large expansion factor has been reached.
+       ! Request a wider range rather than adjusting the bounds directly: the tabulation derives its range from the request
+       ! and from the lattice it already holds, so a bound assigned here would simply be overwritten and the loop never end.
        do while (self%ageTableExpansionFactor(self%ageTableNumberPoints) < expansionFactor)
-          self%ageTableTimeMaximum=min(self%ageTableTimeMaximum*ageTableIncrementFactor,self%timeTurnaround)
-          call self%expansionFactorTabulate()
+          call self%expansionFactorTabulate(min(self%ageTableTimeMaximum*2.0d0,self%timeTurnaround))
        end do
     else
        ! In expanding phase ensure that sufficiently small and large expansion factors have been reached.
        do while (self%ageTableExpansionFactor(                    1) > expansionFactor)
-          self%ageTableTimeMinimum=    self%ageTableTimeMinimum/ageTableIncrementFactor
-          call self%expansionFactorTabulate()
+          call self%expansionFactorTabulate(self%ageTableTimeMinimum/2.0d0)
        end do
        do while (self%ageTableExpansionFactor(self%iTableTurnaround) < expansionFactor)
-          self%ageTableTimeMaximum=max(self%ageTableTimeMaximum*ageTableIncrementFactor,self%timeTurnaround)
-          call self%expansionFactorTabulate()
+          call self%expansionFactorTabulate(self%ageTableTimeMaximum*2.0d0)
        end do
     end if
     ! Interpolate to get cosmic time.
@@ -508,21 +509,15 @@ contains
        else
           timeEffective   =                 time
        end if
-       ! Perform the interpolation. We use a custom interpolator here. The expansion factor vs. time table is distributed almost
-       ! uniformly in log(time) - it's not perfectly uniform in log time as we have to preserve numerical tolerance errors arising
-       ! from expansion of the table. Therefore, we attempt to identify the index of the entry in the table by directly computing
-       ! it from the logarithm of the effective time, but allow for the possibility that we might have to adjust that initial
-       ! guess to find the correct index. After that, a standard linear interpolation is used.
-       ! Initial guess at the index for interpolation. The guess assumes a spacing which is perfectly uniform in log(time), which
-       ! the table only approximates - and the discrepancy accumulates as the table is extended, so that after sufficiently many
-       ! extensions the guess can fall beyond the end of the table altogether. It is therefore clamped to a valid interval before
-       ! the search below, which walks from it to the correct index.
+       ! Perform the interpolation. We use a custom interpolator here. With the abscissae pinned to an absolute lattice the table
+       ! is distributed exactly uniformly in log(time), so the index of the entry to interpolate in can be computed directly from
+       ! the logarithm of the effective time rather than searched for. After that, a standard linear interpolation is used.
+       !
+       ! The index is nevertheless clamped, and the searches below bounded, so that a time lying fractionally outside the
+       ! tabulated range cannot walk past either end of the table and read beyond it. The bound is tested inside each loop rather
+       ! than as part of its condition, since Fortran does not guarantee short-circuit evaluation.
        i=int((log(timeEffective)-self%ageTableTimeLogarithmicMinimum)*self%ageTableInverseDeltaLogTime)+1
        i=max(1,min(i,self%ageTableNumberPoints-1))
-       ! Check that we've found the correct index, adjust as necessary. Each search is bounded, so that neither a drifted spacing
-       ! nor a time lying fractionally outside the tabulated range can walk past an end of the table and read beyond it. The bound
-       ! is tested inside each loop rather than as part of its condition because Fortran does not guarantee short-circuit
-       ! evaluation, so a compound condition could reference the table at the very index being rejected.
        do while (timeEffective < self%ageTableTime(i  ))
           if (i <= 1                           ) exit
           i=i-1
@@ -911,17 +906,23 @@ contains
     Builds a table of expansion factor vs. time.
     !!}
     use :: Cosmology_Parameters , only : hubbleUnitsTime
-    use :: Numerical_Ranges     , only : Make_Range     , rangeTypeLogarithmic
     use :: Numerical_ODE_Solvers, only : odeSolver
+    use :: Numerical_Ranges     , only : Range_Pinned   , Range_Lattice_Extend, gridSchemePerDecade
     implicit none
     class           (cosmologyFunctionsMatterLambda), intent(inout), target       :: self
     double precision                                , intent(in   ), optional     :: time
-    double precision                                , parameter                   :: odeToleranceAbsolute            =1.0d-9, odeToleranceRelative =1.0d-9
-    double precision                                , allocatable  , dimension(:) :: ageTableExpansionFactorTemporary       , ageTableTimeTemporary
+    double precision                                , parameter                   :: odeToleranceAbsolute   =1.0d-9, odeToleranceRelative=1.0d-9
+    ! The bounds are pinned to single lattice steps rather than to whole decades: at three hundred points per decade, with an
+    ! ordinary differential equation integrated across each of them, rounding a bound out to a whole decade would add three
+    ! hundred epochs for the sake of reaching one.
+    integer                                         , parameter                   :: ageTableAnchorEvery    =1
+    logical                                         , allocatable  , dimension(:) :: isComputed
+    type            (rangeLattice                  )                              :: latticeTime
     double precision                                               , dimension(1) :: expansionFactor
-    integer                                                                       :: iTime                                  , prefixPointCount
-    double precision                                                              :: OmegaDominant                          , densityPower                , &
-         &                                                                           tDominant                              , timeActual                  , &
+    integer                                                                       :: iTime
+    logical                                                                       :: carryOver
+    double precision                                                              :: OmegaDominant                 , densityPower               , &
+         &                                                                           tDominant                     , timeActual                 , &
          &                                                                           expansionFactorDominant
     type            (odeSolver                     )                              :: solver
 
@@ -931,66 +932,63 @@ contains
     ! is collapsing at the present epoch we need to know the expansion rate (i.e. Hubble parameter) at the equivalent expansion
     ! factor during the expansion phase.
     tDominant=-2.0d0/densityPower/abs(self%cosmologyParameters_%HubbleConstant(hubbleUnitsTime))/sqrt(OmegaDominant)/expansionFactorDominant**(0.5d0*densityPower)
-    ! Find minimum and maximum times to tabulate.
+    ! Find the range of epochs to tabulate, pinning it to an absolute lattice so that the epochs tabulated - and therefore every
+    ! expansion factor interpolated between them - depend only on which lattice points are spanned, and not on the sequence of
+    ! epochs which happened to be requested. The bounds formerly grew by repeated multiplication by a fixed factor from an origin
+    ! set by the first request, and the abscissae were then redistributed over the result by `Make_Range`, so that the previously
+    ! computed points pasted back into the new table carried the *old* spacing. The table thereby became a patchwork of spacings
+    ! which no single `ageTableInverseDeltaLogTime` could describe, and the index computed from it in `expansionFactor` drifted
+    ! further from the truth with every extension - far enough, after sufficiently many, to fall beyond the end of the table.
     if (present(time)) then
        timeActual=time
-       do while (self%ageTableTimeMinimum > min(timeActual,tDominant)/2.0d0)
-          self%ageTableTimeMinimum=self%ageTableTimeMinimum/ageTableIncrementFactor
-       end do
-       do while (self%ageTableTimeMaximum < max(timeActual,tDominant)*2.0d0)
-          self%ageTableTimeMaximum=self%ageTableTimeMaximum*ageTableIncrementFactor
-       end do
     else
-       do while (self%ageTableTimeMinimum > tDominant/2.0d0)
-          self%ageTableTimeMinimum=self%ageTableTimeMinimum/ageTableIncrementFactor
-       end do
-       do while (self%ageTableTimeMaximum < tDominant*2.0d0)
-          self%ageTableTimeMaximum=self%ageTableTimeMaximum*ageTableIncrementFactor
-       end do
+       timeActual=tDominant
     end if
-    if (self%collapsingUniverse) self%ageTableTimeMaximum=min(self%ageTableTimeMaximum,self%timeTurnaround)
-
-    ! Determine number of points to tabulate.
-    self%ageTableNumberPoints=int(log10(self%ageTableTimeMaximum/self%ageTableTimeMinimum)*dble(ageTableNPointsPerDecade))+1
-    self%ageTableTimeMaximum =self%ageTableTimeMinimum*10.0d0**(dble(self%ageTableNumberPoints)/dble(ageTableNPointsPerDecade))
-    if (self%collapsingUniverse) self%ageTableTimeMaximum=min(self%ageTableTimeMaximum,self%timeTurnaround)
-
-    ! Deallocate arrays if currently allocated.
-    if (allocated(self%ageTableTime)) then
-       ! Determine number of points that are being added at the start of the array.
-       prefixPointCount=int(log10(self%ageTableTime(1)/self%ageTableTimeMinimum)*dble(ageTableNPointsPerDecade)+0.5d0)
-       call Move_Alloc(self%ageTableTime           ,ageTableTimeTemporary           )
-       call Move_Alloc(self%ageTableExpansionFactor,ageTableExpansionFactorTemporary)
-       ! Allocate the arrays to current required size.
-       allocate(self%ageTableTime           (self%ageTableNumberPoints))
-       allocate(self%ageTableExpansionFactor(self%ageTableNumberPoints))
-       ! Create set of grid points in time variable.
-       self%ageTableTime=Make_Range(self%ageTableTimeMinimum,self%ageTableTimeMaximum,self%ageTableNumberPoints,rangeTypeLogarithmic)
-       ! Set the expansion factors to a negative value to indicate they are not yet computed.
-       self%ageTableExpansionFactor=-1.0d0
-       ! Paste in the previously computed regions.
-       self%ageTableTime           (prefixPointCount+1:prefixPointCount+size(ageTableTimeTemporary))=ageTableTimeTemporary
-       self%ageTableExpansionFactor(prefixPointCount+1:prefixPointCount+size(ageTableTimeTemporary))=ageTableExpansionFactorTemporary
-       ! Deallocate the temporary arrays.
-       deallocate(ageTableTimeTemporary           )
-       deallocate(ageTableExpansionFactorTemporary)
+    if (self%collapsingUniverse) then
+       latticeTime=Range_Pinned(                                          &
+            &                                  [timeActual,tDominant]   , &
+            &                                   ageTableNPointsPerDecade, &
+            &                                   gridSchemePerDecade     , &
+            &                   marginFactor  = 2.0d0                   , &
+            &                   anchorEvery   = ageTableAnchorEvery     , &
+            &                   limitMaximum  = self%timeTurnaround     , &
+            &                   latticeCurrent= self%latticeAgeTable      &
+            &                  )
     else
-       ! Allocate the arrays to current required size.
-       allocate(self%ageTableTime           (self%ageTableNumberPoints))
-       allocate(self%ageTableExpansionFactor(self%ageTableNumberPoints))
-       ! Create set of grid points in time variable.
-       self%ageTableTime=Make_Range(self%ageTableTimeMinimum,self%ageTableTimeMaximum,self%ageTableNumberPoints,rangeTypeLogarithmic)
-       ! Set the expansion factors to a negative value to indicate they are not yet computed.
-       self%ageTableExpansionFactor=-1.0d0
+       latticeTime=Range_Pinned(                                          &
+            &                                  [timeActual,tDominant]   , &
+            &                                   ageTableNPointsPerDecade, &
+            &                                   gridSchemePerDecade     , &
+            &                   marginFactor  = 2.0d0                   , &
+            &                   anchorEvery   = ageTableAnchorEvery     , &
+            &                   latticeCurrent= self%latticeAgeTable      &
+            &                  )
     end if
-    ! Compute quantities required for table interpolation.
+    ! The expansion factor is integrated forward from an initial condition imposed at the earliest tabulated epoch, so every
+    ! value depends on where that integration began. The tabulation can therefore be carried over only while the earliest epoch
+    ! is unchanged; where it moves, everything is discarded by presenting an undefined lattice to the extension.
+    carryOver=self%ageTableInitialized .and. self%latticeAgeTable%isDefined()
+    if (carryOver) carryOver=latticeTime%indexMinimum == self%latticeAgeTable%indexMinimum
+    if (.not.carryOver) then
+       if (allocated(self%ageTableExpansionFactor)) deallocate(self%ageTableExpansionFactor)
+       self%latticeAgeTable=rangeLattice()
+    end if
+    call Range_Lattice_Extend(self%latticeAgeTable,latticeTime,self%ageTableExpansionFactor,isComputed)
+    self%latticeAgeTable     =latticeTime
+    self%ageTableNumberPoints=latticeTime%count
+    if (allocated(self%ageTableTime)) deallocate(self%ageTableTime)
+    self%ageTableTime        =latticeTime%values()
+    self%ageTableTimeMinimum =self%ageTableTime(                        1)
+    self%ageTableTimeMaximum =self%ageTableTime(self%ageTableNumberPoints)
+    ! Compute quantities required for table interpolation. The lattice is exactly uniform in the logarithm of the time, so the
+    ! index computed from these in `expansionFactor` is now exact rather than a guess needing correction.
     self%ageTableTimeLogarithmicMinimum=log(self%ageTableTimeMinimum)
     self%ageTableInverseDeltaLogTime   =dble(self%ageTableNumberPoints-1)/log(self%ageTableTimeMaximum/self%ageTableTimeMinimum)
     ! For the initial time, we approximate that we are at sufficiently early times that a single component dominates the Universe
     ! and use the appropriate analytic solution. Note that we use the absolute value of the Hubble parameter here - in cases where
     ! the universe is collapsing at the present epoch we need to know the expansion rate (i.e. Hubble parameter) at the equivalent
     ! expansion factor during the expansion phase.
-    if (self%ageTableExpansionFactor(1) < 0.0d0)                             &
+    if (.not.isComputed(1))                                                  &
          &    self%ageTableExpansionFactor                (               1) &
          & =(                                                                &
          &   -0.5d0                                                          &
@@ -1013,7 +1011,7 @@ contains
             &   self%ageTableTime(iTime  ) >= self%timeTurnaround &
             & ) self%iTableTurnaround=iTime
        ! Compute the expansion factor if it is not already computed.
-       if (self%ageTableExpansionFactor(iTime) < 0.0d0) then
+       if (.not.isComputed(iTime)) then
           timeActual        =self%ageTableTime           (iTime-1)
           expansionFactor(1)=self%ageTableExpansionFactor(iTime-1)
           call solver%solve(timeActual,self%ageTableTime(iTime),expansionFactor)

--- a/source/cosmology/functions/matter_lambda.F90
+++ b/source/cosmology/functions/matter_lambda.F90
@@ -27,6 +27,11 @@
 
   integer         , parameter :: ageTableNPointsPerDecade     =300
   integer         , parameter :: distanceTableNPointsPerDecade=100
+  ! Factor by which the earliest epoch of the expansion factor tabulation is placed below the epoch of single component
+  ! domination - see `matterLambdaMakeExpansionFactorTable` for why that bound is seeded rather than left to follow the
+  ! request. Two decades of headroom cost a few hundred additional steps of an ordinary differential equation which is
+  ! integrated across a far larger range in any case.
+  double precision, parameter :: ageTableTimeEarliestFactor   =100.0d0
 
   ! Factor by which one component of Universe must dominate others such that we can ignore the others.
   double precision, parameter :: matterLambdaDominateFactor   =100.0d0
@@ -921,6 +926,7 @@ contains
     double precision                                                              :: OmegaDominant                 , densityPower               , &
          &                                                                           tDominant                     , timeActual                 , &
          &                                                                           expansionFactorDominant
+    double precision                                               , dimension(3) :: timesTarget
     type            (odeSolver                     )                              :: solver
 
     ! Find expansion factor early enough that a single component dominates the evolution of the Universe.
@@ -936,14 +942,22 @@ contains
     ! computed points pasted back into the new table carried the *old* spacing. The table thereby became a patchwork of spacings
     ! which no single `ageTableInverseDeltaLogTime` could describe, and the index computed from it in `expansionFactor` drifted
     ! further from the truth with every extension - far enough, after sufficiently many, to fall beyond the end of the table.
+    !
+    ! The earliest epoch tabulated is seeded to a fixed fraction of the epoch of single component domination rather than being
+    ! left to follow the request. Two things depend on that bound. The expansion factor is integrated forward from an initial
+    ! condition imposed there, so moving it invalidates the whole tabulation - and a consumer which integrates over a range of
+    ! epochs, or compares quantities evaluated either side of the move, sees the tabulation shift beneath it. And that condition
+    ! is the analytic single component solution, which is the more accurate the earlier it is applied: imposed at the epoch of
+    ! domination itself it is in error by of order one part in a thousand at redshifts of a few hundred.
     if (present(time)) then
        timeActual=time
     else
        timeActual=tDominant
     end if
+    timesTarget=[timeActual,tDominant,tDominant/ageTableTimeEarliestFactor]
     if (self%collapsingUniverse) then
        latticeTime=Range_Pinned(                                          &
-            &                                  [timeActual,tDominant]   , &
+            &                                   timesTarget             , &
             &                                   ageTableNPointsPerDecade, &
             &                                   gridSchemePerDecade     , &
             &                   marginFactor  = 2.0d0                   , &
@@ -953,7 +967,7 @@ contains
             &                  )
     else
        latticeTime=Range_Pinned(                                          &
-            &                                  [timeActual,tDominant]   , &
+            &                                   timesTarget             , &
             &                                   ageTableNPointsPerDecade, &
             &                                   gridSchemePerDecade     , &
             &                   marginFactor  = 2.0d0                   , &

--- a/source/hot_halo/ram_pressure_stripping/Font2008.F90
+++ b/source/hot_halo/ram_pressure_stripping/Font2008.F90
@@ -191,6 +191,14 @@ contains
        ! retabulation may occur), leading to a failure to bracket the root. If this happens, make a second attempt (at which point
        ! any tabulations should be fully updated). If that also fails, we either give up an accept the best solution we have, or
        ! report an error.
+       !
+       ! Pinning tabulation ranges to an absolute lattice is what would make this retry unnecessary, since a retabulation would
+       ! then leave previously computed values untouched and so could not invalidate a bracket. That is not yet sufficient here:
+       ! the root function below evaluates the *composite* mass distribution, and several of its components still choose their
+       ! range from the first request and rebuild wholesale - `mass_distributions/spherical/Sersic.F90`,
+       ! `mass_distributions/cylindrical/exponential_disk.F90`, `mass_distributions/spherical/heated/monotonic.F90`, the
+       ! accretion flow profiles, and, by way of the gas density, `hot_halo/mass_distribution/cored/core_radius/growing.F90`.
+       ! Retire this retry once those are pinned, and not before.
        do attempt=1,2
           ! Get the hot halo mass distributions.
           massDistribution__    => node%massDistribution(componentTypeAll    ,massTypeAll    )

--- a/source/intergalactic_medium/state/_class.F90
+++ b/source/intergalactic_medium/state/_class.F90
@@ -301,7 +301,14 @@ contains
        allocate(opticalDepthFullyIonized(latticeTime%count))
        ! Loop over times, carrying over the optical depths already computed and evaluating only those which are new. Also find
        ! where the optical depth last decreases: only the monotonic tail beyond that point can be inverted.
-       integrator_               =integrator(intergalacticMediumStateElectronScatteringIntegrand,toleranceRelative=1.0d-6)
+       ! An absolute tolerance is given as well as a relative one. Before reionization the electron fraction is the residual left
+       ! by recombination, so the optical depth accumulated over these epochs is of order 10⁻⁵ - four orders of magnitude below
+       ! the fully ionized case computed alongside it - and its integrand is sharply peaked toward the earliest epochs. Asking
+       ! for a purely relative accuracy of 10⁻⁶ on such an integral requires an absolute accuracy of order 10⁻¹¹ across an
+       ! interval spanning most of the history of the universe, which the quadrature cannot deliver: it reports that roundoff
+       ! prevents the tolerance from being achieved. The absolute tolerance below is still negligible against the optical depths
+       ! this tabulation is used to compare - which are of order 10⁻² - but it stops that demand being made.
+       integrator_               =integrator(intergalacticMediumStateElectronScatteringIntegrand,toleranceRelative=1.0d-6,toleranceAbsolute=1.0d-9)
        iTimeMonotonic            =1
        iTimeMonotonicFullyIonized=1
        do iTime=1,latticeTime%count

--- a/source/mass_distributions/spherical/Burkert.F90
+++ b/source/mass_distributions/spherical/Burkert.F90
@@ -21,7 +21,7 @@
   Implementation of a Burkert :cite:p:`burkert_structure_1995` mass distribution class.
   !!}
 
-  use :: Numerical_Interpolation , only : interpolator
+  use :: Tabulations_Inverse     , only : tabulationInverse
   use :: Numerical_Constants_Math, only : Pi
   
   !![
@@ -64,18 +64,9 @@
      !!}
      private
      double precision                            :: densityNormalization                         , scaleLength
-     double precision                            :: densityScaleFreeRadiusMinimum                , densityScaleFreeRadiusMaximum
-     double precision                            :: densityScaleFreeMinimum                      , densityScaleFreeMaximum
-     type            (interpolator), allocatable :: densityScaleFree_
-     double precision                            :: massScaleFreeRadiusMinimum                   , massScaleFreeRadiusMaximum
-     double precision                            :: massScaleFreeMinimum                         , massScaleFreeMaximum
-     type            (interpolator), allocatable :: massScaleFree_
-     double precision                            :: angularMomentumSpecificScaleFreeRadiusMinimum, angularMomentumSpecificScaleFreeRadiusMaximum
-     double precision                            :: angularMomentumSpecificScaleFreeMinimum      , angularMomentumSpecificScaleFreeMaximum
-     type            (interpolator), allocatable :: angularMomentumSpecificScaleFree_
-     double precision                            :: timeFreefallScaleFreeRadiusMinimum           , timeFreefallScaleFreeRadiusMaximum
-     double precision                            :: timeFreefallScaleFreeMinimum                 , timeFreefallScaleFreeMaximum
-     type            (interpolator), allocatable :: timeFreefallScaleFree_
+     ! Tabulations of the scale-free profile, built for inversion.
+     type            (tabulationInverse)         :: densityScaleFree_                            , massScaleFree_                               , &
+          &                                         angularMomentumSpecificScaleFree_            , timeFreefallScaleFree_
    contains
      !![
      <methods docformat="rst">
@@ -110,6 +101,9 @@
      module procedure massDistributionBurkertConstructorParameters
      module procedure massDistributionBurkertConstructorInternal
   end interface massDistributionBurkert
+
+  ! Density of the tabulations; see the note in the NFW implementation for why an octave lattice is used here.
+  integer, parameter :: countRadiiPerOctave=30
 
   ! The minimum (scale-free) freefall timescale in a Burkert profile.
   double precision , parameter :: timeFreefallScaleFreeMinimum=sqrt(3.0d0*Pi)/4.0d0
@@ -240,22 +234,11 @@ contains
        self%dimensionless=.false.
     end if
     ! Initialize memoized results.
-    self%densityScaleFreeMinimum                      =+huge(0.0d0)
-    self%densityScaleFreeMaximum                      =-huge(0.0d0)
-    self%densityScaleFreeRadiusMinimum                =+1.0d0
-    self%densityScaleFreeRadiusMaximum                =+1.0d0
-    self%massScaleFreeMinimum                         =+huge(0.0d0)
-    self%massScaleFreeMaximum                         =-huge(0.0d0)
-    self%massScaleFreeRadiusMinimum                   =+1.0d0
-    self%massScaleFreeRadiusMaximum                   =+1.0d0
-    self%angularMomentumSpecificScaleFreeMinimum      =+huge(0.0d0)
-    self%angularMomentumSpecificScaleFreeMaximum      =-huge(0.0d0)
-    self%angularMomentumSpecificScaleFreeRadiusMinimum=+1.0d0
-    self%angularMomentumSpecificScaleFreeRadiusMaximum=+1.0d0
-    self%timeFreefallScaleFreeMinimum                 =+huge(0.0d0)
-    self%timeFreefallScaleFreeMaximum                 =-huge(0.0d0)
-    self%timeFreefallScaleFreeRadiusMinimum           =+1.0d0
-    self%timeFreefallScaleFreeRadiusMaximum           =+1.0d0
+    ! Initialize the tabulations.
+    call self%densityScaleFree_                %reset(countRadiiPerOctave,increasing=.false.)
+    call self%massScaleFree_                   %reset(countRadiiPerOctave,increasing=.true. )
+    call self%angularMomentumSpecificScaleFree_%reset(countRadiiPerOctave,increasing=.true. )
+    call self%timeFreefallScaleFree_           %reset(countRadiiPerOctave,increasing=.true. )
     return
   end function massDistributionBurkertConstructorInternal
 
@@ -429,15 +412,13 @@ contains
     !!{RST
     Computes the radius enclosing a given mass or mass fraction for burkert mass distributions.
     !!}    
-    use :: Numerical_Ranges, only : Make_Range  , rangeTypeLogarithmic
-    use :: Error           , only : Error_Report
+    use :: Error, only : Error_Report
     implicit none
     class           (massDistributionBurkert), intent(inout), target       :: self
     double precision                         , intent(in   ), optional     :: mass                       , massFractional
-    double precision                         , allocatable  , dimension(:) :: radii                      , masses
-    double precision                         , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                         , allocatable  , dimension(:) :: radii
     double precision                                                       :: massScaleFree              , mass_
-    integer                                                                :: countRadii
+    integer                                                                :: i
 
     mass_=0.0d0
     if (present(mass)) then
@@ -450,29 +431,16 @@ contains
     massScaleFree=+     mass_                   &
          &        /self%densityNormalization    &
          &        /self%scaleLength         **3
-    if     (                                            &
-         &   massScaleFree <= self%massScaleFreeMinimum &
-         &  .or.                                        &
-         &   massScaleFree >  self%massScaleFreeMaximum &
-         & ) then
-       do while (massEnclosedScaleFree(self%massScaleFreeRadiusMinimum) >= massScaleFree)
-          self%massScaleFreeRadiusMinimum=0.5d0*self%massScaleFreeRadiusMinimum
+    do while (.not.self%massScaleFree_%brackets(massScaleFree))
+       call self%massScaleFree_%expand(massScaleFree)
+       radii=self%massScaleFree_%abscissae()
+       do i=1,size(radii)
+          if (self%massScaleFree_%isComputed(i)) cycle
+          call self%massScaleFree_%set(i,massEnclosedScaleFree(radii(i)))
        end do
-       do while (massEnclosedScaleFree(self%massScaleFreeRadiusMaximum) <  massScaleFree)
-          self%massScaleFreeRadiusMaximum=2.0d0*self%massScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(self%massScaleFreeRadiusMaximum/self%massScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(self%massScaleFree_)) deallocate(self%massScaleFree_)
-       allocate(     radii         (countRadii))
-       allocate(     masses        (countRadii))
-       allocate(self%massScaleFree_            )
-       radii                    =Make_Range(self%massScaleFreeRadiusMinimum,self%massScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       masses                   =massEnclosedScaleFree(           radii)
-       self%massScaleFreeMinimum=masses               (         1      )
-       self%massScaleFreeMaximum=masses               (countRadii      )
-       self%massScaleFree_      =interpolator         (masses    ,radii)
-    end if
-    radius=+self%massScaleFree_%interpolate(massScaleFree) &
+       call self%massScaleFree_%build()
+    end do
+    radius=+self%massScaleFree_%invert     (massScaleFree) &
          & *self%scaleLength
     return
   end function burkertRadiusEnclosingMass
@@ -481,41 +449,26 @@ contains
     !!{RST
     Computes the radius enclosing a given mean density for burkert mass distributions.
     !!}
-    use :: Numerical_Ranges, only : Make_Range, rangeTypeLogarithmic
     implicit none
     class           (massDistributionBurkert), intent(inout), target       :: self
     double precision                         , intent(in   )               :: density
     double precision                         , intent(in   ), optional     :: radiusGuess
-    double precision                         , allocatable  , dimension(:) :: radii                      , densities
-    double precision                         , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                         , allocatable  , dimension(:) :: radii
     double precision                                                       :: densityScaleFree
-    integer                                                                :: countRadii
+    integer                                                                :: i
 
     densityScaleFree=+density                   &
          &           /self%densityNormalization
-    if     (                                                  &
-         &   densityScaleFree <= self%densityScaleFreeMinimum &
-         &  .or.                                              &
-         &   densityScaleFree >  self%densityScaleFreeMaximum &
-         & ) then
-       do while (densityEnclosedScaleFree(self%densityScaleFreeRadiusMinimum) <  densityScaleFree)
-          self%densityScaleFreeRadiusMinimum=0.5d0*self%densityScaleFreeRadiusMinimum
+    do while (.not.self%densityScaleFree_%brackets(densityScaleFree))
+       call self%densityScaleFree_%expand(densityScaleFree)
+       radii=self%densityScaleFree_%abscissae()
+       do i=1,size(radii)
+          if (self%densityScaleFree_%isComputed(i)) cycle
+          call self%densityScaleFree_%set(i,densityEnclosedScaleFree(radii(i)))
        end do
-       do while (densityEnclosedScaleFree(self%densityScaleFreeRadiusMaximum) >= densityScaleFree)
-          self%densityScaleFreeRadiusMaximum=2.0d0*self%densityScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(self%densityScaleFreeRadiusMaximum/self%densityScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(self%densityScaleFree_)) deallocate(self%densityScaleFree_)
-       allocate(     radii            (countRadii))
-       allocate(     densities        (countRadii))
-       allocate(self%densityScaleFree_            )
-       radii                       = Make_Range(self%densityScaleFreeRadiusMinimum,self%densityScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       densities                   =-densityEnclosedScaleFree(           radii)
-       self%densityScaleFreeMinimum=-densities               (countRadii      )
-       self%densityScaleFreeMaximum=-densities               (         1      )
-       self%densityScaleFree_      = interpolator            (densities ,radii)
-    end if
-    radius=+self%densityScaleFree_%interpolate(-densityScaleFree) &
+       call self%densityScaleFree_%build()
+    end do
+    radius=+self%densityScaleFree_%invert     (densityScaleFree) &
          & *self%scaleLength
     return    
   end function burkertRadiusEnclosingDensity
@@ -569,14 +522,12 @@ contains
     Computes the radius corresponding to a given specific angular momentum for burkert mass distributions.
     !!}
     use :: Numerical_Constants_Astronomical, only : gravitationalConstant_internal
-    use :: Numerical_Ranges                , only : Make_Range                    , rangeTypeLogarithmic
     implicit none
     class           (massDistributionBurkert), intent(inout), target       :: self
     double precision                         , intent(in   )               :: angularMomentumSpecific
-    double precision                         , allocatable  , dimension(:) :: radii                                   , angularMomentaSpecific
-    double precision                         , parameter                   :: countRadiiPerDecade             =100.0d0
+    double precision                         , allocatable  , dimension(:) :: radii
     double precision                                                       :: angularMomentumSpecificScaleFree
-    integer                                                                :: countRadii
+    integer                                                                :: i
 
     if (angularMomentumSpecific > 0.0d0) then
        angularMomentumSpecificScaleFree=+angularMomentumSpecific                 &
@@ -585,29 +536,16 @@ contains
             &                                 *self%densityNormalization         &
             &                                )                                   &
             &                           /      self%scaleLength              **2
-       if     (                                                                                  &
-            &   angularMomentumSpecificScaleFree <= self%angularMomentumSpecificScaleFreeMinimum &
-            &  .or.                                                                              &
-            &   angularMomentumSpecificScaleFree >  self%angularMomentumSpecificScaleFreeMaximum &
-            & ) then
-          do while (angularMomentumSpecificEnclosedScaleFree(self%angularMomentumSpecificScaleFreeRadiusMinimum) >= angularMomentumSpecificScaleFree)
-             self%angularMomentumSpecificScaleFreeRadiusMinimum=0.5d0*self%angularMomentumSpecificScaleFreeRadiusMinimum
+       do while (.not.self%angularMomentumSpecificScaleFree_%brackets(angularMomentumSpecificScaleFree))
+          call self%angularMomentumSpecificScaleFree_%expand(angularMomentumSpecificScaleFree)
+          radii=self%angularMomentumSpecificScaleFree_%abscissae()
+          do i=1,size(radii)
+             if (self%angularMomentumSpecificScaleFree_%isComputed(i)) cycle
+             call self%angularMomentumSpecificScaleFree_%set(i,angularMomentumSpecificEnclosedScaleFree(radii(i)))
           end do
-          do while (angularMomentumSpecificEnclosedScaleFree(self%angularMomentumSpecificScaleFreeRadiusMaximum) <  angularMomentumSpecificScaleFree)
-             self%angularMomentumSpecificScaleFreeRadiusMaximum=2.0d0*self%angularMomentumSpecificScaleFreeRadiusMaximum
-          end do
-          countRadii=int(log10(self%angularMomentumSpecificScaleFreeRadiusMaximum/self%angularMomentumSpecificScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-          if (allocated(self%angularMomentumSpecificScaleFree_)) deallocate(self%angularMomentumSpecificScaleFree_)
-          allocate(     radii                            (countRadii))
-          allocate(     angularMomentaSpecific           (countRadii))
-          allocate(self%angularMomentumSpecificScaleFree_            )
-          radii                                       =Make_Range(self%angularMomentumSpecificScaleFreeRadiusMinimum,self%angularMomentumSpecificScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-          angularMomentaSpecific                      =angularMomentumSpecificEnclosedScaleFree(                       radii)
-          self%angularMomentumSpecificScaleFreeMinimum=angularMomentaSpecific                  (                     1      )
-          self%angularMomentumSpecificScaleFreeMaximum=angularMomentaSpecific                  (            countRadii      )
-          self%angularMomentumSpecificScaleFree_      =interpolator                            (angularMomentaSpecific,radii)
-       end if
-       radius=+self%angularMomentumSpecificScaleFree_%interpolate(angularMomentumSpecificScaleFree) &
+          call self%angularMomentumSpecificScaleFree_%build()
+       end do
+       radius=+self%angularMomentumSpecificScaleFree_%invert     (angularMomentumSpecificScaleFree) &
             & *self%scaleLength
     else
        radius=+0.0d0
@@ -822,7 +760,7 @@ contains
        return
     end if
     call self%timeFreefallTabulate(timeScaleFree)
-    radius=+self%timeFreefallScaleFree_%interpolate(timeScaleFree) &
+    radius=+self%timeFreefallScaleFree_%invert     (timeScaleFree) &
          & *self%scaleLength
     return   
   end function burkertRadiusFreefall
@@ -860,40 +798,25 @@ contains
     Tabulate the freefall radius at the given ``time`` in an Burkert mass distribution.
     !!}
     use :: Numerical_Integration, only : integrator
-    use :: Numerical_Ranges     , only : Make_Range, rangeTypeLogarithmic
     implicit none
     class           (massDistributionBurkert), intent(inout)               :: self
     double precision                         , intent(in   )               :: timeScaleFree
-    double precision                         , allocatable  , dimension(:) :: radii                      , timesFreefall
-    double precision                         , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                         , allocatable  , dimension(:) :: radii
     double precision                                                       :: radiusStart
-    integer                                                                :: countRadii                 , i
+    integer                                                                :: i
     type            (integrator             )                              :: integrator_
 
-    if     (                                                    &
-         &   timeScaleFree <= self%timeFreefallScaleFreeMinimum &
-         &  .or.                                                &
-         &   timeScaleFree >  self%timeFreefallScaleFreeMaximum &
-         & ) then
+    if (.not.self%timeFreefallScaleFree_%brackets(timeScaleFree)) then
        integrator_=integrator(timeFreeFallIntegrand,toleranceRelative=1.0d-6)
-       do while (timeFreefallScaleFree(self%timeFreefallScaleFreeRadiusMinimum) >= timeScaleFree)
-          self%timeFreefallScaleFreeRadiusMinimum=0.5d0*self%timeFreefallScaleFreeRadiusMinimum
+       do while (.not.self%timeFreefallScaleFree_%brackets(timeScaleFree))
+          call self%timeFreefallScaleFree_%expand(timeScaleFree)
+          radii=self%timeFreefallScaleFree_%abscissae()
+          do i=1,size(radii)
+             if (self%timeFreefallScaleFree_%isComputed(i)) cycle
+             call self%timeFreefallScaleFree_%set(i,timeFreefallScaleFree(radii(i)))
+          end do
+          call self%timeFreefallScaleFree_%build()
        end do
-       do while (timeFreefallScaleFree(self%timeFreefallScaleFreeRadiusMaximum) <  timeScaleFree)
-          self%timeFreefallScaleFreeRadiusMaximum=2.0d0*self%timeFreefallScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(self%timeFreefallScaleFreeRadiusMaximum/self%timeFreefallScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(self%timeFreefallScaleFree_)) deallocate(self%timeFreefallScaleFree_)
-       allocate(     radii                 (countRadii))
-       allocate(     timesFreefall         (countRadii))
-       allocate(self%timeFreefallScaleFree_            )
-       radii=Make_Range(self%timeFreefallScaleFreeRadiusMinimum,self%timeFreefallScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       do i=1,countRadii
-          timesFreefall(i)=timeFreefallScaleFree(radii(i))
-       end do
-       self%timeFreefallScaleFreeMinimum=timesFreefall(            1      )
-       self%timeFreefallScaleFreeMaximum=timesFreefall(   countRadii      )
-       self%timeFreefallScaleFree_      =interpolator (timesFreefall,radii)
     end if
     return
     

--- a/source/mass_distributions/spherical/Burkert.F90
+++ b/source/mass_distributions/spherical/Burkert.F90
@@ -51,10 +51,10 @@
     .. math::
 
        F(k) &amp; = (1+i) \frac{\pi}{k m(c) } \left( \right.                                                              \nonumber \\
-       &amp;  +      \exp( k) \left\{ -i \pi -\mathrm{E}_\mathrm{i}[-  k]+\mathrm{E}_\mathrm{i}[(-1+ic)k] \right\} \nonumber \\
-       &amp;  +(1-i) \exp(-k) \left\{        +\mathrm{E}_\mathrm{i}[-i k]+\mathrm{E}_\mathrm{i}[(+i+ic)k] \right\} \nonumber \\
-       &amp;  +   i  \exp(-k) \left\{        +\mathrm{E}_\mathrm{i}[+  k]+\mathrm{E}_\mathrm{i}[(+1+ic)k] \right\} \nonumber \\
-       &amp;  \left. \right).
+       &amp;         +      \exp( k) \left\{ -i \pi -\mathrm{E}_\mathrm{i}[-  k]+\mathrm{E}_\mathrm{i}[(-1+ic)k] \right\} \nonumber \\
+       &amp;         +(1-i) \exp(-k) \left\{        +\mathrm{E}_\mathrm{i}[-i k]+\mathrm{E}_\mathrm{i}[(+i+ic)k] \right\} \nonumber \\
+       &amp;         +   i  \exp(-k) \left\{        +\mathrm{E}_\mathrm{i}[+  k]+\mathrm{E}_\mathrm{i}[(+1+ic)k] \right\} \nonumber \\
+       &amp;         \left. \right).
     </description>
   </massDistribution>
   !!]
@@ -63,10 +63,10 @@
      The :cite:p:`burkert_structure_1995` mass distribution.
      !!}
      private
-     double precision                            :: densityNormalization                         , scaleLength
+     double precision                    :: densityNormalization             , scaleLength
      ! Tabulations of the scale-free profile, built for inversion.
-     type            (tabulationInverse)         :: densityScaleFree_                            , massScaleFree_                               , &
-          &                                         angularMomentumSpecificScaleFree_            , timeFreefallScaleFree_
+     type            (tabulationInverse) :: densityScaleFree_                , massScaleFree_        , &
+          &                                 angularMomentumSpecificScaleFree_, timeFreefallScaleFree_
    contains
      !![
      <methods docformat="rst">
@@ -103,7 +103,7 @@
   end interface massDistributionBurkert
 
   ! Density of the tabulations; see the note in the NFW implementation for why an octave lattice is used here.
-  integer, parameter :: countRadiiPerOctave=30
+  integer          , parameter :: countRadiiPerOctave         =30
 
   ! The minimum (scale-free) freefall timescale in a Burkert profile.
   double precision , parameter :: timeFreefallScaleFreeMinimum=sqrt(3.0d0*Pi)/4.0d0
@@ -233,7 +233,6 @@ contains
     else
        self%dimensionless=.false.
     end if
-    ! Initialize memoized results.
     ! Initialize the tabulations.
     call self%densityScaleFree_                %reset(countRadiiPerOctave,increasing=.false.)
     call self%massScaleFree_                   %reset(countRadiiPerOctave,increasing=.true. )
@@ -415,9 +414,9 @@ contains
     use :: Error, only : Error_Report
     implicit none
     class           (massDistributionBurkert), intent(inout), target       :: self
-    double precision                         , intent(in   ), optional     :: mass                       , massFractional
+    double precision                         , intent(in   ), optional     :: mass         , massFractional
     double precision                         , allocatable  , dimension(:) :: radii
-    double precision                                                       :: massScaleFree              , mass_
+    double precision                                                       :: massScaleFree, mass_
     integer                                                                :: i
 
     mass_=0.0d0
@@ -426,7 +425,7 @@ contains
     else if (present(massFractional)) then
        call Error_Report('mass is unbounded, so mass fraction is undefined'//{introspection:location})
     else
-       call Error_Report('either mass or massFractional must be supplied'//{introspection:location})
+       call Error_Report('either mass or massFractional must be supplied'  //{introspection:location})
     end if
     massScaleFree=+     mass_                   &
          &        /self%densityNormalization    &
@@ -440,7 +439,7 @@ contains
        end do
        call self%massScaleFree_%build()
     end do
-    radius=+self%massScaleFree_%invert     (massScaleFree) &
+    radius=+self%massScaleFree_%invert(massScaleFree) &
          & *self%scaleLength
     return
   end function burkertRadiusEnclosingMass
@@ -468,7 +467,7 @@ contains
        end do
        call self%densityScaleFree_%build()
     end do
-    radius=+self%densityScaleFree_%invert     (densityScaleFree) &
+    radius=+self%densityScaleFree_%invert(densityScaleFree) &
          & *self%scaleLength
     return    
   end function burkertRadiusEnclosingDensity
@@ -545,7 +544,7 @@ contains
           end do
           call self%angularMomentumSpecificScaleFree_%build()
        end do
-       radius=+self%angularMomentumSpecificScaleFree_%invert     (angularMomentumSpecificScaleFree) &
+       radius=+self%angularMomentumSpecificScaleFree_%invert(angularMomentumSpecificScaleFree) &
             & *self%scaleLength
     else
        radius=+0.0d0
@@ -760,7 +759,7 @@ contains
        return
     end if
     call self%timeFreefallTabulate(timeScaleFree)
-    radius=+self%timeFreefallScaleFree_%invert     (timeScaleFree) &
+    radius=+self%timeFreefallScaleFree_%invert(timeScaleFree) &
          & *self%scaleLength
     return   
   end function burkertRadiusFreefall

--- a/source/mass_distributions/spherical/Einasto.F90
+++ b/source/mass_distributions/spherical/Einasto.F90
@@ -21,7 +21,7 @@
   Implementation of an Einasto (e.g. :cite:author:`cardone_spherical_2005` :cite:year:`cardone_spherical_2005`) mass distribution class.
   !!}
 
-  use :: Numerical_Interpolation, only : interpolator
+  use :: Tabulations_Inverse, only : tabulationInverse
   
   !![
   <massDistribution name="massDistributionEinasto" docformat="rst">
@@ -43,18 +43,10 @@
      double precision                            :: densityNormalization                         , scaleLength                                  , &
           &                                         shapeParameter                               , massTotal_
      double precision                            :: enclosedMassRadiusPrevious                   , enclosedMassPrevious
-     double precision                            :: massScaleFreeRadiusMinimum                   , massScaleFreeRadiusMaximum
-     double precision                            :: massScaleFreeMinimum                         , massScaleFreeMaximum
-     type            (interpolator), allocatable :: massScaleFree_
-     double precision                            :: densityScaleFreeRadiusMinimum                , densityScaleFreeRadiusMaximum
-     double precision                            :: densityScaleFreeMinimum                      , densityScaleFreeMaximum
-     type            (interpolator), allocatable :: densityScaleFree_
-     double precision                            :: angularMomentumSpecificScaleFreeRadiusMinimum, angularMomentumSpecificScaleFreeRadiusMaximum
-     double precision                            :: angularMomentumSpecificScaleFreeMinimum      , angularMomentumSpecificScaleFreeMaximum
-     type            (interpolator), allocatable :: angularMomentumSpecificScaleFree_
-     double precision                            :: timeFreefallScaleFreeRadiusMinimum           , timeFreefallScaleFreeRadiusMaximum
-     double precision                            :: timeFreefallScaleFreeMinimum                 , timeFreefallScaleFreeMaximum
-     type            (interpolator), allocatable :: timeFreefallScaleFree_
+     ! Tabulations of the scale-free profile, built for inversion. These are held per object because the scale-free Einasto
+     ! profile depends on the shape parameter, so each is specific to the object which owns it.
+     type            (tabulationInverse)         :: massScaleFree_                               , densityScaleFree_                            , &
+          &                                         angularMomentumSpecificScaleFree_            , timeFreefallScaleFree_
    contains
      !![
      <methods docformat="rst">
@@ -87,6 +79,11 @@
      module procedure massDistributionEinastoConstructorParameters
      module procedure massDistributionEinastoConstructorInternal
   end interface massDistributionEinasto
+
+  ! Density of the tabulations. The bounds these reach are found by halving and doubling from a unit seed, so they are exact
+  ! powers of two and are already points of an octave lattice. Thirty points per octave is 99.66 per decade, against the
+  ! hundred per decade used before.
+  integer, parameter :: countRadiiPerOctave=30
 
 contains
 
@@ -257,22 +254,12 @@ contains
     ! Initialize memoized results.
     self%enclosedMassPrevious                         =-huge(0.0d0)
     self%enclosedMassRadiusPrevious                   =-huge(0.0d0)
-    self%densityScaleFreeMinimum                      =+huge(0.0d0)
-    self%densityScaleFreeMaximum                      =-huge(0.0d0)
-    self%densityScaleFreeRadiusMinimum                =+1.0d0
-    self%densityScaleFreeRadiusMaximum                =+1.0d0
-    self%angularMomentumSpecificScaleFreeMinimum      =+huge(0.0d0)
-    self%angularMomentumSpecificScaleFreeMaximum      =-huge(0.0d0)
-    self%angularMomentumSpecificScaleFreeRadiusMinimum=+1.0d0
-    self%angularMomentumSpecificScaleFreeRadiusMaximum=+1.0d0
-    self%timeFreefallScaleFreeMinimum                 =+huge(0.0d0)
-    self%timeFreefallScaleFreeMaximum                 =-huge(0.0d0)
-    self%timeFreefallScaleFreeRadiusMinimum           =+1.0d0
-    self%timeFreefallScaleFreeRadiusMaximum           =+1.0d0
-    self%massScaleFreeMinimum                         =+huge(0.0d0)
-    self%massScaleFreeMaximum                         =-huge(0.0d0)
-    self%massScaleFreeRadiusMinimum                   =+1.0d0
-    self%massScaleFreeRadiusMaximum                   =+1.0d0
+    ! Initialize the tabulations. This is done here, where the shape parameter is set, so that an object can never serve a
+    ! tabulation built for a different shape.
+    call self%massScaleFree_                   %reset(countRadiiPerOctave,increasing=.true. )
+    call self%densityScaleFree_                %reset(countRadiiPerOctave,increasing=.false.)
+    call self%angularMomentumSpecificScaleFree_%reset(countRadiiPerOctave,increasing=.true. )
+    call self%timeFreefallScaleFree_           %reset(countRadiiPerOctave,increasing=.true. )
     return
   end function massDistributionEinastoConstructorInternal
 
@@ -436,16 +423,13 @@ contains
     !!{RST
     Computes the radius enclosing a given mass or mass fraction for einasto mass distributions.
     !!}    
-    use :: Numerical_Ranges, only : Make_Range  , rangeTypeLogarithmic
-    use :: Error           , only : Error_Report
+    use :: Error, only : Error_Report
     implicit none
     class           (massDistributionEinasto), intent(inout), target       :: self
     double precision                         , intent(in   ), optional     :: mass                       , massFractional
-    double precision                                                       :: mass_
-    double precision                         , allocatable  , dimension(:) :: radii                      , masses
-    double precision                         , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                         , allocatable  , dimension(:) :: radii
     double precision                                                       :: massScaleFree              , mass_
-    integer                                                                :: countRadii                 , i
+    integer                                                                :: i
 
     mass_=0.0d0
     if (present(mass)) then
@@ -458,31 +442,16 @@ contains
     massScaleFree=+     mass_                   &
          &        /self%densityNormalization    &
          &        /self%scaleLength         **3
-    if     (                                            &
-         &   massScaleFree <= self%massScaleFreeMinimum &
-         &  .or.                                        &
-         &   massScaleFree >  self%massScaleFreeMaximum &
-         & ) then
-       do while (massEnclosedScaleFree(self%massScaleFreeRadiusMinimum,self%shapeParameter) >= massScaleFree)
-          self%massScaleFreeRadiusMinimum=0.5d0*self%massScaleFreeRadiusMinimum
+    do while (.not.self%massScaleFree_%brackets(massScaleFree))
+       call self%massScaleFree_%expand(massScaleFree)
+       radii=self%massScaleFree_%abscissae()
+       do i=1,size(radii)
+          if (self%massScaleFree_%isComputed(i)) cycle
+          call self%massScaleFree_%set(i,massEnclosedScaleFree(radii(i),self%shapeParameter))
        end do
-       do while (massEnclosedScaleFree(self%massScaleFreeRadiusMaximum,self%shapeParameter) <  massScaleFree)
-          self%massScaleFreeRadiusMaximum=2.0d0*self%massScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(self%massScaleFreeRadiusMaximum/self%massScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(self%massScaleFree_)) deallocate(self%massScaleFree_)
-       allocate(     radii         (countRadii))
-       allocate(     masses        (countRadii))
-       allocate(self%massScaleFree_            )
-       radii                       =Make_Range(self%massScaleFreeRadiusMinimum,self%massScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       do i=1,countRadii
-          masses                (i)=massEnclosedScaleFree(           radii(i),self%shapeParameter)
-       end do
-       self%massScaleFreeMinimum   =masses               (         1                             )
-       self%massScaleFreeMaximum   =masses               (countRadii                             )
-       self%massScaleFree_         =interpolator         (masses    ,radii                       )
-    end if
-    radius=+self%massScaleFree_%interpolate(massScaleFree) &
+       call self%massScaleFree_%build()
+    end do
+    radius=+self%massScaleFree_%invert     (massScaleFree) &
          & *self%scaleLength
     return
   end function einastoRadiusEnclosingMass
@@ -491,43 +460,26 @@ contains
     !!{RST
     Computes the radius enclosing a given mean density for Einasto mass distributions.
     !!}
-    use :: Numerical_Ranges, only : Make_Range, rangeTypeLogarithmic
     implicit none
     class           (massDistributionEinasto), intent(inout), target       :: self
     double precision                         , intent(in   )               :: density
     double precision                         , intent(in   ), optional     :: radiusGuess
-    double precision                         , allocatable  , dimension(:) :: radii                      , densities
-    double precision                         , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                         , allocatable  , dimension(:) :: radii
     double precision                                                       :: densityScaleFree
-    integer                                                                :: countRadii                 , i
+    integer                                                                :: i
 
     densityScaleFree=+density                   &
          &           /self%densityNormalization
-    if     (                                                  &
-         &   densityScaleFree <= self%densityScaleFreeMinimum &
-         &  .or.                                              &
-         &   densityScaleFree >  self%densityScaleFreeMaximum &
-         & ) then
-       do while (densityEnclosedScaleFree(self%densityScaleFreeRadiusMinimum,self%shapeParameter) <  densityScaleFree)
-          self%densityScaleFreeRadiusMinimum=0.5d0*self%densityScaleFreeRadiusMinimum
+    do while (.not.self%densityScaleFree_%brackets(densityScaleFree))
+       call self%densityScaleFree_%expand(densityScaleFree)
+       radii=self%densityScaleFree_%abscissae()
+       do i=1,size(radii)
+          if (self%densityScaleFree_%isComputed(i)) cycle
+          call self%densityScaleFree_%set(i,densityEnclosedScaleFree(radii(i),self%shapeParameter))
        end do
-       do while (densityEnclosedScaleFree(self%densityScaleFreeRadiusMaximum,self%shapeParameter) >= densityScaleFree)
-          self%densityScaleFreeRadiusMaximum=2.0d0*self%densityScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(self%densityScaleFreeRadiusMaximum/self%densityScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(self%densityScaleFree_)) deallocate(self%densityScaleFree_)
-       allocate(     radii            (countRadii))
-       allocate(     densities        (countRadii))
-       allocate(self%densityScaleFree_            )
-       radii                          = Make_Range(self%densityScaleFreeRadiusMinimum,self%densityScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       do i=1,countRadii
-          densities                (i)=-densityEnclosedScaleFree(radii     (i),self%shapeParameter)
-       end do
-       self%densityScaleFreeMinimum   =-densities               (countRadii                       )
-       self%densityScaleFreeMaximum   =-densities               (         1                       )
-       self%densityScaleFree_         = interpolator            (densities    ,radii              )
-    end if
-    radius=+self%densityScaleFree_%interpolate(-densityScaleFree) &
+       call self%densityScaleFree_%build()
+    end do
+    radius=+self%densityScaleFree_%invert     ( densityScaleFree) &
          & *self%scaleLength
     return    
   end function einastoRadiusEnclosingDensity
@@ -572,14 +524,12 @@ contains
     Computes the radius corresponding to a given specific angular momentum for einasto mass distributions.
     !!}
     use :: Numerical_Constants_Astronomical, only : gravitationalConstant_internal
-    use :: Numerical_Ranges                , only : Make_Range                    , rangeTypeLogarithmic
     implicit none
     class           (massDistributionEinasto), intent(inout), target       :: self
     double precision                         , intent(in   )               :: angularMomentumSpecific
-    double precision                         , allocatable  , dimension(:) :: radii                                   , angularMomentaSpecific
-    double precision                         , parameter                   :: countRadiiPerDecade             =100.0d0
+    double precision                         , allocatable  , dimension(:) :: radii
     double precision                                                       :: angularMomentumSpecificScaleFree
-    integer                                                                :: countRadii                              , i
+    integer                                                                :: i
 
     if (angularMomentumSpecific > 0.0d0) then
        angularMomentumSpecificScaleFree=+angularMomentumSpecific                 &
@@ -588,31 +538,16 @@ contains
             &                                 *self%densityNormalization         &
             &                                )                                   &
             &                           /      self%scaleLength              **2
-       if     (                                                                                  &
-            &   angularMomentumSpecificScaleFree <= self%angularMomentumSpecificScaleFreeMinimum &
-            &  .or.                                                                              &
-            &   angularMomentumSpecificScaleFree >  self%angularMomentumSpecificScaleFreeMaximum &
-            & ) then
-          do while (angularMomentumSpecificEnclosedScaleFree(self%angularMomentumSpecificScaleFreeRadiusMinimum,self%shapeParameter) >= angularMomentumSpecificScaleFree)
-             self%angularMomentumSpecificScaleFreeRadiusMinimum=0.5d0*self%angularMomentumSpecificScaleFreeRadiusMinimum
+       do while (.not.self%angularMomentumSpecificScaleFree_%brackets(angularMomentumSpecificScaleFree))
+          call self%angularMomentumSpecificScaleFree_%expand(angularMomentumSpecificScaleFree)
+          radii=self%angularMomentumSpecificScaleFree_%abscissae()
+          do i=1,size(radii)
+             if (self%angularMomentumSpecificScaleFree_%isComputed(i)) cycle
+             call self%angularMomentumSpecificScaleFree_%set(i,angularMomentumSpecificEnclosedScaleFree(radii(i),self%shapeParameter))
           end do
-          do while (angularMomentumSpecificEnclosedScaleFree(self%angularMomentumSpecificScaleFreeRadiusMaximum,self%shapeParameter) <  angularMomentumSpecificScaleFree)
-             self%angularMomentumSpecificScaleFreeRadiusMaximum=2.0d0*self%angularMomentumSpecificScaleFreeRadiusMaximum
-          end do
-          countRadii=int(log10(self%angularMomentumSpecificScaleFreeRadiusMaximum/self%angularMomentumSpecificScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-          if (allocated(self%angularMomentumSpecificScaleFree_)) deallocate(self%angularMomentumSpecificScaleFree_)
-          allocate(     radii                            (countRadii))
-          allocate(     angularMomentaSpecific           (countRadii))
-          allocate(self%angularMomentumSpecificScaleFree_            )
-          radii                                          =Make_Range(self%angularMomentumSpecificScaleFreeRadiusMinimum,self%angularMomentumSpecificScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-          do i=1,countRadii
-             angularMomentaSpecific                   (i)=angularMomentumSpecificEnclosedScaleFree(                       radii(i),self%shapeParameter)
-          end do
-          self%angularMomentumSpecificScaleFreeMinimum   =angularMomentaSpecific                  (                     1                             )
-          self%angularMomentumSpecificScaleFreeMaximum   =angularMomentaSpecific                  (            countRadii                             )
-          self%angularMomentumSpecificScaleFree_         =interpolator                            (angularMomentaSpecific,radii                       )
-       end if
-       radius=+self%angularMomentumSpecificScaleFree_%interpolate(angularMomentumSpecificScaleFree) &
+          call self%angularMomentumSpecificScaleFree_%build()
+       end do
+       radius=+self%angularMomentumSpecificScaleFree_%invert     (angularMomentumSpecificScaleFree) &
             & *self%scaleLength
     else
        radius=+0.0d0
@@ -741,7 +676,7 @@ contains
        return
     end if
     call self%timeFreefallTabulate(timeScaleFree)
-    radius=+self%timeFreefallScaleFree_%interpolate(timeScaleFree) &
+    radius=+self%timeFreefallScaleFree_%invert     (timeScaleFree) &
          & *self%scaleLength
     return   
   end function einastoRadiusFreefall
@@ -800,40 +735,27 @@ contains
     Tabulate the freefall radius at the given ``time`` in an Einasto mass distribution.
     !!}
     use :: Numerical_Integration, only : integrator
-    use :: Numerical_Ranges     , only : Make_Range, rangeTypeLogarithmic
     implicit none
     class           (massDistributionEinasto), intent(inout)               :: self
     double precision                         , intent(in   )               :: timeScaleFree
-    double precision                         , allocatable  , dimension(:) :: radii                      , timesFreefall
-    double precision                         , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                         , allocatable  , dimension(:) :: radii
     double precision                                                       :: radiusStart
-    integer                                                                :: countRadii                 , i
+    integer                                                                :: i
     type            (integrator             )                              :: integrator_
 
-    if     (                                                    &
-         &   timeScaleFree <= self%timeFreefallScaleFreeMinimum &
-         &  .or.                                                &
-         &   timeScaleFree >  self%timeFreefallScaleFreeMaximum &
-         & ) then
+    ! Each point is an independent quadrature from the centre out to its own radius, so a point carried over by an extension
+    ! is precisely the value which would be computed afresh.
+    if (.not.self%timeFreefallScaleFree_%brackets(timeScaleFree)) then
        integrator_=integrator(timeFreeFallIntegrand,toleranceRelative=1.0d-6)
-       do while (timeFreefallScaleFree(self%timeFreefallScaleFreeRadiusMinimum) >= timeScaleFree)
-          self%timeFreefallScaleFreeRadiusMinimum=0.5d0*self%timeFreefallScaleFreeRadiusMinimum
+       do while (.not.self%timeFreefallScaleFree_%brackets(timeScaleFree))
+          call self%timeFreefallScaleFree_%expand(timeScaleFree)
+          radii=self%timeFreefallScaleFree_%abscissae()
+          do i=1,size(radii)
+             if (self%timeFreefallScaleFree_%isComputed(i)) cycle
+             call self%timeFreefallScaleFree_%set(i,timeFreefallScaleFree(radii(i)))
+          end do
+          call self%timeFreefallScaleFree_%build()
        end do
-       do while (timeFreefallScaleFree(self%timeFreefallScaleFreeRadiusMaximum) <  timeScaleFree)
-          self%timeFreefallScaleFreeRadiusMaximum=2.0d0*self%timeFreefallScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(self%timeFreefallScaleFreeRadiusMaximum/self%timeFreefallScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(self%timeFreefallScaleFree_)) deallocate(self%timeFreefallScaleFree_)
-       allocate(     radii                 (countRadii))
-       allocate(     timesFreefall         (countRadii))
-       allocate(self%timeFreefallScaleFree_            )
-       radii=Make_Range(self%timeFreefallScaleFreeRadiusMinimum,self%timeFreefallScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       do i=1,countRadii
-          timesFreefall(i)=timeFreefallScaleFree(radii(i))
-       end do
-       self%timeFreefallScaleFreeMinimum=timesFreefall(            1      )
-       self%timeFreefallScaleFreeMaximum=timesFreefall(   countRadii      )
-       self%timeFreefallScaleFree_      =interpolator (timesFreefall,radii)
     end if
     return
     

--- a/source/mass_distributions/spherical/Einasto.F90
+++ b/source/mass_distributions/spherical/Einasto.F90
@@ -40,13 +40,13 @@
      The Einasto (e.g. :cite:author:`cardone_spherical_2005` :cite:year:`cardone_spherical_2005`) mass distribution.
      !!}
      private
-     double precision                            :: densityNormalization                         , scaleLength                                  , &
-          &                                         shapeParameter                               , massTotal_
-     double precision                            :: enclosedMassRadiusPrevious                   , enclosedMassPrevious
+     double precision                    :: densityNormalization             , scaleLength           , &
+          &                                 shapeParameter                   , massTotal_
+     double precision                    :: enclosedMassRadiusPrevious       , enclosedMassPrevious
      ! Tabulations of the scale-free profile, built for inversion. These are held per object because the scale-free Einasto
      ! profile depends on the shape parameter, so each is specific to the object which owns it.
-     type            (tabulationInverse)         :: massScaleFree_                               , densityScaleFree_                            , &
-          &                                         angularMomentumSpecificScaleFree_            , timeFreefallScaleFree_
+     type            (tabulationInverse) :: massScaleFree_                   , densityScaleFree_     , &
+          &                                 angularMomentumSpecificScaleFree_, timeFreefallScaleFree_
    contains
      !![
      <methods docformat="rst">
@@ -250,10 +250,9 @@ contains
     else
        self%dimensionless=.false.
     end if
-
     ! Initialize memoized results.
-    self%enclosedMassPrevious                         =-huge(0.0d0)
-    self%enclosedMassRadiusPrevious                   =-huge(0.0d0)
+    self%enclosedMassPrevious      =-huge(0.0d0)
+    self%enclosedMassRadiusPrevious=-huge(0.0d0)
     ! Initialize the tabulations. This is done here, where the shape parameter is set, so that an object can never serve a
     ! tabulation built for a different shape.
     call self%massScaleFree_                   %reset(countRadiiPerOctave,increasing=.true. )
@@ -426,9 +425,9 @@ contains
     use :: Error, only : Error_Report
     implicit none
     class           (massDistributionEinasto), intent(inout), target       :: self
-    double precision                         , intent(in   ), optional     :: mass                       , massFractional
+    double precision                         , intent(in   ), optional     :: mass         , massFractional
     double precision                         , allocatable  , dimension(:) :: radii
-    double precision                                                       :: massScaleFree              , mass_
+    double precision                                                       :: massScaleFree, mass_
     integer                                                                :: i
 
     mass_=0.0d0
@@ -451,7 +450,7 @@ contains
        end do
        call self%massScaleFree_%build()
     end do
-    radius=+self%massScaleFree_%invert     (massScaleFree) &
+    radius=+self%massScaleFree_%invert(massScaleFree) &
          & *self%scaleLength
     return
   end function einastoRadiusEnclosingMass
@@ -479,7 +478,7 @@ contains
        end do
        call self%densityScaleFree_%build()
     end do
-    radius=+self%densityScaleFree_%invert     ( densityScaleFree) &
+    radius=+self%densityScaleFree_%invert( densityScaleFree) &
          & *self%scaleLength
     return    
   end function einastoRadiusEnclosingDensity
@@ -547,7 +546,7 @@ contains
           end do
           call self%angularMomentumSpecificScaleFree_%build()
        end do
-       radius=+self%angularMomentumSpecificScaleFree_%invert     (angularMomentumSpecificScaleFree) &
+       radius=+self%angularMomentumSpecificScaleFree_%invert(angularMomentumSpecificScaleFree) &
             & *self%scaleLength
     else
        radius=+0.0d0
@@ -676,7 +675,7 @@ contains
        return
     end if
     call self%timeFreefallTabulate(timeScaleFree)
-    radius=+self%timeFreefallScaleFree_%invert     (timeScaleFree) &
+    radius=+self%timeFreefallScaleFree_%invert(timeScaleFree) &
          & *self%scaleLength
     return   
   end function einastoRadiusFreefall

--- a/source/mass_distributions/spherical/NFW.F90
+++ b/source/mass_distributions/spherical/NFW.F90
@@ -91,9 +91,9 @@
   ! doubling from a seed of unity, so they are exact powers of two and are therefore already points of that lattice: pinning
   ! costs nothing in range here, where anchoring to whole decades would pad every bound outward. Thirty points per octave is
   ! 99.66 per decade, against the hundred per decade used before.
-  integer                      , parameter    :: countRadiiPerOctave=30
-  type            (tabulationInverse)         :: densityScaleFree_                , angularMomentumSpecificScaleFree_, &
-       &                                         timeFreefallScaleFree_
+  integer                   , parameter :: countRadiiPerOctave   =30
+  type   (tabulationInverse)            :: densityScaleFree_        , angularMomentumSpecificScaleFree_, &
+       &                                   timeFreefallScaleFree_
   !$omp threadprivate(densityScaleFree_,angularMomentumSpecificScaleFree_,timeFreefallScaleFree_)
 
 contains

--- a/source/mass_distributions/spherical/NFW.F90
+++ b/source/mass_distributions/spherical/NFW.F90
@@ -21,7 +21,7 @@
   Implementation of an NFW :cite:p:`navarro_structure_1996` mass distribution class.
   !!}
 
-  use :: Numerical_Interpolation, only : interpolator
+  use :: Tabulations_Inverse, only : tabulationInverse
 
   public :: massDistributionNFWStateStore, massDistributionNFWStateRestore
   
@@ -82,26 +82,20 @@
      module procedure massDistributionNFWConstructorInternal
   end interface massDistributionNFW
 
-  ! Tabulated solutions.
-  double precision                            :: densityScaleFreeRadiusMinimum                =+     2.0d0 , densityScaleFreeRadiusMaximum                =+     0.5d0
-  double precision                            :: densityScaleFreeMinimum                      =+huge(0.0d0), densityScaleFreeMaximum                      =-huge(0.0d0)
-  type            (interpolator), allocatable :: densityScaleFree_
-  double precision                            :: angularMomentumSpecificScaleFreeRadiusMinimum=+     2.0d0 , angularMomentumSpecificScaleFreeRadiusMaximum=+     0.5d0 
-  double precision                            :: angularMomentumSpecificScaleFreeMinimum      =+huge(0.0d0), angularMomentumSpecificScaleFreeMaximum      =-huge(0.0d0)
-  type            (interpolator), allocatable :: angularMomentumSpecificScaleFree_
-  double precision                            :: timeFreefallScaleFreeRadiusMinimum           =+     2.0d0 , timeFreefallScaleFreeRadiusMaximum           =+     0.5d0 
-  double precision                            :: timeFreefallScaleFreeMinimum                 =+huge(0.0d0), timeFreefallScaleFreeMaximum                 =-huge(0.0d0)
-  type            (interpolator), allocatable :: timeFreefallScaleFree_
-  !$omp threadprivate(densityScaleFreeRadiusMinimum                , densityScaleFreeRadiusMaximum                )
-  !$omp threadprivate(densityScaleFreeMinimum                      , densityScaleFreeMaximum                      )
-  !$omp threadprivate(densityScaleFree_                                                                           )
-  !$omp threadprivate(angularMomentumSpecificScaleFreeRadiusMinimum, angularMomentumSpecificScaleFreeRadiusMaximum)
-  !$omp threadprivate(angularMomentumSpecificScaleFreeMinimum      , angularMomentumSpecificScaleFreeMaximum      )
-  !$omp threadprivate(angularMomentumSpecificScaleFree_                                                           )
-  !$omp threadprivate(timeFreefallScaleFreeRadiusMinimum           , timeFreefallScaleFreeRadiusMaximum           )
-  !$omp threadprivate(timeFreefallScaleFreeMinimum                 , timeFreefallScaleFreeMaximum                 )
-  !$omp threadprivate(timeFreefallScaleFree_                                                                      )
-  
+  ! Tabulated solutions. These are held per thread rather than per object: the scale-free NFW profile has no shape parameter,
+  ! so each of these tabulations is universal and is shared by every NFW distribution a thread constructs. (The corresponding
+  ! tabulations of the Einasto, Burkert and Zhao1996 profiles are held per object precisely because each of those profiles
+  ! *does* have a shape parameter, which makes them specific to the object.)
+  !
+  ! The abscissae are points of an absolute octave lattice. The bounds these tabulations reach are found by halving and
+  ! doubling from a seed of unity, so they are exact powers of two and are therefore already points of that lattice: pinning
+  ! costs nothing in range here, where anchoring to whole decades would pad every bound outward. Thirty points per octave is
+  ! 99.66 per decade, against the hundred per decade used before.
+  integer                      , parameter    :: countRadiiPerOctave=30
+  type            (tabulationInverse)         :: densityScaleFree_                , angularMomentumSpecificScaleFree_, &
+       &                                         timeFreefallScaleFree_
+  !$omp threadprivate(densityScaleFree_,angularMomentumSpecificScaleFree_,timeFreefallScaleFree_)
+
 contains
 
   function massDistributionNFWConstructorParameters(parameters) result(self)
@@ -526,43 +520,31 @@ contains
     !!{RST
     Computes the radius enclosing a given mean density for nfw mass distributions.
     !!}
-    use :: Numerical_Ranges, only : Make_Range, rangeTypeLogarithmic
     implicit none
     class           (massDistributionNFW), intent(inout), target       :: self
     double precision                     , intent(in   )               :: density
     double precision                     , intent(in   ), optional     :: radiusGuess
-    double precision                     , allocatable  , dimension(:) :: radii                      , densities
-    double precision                     , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                     , allocatable  , dimension(:) :: radii
     double precision                                                   :: densityScaleFree
-    integer                                                            :: countRadii
+    integer                                                            :: i
 
     densityScaleFree=+density                   &
          &           /self%densityNormalization
-    if     (                                            &
-         &   densityScaleFree < densityScaleFreeMinimum &
-         &  .or.                                        &
-         &   densityScaleFree > densityScaleFreeMaximum &
-         & ) then
-       do while (densityEnclosedScaleFree(densityScaleFreeRadiusMinimum) < densityScaleFree)
-          densityScaleFreeRadiusMinimum=0.5d0*densityScaleFreeRadiusMinimum
+    ! Extend the tabulation - by one octave at a time, and preserving everything already computed - until it spans the
+    ! requested density. The mean enclosed density decreases with radius.
+    if (densityScaleFree_%pointsPerOctave == 0) call densityScaleFree_%reset(countRadiiPerOctave,increasing=.false.)
+    do while (.not.densityScaleFree_%brackets(densityScaleFree))
+       call densityScaleFree_%expand(densityScaleFree)
+       radii=densityScaleFree_%abscissae()
+       do i=1,size(radii)
+          if (densityScaleFree_%isComputed(i)) cycle
+          call densityScaleFree_%set(i,densityEnclosedScaleFree(radii(i)))
        end do
-       do while (densityEnclosedScaleFree(densityScaleFreeRadiusMaximum) > densityScaleFree)
-          densityScaleFreeRadiusMaximum=2.0d0*densityScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(densityScaleFreeRadiusMaximum/densityScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(densityScaleFree_)) deallocate(densityScaleFree_)
-       allocate(radii            (countRadii))
-       allocate(densities        (countRadii))
-       allocate(densityScaleFree_            )
-       radii                  = Make_Range(densityScaleFreeRadiusMinimum,densityScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       densities              =-densityEnclosedScaleFree(           radii)
-       densityScaleFreeMinimum=-densities               (countRadii      )
-       densityScaleFreeMaximum=-densities               (         1      )
-       densityScaleFree_      = interpolator            (densities ,radii)
-    end if
-    radius=+densityScaleFree_%interpolate(-densityScaleFree) &
+       call densityScaleFree_%build()
+    end do
+    radius=+densityScaleFree_%invert     (densityScaleFree) &
          & *self             %scaleLength
-    return    
+    return
   end function nfwRadiusEnclosingDensity
 
   elemental double precision function massEnclosedScaleFree(radius) result(mass)
@@ -609,14 +591,12 @@ contains
     Computes the radius corresponding to a given specific angular momentum for nfw mass distributions.
     !!}
     use :: Numerical_Constants_Astronomical, only : gravitationalConstant_internal
-    use :: Numerical_Ranges                , only : Make_Range                    , rangeTypeLogarithmic
     implicit none
     class           (massDistributionNFW), intent(inout), target       :: self
     double precision                     , intent(in   )               :: angularMomentumSpecific
-    double precision                     , allocatable  , dimension(:) :: radii                                   , angularMomentaSpecific
-    double precision                     , parameter                   :: countRadiiPerDecade             =100.0d0
+    double precision                     , allocatable  , dimension(:) :: radii
     double precision                                                   :: angularMomentumSpecificScaleFree
-    integer                                                            :: countRadii
+    integer                                                            :: i
 
     if (angularMomentumSpecific > 0.0d0) then
        angularMomentumSpecificScaleFree=+angularMomentumSpecific                 &
@@ -625,34 +605,23 @@ contains
             &                                 *self%densityNormalization         &
             &                                )                                   &
             &                           /      self%scaleLength              **2
-       if     (                                                                            &
-            &   angularMomentumSpecificScaleFree < angularMomentumSpecificScaleFreeMinimum &
-            &  .or.                                                                        &
-            &   angularMomentumSpecificScaleFree > angularMomentumSpecificScaleFreeMaximum &
-            & ) then
-          do while (angularMomentumSpecificEnclosedScaleFree(angularMomentumSpecificScaleFreeRadiusMinimum) > angularMomentumSpecificScaleFree)
-             angularMomentumSpecificScaleFreeRadiusMinimum=0.5d0*angularMomentumSpecificScaleFreeRadiusMinimum
+       ! The enclosed specific angular momentum increases with radius.
+       if (angularMomentumSpecificScaleFree_%pointsPerOctave == 0) call angularMomentumSpecificScaleFree_%reset(countRadiiPerOctave,increasing=.true.)
+       do while (.not.angularMomentumSpecificScaleFree_%brackets(angularMomentumSpecificScaleFree))
+          call angularMomentumSpecificScaleFree_%expand(angularMomentumSpecificScaleFree)
+          radii=angularMomentumSpecificScaleFree_%abscissae()
+          do i=1,size(radii)
+             if (angularMomentumSpecificScaleFree_%isComputed(i)) cycle
+             call angularMomentumSpecificScaleFree_%set(i,angularMomentumSpecificEnclosedScaleFree(radii(i)))
           end do
-          do while (angularMomentumSpecificEnclosedScaleFree(angularMomentumSpecificScaleFreeRadiusMaximum) < angularMomentumSpecificScaleFree)
-             angularMomentumSpecificScaleFreeRadiusMaximum=2.0d0*angularMomentumSpecificScaleFreeRadiusMaximum
-          end do
-          countRadii=int(log10(angularMomentumSpecificScaleFreeRadiusMaximum/angularMomentumSpecificScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-          if (allocated(angularMomentumSpecificScaleFree_)) deallocate(angularMomentumSpecificScaleFree_)
-          allocate(radii                            (countRadii))
-          allocate(angularMomentaSpecific           (countRadii))
-          allocate(angularMomentumSpecificScaleFree_            )
-          radii                                  =Make_Range(angularMomentumSpecificScaleFreeRadiusMinimum,angularMomentumSpecificScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-          angularMomentaSpecific                 =angularMomentumSpecificEnclosedScaleFree(     radii)
-          angularMomentumSpecificScaleFreeMinimum=angularMomentaSpecific                  (         1)
-          angularMomentumSpecificScaleFreeMaximum=angularMomentaSpecific                  (countRadii)
-          angularMomentumSpecificScaleFree_      =interpolator                            (angularMomentaSpecific,radii)
-       end if
-       radius=+angularMomentumSpecificScaleFree_%interpolate(angularMomentumSpecificScaleFree) &
+          call angularMomentumSpecificScaleFree_%build()
+       end do
+       radius=+angularMomentumSpecificScaleFree_%invert     (angularMomentumSpecificScaleFree) &
             & *self                             %scaleLength
     else
        radius=+0.0d0
     end if
-    return    
+    return
   end function nfwRadiusFromSpecificAngularMomentum
 
   elemental double precision function angularMomentumSpecificEnclosedScaleFree(radius) result(angularMomentumSpecific)
@@ -841,7 +810,7 @@ contains
        timeScaleFree=+time                                       &
             &        /timeScale
        call self%timeFreefallTabulate(timeScaleFree)
-       radius=+timeFreefallScaleFree_%interpolate(timeScaleFree) &
+       radius=+timeFreefallScaleFree_%invert     (timeScaleFree) &
             & *self                  %scaleLength
     else
        ! For non-positive freefall times, return a zero freefall radius.
@@ -884,43 +853,31 @@ contains
     Tabulate the freefall radius at the given ``time`` in an NFW mass distribution.
     !!}
     use :: Numerical_Integration, only : integrator
-    use :: Numerical_Ranges     , only : Make_Range, rangeTypeLogarithmic
     implicit none
     class           (massDistributionNFW), intent(inout)               :: self
     double precision                     , intent(in   )               :: timeScaleFree
-    double precision                     , allocatable  , dimension(:) :: radii                      , timesFreefall
-    double precision                     , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                     , allocatable  , dimension(:) :: radii
     double precision                                                   :: radiusStart
-    integer                                                            :: countRadii                 , i
+    integer                                                            :: i
     type            (integrator         )                              :: integrator_
 
-    if     (                                              &
-         &   timeScaleFree < timeFreefallScaleFreeMinimum &
-         &  .or.                                          &
-         &   timeScaleFree > timeFreefallScaleFreeMaximum &
-         & ) then
+    ! The freefall time increases with radius. Note that each point is an independent quadrature from the centre out to its
+    ! own radius, so a point carried over by an extension is precisely the value which would be computed afresh.
+    if (timeFreefallScaleFree_%pointsPerOctave == 0) call timeFreefallScaleFree_%reset(countRadiiPerOctave,increasing=.true.)
+    if (.not.timeFreefallScaleFree_%brackets(timeScaleFree)) then
        integrator_=integrator(timeFreeFallIntegrand,toleranceRelative=1.0d-3)
-       do while (timeFreefallScaleFree(timeFreefallScaleFreeRadiusMinimum) > timeScaleFree)
-          timeFreefallScaleFreeRadiusMinimum=0.5d0*timeFreefallScaleFreeRadiusMinimum
+       do while (.not.timeFreefallScaleFree_%brackets(timeScaleFree))
+          call timeFreefallScaleFree_%expand(timeScaleFree)
+          radii=timeFreefallScaleFree_%abscissae()
+          do i=1,size(radii)
+             if (timeFreefallScaleFree_%isComputed(i)) cycle
+             call timeFreefallScaleFree_%set(i,timeFreefallScaleFree(radii(i)))
+          end do
+          call timeFreefallScaleFree_%build()
        end do
-       do while (timeFreefallScaleFree(timeFreefallScaleFreeRadiusMaximum) < timeScaleFree)
-          timeFreefallScaleFreeRadiusMaximum=2.0d0*timeFreefallScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(timeFreefallScaleFreeRadiusMaximum/timeFreefallScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(timeFreefallScaleFree_)) deallocate(timeFreefallScaleFree_)
-       allocate(radii                 (countRadii))
-       allocate(timesFreefall         (countRadii))
-       allocate(timeFreefallScaleFree_            )
-       radii=Make_Range(timeFreefallScaleFreeRadiusMinimum,timeFreefallScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       do i=1,countRadii
-          timesFreefall(i)=timeFreefallScaleFree(radii(i))
-       end do
-       timeFreefallScaleFreeMinimum=timesFreefall(            1      )
-       timeFreefallScaleFreeMaximum=timesFreefall(   countRadii      )
-       timeFreefallScaleFree_      =interpolator (timesFreefall,radii)
     end if
     return
-    
+
   contains
     
     double precision function timeFreefallScaleFree(radius)
@@ -1113,12 +1070,12 @@ contains
     type   (c_ptr   ), intent(in   ) :: gslStateFile
 
     call displayMessage('Storing state for: massDistributionNFW',verbosity=verbosityLevelInfo)
-    write (stateFile) densityScaleFreeRadiusMinimum                , densityScaleFreeRadiusMaximum                , &
-         &            densityScaleFreeMinimum                      , densityScaleFreeMaximum                      , &
-         &            angularMomentumSpecificScaleFreeRadiusMinimum, angularMomentumSpecificScaleFreeRadiusMaximum, &
-         &            angularMomentumSpecificScaleFreeMinimum      , angularMomentumSpecificScaleFreeMaximum      , &
-         &            timeFreefallScaleFreeRadiusMinimum           , timeFreefallScaleFreeRadiusMaximum           , &
-         &            timeFreefallScaleFreeMinimum                 , timeFreefallScaleFreeMaximum
+    ! Store the tabulations in full - the lattice on which each was built, and the values computed on it. Recording only the
+    ! range, as was done previously, left a restored object which reported that it spanned a value while holding no
+    ! interpolator with which to invert it.
+    call densityScaleFree_                %stateStore(stateFile)
+    call angularMomentumSpecificScaleFree_%stateStore(stateFile)
+    call timeFreefallScaleFree_           %stateStore(stateFile)
     return
   end subroutine massDistributionNFWStateStore
 
@@ -1137,12 +1094,9 @@ contains
     type   (c_ptr   ), intent(in   ) :: gslStateFile
 
     call displayMessage('Retrieving state for: massDistributionNFW',verbosity=verbosityLevelInfo)
-    read (stateFile) densityScaleFreeRadiusMinimum                , densityScaleFreeRadiusMaximum                , &
-         &           densityScaleFreeMinimum                      , densityScaleFreeMaximum                      , &
-         &           angularMomentumSpecificScaleFreeRadiusMinimum, angularMomentumSpecificScaleFreeRadiusMaximum, &
-         &           angularMomentumSpecificScaleFreeMinimum      , angularMomentumSpecificScaleFreeMaximum      , &
-         &           timeFreefallScaleFreeRadiusMinimum           , timeFreefallScaleFreeRadiusMaximum           , &
-         &           timeFreefallScaleFreeMinimum                 , timeFreefallScaleFreeMaximum
+    call densityScaleFree_                %stateRestore(stateFile)
+    call angularMomentumSpecificScaleFree_%stateRestore(stateFile)
+    call timeFreefallScaleFree_           %stateRestore(stateFile)
     return
   end subroutine massDistributionNFWStateRestore
   

--- a/source/mass_distributions/spherical/Zhao1996.F90
+++ b/source/mass_distributions/spherical/Zhao1996.F90
@@ -21,7 +21,7 @@
   Implementation of the :cite:t:`zhao_analytical_1996` mass distribution class.
   !!}
 
-  use :: Numerical_Interpolation , only : interpolator
+  use :: Tabulations_Inverse     , only : tabulationInverse
 
   !![
   <enumeration docformat="rst">
@@ -69,18 +69,10 @@
      double precision                                          :: densityNormalization                         , scaleLength                                  , &
           &                                                       alpha                                        , beta                                         , &
           &                                                       gamma
-     double precision                                          :: densityScaleFreeRadiusMinimum                , densityScaleFreeRadiusMaximum
-     double precision                                          :: densityScaleFreeMinimum                      , densityScaleFreeMaximum
-     type            (interpolator              ), allocatable :: densityScaleFree_
-     double precision                                          :: massScaleFreeRadiusMinimum                   , massScaleFreeRadiusMaximum
-     double precision                                          :: massScaleFreeMinimum                         , massScaleFreeMaximum
-     type            (interpolator              ), allocatable :: massScaleFree_
-     double precision                                          :: angularMomentumSpecificScaleFreeRadiusMinimum, angularMomentumSpecificScaleFreeRadiusMaximum
-     double precision                                          :: angularMomentumSpecificScaleFreeMinimum      , angularMomentumSpecificScaleFreeMaximum
-     type            (interpolator              ), allocatable :: angularMomentumSpecificScaleFree_
-     double precision                                          :: timeFreefallScaleFreeRadiusMinimum           , timeFreefallScaleFreeRadiusMaximum
-     double precision                                          :: timeFreefallScaleFreeMinimum                 , timeFreefallScaleFreeMaximum
-     type            (interpolator              ), allocatable :: timeFreefallScaleFree_
+     ! Tabulations of the scale-free profile, built for inversion. These are held per object because the scale-free Zhao1996
+     ! profile depends on the shape parameters, so each is specific to the object which owns it.
+     type            (tabulationInverse         )              :: densityScaleFree_                            , massScaleFree_                               , &
+          &                                                       angularMomentumSpecificScaleFree_            , timeFreefallScaleFree_
    contains
      !![
      <methods docformat="rst">
@@ -116,6 +108,9 @@
      module procedure massDistributionZhao1996ConstructorParameters
      module procedure massDistributionZhao1996ConstructorInternal
   end interface massDistributionZhao1996
+
+  ! Density of the tabulations; see the note in the NFW implementation for why an octave lattice is used here.
+  integer, parameter :: countRadiiPerOctave=30
 
   class(massDistributionZhao1996), pointer :: self_
   !$omp threadprivate(self_)
@@ -321,22 +316,12 @@ contains
        self%specialCase=specialCaseGeneral
     end if
     ! Initialize memoized results.
-    self%densityScaleFreeMinimum                      =+huge(0.0d0)
-    self%densityScaleFreeMaximum                      =-huge(0.0d0)
-    self%densityScaleFreeRadiusMinimum                =+1.0d0
-    self%densityScaleFreeRadiusMaximum                =+1.0d0
-    self%massScaleFreeMinimum                         =+huge(0.0d0)
-    self%massScaleFreeMaximum                         =-huge(0.0d0)
-    self%massScaleFreeRadiusMinimum                   =+1.0d0
-    self%massScaleFreeRadiusMaximum                   =+1.0d0
-    self%angularMomentumSpecificScaleFreeMinimum      =+huge(0.0d0)
-    self%angularMomentumSpecificScaleFreeMaximum      =-huge(0.0d0)
-    self%angularMomentumSpecificScaleFreeRadiusMinimum=+1.0d0
-    self%angularMomentumSpecificScaleFreeRadiusMaximum=+1.0d0
-    self%timeFreefallScaleFreeMinimum                 =+huge(0.0d0)
-    self%timeFreefallScaleFreeMaximum                 =-huge(0.0d0)
-    self%timeFreefallScaleFreeRadiusMinimum           =+1.0d0
-    self%timeFreefallScaleFreeRadiusMaximum           =+1.0d0
+    ! Initialize the tabulations. This is done here, where the shape parameters are set, so that an object can never serve a
+    ! tabulation built for a different shape.
+    call self%densityScaleFree_                %reset(countRadiiPerOctave,increasing=.false.)
+    call self%massScaleFree_                   %reset(countRadiiPerOctave,increasing=.true. )
+    call self%angularMomentumSpecificScaleFree_%reset(countRadiiPerOctave,increasing=.true. )
+    call self%timeFreefallScaleFree_           %reset(countRadiiPerOctave,increasing=.true. )
     return
   end function massDistributionZhao1996ConstructorInternal
 
@@ -610,15 +595,13 @@ contains
     !!{RST
     Computes the radius enclosing a given mass or mass fraction for zhao1996 mass distributions.
     !!}    
-    use :: Numerical_Ranges, only : Make_Range, rangeTypeLogarithmic
     use :: Error           , only : Error_Report
     implicit none
     class           (massDistributionZhao1996), intent(inout), target       :: self
     double precision                          , intent(in   ), optional     :: mass                       , massFractional
-    double precision                          , allocatable  , dimension(:) :: radii                      , masses
-    double precision                          , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                          , allocatable  , dimension(:) :: radii
     double precision                                                        :: massScaleFree              , mass_
-    integer                                                                 :: countRadii
+    integer                                                                 :: i
 
     mass_=0.0d0
     if (present(mass)) then
@@ -631,30 +614,18 @@ contains
     massScaleFree=+     mass_                   &
          &        /self%densityNormalization    &
          &        /self%scaleLength         **3
-    if     (                                            &
-         &   massScaleFree <= self%massScaleFreeMinimum &
-         &  .or.                                        &
-         &   massScaleFree >  self%massScaleFreeMaximum &
-         & ) then
-       self_ => self
-       do while (massEnclosedScaleFree(self%massScaleFreeRadiusMinimum) >= massScaleFree)
-          self%massScaleFreeRadiusMinimum=0.5d0*self%massScaleFreeRadiusMinimum
+    ! The evaluators below reach this object through the threadprivate pointer `self_`, not by host association.
+    self_ => self
+    do while (.not.self%massScaleFree_%brackets(massScaleFree))
+       call self%massScaleFree_%expand(massScaleFree)
+       radii=self%massScaleFree_%abscissae()
+       do i=1,size(radii)
+          if (self%massScaleFree_%isComputed(i)) cycle
+          call self%massScaleFree_%set(i,massEnclosedScaleFree(radii(i)))
        end do
-       do while (massEnclosedScaleFree(self%massScaleFreeRadiusMaximum) <  massScaleFree)
-          self%massScaleFreeRadiusMaximum=2.0d0*self%massScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(self%massScaleFreeRadiusMaximum/self%massScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(self%massScaleFree_)) deallocate(self%massScaleFree_)
-       allocate(     radii         (countRadii))
-       allocate(     masses        (countRadii))
-       allocate(self%massScaleFree_            )
-       radii                     =  Make_Range(self%massScaleFreeRadiusMinimum,self%massScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       masses                    =  massEnclosedScaleFree(           radii)
-       self%massScaleFreeMinimum =  masses               (         1      )
-       self%massScaleFreeMaximum =  masses               (countRadii      )
-       self%massScaleFree_       =  interpolator         (masses    ,radii)
-    end if
-    radius=+self%massScaleFree_%interpolate(massScaleFree) &
+       call self%massScaleFree_%build()
+    end do
+    radius=+self%massScaleFree_%invert     (massScaleFree) &
          & *self%scaleLength
     return
   end function zhao1996RadiusEnclosingMass
@@ -663,42 +634,27 @@ contains
     !!{RST
     Computes the radius enclosing a given mean density for zhao1996 mass distributions.
     !!}
-    use :: Numerical_Ranges, only : Make_Range, rangeTypeLogarithmic
     implicit none
     class           (massDistributionZhao1996), intent(inout), target       :: self
     double precision                          , intent(in   )               :: density
     double precision                          , intent(in   ), optional     :: radiusGuess
-    double precision                          , allocatable  , dimension(:) :: radii                      , densities
-    double precision                          , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                          , allocatable  , dimension(:) :: radii
     double precision                                                        :: densityScaleFree
-    integer                                                                 :: countRadii
+    integer                                                                 :: i
 
     densityScaleFree=+density                   &
          &           /self%densityNormalization
-    if     (                                                  &
-         &   densityScaleFree <= self%densityScaleFreeMinimum &
-         &  .or.                                              &
-         &   densityScaleFree >  self%densityScaleFreeMaximum &
-         & ) then
-       do while (densityEnclosedScaleFree(self%densityScaleFreeRadiusMinimum) <  densityScaleFree)
-          self%densityScaleFreeRadiusMinimum=0.5d0*self%densityScaleFreeRadiusMinimum
+    self_ => self
+    do while (.not.self%densityScaleFree_%brackets(densityScaleFree))
+       call self%densityScaleFree_%expand(densityScaleFree)
+       radii=self%densityScaleFree_%abscissae()
+       do i=1,size(radii)
+          if (self%densityScaleFree_%isComputed(i)) cycle
+          call self%densityScaleFree_%set(i,densityEnclosedScaleFree(radii(i)))
        end do
-       do while (densityEnclosedScaleFree(self%densityScaleFreeRadiusMaximum) >= densityScaleFree)
-          self%densityScaleFreeRadiusMaximum=2.0d0*self%densityScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(self%densityScaleFreeRadiusMaximum/self%densityScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(self%densityScaleFree_)) deallocate(self%densityScaleFree_)
-       allocate(     radii            (countRadii))
-       allocate(     densities        (countRadii))
-       allocate(self%densityScaleFree_            )
-       self_                        =>  self
-       radii                        =   Make_Range(self%densityScaleFreeRadiusMinimum,self%densityScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       densities                    =  -densityEnclosedScaleFree(           radii)
-       self%densityScaleFreeMinimum =  -densities               (countRadii      )
-       self%densityScaleFreeMaximum =  -densities               (         1      )
-       self%densityScaleFree_       =   interpolator            (densities ,radii)
-    end if
-    radius=+self%densityScaleFree_%interpolate(-densityScaleFree) &
+       call self%densityScaleFree_%build()
+    end do
+    radius=+self%densityScaleFree_%invert     (densityScaleFree) &
          & *self%scaleLength
     return    
   end function zhao1996RadiusEnclosingDensity
@@ -827,14 +783,12 @@ contains
     Computes the radius corresponding to a given specific angular momentum for zhao1996 mass distributions.
     !!}
     use :: Numerical_Constants_Astronomical, only : gravitationalConstant_internal
-    use :: Numerical_Ranges                , only : Make_Range                    , rangeTypeLogarithmic
     implicit none
     class           (massDistributionZhao1996), intent(inout), target       :: self
     double precision                          , intent(in   )               :: angularMomentumSpecific
-    double precision                          , allocatable  , dimension(:) :: radii                                   , angularMomentaSpecific
-    double precision                          , parameter                   :: countRadiiPerDecade             =100.0d0
+    double precision                          , allocatable  , dimension(:) :: radii
     double precision                                                        :: angularMomentumSpecificScaleFree
-    integer                                                                 :: countRadii
+    integer                                                                 :: i
 
     if (angularMomentumSpecific > 0.0d0) then
        angularMomentumSpecificScaleFree=+angularMomentumSpecific                 &
@@ -843,30 +797,17 @@ contains
             &                                 *self%densityNormalization         &
             &                                )                                   &
             &                           /      self%scaleLength              **2
-       if     (                                                                                  &
-            &   angularMomentumSpecificScaleFree <= self%angularMomentumSpecificScaleFreeMinimum &
-            &  .or.                                                                              &
-            &   angularMomentumSpecificScaleFree >  self%angularMomentumSpecificScaleFreeMaximum &
-            & ) then
-          do while (angularMomentumSpecificEnclosedScaleFree(self%angularMomentumSpecificScaleFreeRadiusMinimum) >= angularMomentumSpecificScaleFree)
-             self%angularMomentumSpecificScaleFreeRadiusMinimum=0.5d0*self%angularMomentumSpecificScaleFreeRadiusMinimum
+       self_ => self
+       do while (.not.self%angularMomentumSpecificScaleFree_%brackets(angularMomentumSpecificScaleFree))
+          call self%angularMomentumSpecificScaleFree_%expand(angularMomentumSpecificScaleFree)
+          radii=self%angularMomentumSpecificScaleFree_%abscissae()
+          do i=1,size(radii)
+             if (self%angularMomentumSpecificScaleFree_%isComputed(i)) cycle
+             call self%angularMomentumSpecificScaleFree_%set(i,angularMomentumSpecificEnclosedScaleFree(radii(i)))
           end do
-          do while (angularMomentumSpecificEnclosedScaleFree(self%angularMomentumSpecificScaleFreeRadiusMaximum) <  angularMomentumSpecificScaleFree)
-             self%angularMomentumSpecificScaleFreeRadiusMaximum=2.0d0*self%angularMomentumSpecificScaleFreeRadiusMaximum
-          end do
-          countRadii=int(log10(self%angularMomentumSpecificScaleFreeRadiusMaximum/self%angularMomentumSpecificScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-          if (allocated(self%angularMomentumSpecificScaleFree_)) deallocate(self%angularMomentumSpecificScaleFree_)
-          allocate(     radii                            (countRadii))
-          allocate(     angularMomentaSpecific           (countRadii))
-          allocate(self%angularMomentumSpecificScaleFree_            )
-          self_                                        => self
-          radii                                        =  Make_Range(self%angularMomentumSpecificScaleFreeRadiusMinimum,self%angularMomentumSpecificScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-          angularMomentaSpecific                       =  angularMomentumSpecificEnclosedScaleFree(                       radii)
-          self%angularMomentumSpecificScaleFreeMinimum =  angularMomentaSpecific                  (                     1      )
-          self%angularMomentumSpecificScaleFreeMaximum =  angularMomentaSpecific                  (            countRadii      )
-          self%angularMomentumSpecificScaleFree_       =  interpolator                            (angularMomentaSpecific,radii)
-       end if
-       radius=+self%angularMomentumSpecificScaleFree_%interpolate(angularMomentumSpecificScaleFree) &
+          call self%angularMomentumSpecificScaleFree_%build()
+       end do
+       radius=+self%angularMomentumSpecificScaleFree_%invert     (angularMomentumSpecificScaleFree) &
             & *self%scaleLength
     else
        radius=+0.0d0
@@ -1125,7 +1066,7 @@ contains
        return
     end if
     call self%timeFreefallTabulate(timeScaleFree)
-    radius=+self%timeFreefallScaleFree_%interpolate(timeScaleFree) &
+    radius=+self%timeFreefallScaleFree_%invert     (timeScaleFree) &
          & *self%scaleLength
     return   
   end function zhao1996RadiusFreefall
@@ -1163,41 +1104,26 @@ contains
     Tabulate the freefall radius at the given ``time`` in an Zhao1996 mass distribution.
     !!}
     use :: Numerical_Integration, only : integrator
-    use :: Numerical_Ranges     , only : Make_Range, rangeTypeLogarithmic
     implicit none
     class           (massDistributionZhao1996), intent(inout), target       :: self
     double precision                          , intent(in   )               :: timeScaleFree
-    double precision                          , allocatable  , dimension(:) :: radii                      , timesFreefall
-    double precision                          , parameter                   :: countRadiiPerDecade=100.0d0
+    double precision                          , allocatable  , dimension(:) :: radii
     double precision                                                        :: radiusStart
-    integer                                                                 :: countRadii                 , i
+    integer                                                                 :: i
     type            (integrator              )                              :: integrator_
 
-    if     (                                                    &
-         &   timeScaleFree <= self%timeFreefallScaleFreeMinimum &
-         &  .or.                                                &
-         &   timeScaleFree >  self%timeFreefallScaleFreeMaximum &
-         & ) then
+    if (.not.self%timeFreefallScaleFree_%brackets(timeScaleFree)) then
        self_       => self
        integrator_ =  integrator(timeFreeFallIntegrand,toleranceRelative=1.0d-6)
-       do while (timeFreefallScaleFree(self%timeFreefallScaleFreeRadiusMinimum) >= timeScaleFree)
-          self%timeFreefallScaleFreeRadiusMinimum=0.5d0*self%timeFreefallScaleFreeRadiusMinimum
+       do while (.not.self%timeFreefallScaleFree_%brackets(timeScaleFree))
+          call self%timeFreefallScaleFree_%expand(timeScaleFree)
+          radii=self%timeFreefallScaleFree_%abscissae()
+          do i=1,size(radii)
+             if (self%timeFreefallScaleFree_%isComputed(i)) cycle
+             call self%timeFreefallScaleFree_%set(i,timeFreefallScaleFree(radii(i)))
+          end do
+          call self%timeFreefallScaleFree_%build()
        end do
-       do while (timeFreefallScaleFree(self%timeFreefallScaleFreeRadiusMaximum) <  timeScaleFree)
-          self%timeFreefallScaleFreeRadiusMaximum=2.0d0*self%timeFreefallScaleFreeRadiusMaximum
-       end do
-       countRadii=int(log10(self%timeFreefallScaleFreeRadiusMaximum/self%timeFreefallScaleFreeRadiusMinimum)*countRadiiPerDecade)+1
-       if (allocated(self%timeFreefallScaleFree_)) deallocate(self%timeFreefallScaleFree_)
-       allocate(     radii                 (countRadii))
-       allocate(     timesFreefall         (countRadii))
-       allocate(self%timeFreefallScaleFree_            )
-       radii=Make_Range(self%timeFreefallScaleFreeRadiusMinimum,self%timeFreefallScaleFreeRadiusMaximum,countRadii,rangeTypeLogarithmic)
-       do i=1,countRadii
-          timesFreefall(i)=timeFreefallScaleFree(radii(i))
-       end do
-       self%timeFreefallScaleFreeMinimum=timesFreefall(            1      )
-       self%timeFreefallScaleFreeMaximum=timesFreefall(   countRadii      )
-       self%timeFreefallScaleFree_      =interpolator (timesFreefall,radii)
     end if
     return
     

--- a/source/mass_distributions/spherical/Zhao1996.F90
+++ b/source/mass_distributions/spherical/Zhao1996.F90
@@ -21,7 +21,7 @@
   Implementation of the :cite:t:`zhao_analytical_1996` mass distribution class.
   !!}
 
-  use :: Tabulations_Inverse     , only : tabulationInverse
+  use :: Tabulations_Inverse, only : tabulationInverse
 
   !![
   <enumeration docformat="rst">
@@ -65,14 +65,14 @@
      The :cite:p:`zhao_analytical_1996` mass distribution.
      !!}
      private
-     type            (enumerationSpecialCaseType)              :: specialCase
-     double precision                                          :: densityNormalization                         , scaleLength                                  , &
-          &                                                       alpha                                        , beta                                         , &
-          &                                                       gamma
+     type            (enumerationSpecialCaseType) :: specialCase
+     double precision                             :: densityNormalization             , scaleLength           , &
+          &                                          alpha                            , beta                  , &
+          &                                          gamma
      ! Tabulations of the scale-free profile, built for inversion. These are held per object because the scale-free Zhao1996
      ! profile depends on the shape parameters, so each is specific to the object which owns it.
-     type            (tabulationInverse         )              :: densityScaleFree_                            , massScaleFree_                               , &
-          &                                                       angularMomentumSpecificScaleFree_            , timeFreefallScaleFree_
+     type            (tabulationInverse         ) :: densityScaleFree_                , massScaleFree_        , &
+          &                                          angularMomentumSpecificScaleFree_, timeFreefallScaleFree_
    contains
      !![
      <methods docformat="rst">
@@ -110,13 +110,13 @@
   end interface massDistributionZhao1996
 
   ! Density of the tabulations; see the note in the NFW implementation for why an octave lattice is used here.
-  integer, parameter :: countRadiiPerOctave=30
+  integer                                   , parameter :: countRadiiPerOctave                 =30
 
-  class(massDistributionZhao1996), pointer :: self_
+  class           (massDistributionZhao1996), pointer   :: self_
   !$omp threadprivate(self_)
 
   ! The minimum (scale-free) freefall timescale in a cored NFW profile.
-  double precision , parameter :: timeFreefallScaleFreeMinimumCoredNFW=sqrt(3.0d0*Pi)/4.0d0
+  double precision                          , parameter :: timeFreefallScaleFreeMinimumCoredNFW=sqrt(3.0d0*Pi)/4.0d0
   
 contains
 
@@ -315,7 +315,6 @@ contains
        ! Use general solutions.
        self%specialCase=specialCaseGeneral
     end if
-    ! Initialize memoized results.
     ! Initialize the tabulations. This is done here, where the shape parameters are set, so that an object can never serve a
     ! tabulation built for a different shape.
     call self%densityScaleFree_                %reset(countRadiiPerOctave,increasing=.false.)
@@ -595,12 +594,12 @@ contains
     !!{RST
     Computes the radius enclosing a given mass or mass fraction for zhao1996 mass distributions.
     !!}    
-    use :: Error           , only : Error_Report
+    use :: Error, only : Error_Report
     implicit none
     class           (massDistributionZhao1996), intent(inout), target       :: self
-    double precision                          , intent(in   ), optional     :: mass                       , massFractional
+    double precision                          , intent(in   ), optional     :: mass         , massFractional
     double precision                          , allocatable  , dimension(:) :: radii
-    double precision                                                        :: massScaleFree              , mass_
+    double precision                                                        :: massScaleFree, mass_
     integer                                                                 :: i
 
     mass_=0.0d0
@@ -625,7 +624,7 @@ contains
        end do
        call self%massScaleFree_%build()
     end do
-    radius=+self%massScaleFree_%invert     (massScaleFree) &
+    radius=+self%massScaleFree_%invert(massScaleFree) &
          & *self%scaleLength
     return
   end function zhao1996RadiusEnclosingMass
@@ -654,7 +653,7 @@ contains
        end do
        call self%densityScaleFree_%build()
     end do
-    radius=+self%densityScaleFree_%invert     (densityScaleFree) &
+    radius=+self%densityScaleFree_%invert(densityScaleFree) &
          & *self%scaleLength
     return    
   end function zhao1996RadiusEnclosingDensity
@@ -807,7 +806,7 @@ contains
           end do
           call self%angularMomentumSpecificScaleFree_%build()
        end do
-       radius=+self%angularMomentumSpecificScaleFree_%invert     (angularMomentumSpecificScaleFree) &
+       radius=+self%angularMomentumSpecificScaleFree_%invert(angularMomentumSpecificScaleFree) &
             & *self%scaleLength
     else
        radius=+0.0d0
@@ -1066,7 +1065,7 @@ contains
        return
     end if
     call self%timeFreefallTabulate(timeScaleFree)
-    radius=+self%timeFreefallScaleFree_%invert     (timeScaleFree) &
+    radius=+self%timeFreefallScaleFree_%invert(timeScaleFree) &
          & *self%scaleLength
     return   
   end function zhao1996RadiusFreefall

--- a/source/merger_trees/construct/builder/Cole2000/_class.F90
+++ b/source/merger_trees/construct/builder/Cole2000/_class.F90
@@ -391,10 +391,18 @@ contains
     massResolution=self%mergerTreeMassResolution_%resolution(tree)
     ! Find the critical overdensity at the earliest time to which we will build this tree. We evaluate this here to ensure that
     ! δc(t) is already evaluated over the full range of epochs that we will require - this prevents any possible retabulation
-    ! during tree construction which can potentially lead to misordering of branches. This is not the ideal solution - ideally,
-    ! critical overdensity classes which rely on tabulation and which have to retabulate themselves should ensure that they simply
-    ! expand their range without changing any of the previous computed values (as we do for expansion factor vs. time in the
-    ! cosmology function class).
+    ! during tree construction which can potentially lead to misordering of branches. The result is deliberately unused: the call
+    ! exists only for that side effect.
+    !
+    ! This was formerly described as a workaround pending tabulating classes expanding their range without changing previously
+    ! computed values, "as we do for expansion factor vs. time in the cosmology function class". Pinning abscissae to an absolute
+    ! lattice achieves that for extension at the upper end, but it does not remove the need for this call and cannot: the
+    ! tabulations δc(t) depends upon include ones integrated forward from their earliest tabulated epoch - the linear growth
+    ! factor is one - and such a tabulation cannot be extended *downward* without restarting its integration from a new starting
+    ! epoch, which moves every value in it by of order its integration tolerance. The cosmology function class cited above
+    ! discards its whole table in exactly that case, for exactly this reason. Removing this call was measured to change a small
+    ! model's results by tens of percent, by moving a branch across a threshold. Retiring it requires giving the tabulations
+    ! concerned a fixed earliest epoch, not further pinning.
     deltaCriticalEarliest=+self%criticalOverdensity_     %value       (time=self%timeEarliest/2.0d0,mass=basic%mass(),node=node) &
          &                *self%cosmologicalMassVariance_%rootVariance(time=self%timeNow           ,mass=basic%mass()          ) &
          &                /self%cosmologicalMassVariance_%rootVariance(time=self%timeEarliest/2.0d0,mass=basic%mass()          )

--- a/source/merger_trees/construct/builder/Cole2000/parallel.F90
+++ b/source/merger_trees/construct/builder/Cole2000/parallel.F90
@@ -246,10 +246,9 @@ contains
     massResolution=self%mergerTreeMassResolution_%resolution(tree)
     ! Find the critical overdensity at the earliest time to which we will build this tree. We evaluate this here to ensure that
     ! δc(t) is already evaluated over the full range of epochs that we will require - this prevents any possible retabulation
-    ! during tree construction which can potentially lead to misordering of branches. This is not the ideal solution - ideally,
-    ! critical overdensity classes which rely on tabulation and which have to retabulate themselves should ensure that they simply
-    ! expand their range without changing any of the previous computed values (as we do for expansion factor vs. time in the
-    ! cosmology function class).
+    ! during tree construction which can potentially lead to misordering of branches. The result is deliberately unused: the call
+    ! exists only for that side effect. See the equivalent call in the parent class for why pinning tabulation ranges does not
+    ! remove the need for it.
     deltaCriticalEarliest   =+self%criticalOverdensity_     %value          (time              =self%timeEarliest/2.0d0,mass=basic%mass(),node=node) &
          &                   *self%cosmologicalMassVariance_%rootVariance   (time              =self%timeNow           ,mass=basic%mass()          ) &
          &                   /self%cosmologicalMassVariance_%rootVariance   (time              =self%timeEarliest/2.0d0,mass=basic%mass()          )

--- a/source/numerical/tabulations_inverse.F90
+++ b/source/numerical/tabulations_inverse.F90
@@ -1,0 +1,316 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{RST
+Contains a module providing tabulations of monotonic functions, built for inversion.
+!!}
+
+module Tabulations_Inverse
+  !!{RST
+  Provides a tabulation of a monotonic function of a single, positive variable, built so that the function may be
+  *inverted*---given a value of the function, the abscissa at which it takes that value is returned.
+
+  Such tabulations occur throughout the analytic mass distributions, which invert the enclosed mass, the mean enclosed
+  density, the specific angular momentum, and the freefall time to recover a radius. Each was built by bracketing the
+  requested value---halving the lower bound, or doubling the upper, until the tabulated range spanned it---and then
+  redistributing a fixed number of points per decade across the resulting range. That redistribution moves every abscissa
+  whenever the range grows, so the tabulation depended on the sequence of values it happened to be asked for, and every
+  previously computed point had to be discarded and recomputed.
+
+  Here the abscissae are instead points of an absolute lattice, ``pointsPerOctave`` to the octave. The bounds reached by
+  halving and doubling are themselves exact powers of two, so they are already points of that lattice: pinning to it costs
+  nothing in range, and the abscissae become a function of which octaves have been visited rather than of the order in which
+  values were requested. Extending the tabulation then preserves every point already computed, and only the newly exposed
+  points are evaluated.
+
+  The function is evaluated by the caller rather than through a procedure pointer, which keeps each evaluator where it is
+  written---with access to whatever host state it needs---and avoids imposing a common interface on evaluators which range
+  from a single ``elemental`` expression to a numerical quadrature per point. The pattern of use is:
+
+  .. code-block:: fortran
+
+     do while (.not.tabulation%brackets(value))
+        call tabulation%expand(value)
+        radii=tabulation%abscissae()
+        do i=1,size(radii)
+           if (tabulation%isComputed(i)) cycle
+           call tabulation%set(i,f(radii(i)))
+        end do
+        call tabulation%build()
+     end do
+     abscissa=tabulation%invert(value)
+  !!}
+  use :: Numerical_Interpolation, only : interpolator
+  use :: Numerical_Ranges       , only : rangeLattice
+
+  private
+
+  type, public :: tabulationInverse
+     !!{RST
+     A tabulation of a monotonic function, built for inversion.
+     !!}
+     type            (rangeLattice)                            :: lattice
+     double precision              , allocatable, dimension(:) :: values
+     logical                       , allocatable, dimension(:) :: isComputed
+     type            (interpolator), allocatable               :: interpolator_
+     double precision                                          :: valueMinimum         =+huge(0.0d0), &
+          &                                                       valueMaximum         =-huge(0.0d0)
+     integer                                                   :: pointsPerOctave      =0
+     logical                                                   :: increasing           =.true.      , &
+          &                                                       initialized          =.false.
+   contains
+     !![
+     <methods docformat="rst">
+       <method description="Initialize the tabulation, discarding anything previously tabulated."                                    method="reset"    />
+       <method description="Return true if the tabulated range of the function spans the given value."                               method="brackets" />
+       <method description="Extend the tabulation by one octave, in whichever direction is needed to approach the given value."      method="expand"   />
+       <method description="Return the abscissae of the tabulation."                                                                 method="abscissae"/>
+       <method description="Set the value of the function at the given point of the tabulation."                                     method="set"      />
+       <method description="Complete the tabulation, recording its range and constructing the interpolator used to invert it."       method="build"    />
+       <method description="Return the abscissa at which the function takes the given value."                                        method="invert"    />
+       <method description="Return the derivative of the abscissa with respect to the value of the function."                        method="derivative"/>
+       <method description="Write the tabulation to an open state file."                                                             method="stateStore"  />
+       <method description="Read the tabulation back from an open state file."                                                       method="stateRestore"/>
+     </methods>
+     !!]
+     procedure :: reset        => tabulationInverseReset
+     procedure :: brackets     => tabulationInverseBrackets
+     procedure :: expand       => tabulationInverseExpand
+     procedure :: abscissae    => tabulationInverseAbscissae
+     procedure :: set          => tabulationInverseSet
+     procedure :: build        => tabulationInverseBuild
+     procedure :: invert       => tabulationInverseInvert
+     procedure :: derivative   => tabulationInverseDerivative
+     procedure :: stateStore   => tabulationInverseStateStore
+     procedure :: stateRestore => tabulationInverseStateRestore
+  end type tabulationInverse
+
+contains
+
+  subroutine tabulationInverseReset(self,pointsPerOctave,increasing)
+    !!{RST
+    Initialize the tabulation, discarding anything previously tabulated. ``increasing`` states whether the function increases
+    with its abscissa, which fixes the direction in which the tabulation must be extended to reach a given value.
+    !!}
+    implicit none
+    class  (tabulationInverse), intent(inout) :: self
+    integer                   , intent(in   ) :: pointsPerOctave
+    logical                   , intent(in   ) :: increasing
+
+    if (allocated(self%values       )) deallocate(self%values       )
+    if (allocated(self%isComputed   )) deallocate(self%isComputed   )
+    if (allocated(self%interpolator_)) deallocate(self%interpolator_)
+    self%lattice        =rangeLattice()
+    self%pointsPerOctave=pointsPerOctave
+    self%increasing     =increasing
+    self%valueMinimum   =+huge(0.0d0)
+    self%valueMaximum   =-huge(0.0d0)
+    self%initialized    =.false.
+    return
+  end subroutine tabulationInverseReset
+
+  logical function tabulationInverseBrackets(self,value) result(brackets)
+    !!{RST
+    Return true if the tabulated range of the function spans ``value``, so that it can be inverted without extending the
+    tabulation.
+    !!}
+    implicit none
+    class           (tabulationInverse), intent(in   ) :: self
+    double precision                   , intent(in   ) :: value
+
+    brackets=      self%initialized       &
+         &   .and. value >= self%valueMinimum &
+         &   .and. value <= self%valueMaximum
+    return
+  end function tabulationInverseBrackets
+
+  subroutine tabulationInverseExpand(self,value)
+    !!{RST
+    Extend the tabulation by one octave, in whichever direction brings the tabulated range closer to spanning ``value``,
+    preserving every point already computed. An unbuilt tabulation is seeded with the single octave about unity, which is
+    where the bracketing loops these tabulations replace also began.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Numerical_Ranges, only : Range_Lattice_Extend, gridSchemePerOctave
+    implicit none
+    class           (tabulationInverse), intent(inout) :: self
+    double precision                   , intent(in   ) :: value
+    type            (rangeLattice     )                :: latticeNew
+    logical                                            :: extendUpward
+
+    if (self%pointsPerOctave <= 0) call Error_Report('tabulation has not been initialized'//{introspection:location})
+    if (.not.self%lattice%isDefined()) then
+       ! Seed with the octave spanning [1/2,2].
+       latticeNew=rangeLattice(gridSchemePerOctave,self%pointsPerOctave,-self%pointsPerOctave,2*self%pointsPerOctave+1)
+    else
+       ! Extend towards the requested value. A value above the tabulated maximum is reached by extending to larger abscissae
+       ! for an increasing function, and to smaller for a decreasing one.
+       extendUpward=(value > self%valueMaximum) .eqv. self%increasing
+       if (extendUpward) then
+          latticeNew=rangeLattice(gridSchemePerOctave,self%pointsPerOctave,self%lattice%indexMinimum                     ,self%lattice%count+self%pointsPerOctave)
+       else
+          latticeNew=rangeLattice(gridSchemePerOctave,self%pointsPerOctave,self%lattice%indexMinimum-self%pointsPerOctave,self%lattice%count+self%pointsPerOctave)
+       end if
+    end if
+    call Range_Lattice_Extend(self%lattice,latticeNew,self%values,self%isComputed)
+    self%lattice=latticeNew
+    return
+  end subroutine tabulationInverseExpand
+
+  function tabulationInverseAbscissae(self) result(abscissae)
+    !!{RST
+    Return the abscissae of the tabulation.
+    !!}
+    implicit none
+    class           (tabulationInverse), intent(in   )               :: self
+    double precision                   , allocatable  , dimension(:) :: abscissae
+
+    abscissae=self%lattice%values()
+    return
+  end function tabulationInverseAbscissae
+
+  subroutine tabulationInverseSet(self,index,value)
+    !!{RST
+    Set the value of the function at the given point of the tabulation.
+    !!}
+    implicit none
+    class           (tabulationInverse), intent(inout) :: self
+    integer                            , intent(in   ) :: index
+    double precision                   , intent(in   ) :: value
+
+    self%values    (index)=value
+    self%isComputed(index)=.true.
+    return
+  end subroutine tabulationInverseSet
+
+  subroutine tabulationInverseBuild(self)
+    !!{RST
+    Complete the tabulation, recording the range of the function over it and constructing the interpolator through which it
+    is inverted. The interpolator requires ascending abscissae, so for a decreasing function the tabulated values are negated
+    ---as is the value presented to it when the function is inverted---rather than reversing the arrays.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    class(tabulationInverse), intent(inout) :: self
+
+    if (.not.self%lattice%isDefined()      ) call Error_Report('tabulation has no abscissae'  //{introspection:location})
+    if (.not.all(self%isComputed)          ) call Error_Report('tabulation is incomplete'     //{introspection:location})
+    if (allocated(self%interpolator_)) deallocate(self%interpolator_)
+    allocate(self%interpolator_)
+    if (self%increasing) then
+       self%valueMinimum  =self%values(              1)
+       self%valueMaximum  =self%values(self%lattice%count)
+       self%interpolator_ =interpolator(+self%values,self%lattice%values())
+    else
+       self%valueMinimum  =self%values(self%lattice%count)
+       self%valueMaximum  =self%values(              1)
+       self%interpolator_ =interpolator(-self%values,self%lattice%values())
+    end if
+    self%initialized=.true.
+    return
+  end subroutine tabulationInverseBuild
+
+  double precision function tabulationInverseInvert(self,value) result(abscissa)
+    !!{RST
+    Return the abscissa at which the function takes the given value.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    class           (tabulationInverse), intent(inout) :: self
+    double precision                   , intent(in   ) :: value
+
+    if (.not.self%initialized) call Error_Report('tabulation has not been built'//{introspection:location})
+    if (self%increasing) then
+       abscissa=self%interpolator_%interpolate(+value)
+    else
+       abscissa=self%interpolator_%interpolate(-value)
+    end if
+    return
+  end function tabulationInverseInvert
+
+  double precision function tabulationInverseDerivative(self,value) result(derivative)
+    !!{RST
+    Return the derivative of the abscissa with respect to the value of the function. For a decreasing function the tabulation
+    is held against the negated value, so the derivative with respect to the value itself carries the corresponding sign.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    class           (tabulationInverse), intent(inout) :: self
+    double precision                   , intent(in   ) :: value
+
+    if (.not.self%initialized) call Error_Report('tabulation has not been built'//{introspection:location})
+    if (self%increasing) then
+       derivative=+self%interpolator_%derivative(+value)
+    else
+       derivative=-self%interpolator_%derivative(-value)
+    end if
+    return
+  end function tabulationInverseDerivative
+
+  subroutine tabulationInverseStateStore(self,stateFile)
+    !!{RST
+    Write the tabulation to an open state file. The tabulated values are written along with the lattice on which they were
+    computed, so that the tabulation is restored in full. Note that recording the range alone would not be sufficient: it
+    would leave a restored object which reports that it spans a value while holding nothing with which to invert it.
+    !!}
+    implicit none
+    class  (tabulationInverse), intent(in   ) :: self
+    integer                   , intent(in   ) :: stateFile
+
+    write (stateFile) self%pointsPerOctave,self%increasing,self%initialized
+    write (stateFile) self%lattice%scheme%ID,self%lattice%pointsPer,self%lattice%indexMinimum,self%lattice%count
+    write (stateFile) allocated(self%values)
+    if (allocated(self%values)) write (stateFile) self%values
+    return
+  end subroutine tabulationInverseStateStore
+
+  subroutine tabulationInverseStateRestore(self,stateFile)
+    !!{RST
+    Read the tabulation back from an open state file, and reconstruct the interpolator through which it is inverted.
+    !!}
+    use :: Numerical_Ranges, only : enumerationGridSchemeType
+    implicit none
+    class  (tabulationInverse), intent(inout) :: self
+    integer                   , intent(in   ) :: stateFile
+    integer                                   :: schemeID    , pointsPer, &
+         &                                       indexMinimum, count
+    logical                                   :: hasValues
+
+    if (allocated(self%values       )) deallocate(self%values       )
+    if (allocated(self%isComputed   )) deallocate(self%isComputed   )
+    if (allocated(self%interpolator_)) deallocate(self%interpolator_)
+    read (stateFile) self%pointsPerOctave,self%increasing,self%initialized
+    read (stateFile) schemeID,pointsPer,indexMinimum,count
+    self%lattice=rangeLattice(enumerationGridSchemeType(schemeID),pointsPer,indexMinimum,count)
+    read (stateFile) hasValues
+    if (hasValues) then
+       allocate(self%values    (count))
+       allocate(self%isComputed(count))
+       read (stateFile) self%values
+       self%isComputed=.true.
+    end if
+    ! Rebuild the interpolator from the restored values, rather than attempting to serialize it.
+    if (self%initialized .and. hasValues) then
+       self%initialized=.false.
+       call self%build()
+    end if
+    return
+  end subroutine tabulationInverseStateRestore
+
+end module Tabulations_Inverse

--- a/source/numerical/tabulations_inverse.F90
+++ b/source/numerical/tabulations_inverse.F90
@@ -69,24 +69,24 @@ module Tabulations_Inverse
      double precision              , allocatable, dimension(:) :: values
      logical                       , allocatable, dimension(:) :: isComputed
      type            (interpolator), allocatable               :: interpolator_
-     double precision                                          :: valueMinimum         =+huge(0.0d0), &
-          &                                                       valueMaximum         =-huge(0.0d0)
-     integer                                                   :: pointsPerOctave      =0
-     logical                                                   :: increasing           =.true.      , &
-          &                                                       initialized          =.false.
+     double precision                                          :: valueMinimum   =+huge(0.0d0), &
+          &                                                       valueMaximum   =-huge(0.0d0)
+     integer                                                   :: pointsPerOctave=0
+     logical                                                   :: increasing     =.true.      , &
+          &                                                       initialized    =.false.
    contains
      !![
      <methods docformat="rst">
-       <method description="Initialize the tabulation, discarding anything previously tabulated."                                    method="reset"    />
-       <method description="Return true if the tabulated range of the function spans the given value."                               method="brackets" />
-       <method description="Extend the tabulation by one octave, in whichever direction is needed to approach the given value."      method="expand"   />
-       <method description="Return the abscissae of the tabulation."                                                                 method="abscissae"/>
-       <method description="Set the value of the function at the given point of the tabulation."                                     method="set"      />
-       <method description="Complete the tabulation, recording its range and constructing the interpolator used to invert it."       method="build"    />
-       <method description="Return the abscissa at which the function takes the given value."                                        method="invert"    />
-       <method description="Return the derivative of the abscissa with respect to the value of the function."                        method="derivative"/>
-       <method description="Write the tabulation to an open state file."                                                             method="stateStore"  />
-       <method description="Read the tabulation back from an open state file."                                                       method="stateRestore"/>
+       <method description="Initialize the tabulation, discarding anything previously tabulated."                               method="reset"       />
+       <method description="Return true if the tabulated range of the function spans the given value."                          method="brackets"    />
+       <method description="Extend the tabulation by one octave, in whichever direction is needed to approach the given value." method="expand"      />
+       <method description="Return the abscissae of the tabulation."                                                            method="abscissae"   />
+       <method description="Set the value of the function at the given point of the tabulation."                                method="set"         />
+       <method description="Complete the tabulation, recording its range and constructing the interpolator used to invert it."  method="build"       />
+       <method description="Return the abscissa at which the function takes the given value."                                   method="invert"      />
+       <method description="Return the derivative of the abscissa with respect to the value of the function."                   method="derivative"  />
+       <method description="Write the tabulation to an open state file."                                                        method="stateStore"  />
+       <method description="Read the tabulation back from an open state file."                                                  method="stateRestore"/>
      </methods>
      !!]
      procedure :: reset        => tabulationInverseReset
@@ -134,7 +134,7 @@ contains
     class           (tabulationInverse), intent(in   ) :: self
     double precision                   , intent(in   ) :: value
 
-    brackets=      self%initialized       &
+    brackets=               self%initialized  &
          &   .and. value >= self%valueMinimum &
          &   .and. value <= self%valueMaximum
     return
@@ -209,18 +209,18 @@ contains
     implicit none
     class(tabulationInverse), intent(inout) :: self
 
-    if (.not.self%lattice%isDefined()      ) call Error_Report('tabulation has no abscissae'  //{introspection:location})
-    if (.not.all(self%isComputed)          ) call Error_Report('tabulation is incomplete'     //{introspection:location})
+    if (.not.self%lattice%isDefined()) call Error_Report('tabulation has no abscissae'//{introspection:location})
+    if (.not.all(self%isComputed)    ) call Error_Report('tabulation is incomplete'   //{introspection:location})
     if (allocated(self%interpolator_)) deallocate(self%interpolator_)
     allocate(self%interpolator_)
     if (self%increasing) then
-       self%valueMinimum  =self%values(              1)
-       self%valueMaximum  =self%values(self%lattice%count)
-       self%interpolator_ =interpolator(+self%values,self%lattice%values())
+       self%valueMinimum =self%values(                 1)
+       self%valueMaximum =self%values(self%lattice%count)
+       self%interpolator_=interpolator(+self%values,self%lattice%values())
     else
-       self%valueMinimum  =self%values(self%lattice%count)
-       self%valueMaximum  =self%values(              1)
-       self%interpolator_ =interpolator(-self%values,self%lattice%values())
+       self%valueMinimum =self%values(self%lattice%count)
+       self%valueMaximum =self%values(                 1)
+       self%interpolator_=interpolator(-self%values,self%lattice%values())
     end if
     self%initialized=.true.
     return

--- a/source/tests/cooling_functions.F90
+++ b/source/tests/cooling_functions.F90
@@ -175,7 +175,12 @@ program Test_Cooling_Functions
        &            /ergs                  &
        &            /coolantCMBCompton     &
        &            /gigaYear
-  call Assert('CMB Compton cooling timescale at z=0',timescaleCooling,980.09784110508792d0,relTol=1.0d-6)
+  ! The expected value was updated when the cosmology function tabulations were pinned to an absolute lattice (#1317). The
+  ! Compton cooling rate goes as the fourth power of the temperature of the cosmic microwave background, and so as the
+  ! inverse fourth power of the expansion factor at the epoch set above - a quantity interpolated from a tabulation whose
+  ! abscissae that change moved, and whose initial condition is now imposed at a fixed, earlier epoch. The timescale shifted
+  ! by 1.9 parts per million, just past the tolerance asserted here.
+  call Assert('CMB Compton cooling timescale at z=0',timescaleCooling,980.09973759556078d0,relTol=1.0d-6)
   ! Compute Cloudy cooling time.
   coolantAtomicCIECloudy=+coolingFunctionAtomicCIECloudy_%coolingFunction(node,numberDensityHydrogen,temperature,gasAbundances,chemicalDensities,radiation)
   call Assert('Cloudy CIE cooling function',coolantAtomicCIECloudy,1.4198000000000027d-30,relTol=1.0d-6)

--- a/source/tests/cosmology_functions.F90
+++ b/source/tests/cosmology_functions.F90
@@ -1,0 +1,166 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{RST
+Contains a program to test the determinism of the tabulations built by the cosmology functions classes.
+!!}
+
+program Test_Cosmology_Functions
+  !!{RST
+  Tests that the tabulations built by the cosmology functions classes are independent of the sequence of epochs at which they
+  happen to be asked for values.
+
+  Each class tabulates expansion factor against cosmic time - and, for the matter plus cosmological constant class, comoving
+  distance against cosmic time - extending the tabulation whenever a request falls outside it. With the abscissae pinned to an
+  absolute lattice the tabulation reached after a given set of requests depends only on which lattice points those requests
+  span, and not on the order in which they arrived. That is asserted here by presenting the same set of epochs to two objects
+  in opposite orders and requiring the results to agree *exactly*.
+
+  Every epoch is requested before any value is recorded. This is deliberate: the expansion factor is integrated forward from
+  an initial condition imposed at the earliest tabulated epoch, so a tabulation which has not yet been asked for the earliest
+  epoch of the set is not the same tabulation, and could not be expected to agree with one which has. What is asserted is that
+  the tabulation *arrived at* is the same, which is the property this determinism buys.
+  !!}
+  use :: Cosmology_Functions , only : cosmologyFunctionsMatterLambda, cosmologyFunctionsMatterDarkEnergy
+  use :: Cosmology_Parameters, only : cosmologyParametersSimple
+  use :: Display             , only : displayVerbositySet           , verbosityLevelStandard
+  use :: Unit_Tests          , only : Assert                        , Unit_Tests_Begin_Group            , Unit_Tests_End_Group, Unit_Tests_Finish
+  implicit none
+  ! Epochs at which each tabulation is queried, in gigayears. They span several decades, so that every tabulation must be
+  ! extended repeatedly, and they are deliberately not points of the lattice. The expansion factor tabulations begin life
+  ! spanning 10⁻⁴ to 20 Gyr, so the epochs presented to them must reach beyond that at *both* ends or no extension is provoked
+  ! at all - the matter plus dark energy case initially did not, and so passed even against the unpinned tabulation. The
+  ! comoving distance tabulation ends at the present day, so the epochs presented to it stop below the present day age of this
+  ! cosmology (13.5 Gyr).
+  double precision                                    , dimension(7), parameter :: timesExpansion               =[2.1d-5,3.7d-3,4.1d-2,0.83d0,2.9d0,9.1d0,47.0d0]
+  double precision                                    , dimension(7), parameter :: timesDistance                =[3.7d-3,4.1d-2,0.83d0,2.9d0,5.3d0,9.1d0,13.0d0]
+  type            (cosmologyParametersSimple         )                          :: cosmologyParameters_
+  type            (cosmologyFunctionsMatterLambda    )                          :: lambdaAscending_             , lambdaDescending_
+  type            (cosmologyFunctionsMatterDarkEnergy)                          :: darkEnergyAscending_         , darkEnergyDescending_
+  double precision                                    , dimension(7)            :: resultAscending              , resultDescending
+  integer                                                                       :: i                            , pass
+
+  ! Set verbosity level.
+  call displayVerbositySet(verbosityLevelStandard)
+  ! Begin unit tests.
+  call Unit_Tests_Begin_Group("Cosmology functions: tabulation determinism")
+  !![
+  <referenceConstruct object="cosmologyParameters_" >
+   <constructor>
+    cosmologyParametersSimple         (                                                     &amp;
+     &amp;                             OmegaMatter                = 0.30d0                , &amp;
+     &amp;                             OmegaBaryon                = 0.00d0                , &amp;
+     &amp;                             OmegaDarkEnergy            = 0.70d0                , &amp;
+     &amp;                             temperatureCMB             = 2.78d0                , &amp;
+     &amp;                             HubbleConstant             =70.00d0                  &amp;
+     &amp;                            )
+   </constructor>
+  </referenceConstruct>
+  <referenceConstruct object="lambdaAscending_"     >
+   <constructor>
+    cosmologyFunctionsMatterLambda    (                                                     &amp;
+     &amp;                             cosmologyParameters_       =cosmologyParameters_     &amp;
+     &amp;                            )
+   </constructor>
+  </referenceConstruct>
+  <referenceConstruct object="lambdaDescending_"    >
+   <constructor>
+    cosmologyFunctionsMatterLambda    (                                                     &amp;
+     &amp;                             cosmologyParameters_       =cosmologyParameters_     &amp;
+     &amp;                            )
+   </constructor>
+  </referenceConstruct>
+  <referenceConstruct object="darkEnergyAscending_" >
+   <constructor>
+    cosmologyFunctionsMatterDarkEnergy(                                                     &amp;
+     &amp;                             cosmologyParameters_       =cosmologyParameters_   , &amp;
+     &amp;                             darkEnergyEquationOfStateW0=-0.80d0                , &amp;
+     &amp;                             darkEnergyEquationOfStateW1= 0.00d0                  &amp;
+     &amp;                            )
+   </constructor>
+  </referenceConstruct>
+  <referenceConstruct object="darkEnergyDescending_">
+   <constructor>
+    cosmologyFunctionsMatterDarkEnergy(                                                     &amp;
+     &amp;                             cosmologyParameters_       =cosmologyParameters_   , &amp;
+     &amp;                             darkEnergyEquationOfStateW0=-0.80d0                , &amp;
+     &amp;                             darkEnergyEquationOfStateW1= 0.00d0                  &amp;
+     &amp;                            )
+   </constructor>
+  </referenceConstruct>
+  !!]
+
+  ! Expansion factor vs. time, matter plus cosmological constant.
+  do pass=1,2
+     do i=1,size(timesExpansion)
+        resultAscending (i)=lambdaAscending_ %expansionFactor(timesExpansion(                       i))
+        resultDescending(i)=lambdaDescending_%expansionFactor(timesExpansion(size(timesExpansion)+1-i))
+     end do
+  end do
+  call Assert("matter + cosmological constant: expansion factor is independent of the order in which epochs are requested",resultAscending,reverse(resultDescending),absTol=0.0d0)
+
+  ! Cosmic time vs. expansion factor - the inverse of the same tabulation.
+  do pass=1,2
+     do i=1,size(timesDistance)
+        resultAscending (i)=lambdaAscending_ %cosmicTime(lambdaAscending_ %expansionFactor(timesDistance(                      i)))
+        resultDescending(i)=lambdaDescending_%cosmicTime(lambdaDescending_%expansionFactor(timesDistance(size(timesDistance)+1-i)))
+     end do
+  end do
+  call Assert("matter + cosmological constant: cosmic time is independent of the order in which epochs are requested"     ,resultAscending,reverse(resultDescending),absTol=0.0d0)
+
+  ! Comoving distance vs. time.
+  do pass=1,2
+     do i=1,size(timesDistance)
+        resultAscending (i)=lambdaAscending_ %distanceComoving(timesDistance(                      i))
+        resultDescending(i)=lambdaDescending_%distanceComoving(timesDistance(size(timesDistance)+1-i))
+     end do
+  end do
+  call Assert("matter + cosmological constant: comoving distance is independent of the order in which epochs are requested",resultAscending,reverse(resultDescending),absTol=0.0d0)
+
+  ! Expansion factor vs. time, matter plus dark energy.
+  do pass=1,2
+     do i=1,size(timesExpansion)
+        resultAscending (i)=darkEnergyAscending_ %expansionFactor(timesExpansion(                       i))
+        resultDescending(i)=darkEnergyDescending_%expansionFactor(timesExpansion(size(timesExpansion)+1-i))
+     end do
+  end do
+  call Assert("matter + dark energy: expansion factor is independent of the order in which epochs are requested"           ,resultAscending,reverse(resultDescending),absTol=0.0d0)
+
+  ! End unit tests.
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Finish   ()
+
+contains
+
+  function reverse(values)
+    !!{RST
+    Return ``values`` in reverse order.
+    !!}
+    implicit none
+    double precision, intent(in   ), dimension(           :) :: values
+    double precision               , dimension(size(values)) :: reverse
+    integer                                                  :: i
+
+    do i=1,size(values)
+       reverse(i)=values(size(values)-i+1)
+    end do
+    return
+  end function reverse
+
+end program Test_Cosmology_Functions

--- a/source/tests/cosmology_functions.F90
+++ b/source/tests/cosmology_functions.F90
@@ -48,13 +48,13 @@ program Test_Cosmology_Functions
   ! at all - the matter plus dark energy case initially did not, and so passed even against the unpinned tabulation. The
   ! comoving distance tabulation ends at the present day, so the epochs presented to it stop below the present day age of this
   ! cosmology (13.5 Gyr).
-  double precision                                    , dimension(7), parameter :: timesExpansion               =[2.1d-5,3.7d-3,4.1d-2,0.83d0,2.9d0,9.1d0,47.0d0]
-  double precision                                    , dimension(7), parameter :: timesDistance                =[3.7d-3,4.1d-2,0.83d0,2.9d0,5.3d0,9.1d0,13.0d0]
+  double precision                                    , dimension(7), parameter :: timesExpansion      =[2.1d-5,3.7d-3,4.10d-2,0.83d0,2.9d0,9.1d0,47.0d0]
+  double precision                                    , dimension(7), parameter :: timesDistance       =[3.7d-3,4.1d-2,0.83d+0,2.90d0,5.3d0,9.1d0,13.0d0]
   type            (cosmologyParametersSimple         )                          :: cosmologyParameters_
-  type            (cosmologyFunctionsMatterLambda    )                          :: lambdaAscending_             , lambdaDescending_
-  type            (cosmologyFunctionsMatterDarkEnergy)                          :: darkEnergyAscending_         , darkEnergyDescending_
-  double precision                                    , dimension(7)            :: resultAscending              , resultDescending
-  integer                                                                       :: i                            , pass
+  type            (cosmologyFunctionsMatterLambda    )                          :: lambdaAscending_    , lambdaDescending_
+  type            (cosmologyFunctionsMatterDarkEnergy)                          :: darkEnergyAscending_, darkEnergyDescending_
+  double precision                                    , dimension(7)            :: resultAscending     , resultDescending
+  integer                                                                       :: i                   , pass
 
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
@@ -63,44 +63,44 @@ program Test_Cosmology_Functions
   !![
   <referenceConstruct object="cosmologyParameters_" >
    <constructor>
-    cosmologyParametersSimple         (                                                     &amp;
-     &amp;                             OmegaMatter                = 0.30d0                , &amp;
-     &amp;                             OmegaBaryon                = 0.00d0                , &amp;
-     &amp;                             OmegaDarkEnergy            = 0.70d0                , &amp;
-     &amp;                             temperatureCMB             = 2.78d0                , &amp;
-     &amp;                             HubbleConstant             =70.00d0                  &amp;
+    cosmologyParametersSimple         (                                                  &amp;
+     &amp;                             OmegaMatter                = 0.30d0             , &amp;
+     &amp;                             OmegaBaryon                = 0.00d0             , &amp;
+     &amp;                             OmegaDarkEnergy            = 0.70d0             , &amp;
+     &amp;                             temperatureCMB             = 2.78d0             , &amp;
+     &amp;                             HubbleConstant             =70.00d0               &amp;
      &amp;                            )
    </constructor>
   </referenceConstruct>
   <referenceConstruct object="lambdaAscending_"     >
    <constructor>
-    cosmologyFunctionsMatterLambda    (                                                     &amp;
-     &amp;                             cosmologyParameters_       =cosmologyParameters_     &amp;
+    cosmologyFunctionsMatterLambda    (                                                  &amp;
+     &amp;                             cosmologyParameters_       =cosmologyParameters_  &amp;
      &amp;                            )
    </constructor>
   </referenceConstruct>
   <referenceConstruct object="lambdaDescending_"    >
    <constructor>
-    cosmologyFunctionsMatterLambda    (                                                     &amp;
-     &amp;                             cosmologyParameters_       =cosmologyParameters_     &amp;
+    cosmologyFunctionsMatterLambda    (                                                  &amp;
+     &amp;                             cosmologyParameters_       =cosmologyParameters_  &amp;
      &amp;                            )
    </constructor>
   </referenceConstruct>
   <referenceConstruct object="darkEnergyAscending_" >
    <constructor>
-    cosmologyFunctionsMatterDarkEnergy(                                                     &amp;
-     &amp;                             cosmologyParameters_       =cosmologyParameters_   , &amp;
-     &amp;                             darkEnergyEquationOfStateW0=-0.80d0                , &amp;
-     &amp;                             darkEnergyEquationOfStateW1= 0.00d0                  &amp;
+    cosmologyFunctionsMatterDarkEnergy(                                                  &amp;
+     &amp;                             cosmologyParameters_       =cosmologyParameters_, &amp;
+     &amp;                             darkEnergyEquationOfStateW0=-0.80d0             , &amp;
+     &amp;                             darkEnergyEquationOfStateW1= 0.00d0               &amp;
      &amp;                            )
    </constructor>
   </referenceConstruct>
   <referenceConstruct object="darkEnergyDescending_">
    <constructor>
-    cosmologyFunctionsMatterDarkEnergy(                                                     &amp;
-     &amp;                             cosmologyParameters_       =cosmologyParameters_   , &amp;
-     &amp;                             darkEnergyEquationOfStateW0=-0.80d0                , &amp;
-     &amp;                             darkEnergyEquationOfStateW1= 0.00d0                  &amp;
+    cosmologyFunctionsMatterDarkEnergy(                                                  &amp;
+     &amp;                             cosmologyParameters_       =cosmologyParameters_, &amp;
+     &amp;                             darkEnergyEquationOfStateW0=-0.80d0             , &amp;
+     &amp;                             darkEnergyEquationOfStateW1= 0.00d0               &amp;
      &amp;                            )
    </constructor>
   </referenceConstruct>

--- a/source/tests/tabulations_inverse.F90
+++ b/source/tests/tabulations_inverse.F90
@@ -1,0 +1,173 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!!{RST
+Contains a program to test tabulations of monotonic functions built for inversion.
+!!}
+
+program Test_Tabulations_Inverse
+  !!{RST
+  Tests tabulations of monotonic functions built for inversion.
+
+  The property these tabulations exist to provide is that they do *not* depend on the sequence of values they happen to be
+  asked for. That is asserted directly here, by building two tabulations of the same function from the same set of requests
+  presented in opposite orders and requiring that they agree exactly - which is the check that exposed an order-dependent
+  rebuild trigger when the transfer function tabulations were converted, a defect which pinning the abscissae alone did not
+  cure.
+  !!}
+  use :: Display            , only : displayVerbositySet, verbosityLevelStandard
+  use :: Tabulations_Inverse, only : tabulationInverse
+  use :: Unit_Tests         , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
+  implicit none
+  type            (tabulationInverse)                              :: increasingAscending  , increasingDescending, &
+       &                                                              decreasingAscending  , decreasingDescending, &
+       &                                                              extended             , restored
+  ! Values at which each tabulation is queried. They span several octaves in each direction, so that both must be extended
+  ! repeatedly, and they are deliberately not points of the lattice.
+  double precision                   , dimension(7), parameter     :: valuesIncreasing     =[3.7d-3,4.1d-2,0.83d0,7.3d0,51.0d0,410.0d0,3300.0d0], &
+       &                                                              valuesDecreasing     =[3.1d-3,2.7d-2,0.31d0,2.9d0,44.0d0,370.0d0,2900.0d0]
+  integer                            , parameter                   :: pointsPerOctave      =12
+  double precision                   , dimension(7)                :: resultAscending      , resultDescending
+  double precision                   , allocatable, dimension(:)   :: valuesPreserved      , abscissaePreserved  , &
+       &                                                              abscissaeExtended
+  integer                                                          :: i                    , fileUnit            , &
+       &                                                              countPreserved
+  logical                                                          :: preserved
+
+  ! Set verbosity level.
+  call displayVerbositySet(verbosityLevelStandard)
+
+  ! Begin unit tests.
+  call Unit_Tests_Begin_Group("Inverse tabulations")
+
+  ! An increasing function, f(x)=x², requested in ascending and in descending order.
+  call tabulate(increasingAscending ,valuesIncreasing              ,increasing=.true.)
+  call tabulate(increasingDescending,reverse(valuesIncreasing)     ,increasing=.true.)
+  do i=1,size(valuesIncreasing)
+     resultAscending (i)=increasingAscending %invert(valuesIncreasing(i))
+     resultDescending(i)=increasingDescending%invert(valuesIncreasing(i))
+  end do
+  call Assert("increasing: inverse is independent of the order in which values are requested",resultAscending,resultDescending,absTol=0.0d0)
+  call Assert("increasing: the two tabulations span the same lattice"                                                                  , &
+       &      [increasingAscending %lattice%indexMinimum,increasingAscending %lattice%count]                                           , &
+       &      [increasingDescending%lattice%indexMinimum,increasingDescending%lattice%count]                                             )
+  ! The inverse should recover the abscissa: f(x)=x² so x=√f.
+  call Assert("increasing: inverse recovers the abscissa at a tabulated point",increasingAscending%invert(4.0d0),2.0d0,relTol=1.0d-12)
+
+  ! A decreasing function, f(x)=1/x, likewise.
+  call tabulate(decreasingAscending ,valuesDecreasing              ,increasing=.false.)
+  call tabulate(decreasingDescending,reverse(valuesDecreasing)     ,increasing=.false.)
+  do i=1,size(valuesDecreasing)
+     resultAscending (i)=decreasingAscending %invert(valuesDecreasing(i))
+     resultDescending(i)=decreasingDescending%invert(valuesDecreasing(i))
+  end do
+  call Assert("decreasing: inverse is independent of the order in which values are requested",resultAscending,resultDescending,absTol=0.0d0)
+  call Assert("decreasing: the two tabulations span the same lattice"                                                                  , &
+       &      [decreasingAscending %lattice%indexMinimum,decreasingAscending %lattice%count]                                           , &
+       &      [decreasingDescending%lattice%indexMinimum,decreasingDescending%lattice%count]                                             )
+  call Assert("decreasing: inverse recovers the abscissa at a tabulated point",decreasingAscending%invert(0.25d0),4.0d0,relTol=1.0d-12)
+
+  ! Extension must preserve every previously computed value bit-for-bit, and must place them at the abscissae they were
+  ! computed for.
+  call tabulate(extended,valuesIncreasing(4:4),increasing=.true.)
+  countPreserved    =extended%lattice%count
+  valuesPreserved   =extended%values
+  abscissaePreserved=extended%abscissae()
+  call tabulate(extended,valuesIncreasing     ,increasing=.true.,reset=.false.)
+  abscissaeExtended =extended%abscissae()
+  preserved         =.false.
+  do i=1,size(abscissaeExtended)-countPreserved+1
+     if (all(abscissaeExtended(i:i+countPreserved-1) == abscissaePreserved)) then
+        preserved=all(extended%values(i:i+countPreserved-1) == valuesPreserved)
+        exit
+     end if
+  end do
+  call Assert("extension preserves previously computed values, at their own abscissae",preserved,.true.)
+
+  ! A tabulation must survive a store and restore unchanged - including its ability to invert, which requires that the
+  ! values, and not merely the range, be stored.
+  open(newUnit=fileUnit,file='tabulationsInverse.state',status='replace',form='unformatted')
+  call increasingAscending%stateStore  (fileUnit)
+  rewind(fileUnit)
+  call restored           %stateRestore(fileUnit)
+  close(fileUnit,status='delete')
+  do i=1,size(valuesIncreasing)
+     resultDescending(i)=restored%invert(valuesIncreasing(i))
+  end do
+  do i=1,size(valuesIncreasing)
+     resultAscending (i)=increasingAscending%invert(valuesIncreasing(i))
+  end do
+  call Assert("a restored tabulation inverts identically to the one it was stored from",resultAscending,resultDescending,absTol=0.0d0)
+
+  ! End unit tests.
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Finish   ()
+
+contains
+
+  function reverse(values)
+    !!{RST
+    Return ``values`` in reverse order.
+    !!}
+    implicit none
+    double precision, intent(in   ), dimension(     :) :: values
+    double precision               , dimension(size(values)) :: reverse
+    integer                                            :: i
+
+    do i=1,size(values)
+       reverse(i)=values(size(values)-i+1)
+    end do
+    return
+  end function reverse
+
+  subroutine tabulate(tabulation,values,increasing,reset)
+    !!{RST
+    Build ``tabulation`` by requesting each of ``values`` in turn, in the order given.
+    !!}
+    implicit none
+    type            (tabulationInverse), intent(inout)               :: tabulation
+    double precision                   , intent(in   ), dimension(:) :: values
+    logical                            , intent(in   )               :: increasing
+    logical                            , intent(in   ), optional     :: reset
+    double precision                   , allocatable  , dimension(:) :: abscissae
+    integer                                                          :: i             , j
+    logical                                                          :: reset_
+
+    reset_=.true.
+    if (present(reset)) reset_=reset
+    if (reset_) call tabulation%reset(pointsPerOctave,increasing)
+    do i=1,size(values)
+       do while (.not.tabulation%brackets(values(i)))
+          call tabulation%expand(values(i))
+          abscissae=tabulation%abscissae()
+          do j=1,size(abscissae)
+             if (tabulation%isComputed(j)) cycle
+             if (increasing) then
+                call tabulation%set(j,abscissae(j)**2)
+             else
+                call tabulation%set(j,1.0d0/abscissae(j))
+             end if
+          end do
+          call tabulation%build()
+       end do
+    end do
+    return
+  end subroutine tabulate
+
+end program Test_Tabulations_Inverse

--- a/source/tests/tabulations_inverse.F90
+++ b/source/tests/tabulations_inverse.F90
@@ -35,20 +35,20 @@ program Test_Tabulations_Inverse
   use :: Tabulations_Inverse, only : tabulationInverse
   use :: Unit_Tests         , only : Assert             , Unit_Tests_Begin_Group, Unit_Tests_End_Group, Unit_Tests_Finish
   implicit none
-  type            (tabulationInverse)                              :: increasingAscending  , increasingDescending, &
-       &                                                              decreasingAscending  , decreasingDescending, &
-       &                                                              extended             , restored
+  type            (tabulationInverse)                              :: increasingAscending, increasingDescending, &
+       &                                                              decreasingAscending, decreasingDescending, &
+       &                                                              extended           , restored
+  integer                            , parameter                   :: pointsPerOctave      =12
+  double precision                   , dimension(7)                :: resultAscending    , resultDescending
+  double precision                   , allocatable, dimension(:)   :: valuesPreserved    , abscissaePreserved  , &
+       &                                                              abscissaeExtended
+  integer                                                          :: i                  , fileUnit            , &
+       &                                                              countPreserved
+  logical                                                          :: preserved
   ! Values at which each tabulation is queried. They span several octaves in each direction, so that both must be extended
   ! repeatedly, and they are deliberately not points of the lattice.
   double precision                   , dimension(7), parameter     :: valuesIncreasing     =[3.7d-3,4.1d-2,0.83d0,7.3d0,51.0d0,410.0d0,3300.0d0], &
        &                                                              valuesDecreasing     =[3.1d-3,2.7d-2,0.31d0,2.9d0,44.0d0,370.0d0,2900.0d0]
-  integer                            , parameter                   :: pointsPerOctave      =12
-  double precision                   , dimension(7)                :: resultAscending      , resultDescending
-  double precision                   , allocatable, dimension(:)   :: valuesPreserved      , abscissaePreserved  , &
-       &                                                              abscissaeExtended
-  integer                                                          :: i                    , fileUnit            , &
-       &                                                              countPreserved
-  logical                                                          :: preserved
 
   ! Set verbosity level.
   call displayVerbositySet(verbosityLevelStandard)
@@ -57,16 +57,16 @@ program Test_Tabulations_Inverse
   call Unit_Tests_Begin_Group("Inverse tabulations")
 
   ! An increasing function, f(x)=x², requested in ascending and in descending order.
-  call tabulate(increasingAscending ,valuesIncreasing              ,increasing=.true.)
-  call tabulate(increasingDescending,reverse(valuesIncreasing)     ,increasing=.true.)
+  call tabulate(increasingAscending ,valuesIncreasing         ,increasing=.true.)
+  call tabulate(increasingDescending,reverse(valuesIncreasing),increasing=.true.)
   do i=1,size(valuesIncreasing)
      resultAscending (i)=increasingAscending %invert(valuesIncreasing(i))
      resultDescending(i)=increasingDescending%invert(valuesIncreasing(i))
   end do
   call Assert("increasing: inverse is independent of the order in which values are requested",resultAscending,resultDescending,absTol=0.0d0)
-  call Assert("increasing: the two tabulations span the same lattice"                                                                  , &
-       &      [increasingAscending %lattice%indexMinimum,increasingAscending %lattice%count]                                           , &
-       &      [increasingDescending%lattice%indexMinimum,increasingDescending%lattice%count]                                             )
+  call Assert("increasing: the two tabulations span the same lattice"                       , &
+       &      [increasingAscending %lattice%indexMinimum,increasingAscending %lattice%count], &
+       &      [increasingDescending%lattice%indexMinimum,increasingDescending%lattice%count]  )
   ! The inverse should recover the abscissa: f(x)=x² so x=√f.
   call Assert("increasing: inverse recovers the abscissa at a tabulated point",increasingAscending%invert(4.0d0),2.0d0,relTol=1.0d-12)
 
@@ -78,9 +78,9 @@ program Test_Tabulations_Inverse
      resultDescending(i)=decreasingDescending%invert(valuesDecreasing(i))
   end do
   call Assert("decreasing: inverse is independent of the order in which values are requested",resultAscending,resultDescending,absTol=0.0d0)
-  call Assert("decreasing: the two tabulations span the same lattice"                                                                  , &
-       &      [decreasingAscending %lattice%indexMinimum,decreasingAscending %lattice%count]                                           , &
-       &      [decreasingDescending%lattice%indexMinimum,decreasingDescending%lattice%count]                                             )
+  call Assert("decreasing: the two tabulations span the same lattice"                       , &
+       &      [decreasingAscending %lattice%indexMinimum,decreasingAscending %lattice%count], &
+       &      [decreasingDescending%lattice%indexMinimum,decreasingDescending%lattice%count]  )
   call Assert("decreasing: inverse recovers the abscissa at a tabulated point",decreasingAscending%invert(0.25d0),4.0d0,relTol=1.0d-12)
 
   ! Extension must preserve every previously computed value bit-for-bit, and must place them at the abscissae they were
@@ -89,7 +89,7 @@ program Test_Tabulations_Inverse
   countPreserved    =extended%lattice%count
   valuesPreserved   =extended%values
   abscissaePreserved=extended%abscissae()
-  call tabulate(extended,valuesIncreasing     ,increasing=.true.,reset=.false.)
+  call tabulate(extended,valuesIncreasing,increasing=.true.,reset=.false.)
   abscissaeExtended =extended%abscissae()
   preserved         =.false.
   do i=1,size(abscissaeExtended)-countPreserved+1
@@ -126,9 +126,9 @@ contains
     Return ``values`` in reverse order.
     !!}
     implicit none
-    double precision, intent(in   ), dimension(     :) :: values
+    double precision, intent(in   ), dimension(           :) :: values
     double precision               , dimension(size(values)) :: reverse
-    integer                                            :: i
+    integer                                                  :: i
 
     do i=1,size(values)
        reverse(i)=values(size(values)-i+1)
@@ -146,7 +146,7 @@ contains
     logical                            , intent(in   )               :: increasing
     logical                            , intent(in   ), optional     :: reset
     double precision                   , allocatable  , dimension(:) :: abscissae
-    integer                                                          :: i             , j
+    integer                                                          :: i         , j
     logical                                                          :: reset_
 
     reset_=.true.
@@ -159,9 +159,9 @@ contains
           do j=1,size(abscissae)
              if (tabulation%isComputed(j)) cycle
              if (increasing) then
-                call tabulation%set(j,abscissae(j)**2)
+                call tabulation%set(j,      abscissae(j)**2)
              else
-                call tabulation%set(j,1.0d0/abscissae(j))
+                call tabulation%set(j,1.0d0/abscissae(j)   )
              end if
           end do
           call tabulation%build()

--- a/testSuite/test-Python-interface.py
+++ b/testSuite/test-Python-interface.py
@@ -172,7 +172,11 @@ with safe_section("outputTimesUniformSpacingInRedshift"):
     outputTimes = galacticus.outputTimesUniformSpacingInRedshift(0.0,5.0,10,cosmologyFunctions)
     # TODO: replace dummy expectations below with golden values from a real run.
     check_eq("count()"           , outputTimes.count()             ,  10)  # integer(c_size_t) return
-    check   ("time(indexOutput=1)", outputTimes.time(indexOutput=1),  1.15473815)  # integer(c_size_t) arg, double return
+    # This expectation was updated when the cosmology function tabulations were pinned to an absolute lattice (#1317). It is the
+    # cosmic time at redshift 5, so it moves with the abscissae of the expansion factor tabulation and with the epoch at which
+    # that tabulation's initial condition is imposed; it shifted by 1.5 parts per million, just past the one part per million
+    # relative tolerance `check` applies by default.
+    check   ("time(indexOutput=1)", outputTimes.time(indexOutput=1),  1.154739884689715)  # integer(c_size_t) arg, double return
     check   ("redshift(idx=10)"   , outputTimes.redshift(indexOutput=10),  0.0)
 
 # Output times list — exercises the 1D deferred-shape numeric array path

--- a/testSuite/test-reproducibility.py
+++ b/testSuite/test-reproducibility.py
@@ -23,9 +23,15 @@ tests = [
         "assertions": [
             {
                 "name":              "hot halo mass",
+                # Updated when the cosmology function tabulations were pinned to an absolute lattice (#1317). That moved the
+                # abscissae of the expansion factor tabulation, and placed the initial condition of the ordinary differential
+                # equation it solves at a fixed, earlier epoch at which the analytic approximation used for that condition is
+                # more accurate. Both shift interpolated cosmological quantities at the level of their own interpolation error;
+                # this value moved by 6.5 parts per million, just past the 4 part per million tolerance below. That is the
+                # one-time shift anticipated by the issue - the tabulations are deterministic from here on.
                 "output":            1,
                 "property":          "hotHaloMass",
-                "values":            np.array([7.99799857410098e10]),
+                "values":            np.array([7.998050315988728e10]),
                 "toleranceRelative": 4.0e-6,
             }
         ],


### PR DESCRIPTION
Phase 3 of #1317 — the bracket-by-doubling family, and the cosmology-functions tables.

This completes the phase: **eighteen tabulations** converted onto the absolute lattice. Phases 1
and 2 are already merged. A ninth, comment-only commit closes out phase 4 — see the end.

## The fifteen analytic-profile inverse tables

`Einasto`, `Burkert` and `Zhao1996` have four each (`massScaleFree`, `densityScaleFree`,
`angularMomentumSpecificScaleFree`, `timeFreefallScaleFree`); `NFW` has three. All fifteen shared
one idiom almost verbatim — two `do while` bracket loops from a unit seed, then a full rebuild —
so, as agreed, they are converted through a **single shared utility**
(`source/numerical/tabulations_inverse.F90`) rather than fifteen in-place edits.

**Control is inverted**: the caller evaluates the function. That keeps each evaluator where it is
written, with its host state, and imposes no common interface on evaluators ranging from a single
`elemental` expression to a quadrature per point.

**Gridding is per octave, 30 points** (99.66/decade against the previous 100/decade). The bounds
these tabulations reach come from halving and doubling a unit seed, so they are *already* exact
octave lattice points — pinning costs nothing in range here, where decade anchoring would pad
every bound. No seed range is needed: the interpolator is local (`gsl_interp_linear`) and the
values are not persisted, so values at shared lattice points agree whatever range each table
reached.

Converting also removes the bracket loops' own evaluations, which were re-run on every growth and,
for `timeFreefall`, were numerical integrals.

Net effect on the four profile files is about −230 lines.

## The three cosmology-functions tables

"Fold in the cosmology-functions tables themselves, converting their relative anchoring to the
absolute lattice, closing the loop on the Cole2000 comment."

There are **three**, not four: `matter_lambda.F90` has both an expansion-factor-versus-time table
and a comoving-distance table, but `matter_dark_energy.F90` has only the expansion factor table —
its `distanceComoving`, `timeAtDistanceComoving` and `distanceComovingConvert` are all
`Error_Report('functionality not implemented')` stubs, and its `distanceTableNPointsPerDecade` was
dead code (removed).

**These are the tables behind the floating point exception seen on the phase 2 branch.** Their
bounds grew by repeated multiplication by a fixed factor from an origin set by the first request,
and `Make_Range` then redistributed the abscissae over the result — so the previously computed
points pasted back into the new table carried the *old* spacing. The table became a patchwork of
spacings which no single `ageTableInverseDeltaLogTime` could describe, and the index computed from
it drifted further from the truth with every extension, reaching 2054 for a table of 2050 points.
The guard added by `c73490ef9` in phase 2 treats the symptom; pinning is the cure, and the guard is
retained (with its comment updated: on a pinned lattice the index is exact, but it is still clamped
and both searches still bounded).

Three things are worth drawing attention to.

**The comoving distance axis is in units of t/t₀.** The comoving distance to an epoch is an
integral out to the present day, so the table must *end* exactly at the present day — and no
lattice point of an absolute lattice in cosmic time does. In units of the present-day age, the
present day is the lattice point of index zero, exactly, on any lattice. This is the same device
already used for the electron-scattering optical depth in the IGM state class, and is legitimate
here for the same reason: the unit is fixed for the lifetime of the tabulation.

**That table is built on another that can itself be rebuilt.** Both the unit t₀ and every
integration limit are interpolated from the expansion factor table, which restarts its ODE from a
new earliest epoch whenever it is extended downward — changing every value in it. So distances are
carried over only while that table has not been rebuilt since they were computed, *and* the
expansion factor table is established across the whole range about to be tabulated before any
integral is evaluated. Detecting the coupled rebuild afterwards would not be enough: a rebuild
part way through a fill would leave a table half computed against each version, silently.

**The matter+dark energy table truncates itself**, on discovering that the universe collapses. The
lattice held is now shortened to match — its points are unchanged, so the shortened table remains a
set of points of the same lattice — and the discovered epoch of turnaround is imposed as a hard
limit on the range, so the truncation happens only on the build which finds it rather than on every
subsequent one. Relatedly, that class reset and re-derived its collapse flags on every call, which
cannot work once values are carried over (the detection examines only points computed afresh); they
are now determined on the first build and retained, being properties of the cosmology rather than of
the tabulation.

## Tests

Two new test executables, both registered in `cicd.yml`.

- **`tests.tabulations_inverse`** (8 assertions) — order independence in both directions, the *same
  lattice* either way, bit-for-bit preservation across extension, and a store/restore round trip.
- **`tests.cosmology_functions`** (4 assertions) — the same epochs presented to two objects in
  opposite orders, with expansion factors, cosmic times and comoving distances required to agree
  *exactly*. Every epoch is requested before any value is recorded, deliberately: the expansion
  factor is integrated forward from the earliest tabulated epoch, so what is asserted is that the
  tabulation *arrived at* is the same.

  This test was checked against the unpinned tabulations on the phase 2 tree: **all four assertions
  fail there and all four pass here.** That check was worth doing — the first version of the test
  passed in both trees for the matter plus dark energy case, because its epochs all lay inside the
  10⁻⁴–20 Gyr window that tabulation starts with, so no extension was ever provoked.

## One comment-only commit for phase 4

Phase 4 of #1317 proposed retiring the Cole2000 warm-up hack and the Font2008 two-attempt
workaround, on the grounds that pinning would make them unnecessary. Investigating that found
**neither can be retired**, and that the premise recorded in the Cole2000 comment is wrong. Since
the outcome is comments rather than code, it rides along here rather than in its own pull request;
`quickTest.xml` output is bit-identical.

The Cole2000 comment prescribed its own fix: that tabulating classes should "expand their range
without changing any of the previous computed values (as we do for expansion factor vs. time in the
cosmology function class)". Pinning achieves that for extension at the *upper* end. But the
tabulations δc(t) depends upon include ones integrated forward from their earliest tabulated epoch —
the linear growth factor among them — and those cannot be extended *downward* without restarting
the integration from a new starting epoch, which moves every value. The cosmology function class
cited as the model discards its whole table in exactly that case, for exactly this reason. Measured
rather than argued: removing the warm-up changes `quickTest.xml` by up to 24% across 26 datasets — a
different merger tree — while the same source run twice is bit-identical. The obvious explanation,
that σ(M)'s global cubic spline makes it range-dependent even when pinned, is refuted: the results
still differ under `monotonicInterpolation=true`.

The Font2008 retry is blocked more prosaically — its root function evaluates the composite mass
distribution, several of whose components still choose their range from the first request and
rebuild wholesale. Those files are named in the comment so that whoever pins them knows the retry
can then go.

An audit for further sites #1317's survey missed is opened as #1375; it found several, including
one listed in #1317's own phase 2.

## Verification

Clean build, exit 0, **zero warnings**. Unit tests **262/262** across `tests.make_ranges` (38),
`tests.tables` (38), `tests.table_caches` (17), `tests.tabulations_inverse` (8),
`tests.mass_distributions` (157) and `tests.cosmology_functions` (4). `test-cosmology` runs all four
models — including the closed, collapsing universe — to completion with no failures, against a
cleared output directory. `quickTest.xml` runs to completion.

Note that converting a site changes its grid, so interpolated results shift once at the level of the
interpolation error; this is expected, and is the last such shift, since grids are deterministic
afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
