### PR TITLE
Add source formatters for module use and variable declaration blocks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -149,6 +149,39 @@ change that.
   surrounding style. (See
   [`docs/manuals/developer-guide/editor-setup.rst`](../docs/manuals/developer-guide/editor-setup.rst)
   and [`coding.rst`](../docs/manuals/developer-guide/coding.rst).)
+- **Do run `scripts/aux/formatModuleUses.py` after any change that touches a
+  `use` block** — adding, removing, or renaming an imported symbol, or adding a
+  `use` statement. Unlike the whole-file formatters above it is Galacticus-aware
+  and safe: it rewrites only `use` blocks and leaves the rest of the file, the
+  embedded directive blocks included, byte for byte unchanged.
+  ```bash
+  ./scripts/aux/formatModuleUses.py source/path/to/file.F90   # writes file.F90~ backup
+  ./scripts/aux/formatModuleUses.py source/path/to/file.F90 --check   # exit 1 if it would change
+  ```
+  It aligns `use`/`::`/`, only :`, puts at most four symbols per row (fewer to
+  stay within 132 columns), and aligns the symbol columns across the block —
+  conventions that are tedious to reproduce by hand and easy to get subtly
+  wrong. Note it also sorts symbols alphabetically and merges repeated `use`
+  statements for the same module, so expect more than alignment to change in a
+  file that has not been formatted before. The tool refuses to write if the file
+  does not round-trip exactly or if the reformat would alter which symbols are
+  imported.
+- **Likewise run `scripts/aux/formatDeclarations.py` after any change to a
+  variable declaration block** — adding or removing a variable, changing a type,
+  attribute, or initializer. Same options (`--check`, `--no-backup`, `--suffix`)
+  and the same refuse-to-write safety checks, against the declarations rather
+  than the imports.
+  ```bash
+  ./scripts/aux/formatDeclarations.py source/path/to/file.F90
+  ```
+  It aligns the intrinsic type, its parenthetical, the attribute columns, the
+  `::`, and up to two variables per row with their `=`/`=>` initializers —
+  spanning comments and `#ifdef` guards. It also reorders attributes into the
+  canonical order (`intent`, `pointer`, `allocatable`, `dimension`, `target`,
+  `optional`, …) and splits declarations of more than two variables across rows,
+  so expect more than alignment to change in a file not formatted before. It
+  skips vendored code under `source/external/`, and leaves declarations with
+  hand-wrapped oversized initializers exactly as written.
 
 ## Spelling
 

--- a/aux/words.dict
+++ b/aux/words.dict
@@ -995,3 +995,4 @@ descendent
 AxionCAMB
 NGenHalofit
 Daemmerung
+initializers

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -34,6 +34,61 @@ write:
     logical, intent(  out) :: diskRequired        , spheroidRequired   , &
          &                    radiusVirialRequired, radiusScaleRequired
 
+Like ``use`` blocks, a run of declarations is laid out as a table so that it can be scanned down a column. The conventions are:
+
+* The intrinsic type, its parenthetical (kind specifier, type name, ``len=``), the ``::`` and the variables each occupy a column, whose width is shared by every declaration in the run. A declaration with no parenthetical still leaves room for one, so its ``::`` lines up with the rest.
+* The intrinsic is padded before the bracket opens — ``double precision``, ``type            (treeNode)`` — rather than the padding going inside the brackets.
+* Attributes occupy positional columns: whichever attribute comes first on a row sits in the first attribute column, so one column may hold ``pointer`` on one row and ``intent(inout)`` on the next, sized to the wider.
+* Attributes are written in a canonical order — ``intent``, ``pointer``, ``allocatable``, ``dimension``, ``target``, ``optional``, ``parameter``, ``save``, ``value``, ``public``, ``private``, then anything else alphabetically. Fortran attaches no meaning to the order; fixing one is what lets a given attribute reliably land in the same column.
+* The argument of ``intent`` is padded to the width of the longest spelling, so that ``intent(in   )``, ``intent(inout)`` and ``intent(  out)`` form one column.
+* At most two variables per row, aligned in columns, with any ``=`` or ``=>`` initializer aligned down each column. Continuation rows carry ``&`` five columns in from the block indent.
+* A declaration needed only under OpenMP carries the ``!$`` sentinel; unconditional declarations in the same run are indented three further columns so the intrinsic types still line up.
+* Rows hold fewer variables where two would push the line past 132 columns.
+
+For example:
+
+.. code-block:: fortran
+
+       type            (treeNode), intent(inout)                            :: node
+       double precision          , intent(in   ), allocatable, dimension(:) :: radii
+       logical                   , intent(  out)                            :: isComputed
+       double precision                                                     :: massStellar        , massGas              , &
+         &                                                                     radiusScale        , velocityVirial
+       integer                                                              :: i
+    !$ integer                                                              :: threadCount
+       logical                                                              :: converged  =.false., iterating     =.true.
+
+A comment or a ``#ifdef`` between two runs of declarations does not break the alignment — the columns span it. These conventions are applied automatically by :ref:`manual-sec-formatDeclarations`.
+
+Module ``use`` statements
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Blocks of ``use`` statements are laid out as a table, so that the module names and the symbols imported from them can be scanned down a column. The conventions are:
+
+* Every ``use`` carries an explicit ``::`` and an ``only`` clause naming the symbols imported. One statement per module.
+* Within a block, the ``use``, ``::`` and ``, only :`` tokens are vertically aligned, which means module names are padded to the width of the longest.
+* At most four symbols per row, using continuation lines for more — but fewer per row where four would push the line past 132 columns. The count is chosen once for the whole block, so the symbol columns stay aligned between statements.
+* Symbols are sorted alphabetically and aligned in columns whose widths are shared across the entire block. The sort is case-sensitive, which groups ``Capitalized_With_Underscores`` procedure names ahead of ``camelCase`` types and variables.
+* Modules imported with the ``intrinsic`` attribute come first, keeping their order relative to one another.
+* A ``use`` needed only under OpenMP carries the ``!$`` sentinel. Where a block mixes these with unconditional ``use`` statements, the latter are indented three further columns so that the ``use`` keywords still line up.
+* A ``use`` guarded by a preprocessor conditional keeps its own ``#ifdef``/``#endif`` wrapper.
+
+For example:
+
+.. code-block:: fortran
+
+       use, intrinsic :: ISO_C_Binding     , only : c_size_t
+       use            :: Error             , only : Error_Report
+       use            :: Display           , only : displayIndent         , displayMessage, displayUnindent, displayVerbositySet, &
+       &                                            verbosityLevelStandard
+       use            :: ISO_Varying_String, only : assignment(=)         , varying_string
+   #ifdef USEMPI
+       use            :: MPI_Utilities     , only : mpiBarrier            , mpiSelf
+   #endif
+    !$ use            :: OMP_Lib           , only : OMP_Get_Max_Threads
+
+These conventions are applied automatically by :ref:`manual-sec-formatModuleUses`, so there is no need to align them by hand.
+
 Constants
 ~~~~~~~~~
 

--- a/docs/manuals/developer-guide/editor-setup.rst
+++ b/docs/manuals/developer-guide/editor-setup.rst
@@ -99,6 +99,76 @@ where ``-i3`` sets the indent for block constructs, ``-r2`` the indent for
 procedure bodies, ``-m2`` the indent for module bodies, and ``--openmp=0``
 leaves the ``!$`` sentinels untouched.
 
+.. _manual-sec-formatModuleUses:
+
+Formatting module ``use`` blocks
+--------------------------------
+
+Unlike the general-purpose formatters warned against above, ``formatModuleUses.py``
+understands Galacticus source and is safe to run on a whole file. It rewrites
+``use`` blocks into the layout described in :ref:`manual-sec-styleConventions`
+and leaves everything else in the file — including embedded directive and
+docstring blocks — byte for byte unchanged:
+
+.. code-block:: bash
+
+   ./scripts/aux/formatModuleUses.py source/path/to/file.F90
+
+The original is kept as ``file.F90~`` (change the extension with ``--suffix``, or
+suppress the backup with ``--no-backup``). Pass ``--check`` to report whether a
+file would be reformatted without modifying it; it exits with status 1 if so,
+which makes it usable as a pre-commit or continuous-integration check.
+
+Run it after any edit that adds, removes, or renames imported symbols, rather
+than realigning the columns by hand.
+
+The script refuses to write unless two conditions hold: parsing the file and
+writing it straight back out reproduces it exactly, and re-parsing its own
+output yields the same set of symbols imported from each module under each
+preprocessor condition. A file that fails the first check contains something
+the parser cannot represent, and is left untouched rather than rewritten on a
+guess.
+
+.. note::
+
+   Reformatting sorts the imported symbols alphabetically and merges repeated
+   ``use`` statements for the same module, so a file that has not been formatted
+   before may change by more than alignment alone.
+
+.. _manual-sec-formatDeclarations:
+
+Formatting variable declarations
+--------------------------------
+
+``formatDeclarations.py`` is the companion tool for declaration blocks. It
+rewrites runs of declarations into the column layout described in
+:ref:`manual-sec-styleConventions`, and like ``formatModuleUses.py`` leaves the
+rest of the file untouched:
+
+.. code-block:: bash
+
+   ./scripts/aux/formatDeclarations.py source/path/to/file.F90
+
+It takes the same ``--suffix``, ``--no-backup`` and ``--check`` options, and
+refuses to write unless the file round-trips exactly and its own output
+re-parses to the same declarations — same intrinsic type, type-spec, attribute
+set, variables and initializers. Attribute *order* is excluded from that
+comparison, since the tool sets that order itself.
+
+Two kinds of statement are deliberately left alone. Third-party code under
+``source/external/`` is skipped entirely, so that it can still be compared
+against its upstream original; pass ``--include-external`` to override. And a declaration whose
+initializer is too large to fit the line-length ruler — a ``reshape([...])``
+data table, say — is written back exactly as it was, because the parser has
+already joined away the continuation lines its author used and re-emitting it
+would collapse the table onto one enormous line.
+
+.. note::
+
+   Reformatting reorders attributes into the canonical order and splits
+   declarations of more than two variables across rows, so a file that has not
+   been formatted before may change by more than alignment alone.
+
 .. _manual-sec-editorEmbedded:
 
 Embedded languages in Fortran source

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,9 @@
 testpaths = python scripts/doc scripts/build
 python_files = test_*.py
 python_functions = test_*
+# Markers.  `slow` covers tests that sweep the whole `source/` tree rather than
+# a fixture — they are the ones that catch parser gaps on real code, so they
+# run by default, but a tight edit/test loop can skip them with
+#   python -m pytest -m "not slow"
+markers =
+    slow: sweeps the entire source/ tree (tens of seconds)

--- a/python/Galacticus/Build/SourceTree/Parse/Declarations.py
+++ b/python/Galacticus/Build/SourceTree/Parse/Declarations.py
@@ -27,8 +27,10 @@ def parse_declaration(line):
           'type'          : str or None — kind/type spec (parentheses stripped)
           'openMP'        : bool
           'attributes'    : list of str — e.g. ['intent(in)', 'allocatable']
