### PR TITLE
Improve error diagnostics: defaulted-parameter recording, location lint, class-mismatch messages, HELP hints

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1524,6 +1524,7 @@ jobs:
                 test-parameters-diff.py,
                 test-parameters-extract.py,
                 test-parameters-changes.py,
+                test-parameters-default-reporting.py,
                 test-output-datasets-suffixes.py,
                 test-star-formation-histories.py,
                 test-star-formation-histories-adaptive.py,

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,9 @@
 # `python/Galacticus/Build/SourceTree/tests/` for SourceTree regressions.
 # `scripts/doc` carries regression tests for the ReadTheDocs doc-extraction
 # tooling (e.g. `scripts/doc/tests/test_extractDocsRST.py`); `scripts/build`
-# carries tests for build-time generators (e.g. the parameter-file schema).
-testpaths = python scripts/doc scripts/build
+# carries tests for build-time generators (e.g. the parameter-file schema);
+# `scripts/aux` carries tests for the developer tooling (e.g. the Fortran static
+# analyzer).
+testpaths = python scripts/doc scripts/build scripts/aux
 python_files = test_*.py
 python_functions = test_*

--- a/python/Galacticus/Build/SourceTree/Process/ObjectBuilder.py
+++ b/python/Galacticus/Build/SourceTree/Process/ObjectBuilder.py
@@ -239,21 +239,6 @@ def _handle_object_builder(node, state_storables, function_classes):
     lines += copy_loop_close
 
     if default_name:
-        # Find a free warnObjectBuilderN__ name.
-        i = 0
-        warn_status = "warnObjectBuilder0__"
-        while declaration_exists(parent, warn_status):
-            i += 1
-            warn_status = f"warnObjectBuilder{i}__"
-        add_declarations(parent, [{
-            'intrinsic':     'logical',
-            'type':          None,
-            'openMP':        False,
-            'attributes':    ['save'],
-            'variables':     [f"{warn_status}=.false."],
-            'variableNames': [warn_status],
-            'threadprivate': True,
-        }])
         lines += "   else\n"
         lines += "      ! Object is not explicitly defined. Cause a default object of the class to be added to the parameters. Increment the reference count here as this is a new object.\n"
         lines += copy_loop_open
@@ -264,16 +249,13 @@ def _handle_object_builder(node, state_storables, function_classes):
         lines += f"      call {directive['name']}%referenceCountIncrement()\n"
         lines += f"      call {directive['name']}%autoHook()\n"
         lines += copy_loop_close
+        # Record, in the output file, that this class was not specified and so was built from its
+        # default. This replaces a "Using default class for parameter ..." warning: defaulting is
+        # an extremely common idiom, so those warnings swamped the list which `Error_Report`
+        # replays, crowding genuine warnings out of it. The marker carries the same information,
+        # per parameter, and is recoverable from the output file long after the run.
         lines += (
-            f"      if (mpiSelf%isMaster() .and. .not.{warn_status}) then\n"
-            "         block\n"
-            "            type(varying_string) :: parametersPath\n"
-            "            parametersPath=parametersCurrent%path()\n"
-            "            call Warn('Using default class for parameter "
-            f"''['//char(parametersPath)//'{parameter_name}]''')\n"
-            f"            {warn_status}=.true.\n"
-            "         end block\n"
-            "      end if\n"
+            f"      call parametersCurrent%markDefaulted('{parameter_name}')\n"
             "   end if\n"
         )
 
@@ -281,18 +263,6 @@ def _handle_object_builder(node, state_storables, function_classes):
         lines += "   if (parametersDefaultCreated) call parametersDefault%destroy()\n"
 
     insert_after_node(node, [_code_node(lines, _SOURCE_TAG)])
-
-    # MPI + varying_string module uses when using a default-named object.
-    if default_name:
-        add_uses(parent, {
-            'moduleUse': {
-                'MPI_Utilities':      {'intrinsic': False,
-                                       'only': {'mpiSelf': True}},
-                'ISO_Varying_String': {'intrinsic': False,
-                                       'only': {'varying_string': True}},
-            },
-            'moduleOrder': ['MPI_Utilities', 'ISO_Varying_String'],
-        })
 
     # Main module-use block.  The class-providing module is skipped when the
     # enclosing node is part of the same module that declares the class.
@@ -315,11 +285,10 @@ def _handle_object_builder(node, state_storables, function_classes):
                     is_self = True
                     break
 
+        # `Error` is not listed here: it is added unconditionally, in full, below.
         module_uses = {
             'Input_Parameters':   {'intrinsic': False,
                                    'only': {'inputParameter': True}},
-            'Error':              {'intrinsic': False,
-                                   'only': {'Warn': True}},
             'ISO_Varying_String': {'intrinsic': False,
                                    'only': {'char': True}},
         }

--- a/scripts/aux/staticAnalyzer.py
+++ b/scripts/aux/staticAnalyzer.py
@@ -10,6 +10,8 @@ import sys
 #  2. Duplicated variable assignments in <constructorAssign> directives.
 #  3. Empty constructor functions (no-argument constructors for known types).
 #  4. Empty finalizer subroutines.
+#  5. Error_Report calls building a message from a string literal without
+#     appending {introspection:location}.
 
 if len(sys.argv) != 2:
     print("Usage: staticAnalyzer.py <fileName>", file=sys.stderr)
@@ -79,6 +81,9 @@ _USE_STMT     = re.compile(r'^\s*use(\s*,\s*intrinsic)??\s*::', re.IGNORECASE)
 _IMPLICIT     = re.compile(r'^\s*implicit\s+none\s*$', re.IGNORECASE)
 _RETURN       = re.compile(r'^\s*return\s*$',          re.IGNORECASE)
 
+# A call to Error_Report (check 5).
+_ERROR_REPORT = re.compile(r'\bcall\s+Error_Report\s*\(', re.IGNORECASE)
+
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -104,6 +109,87 @@ def _join_continuations(lines):
     if current is not None:
         result.append(current)
     return result
+
+
+def _join_continuations_numbered(lines):
+    """Join Fortran continuation lines, returning (lineNumber, text) pairs where
+    lineNumber is the 1-indexed line on which each logical line begins.
+
+    This is deliberately separate from `_join_continuations`, which checks 1-4
+    use, for two reasons. It tracks line numbers, and it also treats `&amp;` as a
+    continuation marker: Fortran embedded in the `!![ ... !!]` directive blocks is
+    XML, so its continuations are escaped. Without that, a call spread over
+    several lines inside a directive block is never joined, and check 5 reports a
+    missing location for a call which in fact has one.
+    """
+    result  = []
+    current = None
+    start   = None
+    for number, raw in enumerate(lines, start=1):
+        line = raw.rstrip('\n')
+        if current is not None:
+            # A continued line may optionally begin with the continuation marker.
+            stripped = line.lstrip()
+            for marker in ('&amp;', '&'):
+                if stripped.startswith(marker):
+                    stripped = stripped[len(marker):]
+                    break
+            current = current + stripped
+        else:
+            current = line
+            start   = number
+        trimmed = current.rstrip()
+        for marker in ('&amp;', '&'):
+            if trimmed.endswith(marker):
+                current = trimmed[:-len(marker)]
+                break
+        else:
+            result.append((start, current))
+            current = None
+    if current is not None:
+        result.append((start, current))
+    return result
+
+
+def _call_arguments(line, start):
+    """Return the text of a call's argument list, where `start` is the index just
+    after its opening parenthesis.
+
+    Fortran string literals are respected, so a parenthesis or a `!` inside a
+    message does not end the scan, and doubled quotes (the Fortran escape) do not
+    end a literal. Scanning stops at the matching closing parenthesis, or at a
+    trailing comment. Restricting the checks to this text matters: a `!` comment
+    after the call can easily contain an apostrophe, which would otherwise make a
+    call whose message is a bare variable look as though it were built from a
+    literal.
+    """
+    depth = 1
+    i     = start
+    n     = len(line)
+    while i < n:
+        character = line[i]
+        if character in ("'", '"'):
+            quote = character
+            i    += 1
+            while i < n:
+                if line[i] == quote:
+                    if i + 1 < n and line[i + 1] == quote:
+                        i += 2          # a doubled quote is an escaped quote
+                        continue
+                    i += 1
+                    break
+                i += 1
+            continue
+        if character == '!':
+            break                       # trailing comment, outside any literal
+        if character == '(':
+            depth += 1
+        elif character == ')':
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    return line[start:i]
 
 
 def _is_trivial_body_line(line):
@@ -328,5 +414,31 @@ for line in lines:
         if m:
             names = [n.strip().lower() for n in m.group(1).split(',')]
             constructors.extend(names)
+
+
+# ── Check 5: Error_Report without {introspection:location} ────────────────────
+#
+# Every fatal error should say where it was raised, so `{introspection:location}`
+# must be appended to the message. Only calls whose message is built from a
+# string literal are checked: where the message is a bare variable the location
+# may already have been appended where that variable was assigned, which cannot
+# be determined from this call site alone.
+
+for start_line, line in _join_continuations_numbered(raw_lines):
+    if _COMMENT.match(line):
+        continue
+    m = _ERROR_REPORT.search(line)
+    if not m:
+        continue
+    arguments = _call_arguments(line, m.end())
+    if '{introspection:location}' in arguments:
+        continue
+    # The message is a bare variable (or an expression built only from
+    # variables) - the location cannot be checked here.
+    if "'" not in arguments and '"' not in arguments:
+        continue
+    print(f"Error_Report at line {start_line} of file '{file_name}'"
+          f" does not append {{introspection:location}} to its message")
+    status = 1
 
 raise SystemExit(status)

--- a/scripts/aux/tests/test_static_analyzer.py
+++ b/scripts/aux/tests/test_static_analyzer.py
@@ -1,0 +1,161 @@
+"""Tests for check 5 of scripts/aux/staticAnalyzer.py.
+
+Check 5 requires that an `Error_Report` call whose message is built from a
+string literal appends `{introspection:location}`, so that a fatal error says
+where it was raised. The cases below pin the two judgements that make the check
+usable on this source tree:
+
+  * a message which is a bare variable is *not* flagged, because the location may
+    have been appended where that variable was assigned, and
+  * Fortran embedded in the `!![ ... !!]` directive blocks is XML, so its
+    continuation lines are escaped as `&amp;`; a call spread over several such
+    lines must still be joined before the check is applied, or a call which does
+    append the location is reported as though it did not.
+"""
+
+import os
+import subprocess
+import sys
+
+_ANALYZER = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir, 'staticAnalyzer.py')
+
+
+def _analyze(tmp_path, source):
+    """Run the analyzer over `source`, returning (exitStatus, output)."""
+    fileName = tmp_path / 'test.F90'
+    fileName.write_text(source)
+    result = subprocess.run(
+        [sys.executable, _ANALYZER, str(fileName)],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+    return result.returncode, result.stdout
+
+
+def test_literal_message_without_location_is_reported(tmp_path):
+    status, output = _analyze(tmp_path, """
+  subroutine test()
+    implicit none
+    call Error_Report('something went wrong')
+    return
+  end subroutine test
+""")
+    assert status == 1
+    assert 'introspection:location' in output
+
+
+def test_literal_message_with_location_is_accepted(tmp_path):
+    status, output = _analyze(tmp_path, """
+  subroutine test()
+    implicit none
+    call Error_Report('something went wrong'//{introspection:location})
+    return
+  end subroutine test
+""")
+    assert status == 0
+    assert output == ''
+
+
+def test_location_on_a_continuation_line_is_accepted(tmp_path):
+    """The marker is frequently on a continuation line, so lines must be joined
+    before the check is applied."""
+    status, output = _analyze(tmp_path, """
+  subroutine test()
+    implicit none
+    call Error_Report(                         &
+         &            'something went wrong'// &
+         &            {introspection:location}  &
+         &           )
+    return
+  end subroutine test
+""")
+    assert status == 0
+    assert output == ''
+
+
+def test_variable_message_is_not_reported(tmp_path):
+    """The location may have been appended where the variable was assigned, which
+    cannot be determined from the call site."""
+    status, output = _analyze(tmp_path, """
+  subroutine test()
+    implicit none
+    call Error_Report(message)
+    return
+  end subroutine test
+""")
+    assert status == 0
+    assert output == ''
+
+
+def test_xml_escaped_continuation_is_joined(tmp_path):
+    """Fortran inside a directive block is XML, so continuations are `&amp;`."""
+    status, output = _analyze(tmp_path, """
+  !![
+  <method name="test">
+   <code>
+    if (bad)                                      &amp;
+       &amp; call Error_Report(                   &amp;
+       &amp;                   'something wrong'//&amp;
+       &amp;                   {introspection:location} &amp;
+       &amp;                  )
+   </code>
+  </method>
+  !!]
+""")
+    assert status == 0
+    assert output == ''
+
+
+def test_commented_out_call_is_not_reported(tmp_path):
+    status, output = _analyze(tmp_path, """
+  subroutine test()
+    implicit none
+    ! call Error_Report('something went wrong')
+    return
+  end subroutine test
+""")
+    assert status == 0
+    assert output == ''
+
+
+def test_apostrophe_in_trailing_comment_does_not_defeat_the_exemption(tmp_path):
+    """The literal test must apply to the call's arguments, not to the rest of
+    the line: an apostrophe in a trailing comment would otherwise make a message
+    which is a bare variable look as though it were built from a literal."""
+    status, output = _analyze(tmp_path, """
+  subroutine test()
+    implicit none
+    call Error_Report(message) ! we don't know the location here
+    return
+  end subroutine test
+""")
+    assert status == 0
+    assert output == ''
+
+
+def test_parenthesis_inside_a_message_does_not_end_the_arguments(tmp_path):
+    """A closing parenthesis inside the message must not be mistaken for the end
+    of the argument list, which would hide the location that follows it."""
+    status, output = _analyze(tmp_path, """
+  subroutine test()
+    implicit none
+    call Error_Report('bad value (see the manual)'//{introspection:location})
+    return
+  end subroutine test
+""")
+    assert status == 0
+    assert output == ''
+
+
+def test_location_only_in_a_trailing_comment_is_still_reported(tmp_path):
+    """Mentioning the marker in a comment must not satisfy the check."""
+    status, output = _analyze(tmp_path, """
+  subroutine test()
+    implicit none
+    call Error_Report('something went wrong') ! {introspection:location}
+    return
+  end subroutine test
+""")
+    assert status == 1
+    assert 'introspection:location' in output

--- a/scripts/parameters/parametersExtract.py
+++ b/scripts/parameters/parametersExtract.py
@@ -20,6 +20,10 @@ args = parser.parse_args()
 # Create the root `parameters` element.
 parameters = ET.Element("parameters")
 
+# Suffix used to mark, in the output file's `Parameters` group, a parameter which took a default
+# value. This must match `defaultedMarkerSuffix` in `source/utility/input_parameters.F90`.
+defaultedMarkerSuffix = "{defaulted}"
+
 # Define a function to handle creation of the parameter file structure.
 def createStructure(name, node):
     # Ignore anything other than groups.
@@ -57,6 +61,11 @@ def assignValues(name, node):
             parent = parameters.find(name)
         # Iterate over all attributes in this group.
         for attributeName in node.attrs.keys():
+            # Skip markers recording that a parameter took a default value. These are not parameters
+            # themselves - they annotate the parameter of the same name, minus the suffix - and the
+            # braces are not valid in an XML element name, so they must not be emitted here.
+            if attributeName.endswith(defaultedMarkerSuffix):
+                continue
             isReference = None
             idReference = None
             # Extract the attribute value and convert to a string.

--- a/source/dark_matter_profiles/structure/scale/Ludlow2016/analytic.F90
+++ b/source/dark_matter_profiles/structure/scale/Ludlow2016/analytic.F90
@@ -187,6 +187,7 @@ contains
     use :: Dark_Matter_Profile_Mass_Definitions, only : Dark_Matter_Profile_Mass_Definition
     use :: Galacticus_Nodes                    , only : nodeComponentBasic
     use :: Error                               , only : Error_Report
+    use :: ISO_Varying_String                  , only : char
     implicit none
     double precision                    , intent(in   ) :: timeFormation
     class           (nodeComponentBasic), pointer       :: basic
@@ -232,7 +233,7 @@ contains
        end if
     class default
        massFormation=-huge(0.0d0)
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [darkMatterProfileScaleRadiusLudlow2016Analytic] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     end select
     formationTimeRoot =  +                   massFormation          &
          &               -states(stateCount)%massHaloCharacteristic

--- a/source/galactic_structure/radius_solver/equilibrium.F90
+++ b/source/galactic_structure/radius_solver/equilibrium.F90
@@ -199,6 +199,8 @@ contains
     Hookable wrapper around the solver.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)         :: self
     type (treeNode), intent(inout), target :: node
@@ -206,8 +208,10 @@ contains
     select type (self)
     type is (galacticStructureSolverEquilibrium)
        call self%solve(node)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverEquilibrium] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverEquilibrium] class'//{introspection:location})
     end select
     return
   end subroutine equilibriumSolveHook
@@ -218,6 +222,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : propertyTypeInactive, treeNode
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*       ), intent(inout)         :: self
     type   (treeNode), intent(inout), target :: node
@@ -226,8 +232,10 @@ contains
     select type (self)
     type is (galacticStructureSolverEquilibrium)
        call self%solve(node,plausibilityOnly=propertyType == propertyTypeInactive .and. .not.self%solveForInactiveProperties)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverEquilibrium] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverEquilibrium] class'//{introspection:location})
     end select
     return
   end subroutine equilibriumSolvePreDeriativeHook

--- a/source/galactic_structure/radius_solver/equilibrium.F90
+++ b/source/galactic_structure/radius_solver/equilibrium.F90
@@ -198,7 +198,7 @@ contains
     !!{RST
     Hookable wrapper around the solver.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -220,8 +220,8 @@ contains
     !!{RST
     Hookable wrapper around the solver for pre-derivative events.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : propertyTypeInactive, treeNode
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : propertyTypeInactive, treeNode
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/galactic_structure/radius_solver/fixed.F90
+++ b/source/galactic_structure/radius_solver/fixed.F90
@@ -213,6 +213,8 @@ contains
     Hookable wrapper around the solver.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)         :: self
     type (treeNode), intent(inout), target :: node
@@ -220,8 +222,10 @@ contains
     select type (self)
     type is (galacticStructureSolverFixed)
        call self%solve(node)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverFixed] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverFixed] class'//{introspection:location})
     end select
     return
   end subroutine fixedSolveHook
@@ -231,6 +235,8 @@ contains
     Hookable wrapper around the solver.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*       ), intent(inout)         :: self
     type   (treeNode), intent(inout), target :: node
@@ -240,8 +246,10 @@ contains
     select type (self)
     type is (galacticStructureSolverFixed)
        call self%solve(node)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverFixed] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverFixed] class'//{introspection:location})
     end select
     return
   end subroutine fixedSolvePreDeriativeHook

--- a/source/galactic_structure/radius_solver/fixed.F90
+++ b/source/galactic_structure/radius_solver/fixed.F90
@@ -212,7 +212,7 @@ contains
     !!{RST
     Hookable wrapper around the solver.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -234,7 +234,7 @@ contains
     !!{RST
     Hookable wrapper around the solver.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/galactic_structure/radius_solver/linear.F90
+++ b/source/galactic_structure/radius_solver/linear.F90
@@ -134,7 +134,7 @@ contains
     !!{RST
     Hookable wrapper around the solver.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -156,7 +156,7 @@ contains
     !!{RST
     Hookable wrapper around the solver.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/galactic_structure/radius_solver/linear.F90
+++ b/source/galactic_structure/radius_solver/linear.F90
@@ -135,6 +135,8 @@ contains
     Hookable wrapper around the solver.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)         :: self
     type (treeNode), intent(inout), target :: node
@@ -142,8 +144,10 @@ contains
     select type (self)
     type is (galacticStructureSolverLinear)
        call self%solve(node)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverLinear] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverLinear] class'//{introspection:location})
     end select
     return
   end subroutine linearSolveHook
@@ -153,6 +157,8 @@ contains
     Hookable wrapper around the solver.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*       ), intent(inout)         :: self
     type   (treeNode), intent(inout), target :: node
@@ -162,8 +168,10 @@ contains
     select type (self)
     type is (galacticStructureSolverLinear)
        call self%solve(node)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverLinear] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverLinear] class'//{introspection:location})
     end select
     return
   end subroutine linearSolvePreDeriativeHook

--- a/source/galactic_structure/radius_solver/null.F90
+++ b/source/galactic_structure/radius_solver/null.F90
@@ -100,6 +100,8 @@ contains
     Hookable wrapper around the solver.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)         :: self
     type (treeNode), intent(inout), target :: node
@@ -107,8 +109,10 @@ contains
     select type (self)
     type is (galacticStructureSolverNull)
        call self%solve(node)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverNull] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverNull] class'//{introspection:location})
     end select
     return
   end subroutine nullSolveHook
@@ -118,6 +122,8 @@ contains
     Hookable wrapper around the solver.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*       ), intent(inout)         :: self
     type   (treeNode), intent(inout), target :: node
@@ -127,8 +133,10 @@ contains
     select type (self)
     type is (galacticStructureSolverNull)
        call self%solve(node)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverNull] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverNull] class'//{introspection:location})
     end select
     return
   end subroutine nullSolvePreDeriativeHook

