### PR TITLE
Raise the COZMIC WDM X8 tree counts

### DIFF
--- a/testSuite/parameters/validate_darkMatterOnlySubhalos_COZMIC_resolutionX8_WDM:4keV.xml
+++ b/testSuite/parameters/validate_darkMatterOnlySubhalos_COZMIC_resolutionX8_WDM:4keV.xml
@@ -6,8 +6,11 @@
   <!-- Set the host halo masses. The replication count is higher than for the other COZMIC WDM models: with 2 host halos and
        12 replications (24 trees) the model occasionally produced no subhalo at all in the massRatio=0.136 bin, where the target
        contains a single (LMC analog) subhalo, which makes the subhaloMassFunction likelihood impossible. 32 replications (64
-       trees) reduces the rate of that to a negligible level. -->
-  <change type="update" path="mergerTreeBuildMasses/replicationCount" value="32"/>
+       trees) reduced the rate of that, but not far enough: pooled over the published history the model places 114 subhalos in
+       that bin across 34 runs of 64 trees, a rate of 0.051 per tree, leaving a 4% chance of an empty bin on any given run. This
+       is the lowest rate of any of the COZMIC WDM models at this resolution, so it needs the most trees of any of them: 96
+       replications (192 trees) bring the chance of an empty bin to 5e-05. -->
+  <change type="update" path="mergerTreeBuildMasses/replicationCount" value="96"/>
   <change type="update" path="mergerTreeBuildMasses/mergerTreeBuildMasses/fileName" value="%DATASTATICPATH%/darkMatter/COZMIC/MilkyWay/resolutionX8/WDM:4keV/hostHaloMasses_z0.000.hdf5"/>
   <!-- Set a suitable name for the output file. -->
   <change type="update" path="outputFileName" value="testSuite/outputs/validate_darkMatterOnlySubhalos_COZMIC_MilkyWay_resolutionX8_WDM:4keV.hdf5"/>

--- a/testSuite/parameters/validate_darkMatterOnlySubhalos_COZMIC_resolutionX8_WDM:5keV.xml
+++ b/testSuite/parameters/validate_darkMatterOnlySubhalos_COZMIC_resolutionX8_WDM:5keV.xml
@@ -3,8 +3,13 @@
 <changes>
   <!-- Set the WDM particle mass. -->
   <change type="update" path="darkMatterParticle/mass" value="5.0"/>
-  <!-- Set the host halo masses -->
-  <change type="update" path="mergerTreeBuildMasses/replicationCount" value="16"/>
+  <!-- Set the host halo masses. As for the 3keV, 4keV and 6keV models, the replication count is raised above the value used for
+       the other COZMIC WDM models: with 2 host halos and 16 replications (32 trees) the model can produce no subhalo at all in
+       the massRatio=0.136 bin, where the target contains a single (LMC analog) subhalo, which makes the subhaloMassFunction
+       likelihood impossible. Pooled over the published history the model places 196 subhalos in that bin across 84 runs of 32
+       trees, a rate of 0.073 per tree, leaving a 10% chance of an empty bin on any given run. 64 replications (128 trees) bring
+       that to 9e-05. -->
+  <change type="update" path="mergerTreeBuildMasses/replicationCount" value="64"/>
   <change type="update" path="mergerTreeBuildMasses/mergerTreeBuildMasses/fileName" value="%DATASTATICPATH%/darkMatter/COZMIC/MilkyWay/resolutionX8/WDM:5keV/hostHaloMasses_z0.000.hdf5"/>
   <!-- Set a suitable name for the output file. -->
   <change type="update" path="outputFileName" value="testSuite/outputs/validate_darkMatterOnlySubhalos_COZMIC_MilkyWay_resolutionX8_WDM:5keV.hdf5"/>

--- a/testSuite/parameters/validate_darkMatterOnlySubhalos_COZMIC_resolutionX8_WDM:6.5keV.xml
+++ b/testSuite/parameters/validate_darkMatterOnlySubhalos_COZMIC_resolutionX8_WDM:6.5keV.xml
@@ -3,8 +3,14 @@
 <changes>
   <!-- Set the WDM particle mass. -->
   <change type="update" path="darkMatterParticle/mass" value="6.5"/>
-  <!-- Set the host halo masses -->
-  <change type="update" path="mergerTreeBuildMasses/replicationCount" value="4"/>
+  <!-- Set the host halo masses. As for the 3keV, 4keV, 5keV and 6keV models, the replication count is raised above the value
+       used for the other COZMIC WDM models: with 2 host halos and 4 replications (8 trees) the model can produce no subhalo at
+       all in the massRatio=0.136 bin, where the target contains a single (LMC analog) subhalo, which makes the
+       subhaloMassFunction likelihood impossible. Pooled over the published history the model places 84 subhalos in that bin
+       across 84 runs of 8 trees, a rate of 0.125 per tree - the highest of any of these models, and so the one needing the
+       fewest trees - but with only 8 trees that still leaves a 37% chance of an empty bin on any given run. It has not yet come
+       up empty, which is luck rather than margin. 48 replications (96 trees) bring that to 6e-06. -->
+  <change type="update" path="mergerTreeBuildMasses/replicationCount" value="48"/>
   <change type="update" path="mergerTreeBuildMasses/mergerTreeBuildMasses/fileName" value="%DATASTATICPATH%/darkMatter/COZMIC/MilkyWay/resolutionX8/WDM:6.5keV/hostHaloMasses_z0.000.hdf5"/>
   <!-- Set a suitable name for the output file. -->
   <change type="update" path="outputFileName" value="testSuite/outputs/validate_darkMatterOnlySubhalos_COZMIC_MilkyWay_resolutionX8_WDM:6.5keV.hdf5"/>

