### PR TITLE
docs: contributor markers record names alone

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -258,6 +258,19 @@ reference values for validating `source/tests.prompt_cusps.F90`).
 - **New source files need the GPL v3 header** (copy the block from any existing
   `source/**/*.F90`). Galacticus is licensed under GPL-3.0 (`COPYING`).
 - **Attribution:** add inline `!+` markers to record contributors (auto-extracted
-  by `scripts/doc/extractContributors.py`), and note AI assistance where used —
-  see the *Contributor Attribution* and *AI-Assisted Contributions* sections of
-  [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+  by `scripts/doc/extractContributors.py`) — see the *Contributor Attribution*
+  and *AI-Assisted Contributions* sections of
+  [`CONTRIBUTING.md`](../CONTRIBUTING.md). A marker records **names only**, in
+  the canonical form
+  ```fortran
+  !+    Contributions to this file made by: Andrew Benson, Claude.
+  ```
+  Where an AI tool contributed, add its bare name (`Claude`, `Copilot`, …) to
+  that list — **never** a description of what it contributed, and never a
+  sentence such as "drafted with assistance from Claude and verified by …".
+  The marker is parsed as a comma-separated list of names, so prose leaks into
+  the generated contributor list in the documentation's Acknowledgments, and
+  makes the in-source line needlessly long. Put the description of *what* the AI
+  contributed, and how it was verified, in the **commit message** instead.
+  `python3 scripts/doc/extractContributors.py --check` enforces this (as does
+  the *Validate-Contributor-Markers* CI job); run it after editing a marker.

--- a/.github/workflows/prChecks.yml
+++ b/.github/workflows/prChecks.yml
@@ -182,6 +182,25 @@ jobs:
       - name: Check no LaTeX remains inside converted docstrings
         run: |
           python3 scripts/doc/convertDocstringsToRST.py --check-residual source
+  # Contributor markers must record names only. Everything after the label in a
+  # `!+` marker is parsed as a comma-separated list of contributors, so a
+  # description of what was contributed (by a person or by an AI tool - that
+  # belongs in the commit message) is published in the documentation's
+  # Acknowledgments as if it were a person's name.
+  Validate-Contributor-Markers:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: "Set environmental variables"
+        run: |
+          echo "GALACTICUS_EXEC_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - name: Mark directory safe
+        run: |
+          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
+      - name: Check contributor markers record names only
+        run: |
+          python3 scripts/doc/extractContributors.py --check $GITHUB_WORKSPACE
   # Fortran static analysis
   Fortran-Static-Analysis:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,26 +158,35 @@ We use inline markers to track who contributed to each part of the code. This is
 
 ### Fortran Contributions
 
-Add a comment at the top of the file or function:
+Add a marker comment near the top of the file, listing the contributors by name:
 
 ```fortran
+!+    Contributions to this file made by: Jane Developer, Bob Smith.
+
 module myModule
-  !+ This module was created by Jane Developer
-  !+ Contributions to this file made by: Jane Developer, Bob Smith
-  
-  implicit none
-  
-contains
-  
-  subroutine mySubroutine()
-    !+ Implementation by Jane Developer with assistance from Claude
-    ! ... rest of code
-  end subroutine mySubroutine
-  
+  ! ... rest of code
 end module myModule
 ```
 
-The [extractContributors.py](scripts/doc/extractContributors.py) script automatically generates contributor lists from these markers.
+**A `!+` marker records *names only* — never a description of what was contributed.** The names are parsed as a comma-separated list, so anything else on the line is read as if it were a contributor's name. Keep the marker to the single sentence above; nothing else belongs on the line, not even a trailing comment.
+
+So, not:
+
+```fortran
+!+    Bug fix for issue #1234 implemented by Jane Developer, with tests by Bob Smith.
+```
+
+which names neither developer in the contributor list: it is split on the comma, the first fragment is discarded as too long to be a name, and the second is published as a "contributor" called *with tests by Bob Smith*.
+
+Describe *what* changed in the commit message (and in the pull request), not in the source. This keeps the markers short and keeps the generated contributor list free of stray fragments of prose.
+
+The [extractContributors.py](scripts/doc/extractContributors.py) script automatically generates contributor lists from these markers; the result appears in the Acknowledgments section of the documentation. The same script validates them — run it before you push, as the *Validate-Contributor-Markers* CI job runs the same check on your pull request:
+
+```bash
+python3 scripts/doc/extractContributors.py --check
+```
+
+It reports any marker which is not of the names-only form above, and exits non-zero if it finds one.
 
 ## AI-Assisted Contributions
 
@@ -205,18 +214,31 @@ However, **you are responsible** for:
 2. **Review what it generated** - Read through all the code carefully
 3. **Test it locally** - Build and run your changes, including edge cases
 4. **Fix any issues** - Update the code based on your testing and review
-5. **Add attribution comments** - Document that AI tools assisted you (optional but appreciated)
+5. **Add attribution comments** - Record the AI tool as a contributor (optional but appreciated)
 6. **Submit your PR** - You're now the verified human author of this contribution
 
 ### Attribution
 