--- a/source/galactic_structure/radius_solver/null.F90
+++ b/source/galactic_structure/radius_solver/null.F90
@@ -99,7 +99,7 @@ contains
     !!{RST
     Hookable wrapper around the solver.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -121,7 +121,7 @@ contains
     !!{RST
     Hookable wrapper around the solver.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/galactic_structure/radius_solver/simple.F90
+++ b/source/galactic_structure/radius_solver/simple.F90
@@ -153,7 +153,7 @@ contains
     !!{RST
     Hookable wrapper around the solver.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -175,8 +175,8 @@ contains
     !!{RST
     Hookable wrapper around the solver.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : propertyTypeInactive
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : propertyTypeInactive
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/galactic_structure/radius_solver/simple.F90
+++ b/source/galactic_structure/radius_solver/simple.F90
@@ -154,6 +154,8 @@ contains
     Hookable wrapper around the solver.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)         :: self
     type (treeNode), intent(inout), target :: node
@@ -161,8 +163,10 @@ contains
     select type (self)
     type is (galacticStructureSolverSimple)
        call self%solve(node)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverSimple] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverSimple] class'//{introspection:location})
     end select
     return
   end subroutine simpleSolveHook
@@ -173,6 +177,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : propertyTypeInactive
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*       ), intent(inout)         :: self
     type   (treeNode), intent(inout), target :: node
@@ -182,8 +188,10 @@ contains
     select type (self)
     type is (galacticStructureSolverSimple)
        if (propertyType /= propertyTypeInactive .or. self%solveForInactiveProperties) call self%solve(node)
+    class is (functionClass)
+       call Error_Report('object is not of [galacticStructureSolverSimple] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [galacticStructureSolverSimple] class'//{introspection:location})
     end select
     return
   end subroutine simpleSolvePreDeriativeHook

--- a/source/intergalactic_medium/state/internal.F90
+++ b/source/intergalactic_medium/state/internal.F90
@@ -334,6 +334,8 @@ contains
     Set state in the internal :term:`IGM` state class.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class           (*), intent(inout)               :: self
     double precision   , intent(in   ), dimension(:) :: time            , densityHydrogen1, &
@@ -370,8 +372,10 @@ contains
        if (allocated(self%interpolator_)) deallocate(self%interpolator_)
        allocate(self%interpolator_)
        self%interpolator_=interpolator(self%time)
+    class is (functionClass)
+       call Error_Report('object is not of [intergalacticMediumStateInternal] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [intergalacticMediumStateInternal] class'//{introspection:location})
     end select
     return
   end subroutine internalStateSet

--- a/source/intergalactic_medium/state/internal.F90
+++ b/source/intergalactic_medium/state/internal.F90
@@ -333,7 +333,7 @@ contains
     !!{RST
     Set state in the internal :term:`IGM` state class.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/mass_distributions/spherical/adiabatic_Gnedin2004.F90
+++ b/source/mass_distributions/spherical/adiabatic_Gnedin2004.F90
@@ -558,7 +558,7 @@ contains
        return
     end if
     ! Validate.
-    if (radius <= 0.0d0) call Error_Report('non-positive radius')
+    if (radius <= 0.0d0) call Error_Report('non-positive radius'//{introspection:location})
     ! Compute initial radius, and derivatives of initial and final mean radii.
     radiusInitial                  =self                  %radiusInitial              (radius                )
     radiusInitialMeanSelfDerivative=self                  %radiusOrbitalMeanDerivative(radiusInitial         )

--- a/source/mass_distributions/spherical/soliton/_class.F90
+++ b/source/mass_distributions/spherical/soliton/_class.F90
@@ -164,13 +164,13 @@
         self%radiusCore             =+radiusCore
      else
         self%radiusCore             =+0.0d0
-        call Error_Report('no means to determine core radius')
+        call Error_Report('no means to determine core radius'//{introspection:location})
      end if
      if (present(densitySolitonCentral)) then
         self%densitySolitonCentral  =+densitySolitonCentral
      else
         self%densitySolitonCentral  =+0.0d0
-        call Error_Report('densitySolitonCentral must be specified')
+        call Error_Report('densitySolitonCentral must be specified'//{introspection:location})
      end if
      if (present(dimensionless)) then
         self%dimensionless          =dimensionless

--- a/source/mass_distributions/spherical/soliton_NFW.F90
+++ b/source/mass_distributions/spherical/soliton_NFW.F90
@@ -214,13 +214,13 @@
         self%radiusCore             =+radiusCore
      else
         self%radiusCore             =+0.0d0
-        call Error_Report('no means to determine core radius')
+        call Error_Report('no means to determine core radius'//{introspection:location})
      end if
      if (present(radiusSoliton)) then
         self%radiusSoliton          =+radiusSoliton
      else
         self%radiusSoliton          =+0.0d0
-        call Error_Report('no means to determine Soliton radius')
+        call Error_Report('no means to determine Soliton radius'//{introspection:location})
      end if
      if      (                            &
           &   present(radiusScale  )      &
@@ -234,19 +234,19 @@
              &                       /concentration
      else
         self%radiusScale            =+0.0d0
-        call Error_Report('no means to determine scale radius')
+        call Error_Report('no means to determine scale radius'//{introspection:location})
      end if
      if (present(densityNormalizationNFW)) then
         self%densityNormalizationNFW=+densityNormalizationNFW
      else
         self%densityNormalizationNFW=+0.0d0
-        call Error_Report('densityNormalizationNFW must be specified')
+        call Error_Report('densityNormalizationNFW must be specified'//{introspection:location})
      end if
      if (present(densitySolitonCentral)) then
         self%densitySolitonCentral  =+densitySolitonCentral
      else
         self%densitySolitonCentral  =+0.0d0
-        call Error_Report('densitySolitonCentral must be specified')
+        call Error_Report('densitySolitonCentral must be specified'//{introspection:location})
      end if
      if (present(dimensionless)) then
         self%dimensionless          =dimensionless

--- a/source/mass_distributions/spherical/soliton_NFW_heated.F90
+++ b/source/mass_distributions/spherical/soliton_NFW_heated.F90
@@ -168,17 +168,17 @@ contains
      if (present(radiusCore   )) then
         self%radiusCore             =+radiusCore
      else
-        call Error_Report('core radius must be specified')
+        call Error_Report('core radius must be specified'//{introspection:location})
      end if
      if (present(radiusSoliton   )) then
         self%radiusSoliton          =+radiusSoliton
      else
-        call Error_Report('soliton radius must be specified')
+        call Error_Report('soliton radius must be specified'//{introspection:location})
      end if
      if (present(densitySolitonCentral)) then
         self%densitySolitonCentral  =+densitySolitonCentral
      else
-        call Error_Report('densitySolitonCentral must be specified')
+        call Error_Report('densitySolitonCentral must be specified'//{introspection:location})
      end if
      if (present(toleranceRelativePotential)) then
         self%toleranceRelativePotential = toleranceRelativePotential

--- a/source/merger_trees/build/controller/constrained.F90
+++ b/source/merger_trees/build/controller/constrained.F90
@@ -210,7 +210,7 @@ contains
        varianceConstrained           =0.0d0
        timeConstrained               =0.0d0
        massConstrained               =0.0d0
-       call Error_Report('must provide either [criticalOverdensityConstrained] and [varianceConstrained], or [timeConstrained] and [massConstrained]')
+       call Error_Report('must provide either [criticalOverdensityConstrained] and [varianceConstrained], or [timeConstrained] and [massConstrained]'//{introspection:location})
     end if
     self=mergerTreeBuildControllerConstrained(criticalOverdensityConstrained,varianceConstrained,enumerationConstructionOptionEncode(char(constructionOption),includesPrefix=.false.),label,labelDescription,mergerTreeBranchingProbabilityUnconstrained_,mergerTreeBranchingProbabilityConstrained_,cosmologyFunctions_,linearGrowth_,criticalOverdensity_,cosmologicalMassVariance_,mergerTreeMassResolution_)
     !![

--- a/source/merger_trees/build/controller/subsample.F90
+++ b/source/merger_trees/build/controller/subsample.F90
@@ -118,7 +118,7 @@ contains
        </inputParameter>
        !!]
     else
-       call Error_Report('either [massThreshold] or [fractionMassThreshold] must be present')
+       call Error_Report('either [massThreshold] or [fractionMassThreshold] must be present'//{introspection:location})
     end if
     !![
     <inputParameter docformat="rst">

--- a/source/merger_trees/evolve/timesteps/history.F90
+++ b/source/merger_trees/evolve/timesteps/history.F90
@@ -292,8 +292,8 @@ contains
          &                                               treeNode
     use            :: Mass_Distributions        , only : massDistributionClass
     use, intrinsic :: ISO_C_Binding             , only : c_size_t
-    use :: ISO_Varying_String, only : char
-    use :: Function_Classes  , only : functionClass
+    use            :: ISO_Varying_String        , only : char
+    use            :: Function_Classes          , only : functionClass
     implicit none
     class           (*                            ), intent(inout)          :: self
     type            (mergerTree                   ), intent(in   )          :: tree

--- a/source/merger_trees/evolve/timesteps/history.F90
+++ b/source/merger_trees/evolve/timesteps/history.F90
@@ -292,6 +292,8 @@ contains
          &                                               treeNode
     use            :: Mass_Distributions        , only : massDistributionClass
     use, intrinsic :: ISO_C_Binding             , only : c_size_t
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class           (*                            ), intent(inout)          :: self
     type            (mergerTree                   ), intent(in   )          :: tree
@@ -378,8 +380,10 @@ contains
        if (.not.node%isSatellite()) self%densityNode(timeIndex)=+    self                             %densityNode           (timeIndex                                                   ) &
             &                                                   +    basic                            %mass                  (                                                            ) &
             &                                                   *    tree                             %volumeWeight
+    class is (functionClass)
+       call Error_Report('object is not of [mergerTreeEvolveTimestepHistory] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerTreeEvolveTimestepHistory] class'//{introspection:location})
     end select
     return
   end subroutine historyStore
@@ -394,6 +398,8 @@ contains
     use :: IO_HDF5                         , only : hdf5File    , hdf5Group, hdf5Dataset
     use :: Numerical_Constants_Astronomical, only : gigaYear    , massSolar, megaParsec
     use :: Units_MetaData                  , only : unitType
+    use :: ISO_Varying_String              , only : char
+    use :: Function_Classes                , only : functionClass
     implicit none
     class           (*         ), intent(inout)               :: self
     double precision            , allocatable  , dimension(:) :: rateStarFormationDisk , rateStarFormationSpheroid, &
@@ -451,8 +457,10 @@ contains
        call historyGroup  %writeDataset  (self%densityNode                ,"densityNode"              ,"Node mass density [M⊙/Mpc³]"                   ,datasetReturned=historyDataset)
        call historyDataset%writeAttribute(unitType(massSolar/megaParsec**3         ,"M☉/Mpc³"    ,"solMass/Mpc^3"    ,isComoving=.true.),"units")
        !$ call hdf5Access %unset()
+    class is (functionClass)
+       call Error_Report('object is not of [mergerTreeEvolveTimestepHistory] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerTreeEvolveTimestepHistory] class'//{introspection:location})
     end select
     return
   end subroutine historyWrite

--- a/source/merger_trees/evolve/timesteps/lightcone_crossing.F90
+++ b/source/merger_trees/evolve/timesteps/lightcone_crossing.F90
@@ -211,6 +211,8 @@ contains
     use :: Merger_Trees_Evolve_Deadlock_Status, only : deadlockStatusIsNotDeadlocked
     use :: Merger_Tree_Outputters             , only : outputGroupTypeLightcone
     use :: Galacticus_Nodes                   , only : nodeComponentBasic
+    use :: ISO_Varying_String                 , only : char
+    use :: Function_Classes                   , only : functionClass
     implicit none
     class           (*                            ), intent(inout)               :: self
     type            (mergerTree                   ), intent(in   )               :: tree
@@ -235,8 +237,10 @@ contains
        call basic%floatRank1MetaPropertySet(self%timesCrossingID,timesCrossing(2:size(timesCrossing)))
        ! The tree was changed, so mark that it is not deadlocked.
        deadlockStatus=deadlockStatusIsNotDeadlocked
+    class is (functionClass)
+       call Error_Report('object is not of [mergerTreeEvolveTimestepLightconeCrossing] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerTreeEvolveTimestepLightconeCrossing] class'//{introspection:location})
     end select
     return
   end subroutine lightconeCrossingProcess

--- a/source/merger_trees/evolve/timesteps/record_evolution.F90
+++ b/source/merger_trees/evolve/timesteps/record_evolution.F90
@@ -242,8 +242,8 @@ contains
     use            :: Galacticus_Nodes          , only : mergerTree           , nodeComponentBasic, treeNode
     use            :: Mass_Distributions        , only : massDistributionClass
     use, intrinsic :: ISO_C_Binding             , only : c_size_t
-    use :: ISO_Varying_String, only : char
-    use :: Function_Classes  , only : functionClass
+    use            :: ISO_Varying_String        , only : char
+    use            :: Function_Classes          , only : functionClass
     implicit none
     class           (*                            ), intent(inout)          :: self
     type            (mergerTree                   ), intent(in   )          :: tree
@@ -295,8 +295,8 @@ contains
     use            :: Units_MetaData                  , only : unitType
     use            :: String_Handling                 , only : operator(//)
     use            :: Locks                           , only : ompLock
-    use :: ISO_Varying_String              , only : char
-    use :: Function_Classes                , only : functionClass
+    use            :: ISO_Varying_String              , only : char
+    use            :: Function_Classes                , only : functionClass
     implicit none
     class  (*             ), intent(inout) :: self
     type   (treeNode      ), intent(inout) :: node

--- a/source/merger_trees/evolve/timesteps/record_evolution.F90
+++ b/source/merger_trees/evolve/timesteps/record_evolution.F90
@@ -242,6 +242,8 @@ contains
     use            :: Galacticus_Nodes          , only : mergerTree           , nodeComponentBasic, treeNode
     use            :: Mass_Distributions        , only : massDistributionClass
     use, intrinsic :: ISO_C_Binding             , only : c_size_t
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class           (*                            ), intent(inout)          :: self
     type            (mergerTree                   ), intent(in   )          :: tree
@@ -270,8 +272,10 @@ contains
        <objectDestructor name="massDistributionStellar" />
        <objectDestructor name="massDistributionGalactic"/>
        !!]
+    class is (functionClass)
+       call Error_Report('object is not of [mergerTreeEvolveTimestepRecordEvolution] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerTreeEvolveTimestepRecordEvolution] class'//{introspection:location})
     end select
     return
   end subroutine recordEvolutionStore
@@ -291,6 +295,8 @@ contains
     use            :: Units_MetaData                  , only : unitType
     use            :: String_Handling                 , only : operator(//)
     use            :: Locks                           , only : ompLock
+    use :: ISO_Varying_String              , only : char
+    use :: Function_Classes                , only : functionClass
     implicit none
     class  (*             ), intent(inout) :: self
     type   (treeNode      ), intent(inout) :: node
@@ -322,8 +328,10 @@ contains
           call dataset    %writeAttribute(unitType(massSolar  ,"Solar masses","solMass"),"units")
           call    self    %reset         (                                                                                                                )
        end if
+    class is (functionClass)
+       call Error_Report('object is not of [mergerTreeEvolveTimestepRecordEvolution] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerTreeEvolveTimestepRecordEvolution] class'//{introspection:location})
     end select
     return
   end subroutine recordEvolutionOutput

--- a/source/merger_trees/evolve/timesteps/satellite.F90
+++ b/source/merger_trees/evolve/timesteps/satellite.F90
@@ -217,6 +217,8 @@ contains
     use :: Merger_Trees_Evolve_Deadlock_Status, only : deadlockStatusIsNotDeadlocked
     use :: Satellite_Promotion                , only : Satellite_Move_To_New_Host
     use :: String_Handling                    , only : operator(//)
+    use :: ISO_Varying_String                 , only : char
+    use :: Function_Classes                   , only : functionClass
     implicit none
     class(*                            ), intent(inout)          :: self
     type (mergerTree                   ), intent(in   )          :: tree
@@ -237,8 +239,10 @@ contains
     select type (self)
     class is (mergerTreeEvolveTimestepSatellite)
        call self%nodeOperator_%galaxiesMerge(node)
+    class is (functionClass)
+       call Error_Report('object is not of [mergerTreeEvolveTimestepSatellite] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerTreeEvolveTimestepSatellite] class'//{introspection:location})
     end select
     !![
     <eventHook name="satelliteMerger">

--- a/source/merger_trees/node_evolver/standard.F90
+++ b/source/merger_trees/node_evolver/standard.F90
@@ -1360,6 +1360,8 @@ contains
     Promote a recently promoted subhalo to its new parent.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)          :: self
     type (treeNode), intent(inout), pointer :: node, nodePromotion
@@ -1368,8 +1370,10 @@ contains
     select type (self)
     class is (mergerTreeNodeEvolverStandard)
        call self%promote(node)
+    class is (functionClass)
+       call Error_Report('object is not of [mergerTreeNodeEvolverStandard] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerTreeNodeEvolverStandard] class'//{introspection:location})
     end select
     return
   end subroutine standardNodeSubhaloPromotion

--- a/source/merger_trees/node_evolver/standard.F90
+++ b/source/merger_trees/node_evolver/standard.F90
@@ -1359,7 +1359,7 @@ contains
     !!{RST
     Promote a recently promoted subhalo to its new parent.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/merger_trees/outputter/analyzer.F90
+++ b/source/merger_trees/outputter/analyzer.F90
@@ -163,6 +163,7 @@ contains
     Reduce over the outputter.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(mergerTreeOutputterAnalyzer), intent(inout) :: self
     class(mergerTreeOutputterClass   ), intent(inout) :: reduced
@@ -171,7 +172,7 @@ contains
     type is (mergerTreeOutputterAnalyzer)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerTreeOutputterAnalyzer] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine analyzerReduce

--- a/source/merger_trees/outputter/analyzer.F90
+++ b/source/merger_trees/outputter/analyzer.F90
@@ -162,7 +162,7 @@ contains
     !!{RST
     Reduce over the outputter.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(mergerTreeOutputterAnalyzer), intent(inout) :: self

--- a/source/merger_trees/outputter/multi.F90
+++ b/source/merger_trees/outputter/multi.F90
@@ -190,7 +190,7 @@ contains
     !!{RST
     Reduce over the outputter.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(mergerTreeOutputterMulti), intent(inout) :: self

--- a/source/merger_trees/outputter/multi.F90
+++ b/source/merger_trees/outputter/multi.F90
@@ -191,6 +191,7 @@ contains
     Reduce over the outputter.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(mergerTreeOutputterMulti), intent(inout) :: self
     class(mergerTreeOutputterClass), intent(inout) :: reduced
@@ -206,7 +207,7 @@ contains
           outputterReduced_ => outputterReduced_%next
        end do
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerTreeOutputterMulti] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine multiReduce

--- a/source/models/likelihoods/independent_likelihoods/_class.F90
+++ b/source/models/likelihoods/independent_likelihoods/_class.F90
@@ -97,6 +97,7 @@ contains
     use :: Error           , only : Error_Report
     use :: Input_Parameters, only : inputParameter                         , inputParameterErrorStatusEmptyValue, inputParameterErrorStatusSuccess, inputParameters, &
          &                          enumerationInputParameterErrorStatusType
+    use :: MPI_Utilities   , only : mpiSelf
     use :: String_Handling , only : String_Count_Words                      , String_Split_Words                 , char
     implicit none
     type   (posteriorSampleLikelihoodIndependentLikelihoods)                              :: self

--- a/source/nBody/operator/convex_hull/volume.F90
+++ b/source/nBody/operator/convex_hull/volume.F90
@@ -69,6 +69,8 @@ contains
     use :: Error             , only : Error_Report
     use :: Display           , only : displayIndent, displayUnindent, verbosityLevelStandard
     use :: Points_Convex_Hull, only : convexHull
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (nbodyOperatorConvexHullVolume), intent(inout)                 :: self
     type   (nBodyData                    ), intent(inout), dimension(  :) :: simulations
@@ -82,8 +84,10 @@ contains
        class is (convexHull)
           call simulations(i)%attributesReal%set           (keyCH        ='convexHullVolume',value         =hull%volume())
           call simulations(i)%analysis      %writeAttribute(attributeName='convexHullVolume',attributeValue=hull%volume())
+       class is (functionClass)
+          call Error_Report('object is not of [convexHull] class, but of ['//char(hull%objectType())//'] class'//{introspection:location})
        class default
-          call Error_Report('incorrect class'//{introspection:location})
+          call Error_Report('object is not of [convexHull] class'//{introspection:location})
        end select
        nullify(hull)
     end do

--- a/source/nBody/operator/filter_convex_hull.F90
+++ b/source/nBody/operator/filter_convex_hull.F90
@@ -97,6 +97,8 @@ contains
          &                            displayCounter, displayCounterClear
     use :: Error             , only : Error_Report
     use :: Points_Convex_Hull, only : convexHull
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class           (nbodyOperatorFilterConvexHull), intent(inout)                 :: self
     type            (nBodyData                    ), intent(inout), dimension(  :) :: simulations
@@ -179,8 +181,10 @@ contains
           ! Set the convex hull volume for this simulation.
           call simulations(i)%attributesReal%set('convexHullVolume',hull%volume())
        end do
+    class is (functionClass)
+       call Error_Report('object is not of [convexHull] class, but of ['//char(hull%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [convexHull] class'//{introspection:location})
     end select
     nullify(hull)
     call displayUnindent('done',verbosityLevelStandard)

--- a/source/nodes/operators/analyses/galaxy_gas_major_merger_time.F90
+++ b/source/nodes/operators/analyses/galaxy_gas_major_merger_time.F90
@@ -141,6 +141,8 @@ contains
     use :: Error                           , only : Error_Report
     use :: Galacticus_Nodes                , only : nodeComponentBasic              , nodeComponentDisk, nodeComponentSpheroid
     use :: Satellite_Merging_Mass_Movements, only : enumerationDestinationMergerType
+    use :: ISO_Varying_String              , only : char
+    use :: Function_Classes                , only : functionClass
     implicit none
     class           (*                    ), intent(inout)              :: self
     type            (treeNode             ), intent(inout), target      :: node
@@ -177,8 +179,10 @@ contains
        majorMergerTimesNew(size(majorMergerTimesNew))=basicHost%time()
        call basicHost%floatRank1MetaPropertySet(self%galaxyGasMajorMergerTimeID,majorMergerTimesNew)
     end if
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorGalaxyGasMajorMergerTime] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorGalaxyGasMajorMergerTime] class'//{introspection:location})
     end select
     return
   end subroutine satelliteMerger

--- a/source/nodes/operators/analyses/galaxy_major_merger_time.F90
+++ b/source/nodes/operators/analyses/galaxy_major_merger_time.F90
@@ -139,6 +139,8 @@ contains
     use :: Error                           , only : Error_Report
     use :: Galacticus_Nodes                , only : nodeComponentBasic
     use :: Satellite_Merging_Mass_Movements, only : enumerationDestinationMergerType
+    use :: ISO_Varying_String              , only : char
+    use :: Function_Classes                , only : functionClass
     implicit none
     class           (*                               ), intent(inout)              :: self
     type            (treeNode                        ), intent(inout), target      :: node
@@ -168,8 +170,10 @@ contains
        majorMergerTimesNew(size(majorMergerTimesNew))=basicHost%time()
        call basicHost%floatRank1MetaPropertySet(self%galaxyMajorMergerTimeID,majorMergerTimesNew)
     end if
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorGalaxyMajorMergerTime] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorGalaxyMajorMergerTime] class'//{introspection:location})
     end select
     return
   end subroutine satelliteMerger

--- a/source/nodes/operators/analyses/galaxy_merger_tree.F90
+++ b/source/nodes/operators/analyses/galaxy_merger_tree.F90
@@ -279,6 +279,8 @@ contains
     Record galaxy-galaxy merges and combine trees.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class           (*                               ), intent(inout)               :: self
     type            (treeNode                        ), intent(inout), target       :: node
@@ -340,8 +342,10 @@ contains
        call basicTarget%      floatRank1MetaPropertySet(self%timeMergeID  ,timesMergeNew  )
        call basicTarget%longIntegerRank1MetaPropertySet(self%mergeIndexID ,mergeIndicesNew)
        call basicTarget%longIntegerRank1MetaPropertySet(self%mergeTargetID,mergeTargetsNew)
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorGalaxyMergerTree] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorGalaxyMergerTree] class'//{introspection:location})
     end select
     return
   end subroutine satelliteMerger

--- a/source/nodes/operators/analyses/galaxy_merger_tree.F90
+++ b/source/nodes/operators/analyses/galaxy_merger_tree.F90
@@ -278,7 +278,7 @@ contains
     !!{RST
     Record galaxy-galaxy merges and combine trees.
     !!}
-    use :: Galacticus_Nodes, only : nodeComponentBasic
+    use :: Galacticus_Nodes  , only : nodeComponentBasic
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/analyses/galaxy_mergers.F90
+++ b/source/nodes/operators/analyses/galaxy_mergers.F90
@@ -159,8 +159,8 @@ contains
     !!{RST
     Record galaxy-galaxy mergers.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentBasic, nodeComponentDisk, nodeComponentSpheroid
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : nodeComponentBasic, nodeComponentDisk, nodeComponentSpheroid
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/analyses/galaxy_mergers.F90
+++ b/source/nodes/operators/analyses/galaxy_mergers.F90
@@ -161,6 +161,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentBasic, nodeComponentDisk, nodeComponentSpheroid
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class           (*                    ), intent(inout)              :: self
     type            (treeNode             ), intent(inout), target      :: node
@@ -240,8 +242,10 @@ contains
        call basicHost%      floatRank1MetaPropertySet(self%galaxyMergerHostMassGasID         ,massGasHostNew         )
        call basicHost%      floatRank1MetaPropertySet(self%galaxyMergerSatelliteMassStellarID,massStellarSatelliteNew)
        call basicHost%      floatRank1MetaPropertySet(self%galaxyMergerHostMassStellarID     ,massStellarHostNew     )
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorGalaxyMergers] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorGalaxyMergers] class'//{introspection:location})
     end select
     return
   end subroutine satelliteMerger

--- a/source/nodes/operators/analyses/hierarchy.F90
+++ b/source/nodes/operators/analyses/hierarchy.F90
@@ -241,6 +241,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentBasic
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*                 ), intent(inout)          :: self
     type   (treeNode          ), intent(inout), target  :: node
@@ -265,8 +267,10 @@ contains
           call satelliteHostChange(self,nodeSatellite)
           nodeSatellite => nodeSatellite%sibling
        end do
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorHierarchy] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorHierarchy] class'//{introspection:location})
     end select
     return
   end subroutine satelliteHostChange
@@ -277,6 +281,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*                 ), intent(inout)          :: self
     type (treeNode          ), intent(inout), pointer :: node , nodePromotion
@@ -287,8 +293,10 @@ contains
        basic       => node         %basic()
        basicParent => nodePromotion%basic()
        call basic%floatRank0MetaPropertySet(self%massWhenFirstIsolatedID,basicParent%mass())
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorHierarchy] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorHierarchy] class'//{introspection:location})
     end select
     return
   end subroutine nodeSubhaloPromotion

--- a/source/nodes/operators/analyses/hierarchy.F90
+++ b/source/nodes/operators/analyses/hierarchy.F90
@@ -239,8 +239,8 @@ contains
     !!{RST
     Handle cases where a satellite switches host node.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentBasic
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : nodeComponentBasic
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -279,8 +279,8 @@ contains
     !!{RST
     Reset the mass-when-first-isolated property of the merging statistics component in the event of the subhalo promotion.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : nodeComponentBasic, treeNode
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/analyses/mass_host_maximum.F90
+++ b/source/nodes/operators/analyses/mass_host_maximum.F90
@@ -140,7 +140,7 @@ contains
     !!{RST
     Update the maximum host mass of this node in response to a change in host.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/analyses/mass_host_maximum.F90
+++ b/source/nodes/operators/analyses/mass_host_maximum.F90
@@ -141,6 +141,8 @@ contains
     Update the maximum host mass of this node in response to a change in host.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)         :: self
     type (treeNode), intent(inout), target :: node
@@ -148,8 +150,10 @@ contains
     select type (self)
     class is (nodeOperatorMassHostMaximum)
       call self%update(node,isMerging=.false.)
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorMassHostMaximum] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorMassHostMaximum] class'//{introspection:location})
     end select
     return
   end subroutine massHostMaximumSatelliteHostChange

--- a/source/nodes/operators/analyses/track_outflowed_mass.F90
+++ b/source/nodes/operators/analyses/track_outflowed_mass.F90
@@ -139,8 +139,8 @@ contains
     !!{RST
     Respond to mass removal from the hot halo component.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentHotHalo
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : nodeComponentHotHalo
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/analyses/track_outflowed_mass.F90
+++ b/source/nodes/operators/analyses/track_outflowed_mass.F90
@@ -141,6 +141,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentHotHalo
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class           (*                   ), intent(inout) :: self
     class           (nodeComponentHotHalo), intent(inout) :: hotHalo
@@ -150,8 +152,10 @@ contains
     class is (nodeOperatorTrackOutflowedMass)
        call hotHalo%floatRank0MetaPropertyRate(self%massOutflowedID      ,-hotHalo%floatRank0MetaPropertyGet(self%massOutflowedID      )*massRate/hotHalo%mass())
        call hotHalo%floatRank0MetaPropertyRate(self%massMetalsOutflowedID,-hotHalo%floatRank0MetaPropertyGet(self%massMetalsOutflowedID)*massRate/hotHalo%mass())
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorTrackOutflowedMass] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorTrackOutflowedMass] class'//{introspection:location})
     end select
     return
   end subroutine trackOutflowedMassHotHaloMassRemoval
@@ -163,6 +167,8 @@ contains
     use :: Error               , only : Error_Report
     use :: Galacticus_Nodes    , only : nodeComponentHotHalo
     use :: Abundances_Structure, only : abundances
+    use :: ISO_Varying_String  , only : char
+    use :: Function_Classes    , only : functionClass
     implicit none
     class           (*                    ), intent(inout) :: self
     class           (nodeComponentHotHalo ), intent(inout) :: hotHalo
@@ -173,8 +179,10 @@ contains
     class is (nodeOperatorTrackOutflowedMass)
        call hotHalo%floatRank0MetaPropertyRate(self%massOutflowedID      ,rateMassReturn                    )
        call hotHalo%floatRank0MetaPropertyRate(self%massMetalsOutflowedID,rateAbundancesReturn%metallicity())
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorTrackOutflowedMass] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorTrackOutflowedMass] class'//{introspection:location})
     end select
     return
   end subroutine trackOutflowedMassHotHaloMassReincorporation

--- a/source/nodes/operators/metadata/index_last_host.F90
+++ b/source/nodes/operators/metadata/index_last_host.F90
@@ -129,6 +129,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentBasic
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*                 ), intent(inout)         :: self
     type (treeNode          ), intent(inout), target :: node
@@ -138,8 +140,10 @@ contains
     class is (nodeOperatorIndexLastHost)
        basic => node%basic()
        call basic%longIntegerRank0MetaPropertySet(self%indexLastHostID,node%parent%index())
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorIndexLastHost] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorIndexLastHost] class'//{introspection:location})
     end select
     return
   end subroutine indexLastHostSatelliteHostChange

--- a/source/nodes/operators/metadata/index_last_host.F90
+++ b/source/nodes/operators/metadata/index_last_host.F90
@@ -127,8 +127,8 @@ contains
     !!{RST
     Update the host halo index of this node in response to a change in host.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentBasic
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : nodeComponentBasic
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/physics/black_holes/seed.F90
+++ b/source/nodes/operators/physics/black_holes/seed.F90
@@ -211,8 +211,8 @@ contains
     !!{RST
     Handle cases where two black holes merge.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentBlackHole
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : nodeComponentBlackHole
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/physics/black_holes/seed.F90
+++ b/source/nodes/operators/physics/black_holes/seed.F90
@@ -213,6 +213,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentBlackHole
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*                     ), intent(inout) :: self
     class(nodeComponentBlackHole), intent(inout) :: blackHole1     , blackHole2, &
@@ -226,8 +228,10 @@ contains
       else
          call blackHoleMerged%integerRank0MetaPropertySet(self%blackHoleSeedsFormationChannelID,blackHole2%integerRank0MetaPropertyGet(self%blackHoleSeedsFormationChannelID))
       end if
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorBlackHolesSeed] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorBlackHolesSeed] class'//{introspection:location})
     end select
     return
   end subroutine blackHoleMerger

--- a/source/nodes/operators/physics/circumgalactic_medium/accretion.F90
+++ b/source/nodes/operators/physics/circumgalactic_medium/accretion.F90
@@ -434,6 +434,8 @@ contains
     use :: Error                        , only : Error_Report
     use :: Abundances_Structure         , only : zeroAbundances
     use :: Galacticus_Nodes             , only : nodeComponentHotHalo  , nodeComponentSpin, nodeComponentBasic
+    use :: ISO_Varying_String           , only : char
+    use :: Function_Classes             , only : functionClass
     implicit none
     class(*                   ), intent(inout)         :: self
     type (treeNode            ), intent(inout), target :: node
@@ -504,8 +506,10 @@ contains
                &                                               zeroChemicalAbundances                  &
                &                                             )
        end select
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorCGMAccretion] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorCGMAccretion] class'//{introspection:location})
     end select
     return
   end subroutine satelliteMerger

--- a/source/nodes/operators/physics/circumgalactic_medium/outflow_reincorporation.F90
+++ b/source/nodes/operators/physics/circumgalactic_medium/outflow_reincorporation.F90
@@ -200,6 +200,8 @@ contains
     use :: Abundances_Structure         , only : zeroAbundances
     use :: Chemical_Abundances_Structure, only : zeroChemicalAbundances 
     use :: Galacticus_Nodes             , only : nodeComponentHotHalo  , nodeComponentSpin, nodeComponentBasic
+    use :: ISO_Varying_String           , only : char
+    use :: Function_Classes             , only : functionClass
     implicit none
     class(*                   ), intent(inout)         :: self
     type (treeNode            ), intent(inout), target :: node
@@ -259,8 +261,10 @@ contains
                &                                               zeroChemicalAbundances                 &
                &                                             )
        end select
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorCGMOutflowReincorporation] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorCGMOutflowReincorporation] class'//{introspection:location})
     end select
     return
   end subroutine satelliteMerger

--- a/source/nodes/operators/physics/cooling_energy_radiated.F90
+++ b/source/nodes/operators/physics/cooling_energy_radiated.F90
@@ -376,6 +376,8 @@ contains
     use :: Galacticus_Nodes          , only : nodeComponentBasic   , nodeComponentHotHalo
     use :: Galactic_Structure_Options, only : massTypeGalactic
     use :: Mass_Distributions        , only : massDistributionClass
+    use :: ISO_Varying_String        , only : char
+    use :: Function_Classes          , only : functionClass
     implicit none
     class           (*                    ), intent(inout) :: self
     class           (nodeComponentHotHalo ), intent(inout) :: hotHalo
@@ -399,8 +401,10 @@ contains
        !!]
        if (massNotional > 0.0d0) &
             & call hotHalo%floatRank0MetaPropertyRate(self%energyRadiatedID,-hotHalo%floatRank0MetaPropertyGet(self%energyRadiatedID)*massRate/massNotional)
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorCoolingEnergyRadiated] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorCoolingEnergyRadiated] class'//{introspection:location})
     end select
     return
   end subroutine coolingEnergyRadiatedHotHaloMassEjection

--- a/source/nodes/operators/physics/position/trace_dark_matter.F90
+++ b/source/nodes/operators/physics/position/trace_dark_matter.F90
@@ -149,6 +149,8 @@ contains
     Update the position of a subhalo when it changes host.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)         :: self
     type (treeNode), intent(inout), target :: node
@@ -156,8 +158,10 @@ contains
     select type (self)
     class is (nodeOperatorPositionTraceDarkMatter)
        call self%assignPosition(node,checkSatelliteStatus=.false.)
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorPositionTraceDarkMatter] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorPositionTraceDarkMatter] class'//{introspection:location})
     end select
     return
   end subroutine positionTraceDarkMatterSatelliteHostChange

