### PR TITLE
fix(ci): package the forutils version stamp in the tools archives

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -457,8 +457,14 @@ jobs:
           ! ldd dynamic/RecFast/recfast.exe
           ! ldd dynamic/fsps-${fspsVersion}/src/autosps.exe
           ! ldd dynamic/mangle-${mangleVersion}/bin/ransack
+          # The `forutils` stamp file must be packaged alongside the `camb` executable. At run time
+          # `Interface_CAMB_Initialize` (source/interface/CAMB.F90) rebuilds CAMB unless *both* the
+          # executable and a stamp matching the required `forutils` version are present. Installs made from
+          # the packaged tools (e.g. via PyPI) typically have no Fortran compiler, so a missing stamp turns
+          # into a fatal build attempt rather than a simple use of the pre-built binary.
           tar cfj tools.tar.bz2 \
             dynamic/CAMB-${cambVersion}/fortran/camb \
+            dynamic/CAMB-${cambVersion}/forutils/.galacticusForUtilsVersion_${forutilsVersion} \
             dynamic/axionCAMB-${axioncambVersion}/camb \
             dynamic/class_public-${classVersion}/class \
             dynamic/RecFast/recfast.exe \
@@ -600,8 +606,15 @@ jobs:
           # CDMS/JPL catalogs at data-build time. It is never run by Galacticus, and it is not code-signed
           # above, so leaving it in the archive causes notarization to reject the whole archive ("the binary
           # is not signed", "no secure timestamp", "no hardened runtime"). Exclude it and its debug symbols.
+          #
+          # The `forutils` stamp file must be packaged alongside the `camb` executable. At run time
+          # `Interface_CAMB_Initialize` (source/interface/CAMB.F90) rebuilds CAMB unless *both* the
+          # executable and a stamp matching the required `forutils` version are present. Installs made from
+          # the packaged tools (e.g. via PyPI) typically have no Fortran compiler, so a missing stamp turns
+          # into a fatal build attempt rather than a simple use of the pre-built binary.
           toolProducts=(
             dynamic/CAMB-${cambVersion}/fortran/camb
+            dynamic/CAMB-${cambVersion}/forutils/.galacticusForUtilsVersion_${forutilsVersion}
             dynamic/axionCAMB-${axioncambVersion}/camb
             dynamic/class_public-${classVersion}/class
             dynamic/RecFast/recfast.exe
@@ -758,8 +771,15 @@ jobs:
           # CDMS/JPL catalogs at data-build time. It is never run by Galacticus, and it is not code-signed
           # above, so leaving it in the archive causes notarization to reject the whole archive ("the binary
           # is not signed", "no secure timestamp", "no hardened runtime"). Exclude it and its debug symbols.
+          #
+          # The `forutils` stamp file must be packaged alongside the `camb` executable. At run time
+          # `Interface_CAMB_Initialize` (source/interface/CAMB.F90) rebuilds CAMB unless *both* the
+          # executable and a stamp matching the required `forutils` version are present. Installs made from
+          # the packaged tools (e.g. via PyPI) typically have no Fortran compiler, so a missing stamp turns
+          # into a fatal build attempt rather than a simple use of the pre-built binary.
           toolProducts=(
             dynamic/CAMB-${cambVersion}/fortran/camb
+            dynamic/CAMB-${cambVersion}/forutils/.galacticusForUtilsVersion_${forutilsVersion}
             dynamic/axionCAMB-${axioncambVersion}/camb
             dynamic/class_public-${classVersion}/class
             dynamic/RecFast/recfast.exe


### PR DESCRIPTION
## Problem

`Interface_CAMB_Initialize` (`source/interface/CAMB.F90:106`) skips the download/unpack/compile of CAMB only when **both** the `camb` executable and a stamp file recording the required `forutils` version are present:

```fortran
if (.not.File_Exists(executable) .or. .not.File_Exists(stampForUtils)) then
```

The stamp lives at `<tools>/CAMB-<cambVersion>/forutils/.galacticusForUtilsVersion_<forutilsVersion>` (`CAMB.F90:104`), but the tool-packaging jobs shipped only `dynamic/CAMB-${cambVersion}/fortran/camb`. An install provisioned from those archives — as `galacticus` installed from PyPI is — therefore finds the executable but no stamp, and falls into the branch that downloads and builds CAMB and forutils from source. Such installs typically have no Fortran compiler available, so the attempt is fatal, even though the pre-built binary it needs is already there.

## Change

Add the stamp to the packaged paths in all three tool-packaging jobs:

- `Build-Tools` (Linux, `tar cfj tools.tar.bz2`)
- `Build-Executable-MacOS` (`toolProducts` → `toolsMacOS.zip`)
- `Build-Executable-MacOS-M1` (`toolProducts` → `toolsMacOSM1.zip`)

Nothing else is needed:

- The stamp is created by the CAMB build these jobs already run, and `forutilsVersion` is already in scope at each site (computed inline in the Linux job, exported to `$GITHUB_ENV` by the `buildTools` step in both macOS jobs).
- The macOS `missingProducts` check now covers the stamp, so a future rename fails the job rather than silently shipping an archive that reintroduces this; the Linux `tar` likewise exits non-zero on a missing member.
- `verifySignedMacOS` only codesign-checks entries that `file` reports as Mach-O, so the empty stamp passes through harmlessly.
- The launcher's `_provision_tools` (`python/galacticus_launcher/download.py:252`) does a full `extractall` and then lifts each child of `dynamic/` up, so `CAMB-<ver>/` carries both `fortran/camb` and `forutils/.galacticusForUtilsVersion_*` across intact — dotfiles included.

## Verification

The `cicd.yml` change was checked to still parse, and the reasoning above was traced through the Fortran, the workflow, and the launcher. Confirmation that a produced archive contains the stamp and that a PyPI install then runs CAMB without rebuilding comes from this PR's own CI run. Already-published archives, `bleeding-edge` included, lack the stamp until these jobs next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)