-If you used AI tools, add a comment noting the assistance:
+If you used AI tools, add the tool's name to the file's `!+` contributor marker, alongside your own:
 
 ```fortran
-subroutine doSomething()
-  !+ This subroutine was generated with Claude and thoroughly tested by Jane Developer
-  ! ... implementation
-end subroutine doSomething
+!+    Contributions to this file made by: Jane Developer, Claude.
+
+module myModule
+  ! ... rest of code
+end module myModule
+```
+
+Name the tool as you would a person — `Claude`, `Copilot`, `ChatGPT` — with **no description of what it contributed**. As with every `!+` marker (see [Contributor Attribution](#contributor-attribution) above), the line carries names only: the marker is parsed as a comma-separated list of contributors, so a description would both corrupt the generated contributor list and make the in-source marker needlessly long.
+
+Record *what* the AI contributed, and how you verified it, in the **commit message** instead — that is where the detail belongs, and where `git log`/`git blame` will surface it for whoever needs it:
+
+```
+fix(numerical): correct the dark energy equation of state parameter w_a
+
+The value passed for w_a was 3(1+w_0), which is correct only for w_0 = -1.
+Diagnosed and drafted with assistance from Claude; reviewed, tested, and
+verified by Jane Developer.
 ```
 
 This helps future maintainers understand the code's origin and appreciate your use of modern development tools.

--- a/scripts/doc/extractContributors.py
+++ b/scripts/doc/extractContributors.py
@@ -14,13 +14,45 @@ include, and C++ files).  This module both:
 
 Names are read directly as UTF-8, so accented names need no special handling in
 the RST output.
+
+A marker records **names only** — the canonical form is::
+
+    !+    Contributions to this file made by: Andrew Benson, Claude.
+
+Everything after the label is parsed as a comma-separated list of contributors,
+so a description of *what* was contributed would be rendered as if it were a
+person: prose markers previously leaked entries such as "assistance from
+Claude" and "per-object OpenMP lock" into the documentation's Acknowledgments.
+Where an AI tool contributed, name it as a person would be named (``Claude``,
+``Copilot``, …) and describe its contribution in the commit message.
+
+``--check`` enforces this (for CI): it reports every marker which departs from
+the canonical form, and exits non-zero if any is found.  See the *Contributor
+Attribution* section of ``CONTRIBUTING.md``.
 """
 
+import argparse
 import os
 import re
 import sys
 
 _FORTRAN_MARKER = re.compile(r'^\s*!\+\s*(.*)')
+
+# The canonical label which opens a marker.  A marker may be continued onto
+# further `!+` lines (for a long list of names), which carry no label.
+MARKER_LABEL = 'Contributions to this file made by:'
+
+# Lowercase particles which may legitimately appear within a name, and so are
+# exempt from the "words are capitalized" rule below.
+_NAME_PARTICLES = frozenset({
+    'al', 'bin', 'da', 'das', 'de', 'del', 'della', 'den', 'der', 'di', 'do',
+    'dos', 'du', 'ibn', 'la', 'le', 'van', 'von', 'zu',
+})
+
+# Characters which may appear within a word of a name, besides letters.
+_NAME_PUNCTUATION = frozenset("'’.-")
+
+_MAX_NAME_WORDS = 5
 
 
 def extract_contributors(line, marker_re):
@@ -40,6 +72,49 @@ def extract_contributors(line, marker_re):
     return [p.strip() for p in re.split(r'\s*,\s*', contributors) if p.strip()]
 
 
+def name_problem(name):
+    """Return a description of why *name* is not a personal name, or ``None``
+    if it is one.
+
+    This is deliberately shape-based rather than a lookup: it must accept names
+    never seen before (including accented and hyphenated ones) while rejecting
+    the fragments of prose which result from describing a contribution in the
+    marker.
+    """
+    words = name.split()
+    if not words:
+        return 'is empty'
+    if len(words) > _MAX_NAME_WORDS:
+        return f'has more than {_MAX_NAME_WORDS} words, so reads as prose'
+    for word in words[:-1]:
+        # A period within a name marks an initial or an abbreviation ("S.",
+        # "Jr."); a longer word ending in one ends a sentence, so what follows
+        # it is a description rather than a name.
+        if word.endswith('.') and len(word) > 3:
+            return f'continues past the sentence ending "{word}"'
+    for word in words:
+        if not any(character.isalpha() for character in word):
+            return f'contains "{word}", which is not a word of a name'
+        for character in word:
+            if not character.isalpha() and character not in _NAME_PUNCTUATION:
+                return f'contains "{word}", which is not a word of a name'
+        if not word[0].isupper() and word.lower() not in _NAME_PARTICLES:
+            return f'contains the uncapitalized word "{word}", so reads as prose'
+    return None
+
+
+def iter_source_files(galacticus_dir='.'):
+    """Yield the paths of the source files which may carry ``!+`` markers."""
+    source_dir = os.path.join(galacticus_dir, 'source')
+    if not os.path.isdir(source_dir):
+        return
+    for root, _dirs, files in sorted(os.walk(source_dir)):
+        for file_name in sorted(files):
+            if (re.search(r'\.(F90|Inc|cpp)$', file_name)
+                    and not file_name.startswith('.#')):
+                yield os.path.join(root, file_name)
+
+
 def _scan(file_path, marker_re, names):
     with open(file_path, encoding='utf-8', errors='replace') as fh:
         for line in fh:
@@ -53,15 +128,52 @@ def collect_contributor_names(galacticus_dir='.'):
     source, sorted case-insensitively."""
     names = set()
 
-    source_dir = os.path.join(galacticus_dir, 'source')
-    if os.path.isdir(source_dir):
-        for root, _dirs, files in sorted(os.walk(source_dir)):
-            for file_name in sorted(files):
-                if (re.search(r'\.(F90|Inc|cpp)$', file_name)
-                        and not file_name.startswith('.#')):
-                    _scan(os.path.join(root, file_name), _FORTRAN_MARKER, names)
+    for file_path in iter_source_files(galacticus_dir):
+        _scan(file_path, _FORTRAN_MARKER, names)
 
     return sorted(names, key=str.casefold)
+
+
+def check_markers_in_text(text, path='<text>'):
+    """Return a list of ``(path, lineNumber, problem)`` for every malformed
+    ``!+`` marker in *text*."""
+    problems = []
+    lines = text.split('\n')
+    index = 0
+    while index < len(lines):
+        if not _FORTRAN_MARKER.match(lines[index]):
+            index += 1
+            continue
+        # Consecutive marker lines form a single marker: only the first carries
+        # the label, any others continue its list of names.
+        start = index
+        while index < len(lines) and _FORTRAN_MARKER.match(lines[index]):
+            index += 1
+        block = lines[start:index]
+        content = _FORTRAN_MARKER.match(block[0]).group(1).strip()
+        if not content.startswith(MARKER_LABEL):
+            problems.append((path, start + 1,
+                             f'does not begin "{MARKER_LABEL}"'))
+        for offset, line in enumerate(block):
+            names = extract_contributors(line, _FORTRAN_MARKER)
+            if not names:
+                problems.append((path, start + offset + 1, 'lists no names'))
+            for name in names:
+                problem = name_problem(name)
+                if problem is not None:
+                    problems.append((path, start + offset + 1,
+                                     f'entry "{name}" {problem}'))
+    return problems
+
+
+def check_markers(galacticus_dir='.'):
+    """Return a list of ``(path, lineNumber, problem)`` for every malformed
+    ``!+`` marker in the Galacticus source."""
+    problems = []
+    for file_path in iter_source_files(galacticus_dir):
+        with open(file_path, encoding='utf-8', errors='replace') as fh:
+            problems.extend(check_markers_in_text(fh.read(), file_path))
+    return problems
 
 
 def render_contributors_rst(names):
@@ -69,15 +181,52 @@ def render_contributors_rst(names):
     return ', '.join(names) + '.\n'
 
 
-def main():
-    if len(sys.argv) != 3:
-        print('Usage: extractContributors.py <galacticusDir> <outputFile>',
+def _check_main(galacticus_dir):
+    problems = check_markers(galacticus_dir)
+    for path, line_number, problem in problems:
+        print(f'{path}:{line_number}: contributor marker {problem}',
               file=sys.stderr)
-        sys.exit(1)
-    names = collect_contributor_names(sys.argv[1])
-    with open(sys.argv[2], 'w', encoding='utf-8') as out:
+    if problems:
+        print(f'\n{len(problems)} malformed contributor marker(s) found.\n\n'
+              'A `!+` marker records names only, in the form:\n\n'
+              f'    !+    {MARKER_LABEL} Andrew Benson, Claude.\n\n'
+              'Describe what was contributed - including by any AI tool - in '
+              'the commit message,\nnot in the marker: the marker is parsed as '
+              'a comma-separated list of names, so any\nother text appears in '
+              "the documentation's Acknowledgments as if it were a person.\n"
+              'See the "Contributor Attribution" section of CONTRIBUTING.md.',
+              file=sys.stderr)
+        return 1
+    print('All contributor markers are well formed.', file=sys.stderr)
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('galacticusDir', nargs='?', default='.',
+                        help='the root of the Galacticus source tree '
+                             '(default: the current directory)')
+    parser.add_argument('outputFile', nargs='?',
+                        help='file to which to write the contributor list')
+    parser.add_argument('--check', action='store_true',
+                        help='do not write; report any contributor marker which '
+                             'is not of the canonical, names-only form, exiting '
+                             'non-zero if any is found (for CI)')
+    arguments = parser.parse_args()
+
+    if arguments.check:
+        if arguments.outputFile is not None:
+            parser.error('--check takes no output file')
+        return _check_main(arguments.galacticusDir)
+
+    if arguments.outputFile is None:
+        parser.error('an output file is required (or use --check)')
+    names = collect_contributor_names(arguments.galacticusDir)
+    with open(arguments.outputFile, 'w', encoding='utf-8') as out:
         out.write(render_contributors_rst(names))
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())

--- a/scripts/doc/tests/test_extractContributors.py
+++ b/scripts/doc/tests/test_extractContributors.py
@@ -1,0 +1,128 @@
+"""Regression tests for ``scripts/doc/extractContributors.py``.
+
+Guards both halves of the contributor-marker contract:
+
+* extraction — the names parsed out of ``!+`` markers, which become the
+  Acknowledgments list in the documentation; and
+* validation (``--check``) — the enforcement that a marker records *names
+  only*.  Markers which described a contribution rather than naming its
+  contributors used to leak fragments of prose ("assistance from Claude",
+  "per-object OpenMP lock", "and reviewed") into that published list.
+"""
+import os
+import sys
+
+# extractDocsRST self-inserts its own directory on sys.path for its sibling
+# imports; do the same so we can import this module directly.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
+import extractContributors  # noqa: E402
+
+
+CANONICAL = ('!+    Contributions to this file made by: '
+             'Andrew Benson, Claude.\n')
+
+
+# --- Extraction ------------------------------------------------------------
+
+def test_extracts_names_from_canonical_marker():
+    names = extractContributors.extract_contributors(
+        CANONICAL, extractContributors._FORTRAN_MARKER)
+    assert names == ['Andrew Benson', 'Claude']
+
+
+def test_extraction_ignores_non_markers():
+    assert extractContributors.extract_contributors(
+        '  ! An ordinary comment.\n',
+        extractContributors._FORTRAN_MARKER) == []
+
+
+def test_render_contributors_rst():
+    assert extractContributors.render_contributors_rst(
+        ['Andrew Benson', 'Claude']) == 'Andrew Benson, Claude.\n'
+
+
+# --- Name validation -------------------------------------------------------
+
+def test_accepts_real_names():
+    for name in ('Andrew Benson', 'Claude', 'Copilot', 'Matías Liempi',
+                 'Stéphane Mangeon', 'Luiz Felippe S. Rodrigues',
+                 'Ludwig van Beethoven'):
+        assert extractContributors.name_problem(name) is None, name
+
+
+def test_rejects_prose():
+    for name in ('were drafted with assistance from Claude',
+                 'per-object OpenMP lock',
+                 'and reviewed and verified by',
+                 'for issue #1353',
+                 'Implemented with assistance from Claude (Anthropic)',
+                 # Capitalized prose still ends a sentence first.
+                 'Andrew Benson. The Fix For Issue'):
+        assert extractContributors.name_problem(name) is not None, name
+
+
+# --- Marker validation -----------------------------------------------------
+
+def test_canonical_marker_passes():
+    assert extractContributors.check_markers_in_text(CANONICAL) == []
+
+
+def test_indented_marker_passes():
+    assert extractContributors.check_markers_in_text(
+        '  !+ Contributions to this file made by: Andrew Benson, Claude.\n') == []
+
+
+def test_marker_wrapped_over_two_lines_passes():
+    text = ('!+    Contributions to this file made by: Arya Farahi, '
+            'Andrew Benson,\n'
+            '!+    Christoph Behrens, Xiaolong Du, Claude.\n')
+    assert extractContributors.check_markers_in_text(text) == []
+
+
+def test_marker_without_the_canonical_label_is_reported():
+    problems = extractContributors.check_markers_in_text(
+        '!+ Implemented by Andrew Benson with assistance from Claude.\n')
+    assert any('does not begin' in problem for _, _, problem in problems)
+
+
+def test_marker_describing_the_contribution_is_reported():
+    text = ('!+    Contributions to this file made by: Andrew Benson. The fix '
+            'for issue #1321 was diagnosed and drafted with\n'
+            '!+    assistance from Claude, and reviewed and verified by '
+            'Andrew Benson.\n')
+    problems = extractContributors.check_markers_in_text(text)
+    assert problems, 'prose marker was not reported'
+    assert all(path == '<text>' for path, _, _ in problems)
+
+
+def test_description_appended_after_the_names_is_reported():
+    problems = extractContributors.check_markers_in_text(
+        '!+    Contributions to this file made by: Andrew Benson, Claude. '
+        'Drafted for issue #1317.\n')
+    assert problems
+
+
+def test_ordinary_comments_are_not_markers():
+    assert extractContributors.check_markers_in_text(
+        '  ! Drafted with assistance from Claude, and verified.\n') == []
+
+
+def test_problems_carry_the_path_and_line_number():
+    text = ('module Test\n'
+            '!+ This file was generated with Claude\n')
+    problems = extractContributors.check_markers_in_text(text, 'test.F90')
+    assert problems
+    for path, line_number, _ in problems:
+        assert path == 'test.F90'
+        assert line_number == 2
+
+
+# --- The source tree itself ------------------------------------------------
+
+def test_source_tree_markers_are_well_formed():
+    """The Galacticus source must itself satisfy the check enforced in CI."""
+    root = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
+                        os.pardir)
+    problems = extractContributors.check_markers(root)
+    assert problems == [], '\n'.join(f'{path}:{line}: {problem}'
+                                     for path, line, problem in problems)