--- a/source/nodes/operators/physics/position_to_host.F90
+++ b/source/nodes/operators/physics/position_to_host.F90
@@ -93,6 +93,8 @@ contains
     Update the maximum host mass of this node in response to a change in host.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)         :: self
     type (treeNode), intent(inout), target :: node
@@ -100,8 +102,10 @@ contains
     select type (self)
     class is (nodeOperatorPositionToHost)
        call self%nodePromote(node)
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorPositionToHost] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorPositionToHost] class'//{introspection:location})
     end select
     return
   end subroutine positionToHostSatelliteHostChange

--- a/source/nodes/operators/physics/position_to_host.F90
+++ b/source/nodes/operators/physics/position_to_host.F90
@@ -92,7 +92,7 @@ contains
     !!{RST
     Update the maximum host mass of this node in response to a change in host.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/physics/satellite/minimum_distance.F90
+++ b/source/nodes/operators/physics/satellite/minimum_distance.F90
@@ -196,8 +196,8 @@ contains
     !!{RST
     Update the minimum distance of approach when a satellite changes host node.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentSatellite
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : nodeComponentSatellite
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -236,8 +236,8 @@ contains
     !!{RST
     Reset the minimum distance of approach when a satellite is promoted to be an isolated halo.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentSatellite
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : nodeComponentSatellite
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/physics/satellite/minimum_distance.F90
+++ b/source/nodes/operators/physics/satellite/minimum_distance.F90
@@ -198,6 +198,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentSatellite
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*                     ), intent(inout)          :: self
     type (treeNode              ), intent(inout), target  :: node
@@ -222,8 +224,10 @@ contains
           call satellite%      floatRank0MetaPropertySet(self%satelliteDistanceMinimumID,self        %distanceRelative(node))
           call satellite%longIntegerRank0MetaPropertySet(self%            isolatedHostID,nodeIsolated%uniqueID        (    ))
        end if
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorSatelliteMinimumDistance] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorSatelliteMinimumDistance] class'//{introspection:location})
     end select
     return
   end subroutine satelliteHostChange
@@ -234,6 +238,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentSatellite
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*                     ), intent(inout)          :: self
     type (treeNode              ), intent(inout), pointer :: node        , nodePromotion
@@ -251,8 +257,10 @@ contains
           call satellite%      floatRank0MetaPropertySet(self%satelliteDistanceMinimumID,-1.0d0                 )
           call satellite%longIntegerRank0MetaPropertySet(self%            isolatedHostID,nodeIsolated%uniqueID())
        end if
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorSatelliteMinimumDistance] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorSatelliteMinimumDistance] class'//{introspection:location})
     end select    
     return
   end subroutine nodeSubhaloPromotion

--- a/source/nodes/operators/physics/satellite/orphanize.F90
+++ b/source/nodes/operators/physics/satellite/orphanize.F90
@@ -209,6 +209,8 @@ contains
     use :: Galacticus_Nodes  , only : nodeComponentSatellite, treeNode        , treeNodeLinkedList
     use :: ISO_Varying_String, only : operator(//)          , var_str         , varying_string
     use :: String_Handling   , only : operator(//)
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*                     ), intent(inout)          :: self
     type (treeNode              ), intent(inout), target  :: node
@@ -256,8 +258,10 @@ contains
              call orphanizePerform(nodeWork)
           end do
        end if
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorSatelliteOrphanize] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorSatelliteOrphanize] class'//{introspection:location})
     end select
     return
   end subroutine satelliteHostChange
@@ -271,6 +275,8 @@ contains
     use :: Galacticus_Nodes  , only : nodeComponentSatellite, treeNode        , treeNodeLinkedList
     use :: ISO_Varying_String, only : operator(//)          , var_str         , varying_string
     use :: String_Handling   , only : operator(//)
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*                     ), intent(inout)          :: self
     type (treeNode              ), intent(inout), pointer :: node
@@ -323,8 +329,10 @@ contains
           ! Process the node.
           call orphanizePerform(nodeWork)
        end do
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorSatelliteOrphanize] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorSatelliteOrphanize] class'//{introspection:location})
     end select
     return
   end subroutine branchJumpPostProcess

--- a/source/nodes/operators/physics/satellite_merging/time.F90
+++ b/source/nodes/operators/physics/satellite_merging/time.F90
@@ -180,6 +180,8 @@ contains
     Handle cases where a satellite switches host node.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout)         :: self
     type (treeNode), intent(inout), target :: node
@@ -187,8 +189,10 @@ contains
     select type (self)
     class is (nodeOperatorSatelliteMergingTime)
        call self%timeMergingSet(node)
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorSatelliteMergingTime] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorSatelliteMergingTime] class'//{introspection:location})
     end select
     return
   end subroutine satelliteHostChange
@@ -198,6 +202,8 @@ contains
     Handle cases where a host halo reforms.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class(*       ), intent(inout) :: self
     type (treeNode), intent(inout) :: node
@@ -214,8 +220,10 @@ contains
           call self%timeMergingSet(nodeSatellite)
           nodeSatellite => nodeSatellite%sibling
        end do
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorSatelliteMergingTime] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorSatelliteMergingTime] class'//{introspection:location})
     end select
     return
   end subroutine haloFormation

--- a/source/nodes/operators/physics/satellite_merging/time.F90
+++ b/source/nodes/operators/physics/satellite_merging/time.F90
@@ -179,7 +179,7 @@ contains
     !!{RST
     Handle cases where a satellite switches host node.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -201,7 +201,7 @@ contains
     !!{RST
     Handle cases where a host halo reforms.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/nodes/operators/physics/satellite_orbits.F90
+++ b/source/nodes/operators/physics/satellite_orbits.F90
@@ -198,6 +198,8 @@ contains
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : treeNode    , nodeComponentSatellite
     use :: Kepler_Orbits   , only : keplerOrbit
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*                     ), intent(inout)           :: self
     type   (treeNode              ), intent(inout)           :: node
@@ -240,8 +242,10 @@ contains
           ! Store the orbit.
           call satellite%virialOrbitSet(orbit)
        end if
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorSatelliteOrbit] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [nodeOperatorSatelliteOrbit] class'//{introspection:location})
     end select
     return
   end subroutine subhaloOrbitInitialize

