### PR TITLE
fix(build): add a self-hosted mirror for the RecFast download

### DIFF
--- a/source/interface/RecFast.F90
+++ b/source/interface/RecFast.F90
@@ -73,14 +73,18 @@ contains
           pathFor=recfastPath//"recfast.for"
           if (.not.File_Exists(pathFor)) then
              block
-               type(varying_string), dimension(2) :: urls
+               type(varying_string), dimension(3) :: urls
 
                call displayMessage("downloading RecFast code....",verbosityLevelWorking)
-               ! The Internet Archive snapshot is tried first as `www.astro.ubc.ca` currently serves an incomplete certificate
-               ! chain (its intermediate certificate is not sent), so its identity can not be verified. The two sources are
-               ! byte-identical; the original is retained as a fallback, and will be used again once that is corrected.
-               urls(1)=var_str("https://web.archive.org/web/20250818121544im_/https://www.astro.ubc.ca/people/scott/recfast.for")
+               ! Three byte-identical sources are tried in turn. RecFast is distributed under a permissive license, so a copy is
+               ! hosted at `users.obs.carnegiescience.edu` and is tried first: the canonical source, `www.astro.ubc.ca`, currently
+               ! serves an incomplete certificate chain (its intermediate certificate is not sent), so its identity can not be
+               ! verified and downloads from it will fail until that is corrected---placing it first would mean every download
+               ! exhausting all retries against it before falling through. It is retained as a fallback, and should be restored to
+               ! first place once that is corrected, with an Internet Archive snapshot of it as a final fallback.
+               urls(1)=var_str("https://users.obs.carnegiescience.edu/abenson/galacticus/recfast.for"                           )
                urls(2)=var_str("https://www.astro.ubc.ca/people/scott/recfast.for"                                              )
+               urls(3)=var_str("https://web.archive.org/web/20250818121544im_/https://www.astro.ubc.ca/people/scott/recfast.for")
                call download(urls,pathFor,retries=5,retryWait=10)
                if (.not.File_Exists(pathFor)) &
                   & call Error_Report("failed to download RecFast code"//{introspection:location})


### PR DESCRIPTION
## Motivation

Both existing sources for `recfast.for` have been unreliable recently, leading to a lot of failed CI jobs. RecFast is distributed under a permissive license, so a copy is now hosted at `users.obs.carnegiescience.edu` and added as a third source.

## Changes

`source/interface/RecFast.F90` now lists three sources, tried in this order:

1. `users.obs.carnegiescience.edu` — the new self-hosted copy
2. `www.astro.ubc.ca` — the canonical source
3. `web.archive.org` — Internet Archive snapshot, final fallback

### Why the canonical source is not first

`www.astro.ubc.ca` still serves an incomplete certificate chain (its intermediate certificate is not sent), so its identity cannot be verified:

```
$ curl https://www.astro.ubc.ca/people/scott/recfast.for
curl: (60) SSL certificate problem: unable to get local issuer certificate
```

This was already the reason it sat below the Internet Archive snapshot before this change. Since `downloadMultiple` (`source/system/downloader.F90`) tries each URL in turn and exhausts its retries before moving to the next, leaving that source first would make every fresh RecFast build burn all six attempts against it — roughly a minute of guaranteed-doomed retries plus TLS timeouts — before falling through to a working source.

The canonical source is retained in second place, and an inline comment records that it should be restored to first place once its certificate chain is corrected.

## Verification

- All three sources confirmed **byte-identical** (md5 `7eef44bb354cb09c3a8ea3e32c557b8a`, 47139 bytes), so the subsequent patch and compile steps are unaffected.
- Confirmed this is the only place the RecFast download URLs are defined — `source/tasks/build_tool/RecFast.F90` routes through `Interface_RecFast_Initialize`, and the `RECFAST_*` hits in `CAMB.F90`/`AxionCAMB.F90` are unrelated parameter names.
- Two pre-existing issues in this file were deliberately left untouched as unrelated: one over-length line, and a `scripts/aux/formatDeclarations.py --check` complaint that also reproduces on the unmodified file at `master`.

## Note

Developed with assistance from Claude Code, and reviewed and verified by a human before submission, per the AI-Assisted Contributions policy in `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