--- a/source/cosmology/functions/matter_dark_energy_CPL.F90
+++ b/source/cosmology/functions/matter_dark_energy_CPL.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. This class was drafted with assistance from Claude, and reviewed and
-!+    verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   An implementation of the cosmological functions class for cosmologies consisting of collisionless matter and dark energy with an equation of state of the form: :math:`P=\rho^w` with :math:`w(a)=w_0+w_\mathrm{a}(1-a)`.

--- a/source/dark_matter_halos/splashback_radii/Diemer_Kravtsov2014.F90
+++ b/source/dark_matter_halos/splashback_radii/Diemer_Kravtsov2014.F90
@@ -21,7 +21,7 @@
   An implementation of dark matter halo splashback radii using the truncation radius of :cite:t:`diemer_dependence_2014`.
   !!}
 
-  !+ Implemented by Andrew Benson with assistance from Claude.
+  !+ Contributions to this file made by: Andrew Benson, Claude.
 
   use :: Cosmology_Functions                        , only : cosmologyFunctionsClass
   use :: Cosmology_Parameters                       , only : cosmologyParametersClass

--- a/source/dark_matter_halos/splashback_radii/Shi2016.F90
+++ b/source/dark_matter_halos/splashback_radii/Shi2016.F90
@@ -21,7 +21,7 @@
   An implementation of dark matter halo splashback radii using the fitting functions of :cite:t:`shi_outer_2016`.
   !!}
 