--- a/source/nodes/operators/physics/satellite_orbits.F90
+++ b/source/nodes/operators/physics/satellite_orbits.F90
@@ -195,9 +195,9 @@ contains
     !!{RST
     Initialize a new subhalo orbit.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : treeNode    , nodeComponentSatellite
-    use :: Kepler_Orbits   , only : keplerOrbit
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : treeNode     , nodeComponentSatellite
+    use :: Kepler_Orbits     , only : keplerOrbit
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/objects/chemical_structure.F90
+++ b/source/objects/chemical_structure.F90
@@ -97,6 +97,7 @@ contains
     !!{RST
     Initialize the chemical structure database by reading the atomic structure database. Note: this implementation is not fully compatible with chemical markup language (CML), but only a limited subset of it.
     !!}
+    use :: Display           , only : displayGreen                , displayReset
     use :: FoX_dom           , only : Node                        , destroy           , extractDataContent
     use :: Error             , only : Error_Report
     use :: Input_Paths       , only : inputPath                   , pathTypeDataStatic
@@ -120,7 +121,15 @@ contains
        fileName=char(inputPath(pathTypeDataStatic))//'abundances/Chemical_Database.cml'
        !$omp critical (FoX_DOM_Access)
        doc => XML_Parse(char(fileName),iostat=ioErr)
-       if (ioErr /= 0) call Error_Report('Unable to find chemical database file'//{introspection:location})
+       if (ioErr /= 0) call Error_Report(                                                                                       &
+            &                            'Unable to find data file "'//char(fileName)//'"'//char(10)                         // &
+            &                            displayGreen()//'HELP:'//displayReset()                                             // &
+            &                            ' this file is provided by the Galacticus datasets repository. If the path above'   // &
+            &                            ' begins with "./" then the `GALACTICUS_DATA_PATH` environment variable is not set;'// &
+            &                            ' set it to the location of your clone of'                                          // &
+            &                            ' https://github.com/galacticusorg/datasets'                                        // &
+            &                            {introspection:location}                                                               &
+            &                           )
        ! Get a list of all chemicals.
        call XML_Get_Elements_By_Tag_Name(doc,"chemical",chemicalList)
        ! Allocate the array of chemicals.

--- a/source/objects/function_class.F90
+++ b/source/objects/function_class.F90
@@ -45,8 +45,10 @@ module Function_Classes
        <method method="isDefault"               description="Return true if this is the default object of this class."                        />
        <method method="reportOn"                description="Indicate that reference count changes to this object should be reported on."     />
        <method method="isRecursiveShim"         description="Return true if this is a generated recursion shim (see issue #695)."            />
+       <method method="objectType"              description="Return the name of the class of this object."                                   />
      </methods>
      !!]
+     procedure :: objectType              => functionClassObjectType
      procedure :: isDefault               => functionClassIsDefault
      procedure :: reportOn                => functionClassReportOn
      procedure :: isRecursiveShim         => functionClassIsRecursiveShim
@@ -56,6 +58,29 @@ module Function_Classes
   end type functionClass
 
 contains
+
+  function functionClassObjectType(self,short)
+    !!{RST
+    Return the name of the class of this object.
+
+    Every ``functionClass`` has this method generated for it, returning the name
+    of its concrete class (or, with ``short``, the name by which it is selected
+    in a parameter file). It is declared here so that those generated methods
+    *override* a binding on the base class, which in turn means the name of an
+    object's class can be obtained through a ``class(functionClass)`` reference -
+    for example when reporting that an object passed as ``class(*)`` is not of
+    the class that was expected. This default implementation is reached only by a
+    class for which no method was generated.
+    !!}
+    implicit none
+    type     (varying_string)                           :: functionClassObjectType
+    class    (functionClass ), intent(inout)            :: self
+    logical                  , intent(in   ), optional  :: short
+    !$GLC attributes unused :: self, short
+
+    functionClassObjectType='functionClass'
+    return
+  end function functionClassObjectType
 
   subroutine functionClassReportOn(self)
     !!{RST

--- a/source/objects/function_class.F90
+++ b/source/objects/function_class.F90
@@ -44,8 +44,8 @@ module Function_Classes
        <method method="referenceCountDecrement" description="Decrement the reference count to this object and return the new reference count."/>
        <method method="isDefault"               description="Return true if this is the default object of this class."                        />
        <method method="reportOn"                description="Indicate that reference count changes to this object should be reported on."     />
-       <method method="isRecursiveShim"         description="Return true if this is a generated recursion shim (see issue #695)."            />
-       <method method="objectType"              description="Return the name of the class of this object."                                   />
+       <method method="isRecursiveShim"         description="Return true if this is a generated recursion shim (see issue #695)."             />
+       <method method="objectType"              description="Return the name of the class of this object."                                    />
      </methods>
      !!]
      procedure :: objectType              => functionClassObjectType

--- a/source/output/analyses/Local_Group/luminosity_function.F90
+++ b/source/output/analyses/Local_Group/luminosity_function.F90
@@ -598,7 +598,7 @@ contains
     !!{RST
     Implement a ``localGroupLuminosityFunction`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupLuminosityFunction), intent(inout) :: self

--- a/source/output/analyses/Local_Group/luminosity_function.F90
+++ b/source/output/analyses/Local_Group/luminosity_function.F90
@@ -599,6 +599,7 @@ contains
     Implement a ``localGroupLuminosityFunction`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupLuminosityFunction), intent(inout) :: self
     class(outputAnalysisClass                       ), intent(inout) :: reduced
@@ -608,7 +609,7 @@ contains
        call self%volumeFunctionSatellites%reduce(reduced%volumeFunctionSatellites)
        call self%volumeFunctionCentrals  %reduce(reduced%volumeFunctionCentrals  )
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisLocalGroupLuminosityFunction] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine localGroupLuminosityFunctionReduce

--- a/source/output/analyses/Local_Group/mass_metallicity_relation.F90
+++ b/source/output/analyses/Local_Group/mass_metallicity_relation.F90
@@ -552,7 +552,7 @@ contains
     !!{RST
     Implement a ``localGroupMassMetallicityRelation`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupMassMetallicityRelation), intent(inout) :: self

--- a/source/output/analyses/Local_Group/mass_metallicity_relation.F90
+++ b/source/output/analyses/Local_Group/mass_metallicity_relation.F90
@@ -553,6 +553,7 @@ contains
     Implement a ``localGroupMassMetallicityRelation`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupMassMetallicityRelation), intent(inout) :: self
     class(outputAnalysisClass                            ), intent(inout) :: reduced
@@ -561,7 +562,7 @@ contains
     class is (outputAnalysisLocalGroupMassMetallicityRelation)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisLocalGroupMassMetallicityRelation] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine localGroupMassMetallicityRelationReduce

--- a/source/output/analyses/Local_Group/mass_size_relation.F90
+++ b/source/output/analyses/Local_Group/mass_size_relation.F90
@@ -567,7 +567,7 @@ contains
     !!{RST
     Implement a ``localGroupMassSizeRelation`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupMassSizeRelation), intent(inout) :: self

--- a/source/output/analyses/Local_Group/mass_size_relation.F90
+++ b/source/output/analyses/Local_Group/mass_size_relation.F90
@@ -568,6 +568,7 @@ contains
     Implement a ``localGroupMassSizeRelation`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupMassSizeRelation), intent(inout) :: self
     class(outputAnalysisClass                            ), intent(inout) :: reduced
@@ -576,7 +577,7 @@ contains
     class is (outputAnalysisLocalGroupMassSizeRelation)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisLocalGroupMassSizeRelation] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine localGroupMassSizeRelationReduce

--- a/source/output/analyses/Local_Group/mass_velocity_dispersion_relation.F90
+++ b/source/output/analyses/Local_Group/mass_velocity_dispersion_relation.F90
@@ -582,7 +582,7 @@ contains
     !!{RST
     Implement a ``localGroupMassVelocityDispersionRelation`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupMassVelocityDispersionRelation), intent(inout) :: self

--- a/source/output/analyses/Local_Group/mass_velocity_dispersion_relation.F90
+++ b/source/output/analyses/Local_Group/mass_velocity_dispersion_relation.F90
@@ -583,6 +583,7 @@ contains
     Implement a ``localGroupMassVelocityDispersionRelation`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupMassVelocityDispersionRelation), intent(inout) :: self
     class(outputAnalysisClass                            ), intent(inout) :: reduced
@@ -591,7 +592,7 @@ contains
     class is (outputAnalysisLocalGroupMassVelocityDispersionRelation)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisLocalGroupMassVelocityDispersionRelation] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine localGroupMassVelocityDispersionRelationReduce

--- a/source/output/analyses/Local_Group/occupation_fraction.F90
+++ b/source/output/analyses/Local_Group/occupation_fraction.F90
@@ -493,6 +493,7 @@ contains
     Implement a ``localGroupOccupationFraction`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupOccupationFraction), intent(inout) :: self
     class(outputAnalysisClass                       ), intent(inout) :: reduced
@@ -501,7 +502,7 @@ contains
     class is (outputAnalysisLocalGroupOccupationFraction)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisLocalGroupOccupationFraction] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine localGroupOccupationFractionReduce

--- a/source/output/analyses/Local_Group/occupation_fraction.F90
+++ b/source/output/analyses/Local_Group/occupation_fraction.F90
@@ -492,7 +492,7 @@ contains
     !!{RST
     Implement a ``localGroupOccupationFraction`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupOccupationFraction), intent(inout) :: self

--- a/source/output/analyses/Local_Group/stellar_mass_function.F90
+++ b/source/output/analyses/Local_Group/stellar_mass_function.F90
@@ -589,7 +589,7 @@ contains
     !!{RST
     Implement a ``localGroupStellarMassFunction`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupStellarMassFunction), intent(inout) :: self

--- a/source/output/analyses/Local_Group/stellar_mass_function.F90
+++ b/source/output/analyses/Local_Group/stellar_mass_function.F90
@@ -590,6 +590,7 @@ contains
     Implement a ``localGroupStellarMassFunction`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupStellarMassFunction), intent(inout) :: self
     class(outputAnalysisClass                        ), intent(inout) :: reduced
@@ -599,7 +600,7 @@ contains
        call self%volumeFunctionSatellites%reduce(reduced%volumeFunctionSatellites)
        call self%volumeFunctionCentrals  %reduce(reduced%volumeFunctionCentrals  )
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisLocalGroupStellarMassFunction] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine localGroupStellarMassFunctionReduce

--- a/source/output/analyses/Local_Group/stellar_mass_halo_mass_relation.F90
+++ b/source/output/analyses/Local_Group/stellar_mass_halo_mass_relation.F90
@@ -489,7 +489,7 @@ contains
     !!{RST
     Implement a ``localGroupStellarMassHaloMassRelation`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupStellarMassHaloMassRelation), intent(inout) :: self

--- a/source/output/analyses/Local_Group/stellar_mass_halo_mass_relation.F90
+++ b/source/output/analyses/Local_Group/stellar_mass_halo_mass_relation.F90
@@ -490,6 +490,7 @@ contains
     Implement a ``localGroupStellarMassHaloMassRelation`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisLocalGroupStellarMassHaloMassRelation), intent(inout) :: self
     class(outputAnalysisClass                                ), intent(inout) :: reduced
@@ -498,7 +499,7 @@ contains
     class is (outputAnalysisLocalGroupStellarMassHaloMassRelation)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisLocalGroupStellarMassHaloMassRelation] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine localGroupStellarMassHaloMassRelationReduce

--- a/source/output/analyses/black_hole_vs_halo_mass_relation.F90
+++ b/source/output/analyses/black_hole_vs_halo_mass_relation.F90
@@ -738,6 +738,7 @@ contains
     Implement reduction for the ``blackHoleVsHaloMassRelation`` output analysis class.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisBlackHoleVsHaloMassRelation), intent(inout) :: self
     class(outputAnalysisClass                      ), intent(inout) :: reduced
@@ -746,7 +747,7 @@ contains
     class is (outputAnalysisBlackHoleVsHaloMassRelation)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisBlackHoleVsHaloMassRelation] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine blackHoleVsHaloMassRelationReduce

--- a/source/output/analyses/black_hole_vs_halo_mass_relation.F90
+++ b/source/output/analyses/black_hole_vs_halo_mass_relation.F90
@@ -737,7 +737,7 @@ contains
     !!{RST
     Implement reduction for the ``blackHoleVsHaloMassRelation`` output analysis class.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisBlackHoleVsHaloMassRelation), intent(inout) :: self

--- a/source/output/analyses/correlation_function/_class.F90
+++ b/source/output/analyses/correlation_function/_class.F90
@@ -876,7 +876,7 @@ contains
     !!{RST
     Implement a ``correlationFunction`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisCorrelationFunction), intent(inout) :: self

--- a/source/output/analyses/correlation_function/_class.F90
+++ b/source/output/analyses/correlation_function/_class.F90
@@ -877,6 +877,7 @@ contains
     Implement a ``correlationFunction`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisCorrelationFunction), intent(inout) :: self
     class(outputAnalysisClass              ), intent(inout) :: reduced
@@ -894,7 +895,7 @@ contains
        reduced%termCovariance       =reduced%termCovariance       +self%termCovariance
        !$ call reduced%accumulateLock%unset()
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisCorrelationFunction] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine correlationFunctionReduce

--- a/source/output/analyses/cross_correlator_1d.F90
+++ b/source/output/analyses/cross_correlator_1d.F90
@@ -464,6 +464,7 @@ contains
     !!}
     use :: Error                  , only : Error_Report
     use :: Output_Analyses_Options, only : outputAnalysisCovarianceModelBinomial
+    use :: ISO_Varying_String     , only : char
     implicit none
     class(outputAnalysisCrossCorrelator1D), intent(inout) :: self
     class(outputAnalysisClass            ), intent(inout) :: reduced
@@ -478,7 +479,7 @@ contains
        reduced%functionCovariance      =reduced%functionCovariance   +self%functionCovariance
        !$ call reduced%accumulateLock%unset()
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisCrossCorrelator1D] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine crossCorrelator1DReduce

--- a/source/output/analyses/formation_time_distribution.F90
+++ b/source/output/analyses/formation_time_distribution.F90
@@ -778,7 +778,7 @@ contains
     !!{RST
     Implement reduction over progenitor mass functions.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisFormationTimeDistribution), intent(inout) :: self

--- a/source/output/analyses/formation_time_distribution.F90
+++ b/source/output/analyses/formation_time_distribution.F90
@@ -779,6 +779,7 @@ contains
     Implement reduction over progenitor mass functions.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisFormationTimeDistribution), intent(inout) :: self
     class(outputAnalysisClass                    ), intent(inout) :: reduced
@@ -790,7 +791,7 @@ contains
             &                +self   %weightParents
        !$ call reduced%accumulateLock%unset()
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisFormationTimeDistribution] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     call self%outputAnalysisVolumeFunction1D%reduce(reduced)
     return

--- a/source/output/analyses/heated_likelihood.F90
+++ b/source/output/analyses/heated_likelihood.F90
@@ -165,6 +165,7 @@ contains
     Reduce over the analysis.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisHeatedLikelihood), intent(inout) :: self
     class(outputAnalysisClass           ), intent(inout) :: reduced
@@ -173,7 +174,7 @@ contains
     type is (outputAnalysisHeatedLikelihood)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisHeatedLikelihood] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine heatedLikelihoodReduce

--- a/source/output/analyses/heated_likelihood.F90
+++ b/source/output/analyses/heated_likelihood.F90
@@ -164,7 +164,7 @@ contains
     !!{RST
     Reduce over the analysis.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisHeatedLikelihood), intent(inout) :: self

--- a/source/output/analyses/mass_size_relation/Shen2003.F90
+++ b/source/output/analyses/mass_size_relation/Shen2003.F90
@@ -213,6 +213,7 @@ contains
     Reduce over the mass-size output analysis.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisMassSizeRelationShen2003), intent(inout) :: self
     class(outputAnalysisClass                   ), intent(inout) :: reduced
@@ -223,7 +224,7 @@ contains
        reduced%logLikelihood_=reduced%logLikelihood_+self%logLikelihood_
        !$ call reduced%accumulateLock%set()
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisMassSizeRelationShen2003] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine massSizeRelationShen2003Reduce

--- a/source/output/analyses/mass_size_relation/Shen2003.F90
+++ b/source/output/analyses/mass_size_relation/Shen2003.F90
@@ -212,7 +212,7 @@ contains
     !!{RST
     Reduce over the mass-size output analysis.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisMassSizeRelationShen2003), intent(inout) :: self

--- a/source/output/analyses/mean_function_1d.F90
+++ b/source/output/analyses/mean_function_1d.F90
@@ -793,7 +793,7 @@ contains
     !!{RST
     Implement a volumeFunction1D output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisMeanFunction1D), intent(inout) :: self

--- a/source/output/analyses/mean_function_1d.F90
+++ b/source/output/analyses/mean_function_1d.F90
@@ -794,6 +794,7 @@ contains
     Implement a volumeFunction1D output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisMeanFunction1D), intent(inout) :: self
     class(outputAnalysisClass         ), intent(inout) :: reduced
@@ -804,7 +805,7 @@ contains
        call self%volumeFunctionWeighted  %reduce(reduced%volumeFunctionWeighted  )
        call self%crossCovariance         %reduce(reduced%crossCovariance         )
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisMeanFunction1D] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine meanFunction1DReduce

--- a/source/output/analyses/multi.F90
+++ b/source/output/analyses/multi.F90
@@ -207,6 +207,7 @@ contains
     Reduce over the analysis.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisMulti), intent(inout) :: self
     class(outputAnalysisClass), intent(inout) :: reduced
@@ -222,7 +223,7 @@ contains
           analysisReduced_ => analysisReduced_%next
        end do
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisMulti] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine multiReduce

--- a/source/output/analyses/multi.F90
+++ b/source/output/analyses/multi.F90
@@ -206,7 +206,7 @@ contains
     !!{RST
     Reduce over the analysis.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisMulti), intent(inout) :: self

--- a/source/output/analyses/progenitor_mass_functions.F90
+++ b/source/output/analyses/progenitor_mass_functions.F90
@@ -946,7 +946,7 @@ contains
     !!{RST
     Implement reduction over progenitor mass functions.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisProgenitorMassFunction), intent(inout) :: self

--- a/source/output/analyses/progenitor_mass_functions.F90
+++ b/source/output/analyses/progenitor_mass_functions.F90
@@ -947,6 +947,7 @@ contains
     Implement reduction over progenitor mass functions.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisProgenitorMassFunction), intent(inout) :: self
     class(outputAnalysisClass                 ), intent(inout) :: reduced
@@ -958,7 +959,7 @@ contains
             &                +self   %weightParents
        !$ call reduced%accumulateLock%unset()
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisProgenitorMassFunction] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     call self%outputAnalysisVolumeFunction1D%reduce(reduced)
     return

--- a/source/output/analyses/satellite_bound_mass.F90
+++ b/source/output/analyses/satellite_bound_mass.F90
@@ -211,7 +211,7 @@ contains
     !!{RST
     Reduce over the maximum velocity tidal track output analysis.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSatelliteBoundMass), intent(inout) :: self

--- a/source/output/analyses/satellite_bound_mass.F90
+++ b/source/output/analyses/satellite_bound_mass.F90
@@ -212,6 +212,7 @@ contains
     Reduce over the maximum velocity tidal track output analysis.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSatelliteBoundMass), intent(inout) :: self
     class(outputAnalysisClass             ), intent(inout) :: reduced
@@ -223,7 +224,7 @@ contains
        reduced%logLikelihood_   =reduced%logLikelihood_   +self%logLikelihood_
        !$ call reduced%accumulateLock%unset()
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisSatelliteBoundMass] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine satelliteBoundMassReduce

--- a/source/output/analyses/satellite_radius_velocity_maximum.F90
+++ b/source/output/analyses/satellite_radius_velocity_maximum.F90
@@ -226,7 +226,7 @@ contains
     !!{RST
     Reduce over the maximum velocity tidal track output analysis.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSatelliteRadiusVelocityMaximum), intent(inout) :: self

--- a/source/output/analyses/satellite_radius_velocity_maximum.F90
+++ b/source/output/analyses/satellite_radius_velocity_maximum.F90
@@ -227,6 +227,7 @@ contains
     Reduce over the maximum velocity tidal track output analysis.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSatelliteRadiusVelocityMaximum), intent(inout) :: self
     class(outputAnalysisClass                         ), intent(inout) :: reduced
@@ -238,7 +239,7 @@ contains
        reduced%logLikelihood_               =reduced%logLikelihood_               +self%logLikelihood_
        !$ call reduced%accumulateLock%unset()
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisSatelliteRadiusVelocityMaximum] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine satelliteRadiusVelocityMaximumReduce

--- a/source/output/analyses/satellite_velocity_maximum.F90
+++ b/source/output/analyses/satellite_velocity_maximum.F90
@@ -227,6 +227,7 @@ contains
     Reduce over the maximum velocity tidal track output analysis.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSatelliteVelocityMaximum), intent(inout) :: self
     class(outputAnalysisClass                   ), intent(inout) :: reduced
@@ -238,7 +239,7 @@ contains
        reduced%logLikelihood_         =reduced%logLikelihood_         +self%logLikelihood_
        !$ call reduced%accumulateLock%unset()
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisSatelliteVelocityMaximum] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine satelliteVelocityMaximumReduce

