### PR TITLE
fix(mergerTreeOperator): prune all progenitors when an unformed primary progenitor is removed

### DIFF
--- a/parameters/reference/warmDarkMatter.xml
+++ b/parameters/reference/warmDarkMatter.xml
@@ -76,6 +76,7 @@
   <change type="append" path="">
     <mergerTreeOperator value="pruneByFilter">
       <preservePrimaryProgenitor value="false"/>
+      <pruneAllProgenitors       value="true" />
       <galacticFilter value="labelled">
 	<label value="promptCuspUnformed"/>
       </galacticFilter>

--- a/source/merger_trees/operators/prune_by_filter.F90
+++ b/source/merger_trees/operators/prune_by_filter.F90
@@ -44,7 +44,7 @@ Implements a pruning-by-filter operator on merger trees.
      !!}
      private
      class  (galacticFilterClass), pointer :: galacticFilter_           => null()
-     logical                               :: preservePrimaryProgenitor
+     logical                               :: preservePrimaryProgenitor          , pruneAllProgenitors
    contains
      final     ::                        pruneByFilterDestructor
      procedure :: operatePreEvolution => pruneByFilterOperatePreEvolution
@@ -69,7 +69,7 @@ contains
     type   (mergerTreeOperatorPruneByFilter)                :: self
     type   (inputParameters                ), intent(inout) :: parameters
     class  (galacticFilterClass            ), pointer       :: galacticFilter_
-    logical                                                 :: preservePrimaryProgenitor
+    logical                                                 :: preservePrimaryProgenitor, pruneAllProgenitors
 
     !![
     <inputParameter docformat="rst">
@@ -80,9 +80,22 @@ contains
       If true, primary progenitor status is preserved even if the primary progenitor is pruned from the tree.
       </description>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>pruneAllProgenitors</name>
+      <source>parameters</source>
+      <defaultValue>.false.</defaultValue>
+      <description>
+      If true, when the primary progenitor of a node is pruned every remaining progenitor of that node is pruned also, leaving it
+      with no progenitors at all. This is appropriate where passing ``[galacticFilter]`` means that the branch could not have
+      formed: for example, halos labeled ``promptCuspUnformed`` by
+      :galacticus-class:`nodeOperatorDarkMatterProfilePromptCusps`, since a prompt cusp forms from a smooth patch of the initial
+      density field and so the halo which forms with it can have no progenitors. If false (the default), only the branch which
+      passes the filter is pruned, and any remaining progenitor inherits primary progenitor status.
+      </description>
+    </inputParameter>
     <objectBuilder class="galacticFilter" name="galacticFilter_" source="parameters"/>
     !!]