-  !+ Implemented by Andrew Benson with assistance from Claude.
+  !+ Contributions to this file made by: Andrew Benson, Claude.
 
   use :: Cosmology_Functions                        , only : cosmologyFunctionsClass
   use :: Cosmology_Parameters                       , only : cosmologyParametersClass

--- a/source/dark_matter_halos/splashback_radii/_class.F90
+++ b/source/dark_matter_halos/splashback_radii/_class.F90
@@ -25,7 +25,7 @@ module Dark_Matter_Halo_Splashback_Radii
   !!{RST
   Provides a class implementing splashback radii of dark matter halos.
   !!}
-  !+ Implemented by Andrew Benson with assistance from Claude.
+  !+ Contributions to this file made by: Andrew Benson, Claude.
   use :: Galacticus_Nodes  , only : treeNode
   use :: Mass_Distributions, only : massDistributionClass
   private

--- a/source/dark_matter_halos/splashback_radii/diemer/Diemer2017.F90
+++ b/source/dark_matter_halos/splashback_radii/diemer/Diemer2017.F90
@@ -21,7 +21,7 @@
   An implementation of dark matter halo splashback radii using the model of :cite:t:`diemer_splashback_2017`.
   !!}
 
-  !+ Implemented by Andrew Benson with assistance from Claude.
+  !+ Contributions to this file made by: Andrew Benson, Claude.
 
   !![
   <darkMatterHaloSplashbackRadius name="darkMatterHaloSplashbackRadiusDiemer2017" docformat="rst">

--- a/source/dark_matter_halos/splashback_radii/diemer/Diemer2020.F90
+++ b/source/dark_matter_halos/splashback_radii/diemer/Diemer2020.F90
@@ -21,7 +21,7 @@
   An implementation of dark matter halo splashback radii using the model of :cite:t:`diemer_splashback_2020`.
   !!}
 