+          'attributesOriginal' : list of str — as above, original case
           'variables'     : list of str — lowercase names, qualifiers preserved
           'variableNames' : list of str — original-case names, no qualifiers
+          'variablesOriginal' : list of str — original-case, qualifiers preserved
     """
     # Use a unified approach: match declaration pattern, then split manually
     # This avoids complex capture group indexing issues.
@@ -67,6 +69,7 @@ def parse_declaration(line):
     # Parse type and attributes
     type_val = None
     attributes = []
+    attributes_original = []
     if type_attrs_raw:
         # Carve a leading balanced parenthesised group off `type_attrs_raw` if
         # one is present.  Uses `extract_bracketed` so that nested parens
@@ -102,25 +105,43 @@ def parse_declaration(line):
             type_val = first_part[1:-1].strip()
             consumed_as_type = True
 
+        # Attributes are extracted twice for the same reason as the variables
+        # below: the lower-cased form is what the code generators match
+        # against, but a formatter must write `dimension(nBins)` back with its
+        # original case rather than `dimension(nbins)`.
         if rest:
-            attributes = extract_variables(rest, keep_qualifiers=True)
+            attributes          = extract_variables(rest, keep_qualifiers=True)
+            attributes_original = extract_variables(rest, keep_qualifiers=True,
+                                                    lower_case=False)
         elif not consumed_as_type and first_part:
             # `first_part` carries parens that aren't a type-spec (rare —
             # `dimension(:)` written without a leading comma).
-            attributes = extract_variables(first_part, keep_qualifiers=True)
+            attributes          = extract_variables(first_part, keep_qualifiers=True)
+            attributes_original = extract_variables(first_part, keep_qualifiers=True,
+                                                    lower_case=False)
         else:
-            attributes = []
+            attributes          = []
+            attributes_original = []
 
     variables = extract_variables(variables_raw, keep_qualifiers=True, lower_case=True)
     variable_names = extract_variables(variables_raw, keep_qualifiers=False, lower_case=False)
+    # `variables` is lower-cased (the code generators match against it
+    # case-insensitively) and `variableNames` drops qualifiers.  A formatter
+    # needs both preserved at once — it must write `massStellar` back as
+    # `massStellar`, initializer and dimension qualifiers included — so keep a
+    # third rendering rather than perturbing either existing one.
+    variables_original = extract_variables(
+        variables_raw, keep_qualifiers=True, lower_case=False)
 
     return {
-        'intrinsic':     intrinsic,
-        'type':          type_val,
-        'openMP':        bool(openmp_marker),
-        'attributes':    attributes,
-        'variables':     variables,
-        'variableNames': variable_names,
+        'intrinsic':          intrinsic,
+        'type':               type_val,
+        'openMP':             bool(openmp_marker),
+        'attributes':         attributes,
+        'attributesOriginal': attributes_original,
+        'variables':          variables,
+        'variableNames':      variable_names,
+        'variablesOriginal':  variables_original,
     }
 
 
@@ -330,3 +351,483 @@ def declaration_exists(node, variable_name):
                         return True
         child = child.get('sibling')
     return False
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+#
+# `build_declarations()` above serializes declarations for the *code
+# generators*: fixed indent, no alignment, minimal spacing.  The functions
+# below instead reproduce the hand-maintained house style described in the
+# developer guide, for use by `scripts/aux/formatDeclarations.py`.  They are
+# deliberately separate so that changing the formatting rules cannot perturb
+# generated code.
+# ---------------------------------------------------------------------------
+
+# Line width beyond which the emitter packs fewer variables per row, and the
+# usual maximum number of variables on one row.
+LINE_LENGTH_MAX      = 132
+VARIABLES_PER_ROW_MAX = 2
+
+# Canonical ordering of declaration attributes.
+#
+# Fortran attaches no meaning to attribute order, but fixing one turns "the
+# same attribute should sit in the same column" from a multiple-sequence
+# alignment problem into a per-position maximum width.  This order was derived
+# from pairwise precedence counts over the whole source tree — for every pair
+# of attributes, which one appears first more often — and reorders about 17% of
+# the multi-attribute declarations in the tree (roughly 3% of all
+# declarations).  Attributes not listed sort last, alphabetically.
+ATTRIBUTE_ORDER = (
+    'intent',
+    'pointer',
+    'allocatable',
+    'dimension',
+    'target',
+    'optional',
+    'parameter',
+    'save',
+    'value',
+    'public',
+    'private',
+)
+
+_ATTRIBUTE_RANK = {name: index for index, name in enumerate(ATTRIBUTE_ORDER)}
+
+# Type-bound declarations (`procedure :: name => target`) carry no attribute or
+# variable columns and are laid out on their own axis.
+_TYPE_BOUND_INTRINSICS = frozenset(('procedure', 'generic', 'final'))
+
+# The `intent` field is padded to the width of the longest spelling, `inout`,
+# so that the three forms occupy one column: `in` is left-aligned within it and
+# `out` right-aligned, giving `intent(in   )`, `intent(inout)`, `intent(  out)`.
+_INTENT_FIELD = {'in': 'in   ', 'out': '  out', 'inout': 'inout'}
+
+
+def _attribute_name(attribute):
+    """The bare name of an attribute, without any parenthesized argument."""
+    return re.sub(r'\(.*', '', attribute).strip().lower()
+
+
+def _normalize_attribute(attribute):
+    """Return `attribute` in canonical spelling."""
+    name = _attribute_name(attribute)
+    if name == 'intent':
+        match = re.match(r'^\s*intent\s*\(\s*([a-zA-Z]*)\s*\)\s*$', attribute,
+                         re.IGNORECASE)
+        if match:
+            field = _INTENT_FIELD.get(match.group(1).lower())
+            if field is not None:
+                return 'intent(' + field + ')'
+    return attribute
+
+
+def _ordered_attributes(declaration):
+    """Attributes of `declaration`, canonically ordered and spelled.
+
+    The sort is stable on the canonical rank, so attributes sharing a rank
+    (only those outside `ATTRIBUTE_ORDER`, which all rank last) keep their
+    source order relative to one another apart from the alphabetical tie-break.
+    """
+    source = (declaration.get('attributesOriginal')
+              or declaration.get('attributes')
+              or [])
+    attributes = [_normalize_attribute(a) for a in source]
+    return sorted(
+        attributes,
+        key=lambda a: (_ATTRIBUTE_RANK.get(_attribute_name(a), len(ATTRIBUTE_ORDER)),
+                       _attribute_name(a)),
+    )
+
+
+def _split_initializer(variable):
+    """Split `variable` into (name, operator, value).
+
+    `operator` is `'=>'`, `'='` or `''`.  The scan ignores `=` characters
+    inside brackets, so that a dimension qualifier such as `x(kind=c_int)` is
+    not mistaken for an initializer.
+    """
+    depth = 0
+    for index, character in enumerate(variable):
+        if character in '([':
+            depth += 1
+        elif character in ')]':
+            depth -= 1
+        elif depth == 0 and character == '=':
+            if variable[index + 1:index + 2] == '>':
+                return variable[:index], '=>', variable[index + 2:]
+            return variable[:index], '=', variable[index + 1:]
+    return variable, '', ''
+
+
+def _paren_body(declaration):
+    """The body of a declaration's parenthetical, without its brackets.
+
+    `parse_declaration` strips the outer brackets from most type-specs but
+    leaves them on some, so normalize both spellings here.
+    """
+    type_value = declaration.get('type')
+    if type_value is None:
+        return ''
+    if type_value.startswith('(') and type_value.endswith(')'):
+        return type_value[1:-1].strip()
+    return type_value.strip()
+
+
+def _variables_of(declaration):
+    """The declaration's variables, original case and qualifiers preserved.
+
+    Falls back to the lower-cased `variables` for declaration dicts built by
+    the code generators, which do not carry `variablesOriginal`.
+    """
+    return (declaration.get('variablesOriginal')
+            or declaration.get('variables')
+            or [])
+
+
+def _operator_text(operator):
+    """The operator as written, including any spaces around it.
+
+    `=>` is spaced on both sides (`x => null()`) while `=` is written tight
+    against both name and value (`x=0.0d0`).  The spaces belong to the operator
+    rather than to the name column, so that the widest name in a column keeps
+    its separator too — `nameThatIsLongest => target`, not `nameThatIsLongest=>`.
+    """
+    return ' => ' if operator == '=>' else operator
+
+
+def _variable_fields(declaration, variable):
+    """Split one variable into its (name, operator, value) columns.
+
+    A `final` binding names no target, and the house style places it in the
+    *target* column rather than the name column so that it lines up with the
+    targets of the `procedure` bindings beside it — `final :: fooDestructor`
+    sits under `procedure :: bar => fooBar`'s `fooBar`.
+    """
+    if declaration['intrinsic'] == 'final':
+        return '', '', variable
+    return _split_initializer(variable)
+
+
+def _variables_per_row(declaration, per_row):
+    """How many variables share one row for this declaration.
+
+    Type-bound declarations (`procedure :: name => target`) take one binding
+    per row regardless of the group's setting; everything else takes `per_row`.
+    """
+    if declaration['intrinsic'] in _TYPE_BOUND_INTRINSICS:
+        return 1
+    return per_row
+
+
+class _Layout:
+    """Column widths shared by every declaration in one alignment group.
+
+    Attribute columns are *positional*, not per-attribute: column 0 holds
+    whichever attribute comes first on each row, so a row with `pointer` and a
+    row with `intent(inout)` share one column sized to the wider of the two.
+    Canonical ordering (`ATTRIBUTE_ORDER`) is what makes that produce a
+    coherent table — without it, position 0 would hold an arbitrary attribute
+    on each row.
+    """
+
+    def __init__(self, declarations, per_row):
+        self.intrinsic = max((len(d['intrinsic']) for d in declarations), default=0)
+
+        parenthesized = [d for d in declarations if d.get('type') is not None]
+        self.paren = max((len(_paren_body(d)) for d in parenthesized), default=0)
+        # Width of the whole parenthetical field, brackets included.  Zero when
+        # no declaration in the group has one, so that a group of plain
+        # `double precision` declarations carries no dead column.
+        self.paren_field = self.paren + 2 if parenthesized else 0
+
+        attribute_lists = [_ordered_attributes(d) for d in declarations]
+        self.attributes = [
+            max(a[column] and len(a[column]) or 0
+                for a in attribute_lists if len(a) > column)
+            for column in range(max((len(a) for a in attribute_lists), default=0))
+        ]
+
+        # Variable columns.  Name, operator and value are sized independently
+        # so that `=` and `=>` line up down each column.
+        self.names     = []
+        self.operators = []
+        self.values    = []
+        for declaration in declarations:
+            columns = _variables_per_row(declaration, per_row)
+            for index, variable in enumerate(_variables_of(declaration)):
+                column = index % columns
+                while len(self.names) <= column:
+                    self.names.append(0)
+                    self.operators.append(0)
+                    self.values.append(0)
+                name, operator, value = _variable_fields(declaration, variable)
+                self.names[column]     = max(self.names[column], len(name))
+                self.operators[column] = max(self.operators[column],
+                                             len(_operator_text(operator)))
+                self.values[column]    = max(self.values[column], len(value))
+
+    def prefix_width(self, indent, openmp_any):
+        """The column at which the variable list starts."""
+        width = len(indent) + (3 if openmp_any else 0)
+        width += self.intrinsic + self.paren_field
+        for column_width in self.attributes:
+            width += 2 + column_width
+        return width + 4          # " :: "
+
+
+def _emit_variable(declaration, variable, layout, column, pad):
+    """Render one variable into its column.
+
+    `pad` is False for the last variable on the last row, so that the line ends
+    ragged rather than carrying trailing whitespace.  The *name* is still
+    padded whenever the column holds any initializer, since otherwise the `=`
+    and `=>` of a column would not line up.
+    """
+    name, operator, value = _variable_fields(declaration, variable)
+    # Anything after the name — an operator column shared with other rows, or
+    # this row's own value — means the name must be padded out to its column so
+    # that what follows lines up.  A `final` binding has *only* a value, so the
+    # value must be emitted whether or not the column carries an operator.
+    trailing = bool(layout.operators[column]) or bool(value)
+    text = name.ljust(layout.names[column]) if (pad or trailing) else name
+    if trailing:
+        text += _operator_text(operator).ljust(layout.operators[column])
+        text += value.ljust(layout.values[column]) if pad else value
+    return text
+
+
+def _emit_declaration(declaration, layout, indent, openmp_any, per_row):
+    """Render one declaration statement, with continuation lines as needed."""
+    prefix = indent
+    if declaration.get('openMP'):
+        prefix += '!$ '
+    elif openmp_any:
+        prefix += '   '
+
+    head = prefix + declaration['intrinsic'].ljust(layout.intrinsic)
+
+    if layout.paren_field:
+        if declaration.get('type') is not None:
+            head += '(' + _paren_body(declaration).ljust(layout.paren) + ')'
+        else:
+            head += ' ' * layout.paren_field
+
+    attributes = _ordered_attributes(declaration)
+    for column, width in enumerate(layout.attributes):
+        if column < len(attributes):
+            head += ', ' + attributes[column].ljust(width)
+        else:
+            head += ' ' * (2 + width)
+    head += ' :: '
+
+    variables = _variables_of(declaration)
+    if not variables:
+        # No variables to lay out — emit the head alone rather than dropping
+        # the statement.  `parse_declaration` should not produce this, but a
+        # declaration dict synthesized by a code generator can.
+        return head.rstrip() + '\n'
+    columns = _variables_per_row(declaration, per_row)
+    # Continuation lines carry the `&` five columns in from the block indent,
+    # then run out to the variable column.
+    continuation = (indent + ' ' * 5 + '&').ljust(
+        layout.prefix_width(indent, openmp_any))
+
+    lines = []
+    for start in range(0, len(variables), columns):
+        row      = variables[start:start + columns]
+        last_row = start + columns >= len(variables)
+        text     = head if start == 0 else continuation
+        for column, variable in enumerate(row):
+            is_last = last_row and column == len(row) - 1
+            text += _emit_variable(
+                declaration, variable, layout, column, pad=not is_last)
+            if not is_last:
+                text += ', '
+        lines.append(text.rstrip() if last_row else text + '&')
+    return ''.join(line + '\n' for line in lines)
+
+
+def _choose_variables_per_row(declarations, indent, openmp_any):
+    """Largest variables-per-row (up to the maximum) whose rows fit the ruler.
+
+    Chosen once for the whole group, because the variable column widths are
+    shared across it — varying it per statement would break the alignment those
+    widths exist to produce.  A group that cannot fit even one variable per row
+    emits one per row and overflows; there is nowhere else to break.
+    """
+    for per_row in range(VARIABLES_PER_ROW_MAX, 0, -1):
+        layout = _Layout(declarations, per_row)
+        widest = 0
+        for declaration in declarations:
+            text = _emit_declaration(
+                declaration, layout, indent, openmp_any, per_row)
+            widest = max(widest,
+                         max((len(line) for line in text.splitlines()),
+                             default=0))
+        if widest <= LINE_LENGTH_MAX:
+            return per_row
+    return 1
+
+
+def _minimum_width(declaration, indent):
+    """Width of this declaration at its narrowest — every column unpadded."""
+    width = len(indent) + len(declaration['intrinsic'])
+    if declaration.get('type') is not None:
+        width += len(_paren_body(declaration)) + 2
+    for attribute in _ordered_attributes(declaration):
+        width += 2 + len(attribute)
+    width += 4                                        # " :: "
+    longest = 0
+    for variable in _variables_of(declaration):
+        name, operator, value = _variable_fields(declaration, variable)
+        longest = max(longest,
+                      len(name) + len(_operator_text(operator)) + len(value))
+    return width + longest
+
+
+def _is_unformattable(declaration, indent):
+    """True if no layout of this declaration can fit within the ruler.
+
+    A single variable carrying a large initializer — a `reshape([...])` data
+    table, say — cannot be broken by a formatter that only breaks *between*
+    variables.  `get_fortran_line` has already joined away the continuation
+    lines its author used, so re-emitting it from the parsed fields would
+    collapse a carefully wrapped table onto one enormous line.  Such
+    declarations are written back verbatim instead, and are kept out of the
+    column-width calculation so that they cannot pad their neighbours out to
+    their own width.
+    """
+    return (declaration.get('rawText') is not None
+            and _minimum_width(declaration, indent) > LINE_LENGTH_MAX)
+
+
+def _is_type_definition(declaration):
+    """True if this is a derived-type *definition*, not a variable declaration.
+
+    `type, bind(c) :: unitType` opens a derived type; `type(unitType) :: x`
+    declares a variable of one.  The unit parser normally claims the former, so
+    it never reaches a declaration node — but it recognizes the statement by
+    pattern, and a few in the tree carry enough internal padding
+    (`type, extends(hdf5Group             ) :: hdf5File`) to slip past it and
+    land here instead.
+
+    Reformatting such a statement would tidy away exactly the padding that hid
+    it, so on the next parse the unit parser *would* claim it and the shape of
+    the tree would change underneath the formatter.  There are four in the tree;
+    leaving them untouched is simpler and safer than teaching the emitter to
+    reproduce their disguise.
+    """
+    return (declaration.get('intrinsic') in ('type', 'class')
+            and declaration.get('type') is None)
+
+
+def _is_separator(node):
+    """True if `node` is code that may sit *inside* an alignment group.
+
+    `_pass_declarations` ends a declaration block at any line it does not
+    recognize as a declaration, so a comment or `#ifdef` between two runs of
+    declarations splits them into separate nodes.  Hand-formatted Galacticus
+    source aligns straight through both, so the formatter rejoins runs
+    separated only by comments, preprocessor directives and blank lines.
+    Anything else — a real statement — genuinely ends the group.
+    """
+    if node.get('type') != 'code':
+        return False
+    for line in node.get('content', '').splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith(('!', '#')):
+            return False
+    return True
+
+
+def declaration_groups(node):
+    """Yield runs of sibling declaration nodes that share one alignment.
+
+    Each group is a list of `declaration` nodes, in source order, which may be
+    separated in the sibling chain by comment/preprocessor/blank code nodes.
+    """
+    from Galacticus.Build.SourceTree import children
+
+    group     = []
+    pending   = []          # separators seen since the last declaration node
+    for child in children(node):
+        if child.get('type') == 'declaration':
+            group.append(child)
+            pending = []
+        elif group and _is_separator(child):
+            pending.append(child)
+        else:
+            if group:
+                yield group
+            group   = []
+            pending = []
+    if group:
+        yield group
+
+
+def format_declarations(group):
+    """Re-emit a group of declaration nodes in the house style.
+
+    Rewrites each node's `firstChild['content']` in place.  Column widths are
+    computed across the whole group so that declarations separated by a comment
+    or a `#ifdef` still line up with one another.
+    """
+    declarations = [d for node in group for d in node.get('declarations', [])]
+    if not declarations:
+        return
+    if any(_is_type_definition(d) for d in declarations):
+        # Leave the whole group alone — see `_is_type_definition`.
+        return
+
+    # The block indent is the smallest indent of any declaration line in the
+    # group.  As with `use` blocks, the minimum is what makes this idempotent:
+    # the emitter indents non-OpenMP declarations three further columns when
+    # the group also contains `!$` ones, and reading the indent off the first
+    # line would pick that padding up again on every pass.
+    indents = []
+    for node in group:
+        for line in node['firstChild']['content'].splitlines():
+            stripped = line.lstrip()
+            if not stripped or stripped.startswith('#'):
+                continue
+            # `!$` is an OpenMP sentinel, not a comment: such a line *is* a
+            # declaration and sits at the base indent, while its unconditional
+            # neighbours are padded three columns past it.  Skipping it here
+            # would leave only the padded lines to measure, and the block would
+            # march three columns right on every pass.
+            if stripped.startswith('!') and not stripped.startswith('!$'):
+                continue
+            indents.append(re.match(r'^(\s*)', line).group(1))
+    indent = min(indents, key=len) if indents else '  '
+
+    openmp_any = any(d.get('openMP') for d in declarations)
+
+    # Declarations too wide for any layout are written back as they were, and
+    # take no part in sizing the columns.
+    laid_out = [d for d in declarations if not _is_unformattable(d, indent)]
+    if not laid_out:
+        return
+    per_row = _choose_variables_per_row(laid_out, indent, openmp_any)
+    layout  = _Layout(laid_out, per_row)
+
+    for node in group:
+        content = indent + 'implicit none\n' if node.get('implicitNone') else ''
+        for declaration in node.get('declarations', []):
+            if _is_unformattable(declaration, indent):
+                content += declaration['rawText']
+            else:
+                content += _emit_declaration(
+                    declaration, layout, indent, openmp_any, per_row)
+        node['firstChild']['content'] = content
+
+
+def format_declarations_tree(tree):
+    """Apply `format_declarations` to every alignment group in `tree`."""
+    from Galacticus.Build.SourceTree import walk_tree
+
+    for node in list(walk_tree(tree)):
+        for group in declaration_groups(node):
+            format_declarations(group)

--- a/python/Galacticus/Build/SourceTree/Parse/ModuleUses.py
+++ b/python/Galacticus/Build/SourceTree/Parse/ModuleUses.py
@@ -10,6 +10,14 @@ import copy
 
 from Galacticus.Build.FortranUtils import get_fortran_line
 
+# Formatting rules for emitted `use` statements.  `SYMBOLS_PER_ROW_MAX` is the
+# usual number of `only` symbols per row; `LINE_LENGTH_MAX` is the column
+# beyond which `update_uses()` drops to fewer symbols per row.  132 is the
+# Fortran free-form standard limit — not enforced here (the build passes
+# `-ffree-line-length-none`) but kept as the house style.
+SYMBOLS_PER_ROW_MAX = 4
+LINE_LENGTH_MAX     = 132
+
 # NB: the `(?![a-zA-Z0-9_])` after `use` is essential — without it, an
 # assignment to a variable whose name merely *starts* with "use" (e.g.
 # `useCache=lastCache`) parses as `use Cache, only : =lastCache`, fabricating
@@ -42,6 +50,29 @@ def _as_entry_list(value):
 def _condition_key(entry):
     """A hashable identity for an entry's preprocessor condition set."""
     return tuple((c['name'], c['invert']) for c in entry.get('conditions', []))
