### PR TITLE
fix(download): work around hosts which reject `wget` on its TLS handshake

### DIFF
--- a/scripts/aux/archive.py
+++ b/scripts/aux/archive.py
@@ -177,8 +177,20 @@ for group in links:
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         report["report"] += f"RETRIEVING: {link}\n"
         # `--no-check-certificate` matches the behavior of the run-time downloader (`downloadMultiple()` in
-        # `source/system/downloader.F90`), so that the archiver can retrieve exactly what a model run would.
-        result = subprocess.run(["wget", "--no-check-certificate", link, "-O", dest])
+        # `source/system/downloader.F90`), so that the archiver can retrieve exactly what a model run would. `--ciphers=DEFAULT`
+        # likewise matches it: `wget`'s own default cipher list yields a TLS handshake which some content delivery networks
+        # (bitbucket.org, which hosts the NGenHalofit source, among them) fingerprint as a bot and reject with a "404 Not Found"
+        # for every URL on the host, so that the failure looks like missing content rather than a refused client.
+        result = subprocess.run(["wget", "--no-check-certificate", "--ciphers=DEFAULT", link, "-O", dest])
+        if result.returncode != 0:
+            # Fall back to `curl`, again mirroring the run-time downloader. A failure of one downloader does not establish that
+            # the content is unavailable, since a host may reject one client at the TLS layer while accepting the other.
+            if os.path.exists(dest):
+                os.remove(dest)
+            # `--fail` is essential: without it `curl` treats an HTTP error response as a successful transfer, exiting with zero
+            # status after writing the server's error page to the output file. That page would then be archived as though it were
+            # the requested content, and counted as "already archived" on every subsequent run.
+            result = subprocess.run(["curl", "--location", "--insecure", "--fail", "--output", dest, "--", link])
         if result.returncode == 0:
             break
         # Do not leave a partial file behind, which would otherwise count as "already archived" on the next run.

--- a/source/system/downloader.F90
+++ b/source/system/downloader.F90
@@ -17,6 +17,10 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    The fallback from `wget` to `curl` within a single download attempt, and the use of `--ciphers=DEFAULT` to avoid hosts which
+!+    reject `wget` on the basis of its TLS handshake, were diagnosed and drafted with assistance from Claude, and reviewed and
+!+    verified by Andrew Benson.
+
 !!{RST
 Contains a module which downloads content from a supplied URL (or list of URLs).
 !!}
@@ -232,6 +236,10 @@ contains
     Download content to the given ``outputFileName``, trying each URL in url in turn. If the download from one URL fails (even
     after any retries), the next URL is used as a fallback. The download is considered successful as soon as any URL succeeds.
 
+    Each attempt uses ``wget``, falling back to ``curl`` if ``wget`` is unavailable or fails. Both are tried because a failure of
+    one does not establish that the content is unavailable---a host which fingerprints and rejects a client at the TLS layer will
+    reject it for every URL and on every retry, while accepting the other client.
+
     TLS certificates are verified by default. Setting ``allowInsecure`` to true disables that verification, which leaves the
     download open to interception and modification by anyone able to intercept the connection---content fetched this way must be
     treated as untrusted. It exists only for hosts which serve an unusable certificate and for which no alternative source is
@@ -266,15 +274,22 @@ contains
        tries=0
        do while (tries <= retries_)
           status_=errorStatusFail
-          if      (downloadUsingWget) then
+          if (downloadUsingWget) then
              command=downloadCommand(url(i),outputFileName,timeout_,allowInsecure_,downloaderWget)
              call System_Command_Do(char(command),status_)
-          else if (downloadUsingCurl) then
+          end if
+          ! If `wget` is unavailable, or failed, try `curl`. A failure of one downloader does not imply that the content is
+          ! unavailable: hosts which fingerprint and reject a client at the TLS layer do so irrespective of the URL requested, so
+          ! the other downloader may well succeed where this one could never do so no matter how many times it is retried.
+          if (status_ /= errorStatusSuccess .and. downloadUsingCurl) then
+             ! Remove any partial file left behind by a failed `wget` attempt, so that no part of it can survive into the file
+             ! written by `curl`.
+             if (File_Exists(outputFileName)) call File_Remove(outputFileName)
              command=downloadCommand(url(i),outputFileName,timeout_,allowInsecure_,downloaderCurl)
              call System_Command_Do(char(command),status_)