-  !+ Implemented by Andrew Benson with assistance from Claude.
+  !+ Contributions to this file made by: Andrew Benson, Claude.
 
   !![
   <darkMatterHaloSplashbackRadius name="darkMatterHaloSplashbackRadiusDiemer2020" docformat="rst">

--- a/source/dark_matter_halos/splashback_radii/diemer/_class.F90
+++ b/source/dark_matter_halos/splashback_radii/diemer/_class.F90
@@ -24,7 +24,7 @@
   the coefficient sets.
   !!}
 
-  !+ Implemented by Andrew Benson with assistance from Claude.
+  !+ Contributions to this file made by: Andrew Benson, Claude.
 
   use :: Cosmology_Functions                        , only : cosmologyFunctionsClass
   use :: Cosmology_Parameters                       , only : cosmologyParametersClass

--- a/source/dark_matter_halos/splashback_radii/reference.F90
+++ b/source/dark_matter_halos/splashback_radii/reference.F90
@@ -33,7 +33,7 @@ module Dark_Matter_Halo_Splashback_Radii_Reference
   !!{RST
   Computes the reference mass and radius used by the splashback radius classes.
   !!}
-  !+ Implemented by Andrew Benson with assistance from Claude.
+  !+ Contributions to this file made by: Andrew Benson, Claude.
   use :: Cosmology_Functions    , only : cosmologyFunctionsClass
   use :: Cosmology_Parameters   , only : cosmologyParametersClass
   use :: Galacticus_Nodes       , only : treeNode

--- a/source/dust/attenuation_descriptors.F90
+++ b/source/dust/attenuation_descriptors.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson
-!+    Implemented with assistance from Claude (Anthropic).
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Contains a module which provides the data structures used to describe emission to be attenuated by dust.

--- a/source/error/_module.F90
+++ b/source/error/_module.F90
@@ -17,9 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The bounded accumulation of warning messages for issue #1359 and
-!+    the "GSL_Error_Handler_Aborting" function added for issue #1360 were drafted with assistance from Claude, and
-!+    reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Contains a module which implements error reporting for the  Galacticus package.