+
+
+def _insert_module_ordered(module_order, module_uses, mod_name, is_intrinsic):
+    """Record `mod_name` in `module_order`, intrinsic modules first.
+
+    Intrinsic modules (`use, intrinsic :: ISO_C_Binding`) are hoisted ahead of
+    the rest, but keep their order of appearance *among themselves* — they are
+    inserted after any intrinsic modules already recorded, not at index zero.
+
+    Inserting at index zero instead would reverse the intrinsic modules on
+    every pass, so a block naming two of them oscillated between two layouts
+    and reformatting never reached a fixed point.
+    """
+    if not is_intrinsic:
+        module_order.append(mod_name)
+        return
+    index = 0
+    for name in module_order:
+        if not any(entry.get('intrinsic')
+                   for entry in _as_entry_list(module_uses.get(name, []))):
+            break
+        index += 1
+    module_order.insert(index, mod_name)
 
 
 def parse_module_uses(tree):
@@ -168,10 +199,8 @@ def parse_module_uses(tree):
                 entries = module_uses.setdefault(mod_name, [])
                 if not entries:
                     # First occurrence of this module name fixes its order.
-                    if is_intrinsic:
-                        module_order.insert(0, mod_name)
-                    else:
-                        module_order.append(mod_name)
+                    _insert_module_ordered(
+                        module_order, module_uses, mod_name, is_intrinsic)
 
                 entry = next(
                     (e for e in entries if _condition_key(e) == cond_key), None)