--- a/source/output/analyses/satellite_velocity_maximum.F90
+++ b/source/output/analyses/satellite_velocity_maximum.F90
@@ -226,7 +226,7 @@ contains
     !!{RST
     Reduce over the maximum velocity tidal track output analysis.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSatelliteVelocityMaximum), intent(inout) :: self

--- a/source/output/analyses/scatter_function_1d.F90
+++ b/source/output/analyses/scatter_function_1d.F90
@@ -683,6 +683,7 @@ contains
     Implement a scatterFunction1D output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisScatterFunction1D), intent(inout) :: self
     class(outputAnalysisClass            ), intent(inout) :: reduced
@@ -692,7 +693,7 @@ contains
        call self%meanFunction       %reduce(reduced%meanFunction       )
        call self%meanSquaredFunction%reduce(reduced%meanSquaredFunction)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisScatterFunction1D] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine scatterFunction1DReduce

--- a/source/output/analyses/scatter_function_1d.F90
+++ b/source/output/analyses/scatter_function_1d.F90
@@ -682,7 +682,7 @@ contains
     !!{RST
     Implement a scatterFunction1D output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisScatterFunction1D), intent(inout) :: self

--- a/source/output/analyses/size_vs_stellar_mass_relation.F90
+++ b/source/output/analyses/size_vs_stellar_mass_relation.F90
@@ -785,7 +785,7 @@ contains
     !!{RST
     Implement reduction for the ``sizeVsStellarMassRelation`` output analysis class.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSizeVsStellarMassRelation), intent(inout) :: self

--- a/source/output/analyses/size_vs_stellar_mass_relation.F90
+++ b/source/output/analyses/size_vs_stellar_mass_relation.F90
@@ -786,6 +786,7 @@ contains
     Implement reduction for the ``sizeVsStellarMassRelation`` output analysis class.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSizeVsStellarMassRelation), intent(inout) :: self
     class(outputAnalysisClass                    ), intent(inout) :: reduced
@@ -794,7 +795,7 @@ contains
     class is (outputAnalysisSizeVsStellarMassRelation)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisSizeVsStellarMassRelation] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine sizeVsStellarMassRelationReduce

--- a/source/output/analyses/stellar_vs_halo_mass_relation/COSMOS_Leauthaud2012.F90
+++ b/source/output/analyses/stellar_vs_halo_mass_relation/COSMOS_Leauthaud2012.F90
@@ -645,7 +645,7 @@ contains
     !!{RST
     Implement reduction for the ``stellarVsHaloMassRelationLeauthaud2012`` output analysis class.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisStellarVsHaloMassRelationLeauthaud2012), intent(inout) :: self

--- a/source/output/analyses/stellar_vs_halo_mass_relation/COSMOS_Leauthaud2012.F90
+++ b/source/output/analyses/stellar_vs_halo_mass_relation/COSMOS_Leauthaud2012.F90
@@ -646,6 +646,7 @@ contains
     Implement reduction for the ``stellarVsHaloMassRelationLeauthaud2012`` output analysis class.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisStellarVsHaloMassRelationLeauthaud2012), intent(inout) :: self
     class(outputAnalysisClass                                 ), intent(inout) :: reduced
@@ -654,7 +655,7 @@ contains
     class is (outputAnalysisStellarVsHaloMassRelationLeauthaud2012)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisStellarVsHaloMassRelationLeauthaud2012] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine stellarVsHaloMassRelationLeauthaud2012Reduce

--- a/source/output/analyses/stellar_vs_halo_mass_relation/_class.F90
+++ b/source/output/analyses/stellar_vs_halo_mass_relation/_class.F90
@@ -738,7 +738,7 @@ contains
     !!{RST
     Implement reduction for the ``stellarVsHaloMassRelation`` output analysis class.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisStellarVsHaloMassRelation), intent(inout) :: self

--- a/source/output/analyses/stellar_vs_halo_mass_relation/_class.F90
+++ b/source/output/analyses/stellar_vs_halo_mass_relation/_class.F90
@@ -739,6 +739,7 @@ contains
     Implement reduction for the ``stellarVsHaloMassRelation`` output analysis class.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisStellarVsHaloMassRelation), intent(inout) :: self
     class(outputAnalysisClass                    ), intent(inout) :: reduced
@@ -747,7 +748,7 @@ contains
     class is (outputAnalysisStellarVsHaloMassRelation)
        call self%outputAnalysis_%reduce(reduced%outputAnalysis_)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisStellarVsHaloMassRelation] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine stellarVsHaloMassRelationReduce

--- a/source/output/analyses/subhalo_mass_function.F90
+++ b/source/output/analyses/subhalo_mass_function.F90
@@ -531,6 +531,7 @@ contains
     Implement a ``subhaloMassFunction`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSubhaloMassFunction), intent(inout) :: self
     class(outputAnalysisClass              ), intent(inout) :: reduced
@@ -540,7 +541,7 @@ contains
        call self%volumeFunctionsSubHalos %reduce(reduced%volumeFunctionsSubHalos )
        call self%volumeFunctionsHostHalos%reduce(reduced%volumeFunctionsHostHalos)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisSubhaloMassFunction] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine subhaloMassFunctionReduce

--- a/source/output/analyses/subhalo_mass_function.F90
+++ b/source/output/analyses/subhalo_mass_function.F90
@@ -530,7 +530,7 @@ contains
     !!{RST
     Implement a ``subhaloMassFunction`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSubhaloMassFunction), intent(inout) :: self

--- a/source/output/analyses/subhalo_radial_distribution.F90
+++ b/source/output/analyses/subhalo_radial_distribution.F90
@@ -567,7 +567,7 @@ contains
     !!{RST
     Implement a ``subhaloRadialDistribution`` output analysis reduction.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSubhaloRadialDistribution), intent(inout) :: self

--- a/source/output/analyses/subhalo_radial_distribution.F90
+++ b/source/output/analyses/subhalo_radial_distribution.F90
@@ -568,6 +568,7 @@ contains
     Implement a ``subhaloRadialDistribution`` output analysis reduction.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class(outputAnalysisSubhaloRadialDistribution), intent(inout) :: self
     class(outputAnalysisClass              ), intent(inout) :: reduced
@@ -577,7 +578,7 @@ contains
        call self%volumeFunctionsSubHalos %reduce(reduced%volumeFunctionsSubHalos )
        call self%volumeFunctionsHostHalos%reduce(reduced%volumeFunctionsHostHalos)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisSubhaloRadialDistribution] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine subhaloRadialDistributionReduce

--- a/source/output/analyses/tidal_tracks/velocity_maximum.F90
+++ b/source/output/analyses/tidal_tracks/velocity_maximum.F90
@@ -208,6 +208,7 @@ contains
     Reduce over the maximum velocity tidal track output analysis.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
     implicit none
     class           (outputAnalysisTidalTracksVelocityMaximum), intent(inout)              :: self
     class           (outputAnalysisClass                     ), intent(inout)              :: reduced
@@ -240,7 +241,7 @@ contains
        reduced%countPointsOnTrack=reduced%countPointsOnTrack+self%countPointsOnTrack
        !$ call reduced%accumulateLock%unset()
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisTidalTracksVelocityMaximum] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine tidalTracksVelocityMaximumReduce