--- a/source/kinematic_distributions/finite-resolution/NFW.F90
+++ b/source/kinematic_distributions/finite-resolution/NFW.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !+    Contributions to this file made by: Andrew Benson. The pinning of the tabulation range to absolute lattices for issue
-  !+    #1317 was drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+  !+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   Implementation of a kinematic distribution class for finite-resolution NFW mass distributions.

--- a/source/mass_distributions/spherical/finite_resolution/NFW.F90
+++ b/source/mass_distributions/spherical/finite_resolution/NFW.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !+    Contributions to this file made by: Andrew Benson. The pinning of the tabulation ranges to absolute lattices for issue
-  !+    #1317 was drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+  !+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   Implements a finite resolution NFW spherical mass distribution.

--- a/source/mass_distributions/spherical/soliton/Schive2014.F90
+++ b/source/mass_distributions/spherical/soliton/Schive2014.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+  !+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   Contains a module which provides utility variables for the :cite:t:`schive_understanding_2014` soliton density profile.
   !!}
@@ -30,8 +32,6 @@
 
     ! Coefficient of the dimensionless radius in the soliton profile.
     double precision, parameter, public  :: coefficientCore              =0.091d0 ! Schive et al. (2014; https://ui.adsabs.harvard.edu/abs/2014PhRvL.113z1302S; equation 3).
-
-    !+ The closed-form expression for coefficientMassCore below was derived with assistance from Claude (Anthropic).
 
     ! Coefficient relating the solitonic core mass to the central density and core radius, such that
     !

--- a/source/mass_distributions/spherical/tabulated.F90
+++ b/source/mass_distributions/spherical/tabulated.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !+    Contributions to this file made by: Andrew Benson. The pinning of the tabulation ranges to absolute lattices for issue
-  !+    #1317 was drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+  !+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   Implementation of an abstract mass distribution class for tabulated spherically symmetric distributions.

--- a/source/merger_trees/operators/prune_by_filter.F90
+++ b/source/merger_trees/operators/prune_by_filter.F90
@@ -21,8 +21,7 @@
 Implements a pruning-by-filter operator on merger trees.
 !!}
 
-!+ Contributions to this file made by: Andrew Benson
-!+ This file was generated with assistance from Claude, and reviewed and tested by Andrew Benson.
+!+ Contributions to this file made by: Andrew Benson, Claude.
 
   use :: Galactic_Filters, only : galacticFilterClass
 

--- a/source/numerical/interpolation/multiD.F90
+++ b/source/numerical/interpolation/multiD.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson
-!+    Implemented with assistance from Claude (Anthropic).
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Contains a module which implements multilinear interpolation in tables of arbitrary dimensionality.

--- a/source/numerical/root_finder.F90
+++ b/source/numerical/root_finder.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The routing of all exits through a common finalization for issue #1360
-!+    was drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 ! Specify an explicit dependence on the interface.GSL.C.root_finding.o object file.
 !: $(BUILDPATH)/interface/GSL/C/root_finding.o

--- a/source/output/analyses/Local_Group/luminosity_function.F90
+++ b/source/output/analyses/Local_Group/luminosity_function.F90
@@ -17,7 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+ This file was generated with Claude and verified by Andrew Benson
+!+ Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   Implements an output analysis class that computes the :math:`V`-band luminosity function of Local Group satellite galaxies.

--- a/source/output/analyses/weight_operator/local_group_detection.F90
+++ b/source/output/analyses/weight_operator/local_group_detection.F90
@@ -17,7 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+ This file was generated with Claude and verified by Andrew Benson
+!+ Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Implements a weight operator which applies the observational selection function for Milky Way satellite galaxies.

--- a/source/satellites/merging/virial_orbits/loss_cone.F90
+++ b/source/satellites/merging/virial_orbits/loss_cone.F90
@@ -17,9 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The fixes for issue #1321, and the pinning of the mass tabulation to an
-!+    absolute lattice for issue #1317, were diagnosed and drafted with assistance from Claude, and reviewed and verified by
-!+    Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   An implementation of virial orbits using a loss cone model.

--- a/source/star_formation/rate_surface_density/disks/Blitz2006.F90
+++ b/source/star_formation/rate_surface_density/disks/Blitz2006.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !+    Contributions to this file made by: Andrew Benson. The pinning of the tabulated star formation rate solution to absolute
-  !+    lattices for issue #1317 was drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+  !+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   Implementation of the :cite:t:`blitz_role_2006` star formation rate surface density law for galactic disks.

--- a/source/star_formation/rate_surface_density/disks/Krumholz2009.F90
+++ b/source/star_formation/rate_surface_density/disks/Krumholz2009.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !+    The truncation of the integration range at the radius where the molecular fraction becomes negligible was implemented with
-  !+    assistance from Claude and verified by Andrew Benson.
+  !+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   Implementation of the :cite:t:`krumholz_star_2009` star formation rate surface density law for galactic disks.