@@ -252,17 +281,31 @@ def update_uses(uses_node):
     """
     from Galacticus.Build.FortranUtils import get_fortran_line
 
-    # Determine indentation from the existing raw content.
-    indent = ""
+    # Determine the block's indentation from the existing raw content: the
+    # smallest indent of any `use` statement in it.
+    #
+    # The minimum is what makes this function idempotent.  When a block mixes
+    # OpenMP-conditional and unconditional uses, the emitter below indents the
+    # unconditional ones by a further three columns so that `use` lines up
+    # with the `use` after a `!$ ` sentinel.  Reading the indent off the first
+    # line of an already-formatted block would therefore pick up that padding
+    # and add three more columns on every pass.  Taking the minimum over the
+    # `use` lines recovers the base indent whether or not the block has been
+    # formatted before, since the `!$ ` lines sit at the base indent and are
+    # never padded.
+    #
+    # Only `use` lines are considered: any `#ifdef` guards in the block start
+    # at column zero and would otherwise drag the indent to nothing.
     raw_content = uses_node['firstChild']['content'] if uses_node.get('firstChild') else ""
+    indents = []
     fh = io.StringIO(raw_content)
-    while indent == "":
+    while True:
         raw_line, processed_line, _ = get_fortran_line(fh)
         if not raw_line and not processed_line:
             break
-        m = re.match(r'^(\s*)', raw_line)
-        if m:
-            indent = m.group(1)
+        if _MODULE_USE_RE.match(processed_line):
+            indents.append(re.match(r'^(\s*)', raw_line).group(1))
+    indent = min(indents, key=len) if indents else ""
 
     module_use  = uses_node.get('moduleUse', {})
     module_order = uses_node.get('moduleOrder', list(module_use.keys()))
@@ -276,18 +319,22 @@ def update_uses(uses_node):
 
     name_len_max = max((len(n) for n in module_use), default=0)
 
-    # Compute 4-column max widths for 'only' symbols.
-    col_max = [0, 0, 0, 0]
-    for v in module_use.values():
-        for entry in _as_entry_list(v):
-            only = entry.get('only', {})
-            if only:
-                for i, sym in enumerate(sorted(only.keys())):
-                    j = i % 4
+    def _column_widths(symbols_per_row):
+        """Max width of each symbol column, over every `use` in the block.
+
+        Widths are shared across the whole block so that symbols line up
+        between `use` statements, not merely within one.
+        """
+        col_max = [0] * symbols_per_row
+        for v in module_use.values():
+            for entry in _as_entry_list(v):
+                for i, sym in enumerate(sorted(entry.get('only', {}).keys())):
+                    j = i % symbols_per_row
                     if len(sym) > col_max[j]:
                         col_max[j] = len(sym)
+        return col_max
 
-    def _emit_entry(mod_name, entry):
+    def _emit_entry(mod_name, entry, symbols_per_row, col_max):
         text = ""
 
         # Emit preprocessor conditions.
@@ -319,13 +366,13 @@ def update_uses(uses_node):
             symbols = sorted(only.keys())
             remaining = symbol_count
             for i, sym in enumerate(symbols):
-                j = i % 4
+                j = i % symbols_per_row
                 use_line += sym
                 remaining -= 1
                 if remaining > 0:
                     use_line += " " * (col_max[j] - len(sym))
                     use_line += ", "
-                    if j == 3:
+                    if j == symbols_per_row - 1:
                         use_line += "&\n"
                         if entry.get('openMP'):
                             cont_prefix = indent + "!$ "
@@ -343,10 +390,29 @@ def update_uses(uses_node):
             text += "#endif\n"
         return text
 
-    content = ""
-    for mod_name in module_order:
-        for entry in _as_entry_list(module_use.get(mod_name, [])):
-            content += _emit_entry(mod_name, entry)
+    def _emit_block(symbols_per_row):
+        col_max = _column_widths(symbols_per_row)
+        text = ""
+        for mod_name in module_order:
+            for entry in _as_entry_list(module_use.get(mod_name, [])):
+                text += _emit_entry(mod_name, entry, symbols_per_row, col_max)
+        return text
+
+    # Use as many symbols per row as fit: SYMBOLS_PER_ROW_MAX normally, fewer
+    # when the resulting rows would run past LINE_LENGTH_MAX.  The count is
+    # chosen once for the whole block rather than per statement, because the
+    # column widths are shared across the block — varying it per statement
+    # would destroy the alignment the widths exist to produce.
+    #
+    # A block whose symbols are too long to fit even one per row still emits
+    # one per row and overflows: there is nowhere to break a single symbol,
+    # and Galacticus compiles with `-ffree-line-length-none`, so the limit is
+    # a style rule rather than a constraint.
+    for symbols_per_row in range(SYMBOLS_PER_ROW_MAX, 0, -1):
+        content = _emit_block(symbols_per_row)
+        if max((len(line) for line in content.splitlines()),
+               default=0) <= LINE_LENGTH_MAX:
+            break
 
     if uses_node.get('firstChild') is None:
         uses_node['firstChild'] = {
@@ -420,10 +486,9 @@ def add_uses(node, module_uses_node):
             entries  = uses_node['moduleUse'].setdefault(mod_name, [])
 
             if mod_name not in uses_node['moduleOrder']:
-                if new_entry.get('intrinsic'):
-                    uses_node['moduleOrder'].insert(0, mod_name)
-                else:
-                    uses_node['moduleOrder'].append(mod_name)
+                _insert_module_ordered(
+                    uses_node['moduleOrder'], uses_node['moduleUse'],
+                    mod_name, new_entry.get('intrinsic'))
 
             # Merge into the entry with the *same* condition set.  An
             # unconditional `use` thus joins (or creates) the unconditional

--- a/python/Galacticus/Build/SourceTree/__init__.py
+++ b/python/Galacticus/Build/SourceTree/__init__.py
@@ -73,6 +73,72 @@ def parse_code(code, name='<string>', source=None, instrument=True):
     return root
 
 
+def parse_code_for_format(code, name='<string>', source=None):
+    """Build an AST suitable for *reformatting* a source file.
+
+    `parse_code()` is built for code generation: it is free to rewrite parts
+    of the file that the compiler will not care about, and it does.  Three of
+    those rewrites make its trees unusable for a formatter, and this entry
+    point suppresses each:
+
+    * `{introspection:location}` placeholders are **not** instrumented with
+      their line numbers (`parse_code(instrument=True)` rewrites them in
+      place, so `…:location}` comes back as `…:location:338}`).
+    * The directives pass is **not** run.  It splits a multi-directive
+      `!![ … !!]` block into one node per directive, each re-emitting its own
+      `!![`/`!!]` marker pair — invisible to the compiler, but it means a
+      block holding three `<objectDestructor>` directives serializes back as
+      three separate blocks.
+    * Only the module-use and declaration passes run, since those are the
+      only node types a formatter rewrites.  The visibility and OpenMP passes
+      are pure overhead here.
+
+    Embedded LaTeX/XML blocks are still commented out by
+    `_comment_embedded()`, because their bodies would otherwise be scanned
+    for Fortran unit openers and declarations; pair this with
+    `serialize_for_format()`, which undoes that on the way out.
+
+    The result is a tree that serializes back to a byte-identical copy of
+    `code` until something deliberately modifies it.
+    """
+    root = {
+        'type':       'file',
+        'name':       name,
+        'content':    _comment_embedded(code),
+        'parent':     None,
+        'firstChild': None,
+        'sibling':    None,
+        'source':     source if source is not None else name,
+        'line':       0,
+    }
+    _link_children(root, _parse_units(root))
+    _pass_module_uses(root)
+    _pass_declarations(root)
+    return root
+
+
+def parse_file_for_format(filename):
+    """Read a Fortran source file and return a tree suitable for reformatting.
+
+    See `parse_code_for_format()`.
+    """
+    with open(filename, 'r', errors='replace') as fh:
+        content = fh.read()
+    return parse_code_for_format(content,
+                                 name=_name_relative_to_source(filename),
+                                 source=filename)
+
+
+def serialize_for_format(node):
+    """Serialize a tree from `parse_code_for_format()` back to source text.
+
+    Undoes the `!< ` marker that `_comment_embedded()` adds to embedded
+    LaTeX/XML block bodies, which plain `serialize()` deliberately leaves in
+    place for the benefit of the compiler.
+    """
+    return uncomment_embedded(serialize(node))
+
+
 def walk_tree(node):
     """Depth-first generator over all nodes in the tree.
 
@@ -159,7 +225,64 @@ def _comment_embedded(content):
         if re.match(r'^\s*!!\[',line):
             in_XML = True
     return code_commented
