### PR TITLE
Wire the source formatters into pre-commit and PR checks (advisory)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -182,6 +182,11 @@ change that.
   so expect more than alignment to change in a file not formatted before. It
   skips vendored code under `source/external/`, and leaves declarations with
   hand-wrapped oversized initializers exactly as written.
+- **The tree was not reformatted in one sweep**, so most files still predate the
+  formatters. The first change to such a file will also reformat it, often by
+  far more lines than the change itself — make that a separate `style(...)`
+  commit so the two can be reviewed apart. Both the pre-commit hook and the
+  *Check-Source-Formatting* CI job enforce this on the files a change touches.
 
 ## Spelling
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -183,10 +183,11 @@ change that.
   skips vendored code under `source/external/`, and leaves declarations with
   hand-wrapped oversized initializers exactly as written.
 - **The tree was not reformatted in one sweep**, so most files still predate the
-  formatters. The first change to such a file will also reformat it, often by
-  far more lines than the change itself — make that a separate `style(...)`
-  commit so the two can be reviewed apart. Both the pre-commit hook and the
-  *Check-Source-Formatting* CI job enforce this on the files a change touches.
+  formatters. Reformatting such a file changes far more lines than the edit that
+  prompted it, so make it a separate `style(...)` commit rather than folding it
+  into a substantive change. The pre-commit hook and the *Check-Source-Formatting*
+  CI job both report unformatted files, but are **advisory** — neither blocks a
+  commit nor fails a pull request.
 
 ## Spelling
 

--- a/.github/workflows/prChecks.yml
+++ b/.github/workflows/prChecks.yml
@@ -217,6 +217,69 @@ jobs:
             fi
           done
           exit $status