--- a/source/structure_formation/cosmological_mass_variance/filtered_power_spectrum.F90
+++ b/source/structure_formation/cosmological_mass_variance/filtered_power_spectrum.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !+    Contributions to this file made by: Andrew Benson, Christoph Behrens, Xiaolong Du. The pinning of the σ(M) tabulation to
-  !+    absolute lattices for issue #1317 was drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+  !+    Contributions to this file made by: Andrew Benson, Christoph Behrens, Xiaolong Du, Claude.
 
   !!{RST
   An implementation of cosmological density field mass variance computed using a filtered power spectrum.

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/_class.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/_class.F90
@@ -17,9 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Arya Farahi, Andrew Benson, Christoph Behrens, Xiaolong Du. The pinning of the first
-!+    crossing probability and rate tabulations to absolute lattices for issue #1317 was drafted with assistance from Claude, and
-!+    reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Arya Farahi, Andrew Benson, Christoph Behrens, Xiaolong Du, Claude.
 
 !!{RST
 Implements a excursion set first crossing statistics class using the algorithm of :cite:t:`benson_dark_2012`.

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/midpoint/Brownian_bridge.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/midpoint/Brownian_bridge.F90
@@ -17,9 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson, Ethan Nadler. The separation of the hard upper limit on the tabulated
-!+    variance from the range requested, for the pinning of the first crossing rate tabulation for issue #1317, was drafted with
-!+    assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Ethan Nadler, Claude.
 
 !!{RST
 Implements an excursion set first crossing statistics class using the algorithm of :cite:t:`benson_dark_2012`, but using a midpoint method to perform the integrations :cite:p:`du_substructure_2017`, and with a Brownian bridge constraint.

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/midpoint/_class.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/midpoint/_class.F90
@@ -17,9 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson, Christoph Behrens, Xiaolong Du. The pinning of the first crossing
-!+    probability and rate tabulations to absolute lattices for issue #1317 was drafted with assistance from Claude, and reviewed
-!+    and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Christoph Behrens, Xiaolong Du, Claude.
 
 !!{RST
 Implements an excursion set first crossing statistics class using the algorithm of :cite:t:`benson_dark_2012`, but using a midpoint method to perform the integrations :cite:p:`du_substructure_2017`.

--- a/source/structure_formation/linear_growth/baryons_darkMatter.F90
+++ b/source/structure_formation/linear_growth/baryons_darkMatter.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !+    Contributions to this file made by: Andrew Benson. The pinning of the linear growth tabulation to absolute lattices for
-  !+    issue #1317 was drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+  !+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   An implementation of linear growth of cosmological structure in models containing baryons and dark matter. Assumes no growth of radiation perturbations.

--- a/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/CosmicEmu.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The correction to the dark energy equation of state parameter
-!+    w_a was diagnosed and drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Implements a nonlinear power spectrum class in which the nonlinear power spectrum is computed using the code of :cite:t:`moran_mira-titan_2023`.

--- a/source/structure_formation/power_spectrum/nonlinear/EuclidEmulator2.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/EuclidEmulator2.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The interface to EuclidEmulator2 requested in issue #59 was
-!+    drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Implements a nonlinear power spectrum class in which the nonlinear power spectrum is computed by applying the nonlinear correction factor emulated by the :term:`EuclidEmulator2` code of :cite:t:`euclid_collaboration_euclid_2021` to the linear theory power spectrum.

--- a/source/structure_formation/power_spectrum/nonlinear/NGenHalofit.F90
+++ b/source/structure_formation/power_spectrum/nonlinear/NGenHalofit.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The interface to NGenHalofit requested in issue #42 was drafted with
-!+    assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Implements a nonlinear power spectrum class in which the nonlinear power spectrum is computed using the :term:`NGenHalofit` model of :cite:t:`smith_precision_2019`.

--- a/source/structure_formation/power_spectrum/variance/window_function/ETHOS/extended.F90
+++ b/source/structure_formation/power_spectrum/variance/window_function/ETHOS/extended.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The analytic evaluation of the smoothed power spectrum slope was
-!+    drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   Implements a generalization of the ETHOS power spectrum window function class from :cite:t:`bohr_halo_2021`.

--- a/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The fix for issue #1321 was diagnosed and drafted with
-!+    assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
   !!{RST
   A spherical collapse solver class for universes consisting of collisionless matter and a cosmological constant.

--- a/source/system/downloader.F90
+++ b/source/system/downloader.F90
@@ -17,9 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    The fallback from `wget` to `curl` within a single download attempt, and the use of `--ciphers=DEFAULT` to avoid hosts which
-!+    reject `wget` on the basis of its TLS handshake, were diagnosed and drafted with assistance from Claude, and reviewed and
-!+    verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Contains a module which downloads content from a supplied URL (or list of URLs).

--- a/source/tasks/mass_function_covariance.F90
+++ b/source/tasks/mass_function_covariance.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The fix for issue #1321 was diagnosed and drafted with
-!+    assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
   use :: Conditional_Mass_Functions, only : conditionalMassFunction, conditionalMassFunctionClass
   use :: Cosmology_Functions       , only : cosmologyFunctions     , cosmologyFunctionsClass

--- a/source/tests/dark_energy_CPL.F90
+++ b/source/tests/dark_energy_CPL.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. This test was drafted with assistance from Claude, and reviewed and
-!+    verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 program Tests_Dark_Energy_CPL
   !!{RST

--- a/source/tests/dust/attenuation_descriptors.F90
+++ b/source/tests/dust/attenuation_descriptors.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson
-!+    Implemented with assistance from Claude (Anthropic).
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Contains a program to test the dust attenuation descriptor data structures.

--- a/source/tests/interpolation/multiD.F90
+++ b/source/tests/interpolation/multiD.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson
-!+    Implemented with assistance from Claude (Anthropic).
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Contains a program to test multi-dimensional interpolation.

--- a/source/tests/root_finding.F90
+++ b/source/tests/root_finding.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The tests of the GSL abort-on-error handler state added for issue #1360
-!+    were drafted with assistance from Claude, and reviewed and verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Contains a program to test root finding routines.

--- a/source/tests/splashback_radii.F90
+++ b/source/tests/splashback_radii.F90
@@ -21,7 +21,7 @@
 Contains a program to test the fitting functions used by the splashback radius classes.
 !!}
 
-!+ Implemented by Andrew Benson with assistance from Claude.
+!+ Contributions to this file made by: Andrew Benson, Claude.
 
 program Test_Splashback_Radii
   !!{RST

--- a/source/tests/warnings.F90
+++ b/source/tests/warnings.F90
@@ -17,8 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. This test was drafted with assistance from Claude, and reviewed and
-!+    verified by Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Contains a program to test the accumulation of warning messages.

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -17,10 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-!+    Contributions to this file made by: Andrew Benson. The fix to the deduplication of reports of the use of default
-!+    parameter values, the marking of defaulted parameters in the output file, and the removal of the then-unused
-!+    per-object OpenMP lock, for issue #1353, were drafted with assistance from Claude, and reviewed and verified by
-!+    Andrew Benson.
+!+    Contributions to this file made by: Andrew Benson, Claude.
 
 !!{RST
 Contains a module which implements reading of parameters from an XML data file.


### PR DESCRIPTION
## Summary
- **Policy.** A `!+` contributor marker records **names only**, in the canonical form `!+    Contributions to this file made by: Andrew Benson, Claude.` Where an AI tool contributed, its bare name (`Claude`, `Copilot`, …) joins that list; what it contributed, and how that was verified, goes in the commit message instead. `CONTRIBUTING.md` (*Contributor Attribution*, *AI-Assisted Contributions*) and `.claude/CLAUDE.md` are updated to say so — the previous text invited the opposite, illustrating attribution with prose markers such as *"This subroutine was generated with Claude and thoroughly tested by …"*.
- **Cleanup.** All 42 such markers, across 41 files, are reduced to that form, with the AI folded into the list of names and co-contributors preserved.
- **Enforcement.** `scripts/doc/extractContributors.py --check` reports any marker which departs from the form, and a new `Validate-Contributor-Markers` job runs it on every PR.

### Why

Everything after the label in a marker is parsed as a comma-separated list of contributors, so the descriptions were published in the documentation's Acknowledgments **as if they were people**. The generated list read, in part:

> absolute lattice for issue #1317, Alex Merson, and, and reviewed, and reviewed and, and verified by Andrew Benson, Andrew Benson, … assistance from Claude, … per-object OpenMP lock, … variance from the range requested, was drafted with, Xiaolong Du, Yu Zhao.

Because every mention of Claude was embedded in prose, the list contained **no entry for Claude at all**. It now holds 25 names and no fragments; Ethan Nadler, previously swallowed by a trailing sentence, is restored to it. The markers also shrink from three or four wrapped lines to one.

Three files carried no name list at all, only prose, and gain one: `system/downloader.F90`, `star_formation/rate_surface_density/disks/Krumholz2009.F90`, and `mass_distributions/spherical/soliton/Schive2014.F90` — the last of which had its marker beside a formula in the module body, replaced by a contributor line in the file header.

### How the check works

A marker is well formed when its first line opens with `Contributions to this file made by:` and every comma-separated field — on that line and on any continuation lines — is name-shaped. The test for a name is structural rather than a lookup, so contributors never seen before are accepted: at most five words; letters, apostrophes, hyphens and periods only; each word capitalized unless it is a known particle (`van`, `de`, …); and no sentence ending within the field, which catches a description appended after the names even when capitalized, while leaving initials and `Jr.` alone.

## Type of change
- [x] Docs / tooling

## How to test
```bash
python3 scripts/doc/extractContributors.py --check     # exits 0 on this branch
python3 -m pytest scripts/doc/tests -q                 # 50 passed
```

## Checklist
- [x] I ran relevant tests: full `python -m pytest` suite — 969 passed, 1 skipped; `scripts/doc/tests` — 50 passed (14 new, including one that runs the check over the real source tree, so the existing `Test-Preprocessor` job fails on a bad marker too). `extractDocsRST.py` regenerates the docs and the contributor list cleanly, and the two-positional invocation of `extractContributors.py` produces byte-identical output to `master`. No build or model run: `!+` markers are comments read only by `extractContributors.py`.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

---

Drafted with assistance from Claude, and reviewed and verified by Andrew Benson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