-        
+
+
+def uncomment_embedded(content):
+    """Invert `_comment_embedded()`, restoring embedded LaTeX/XML block bodies.
+
+    `_comment_embedded()` prefixes every line inside a `!!{ … !!}` (LaTeX) or
+    `!![ … !!]` (XML) block with `"!< "`, so that the body cannot be mistaken
+    for Fortran when the tree is serialized straight to the compiler.  The
+    build's code generators serialize *to the compiler* and so want that
+    prefix left in place; anything that serializes back to *source* — a
+    formatter — must undo it, or every directive and documentation block in
+    the file is rewritten.
+
+    The state machine below mirrors `_comment_embedded()` line for line, so
+    only lines that function would have prefixed are stripped.  Note that
+    `_comment_embedded()` skips lines that already begin with `!<`, which
+    makes it non-injective in principle; in practice no Galacticus source
+    file contains such a line (the marker is internal to the parser), and
+    callers that care should verify the round-trip per file rather than
+    assume it — see `scripts/aux/formatModuleUses.py`.
+    """
+    import io
+
+    code_uncommented = ""
+    in_LaTeX = False
+    in_XML   = False
+    for line in io.StringIO(content):
+        # Both state transitions are tested against the line as it appears in
+        # the *commented* content, i.e. before the marker is stripped.  That
+        # is what makes this an exact mirror of `_comment_embedded()`: there,
+        # the end test runs before the prefix is added and the start test
+        # runs after, so in both functions a marker nested inside a block
+        # (which `_comment_embedded()` will have prefixed to `!< !!{`) fails
+        # to match and correctly does not open a second block.
+        marker = line
+
+        # Detect the end of a LaTeX section and change state.
+        if re.match(r'^\s*!!\}', marker):
+            in_LaTeX = False
+        # Detect the end of an XML section and change state.
+        if re.match(r'^\s*!!\]', marker):
+            in_XML = False
+        # Strip the marker from lines inside a block.  Only the exact `"!< "`
+        # prefix that `_comment_embedded()` adds is removed, and only at the
+        # very start of the line — it prepends, so the body's own indentation
+        # follows the marker untouched.
+        if (in_LaTeX or in_XML) and line.startswith("!< "):
+            line = line[3:]
+        code_uncommented = code_uncommented + line
+        # Detect the start of a LaTeX section and change state.
+        if re.match(r'^\s*!!\{', marker):
+            in_LaTeX = True
+        # Detect the start of an XML section and change state.
+        if re.match(r'^\s*!!\[', marker):
+            in_XML = True
+    return code_uncommented
+
+
 def _make_code_node(content, source, line, parent=None):
     return {
         'type':       'code',
@@ -717,6 +840,13 @@ def _pass_declarations(tree):
             if decl:
                 is_decl = True
                 decl['line'] = start_line
+                # Keep the statement exactly as written.  Continuation lines
+                # are joined away by `get_fortran_line`, so a declaration whose
+                # author wrapped a long initializer by hand cannot be put back
+                # the way it was from the parsed fields alone; the formatter
+                # falls back to this text for statements it cannot lay out
+                # within the line-length ruler.
+                decl['rawText'] = raw_line
 
             if is_decl:
                 flush_code()

--- a/python/Galacticus/Build/SourceTree/tests/test_format_declarations.py
+++ b/python/Galacticus/Build/SourceTree/tests/test_format_declarations.py
@@ -1,0 +1,445 @@
+"""Tests for the variable-declaration formatter.
+
+The emitter in `Parse.Declarations` reproduces the column layout described in
+the developer guide: the intrinsic type, its parenthetical, the attributes, the
+`::` and the variables each occupy a column whose width is shared across the
+whole alignment group.
+
+Covered here:
+
+  1. The columns themselves, including the parenthetical field, the positional
+     attribute columns, and `=` / `=>` alignment down a variable column.
+  2. Canonical attribute ordering and the padded `intent` field, which is what
+     makes "the same attribute in the same column" achievable at all.
+  3. Alignment groups that span comments and `#ifdef` — `_pass_declarations`
+     ends a declaration node at any line it does not recognize, so without
+     rejoining, alignment would silently reset at every comment.
+  4. Statements the formatter must *not* touch: derived-type definitions that
+     slipped past the unit parser, and declarations whose hand-wrapped
+     initializer no layout can fit.
+  5. Idempotence, which two separate bugs broke — the OpenMP `!$` lines were
+     skipped when measuring the block indent (so blocks marched three columns
+     right per pass), and `final` bindings were dropped entirely.
+"""
+
+import os
+import re
+
+import pytest
+
+from Galacticus.Build.SourceTree import (
+    parse_code_for_format,
+    serialize_for_format,
+    walk_tree,
+)
+from Galacticus.Build.SourceTree.Parse.Declarations import (
+    ATTRIBUTE_ORDER,
+    LINE_LENGTH_MAX,
+    format_declarations_tree,
+)
+
+
+def _format(source):
+    tree = parse_code_for_format(source, name='<test>')
+    format_declarations_tree(tree)
+    return serialize_for_format(tree['firstChild'])
+
+
+def _column_of(text, needle):
+    """Column at which `needle` appears on each line that contains it."""
+    return {line.index(needle) for line in text.splitlines() if needle in line}
+
+
+# ---------------------------------------------------------------------------
+# 1. Columns
+# ---------------------------------------------------------------------------
+
+def test_double_colon_aligns_across_group():
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    integer :: i\n"
+        "    double precision :: x\n"
+        "    type(varying_string) :: name\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    assert len(_column_of(out, '::')) == 1, out
+
+
+def test_parenthetical_field_pads_declarations_without_one():
+    """`double precision` has no type-spec, but must still leave room for the
+    parenthetical so that the `::` of the group lines up."""
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    type(someVeryLongTypeName) :: a\n"
+        "    double precision :: b\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    assert len(_column_of(out, '::')) == 1, out
+    assert '(someVeryLongTypeName)' in out, out
+
+
+def test_intrinsic_is_padded_before_the_parenthetical():
+    """The house style pads the intrinsic and then opens the bracket —
+    `class(x)` and `type (x)` — rather than padding inside the brackets."""
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    type(a) :: p\n"
+        "    class(b) :: q\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    assert len(_column_of(out, '(')) == 1, out
+
+
+def test_initializers_align_down_a_column():
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    logical :: shortName=.false., otherFlag=.true.\n"
+        "    logical :: aMuchLongerName=.false., b=.true.\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    equals = [line.index('=') for line in out.splitlines() if '=' in line]
+    assert len(set(equals)) == 1, out
+
+
+def test_pointer_arrow_keeps_its_spaces_on_the_longest_name():
+    """` => ` is spaced on both sides.  Because the padding of the name column
+    is what separates shorter names from the arrow, the *widest* name in a
+    column would otherwise come out as `widestName=> target`."""
+    source = (
+        "  type t\n"
+        "     class(fooClass), pointer :: shortOne => null()\n"
+        "     class(fooClass), pointer :: aDecidedlyLongerName => null()\n"
+        "  end type t\n"
+    )
+    out = _format(source)
+    assert 'aDecidedlyLongerName => null()' in out, out
+    assert len(_column_of(out, '=>')) == 1, out
+
+
+# ---------------------------------------------------------------------------
+# 2. Attributes
+# ---------------------------------------------------------------------------
+
+def test_attributes_are_canonically_ordered():
+    source = (
+        "  subroutine s(x)\n"
+        "    implicit none\n"
+        "    double precision, dimension(:), allocatable, intent(inout) :: x\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    line = next(l for l in out.splitlines() if '::' in l and 'x' in l)
+    positions = [line.index(name) for name in
+                 ('intent', 'allocatable', 'dimension') if name in line]
+    assert positions == sorted(positions), line
+    # And that is the order the canonical list prescribes.
+    assert (ATTRIBUTE_ORDER.index('intent')
+            < ATTRIBUTE_ORDER.index('allocatable')
+            < ATTRIBUTE_ORDER.index('dimension'))
+
+
+def test_intent_field_is_padded_to_a_single_column():
+    """`in`, `out` and `inout` share one column: `in` left-aligned within it,
+    `out` right-aligned, so all three `)` line up."""
+    source = (
+        "  subroutine s(a, b, c)\n"
+        "    implicit none\n"
+        "    integer, intent(in) :: a\n"
+        "    integer, intent(out) :: b\n"
+        "    integer, intent(inout) :: c\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    assert 'intent(in   )' in out, out
+    assert 'intent(  out)' in out, out
+    assert 'intent(inout)' in out, out
+
+
+def test_differing_attributes_share_a_positional_column():
+    """A column holds whichever attribute comes first on each row — `pointer`
+    on one, `intent(inout)` on another — sized to the wider of the two."""
+    source = (
+        "  subroutine s(p, q)\n"
+        "    implicit none\n"
+        "    class(fooClass), pointer :: p\n"
+        "    type(barType), intent(inout) :: q\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    assert len(_column_of(out, '::')) == 1, out
+
+
+def test_attribute_case_is_preserved():
+    """`dimension(nBins)` must not come back as `dimension(nbins)`."""
+    source = (
+        "  subroutine s(x)\n"
+        "    implicit none\n"
+        "    double precision, dimension(nBinsTotal) :: x\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    assert 'dimension(nBinsTotal)' in out, out
+
+
+def test_variable_case_is_preserved():
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    double precision :: massStellarDisk\n"
+        "  end subroutine s\n"
+    )
+    assert 'massStellarDisk' in _format(source)
+
+
+# ---------------------------------------------------------------------------
+# 3. Alignment groups
+# ---------------------------------------------------------------------------
+
+def test_alignment_spans_a_comment():
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    integer :: i\n"
+        "    ! A dividing comment.\n"
+        "    double precision :: someLongerVariable\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    assert '! A dividing comment.' in out, out
+    assert len(_column_of(out, '::')) == 1, out
+
+
+def test_alignment_spans_a_preprocessor_guard():
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    integer :: i\n"
+        "#ifdef USEMPI\n"
+        "    type(mpiCommunicator) :: communicator\n"
+        "#endif\n"
+        "    double precision :: x\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    assert out.count('#ifdef USEMPI') == 1, out
+    assert out.count('#endif') == 1, out
+    assert len(_column_of(out, '::')) == 1, out
+
+
+def test_real_code_ends_an_alignment_group():
+    """A statement between two runs of declarations is a genuine boundary, so
+    the runs are sized independently."""
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    integer :: i\n"
+        "    call somethingEntirely()\n"
+        "    double precision :: aVeryMuchLongerVariableName\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    assert len(_column_of(out, '::')) == 2, out
+
+
+# ---------------------------------------------------------------------------
+# 4. What must not be touched
+# ---------------------------------------------------------------------------
+
+def test_derived_type_definition_is_left_alone():
+    """`type, extends(...) :: name` opens a derived type.  A few in the tree
+    carry enough padding to slip past the unit parser and reach the declaration
+    parser instead; tidying that padding away would change the tree shape on
+    the next parse, so such groups are skipped."""
+    source = (
+        "  type, extends(hdf5Group             ) :: hdf5File\n"
+        "     integer :: identifier\n"
+        "  end type hdf5File\n"
+    )
+    out = _format(source)
+    assert 'extends(hdf5Group             )' in out, out
+
+
+def test_unfittable_initializer_keeps_its_hand_wrapping():
+    """A single variable with a large initializer cannot be broken by a
+    formatter that only breaks between variables, and its continuation lines
+    have already been joined away by the parser.  Re-emitting it from the
+    parsed fields would collapse it onto one enormous line, so the original
+    text is written back instead."""
+    values = ', '.join(f'{n}.0d0' for n in range(60))
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        f"    double precision, dimension(60), parameter :: table=[ &\n"
+        f"         & {values} &\n"
+        "         & ]\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    # The statement comes back exactly as written — continuation lines, spacing
+    # and all — rather than rebuilt from the parsed fields.
+    for line in source.splitlines():
+        if 'table=' in line or line.strip().startswith('&'):
+            assert line in out.splitlines(), (line, out)
+
+
+def test_oversized_declaration_does_not_pad_its_neighbours():
+    """A declaration left verbatim takes no part in sizing the columns — one
+    huge data table used to pad every declaration beside it out to its width."""
+    values = ', '.join(f'{n}.0d0' for n in range(60))
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        f"    double precision, dimension(60), parameter :: table=[ &\n"
+        f"         & {values} &\n"
+        "         & ]\n"
+        "    integer :: i\n"
+        "  end subroutine s\n"
+    )
+    out = _format(source)
+    short = next(l for l in out.splitlines() if l.strip().startswith('integer'))
+    assert len(short) <= LINE_LENGTH_MAX, repr(short)
+
+
+# ---------------------------------------------------------------------------
+# 5. Idempotence
+# ---------------------------------------------------------------------------
+
+def test_openmp_declaration_indent_is_stable():
+    """Unconditional declarations in a group that also has `!$` ones are
+    indented three further columns.  The `!$` lines start with `!`, and
+    skipping them as comments when measuring the block indent left only the
+    padded lines to measure — so the block moved right on every pass."""
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    integer :: i\n"
+        "    !$ integer :: threadCount\n"
+        "  end subroutine s\n"
+    )
+    once  = _format(source)
+    twice = _format(once)
+    assert twice == once, (once, twice)
+    assert '\n    !$ integer' in once, once
+
+
+def test_final_binding_survives():
+    """A `final` binding names no target and is placed in the *target* column.
+    Emitting the value only when the column carried an operator dropped these
+    bindings from the output entirely."""
+    source = (
+        "  type t\n"
+        "   contains\n"
+        "     final :: fooDestructor\n"
+        "     procedure :: value => fooValue\n"
+        "  end type t\n"
+    )
+    out = _format(source)
+    assert 'fooDestructor' in out, out
+    assert _format(out) == out
+
+
+def test_formatting_is_idempotent_over_a_mixed_block():
+    source = (
+        "  subroutine s(a, b)\n"
+        "    implicit none\n"
+        "    double precision, intent(in), dimension(:), allocatable :: a\n"
+        "    class(fooClass), pointer :: b => null()\n"
+        "    ! A comment inside the block.\n"
+        "#ifdef USEMPI\n"
+        "    integer :: rank\n"
+        "#endif\n"
+        "    logical :: flagOne=.false., flagTwo=.true.\n"
+        "  end subroutine s\n"
+    )
+    once  = _format(source)
+    twice = _format(once)
+    assert twice == once, (once, twice)
+
+
+# ---------------------------------------------------------------------------
+# 6. The whole source tree
+# ---------------------------------------------------------------------------
+
+def _source_files():
+    root = os.path.join(os.environ.get('GALACTICUS_EXEC_PATH', '.'), 'source')
+    if not os.path.isdir(root):
+        return []
+    return sorted(
+        os.path.join(directory, name)
+        for directory, _, names in os.walk(root)
+        for name in names
+        if name.endswith(('.F90', '.Inc'))
+    )
+
+
+def _declaration_summary(tree):
+    summary = []
+    for node in walk_tree(tree):
+        if node.get('type') != 'declaration':
+            continue
+        for declaration in node.get('declarations', []):
+            type_spec = declaration.get('type')
+            summary.append((
+                declaration['intrinsic'],
+                re.sub(r'\s+', '', type_spec).lower() if type_spec else '',
+                frozenset(re.sub(r'\s+', '', a).lower()
+                          for a in (declaration.get('attributes') or [])),
+                tuple(re.sub(r'\s+', '', v).lower()
+                      for v in declaration.get('variables', [])),
+                bool(declaration.get('openMP')),
+            ))
+    return sorted(summary)
+
+
+@pytest.mark.slow
+def test_declaration_formatting_preserves_semantics_tree_wide():
+    """Reformatting must never change what is declared.
+
+    Attribute *order* is deliberately excluded from the comparison — the
+    formatter canonicalizes it — but the intrinsic, type-spec, attribute set,
+    variables and initializers must all survive untouched.
+    """
+    files = _source_files()
+    assert files, 'no source files found — is GALACTICUS_EXEC_PATH set?'
+
+    failures = []
+    for path in files:
+        with open(path, errors='replace') as fh:
+            original = fh.read()
+        tree   = parse_code_for_format(original, source=path)
+        before = _declaration_summary(tree)
+        format_declarations_tree(tree)
+        formatted = serialize_for_format(tree['firstChild'])
+        after = _declaration_summary(
+            parse_code_for_format(formatted, source=path))
+        if after != before:
+            failures.append(path)
+    assert not failures, '\n'.join(failures[:20])
+
+
+@pytest.mark.slow
+def test_declaration_formatting_is_idempotent_tree_wide():
+    files = _source_files()
+    assert files, 'no source files found — is GALACTICUS_EXEC_PATH set?'
+
+    def once(text, path):
+        tree = parse_code_for_format(text, source=path)
+        format_declarations_tree(tree)
+        return serialize_for_format(tree['firstChild'])
+
+    failures = []
+    for path in files:
+        with open(path, errors='replace') as fh:
+            original = fh.read()
+        first = once(original, path)
+        if once(first, path) != first:
+            failures.append(path)
+    assert not failures, '\n'.join(failures[:20])

--- a/python/Galacticus/Build/SourceTree/tests/test_format_round_trip.py
+++ b/python/Galacticus/Build/SourceTree/tests/test_format_round_trip.py
@@ -1,0 +1,376 @@
+"""Tests for reformatting Fortran source in place.
+
+Reformatting differs from the build's code generation in one demanding
+respect: whatever the formatter does not deliberately change, it must leave
+byte-identical.  `parse_code()` does not offer that — it is free to rewrite
+anything the compiler will not notice, and does — so formatters go through
+`parse_code_for_format()` / `serialize_for_format()` instead.
+
+Covered here:
+
+  1. `uncomment_embedded()` inverts `_comment_embedded()`, which prefixes the
+     body of every `!!{ … !!}` and `!![ … !!]` block with `"!< "`.  Without an
+     inverse, serializing a parsed tree back to source rewrote every directive
+     and documentation block in the file.
+
+  2. `parse_code_for_format()` suppresses the other two rewrites: the
+     `{introspection:location}` line-number instrumentation, and the
+     directives pass, which re-emits a `!![`/`!!]` marker pair around each
+     individual directive and so split one multi-directive block into several.
+
+  3. The `use`-statement line-length ruler: `update_uses()` emits
+     `SYMBOLS_PER_ROW_MAX` symbols per row, but drops to fewer when that would
+     push a row past `LINE_LENGTH_MAX`.
+
+  4. Idempotence.  Two bugs broke it, and both are easy to reintroduce: the
+     indent was read off the first line of the block, picking up the OpenMP
+     padding the previous pass had added; and intrinsic modules were hoisted
+     to index zero, which reversed them relative to each other on every pass.
+"""
+
+import os
+import re
+
+import pytest
+
+from Galacticus.Build.SourceTree import (
+    _comment_embedded,
+    uncomment_embedded,
+    parse_code_for_format,
+    serialize_for_format,
+    walk_tree,
+)
+from Galacticus.Build.SourceTree.Parse.ModuleUses import (
+    LINE_LENGTH_MAX,
+    SYMBOLS_PER_ROW_MAX,
+    update_uses,
+)
+
+
+def _format(source):
+    """Apply the `use`-block formatter to `source` and return the result."""
+    tree = parse_code_for_format(source, name='<test>')
+    for node in walk_tree(tree):
+        if node.get('type') == 'moduleUse':
+            update_uses(node)
+    return serialize_for_format(tree['firstChild'])
+
+
+def _use_lines(text):
+    return [line for line in text.splitlines()
+            if re.match(r'^\s*(!\$\s*)?(&|use(?![a-zA-Z0-9_]))', line)]
+
+
+def _symbols_in_row(line):
+    """Count the `only` symbols on one physical line of a `use` statement.
+
+    Everything up to and including `, only : ` is the statement's own prefix,
+    whose comma must not be counted; continuation rows carry only symbols.  A
+    trailing `&` marks a row that continues, so the last symbol on it is
+    followed by a comma like the others.
+    """
+    body = line.split(", only : ", 1)[-1].lstrip("& ").rstrip()
+    return len([symbol for symbol in body.rstrip("&").split(",") if symbol.strip()])
+
+
+# ---------------------------------------------------------------------------
+# 1. uncomment_embedded
+# ---------------------------------------------------------------------------
+
+def test_uncomment_embedded_inverts_comment_embedded():
+    source = (
+        "module foo\n"
+        "  !!{RST\n"
+        "  Documentation body.\n"
+        "  !!}\n"
+        "  !![\n"
+        "  <directive name=\"a\"/>\n"
+        "  <directive name=\"b\"/>\n"
+        "  !!]\n"
+        "  implicit none\n"
+        "end module foo\n"
+    )
+    commented = _comment_embedded(source)
+    # Sanity: the transform really did something to the block bodies.
+    assert "!<   Documentation body.\n" in commented, commented
+    assert uncomment_embedded(commented) == source
+
+
+def test_uncomment_embedded_leaves_plain_source_alone():
+    """Lines outside a `!!{`/`!![` block never carry the marker, so a file
+    with no embedded blocks must pass through untouched."""
+    source = (
+        "subroutine bar\n"
+        "  ! An ordinary comment.\n"
+        "  integer :: i\n"
+        "end subroutine bar\n"
+    )
+    assert uncomment_embedded(source) == source
+
+
+def test_uncomment_embedded_ignores_nested_markers():
+    """`_comment_embedded()` prefixes a `!!{` that appears *inside* a block
+    rather than treating it as opening a second one.  The inverse has to make
+    the same call, or its notion of where the block ends drifts out of step
+    and it strips markers off lines that never had them."""
+    source = (
+        "  !![\n"
+        "  <description>\n"
+        "  !!{\n"
+        "  </description>\n"
+        "  !!]\n"
+        "  integer :: i\n"
+    )
+    assert uncomment_embedded(_comment_embedded(source)) == source
+
+
+# ---------------------------------------------------------------------------
+# 2. Round-trip fidelity of the format-oriented parse
+# ---------------------------------------------------------------------------
+
+def test_directive_block_survives_round_trip():
+    """The directives pass emits one `!![ … !!]` pair per directive, so a
+    block holding three of them came back as three blocks.  The
+    format-oriented parse must not run that pass."""
+    source = (
+        "  function f()\n"
+        "    !![\n"
+        "    <objectDestructor name=\"a_\"/>\n"
+        "    <objectDestructor name=\"b_\"/>\n"
+        "    <objectDestructor name=\"c_\"/>\n"
+        "    !!]\n"
+        "    return\n"
+        "  end function f\n"
+    )
+    out = serialize_for_format(parse_code_for_format(source)['firstChild'])
+    assert out == source
+    assert out.count("!![") == 1, out
+
+
+def test_introspection_location_not_instrumented():
+    """`parse_code(instrument=True)` tags each placeholder with its line
+    number, turning `…:location}` into `…:location:3}`."""
+    source = (
+        "  subroutine s\n"
+        "    implicit none\n"
+        "    call Error_Report('bad'//{introspection:location})\n"
+        "  end subroutine s\n"
+    )
+    out = serialize_for_format(parse_code_for_format(source)['firstChild'])
+    assert out == source
+    assert "{introspection:location}" in out, out
+
+
+def test_round_trip_preserves_unformatted_use_block():
+    """Nothing may change until a formatter asks for it — including a `use`
+    block whose layout does not match the house style."""
+    source = (
+        "module foo\n"
+        "  use::Error,only:Error_Report\n"
+        "  use :: Display, only : displayMessage\n"
+        "  implicit none\n"
+        "end module foo\n"
+    )
+    out = serialize_for_format(parse_code_for_format(source)['firstChild'])
+    assert out == source
+
+
+# ---------------------------------------------------------------------------
+# 3. The line-length ruler
+# ---------------------------------------------------------------------------
+
+def test_short_symbols_use_full_row():
+    """A block whose rows fit comfortably keeps the full complement of
+    symbols per row."""
+    source = (
+        "module foo\n"
+        "  use :: M, only : a, b, c, d, e\n"
+        "  implicit none\n"
+        "end module foo\n"
+    )
+    out = _format(source)
+    first = _use_lines(out)[0]
+    assert _symbols_in_row(first) == SYMBOLS_PER_ROW_MAX, out
+    assert first.rstrip().endswith("&"), out
+
+
+def test_long_symbols_reduce_symbols_per_row():
+    """Four symbols per row would run past the limit here, so the formatter
+    must fall back to fewer — and every emitted row must then fit."""
+    symbols = [f"aVeryLongSymbolNameIndeed{i:02d}" * 2 for i in range(8)]
+    source = (
+        "module foo\n"
+        f"  use :: M, only : {', '.join(symbols)}\n"
+        "  implicit none\n"
+        "end module foo\n"
+    )
+    out = _format(source)
+    lines = _use_lines(out)
+    assert all(len(line) <= LINE_LENGTH_MAX for line in lines), lines
+    # Fewer than the maximum symbols per row, but still more than one.
+    assert 1 < max(_symbols_in_row(line) for line in lines) < SYMBOLS_PER_ROW_MAX, lines
+    # No symbol was lost.
+    for symbol in symbols:
+        assert symbol in out, symbol
+
+
+def test_single_oversized_symbol_overflows_rather_than_breaking():
+    """A symbol that cannot fit on a line of its own is emitted anyway —
+    there is nowhere to break it, and the build passes
+    `-ffree-line-length-none`, so the limit is a style rule."""
+    symbol = "x" * (LINE_LENGTH_MAX + 20)
+    source = (
+        "module foo\n"
+        f"  use :: M, only : {symbol}, y\n"
+        "  implicit none\n"
+        "end module foo\n"
+    )
+    out = _format(source)
+    assert symbol in out, out
+    # One symbol per row: the long one overflows, the short one does not.
+    assert max(len(line) for line in _use_lines(out)) > LINE_LENGTH_MAX
+
+
+def test_ruler_keeps_columns_aligned_across_statements():
+    """Symbol columns are shared across the whole block, so the count per row
+    is chosen once for the block rather than per statement."""
+    source = (
+        "module foo\n"
+        "  use :: Alpha, only : one, two, three, four, five\n"
+        "  use :: Beta , only : six, seven\n"
+        "  implicit none\n"
+        "end module foo\n"
+    )
+    out = _format(source)
+    lines = [line for line in out.splitlines() if ", only : " in line]
+    columns = {line.index(", only : ") for line in lines}
+    assert len(columns) == 1, lines
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotence
+# ---------------------------------------------------------------------------
+
+def test_openmp_block_indent_is_stable():
+    """Unconditional uses in a block that also has `!$ use` lines are indented
+    three columns further, so that `use` lines up across the sentinel.  Reading
+    the block indent off its first line picked that padding up and added three
+    more columns on every pass."""
+    source = (
+        "  subroutine s\n"
+        "    use :: Error, only : Error_Report\n"
+        "    !$ use :: OMP_Lib, only : OMP_Get_Max_Threads\n"
+        "    implicit none\n"
+        "  end subroutine s\n"
+    )
+    once  = _format(source)
+    twice = _format(once)
+    assert twice == once, (once, twice)
+    # And the sentinel line still sits at the original indent.
+    assert "\n    !$ use :: OMP_Lib" in once, once
+
+
+def test_multiple_intrinsic_modules_keep_relative_order():
+    """Intrinsic modules are hoisted ahead of the rest but must keep their own
+    order.  Inserting each at index zero reversed them, so reformatting
+    oscillated between two layouts and never reached a fixed point."""
+    source = (
+        "module foo\n"
+        "  use, intrinsic :: ISO_C_Binding   , only : c_size_t\n"
+        "  use, intrinsic :: ISO_Fortran_Env , only : output_unit\n"
+        "  use            :: Display         , only : displayMessage\n"
+        "  implicit none\n"
+        "end module foo\n"
+    )
+    once  = _format(source)
+    twice = _format(once)
+    assert twice == once, (once, twice)
+    assert once.index("ISO_C_Binding") < once.index("ISO_Fortran_Env"), once
+    # Intrinsics still come first.
+    assert once.index("ISO_Fortran_Env") < once.index("Display"), once
+
+
+def test_formatting_is_idempotent_over_mixed_block():
+    source = (
+        "  subroutine s\n"
+        "    use, intrinsic :: ISO_C_Binding, only : c_size_t, c_int\n"
+        "    use :: Error, only : Error_Report\n"
+        "#ifdef USEMPI\n"
+        "    use :: MPI_Utilities, only : mpiSelf, mpiBarrier\n"
+        "#endif\n"
+        "    !$ use :: OMP_Lib, only : OMP_Get_Max_Threads\n"
+        "    implicit none\n"
+        "  end subroutine s\n"
+    )
+    once  = _format(source)
+    twice = _format(once)
+    assert twice == once, (once, twice)
+    # The preprocessor guard survives, exactly once.
+    assert once.count("#ifdef USEMPI") == 1, once
+    assert once.count("#endif") == 1, once
+
+
+# ---------------------------------------------------------------------------
+# 5. The whole source tree
+# ---------------------------------------------------------------------------
+
+def _source_files():
+    """Every Fortran source file in the repository's `source/` tree."""
+    root = os.path.join(os.environ.get('GALACTICUS_EXEC_PATH', '.'), 'source')
+    if not os.path.isdir(root):
+        return []
+    return sorted(
+        os.path.join(directory, name)
+        for directory, _, names in os.walk(root)
+        for name in names
+        if name.endswith(('.F90', '.Inc'))
+    )
+
+
+@pytest.mark.slow
+def test_every_source_file_round_trips_unchanged():
+    """Parsing and reserializing any file in the tree must return it byte for
+    byte.  Fixtures cannot stand in for this: the failures worth catching are
+    the constructs nobody thought to write a fixture for.
+
+    A file that fails here is not merely formatted oddly — it means the parser
+    cannot represent something the file contains, so reformatting it would
+    silently drop or mangle that construct.
+    """
+    files = _source_files()
+    assert files, 'no source files found — is GALACTICUS_EXEC_PATH set?'
+
+    failures = []
+    for path in files:
+        with open(path, errors='replace') as fh:
+            original = fh.read()
+        try:
+            out = serialize_for_format(
+                parse_code_for_format(original, source=path)['firstChild'])
+        except Exception as error:                      # noqa: BLE001
+            failures.append(f'{path}: raised {error!r}')
+            continue
+        if out != original:
+            failures.append(f'{path}: round-trip differs')
+    assert not failures, '\n'.join(failures[:20])
+
+
+@pytest.mark.slow
+def test_formatting_every_source_file_is_idempotent():
+    """Reformatting a file that is already formatted must be a no-op.
+
+    Without this, two separate bugs went unnoticed — the OpenMP indent grew by
+    three columns per pass, and pairs of intrinsic modules swapped places on
+    every pass — because both need a *second* run to become visible.
+    """
+    files = _source_files()
+    assert files, 'no source files found — is GALACTICUS_EXEC_PATH set?'
+
+    failures = []
+    for path in files:
+        with open(path, errors='replace') as fh:
+            original = fh.read()
+        once = _format(original)
+        if _format(once) != once:
+            failures.append(path)
+    assert not failures, '\n'.join(failures[:20])

--- a/scripts/aux/formatDeclarations.py
+++ b/scripts/aux/formatDeclarations.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Format variable declaration blocks of Fortran source files.
+# Andrew Benson (2026)
+
+import os
+import re
+import sys
+import tempfile
+import argparse
+
+
+from Galacticus.Build.SourceTree import (
+    parse_code_for_format,
+    serialize_for_format,
+    walk_tree,
+)
+from Galacticus.Build.SourceTree.Parse.Declarations import format_declarations_tree
+
+parser = argparse.ArgumentParser(
+    description='Format variable declaration blocks of Fortran source files')
+parser.add_argument('infile', help='Input Fortran source file')
+parser.add_argument('--suffix', default='~', help='Suffix for backup file (default: ~)')
+parser.add_argument('--check', action='store_true',
+                    help='Report whether the file is correctly formatted without modifying it; '
+                         'exit status 1 if it would change')
+parser.add_argument('--no-backup', action='store_true',
+                    help='Overwrite the input file without leaving a backup')
+parser.add_argument('--include-external', action='store_true',
+                    help='Also format files under source/external/ (vendored third-party '
+                         'code, skipped by default)')
+args = parser.parse_args()
+
+
+def is_vendored(path):
+    """True for third-party code vendored under `source/external/`.
+
+    Reformatting vendored sources makes them impossible to diff against
+    upstream, so they are left alone by default — the same exclusion the build
+    applies when discovering executables (`scripts/build/findExecutables.py`).
+    """
+    parts = os.path.normpath(os.path.abspath(path)).split(os.sep)
+    for index in range(len(parts) - 1):
+        if parts[index] == 'source' and parts[index + 1] == 'external':
+            return True
+    return False
+
+
+def declaration_summary(tree):
+    """Reduce a tree to the declaration content that formatting must preserve.
+
+    For each declaration: the intrinsic type, the type-spec, the *set* of
+    attributes (the formatter reorders them, so order is deliberately dropped)
+    and the variables with their initializers.  Whitespace and case are
+    normalized, since Fortran is insensitive to both and the emitter adjusts
+    both.  Comparing this before and after catches a dropped variable, a lost
+    attribute or a mangled initializer.
+    """
+    summary = []
+    for node in walk_tree(tree):
+        if node.get('type') != 'declaration':
+            continue
+        for declaration in node.get('declarations', []):
+            attributes = frozenset(
+                re.sub(r'\s+', '', a).lower()
+                for a in (declaration.get('attributes') or []))
+            type_spec = declaration.get('type')
+            summary.append((
+                declaration['intrinsic'],
+                re.sub(r'\s+', '', type_spec).lower() if type_spec else '',
+                attributes,
+                tuple(re.sub(r'\s+', '', v).lower()
+                      for v in declaration.get('variables', [])),
+                bool(declaration.get('openMP')),
+            ))
+    return sorted(summary)
+
+
+if is_vendored(args.infile) and not args.include_external:
+    sys.exit(0)
+
+with open(args.infile, 'r', errors='replace') as fh:
+    original = fh.read()
+
+tree = parse_code_for_format(original, source=args.infile)
+
+# Safety check 1 — the parse/serialize round-trip must be exact *before* any
+# formatting is applied.  If it is not, the parser has failed to represent
+# something in this file and any output would silently corrupt it.
+unmodified = serialize_for_format(tree['firstChild'])
+if unmodified != original:
+    sys.stderr.write(
+        f'{args.infile}: parse/serialize round-trip is not exact — refusing to '
+        f'reformat.\n')
+    sys.exit(2)
+
+before = declaration_summary(tree)
+
+format_declarations_tree(tree)
+content = serialize_for_format(tree['firstChild'])
+
+# Safety check 2 — reformatting must not change what is declared.  This
+# re-parses the formatted text rather than trusting the tree it came from, so a
+# bug in the emitter is caught too.
+after = declaration_summary(parse_code_for_format(content, source=args.infile))
+if after != before:
+    sys.stderr.write(
+        f'{args.infile}: reformatting would change the declarations — refusing '
+        f'to write.\n')
+    sys.exit(2)
+
+if content == original:
+    sys.exit(0)
+
+if args.check:
+    print(f'{args.infile}: would be reformatted')
+    sys.exit(1)
+
+dirpath  = os.path.dirname(os.path.abspath(args.infile))
+tmp_path = None
+try:
+    fd, tmp_path = tempfile.mkstemp(dir=dirpath)
+    with os.fdopen(fd, 'w') as fh:
+        fh.write(content)
+        fh.flush()
+        os.fsync(fh.fileno())
+    if args.no_backup:
+        os.replace(tmp_path, args.infile)
+    else:
+        os.replace(args.infile, args.infile + args.suffix)
+        os.replace(tmp_path, args.infile)
+    tmp_path = None
+except Exception:
+    if tmp_path is not None:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+    raise

--- a/scripts/aux/formatModuleUses.py
+++ b/scripts/aux/formatModuleUses.py
@@ -3,24 +3,97 @@
 # Andrew Benson (2026)
 
 import os
+import sys
 import tempfile
 import argparse
 
 
-from Galacticus.Build.SourceTree import parse_file, walk_tree, serialize
+from Galacticus.Build.SourceTree import (
+    parse_code_for_format,
+    serialize_for_format,
+    walk_tree,
+)
 from Galacticus.Build.SourceTree.Parse.ModuleUses import update_uses
 
 parser = argparse.ArgumentParser(description='Format module use sections of Fortran source files')
 parser.add_argument('infile', help='Input Fortran source file')
 parser.add_argument('--suffix', default='~', help='Suffix for backup file (default: ~)')
+parser.add_argument('--check', action='store_true',
+                    help='Report whether the file is correctly formatted without modifying it; '
+                         'exit status 1 if it would change')
+parser.add_argument('--no-backup', action='store_true',
+                    help='Overwrite the input file without leaving a backup')
 args = parser.parse_args()
 
-tree = parse_file(args.infile)
+
+def module_use_summary(tree):
+    """Reduce a tree to the module-use content that formatting must preserve.
+
+    Maps each module name to the set of `(condition set, symbol set)` pairs
+    declared for it, ignoring order and layout — exactly the axes the
+    formatter is allowed to change.  Comparing this before and after catches
+    a dropped, duplicated, or mangled symbol even though the formatter sorts
+    symbols and merges repeated `use` statements for the same module.
+    """
+    summary = {}
+    for node in walk_tree(tree):
+        if node.get('type') != 'moduleUse':
+            continue
+        for name, entries in node.get('moduleUse', {}).items():
+            if not isinstance(entries, list):
+                entries = [entries]
+            for entry in entries:
+                conditions = tuple(sorted(
+                    (c['name'], c['invert']) for c in entry.get('conditions', [])))
+                symbols = frozenset(entry.get('only', {}).keys())
+                summary.setdefault(name.lower(), set()).add(
+                    (conditions, symbols, bool(entry.get('all')),
+                     bool(entry.get('openMP')), bool(entry.get('intrinsic'))))
+    return summary
+
+
+with open(args.infile, 'r', errors='replace') as fh:
+    original = fh.read()
+
+tree = parse_code_for_format(original, source=args.infile)
+
+# Safety check 1 — the parse/serialize round-trip must be exact *before* any
+# formatting is applied.  If it is not, the parser has failed to represent
+# something in this file and any output would silently corrupt it, so refuse
+# to write rather than guess.
+unmodified = serialize_for_format(tree['firstChild'])
+if unmodified != original:
+    sys.stderr.write(
+        f'{args.infile}: parse/serialize round-trip is not exact — refusing to '
+        f'reformat.\n')
+    sys.exit(2)
+
+before = module_use_summary(tree)
+
 for node in walk_tree(tree):
     if node.get('type') == 'moduleUse':
         update_uses(node)
 
-content  = serialize(tree['firstChild'])
+content = serialize_for_format(tree['firstChild'])
+
+# Safety check 2 — reformatting must not change which symbols are imported
+# from which modules under which preprocessor conditions.  This re-parses the
+# formatted text rather than trusting the tree it came from, so a bug in the
+# emitter is caught too.
+after = module_use_summary(parse_code_for_format(content, source=args.infile))
+if after != before:
+    sys.stderr.write(
+        f'{args.infile}: reformatting would change the module uses — refusing to '
+        f'write.\n')
+    sys.exit(2)
+
+if content == original:
+    sys.exit(0)
+
+if args.check:
+    print(f'{args.infile}: would be reformatted')
+    sys.exit(1)
+
 dirpath  = os.path.dirname(os.path.abspath(args.infile))
 tmp_path = None
 try:
@@ -29,8 +102,11 @@ try:
         fh.write(content)
         fh.flush()
         os.fsync(fh.fileno())
-    os.replace(args.infile, args.infile + args.suffix)
-    os.replace(tmp_path, args.infile)
+    if args.no_backup:
+        os.replace(tmp_path, args.infile)
+    else:
+        os.replace(args.infile, args.infile + args.suffix)
+        os.replace(tmp_path, args.infile)
     tmp_path = None
 except Exception:
     if tmp_path is not None:


### PR DESCRIPTION
Adds two Galacticus-aware source formatters — one for module `use` blocks, one
for variable declaration blocks — and the round-trip fix both depend on. **No
source file is reformatted by this PR**; it lands the tools, their tests, and
the documentation only.

## Why the round-trip fix comes first

`scripts/aux/formatModuleUses.py` already existed but was unusable: running it
corrupted every directive and documentation block in the file. `parse_code()`
is built for code generation and rewrites three things the compiler will not
notice — the `"!< "` marker `_comment_embedded()` adds inside `!!{ … !!}` and
`!![ … !!]` blocks (with no inverse anywhere), the line numbers baked into
`{introspection:location}`, and the marker pair the directives pass re-emits
around each individual directive.

`parse_code_for_format()` / `serialize_for_format()` suppress all three. All
**1971** `.F90`/`.Inc` files under `source/` now serialize back byte-identically;
none did before.

## What the formatters do

Both are documented in the developer guide with worked examples generated by the
tools themselves, so the documentation cannot drift from the behaviour.

**`use` blocks** — aligns `use`, `::` and `, only :`, shares symbol column widths
across the block, and picks the symbols-per-row count from a 132-column budget.
Over-long `use` lines go **1239 → 0**; the longest becomes exactly 132.

**Declaration blocks** — columns for the intrinsic type, its parenthetical,
positional attribute columns, the `::`, and up to two variables per row with
`=` / `=>` aligned. Alignment groups span the comments and `#ifdef` guards that
`_pass_declarations()` breaks a node at (708 and 140 places). Attributes are
written in a canonical order derived from pairwise precedence counts over the
whole tree, not chosen by taste — it reorders ~3% of declarations.

Both drivers take `--check` (report-only, exit 1 if the file would change), so
they can be wired into a pre-commit or CI check.

## Safety

Neither tool writes unless two checks pass: the file round-trips exactly before
any formatting, and its own output — re-parsed, not merely trusted — declares
the same things. For declarations that means the same intrinsic, type-spec,
attribute *set*, variables and initializers; attribute order is excluded because
the tool sets it.

Verified over the whole tree: **0 round-trip failures, 0 semantic failures,
0 non-idempotent files**, for both formatters. New tests cover the columns, the
ruler, the canonical order, group-spanning, the deliberate exclusions and
idempotence, plus four corpus sweeps over real `source/` marked `slow`. Full
suite: **946 passed, 1 skipped**.

Generated code is unaffected — the parser changes are additive keys, confirmed
byte-identical across a 65-file sample of preprocessed output.

## Deliberate exclusions

Three kinds of statement are left exactly as written:

- declarations whose initializer no layout can fit (a `reshape([...])` data
  table). Continuation lines are joined away by the parser, so re-emitting from
  the parsed fields collapsed one hand-wrapped table from 553 columns to 1467.
  These are written back verbatim *and* excluded from the column widths, since
  one such table otherwise padded every declaration beside it to its own width;
- four derived-type definitions that reach the declaration parser only because
  internal padding hides them from the unit parser — see #1381, found while
  building this and deliberately not fixed here;
- third-party code under `source/external/`, so it stays comparable with
  upstream (`--include-external` overrides).

## Two idempotence bugs fixed

Both needed a second pass to become visible, which is why they had survived:
the block indent was re-read from a line the previous pass had already padded,
so blocks mixing `!$` and unconditional statements marched three columns right
every run; and intrinsic modules were hoisted with `insert(0, …)`, so a block
naming two of them oscillated between two layouts forever.

## The sweeps are not in this PR

Running the tools over the tree would touch 884 files (11,295 lines) for `use`
blocks and 1343 files (52,923 lines) for declarations. Those are best applied as
separate mechanical commits, timed for when few branches are open and added to
`.git-blame-ignore-revs`. Worth knowing before then: a first-time format also
sorts imported symbols alphabetically, merges repeated `use` statements for one
module, reorders attributes, and splits declarations of more than two variables
across rows — more than alignment alone.

## Verification

Developed with assistance from Claude. Per `CONTRIBUTING.md`, this needs human
review before merge — in particular the canonical attribute order and the three
exclusion rules above are judgement calls worth a second opinion, even though
each is backed by a measurement over the tree.