+  # Source formatting. `use` blocks and variable declaration blocks follow the
+  # column layout described in the developer guide, applied by the formatters in
+  # `scripts/aux/`. Only files touched by the pull request are checked, so a
+  # change is never blocked by formatting elsewhere in the tree.
+  Check-Source-Formatting:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/galacticusorg/buildenv:latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - name: Mark directory safe
+        run: |
+          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          # Vendored third-party code under `source/external/` is excluded, so
+          # that it stays comparable with its upstream original.
+          files: |
+            source/**/*.F90
+            source/**/*.Inc
+          files_ignore: |
+            source/external/**
+          safe_output: false
+      - name: Check formatting of Fortran sources
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          set -f
+          status=0
+          for file in ${CHANGED_FILES}; do
+            # Deleted or renamed-away files still appear in the changed list.
+            [ -f "$file" ] || continue
+            for tool in formatModuleUses formatDeclarations; do
+              # `run:` executes under `bash -e`, so the exit status has to be
+              # captured somewhere errexit does not apply — a bare call
+              # followed by `case $?` would abort the step on the first
+              # unformatted file, before any annotation was emitted.
+              rc=0
+              PYTHONPATH=$GITHUB_WORKSPACE/python python3 "scripts/aux/$tool.py" "$file" --check || rc=$?
+              case $rc in
+                0)
+                  ;;
+                1)
+                  echo "::error file=$file::Formatting differs from the house style. Run: ./scripts/aux/$tool.py $file"
+                  status=1
+                  ;;
+                *)
+                  # Exit 2 means the tool declined to touch the file — it does
+                  # not round-trip, or reformatting would change what it
+                  # declares or unbalance its preprocessor guards. That is a
+                  # tool limitation rather than a style problem, so report it
+                  # without failing the check.
+                  echo "::warning file=$file::$tool.py could not process this file; formatting not verified"
+                  ;;
+              esac
+            done
+          done
+          exit $status
   # Embedded XML directive validation (the LaTeX checks were retired with the
   # migration of the embedded documentation to reStructuredText).
   Validate-Embedded-XML:

--- a/.github/workflows/prChecks.yml
+++ b/.github/workflows/prChecks.yml
@@ -256,6 +256,7 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           set -f
+          : > rows.md
           for file in ${CHANGED_FILES}; do
             # Deleted or renamed-away files still appear in the changed list.
             [ -f "$file" ] || continue
@@ -263,25 +264,45 @@ jobs:
               # `run:` executes under `bash -e`, so the exit status has to be
               # captured somewhere errexit does not apply — a bare call
               # followed by `case $?` would abort the step on the first
-              # unformatted file, before any annotation was emitted.
+              # unformatted file, before anything was recorded.
               rc=0
               PYTHONPATH=$GITHUB_WORKSPACE/python python3 "scripts/aux/$tool.py" "$file" --check || rc=$?
               case $rc in
                 0)
                   ;;
                 1)
-                  echo "::warning file=$file::Formatting differs from the house style. Run ./scripts/aux/$tool.py $file, ideally as a separate follow-up commit."
+                  printf '| `%s` | differs from the house style | `./scripts/aux/%s.py %s` |\n' \
+                    "$file" "$tool" "$file" >> rows.md
+                  # Annotations are capped at ten of each level per step, so
+                  # the job summary below — not this — is the complete record.
+                  echo "::warning file=$file::Formatting differs from the house style; see the job summary."
                   ;;
                 *)
                   # Exit 2 means the tool declined to touch the file — it does
                   # not round-trip, or reformatting would change what it
                   # declares or unbalance its preprocessor guards. That is a
-                  # tool limitation rather than a style problem.
-                  echo "::warning file=$file::$tool.py could not process this file; formatting not verified"
+                  # tool limitation rather than a style problem, and needs no
+                  # action from the author.
+                  printf '| `%s` | `%s.py` could not process it; formatting not verified | _none needed_ |\n' \
+                    "$file" "$tool" >> rows.md
                   ;;
               esac
             done
           done
+          if [ -s rows.md ]; then
+            {
+              printf '## :warning: Source formatting (advisory)\n\n'
+              printf 'The files below differ from the house style. See '
+              printf '[how the formatting is rolled out](https://galacticus.readthedocs.io/en/latest/manuals/developer-guide/editor-setup.html#manual-sec-formattingadoption) '
+              printf 'in the developer guide.\n\n'
+              printf '| File | Finding | To fix |\n|---|---|---|\n'
+              cat rows.md
+              printf '\n**Nothing here blocks this pull request.** Most of the tree predates the\n'
+              printf 'formatters, so the first change to a file often reformats far more lines than\n'
+              printf 'the change itself. If you do reformat, please do it as a separate commit so\n'
+              printf 'that reviewers can read the two apart.\n'
+            } >> $GITHUB_STEP_SUMMARY
+          fi
           # Advisory only — see the comment on this job.
           exit 0
   # Embedded XML directive validation (the LaTeX checks were retired with the

--- a/.github/workflows/prChecks.yml
+++ b/.github/workflows/prChecks.yml
@@ -219,8 +219,14 @@ jobs:
           exit $status
   # Source formatting. `use` blocks and variable declaration blocks follow the
   # column layout described in the developer guide, applied by the formatters in
-  # `scripts/aux/`. Only files touched by the pull request are checked, so a
-  # change is never blocked by formatting elsewhere in the tree.
+  # `scripts/aux/`. Only files touched by the pull request are checked.
+  #
+  # Advisory: this job reports through annotations and never fails. The tree was
+  # not reformatted in one sweep, so most files still predate the formatters;
+  # failing here would force the first change to any of them to carry a
+  # whole-file reformat in the same pull request, mixing it with the substantive
+  # change. Reporting instead lets that reformat be made as a separate
+  # follow-up commit.
   Check-Source-Formatting:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
@@ -250,7 +256,6 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           set -f
-          status=0
           for file in ${CHANGED_FILES}; do
             # Deleted or renamed-away files still appear in the changed list.
             [ -f "$file" ] || continue
@@ -265,21 +270,20 @@ jobs:
                 0)
                   ;;
                 1)
-                  echo "::error file=$file::Formatting differs from the house style. Run: ./scripts/aux/$tool.py $file"
-                  status=1
+                  echo "::warning file=$file::Formatting differs from the house style. Run ./scripts/aux/$tool.py $file, ideally as a separate follow-up commit."
                   ;;
                 *)
                   # Exit 2 means the tool declined to touch the file — it does
                   # not round-trip, or reformatting would change what it
                   # declares or unbalance its preprocessor guards. That is a
-                  # tool limitation rather than a style problem, so report it
-                  # without failing the check.
+                  # tool limitation rather than a style problem.
                   echo "::warning file=$file::$tool.py could not process this file; formatting not verified"
                   ;;
               esac
             done
           done
-          exit $status
+          # Advisory only — see the comment on this job.
+          exit 0
   # Embedded XML directive validation (the LaTeX checks were retired with the
   # migration of the embedded documentation to reStructuredText).
   Validate-Embedded-XML:

--- a/docs/manuals/developer-guide/editor-setup.rst
+++ b/docs/manuals/developer-guide/editor-setup.rst
@@ -176,16 +176,19 @@ How the formatting is rolled out
 
 The source tree has deliberately *not* been reformatted in one sweep. Doing so
 would have rewritten around 1500 files at once, wrecking ``git blame`` and
-conflicting with every branch open at the time. Instead the formatters are
-enforced going forward: both the pre-commit hook and the *Check-Source-Formatting*
-job on pull requests run them in ``--check`` mode over the files a change
-touches, so the tree converges on the house style file by file as it is worked
-on.
+conflicting with every branch open at the time. Instead the tree converges on
+the house style file by file as it is worked on: both the pre-commit hook and
+the *Check-Source-Formatting* job on pull requests run the formatters in
+``--check`` mode over the files a change touches, and report what differs.
 
-The practical consequence is that the first change to a file which predates the
-formatters will also reformat it, and that reformatting may be considerably
-larger than the change itself. Run the tools as a separate commit from your
-substantive change so that reviewers can read the two apart:
+Both are **advisory** — neither blocks a commit or fails a pull request. Since
+most files still predate the formatters, blocking would force the first change
+to any of them to carry a whole-file reformat in the same commit, mixed in with
+the substantive change. Reporting instead leaves the choice of when to reformat
+with you.
+
+When you do reformat, make it a commit of its own, so that reviewers can read
+the reformatting and the substantive change apart:
 
 .. code-block:: bash
 

--- a/docs/manuals/developer-guide/editor-setup.rst
+++ b/docs/manuals/developer-guide/editor-setup.rst
@@ -169,6 +169,34 @@ would collapse the table onto one enormous line.
    declarations of more than two variables across rows, so a file that has not
    been formatted before may change by more than alignment alone.
 
+.. _manual-sec-formattingAdoption:
+
+How the formatting is rolled out
+--------------------------------
+
+The source tree has deliberately *not* been reformatted in one sweep. Doing so
+would have rewritten around 1500 files at once, wrecking ``git blame`` and
+conflicting with every branch open at the time. Instead the formatters are
+enforced going forward: both the pre-commit hook and the *Check-Source-Formatting*
+job on pull requests run them in ``--check`` mode over the files a change
+touches, so the tree converges on the house style file by file as it is worked
+on.
+
+The practical consequence is that the first change to a file which predates the
+formatters will also reformat it, and that reformatting may be considerably
+larger than the change itself. Run the tools as a separate commit from your
+substantive change so that reviewers can read the two apart:
+
+.. code-block:: bash
+
+   ./scripts/aux/formatModuleUses.py  source/path/to/file.F90
+   ./scripts/aux/formatDeclarations.py source/path/to/file.F90
+   git commit -m "style(...): format <file>"
+
+A file that either tool declines to process is reported as a warning rather
+than a failure, and needs no action — see
+:ref:`manual-sec-formatDeclarations` for the statements the tools leave alone.
+
 .. _manual-sec-editorEmbedded:
 
 Embedded languages in Fortran source

--- a/python/Galacticus/Build/SourceTree/Parse/Declarations.py
+++ b/python/Galacticus/Build/SourceTree/Parse/Declarations.py
@@ -398,6 +398,10 @@ _ATTRIBUTE_RANK = {name: index for index, name in enumerate(ATTRIBUTE_ORDER)}
 # variable columns and are laid out on their own axis.
 _TYPE_BOUND_INTRINSICS = frozenset(('procedure', 'generic', 'final'))
 
+# Generic-programming placeholders, e.g. `{Type¦label}`.  Statements carrying
+# one are line-structure-sensitive — see `_has_generic_placeholder`.
+_GENERIC_PLACEHOLDER_RE = re.compile(r'\{[^{}]*\}')
+
 # The `intent` field is padded to the width of the longest spelling, `inout`,
 # so that the three forms occupy one column: `in` is left-aligned within it and
 # `out` right-aligned, giving `intent(in   )`, `intent(inout)`, `intent(  out)`.
@@ -686,20 +690,45 @@ def _minimum_width(declaration, indent):
     return width + longest
 
 
-def _is_unformattable(declaration, indent):
-    """True if no layout of this declaration can fit within the ruler.
+def _has_generic_placeholder(declaration):
+    """True if the statement carries a generic-programming placeholder.
 
-    A single variable carrying a large initializer — a `reshape([...])` data
-    table, say — cannot be broken by a formatter that only breaks *between*
-    variables.  `get_fortran_line` has already joined away the continuation
-    lines its author used, so re-emitting it from the parsed fields would
-    collapse a carefully wrapped table onto one enormous line.  Such
-    declarations are written back verbatim instead, and are kept out of the
-    column-width calculation so that they cannot pad their neighbours out to
-    their own width.
+    `Process.Generics` expands `{Type¦label}` placeholders one *physical line*
+    at a time (`_expand_content_lines`): a line containing one is emitted once
+    per instance, and lines without one are copied through. A statement split
+    across a continuation would therefore expand into N copies of its first
+    line followed by N copies of its second, and the trailing `&` of each copy
+    of the first line would glue it to the *next* copy rather than to its own
+    second line — silently fusing N statements into one.
+
+    All 106 such declarations in the tree are written on a single line, which
+    is precisely what makes the existing expansion work; the formatter must
+    not be the thing that breaks that.
     """
-    return (declaration.get('rawText') is not None
-            and _minimum_width(declaration, indent) > LINE_LENGTH_MAX)
+    return bool(_GENERIC_PLACEHOLDER_RE.search(declaration.get('rawText') or ''))
+
+
+def _emit_verbatim(declaration, indent):
+    """True if this declaration must be written back exactly as it was.
+
+    Two cases, both of which turn on line structure the emitter cannot safely
+    reproduce:
+
+    * A statement carrying a generic-programming placeholder, whose expansion
+      is line-based — see `_has_generic_placeholder`.
+    * A single variable carrying a large initializer — a `reshape([...])` data
+      table, say — which cannot be broken by a formatter that only breaks
+      *between* variables. `get_fortran_line` has already joined away the
+      continuation lines its author used, so re-emitting it from the parsed
+      fields would collapse a carefully wrapped table onto one enormous line.
+
+    Such declarations are also kept out of the column-width calculation, so
+    that they cannot pad their neighbours out to their own width.
+    """
+    if declaration.get('rawText') is None:
+        return False
+    return (_has_generic_placeholder(declaration)
+            or _minimum_width(declaration, indent) > LINE_LENGTH_MAX)
 
 
 def _is_type_definition(declaration):
@@ -807,7 +836,7 @@ def format_declarations(group):
 
     # Declarations too wide for any layout are written back as they were, and
     # take no part in sizing the columns.
-    laid_out = [d for d in declarations if not _is_unformattable(d, indent)]
+    laid_out = [d for d in declarations if not _emit_verbatim(d, indent)]
     if not laid_out:
         return
     per_row = _choose_variables_per_row(laid_out, indent, openmp_any)
@@ -816,7 +845,7 @@ def format_declarations(group):
     for node in group:
         content = indent + 'implicit none\n' if node.get('implicitNone') else ''
         for declaration in node.get('declarations', []):
-            if _is_unformattable(declaration, indent):
+            if _emit_verbatim(declaration, indent):
                 content += declaration['rawText']
             else:
                 content += _emit_declaration(

--- a/python/Galacticus/Build/SourceTree/__init__.py
+++ b/python/Galacticus/Build/SourceTree/__init__.py
@@ -139,6 +139,33 @@ def serialize_for_format(node):
     return uncomment_embedded(serialize(node))
 
 
+_GUARD_OPEN_RE  = re.compile(r'^\s*#\s*(?:ifdef|ifndef|if)\b')
+_GUARD_CLOSE_RE = re.compile(r'^\s*#\s*endif\b')
+
+
+def preprocessor_guard_balance(text):
+    """Net count of opened-minus-closed preprocessor conditionals in `text`.
+
+    Reformatting must never change this.  `update_uses()` re-emits a guard
+    around each `use` statement it owns, so where a `#ifdef` in the source
+    covered a `use` *and* the code following it, the rebuilt block closes its
+    own guard while the original `#endif` survives in the following code —
+    leaving an unbalanced `#endif` that fails to compile.
+
+    Comparing the whole-file balance before and after catches that class of
+    error whatever its cause, which a check on the parsed structure alone does
+    not: the structure round-trips perfectly, and it is the *interleaving* of
+    the rebuilt block with its surroundings that goes wrong.
+    """
+    balance = 0
+    for line in text.splitlines():
+        if _GUARD_OPEN_RE.match(line):
+            balance += 1
+        elif _GUARD_CLOSE_RE.match(line):
+            balance -= 1
+    return balance
+
+
 def walk_tree(node):
     """Depth-first generator over all nodes in the tree.
 

--- a/python/Galacticus/Build/SourceTree/tests/test_format_declarations.py
+++ b/python/Galacticus/Build/SourceTree/tests/test_format_declarations.py
@@ -290,6 +290,30 @@ def test_unfittable_initializer_keeps_its_hand_wrapping():
             assert line in out.splitlines(), (line, out)
 
 
+def test_generic_placeholder_statement_is_never_wrapped():
+    """`Process.Generics` expands `{Type¦label}` placeholders one *physical
+    line* at a time, emitting a line carrying one once per instance. A
+    statement split across a continuation would expand into N copies of its
+    first line followed by N copies of its second, and the trailing `&` of each
+    copy of the first line would glue it to the *next* copy — fusing N
+    statements into one. Such statements must come back exactly as written."""
+    source = (
+        "  type t\n"
+        "   contains\n"
+        "     generic :: readAttribute => IO_HDF5_Read_Attribute_{Type\u00a6label}_Scalar, "
+        "IO_HDF5_Read_Attribute_{Type\u00a6label}_1D_Array_Allocatable\n"
+        "     procedure :: shortOne => fooShortOne\n"
+        "  end type t\n"
+    )
+    out = _format(source)
+    generic = [l for l in out.splitlines() if 'generic' in l]
+    assert len(generic) == 1, out
+    assert not generic[0].rstrip().endswith('&'), generic[0]
+    # Both specific procedures remain on that one line.
+    assert 'IO_HDF5_Read_Attribute_{Type\u00a6label}_Scalar' in generic[0], generic[0]
+    assert 'IO_HDF5_Read_Attribute_{Type\u00a6label}_1D_Array_Allocatable' in generic[0], generic[0]
+
+
 def test_oversized_declaration_does_not_pad_its_neighbours():
     """A declaration left verbatim takes no part in sizing the columns — one
     huge data table used to pad every declaration beside it out to its width."""

--- a/python/Galacticus/Build/SourceTree/tests/test_format_round_trip.py
+++ b/python/Galacticus/Build/SourceTree/tests/test_format_round_trip.py
@@ -35,6 +35,7 @@ import pytest
 
 from Galacticus.Build.SourceTree import (
     _comment_embedded,
+    preprocessor_guard_balance,
     uncomment_embedded,
     parse_code_for_format,
     serialize_for_format,
@@ -374,3 +375,41 @@ def test_formatting_every_source_file_is_idempotent():
         if _format(once) != once:
             failures.append(path)
     assert not failures, '\n'.join(failures[:20])
+
+
+# ---------------------------------------------------------------------------
+# 6. Preprocessor guard balance
+# ---------------------------------------------------------------------------
+
+def test_guard_balance_counts_conditionals():
+    text = (
+        "#ifdef A\n"
+        "  use :: X, only : y\n"
+        "#endif\n"
+    )
+    assert preprocessor_guard_balance(text) == 0
+    assert preprocessor_guard_balance(text + "#endif\n") == -1
+    assert preprocessor_guard_balance("#ifndef B\n") == 1
+
+
+def test_guard_spanning_use_and_code_is_detected():
+    """A `#ifdef` covering a `use` *and* the code after it is the case the
+    balance check exists for: `update_uses` re-emits its own guard around the
+    `use` it owns, and the original `#endif` is left stranded in the following
+    code. The parsed structure round-trips perfectly, so only a whole-file
+    balance comparison sees it."""
+    source = (
+        "  subroutine s\n"
+        "#ifdef USEMPI\n"
+        "    use :: MPI_F08, only : MPI_Comm_Rank\n"
+        "    implicit none\n"
+        "    integer :: rank\n"
+        "#endif\n"
+        "    return\n"
+        "  end subroutine s\n"
+    )
+    assert preprocessor_guard_balance(source) == 0
+    out = _format(source)
+    # The formatter itself does not repair this; the driver script refuses to
+    # write when the balance changes. Assert the detector fires.
+    assert preprocessor_guard_balance(out) != preprocessor_guard_balance(source), out

--- a/scripts/aux/formatDeclarations.py
+++ b/scripts/aux/formatDeclarations.py
@@ -12,6 +12,7 @@ import argparse
 from Galacticus.Build.SourceTree import (
     parse_code_for_format,
     serialize_for_format,
+    preprocessor_guard_balance,
     walk_tree,
 )
 from Galacticus.Build.SourceTree.Parse.Declarations import format_declarations_tree
@@ -43,6 +44,7 @@ def is_vendored(path):
         if parts[index] == 'source' and parts[index + 1] == 'external':
             return True
     return False
+
 
 
 def declaration_summary(tree):
@@ -102,6 +104,12 @@ content = serialize_for_format(tree['firstChild'])
 # re-parses the formatted text rather than trusting the tree it came from, so a
 # bug in the emitter is caught too.
 after = declaration_summary(parse_code_for_format(content, source=args.infile))
+if preprocessor_guard_balance(content) != preprocessor_guard_balance(original):
+    sys.stderr.write(
+        f'{args.infile}: reformatting would leave the preprocessor conditionals '
+        f'unbalanced — refusing to write.\n')
+    sys.exit(2)
+
 if after != before:
     sys.stderr.write(
         f'{args.infile}: reformatting would change the declarations — refusing '

--- a/scripts/aux/formatModuleUses.py
+++ b/scripts/aux/formatModuleUses.py
@@ -11,6 +11,7 @@ import argparse
 from Galacticus.Build.SourceTree import (
     parse_code_for_format,
     serialize_for_format,
+    preprocessor_guard_balance,
     walk_tree,
 )
 from Galacticus.Build.SourceTree.Parse.ModuleUses import update_uses
@@ -24,6 +25,7 @@ parser.add_argument('--check', action='store_true',
 parser.add_argument('--no-backup', action='store_true',
                     help='Overwrite the input file without leaving a backup')
 args = parser.parse_args()
+
 
 
 def module_use_summary(tree):
@@ -81,6 +83,12 @@ content = serialize_for_format(tree['firstChild'])
 # formatted text rather than trusting the tree it came from, so a bug in the
 # emitter is caught too.
 after = module_use_summary(parse_code_for_format(content, source=args.infile))
+if preprocessor_guard_balance(content) != preprocessor_guard_balance(original):
+    sys.stderr.write(
+        f'{args.infile}: reformatting would leave the preprocessor conditionals '
+        f'unbalanced — refusing to write.\n')
+    sys.exit(2)
+
 if after != before:
     sys.stderr.write(
         f'{args.infile}: reformatting would change the module uses — refusing to '


### PR DESCRIPTION
Follow-up to #1383. Fixes two bugs in the source formatters and wires them into
the pre-commit hook and the pull-request checks, as **advisory** reports.

**No source file is reformatted here.** `source/` is byte-identical to `master`.

## Why the tree is not reformatted

Running the formatters over the whole tree touches ~1500 files: 889 for `use`
blocks, 1350 for declarations, some 65,000 changed lines. That would wreck
`git blame` and conflict with every open branch. Instead the formatters are
reported on the files each change touches, so the tree converges file by file.

I did run the full sweep and build it, which is how both bugs below were found.
That work is not in this branch.

## Two bugs, both found by building rather than by any static check

**Wrapping a statement carrying a generic placeholder corrupts it.**
`Process.Generics` expands `{Type¦label}` one *physical line* at a time: a line
carrying a placeholder is emitted once per instance. A statement split across a
continuation therefore expands into N copies of its first line followed by N
copies of its second — and the trailing `&` on each copy of the first line glues
it to the *next copy* rather than to its own second line, fusing N statements
into one. The build died in `extract_variables` on a variable list that had
swallowed two `generic ::` statements whole. Such declarations are now emitted
verbatim; all 106 in the tree are single-line, which is exactly what makes the
existing expansion work.

**Rebuilding a `use` block can unbalance preprocessor guards.** Where a `#ifdef`
covered a `use` *and* the code after it, `update_uses` re-emits its own guard
around just the `use`, and the original `#endif` is left stranded — one `#endif`
too many, which fails to compile. **None of the existing safety checks could see
this**: the parsed structure round-trips perfectly, and it is the *interleaving*
of the rebuilt block with its surroundings that goes wrong. Added
`preprocessor_guard_balance()` as a whole-file invariant both drivers now
enforce, refusing to write when it changes. Two files are affected and are left
alone; the underlying parser bug is #1385.

## Advisory, not blocking

Both the hook and the CI job report and move on. Most of the tree predates the
formatters, so blocking would force the first change to any such file to carry a
whole-file reformat in the same commit — hundreds of lines of formatting bundled
with a one-line fix, which is worse to review than either change alone.

CI writes its findings to the job summary as a table, matching how
`Spell-Check-RST` already surfaces advisory output; annotations are kept but
point at the summary, since GitHub caps them at ten of each level per step and
anchors a line-less annotation at line 1, which is usually outside the diff.

## Verification

* Whole tree: 0 round-trip failures, 0 semantic failures, 0 non-idempotent
  files, 0 preprocessor-guard changes, for both formatters.
* The reformatted tree builds clean (1745 objects) and `quickTest.xml` runs
  clean.
* **Model output from the reformatted tree is bit-identical to `master`** —
  41/41 datasets, single-threaded.
* 958 tests pass, including four corpus sweeps over real `source/`.
* The CI step was verified by extracting the `run:` block from the parsed YAML
  and executing it under `bash -eo pipefail` against real files, covering the
  conformant, unformatted, refused, and deleted-file cases.

### A separate finding, not addressed here

Establishing that baseline turned up something worth a look on its own. My first
comparison showed large differences — until I ran the **unchanged `master`
binary twice** and reproduced exactly the same differences. `quickTest.xml` is
reproducible run to run *except for the first run after a build*, which differs
by up to **2.2%** relative in evolved quantities (`diskMassGas`, `blackHoleMass`
and others) while tree construction is identical. Runs 2, 3 and 4 agree bit for
bit. I could find no cache written to explain it. This predates this work and
this pull request does not address it, but a deterministic model whose first
post-build run differs by 2% looks worth investigating.

## Verification note

Developed with assistance from Claude. Per `CONTRIBUTING.md` this needs human
review before merge. The judgement calls most worth a second opinion are the
decision to report rather than block, and the set of statements the formatters
deliberately leave alone.

The companion pre-commit hook change lives in the `gitHooks` repository.