-    self=mergerTreeOperatorPruneByFilter(preservePrimaryProgenitor,galacticFilter_)
+    self=mergerTreeOperatorPruneByFilter(preservePrimaryProgenitor,pruneAllProgenitors,galacticFilter_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="galacticFilter_"/>
@@ -90,16 +103,16 @@ contains
     return
   end function pruneByFilterConstructorParameters
 
-  function pruneByFilterConstructorInternal(preservePrimaryProgenitor,galacticFilter_) result(self)
+  function pruneByFilterConstructorInternal(preservePrimaryProgenitor,pruneAllProgenitors,galacticFilter_) result(self)
     !!{RST
     Internal constructor for the prune-by-filter merger tree operator class.
     !!}
     implicit none
     type   (mergerTreeOperatorPruneByFilter)                        :: self
     class  (galacticFilterClass            ), intent(in   ), target :: galacticFilter_
-    logical                                 , intent(in   )         :: preservePrimaryProgenitor
+    logical                                 , intent(in   )         :: preservePrimaryProgenitor, pruneAllProgenitors
     !![
-    <constructorAssign variables="preservePrimaryProgenitor, *galacticFilter_"/>
+    <constructorAssign variables="preservePrimaryProgenitor, pruneAllProgenitors, *galacticFilter_"/>
     !!]
 
     return
@@ -128,8 +141,8 @@ contains
     implicit none
     class  (mergerTreeOperatorPruneByFilter), intent(inout), target :: self
     type   (mergerTree                     ), intent(inout), target :: tree
-    type   (treeNode                       ), pointer               :: nodeNext   , nodeWork, &
-         &                                                             node
+    type   (treeNode                       ), pointer               :: nodeNext   , nodeWork          , &
+         &                                                             node       , nodeParent
     type   (mergerTree                     ), pointer               :: currentTree
     type   (mergerTreeWalkerIsolatedNodes  )                        :: treeWalker
     logical                                                         :: didPruning , parentWillBePruned
@@ -176,13 +189,31 @@ contains
                    ! Determine whether the parent will also be pruned - if it will, there is no need to preserve primary
                    ! progenitor status within it.
                    parentWillBePruned=self%galacticFilter_%passes(node%parent)
-                   ! Decouple from other nodes.
-                   call Merger_Tree_Prune_Unlink_Parent(node,node%parent,parentWillBePruned,self%preservePrimaryProgenitor)
-                   ! Clean the branch.
-                   call Merger_Tree_Prune_Clean_Branch (node)
-                   ! Destroy the branch.
-                   call node%destroyBranch()
-                   deallocate(node)
+                   if (self%pruneAllProgenitors .and. node%isPrimaryProgenitorOf(node%parent)) then
+                      ! The primary progenitor could not have formed, so neither could the node it is a progenitor of have had
+                      ! any progenitor: prune every progenitor of the parent, leaving it with none. Retaining the siblings here
+                      ! would instead make one of them the de facto primary progenitor while it still carries the virial orbit
+                      ! assigned to it as a secondary progenitor - an orbit which is then carried up the branch by successive
+                      ! node promotions until it meets a parent holding an orbit of its own.
+                      nodeParent => node%parent
+                      nodeWork   => nodeParent%firstChild
+                      do while (associated(nodeWork))
+                         nodeNext => nodeWork%sibling
+                         call Merger_Tree_Prune_Clean_Branch(nodeWork)
+                         call nodeWork%destroyBranch()
+                         deallocate(nodeWork)
+                         nodeWork => nodeNext
+                      end do
+                      nullify(nodeParent%firstChild)
+                   else
+                      ! Decouple from other nodes.
+                      call Merger_Tree_Prune_Unlink_Parent(node,node%parent,parentWillBePruned,self%preservePrimaryProgenitor)
+                      ! Clean the branch.
+                      call Merger_Tree_Prune_Clean_Branch (node)
+                      ! Destroy the branch.
+                      call node%destroyBranch()
+                      deallocate(node)
+                   end if
                 end if
              end do
           end if

--- a/testSuite/parameters/promptCuspsUnformed.xml
+++ b/testSuite/parameters/promptCuspsUnformed.xml
@@ -442,6 +442,7 @@
   <mergerTreeOperator value="sequence">
     <mergerTreeOperator value="pruneByFilter">
       <preservePrimaryProgenitor value="false"/>
+      <pruneAllProgenitors       value="true" />
       <galacticFilter value="labelled">
         <label value="promptCuspUnformed"/>
       </galacticFilter>

--- a/testSuite/parameters/testPromptCuspNFW.xml
+++ b/testSuite/parameters/testPromptCuspNFW.xml
@@ -440,6 +440,7 @@
   <mergerTreeOperator value="sequence">
     <mergerTreeOperator value="pruneByFilter">
       <preservePrimaryProgenitor value="false"/>
+      <pruneAllProgenitors       value="true" />
       <galacticFilter value="labelled">
         <label value="promptCuspUnformed"/>
       </galacticFilter>


### PR DESCRIPTION
## The failure

The `Validate-Dark-Matter-Only-Subhalos-COZMICWDM (WDM5keV, X8)` model intermittently aborts with

```
Fatal error: multiple satellite components defined on branch have differnt orbits
Occurred at:   subroutine:nodePromotion       module:Node_Component_Satellite_Orbiting
file:objects/nodes/components/satellite/orbiting.F90   [line 284]
```

## Cause

When `pruneByFilter` removes a halo labelled `promptCuspUnformed` with
`preservePrimaryProgenitor=false`, `Merger_Tree_Prune_Unlink_Parent` does

```fortran
nodeParent%firstChild => node%sibling
```

so the pruned primary progenitor is replaced by its sibling. That sibling becomes the de facto
primary progenitor while still holding the virial orbit which `haloAngularMomentumVitvitska2002`
assigned it as a *secondary* progenitor. The orbit is then carried up the branch by successive node
promotions - each of which sees only one satellite component and so passes the check - until it
reaches a parent which holds a virial orbit of its own. At that promotion `nodePromotion` sees two
orbiting satellite components with different orbits on one branch, and aborts.

Traced directly in a reproducing run (consecutive log lines, at `verbosityLevel="info"`):

```
pruning promoted node 62090 to primary progenitor of 62089; satellite count 1
...
Promoting node 62090 to 62089
Promoting node 62089 to 62088
Promoting node 62088 to 62087
Promoting node 62087 to 62086
Promoting node 62086 to 62085
Promoting node 62085 to 62084
Promoting node 62084 to 62083
Promoting node 62083 to 62082
Promoting node 62082 to 60617     <-- aborts here
```

The two orbits differ substantively rather than in some unset field: the node carries an orbit for a
host of 9.88e6 M_sun, its parent one for 1.90e11 M_sun.

The eight-promotion gap between cause and symptom is why this was hard to localise. When pruning
finishes, the stale orbit sits on a node which *is* a legitimate primary progenitor; it only becomes
a contradiction nine promotions later. A scan for stale orbits immediately after pruning therefore
finds nothing.

## Change

Adds `pruneAllProgenitors` to `mergerTreeOperatorPruneByFilter`. When true and the pruned node is the
primary progenitor, every remaining progenitor of the parent is cleaned and destroyed, leaving it
childless.

This is the physically correct behaviour wherever the filter identifies halos which could not have
formed. A prompt cusp forms from a smooth patch of the initial density field, so the halo which forms
with it can have no progenitors at all - not merely no primary progenitor.

The option defaults to `false`, so behaviour is unchanged for any other use of this operator (pruning
by halo mass, say, where deleting the surviving siblings would be badly wrong). It is enabled in the
three prompt-cusp parameter files: `parameters/reference/warmDarkMatter.xml`,
`testSuite/parameters/promptCuspsUnformed.xml`, `testSuite/parameters/testPromptCuspNFW.xml`.

## Verification

The full 128-tree model is a poor test here: the failure occurs for roughly **1 tree in 600**, so
that job fails only about one run in five and a single green run is weak evidence either way. The
model was instead reduced to a single tree - faithful, because every tree in it uses the same host
mass and differs only in seed - which runs in ~53 s, allowing random seeds to be scanned.

| test | result |
|---|---|
| 600 seeds, before the change | 1 failure (seed 349) |
| 600 seeds, after the change | **600 pass** |
| seed 349, `pruneAllProgenitors=true` | pass |
| seed 349, `pruneAllProgenitors=false`, same executable | aborts |

The last two rows isolate the new parameter as the cause of the fix, rather than the rebuild.

**Model predictions are unchanged.** Node counts are identical across 218 before/after comparisons,
and in direct A/B tests on individual seeds. This is expected: the sibling which inherits primary
progenitor status is normally itself `promptCuspUnformed` and so is pruned on a later iteration of
the restart-the-walk loop, leaving the same tree by a longer route. The trees only differ where the
inherited sibling is *not* unformed and survives carrying its stale orbit - precisely the rare
configuration which aborted. So validation metrics should be unaffected.

## Note for reviewers

Because the underlying rate is ~1/600 per tree, a green CI run on this job does **not** by itself
demonstrate the fix works - it would be ~80% likely even without the change. The 600-seed sweep above
is the substantive evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