-          else if (.not.present(status)) then
-             call Error_Report('no downloader available'//{introspection:location})
           end if
+          if (.not.downloadUsingWget .and. .not.downloadUsingCurl .and. .not.present(status)) &
+               & call Error_Report('no downloader available'//{introspection:location})
           if (status_ == errorStatusSuccess) then
              if (present(status)) status=status_
              return
@@ -335,14 +350,26 @@ contains
        ! `downloadMultiple`, so allowing `wget` to also retry internally results in a multiplicative number of attempts (and can
        ! cause the download to far exceed any time limit when each internal attempt hangs until its read-timeout). The `--timeout`
        ! option bounds the time spent on DNS lookup, connection, and reads for the single attempt.
-       command='wget --tries=1 --timeout='//trim(timeoutLabel)//' '
+       !
+       ! `--ciphers=DEFAULT` replaces `wget`'s own, more restrictive, default cipher list with that of the underlying TLS library.
+       ! `wget`'s default list yields a TLS handshake which some content delivery networks (bitbucket.org, which hosts the
+       ! NGenHalofit source, among them) fingerprint as a bot and reject---returning a "404 Not Found" for every URL on the host,
+       ! including its front page, so that the failure masquerades as missing content rather than a refused client. This does not
+       ! weaken certificate verification, which remains controlled by `--no-check-certificate` below. A `wget` too old to accept
+       ! `--ciphers` will reject the option and exit without contacting the host---the fallback to `curl` in `downloadMultiple`
+       ! covers that case, so downloads still succeed wherever `curl` is available.
+       command='wget --tries=1 --ciphers=DEFAULT --timeout='//trim(timeoutLabel)//' '
        if (allowInsecure) command=command//'--no-check-certificate '
        command=command//'-O '//escapedOutputFile//' -- '//escapedURL
     case (downloaderCurl)
        ! Force `curl` to make only a single attempt (i.e. disable its own retrying) so that retries are handled solely by the
        ! calling loop, consistent with the behavior of `wget` above. The `--max-time` option bounds the total time allowed for the
        ! single attempt.
-       command='curl --location --retry 0 --max-time '//trim(timeoutLabel)//' '
+       !
+       ! `--fail` is essential: without it `curl` treats an HTTP error response as a successful transfer, exiting with zero status
+       ! after writing the server's error page to the output file. The download would then be reported as having succeeded, and
+       ! the error page used as though it were the requested content.
+       command='curl --location --retry 0 --fail --max-time '//trim(timeoutLabel)//' '
        if (allowInsecure) command=command//'--insecure '
        command=command//'--output '//escapedOutputFile//' -- '//escapedURL
     case default


### PR DESCRIPTION
## Problem

The `ngenhalofitpublic` tarball could not be downloaded from bitbucket.org — the nightly `archive.py` cron job failed, and so would any model run using the NGenHalofit class.

The failure presented as a **404**, but the URL is valid: `curl` retrieves it from the same machine.

bitbucket.org rejects `wget` on the basis of its **TLS handshake**. `wget`'s own, more restrictive, default cipher list yields a ClientHello which AtlassianEdge fingerprints as a bot, and it answers with a 404 for **every** URL on the host — including `https://bitbucket.org/` itself — so a refused client masquerades as missing content.

Neither the user agent nor the request headers are implicated: replaying `wget`'s exact header block (UA included) through `curl`, and through a raw `openssl s_client`, both return 200.

| client | result |
|---|---|
| `curl` (any UA, incl. `Wget/1.21.4`) | 200, 13,172,956 bytes, valid tarball |
| `python urllib` | 200 |
| `wget` (default options) | 404 |

## Changes

- **`--ciphers=DEFAULT`** on the `wget` command — defers cipher selection to the underlying TLS library, which is sufficient to be served normally. Certificate verification is unaffected, remaining under the control of `--no-check-certificate`.
- **`downloadMultiple()` falls back to `curl` when `wget` *fails*,** not only when `wget` is absent. Previously an `if`/`else` meant that wherever `wget` was installed, `curl` was never reached — and the retry loop just re-ran the same blocked client. This also covers a `wget` too old to accept `--ciphers`.
- **`--fail` on the `curl` command.** Without it `curl` treats an HTTP error response as a successful transfer, exiting zero after writing the server's error page to the output file. Harmless while `curl` ran only where `wget` was absent; it would have become the common path once the fallback above is in place.

The same changes are applied to `scripts/aux/archive.py`, which retrieves the same content and failed the same way.

## Verification

The local box cannot build Galacticus (unrelated toolchain breakage), so the Fortran was verified without a full build — **CI is the real compile check here.**

- Tarball retrieved with both downloaders: 13,172,956 bytes, valid gzip, **byte-identical** between `wget` and `curl`.
- `--ciphers=DEFAULT` → 200 on 3/3 runs; default `wget` → 404 on 3/3.
- `--fail` verified against a genuine 404: `curl` exits 22 and writes **no** file, where previously it exited **0** and wrote a 23-byte error page.
- `archive.py` fallback exercised by running the **verbatim** edited block against a `wget` shim forced to exit 1; `curl` took over and produced a file identical to the wget-fetched copy.
- `downloadMultiple()` extracted verbatim from source, its build directives expanded as the code generator expands them, dependencies stubbed, then compiled (`-fsyntax-only -Wall`, clean) and **run**:

| case | result |
|---|---|
| both tools present, `wget` blocked | recovers via `curl` — PASS |
| `wget` only, blocked | still fails — PASS |
| `curl` only (`wget` absent) | works — PASS |
| genuine 404, both fail | reported as failure — PASS |

The same harness run against the pre-change source fails case 1 (`status=1`, only `wget` called) and passes cases 2–3, confirming the test discriminates and the unchanged paths are undisturbed.

Not verified here: that the routine compiles *in situ* against the real modules and preprocessor output. The stubs match the imported interfaces and the edit adds no new identifiers, but that is an argument, not a compile — CI settles it.

## Note

Diagnosed and drafted with assistance from Claude, reviewed and verified by @abensonca; inline `!+` attribution added per `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)