--- a/source/output/analyses/tidal_tracks/velocity_maximum.F90
+++ b/source/output/analyses/tidal_tracks/velocity_maximum.F90
@@ -207,7 +207,7 @@ contains
     !!{RST
     Reduce over the maximum velocity tidal track output analysis.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     implicit none
     class           (outputAnalysisTidalTracksVelocityMaximum), intent(inout)              :: self

--- a/source/output/analyses/volume_function_1d.F90
+++ b/source/output/analyses/volume_function_1d.F90
@@ -796,6 +796,7 @@ contains
     use :: Error                  , only : Error_Report
     use :: Output_Analyses_Options, only : outputAnalysisCovarianceModelBinomial
     use :: String_Handling        , only : operator(//)
+    use :: ISO_Varying_String     , only : char
     implicit none
     class    (outputAnalysisVolumeFunction1D), intent(inout) :: self
     class    (outputAnalysisClass           ), intent(inout) :: reduced
@@ -838,7 +839,7 @@ contains
        end if
        if (self%report) call displayUnindent('end reduction lock: '//char(self%reportLabel))
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [outputAnalysisVolumeFunction1D] class, but of ['//char(reduced%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine volumeFunction1DReduce

--- a/source/radiation/intergalactic_background/internal.F90
+++ b/source/radiation/intergalactic_background/internal.F90
@@ -443,8 +443,8 @@ contains
     !!{RST
     Attach an initial event to the universe to cause the background radiation update function to be called.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : universe    , universeEvent
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : universe     , universeEvent
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/radiation/intergalactic_background/internal.F90
+++ b/source/radiation/intergalactic_background/internal.F90
@@ -445,6 +445,8 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : universe    , universeEvent
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*                                   ), intent(inout), target :: self
     type   (universe                            ), intent(inout)         :: universe_
@@ -474,8 +476,10 @@ contains
           self%timePrevious             =  -1.0d0
           self%statePrevious            => null()
        end if
+    class is (functionClass)
+       call Error_Report('object is not of [radiationFieldIntergalacticBackgroundInternal] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiationFieldIntergalacticBackgroundInternal] class'//{introspection:location})
     end select
     return
   end subroutine intergalacticBackgroundInternalUniversePreEvolve

--- a/source/radiative_transfer/matter/atomic.F90
+++ b/source/radiative_transfer/matter/atomic.F90
@@ -451,7 +451,7 @@ contains
                &                            *self       %numberDensityMassDensityRatio
        end if
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
 
@@ -488,7 +488,7 @@ contains
     type is (radiativeTransferPropertiesMatterAtomic)
        call mpiSelf%broadcastData(sendFromProcess,properties%elements%densityNumber)
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
   end subroutine atomicBroadcastDomain
@@ -515,7 +515,7 @@ contains
        end do
        properties               %iterationCount             =properties            %iterationCount     +1
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
   end subroutine atomicReset
@@ -619,7 +619,7 @@ contains
             &                             *megaParsec
     class default
        atomicAbsorptionCoefficientSpecies=0.0d0
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
   end function atomicAbsorptionCoefficientSpecies
@@ -679,7 +679,7 @@ contains
           end do
        end do
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
   end subroutine atomicAccumulatePhotonPacket
@@ -717,7 +717,7 @@ contains
           properties%elements(i)%photoHeatingRate   =mpiSelf%sum(properties%elements(i)%photoHeatingRate   )
        end do
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
   end subroutine atomicAccumulationReduction
@@ -1155,7 +1155,7 @@ contains
        end do
        call self%historyUpdate(properties)       
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
 #ifdef RADTRANSDEBUG
     call Signal(8,handlerPrevious)
@@ -1266,7 +1266,7 @@ contains
           end do
        end if
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
   end subroutine atomicHistoryUpdate
@@ -1295,7 +1295,7 @@ contains
        end do
        call    mpiSelf%broadcastData(sendFromProcess,properties            %temperature                )
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
   end subroutine atomicBroadcastState
@@ -1354,7 +1354,7 @@ contains
        atomicConvergenceMeasure=max(convergenceMeasures(1),1.0d0)
        class default
        atomicConvergenceMeasure=0.0d0
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
   end function atomicConvergenceMeasure
@@ -1420,7 +1420,7 @@ contains
        end if
     class default
        atomicOutputProperty=0.0d0
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [radiativeTransferPropertiesMatterAtomic] class'//{introspection:location})
     end select
     return
   end function atomicOutputProperty

--- a/source/satellites/merging/mass_movements/Baugh2005.F90
+++ b/source/satellites/merging/mass_movements/Baugh2005.F90
@@ -172,8 +172,8 @@ contains
     !!{RST
     Reset the dark matter profile calculation.
     !!}
-    use :: Error       , only : Error_Report
-    use :: Kind_Numbers, only : kind_int8
+    use :: Error             , only : Error_Report
+    use :: Kind_Numbers      , only : kind_int8
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -198,7 +198,7 @@ contains
     !!{RST
     Hookable wrapper around the get function.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/satellites/merging/mass_movements/Baugh2005.F90
+++ b/source/satellites/merging/mass_movements/Baugh2005.F90
@@ -174,6 +174,8 @@ contains
     !!}
     use :: Error       , only : Error_Report
     use :: Kind_Numbers, only : kind_int8
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*        ), intent(inout) :: self
     type   (treeNode ), intent(inout) :: node
@@ -184,8 +186,10 @@ contains
     class is (mergerMassMovementsBaugh2005)
        self%movementsCalculated=.false.
        self%lastUniqueID       =uniqueID
+    class is (functionClass)
+       call Error_Report('object is not of [mergerMassMovementsBaugh2005] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerMassMovementsBaugh2005] class'//{introspection:location})
     end select
     return
   end subroutine baugh2005CalculationReset
@@ -195,6 +199,8 @@ contains
     Hookable wrapper around the get function.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*                               ), intent(inout)         :: self
     type   (treeNode                        ), intent(inout), target :: node
@@ -205,8 +211,10 @@ contains
     select type (self)
     type is (mergerMassMovementsBaugh2005)
        call self%get(node,destinationGasSatellite,destinationStarsSatellite,destinationGasHost,destinationStarsHost,mergerIsMajor)
+    class is (functionClass)
+       call Error_Report('object is not of [mergerMassMovementsBaugh2005] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerMassMovementsBaugh2005] class'//{introspection:location})
     end select
     return
   end subroutine baugh2005GetHook

--- a/source/satellites/merging/mass_movements/simple.F90
+++ b/source/satellites/merging/mass_movements/simple.F90
@@ -158,8 +158,8 @@ contains
     !!{RST
     Reset the dark matter profile calculation.
     !!}
-    use :: Error       , only : Error_Report
-    use :: Kind_Numbers, only : kind_int8
+    use :: Error             , only : Error_Report
+    use :: Kind_Numbers      , only : kind_int8
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -184,7 +184,7 @@ contains
     !!{RST
     Hookable wrapper around the get function.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/satellites/merging/mass_movements/simple.F90
+++ b/source/satellites/merging/mass_movements/simple.F90
@@ -160,6 +160,8 @@ contains
     !!}
     use :: Error       , only : Error_Report
     use :: Kind_Numbers, only : kind_int8
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*        ), intent(inout) :: self
     type   (treeNode ), intent(inout) :: node
@@ -170,8 +172,10 @@ contains
     class is (mergerMassMovementsSimple)
        self%movementsCalculated=.false.
        self%lastUniqueID       =uniqueID
+       class is (functionClass)
+       call Error_Report('object is not of [mergerMassMovementsSimple] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
        class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerMassMovementsSimple] class'//{introspection:location})
     end select
     return
   end subroutine simpleCalculationReset
@@ -181,6 +185,8 @@ contains
     Hookable wrapper around the get function.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*                               ), intent(inout)         :: self
     type   (treeNode                        ), intent(inout), target :: node
@@ -191,8 +197,10 @@ contains
     select type (self)
     type is (mergerMassMovementsSimple)
        call self%get(node,destinationGasSatellite,destinationStarsSatellite,destinationGasHost,destinationStarsHost,mergerIsMajor)
+    class is (functionClass)
+       call Error_Report('object is not of [mergerMassMovementsSimple] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerMassMovementsSimple] class'//{introspection:location})
     end select
     return
   end subroutine simpleGetHook

--- a/source/satellites/merging/mass_movements/very_simple.F90
+++ b/source/satellites/merging/mass_movements/very_simple.F90
@@ -128,8 +128,8 @@ contains
     !!{RST
     Reset the dark matter profile calculation.
     !!}
-    use :: Error       , only : Error_Report
-    use :: Kind_Numbers, only : kind_int8
+    use :: Error             , only : Error_Report
+    use :: Kind_Numbers      , only : kind_int8
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -154,7 +154,7 @@ contains
     !!{RST
     Hookable wrapper around the get function.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/satellites/merging/mass_movements/very_simple.F90
+++ b/source/satellites/merging/mass_movements/very_simple.F90
@@ -130,6 +130,8 @@ contains
     !!}
     use :: Error       , only : Error_Report
     use :: Kind_Numbers, only : kind_int8
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*        ), intent(inout) :: self
     type   (treeNode ), intent(inout) :: node
@@ -140,8 +142,10 @@ contains
     class is (mergerMassMovementsVerySimple)
        self%movementsCalculated=.false.
        self%lastUniqueID       =uniqueID
+    class is (functionClass)
+       call Error_Report('object is not of [mergerMassMovementsVerySimple] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerMassMovementsVerySimple] class'//{introspection:location})
     end select
     return
   end subroutine verySimpleCalculationReset
@@ -151,6 +155,8 @@ contains
     Hookable wrapper around the get function.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*                               ), intent(inout)         :: self
     type   (treeNode                        ), intent(inout), target :: node
@@ -161,8 +167,10 @@ contains
     select type (self)
     type is (mergerMassMovementsVerySimple)
        call self%get(node,destinationGasSatellite,destinationStarsSatellite,destinationGasHost,destinationStarsHost,mergerIsMajor)
+    class is (functionClass)
+       call Error_Report('object is not of [mergerMassMovementsVerySimple] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerMassMovementsVerySimple] class'//{introspection:location})
     end select
     return
   end subroutine verySimpleGetHook

--- a/source/satellites/merging/remnant_sizes/Cole2000.F90
+++ b/source/satellites/merging/remnant_sizes/Cole2000.F90
@@ -179,8 +179,8 @@ contains
     !!{RST
     Reset the dark matter profile calculation.
     !!}
-    use :: Error       , only : Error_Report
-    use :: Kind_Numbers, only : kind_int8
+    use :: Error             , only : Error_Report
+    use :: Kind_Numbers      , only : kind_int8
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -205,7 +205,7 @@ contains
     !!{RST
     Hookable wrapper around the get function.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/satellites/merging/remnant_sizes/Cole2000.F90
+++ b/source/satellites/merging/remnant_sizes/Cole2000.F90
@@ -181,6 +181,8 @@ contains
     !!}
     use :: Error       , only : Error_Report
     use :: Kind_Numbers, only : kind_int8
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*        ), intent(inout) :: self
     type   (treeNode ), intent(inout) :: node
@@ -191,8 +193,10 @@ contains
     class is (mergerRemnantSizeCole2000)
        self%propertiesCalculated=.false.
        self%lastUniqueID       =uniqueID
+    class is (functionClass)
+       call Error_Report('object is not of [mergerRemnantSizeCole2000] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerRemnantSizeCole2000] class'//{introspection:location})
     end select
     return
   end subroutine cole2000CalculationReset
@@ -202,6 +206,8 @@ contains
     Hookable wrapper around the get function.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class           (*       ), intent(inout)         :: self
     type            (treeNode), intent(inout), target :: node
@@ -211,8 +217,10 @@ contains
     select type (self)
     type is (mergerRemnantSizeCole2000)
        call self%get(node,radius,velocityCircular,angularMomentumSpecific)
+    class is (functionClass)
+       call Error_Report('object is not of [mergerRemnantSizeCole2000] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerRemnantSizeCole2000] class'//{introspection:location})
     end select
     return
   end subroutine cole2000GetHook

--- a/source/satellites/merging/remnant_sizes/Covington2008.F90
+++ b/source/satellites/merging/remnant_sizes/Covington2008.F90
@@ -171,8 +171,8 @@ contains
     !!{RST
     Reset the dark matter profile calculation.
     !!}
-    use :: Error       , only : Error_Report
-    use :: Kind_Numbers, only : kind_int8
+    use :: Error             , only : Error_Report
+    use :: Kind_Numbers      , only : kind_int8
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none
@@ -197,7 +197,7 @@ contains
     !!{RST
     Hookable wrapper around the get function.
     !!}
-    use :: Error, only : Error_Report
+    use :: Error             , only : Error_Report
     use :: ISO_Varying_String, only : char
     use :: Function_Classes  , only : functionClass
     implicit none

--- a/source/satellites/merging/remnant_sizes/Covington2008.F90
+++ b/source/satellites/merging/remnant_sizes/Covington2008.F90
@@ -173,6 +173,8 @@ contains
     !!}
     use :: Error       , only : Error_Report
     use :: Kind_Numbers, only : kind_int8
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class  (*        ), intent(inout) :: self
     type   (treeNode ), intent(inout) :: node
@@ -183,8 +185,10 @@ contains
     class is (mergerRemnantSizeCovington2008)
        self%propertiesCalculated=.false.
        self%lastUniqueID       =uniqueID
+    class is (functionClass)
+       call Error_Report('object is not of [mergerRemnantSizeCovington2008] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerRemnantSizeCovington2008] class'//{introspection:location})
     end select
     return
   end subroutine covington2008CalculationReset
@@ -194,6 +198,8 @@ contains
     Hookable wrapper around the get function.
     !!}
     use :: Error, only : Error_Report
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
     implicit none
     class           (*       ), intent(inout)         :: self
     type            (treeNode), intent(inout), target :: node
@@ -203,8 +209,10 @@ contains
     select type (self)
     type is (mergerRemnantSizeCovington2008)
        call self%get(node,radius,velocityCircular,angularMomentumSpecific)
+    class is (functionClass)
+       call Error_Report('object is not of [mergerRemnantSizeCovington2008] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [mergerRemnantSizeCovington2008] class'//{introspection:location})
     end select
     return
   end subroutine covington2008GetHook

--- a/source/star_formation/histories/in_situ.F90
+++ b/source/star_formation/histories/in_situ.F90
@@ -231,8 +231,8 @@ contains
     !!{RST
     Zero any in-situ star formation history for the galaxy about to merge.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentDisk, nodeComponentSpheroid, treeNode
+    use :: Error             , only : Error_Report
+    use :: Galacticus_Nodes  , only : nodeComponentDisk, nodeComponentSpheroid, treeNode
     use :: ISO_Varying_String, only : char
     implicit none
     class(starFormationHistoryInSitu), intent(inout) :: self

--- a/source/star_formation/histories/in_situ.F90
+++ b/source/star_formation/histories/in_situ.F90
@@ -233,6 +233,7 @@ contains
     !!}
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentDisk, nodeComponentSpheroid, treeNode
+    use :: ISO_Varying_String, only : char
     implicit none
     class(starFormationHistoryInSitu), intent(inout) :: self
     type (treeNode                  ), intent(inout) :: node
@@ -255,7 +256,7 @@ contains
           call spheroid%starFormationHistorySet(historyStarFormationSpheroid)
        end if
     class default
-       call Error_Report('incorrect class'//{introspection:location})
+       call Error_Report('object is not of [starFormationHistoryInSitu] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
     end select
     return
   end subroutine inSituSatelliteMerger

--- a/source/structure_formation/critical_overdensity/Marsh2016/FDM.F90
+++ b/source/structure_formation/critical_overdensity/Marsh2016/FDM.F90
@@ -142,10 +142,12 @@ contains
     !!}
     use :: Cosmology_Parameters        , only : hubbleUnitsLittleH
     use :: Dark_Matter_Particles       , only : darkMatterParticleFuzzyDarkMatter
+    use :: Display                     , only : displayGreen                     , displayReset
     use :: FoX_DOM                     , only : destroy                          , node
     use :: Error                       , only : Error_Report
     use :: Input_Paths                 , only : inputPath                        , pathTypeDataStatic
     use :: IO_XML                      , only : XML_Array_Read                   , XML_Get_First_Element_By_Tag_Name, XML_Parse
+    use :: ISO_Varying_String          , only : char
     use :: Numerical_Interpolation     , only : GSL_Interp_CSpline
     use :: Table_Labels                , only : extrapolationTypeFix
     use :: Numerical_Constants_Prefixes, only : kilo
@@ -185,7 +187,16 @@ contains
        ! Read in the tabulated critical overdensity scaling.
        !$omp critical (FoX_DOM_Access)
        doc => XML_Parse(char(inputPath(pathTypeDataStatic))//"darkMatter/criticalOverdensityFuzzyDarkMatterMarsh.xml",iostat=ioStatus)
-       if (ioStatus /= 0) call Error_Report('unable to find or parse the tabulated data'//{introspection:location})
+       if (ioStatus /= 0) call Error_Report(                                                                                                 &
+            &                               'Unable to find data file "'//char(inputPath(pathTypeDataStatic))//                              &
+            &                               'darkMatter/criticalOverdensityFuzzyDarkMatterMarsh.xml"'                           //char(10)// &
+            &                               displayGreen()//'HELP:'//displayReset()                                                       // &
+            &                               ' this file is provided by the Galacticus datasets repository. If the path above'             // &
+            &                               ' begins with "./" then the `GALACTICUS_DATA_PATH` environment variable is not set;'          // &
+            &                               ' set it to the location of your clone of'                                                    // &
+            &                               ' https://github.com/galacticusorg/datasets'                                                  // &
+            &                               {introspection:location}                                                                         &
+            &                              )
        ! Extract the datum lists.
        element    => XML_Get_First_Element_By_Tag_Name(doc,"mass" )
        call XML_Array_Read(element,"datum",self%deltaTableMass )

--- a/source/structure_formation/critical_overdensity/warm_dark_matter.F90
+++ b/source/structure_formation/critical_overdensity/warm_dark_matter.F90
@@ -144,10 +144,12 @@ contains
     !!}
     use :: Cosmology_Parameters   , only : hubbleUnitsLittleH
     use :: Dark_Matter_Particles  , only : darkMatterParticleWDMThermal
+    use :: Display                , only : displayGreen                , displayReset
     use :: FoX_DOM                , only : destroy                     , node
     use :: Error                  , only : Error_Report
     use :: Input_Paths            , only : inputPath                   , pathTypeDataStatic
     use :: IO_XML                 , only : XML_Array_Read              , XML_Get_First_Element_By_Tag_Name, XML_Parse
+    use :: ISO_Varying_String     , only : char
     use :: Numerical_Interpolation, only : GSL_Interp_CSpline
     use :: Table_Labels           , only : extrapolationTypeFix
     implicit none
@@ -193,7 +195,15 @@ contains
     fileCriticalOverdensity=inputPath(pathTypeDataStatic)//"darkMatter/criticalOverdensityWarmDarkMatterBarkana.xml"
     !$omp critical (FoX_DOM_Access)
     doc => XML_Parse(fileCriticalOverdensity,iostat=ioStatus)
-    if (ioStatus /= 0) call Error_Report('unable to find or parse the tabulated data'//{introspection:location})
+    if (ioStatus /= 0) call Error_Report(                                                                                                 &
+         &                               'Unable to find data file "'//char(fileCriticalOverdensity)//'"'                    //char(10)// &
+         &                               displayGreen()//'HELP:'//displayReset()                                                       // &
+         &                               ' this file is provided by the Galacticus datasets repository. If the path above'             // &
+         &                               ' begins with "./" then the `GALACTICUS_DATA_PATH` environment variable is not set;'          // &
+         &                               ' set it to the location of your clone of'                                                    // &
+         &                               ' https://github.com/galacticusorg/datasets'                                                  // &
+         &                               {introspection:location}                                                                         &
+         &                              )
     ! Extract the datum lists.
     element    => XML_Get_First_Element_By_Tag_Name(doc,"mass" )
     call XML_Array_Read(element,"datum",self%deltaTableMass )

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/midpoint/Brownian_bridge.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/midpoint/Brownian_bridge.F90
@@ -211,7 +211,7 @@ contains
        varianceConstrained           =0.0d0
        timeConstrained               =0.0d0
        massConstrained               =0.0d0
-       call Error_Report('must provide either [criticalOverdensityConstrained] and [varianceConstrained], or [timeConstrained] and [massConstrained]')
+       call Error_Report('must provide either [criticalOverdensityConstrained] and [varianceConstrained], or [timeConstrained] and [massConstrained]'//{introspection:location})
     end if
     self%criticalOverdensityConstrained=criticalOverdensityConstrained
     self%varianceConstrained           =varianceConstrained

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/linear_barrier/Brownian_bridge.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/linear_barrier/Brownian_bridge.F90
@@ -229,7 +229,7 @@ contains
        varianceConstrained           =0.0d0
        timeConstrained               =0.0d0
        massConstrained               =0.0d0
-       call Error_Report('must provide either [criticalOverdensityConstrained] and [varianceConstrained], or [timeConstrained] and [massConstrained]')
+       call Error_Report('must provide either [criticalOverdensityConstrained] and [varianceConstrained], or [timeConstrained] and [massConstrained]'//{introspection:location})
     end if
     self=excursionSetFirstCrossingLinearBarrierBrownianBridge(varianceConstrained,criticalOverdensityConstrained,fractionalTimeStep,cosmologyFunctions_,excursionSetFirstCrossing_,excursionSetBarrier_,cosmologicalMassVariance_,criticalOverdensity_,linearGrowth_)
     !![

--- a/source/structure_formation/halo_mass_function/Tinker2008.F90
+++ b/source/structure_formation/halo_mass_function/Tinker2008.F90
@@ -127,6 +127,7 @@ contains
     !!{RST
     Internal constructor for the :galacticus-class:`haloMassFunctionTinker2008` halo mass function class.
     !!}
+    use :: Display           , only : displayGreen                , displayReset
     use :: File_Utilities    , only : File_Exists
     use :: FoX_DOM           , only : destroy                     , node
     use :: Error             , only : Error_Report
@@ -156,7 +157,15 @@ contains
     self%massParameters=-1.0d0
     ! Read the data file which gives fitting parameters as a function of halo overdensity.
     parameterFileName=inputPath(pathTypeDataStatic)//"darkMatter/Halo_Mass_Function_Parameters_Tinker_2008.xml"
-    if (.not.File_Exists(parameterFileName)) call Error_Report('Unable to find data file "'//parameterFileName//'"'//{introspection:location})
+    if (.not.File_Exists(parameterFileName)) call Error_Report(                                                                                    &
+         &                                                      'Unable to find data file "'//parameterFileName//'"'                  //char(10)// &
+         &                                                      displayGreen()//'HELP:'//displayReset()                                         // &
+         &                                                      ' this file is provided by the Galacticus datasets repository. If the'          // &
+         &                                                      ' path above begins with "./" then the `GALACTICUS_DATA_PATH`'                  // &
+         &                                                      ' environment variable is not set; set it to the location of your'              // &
+         &                                                      ' clone of https://github.com/galacticusorg/datasets'                           // &
+         &                                                      {introspection:location}                                                           &
+         &                                                     )
     !$omp critical (FoX_DOM_Access)
     doc => XML_Parse(parameterFileName,ioStat=ioStatus)
     if (ioStatus /= 0) call Error_Report('Unable to parse data file "'//parameterFileName//'"'//{introspection:location})

--- a/source/universe/operators/intergalactic_medium_state_evolve.F90
+++ b/source/universe/operators/intergalactic_medium_state_evolve.F90
@@ -376,6 +376,8 @@ contains
      Attach an initial event to a merger tree to cause the properties update function to be called.
      !!}
      use :: Galacticus_Nodes, only : universe, universeEvent
+    use :: ISO_Varying_String, only : char
+    use :: Function_Classes  , only : functionClass
      implicit none
      class(universeOperatorIntergalacticMediumStateEvolve), intent(inout), target :: self
      type (universe                                      ), intent(inout)         :: universe_
@@ -538,8 +540,10 @@ contains
         call self%stateSet(iNow)
         ! Display message.
         call displayUnindent('done')
+        class is (functionClass)
+        call Error_Report('object is not of [universeOperatorIntergalacticMediumStateEvolve] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
         class default
-        call Error_Report('incorrect class'//{introspection:location})
+        call Error_Report('object is not of [universeOperatorIntergalacticMediumStateEvolve] class'//{introspection:location})
      end select
      ! Return true since we've performed our task.
      success=.true.

--- a/source/universe/operators/intergalactic_medium_state_evolve.F90
+++ b/source/universe/operators/intergalactic_medium_state_evolve.F90
@@ -375,9 +375,9 @@ contains
      !!{RST
      Attach an initial event to a merger tree to cause the properties update function to be called.
      !!}
-     use :: Galacticus_Nodes, only : universe, universeEvent
-    use :: ISO_Varying_String, only : char
-    use :: Function_Classes  , only : functionClass
+     use :: Galacticus_Nodes  , only : universe     , universeEvent
+     use :: ISO_Varying_String, only : char
+     use :: Function_Classes  , only : functionClass
      implicit none
      class(universeOperatorIntergalacticMediumStateEvolve), intent(inout), target :: self
      type (universe                                      ), intent(inout)         :: universe_
@@ -540,9 +540,9 @@ contains
         call self%stateSet(iNow)
         ! Display message.
         call displayUnindent('done')
-        class is (functionClass)
+     class is (functionClass)
         call Error_Report('object is not of [universeOperatorIntergalacticMediumStateEvolve] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
-        class default
+     class default
         call Error_Report('object is not of [universeOperatorIntergalacticMediumStateEvolve] class'//{introspection:location})
      end select
      ! Return true since we've performed our task.

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -557,7 +557,13 @@ contains
     character(len=32         )                                        :: changeType
 
     ! Check that the file exists.
-    if (.not.File_Exists(fileName)) call Error_Report("parameter file '"//trim(fileName)//"' does not exist"//{introspection:location})
+    if (.not.File_Exists(fileName))                                                                                                           &
+         & call Error_Report(                                                                                                                 &
+         &                   "parameter file '"//trim(fileName)//"' does not exist"//char(10)//                                               &
+         &                   displayGreen()//"HELP:"//displayReset()//" this path is interpreted relative to the directory Galacticus was" // &
+         &                   " run from, not to the location of the executable"                                                            // &
+         &                   {introspection:location}                                                                                         &
+         &                  )
     ! Open and parse the data file.
     !$omp critical (FoX_DOM_Access)
     doc           => XML_Parse(fileName,iostat=errorStatus,ex=exception,fileNameCurrent=fileNameFailed)
@@ -1600,12 +1606,13 @@ contains
 
   subroutine inputParametersCheckParameters(self,allowedParameterNamesGlobal,allowedParameterNames,allowedMultiParameterNames)
     use :: Error              , only : Error_Report
-    use :: Display            , only : displayIndent              , displayMagenta  , displayMessage                 , displayReset        , &
-          &                            displayUnindent            , displayVerbosity, enumerationVerbosityLevelEncode, verbosityLevelSilent
-    use :: FoX_dom            , only : DOMException               , destroy         , extractDataContent             , getAttributeNode    , &
-          &                            getNodeName                , hasAttribute    , inException                    , node                , &
+    use :: Display            , only : displayGreen               , displayIndent   , displayMagenta    , displayMessage      , &
+          &                            displayReset               , displayUnindent , displayVerbosity  , verbosityLevelSilent, &
+          &                            enumerationVerbosityLevelEncode
+    use :: FoX_dom            , only : DOMException               , destroy         , extractDataContent, getAttributeNode    , &
+          &                            getNodeName                , hasAttribute    , inException       , node                , &
           &                            getParentNode
-    use :: ISO_Varying_String , only : assignment(=)              , char            , operator(//)                   , operator(==)
+    use :: ISO_Varying_String , only : assignment(=)              , char            , operator(//)      , operator(==)
     use :: Regular_Expressions, only : regEx
     use :: String_Handling    , only : String_Levenshtein_Distance
     implicit none
@@ -1780,7 +1787,14 @@ contains
        end do
     end if
     if (warningsFound .and. verbose) call displayUnindent('')
-    if (warningsFound .and. self%strict) call Error_Report('warnings found and strict compliance requested'//{introspection:location})
+    if (warningsFound .and. self%strict)                                                                                                     &
+         & call Error_Report(                                                                                                                &
+         &                   'problems were found with the input parameters, and this parameter file requests strict compliance'//char(10)// &
+         &                   displayGreen()//'HELP:'//displayReset()//' the problems are listed above. Correct them, or remove'           // &
+         &                   ' `strict="true"` from the `<lastModified>` element of your parameter file to have them reported as'         // &
+         &                   ' warnings rather than as an error'                                                                          // &
+         &                   {introspection:location}                                                                                        &
+         &                  )
     return
   end subroutine inputParametersCheckParameters
 
@@ -2277,8 +2291,11 @@ contains
     !!{RST
     Return the value of the parameter specified by name.
     !!}
-    use :: Error      , only : Error_Report
-    use :: HDF5_Access, only : hdf5Access
+    use :: Display           , only : displayGreen, displayReset
+    use :: Error             , only : Error_Report
+    use :: HDF5_Access       , only : hdf5Access
+    use :: ISO_Varying_String, only : char        , varying_string, assignment(=), operator(==), &
+         &                            operator(//)
     implicit none
     class           (inputParameters                         ), intent(inout), target   :: self
     character       (len=*                                   ), intent(in   )           :: parameterName
@@ -2322,7 +2339,25 @@ contains
     else if (present(errorStatus )) then
        errorStatus   =inputParameterErrorStatusNotPresent
     else
-       call Error_Report('parameter ['//parameterName//'] not present and no default given'//{introspection:location})
+       block
+         type     (varying_string)              :: whereToAdd
+         character(len=:         ), allocatable :: pathText
+
+         ! `path()` is empty for a parameter at the top level of the file, and otherwise ends with
+         ! the "/" separator, which reads oddly inside brackets - so trim it.
+         pathText=char(self%path())
+         if (len(pathText) == 0) then
+            whereToAdd="at the top level of your parameter file"
+         else
+            whereToAdd="within the ["//pathText(1:len(pathText)-1)//"] element of your parameter file"
+         end if
+         call Error_Report(                                                                                                        &
+              &             'parameter ['//parameterName//'] is required, but is not present and has no default value'//char(10)// &
+              &             displayGreen()//'HELP:'//displayReset()//' add it '//char(whereToAdd)//', as:'            //char(10)// &
+              &             '        <'//parameterName//' value="..."/>'                                                        // &
+              &             {introspection:location}                                                                               &
+              &            )
+       end block
     end if
     return
   end subroutine inputParametersValueName{Type¦label}
@@ -2332,6 +2367,7 @@ contains
     Return the value of the specified parameter.
     !!}
     use, intrinsic :: ISO_C_Binding     , only : c_int64_t                        , c_size_t
+    use            :: Display           , only : displayGreen                     , displayReset
     use            :: FoX_dom           , only : DOMException                     , getAttributeNode  , getNodeName   , hasAttribute      , &
           &                                      inException                      , node              , getTextContent, extractDataContent
     use            :: Error             , only : Error_Report
@@ -2520,7 +2556,12 @@ contains
                    valueElement => getAttributeNode(parameterNode%content,"value")
                    !$omp end critical (FoX_DOM_Access)
 #else
-                   call Error_Report('derived parameters require libmatheval, but it is not installed'//{introspection:location})
+                   call Error_Report(                                                                                                        &
+                        &             'derived parameters require libmatheval, but Galacticus was built without it'             //char(10)// &
+                        &             displayGreen()//'HELP:'//displayReset()//' install libmatheval and rebuild Galacticus, or'          // &
+                        &             ' replace the derived parameter with a literal value in your parameter file'                        // &
+                        &             {introspection:location}                                                                               &
+                        &            )
 #endif
                 else if (isText) then
                    call parameterNode%set(var_str(trim(expression)))

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -2237,10 +2237,13 @@ contains
     class(inputParameters), intent(in   ), target :: self
     type (inputParameter ), pointer               :: parameterNode
     
+    ! The tree is walked from this node *upwards*, so each ancestor's name is prepended, not
+    ! appended: appending would build the path in reverse, reporting `b/a/` for a node `a` which
+    ! contains `b`.
     parameterNode       => self%parameters
     inputParametersPath =  ""
     do while (associated(parameterNode))
-       if (associated(parameterNode%content)) inputParametersPath=inputParametersPath//getNodeName(parameterNode%content)//"/"
+       if (associated(parameterNode%content)) inputParametersPath=getNodeName(parameterNode%content)//"/"//inputParametersPath
        parameterNode => parameterNode%parent
     end do
     return

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -162,6 +162,7 @@ module Input_Parameters
        <method description="Reset all objects in this parameter set." method="reset" />
        <method description="Destroy the parameters document." method="destroy" />
        <method description="Return the path to this parameters object." method="path" />
+       <method description="Mark a parameter, in the output file, as having taken a default value." method="markDefaulted" />
        <method description="Assign input parameter objects." method="assignment(=)"/>
      </methods>
      !!]
@@ -188,6 +189,7 @@ module Input_Parameters
      procedure :: addParameter         => inputParametersAddParameter
      procedure :: reset                => inputParametersReset
      procedure :: path                 => inputParametersPath
+     procedure :: markDefaulted        => inputParametersMarkDefaulted
      procedure ::                         inputParametersAssignment
      generic   :: assignment(=)        => inputParametersAssignment
   end type inputParameters
@@ -280,20 +282,6 @@ module Input_Parameters
   type   (buildStackEntry), allocatable, dimension(:) :: buildStack
   integer                                             :: buildStackDepth=0
   !$omp threadprivate(buildStack,buildStackDepth)
-
-  ! Record of parameters for which a default value has been used, so that each is reported to the
-  ! user precisely once. Keys are the full parameter path (i.e. the path of the containing parameters
-  ! node, followed by the parameter name) - the same text that appears in the message - so that
-  ! distinct parameters sharing a container do not collide.
-  !
-  ! This record is deliberately *shared*: it is a module-level variable, not a component of
-  ! `inputParameters`, and is not threadprivate. Parameter sets are freely copied (once per OpenMP
-  ! thread, for example), and a parameter defaulted in one copy has already been reported to the
-  ! user, so must not be reported again by another - were this record held per-object and deep-copied
-  ! along with the parameter set, the number of messages would scale with the number of copies.
-  ! Access is guarded by the `inputParametersWarnedDefaults` critical section.
-  type   (integerDictionary)                          :: warnedDefaults
-  logical                                             :: warnedDefaultsInitialized=.false.
 
   ! Suffix appended to a parameter name to form the name of the attribute, written into the
   ! `Parameters` group of the output file, that marks the parameter as having taken a default value.
@@ -2258,14 +2246,36 @@ contains
     return
   end function inputParametersPath
 
+  subroutine inputParametersMarkDefaulted(self,parameterName)
+    !!{RST
+    Mark the named parameter, in the ``Parameters`` group of the output file, as having taken a
+    default value. Used for parameters which are not read through ``value()`` - in particular the
+    name of a ``functionClass`` object which was not specified and so was built from its default
+    class. A parameter given explicitly in the parameter file is never marked, so the absence of the
+    marker means that the value was supplied by the user.
+    !!}
+    use :: HDF5_Access, only : hdf5Access
+    implicit none
+    class    (inputParameters), intent(inout) :: self
+    character(len=*          ), intent(in   ) :: parameterName
+
+    if (.not.associated(self%outputParameters)) return
+    !$ call hdf5Access%set()
+    if (self%outputParameters%isOpen()) then
+       ! Write the marker only if it is absent: attributes are not, in general, overwritable.
+       if (.not.self%outputParameters%hasAttribute(parameterName//defaultedMarkerSuffix)) &
+            & call self%outputParameters%writeAttribute(.true.,parameterName//defaultedMarkerSuffix)
+    end if
+    !$ call hdf5Access%unset()
+    return
+  end subroutine inputParametersMarkDefaulted
+
   recursive subroutine inputParametersValueName{Type¦label}(self,parameterName,parameterValue,defaultValue,errorStatus,writeOutput,copyInstance,evaluate)
     !!{RST
     Return the value of the parameter specified by name.
     !!}
-    use :: Error             , only : Error_Report, Warn
+    use :: Error             , only : Error_Report
     use :: HDF5_Access       , only : hdf5Access
-    use :: ISO_Varying_String, only : char
-    use :: MPI_Utilities     , only : mpiSelf
     implicit none
     class           (inputParameters                         ), intent(inout), target   :: self
     character       (len=*                                   ), intent(in   )           :: parameterName
@@ -2275,7 +2285,6 @@ contains
     integer                                                   , intent(in   ), optional :: copyInstance
     logical                                                   , intent(in   ), optional :: writeOutput   , evaluate
     type            (inputParameter                          ), pointer                 :: parameterNode
-    type            (varying_string                          )                          :: parameterPath
     !![
     <optionalArgument name="writeOutput" defaultsTo=".true." />
     !!]
@@ -2284,21 +2293,12 @@ contains
        parameterNode => self%node(parameterName,copyInstance=copyInstance,writeOutput=writeOutput)
        call self%value(parameterNode,parameterValue,errorStatus,writeOutput,evaluate)
     else if (present(defaultValue)) then
-       ! Report the use of a default value for this parameter, but only the first time that it is
-       ! used. The key must be the full path *including* the parameter name - `path()` returns the
-       ! path of the containing parameters node only, so keying on that alone would cause distinct
-       ! parameters within the same container to collide, suppressing all but the first of them.
-       parameterPath=self%path()
-       !$omp critical (inputParametersWarnedDefaults)
-       if (.not.warnedDefaultsInitialized) then
-          warnedDefaults           =integerDictionary()
-          warnedDefaultsInitialized=.true.
-       end if
-       if (.not.warnedDefaults%exists(char(parameterPath)//parameterName)) then
-          if (mpiSelf%isMaster()) call Warn("Using default value for parameter '["//char(parameterPath)//parameterName//"]'")
-          call warnedDefaults%set(char(parameterPath)//parameterName,1)
-       end if
-       !$omp end critical (inputParametersWarnedDefaults)
+       ! The use of a default value is not reported to the terminal. Using a default is an extremely
+       ! common idiom - a small model defaults of order a hundred parameters - so reporting each one
+       ! swamped the warning list which `Error_Report` replays, crowding genuine warnings out of it
+       ! entirely (the list retains a bounded number of unique messages). The information is instead
+       ! recorded in the output file, where each defaulted parameter is marked; see
+       ! `defaultedMarkerSuffix`.
        parameterValue=defaultValue
        ! Write the parameter file to an HDF5 object.
        if (associated(self%outputParameters)) then

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -2277,8 +2277,8 @@ contains
     !!{RST
     Return the value of the parameter specified by name.
     !!}
-    use :: Error             , only : Error_Report
-    use :: HDF5_Access       , only : hdf5Access
+    use :: Error      , only : Error_Report
+    use :: HDF5_Access, only : hdf5Access
     implicit none
     class           (inputParameters                         ), intent(inout), target   :: self
     character       (len=*                                   ), intent(in   )           :: parameterName

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -17,6 +17,11 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson. The fix to the deduplication of reports of the use of default
+!+    parameter values, the marking of defaulted parameters in the output file, and the removal of the then-unused
+!+    per-object OpenMP lock, for issue #1353, were drafted with assistance from Claude, and reviewed and verified by
+!+    Andrew Benson.
+
 !!{RST
 Contains a module which implements reading of parameters from an XML data file.
 !!}
@@ -36,7 +41,6 @@ module Input_Parameters
   use            :: Kind_Numbers      , only : kind_int8
   use            :: String_Handling   , only : char
   use            :: Dictionaries      , only : integerDictionary
-  use            :: Locks             , only : ompLock
   use            :: Resource_Manager  , only : resourceManager
   private
   public :: inputParameters                 , inputParameter                         , inputParameterList                           , Input_Parameters_Build_Stack_Push, &
@@ -113,14 +117,6 @@ module Input_Parameters
      procedure :: get           => inputParameterGet
   end type inputParameter
 
-  !![
-  <deepCopyActions class="inputParameters">
-   <inputParameters>
-    <methodCall method="lockReinitialize"/>
-   </inputParameters>
-  </deepCopyActions>
-  !!]
-    
   type :: documentWrapper
      !!{RST
      Wrapper class for managing XML documents.
@@ -143,9 +139,6 @@ module Input_Parameters
      type   (inputParameters)  , pointer, public :: parent                    => null() , original                         => null()
      logical                                     :: outputParametersCopied    =  .false., outputParametersTemporary        = .false., &
           &                                         isNull                    =  .false., strict                           = .false.
-     type   (integerDictionary), allocatable     :: warnedDefaults
-     type   (ompLock          ), pointer         :: lock                      => null()
-     type   (resourceManager  )                  :: lockManager
    contains
      !![
      <methods docformat="rst">
@@ -169,7 +162,6 @@ module Input_Parameters
        <method description="Reset all objects in this parameter set." method="reset" />
        <method description="Destroy the parameters document." method="destroy" />
        <method description="Return the path to this parameters object." method="path" />
-       <method description="Reinitialize lock." method="lockReinitialize" />
        <method description="Assign input parameter objects." method="assignment(=)"/>
      </methods>
      !!]
@@ -196,7 +188,6 @@ module Input_Parameters
      procedure :: addParameter         => inputParametersAddParameter
      procedure :: reset                => inputParametersReset
      procedure :: path                 => inputParametersPath
-     procedure :: lockReinitialize     => inputParametersLockReinitialize
      procedure ::                         inputParametersAssignment
      generic   :: assignment(=)        => inputParametersAssignment
   end type inputParameters
@@ -289,6 +280,28 @@ module Input_Parameters
   type   (buildStackEntry), allocatable, dimension(:) :: buildStack
   integer                                             :: buildStackDepth=0
   !$omp threadprivate(buildStack,buildStackDepth)
+
+  ! Record of parameters for which a default value has been used, so that each is reported to the
+  ! user precisely once. Keys are the full parameter path (i.e. the path of the containing parameters
+  ! node, followed by the parameter name) - the same text that appears in the message - so that
+  ! distinct parameters sharing a container do not collide.
+  !
+  ! This record is deliberately *shared*: it is a module-level variable, not a component of
+  ! `inputParameters`, and is not threadprivate. Parameter sets are freely copied (once per OpenMP
+  ! thread, for example), and a parameter defaulted in one copy has already been reported to the
+  ! user, so must not be reported again by another - were this record held per-object and deep-copied
+  ! along with the parameter set, the number of messages would scale with the number of copies.
+  ! Access is guarded by the `inputParametersWarnedDefaults` critical section.
+  type   (integerDictionary)                          :: warnedDefaults
+  logical                                             :: warnedDefaultsInitialized=.false.
+
+  ! Suffix appended to a parameter name to form the name of the attribute, written into the
+  ! `Parameters` group of the output file, that marks the parameter as having taken a default value.
+  ! A parameter given explicitly in the parameter file carries no such attribute, so the absence of
+  ! the marker means "set explicitly". The braced form follows the convention already used to
+  ! annotate attribute names in this group (`{id:...}` on a reference target); braces cannot appear
+  ! in a parameter name, which is an XML element name, so the marker cannot collide with one.
+  character(len=*), parameter :: defaultedMarkerSuffix="{defaulted}"
 
   ! Interface to the (auto-generated) knownParameterNames() function.
   interface
@@ -439,11 +452,9 @@ contains
     use :: FoX_dom, only : createDocument, getDocumentElement, getImplementation, setLiveNodeLists
     implicit none
     type (inputParameters)          :: self
-    class(*              ), pointer :: lock_, document_
+    class(*              ), pointer :: document_
 
-    allocate(self%warnedDefaults)
-    allocate(self%lock          )
-    allocate(self%document      )
+    allocate(self%document)
     !$omp critical (FoX_DOM_Access)
     self%document%document => createDocument    (                                  &
          &                                       getImplementation()             , &
@@ -464,21 +475,8 @@ contains
     !![
     </workaround>
     !!]
-    self%parameters     => null              (             )
-    self%warnedDefaults =  integerDictionary (             )
-    self%lock           =  ompLock           (             )
-    !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
-      <description>
-      ICE when passing a derived type component to a class(*) function argument.
-      </description>
-    !!]
-    lock_ => self%lock
-    self%lockManager    =  resourceManager   (     lock_   )
-    !![
-    </workaround>
-    !!]
-    self%isNull         = .true.
+    self%parameters => null()
+    self%isNull     = .true.
    return
   end function inputParametersConstructorNull
 
@@ -764,33 +762,11 @@ contains
     implicit none
     type (inputParameters)                :: self
     type (inputParameters), intent(in   ) :: parameters
-    class(*              ), pointer       :: lock_
 
     self            =  inputParameters(parameters%rootNode  ,noOutput=.true.,noBuild=.true.,documentManager=parameters%documentManager,document=parameters%document)
     self%parameters =>                 parameters%parameters
     self%parent     =>                 parameters%parent
-    self%original   =>                 parameters%original       
-    if (allocated(parameters%warnedDefaults)) then
-       if (allocated(self%warnedDefaults)) deallocate(self%warnedDefaults)
-       allocate(self%warnedDefaults)
-       self%warnedDefaults=parameters%warnedDefaults
-    end if
-    if (associated(parameters%lock)) then
-       call self%lockManager%release()
-       allocate  (self%lock)
-       self%lock=ompLock()
-       !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
-	 <description>
-	 ICE when passing a derived type component to a class(*) function argument.
-	 </description>
-       !!]
-       lock_ => self%lock
-       self%lockManager    =  resourceManager   (     lock_   )
-       !![
-       </workaround>
-       !!]
-    end if
+    self%original   =>                 parameters%original
     return
   end function inputParametersConstructorCopy
 
@@ -851,24 +827,9 @@ contains
     !!]
 #include "os.inc"
 
-    allocate(self%warnedDefaults)
-    allocate(self%lock          )
     self%isNull         =  .false.
     self%rootNode       =>                   parametersNode
     self%parent         => null             (              )
-    self%warnedDefaults =  integerDictionary(              )
-    self%lock           =  ompLock          (              )
-    !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
-      <description>
-      ICE when passing a derived type component to a class(*) function argument.
-      </description>
-    !!]
-    dummyPointer_       => self%lock
-    self%lockManager    =  resourceManager (dummyPointer_ )
-    !![
-    </workaround>
-    !!]
     if (present(documentManager)) then
        if (.not.present(document)) call Error_Report('If `documentManager` is provided, `document` must also be provided'//{introspection:location})
        self%document        => document
@@ -1367,7 +1328,6 @@ contains
     self%parameters                       => from%parameters
     self%parent                           => from%parent
     self%original                         => from%original
-    self%lock                             => from%lock
     self%outputParametersCopied           =  from%outputParametersCopied
     self%outputParametersTemporary        =  from%outputParametersTemporary
     self%isNull                           =  from%isNull
@@ -1375,12 +1335,6 @@ contains
     self%outputParametersManager          =  from%outputParametersManager
     self%outputParametersContainerManager =  from%outputParametersContainerManager
     self%documentManager                  =  from%documentManager
-    self%lockManager                      =  from%lockManager
-    if (allocated(self%warnedDefaults)) deallocate(self%warnedDefaults)
-    if (allocated(from%warnedDefaults)) then
-       allocate(self%warnedDefaults,mold=from%warnedDefaults)
-       self%warnedDefaults=from%warnedDefaults
-    end if
     return
   end subroutine inputParametersAssignment
   
@@ -2320,7 +2274,6 @@ contains
     type            (enumerationInputParameterErrorStatusType), intent(  out), optional :: errorStatus
     integer                                                   , intent(in   ), optional :: copyInstance
     logical                                                   , intent(in   ), optional :: writeOutput   , evaluate
-    type            (inputParameters                         ), pointer                 :: parametersRoot
     type            (inputParameter                          ), pointer                 :: parameterNode
     type            (varying_string                          )                          :: parameterPath
     !![
@@ -2331,23 +2284,35 @@ contains
        parameterNode => self%node(parameterName,copyInstance=copyInstance,writeOutput=writeOutput)
        call self%value(parameterNode,parameterValue,errorStatus,writeOutput,evaluate)
     else if (present(defaultValue)) then
-       parametersRoot => self
-       do while (associated(parametersRoot%parent))
-          parametersRoot => parametersRoot%parent
-       end do
+       ! Report the use of a default value for this parameter, but only the first time that it is
+       ! used. The key must be the full path *including* the parameter name - `path()` returns the
+       ! path of the containing parameters node only, so keying on that alone would cause distinct
+       ! parameters within the same container to collide, suppressing all but the first of them.
        parameterPath=self%path()
-       call parametersRoot%lock%set()
-       if (.not.parametersRoot%warnedDefaults%exists(parameterPath)) then
-          if (mpiSelf%isMaster()) call Warn("Using default value for parameter '["//char(parameterPath)//parameterName//"]'")
-          call parametersRoot%warnedDefaults%set(parameterPath,1)
+       !$omp critical (inputParametersWarnedDefaults)
+       if (.not.warnedDefaultsInitialized) then
+          warnedDefaults           =integerDictionary()
+          warnedDefaultsInitialized=.true.
        end if
-       call parametersRoot%lock%unset()
+       if (.not.warnedDefaults%exists(char(parameterPath)//parameterName)) then
+          if (mpiSelf%isMaster()) call Warn("Using default value for parameter '["//char(parameterPath)//parameterName//"]'")
+          call warnedDefaults%set(char(parameterPath)//parameterName,1)
+       end if
+       !$omp end critical (inputParametersWarnedDefaults)
        parameterValue=defaultValue
        ! Write the parameter file to an HDF5 object.
        if (associated(self%outputParameters)) then
           if (self%outputParameters%isOpen().and.writeOutput_) then
              !$ call hdf5Access%set()
-             if (.not.self%outputParameters%hasAttribute(parameterName)) call self%outputParameters%writeAttribute({Type¦outputConverter¦parameterValue},parameterName)
+             if (.not.self%outputParameters%hasAttribute(parameterName)) then
+                call self%outputParameters%writeAttribute({Type¦outputConverter¦parameterValue},parameterName)
+                ! Mark this parameter as having taken a default value. The marker is written here, at
+                ! the same instant as the value itself, so that it survives a fatal error exactly as
+                ! the value does - `Error_Report` closes the HDF5 library (flushing open files) but
+                ! never calls `Output_HDF5_Close_File`, so anything deferred to output-file closure
+                ! would be lost. Parameters set explicitly carry no marker.
+                call self%outputParameters%writeAttribute(.true.,parameterName//defaultedMarkerSuffix)
+             end if
              !$ call hdf5Access%unset()
           end if
        end if
@@ -2866,31 +2831,5 @@ contains
     return
   end subroutine inputParametersReset
 
-  subroutine inputParametersLockReinitialize(self)
-    !!{RST
-    Reinitialize the OpenMP lock.
-    !!}
-    implicit none
-    class(inputParameters), intent(inout) :: self
-    class(*              ), pointer :: lock_
-    
-    if (associated(self%lock)) then
-       call self%lockManager%release()
-       allocate(self%lock)
-       self%lock=ompLock()
-       !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
-	 <description>
-	 ICE when passing a derived type component to a class(*) function argument.
-	 </description>
-       !!]
-       lock_ => self%lock
-       self%lockManager    =  resourceManager   (     lock_   )
-       !![
-       </workaround>
-       !!]
-    end if
-    return
-  end subroutine inputParametersLockReinitialize
 
 end module Input_Parameters

--- a/testSuite/parameters/defaultParameterReporting.xml
+++ b/testSuite/parameters/defaultParameterReporting.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Changes applied to `parametersExtract.xml` for `test-parameters-default-reporting.py`.       -->
-<!-- The verbosity is raised to `warn` so that reports of the use of default parameter values are -->
-<!-- displayed as they are issued (below that level they are merely accumulated for replay on a   -->
-<!-- fatal error), and the output is directed to a file of its own.                               -->
+<!-- The verbosity is raised to `warn` so that any warning issued would be displayed as it is     -->
+<!-- issued; the test relies on this to show that the use of a default value or class is *not*    -->
+<!-- reported to the terminal. The output is directed to a file of its own.                       -->
 <changes>
 
   <change type="replaceOrAppend" path="verbosityLevel">

--- a/testSuite/parameters/defaultParameterReporting.xml
+++ b/testSuite/parameters/defaultParameterReporting.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Changes applied to `parametersExtract.xml` for `test-parameters-default-reporting.py`.       -->
+<!-- The verbosity is raised to `warn` so that reports of the use of default parameter values are -->
+<!-- displayed as they are issued (below that level they are merely accumulated for replay on a   -->
+<!-- fatal error), and the output is directed to a file of its own.                               -->
+<changes>
+
+  <change type="replaceOrAppend" path="verbosityLevel">
+    <verbosityLevel value="warn"/>
+  </change>
+
+  <change type="replaceOrAppend" path="outputFileName">
+    <outputFileName value="testSuite/outputs/defaultParameterReporting.hdf5"/>
+  </change>
+
+</changes>

--- a/testSuite/parameters/strictOutdated.xml
+++ b/testSuite/parameters/strictOutdated.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- A parameter file with an outdated revision and no strict compliance requested -->
+<!-- A parameter file with an outdated revision and strict compliance requested    -->
 
 <!-- 02-December-2025                                                              -->
 
 <parameters>
-  <lastModified revision="262562000c251ee5b935019673f606a8a8c47c10" time="2026-07-28T17:29:21"/>
+  <lastModified revision="262562000c251ee5b935019673f606a8a8c47c10" time="2026-07-28T17:29:21" strict="true"/>
   <formatVersion>2</formatVersion>
 
   <!-- Component selection -->

--- a/testSuite/test-parameters-default-reporting.py
+++ b/testSuite/test-parameters-default-reporting.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Test the reporting of parameters which take default values (issue #1353).
+
+Two properties are pinned here, corresponding to the two defects that this test
+was written alongside the fix for. They partly masked one another, so both must
+be checked:
+
+  * Each defaulted parameter is reported *exactly once*, however many threads the
+    model runs on. The record of which parameters have already been reported is
+    shared, rather than being deep-copied into the per-thread copies of the
+    parameter set - were it copied, each thread would re-report parameters that
+    another thread had already reported, and the message count would scale with
+    the thread count. The model is therefore run multi-threaded here; on a single
+    thread this check could not fail.
+
+  * Parameters which share a container are reported *separately*. The record is
+    keyed on the full parameter path including the parameter name; were it keyed
+    on the containing node's path alone, all but the first parameter defaulted
+    within any one container would be silently suppressed.
+
+The marking of defaulted parameters in the output file's `Parameters` group is
+also checked: a parameter which took a default value carries a companion
+attribute named for it plus the `{defaulted}` suffix, and one given explicitly in
+the parameter file carries no such attribute.
+
+Andrew Benson
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+import h5py
+
+# The suffix marking a defaulted parameter in the output file. This must match
+# `defaultedMarkerSuffix` in `source/utility/input_parameters.F90`.
+defaultedMarkerSuffix = "{defaulted}"
+
+parameterFile = "testSuite/parameters/parametersExtract.xml"
+changeFile    = "testSuite/parameters/defaultParameterReporting.xml"
+outputFile    = "outputs/defaultParameterReporting.hdf5"
+logFileName   = "outputs/test-parameters-default-reporting.log"
+
+subprocess.run("mkdir -p outputs",shell=True)
+subprocess.run(f"rm -f {outputFile}",shell=True)
+
+failed = False
+
+# Run the model on several threads. The thread count matters: the duplicate
+# reporting this test guards against was produced by the per-thread copies of the
+# parameter set, so it is invisible on a single thread.
+print("Running model...")
+process = subprocess.run(
+    "export OMP_NUM_THREADS=4; cd ..; "
+    f"./Galacticus.exe {parameterFile} {changeFile}",
+    shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    universal_newlines=True,
+)
+output = process.stdout or ""
+with open(logFileName,"w") as logFile:
+    logFile.write(output)
+print("...done")
+
+if process.returncode != 0:
+    print(f"FAILED: model did not run to completion (return code {process.returncode}) - see {logFileName}")
+    failed = True
+
+# Collect the reported parameters. The message names the parameter by its full
+# path, in brackets.
+reported = re.findall(r"Using default value for parameter '\[([^\]]+)\]'",output)
+
+if not failed and len(reported) == 0:
+    print("FAILED: no default parameter values were reported - the test model is expected to default many parameters")
+    failed = True
+
+# Each parameter must be reported exactly once.
+if not failed:
+    repeated = sorted({parameter for parameter in reported if reported.count(parameter) > 1})
+    if repeated:
+        print(f"FAILED: {len(repeated)} parameters were reported more than once; the record of already-reported parameters is not being shared between copies of the parameter set. First few: {repeated[:5]}")
+        failed = True
+    else:
+        print(f"SUCCESS: each of the {len(reported)} defaulted parameters was reported exactly once")
+
+# Parameters sharing a container must be reported separately. Split each reported
+# path into its containing path and the parameter name, and require that at least
+# one container contributes more than one parameter - which cannot happen if the
+# containing path alone is used to identify a parameter.
+if not failed:
+    containers = {}
+    for parameter in reported:
+        container,_,name = parameter.rpartition("/")
+        containers.setdefault(container,[]).append(name)
+    shared = {container: names for container,names in containers.items() if len(names) > 1}
+    if shared:
+        print(f"SUCCESS: parameters sharing a container are reported separately ({len(shared)} containers report more than one parameter)")
+    else:
+        print("FAILED: no container reported more than one parameter, which suggests that parameters sharing a container are colliding and all but the first are being suppressed")
+        failed = True
+
+# Check the marking of defaulted parameters in the output file.
+if not failed:
+    if not os.path.exists(outputFile):
+        print(f"FAILED: output file {outputFile} was not produced")
+        failed = True
+
+if not failed:
+    with h5py.File(outputFile,"r") as outputFileHDF5:
+        parameters = outputFileHDF5["Parameters"]
+
+        # Every marker must annotate a parameter which is itself present.
+        markerCount = 0
+        orphaned    = []
+
+        def checkGroup(name,node):
+            global markerCount
+            if not isinstance(node,h5py.Group):
+                return
+            for attributeName in node.attrs.keys():
+                if attributeName.endswith(defaultedMarkerSuffix):
+                    markerCount += 1
+                    marked = attributeName[:-len(defaultedMarkerSuffix)]
+                    if marked not in node.attrs:
+                        orphaned.append(f"{name}/{attributeName}")
+
+        checkGroup("parameters",parameters)
+        parameters.visititems(checkGroup)
+
+        if markerCount == 0:
+            print("FAILED: no defaulted parameters were marked in the output file's `Parameters` group")
+            failed = True
+        elif orphaned:
+            print(f"FAILED: {len(orphaned)} defaulted markers annotate no parameter of their own. First few: {orphaned[:5]}")
+            failed = True
+        else:
+            print(f"SUCCESS: {markerCount} defaulted parameters are marked in the output file")
+
+        # A parameter given explicitly in the parameter file must carry no marker.
+        explicit = "componentBasic"
+        if explicit not in parameters.attrs:
+            print(f"FAILED: expected parameter `{explicit}` is absent from the output file, so the marking of explicitly-set parameters cannot be checked")
+            failed = True
+        elif explicit+defaultedMarkerSuffix in parameters.attrs:
+            print(f"FAILED: parameter `{explicit}` is set explicitly in the parameter file but is marked as having taken a default value")
+            failed = True
+        else:
+            print(f"SUCCESS: explicitly-set parameter `{explicit}` carries no defaulted marker")
+
+# Failure is signaled by the text above, not by the exit status.
+if failed:
+    print("FAILED: default parameter reporting")
+else:
+    print("SUCCESS: default parameter reporting")
+sys.exit(0)

--- a/testSuite/test-parameters-default-reporting.py
+++ b/testSuite/test-parameters-default-reporting.py
@@ -1,27 +1,24 @@
 #!/usr/bin/env python3
-"""Test the reporting of parameters which take default values (issue #1353).
+"""Test the recording of parameters which take default values (issue #1353).
 
-Two properties are pinned here, corresponding to the two defects that this test
-was written alongside the fix for. They partly masked one another, so both must
-be checked:
+Galacticus does not report the use of a default to the terminal. Defaulting is
+an extremely common idiom - a small model defaults of order a hundred parameters
+and as many classes - so reporting each one swamped the bounded list of warnings
+that `Error_Report` replays on a fatal error, crowding genuine warnings out of it
+entirely. The information is recorded in the output file instead, where each
+defaulted parameter carries a companion attribute named for it plus the
+`{defaulted}` suffix.
 
-  * Each defaulted parameter is reported *exactly once*, however many threads the
-    model runs on. The record of which parameters have already been reported is
-    shared, rather than being deep-copied into the per-thread copies of the
-    parameter set - were it copied, each thread would re-report parameters that
-    another thread had already reported, and the message count would scale with
-    the thread count. The model is therefore run multi-threaded here; on a single
-    thread this check could not fail.
+This test pins that contract from both sides:
 
-  * Parameters which share a container are reported *separately*. The record is
-    keyed on the full parameter path including the parameter name; were it keyed
-    on the containing node's path alone, all but the first parameter defaulted
-    within any one container would be silently suppressed.
-
-The marking of defaulted parameters in the output file's `Parameters` group is
-also checked: a parameter which took a default value carries a companion
-attribute named for it plus the `{defaulted}` suffix, and one given explicitly in
-the parameter file carries no such attribute.
+  * No default-related message appears on the terminal, even at `warn` verbosity.
+  * Both kinds of default are marked in the output file - a parameter whose
+    *value* was defaulted, and a `functionClass` parameter whose *class* was not
+    specified and so was built from its default.
+  * A parameter given explicitly in the parameter file is not marked, so the
+    absence of a marker means the value came from the user.
+  * Every marker annotates a parameter which is itself present, and the set of
+    markers does not depend on the number of threads.
 
 Andrew Benson
 """
@@ -43,113 +40,138 @@ outputFile    = "outputs/defaultParameterReporting.hdf5"
 logFileName   = "outputs/test-parameters-default-reporting.log"
 
 subprocess.run("mkdir -p outputs",shell=True)
-subprocess.run(f"rm -f {outputFile}",shell=True)
 
 failed = False
 
-# Run the model on several threads. The thread count matters: the duplicate
-# reporting this test guards against was produced by the per-thread copies of the
-# parameter set, so it is invisible on a single thread.
+
+def runModel(threadCount):
+    """Run the model on the given number of threads, returning its output."""
+    subprocess.run(f"rm -f {outputFile}",shell=True)
+    process = subprocess.run(
+        f"export OMP_NUM_THREADS={threadCount}; cd ..; "
+        f"./Galacticus.exe {parameterFile} {changeFile}",
+        shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+    return process.returncode, process.stdout or ""
+
+
+def readMarkers():
+    """Return {group: (values, markers)} for the output file's Parameters group."""
+    groups = {}
+
+    def visit(name,node):
+        if not isinstance(node,h5py.Group):
+            return
+        values  = set()
+        markers = set()
+        for attributeName in node.attrs.keys():
+            if attributeName.endswith(defaultedMarkerSuffix):
+                markers.add(attributeName[:-len(defaultedMarkerSuffix)])
+            else:
+                values.add(attributeName)
+        groups[name] = (values,markers)
+
+    with h5py.File(outputFile,"r") as outputFileHDF5:
+        parameters = outputFileHDF5["Parameters"]
+        visit("parameters",parameters)
+        parameters.visititems(visit)
+    return groups
+
+
+# Run the model. The thread count matters: the record of defaulted parameters is
+# shared rather than copied per thread, so a per-thread copy must not be able to
+# change what is recorded.
 print("Running model...")
-process = subprocess.run(
-    "export OMP_NUM_THREADS=4; cd ..; "
-    f"./Galacticus.exe {parameterFile} {changeFile}",
-    shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-    universal_newlines=True,
-)
-output = process.stdout or ""
+returnCode,output = runModel(4)
 with open(logFileName,"w") as logFile:
     logFile.write(output)
 print("...done")
 
-if process.returncode != 0:
-    print(f"FAILED: model did not run to completion (return code {process.returncode}) - see {logFileName}")
+if returnCode != 0:
+    print(f"FAILED: model did not run to completion (return code {returnCode}) - see {logFileName}")
     failed = True
 
-# Collect the reported parameters. The message names the parameter by its full
-# path, in brackets.
-reported = re.findall(r"Using default value for parameter '\[([^\]]+)\]'",output)
+# No default-related message may be emitted, even at `warn` verbosity.
+if not failed:
+    stray = re.findall(r"Using default (?:value|class) for parameter '\[[^\]]+\]'",output)
+    if stray:
+        print(f"FAILED: {len(stray)} default-related messages were emitted to the terminal; these are recorded in the output file and must not be reported as warnings")
+        failed = True
+    else:
+        print("SUCCESS: no default-related messages were emitted to the terminal")
 
-if not failed and len(reported) == 0:
-    print("FAILED: no default parameter values were reported - the test model is expected to default many parameters")
+if not failed and not os.path.exists(outputFile):
+    print(f"FAILED: output file {outputFile} was not produced")
     failed = True
 
-# Each parameter must be reported exactly once.
 if not failed:
-    repeated = sorted({parameter for parameter in reported if reported.count(parameter) > 1})
-    if repeated:
-        print(f"FAILED: {len(repeated)} parameters were reported more than once; the record of already-reported parameters is not being shared between copies of the parameter set. First few: {repeated[:5]}")
+    groups = readMarkers()
+
+    # Every marker must annotate a parameter which is itself present.
+    markerCount = sum(len(markers) for _,markers in groups.values())
+    orphaned    = [f"{group}/{marker}"
+                   for group,(values,markers) in groups.items()
+                   for marker in markers if marker not in values]
+    if markerCount == 0:
+        print("FAILED: no defaulted parameters were marked in the output file's `Parameters` group")
+        failed = True
+    elif orphaned:
+        print(f"FAILED: {len(orphaned)} markers annotate no parameter of their own. First few: {orphaned[:5]}")
         failed = True
     else:
-        print(f"SUCCESS: each of the {len(reported)} defaulted parameters was reported exactly once")
+        print(f"SUCCESS: {markerCount} defaulted parameters are marked, each annotating a parameter that is present")
 
-# Parameters sharing a container must be reported separately. Split each reported
-# path into its containing path and the parameter name, and require that at least
-# one container contributes more than one parameter - which cannot happen if the
-# containing path alone is used to identify a parameter.
+# A defaulted *class* must be marked. `linearGrowth` is not specified in the
+# parameter file, so its class is built from the default - the same default that
+# `test-parameters-extract.py` checks appears in an extracted parameter file.
 if not failed:
-    containers = {}
-    for parameter in reported:
-        container,_,name = parameter.rpartition("/")
-        containers.setdefault(container,[]).append(name)
-    shared = {container: names for container,names in containers.items() if len(names) > 1}
-    if shared:
-        print(f"SUCCESS: parameters sharing a container are reported separately ({len(shared)} containers report more than one parameter)")
+    topLevelValues,topLevelMarkers = groups["parameters"]
+    defaultedClass = "linearGrowth"
+    if defaultedClass not in topLevelValues:
+        print(f"FAILED: expected defaulted class `{defaultedClass}` is absent from the output file")
+        failed = True
+    elif defaultedClass not in topLevelMarkers:
+        print(f"FAILED: class `{defaultedClass}` was built from its default but is not marked as defaulted")
+        failed = True
     else:
-        print("FAILED: no container reported more than one parameter, which suggests that parameters sharing a container are colliding and all but the first are being suppressed")
-        failed = True
+        print(f"SUCCESS: defaulted class `{defaultedClass}` is marked in the output file")
 
-# Check the marking of defaulted parameters in the output file.
+# A parameter given explicitly in the parameter file must carry no marker.
 if not failed:
-    if not os.path.exists(outputFile):
-        print(f"FAILED: output file {outputFile} was not produced")
+    explicit = "componentBasic"
+    if explicit not in topLevelValues:
+        print(f"FAILED: expected parameter `{explicit}` is absent from the output file, so the marking of explicitly-set parameters cannot be checked")
         failed = True
+    elif explicit in topLevelMarkers:
+        print(f"FAILED: parameter `{explicit}` is set explicitly in the parameter file but is marked as having taken a default value")
+        failed = True
+    else:
+        print(f"SUCCESS: explicitly-set parameter `{explicit}` carries no defaulted marker")
 
+# The set of markers must not depend on the thread count.
 if not failed:
-    with h5py.File(outputFile,"r") as outputFileHDF5:
-        parameters = outputFileHDF5["Parameters"]
-
-        # Every marker must annotate a parameter which is itself present.
-        markerCount = 0
-        orphaned    = []
-
-        def checkGroup(name,node):
-            global markerCount
-            if not isinstance(node,h5py.Group):
-                return
-            for attributeName in node.attrs.keys():
-                if attributeName.endswith(defaultedMarkerSuffix):
-                    markerCount += 1
-                    marked = attributeName[:-len(defaultedMarkerSuffix)]
-                    if marked not in node.attrs:
-                        orphaned.append(f"{name}/{attributeName}")
-
-        checkGroup("parameters",parameters)
-        parameters.visititems(checkGroup)
-
-        if markerCount == 0:
-            print("FAILED: no defaulted parameters were marked in the output file's `Parameters` group")
-            failed = True
-        elif orphaned:
-            print(f"FAILED: {len(orphaned)} defaulted markers annotate no parameter of their own. First few: {orphaned[:5]}")
-            failed = True
+    markersMultiThreaded = {(group,marker)
+                            for group,(_,markers) in groups.items()
+                            for marker in markers}
+    returnCodeSingle,_ = runModel(1)
+    if returnCodeSingle != 0:
+        print(f"FAILED: single-threaded model did not run to completion (return code {returnCodeSingle})")
+        failed = True
+    else:
+        markersSingleThreaded = {(group,marker)
+                                 for group,(_,markers) in readMarkers().items()
+                                 for marker in markers}
+        if markersSingleThreaded == markersMultiThreaded:
+            print(f"SUCCESS: the {len(markersMultiThreaded)} markers are identical on 1 and 4 threads")
         else:
-            print(f"SUCCESS: {markerCount} defaulted parameters are marked in the output file")
-
-        # A parameter given explicitly in the parameter file must carry no marker.
-        explicit = "componentBasic"
-        if explicit not in parameters.attrs:
-            print(f"FAILED: expected parameter `{explicit}` is absent from the output file, so the marking of explicitly-set parameters cannot be checked")
+            difference = markersSingleThreaded ^ markersMultiThreaded
+            print(f"FAILED: the markers differ between 1 and 4 threads ({len(difference)} differences). First few: {sorted(difference)[:5]}")
             failed = True
-        elif explicit+defaultedMarkerSuffix in parameters.attrs:
-            print(f"FAILED: parameter `{explicit}` is set explicitly in the parameter file but is marked as having taken a default value")
-            failed = True
-        else:
-            print(f"SUCCESS: explicitly-set parameter `{explicit}` carries no defaulted marker")
 
 # Failure is signaled by the text above, not by the exit status.
 if failed:
-    print("FAILED: default parameter reporting")
+    print("FAILED: default parameter recording")
 else:
-    print("SUCCESS: default parameter reporting")
+    print("SUCCESS: default parameter recording")
 sys.exit(0)


### PR DESCRIPTION
Addresses items 3 and 5 of #1353, plus two defects and a broken test found along the way.

### Reports of defaulted parameters were both duplicated and suppressed

Two defects in the deduplication partly masked one another. The record of already-reported parameters was deep-copied into every copy of a parameter set, so each per-thread copy re-reported what another had already reported; and the record was keyed on `path()`, which returns the path of the *containing* node, so parameters sharing a container collided and all but the first were silently dropped.

Measured on `parameters/quickTest.xml` at `verbosityLevel="warn"`:

| | 2 threads | 20 threads |
| --- | --- | --- |
| Before | 60 messages / 52 distinct | 204 messages / 52 distinct |
| After | 168 / 168 | 168 / 168 |

The volume no longer varies with thread count, and the rise in distinct parameters is the 116 reports the key collision had been suppressing.

### The warning replay contained no warnings

With the duplication fixed, ~208 default-related messages remained against the 100-message cap on the replay `Error_Report` performs. Interrupting a run showed the replay to be **entirely** default-related noise - 86 "default value" plus 14 "default class" - with a further 109 warnings issued but not recorded. Because the budget is claimed during start-up, no genuine warning issued during evolution could ever reach the replay.

Both messages are therefore retired. The information moves to the output file: parameters whose *value* was defaulted were already recorded there and are now marked, and `functionClass` parameters whose *class* was defaulted are marked the same way via a new `markDefaulted` method emitted by the object builder. The same interrupted run now reports no warnings at all.

Marking is written at the point of defaulting rather than at file closure, because `Error_Report` closes the HDF5 library without calling `Output_HDF5_Close_File`, so anything deferred would be lost on a fatal error - which is exactly when it is wanted.

### `Error_Report` messages must carry their location

15 call sites built a message from a string literal and appended no `{introspection:location}`, leaving only a backtrace into the preprocessed sources. `staticAnalyzer.py` gains a check for this and the sites are fixed; the check reports nothing anywhere in `source/`, so it cannot fail a PR that happens to touch an unrelated file. Mirrored into the `gitHooks` pre-commit hook (galacticusorg/gitHooks@0666e73) so it is caught before the commit is made - **that commit needs pushing for the pre-commit half to take effect**.

Two judgements make it usable here: only literal-built messages are checked, since a bare variable may have had the location appended where it was assigned; and the checks apply to the call's parsed argument list rather than the rest of the line, so an apostrophe in a trailing comment cannot defeat the exemption.

### Class-mismatch errors now name both classes

97 sites reported a bare `incorrect class`, naming neither the expected nor the received class. `objectType` is generated for every `functionClass` but was not declared on `functionClass` itself, so it could only be reached through a specific-class reference. Declaring it on the base class turns all 192 generated implementations into overrides and makes the name reachable through any `class(functionClass)` reference - which matters because the selector is `class(*)` at 55 of these sites. Those gate on `class is (functionClass)` before `class default`, which remains as the genuine catch-all.

11 sites in `radiative_transfer/matter/atomic.F90` name the expected class only: their selector is `radiativeTransferPropertiesMatter`, a standalone abstract type with no `objectType`. Which selectors derive from `functionClass` was determined by walking the type hierarchy rather than assumed.

### `HELP:` hints on the errors users actually hit

Eight hints, each checked by triggering the error rather than only by compiling it. The dataset wording follows the troubleshooting guide, which documents this failure under `Unable to find data file "./static/foo/bar.xml"`; the `./` prefix is the diagnostic, appearing exactly when `GALACTICUS_DATA_PATH` is unset. Three of the four dataset sites did not name the file at all, which left that advice unusable.

Running `quickTest.xml` with the variable unset - the first dataset it reads - now reports:

```
Unable to find data file "./static/darkMatter/Halo_Mass_Function_Parameters_Tinker_2008.xml"
HELP: this file is provided by the Galacticus datasets repository. If the path above begins
with "./" then the `GALACTICUS_DATA_PATH` environment variable is not set; ...
```

### Two defects and a broken test found along the way

* `path()` walked the tree upwards while *appending*, so it built paths in reverse, reporting `b/a/` for a node `a` containing `b`. Safe to fix here because retiring the two messages left it with a single consumer.
* The per-object `ompLock` on `inputParameters` existed solely to guard the record of reported parameters; with that record shared it is unused, and is removed along with `lockReinitialize` and the `deepCopyActions` directive whose only action was to reinitialize it.
* `strictOutdated.xml` carried no `strict="true"`, so `test-strict-parameters.py` had been reporting `FAIL: model strictOutdated succeeded`. The attribute was lost when the element - originally misspelled `lastModifieds`, and so never read at all - was corrected in f7112e31c.

### Verification

Full build clean; `quickTest`; 919 Python unit tests; `test-parameters-default-reporting.py` (new, registered in `cicd.yml`), `test-parameters-extract.py`, `test-parameters-changes.py`, `test-parameters-diff.py`, `test-strict-parameters.py`, `test-branchSubsampling.py`, `test-constrained-merger-trees.py`; the analyzer over every changed file.

Not verified locally, and wanted from CI:

* the MPI-only radiative-transfer test, which exercises `atomic.F90` where 11 class-message edits were made;
* the wider model regression suite - roughly eight of ~79 scripts were run;
* Spell-Check-RST over the new message and comment prose;
* the `libmatheval` hint, which needs a build without `MATHEVALAVAIL`;
* the empty-path branch of the missing-parameter hint - the classes with required top-level parameters are built lazily, so a model completes rather than reaching it.

Note that `test-strict-parameters.py` adds its two `*Outdated` models only when the executable reports `GIT2AVAIL`, so CI - whose build lacks libgit2 - skips them. The fixture fix above therefore still gets no CI coverage; those paths are exercised only by a local run.

### Follow-ups

#1377 records a separate, wider gap found while marking defaults: parameters read during node-component *thread* initialization never reach the output file, because thread initialization runs against a copy created with `noOutput=.true.`. User-supplied values are lost too, which makes `parametersExtract.py` silently produce a parameter file that runs different physics from the one that produced it.

Items 1, 2, 4, 6 and 7 of #1353 remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