--- a/testSuite/parameters/validate_darkMatterOnlySubhalos_COZMIC_resolutionX8_WDM:6keV.xml
+++ b/testSuite/parameters/validate_darkMatterOnlySubhalos_COZMIC_resolutionX8_WDM:6keV.xml
@@ -3,8 +3,15 @@
 <changes>
   <!-- Set the WDM particle mass. -->
   <change type="update" path="darkMatterParticle/mass" value="6.0"/>
-  <!-- Set the host halo masses -->
-  <change type="update" path="mergerTreeBuildMasses/replicationCount" value="12"/>
+  <!-- Set the host halo masses. As for the 3keV and 4keV models, the replication count is raised above the value used for the
+       other COZMIC WDM models, here because of the subhaloRadialDistribution analysis rather than the subhaloMassFunction: with
+       2 host halos and 12 replications (24 trees) the model can produce no subhalo at all in the r/rvir=0.032 bin, where the
+       target contains one, which makes that likelihood impossible. Across the seven runs of 2026-08-03 to 2026-08-13 the model
+       placed 53 subhalos in that bin over 168 trees, a rate of 0.32 per tree; the merger tree branching changes of #1368 then
+       reduced the inner radial bins by a factor of 0.36, leaving 0.11 per tree and so a 6% chance of an empty bin on any given
+       run - which is what happened on 2026-08-14. 64 replications (128 trees) reduce that to a negligible level, and leave it
+       negligible even if that rate is overestimated by a factor of two. -->
+  <change type="update" path="mergerTreeBuildMasses/replicationCount" value="64"/>
   <change type="update" path="mergerTreeBuildMasses/mergerTreeBuildMasses/fileName" value="%DATASTATICPATH%/darkMatter/COZMIC/MilkyWay/resolutionX8/WDM:6keV/hostHaloMasses_z0.000.hdf5"/>
   <!-- Set a suitable name for the output file. -->
   <change type="update" path="outputFileName" value="testSuite/outputs/validate_darkMatterOnlySubhalos_COZMIC_MilkyWay_resolutionX8_WDM:6keV.hdf5"/>


### PR DESCRIPTION
The 2026-08-14 validation run returned an impossible likelihood for `darkMatterOnlySubhalosCOZMICWDM6keVMilkyWayX8 / subhaloRadialDistribution`. The model placed no subhalo at all in the `r/rvir = 0.032` bin, where the target holds one, and `source/output/analyses/subhalo_radial_distribution.F90:681` returns `logImpossible` for exactly that configuration — a negative binomial with zero mean makes a nonzero observed count strictly impossible. That is the analysis behaving correctly, not a numerical failure.

Investigating it showed the same exposure across every COZMIC WDM model at this resolution, so all four under-sampled models are raised here.

## The two sparse bins

**`subhaloRadialDistribution`, `r/rvir = 0.032` — 6keV only.** Over the seven runs of 2026-08-03 to 2026-08-13 the model placed 53 subhalos there across 168 trees, 0.32 per tree. The merger tree branching changes of #1368 then reduced the inner radial bins by a factor of 0.36, leaving 0.11 per tree and a 6% chance of an empty bin at 24 trees. On 2026-08-14 it came up.

**`subhaloMassFunction`, `massRatio = 0.136` (LMC analog) — all models.** This is the bin the existing 3keV and 4keV comments are about. Pooling its occupancy over the full published history of each model, accounting for the tree count in force at each run:

| model | trees | runs | subhalos | per tree | P(empty) | → trees | P(empty) |
|---|---|---|---|---|---|---|---|
| 3keV | 128 | 8 | 109 | 0.106 | 1.3e-06 | — | unchanged |
| **4keV** | 64 | 34 | 114 | 0.051 | **3.7e-02** | **192** | 5.2e-05 |
| **5keV** | 32 | 84 | 196 | 0.073 | **9.7e-02** | **128** | 8.9e-05 |
| **6keV** | 24 | 84 | 143 | 0.071 | **1.8e-01** | **128** | 1.1e-04 |
| **6.5keV** | 8 | 84 | 84 | 0.125 | **3.7e-01** | **96** | 6.1e-06 |
| 10keV | 128 | 84 | 707 | 0.066 | 2.2e-04 | — | unchanged |

Each is sized for a chance below 1e-04. 4keV needs the most trees despite already having the second most, because its rate is the lowest. 6.5keV has never actually come up empty, which at a 37% rate is luck rather than margin.

## CI cost

#1368's tabulation reuse made these models substantially cheaper — the 3keV X8 job fell from 102.5 to 36.9 minutes at an unchanged 128 trees — so there is more headroom than there was. Separating the fixed cost of each job from its per-tree cost gives projections of 60–100 minutes, against the 125 minutes the 10keV model of the same resolution already takes and the 257 minutes of the decaying dark matter job that sets the critical path. Validation jobs run in parallel, so the wall clock of the suite is unchanged.

## Verification

- All four files parse; `replicationCount` reads back as 96 / 64 / 64 / 48
- All pre-commit hooks pass, including `01-claude-review`

## Follow-up

More trees shrink the model sampling error, which raises chi-square for the binned-mean analyses — 3keV X8's `subhaloVelocityMaximumMean` fell 7× after #1351 for exactly this reason. All twelve analyses across these four models will settle at new levels, and their dashboard thresholds will need re-anchoring once those levels are known. None of them is currently warning or failing, so nothing is being left broken in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
