### PR TITLE
fix(build): recognize `bind(c)` and spaced `extends(...)` in derived-type openers

### DIFF
--- a/python/Fortran/Utils.py
+++ b/python/Fortran/Utils.py
@@ -12,6 +12,8 @@ __all__ = [
     'extract_variables', 'unformat_variables',
     'check_no_parameterized_derived_type',
     'LABEL', 'ARGUMENT_LIST',
+    'TYPE_ATTRIBUTE', 'TYPE_ATTRIBUTES', 'TYPE_ATTRIBUTES_TAGGED',
+    'type_opener_regex',
     'UNIT_OPENERS', 'UNIT_CLOSERS', 'INTRINSIC_DECLARATIONS',
 ]
 
@@ -21,6 +23,68 @@ __all__ = [
 
 LABEL         = r'[a-zA-Z0-9_{}¦]+'
 ARGUMENT_LIST = r'[a-zA-Z0-9_{}¦,\s]*'
+
+# ---------------------------------------------------------------------------
+# Derived-type definition openers
+# ---------------------------------------------------------------------------
+#
+# Fortran allows exactly five attributes on a `type` statement — `abstract`,
+# `bind(c)`, `extends(parent)`, `public` and `private` — and permits whitespace
+# wherever the standard allows it, including inside `bind( c )` and
+# `extends( parent )`.  The tree uses both freedoms: `type, bind(C) ::
+# unitType` and `type, extends(hdf5Group             ) :: hdf5File`.
+#
+# An opener that fails to match is *not* merely left unlabelled.  The unit
+# parser never opens a `type` node, so the type's components are absorbed into
+# the enclosing scope's declaration node as though they were ordinary
+# variables, and its `end type` is stranded as an orphan code node.  Nothing
+# raises when that happens, so the damage is silent: consumers that walk `type`
+# nodes, or that query declarations at module scope, simply see the wrong tree.
+#
+# These fragments exist so that every consumer shares one definition.  The
+# pattern was previously copied into eight modules, which then drifted apart —
+# which is precisely what let `bind(c)` and padded `extends(...)` go unmatched.
+#
+# `bind(c)` types need no special handling downstream.  A C-interoperable
+# derived type may neither extend another type nor be extended, so it can never
+# appear in a functionClass, stateStorable or deepCopyActions inheritance
+# chain.  Those generators emit code by walking such chains, so they skip these
+# types naturally, without any explicit exclusion.
+
+TYPE_ATTRIBUTE = (
+    r'abstract|public|private'
+    r'|bind\s*\(\s*c\s*\)'
+    r'|extends\s*\(\s*' + LABEL + r'\s*\)'
+)
+
+# Attribute list, capturing nothing.
+TYPE_ATTRIBUTES = r'(?:,\s*(?:' + TYPE_ATTRIBUTE + r')\s*)*'
+
+# Attribute list tagging `abstract` and the `extends` parent.  Both groups sit
+# inside a repeated group, so each holds its last occurrence — and Fortran
+# permits an attribute at most once, so that is also its only occurrence.
+TYPE_ATTRIBUTES_TAGGED = (
+    r'(?:,\s*(?:(?P<abstract>abstract)|public|private|bind\s*\(\s*c\s*\)'
+    r'|extends\s*\(\s*(?P<extends>' + LABEL + r')\s*\))\s*)*'
+)
+
+
+def type_opener_regex(name=LABEL, attributes=TYPE_ATTRIBUTES,
+                      flags=re.IGNORECASE):
+    """Compile a matcher for a derived-type definition opener.
+
+    The type name is captured as `name`.  Pass `attributes` as
+    `TYPE_ATTRIBUTES_TAGGED` to also capture `abstract` and `extends`; the
+    groups are named, so callers index by name and are unaffected by which
+    variant they chose.  `name` may be narrowed to scan for a single family of
+    types — e.g. `re.escape(directive) + r'[a-z0-9_]+'`, which captures the
+    whole name while requiring the family prefix.
+    """
+    return re.compile(
+        r'^\s*type\s*' + attributes + r'(?:::)?\s*(?P<name>' + name + r')\s*$',
+        flags,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Unit opener / closer patterns
@@ -100,12 +164,7 @@ UNIT_OPENERS = {
     # Derived type
     'type': {
         'unit_name': 0,
-        'regex': re.compile(
-            r'^\s*type\s*'
-            r'(?:,\s*(?:abstract|public|private|extends\s*\(' + LABEL + r'\))\s*)*'
-            r'(?:::)?\s*(' + LABEL + r')\s*$',
-            re.IGNORECASE,
-        ),
+        'regex': type_opener_regex(),
     },
     # `contains` marker — self-closing.  Rather than a container whose
     # children are the post-contains subprograms, `contains` is a sibling

--- a/python/Galacticus/Build/SourceTree/Parse/Declarations.py
+++ b/python/Galacticus/Build/SourceTree/Parse/Declarations.py
@@ -706,17 +706,16 @@ def _is_type_definition(declaration):
     """True if this is a derived-type *definition*, not a variable declaration.
 
     `type, bind(c) :: unitType` opens a derived type; `type(unitType) :: x`
-    declares a variable of one.  The unit parser normally claims the former, so
-    it never reaches a declaration node — but it recognizes the statement by
-    pattern, and a few in the tree carry enough internal padding
-    (`type, extends(hdf5Group             ) :: hdf5File`) to slip past it and
-    land here instead.
+    declares a variable of one.  The unit parser claims the former, so it
+    should never reach a declaration node.
 
-    Reformatting such a statement would tidy away exactly the padding that hid
-    it, so on the next parse the unit parser *would* claim it and the shape of
-    the tree would change underneath the formatter.  There are four in the tree;
-    leaving them untouched is simpler and safer than teaching the emitter to
-    reproduce their disguise.
+    It once could: the opener pattern missed `bind(c)` and padded
+    `extends(...)`, so four such statements in the tree slipped past the unit
+    parser and landed here, where reformatting would have tidied away exactly
+    the padding that hid them — changing the tree shape underneath the
+    formatter on the next parse.  That gap is fixed (the pattern now lives once
+    in `Fortran.Utils`), so this guard is expected to be inert; it stays as a
+    cheap backstop, since the failure it prevents is silent.
     """
     return (declaration.get('intrinsic') in ('type', 'class')
             and declaration.get('type') is None)

--- a/python/Galacticus/Build/SourceTree/Process/DeepCopyActions.py
+++ b/python/Galacticus/Build/SourceTree/Process/DeepCopyActions.py
@@ -10,6 +10,7 @@ Andrew Benson (ported to Python 2026)
 import re
 
 
+from Fortran.Utils                       import TYPE_ATTRIBUTES_TAGGED, type_opener_regex
 from List.ExtraUtils                     import as_array
 from Galacticus.Build.SourceTree         import (
     walk_tree, parse_code, children, insert_post_contains,
@@ -17,13 +18,7 @@ from Galacticus.Build.SourceTree         import (
 from Galacticus.Build.SourceTree.Process import register_process, process_tree
 
 
-_TYPE_OPENER_RE = re.compile(
-    r'^\s*type\s*'
-    r'((?:,\s*(?:abstract|public|private|extends\s*\([a-zA-Z0-9_]+\))\s*)*)'
-    r'(?:::)?\s*([a-zA-Z0-9_]+)\s*$',
-    re.IGNORECASE,
-)
-_EXTENDS_ATTR_RE = re.compile(r'extends\(([a-zA-Z0-9_]+)\)', re.IGNORECASE)
+_TYPE_OPENER_RE = type_opener_regex(attributes=TYPE_ATTRIBUTES_TAGGED)
 
 
 def _parse_type_opener(opener):
@@ -38,17 +33,7 @@ def _parse_type_opener(opener):
     if not m:
         raise RuntimeError(
             "process_deep_copy_actions: unable to parse type definition opener")
-    attrs_text = m.group(1).strip().strip(',').strip()
-    type_name  = m.group(2)
-    extends    = None
-    abstract   = False
-    for attr in re.split(r'\s*,\s*', attrs_text) if attrs_text else []:
-        if attr == 'abstract':
-            abstract = True
-        em = _EXTENDS_ATTR_RE.match(attr)
-        if em:
-            extends = em.group(1)
-    return type_name, extends, abstract
+    return m.group('name'), m.group('extends'), m.group('abstract') is not None
 
 
 def _emit_deep_copy_action(class_name, classes, directive):

--- a/python/Galacticus/Build/SourceTree/Process/FunctionClass/Utils.py
+++ b/python/Galacticus/Build/SourceTree/Process/FunctionClass/Utils.py
@@ -6,6 +6,7 @@ Andrew Benson (ported to Python 2026)
 import re
 
 
+from Fortran.Utils              import TYPE_ATTRIBUTES_TAGGED, type_opener_regex
 from Galacticus.Build.SourceTree import walk_tree
 
 
@@ -41,11 +42,9 @@ def class_dependencies(class_node, directive_name):
     """
     class_record = {}
     dependencies = []
-    pattern = re.compile(
-        r'^\s*type\s*(,\s*abstract\s*|,\s*public\s*|,\s*private\s*'
-        r'|,\s*extends\s*\(([a-zA-Z0-9_]+)\)\s*)*'
-        r'(?:::)?\s*' + re.escape(directive_name) + r'([a-z0-9_]+)\s*$',
-        re.IGNORECASE,
+    pattern = type_opener_regex(
+        name=re.escape(directive_name) + r'[a-z0-9_]+',
+        attributes=TYPE_ATTRIBUTES_TAGGED,
     )
 
     for node in _walk_forward(class_node):
@@ -58,11 +57,11 @@ def class_dependencies(class_node, directive_name):
 
         if node.get('type') == 'type':
             m = pattern.match(node.get('opener') or '')
-            if not m or m.group(2) is None:
+            if not m or m.group('extends') is None:
                 continue
-            class_record['extends'] = m.group(2)
-            class_record['type']    = directive_name + m.group(3)
-            dependencies.append(m.group(2))
+            class_record['extends'] = m.group('extends')
+            class_record['type']    = m.group('name')
+            dependencies.append(m.group('extends'))
             # Pull in cross-references: `class(Xfoo)` / `type(Xfoo)` members
             # whose type is another member of the same functionClass family.
             child = node.get('firstChild')

--- a/python/Galacticus/Build/SourceTree/Process/StateStorable.py
+++ b/python/Galacticus/Build/SourceTree/Process/StateStorable.py
@@ -13,6 +13,7 @@ import re
 import xml.etree.ElementTree as ET
 
 
+from Fortran.Utils                       import TYPE_ATTRIBUTES_TAGGED, type_opener_regex
 from List.ExtraUtils                     import as_array
 from XML.Utils                           import xml_to_dict
 from Galacticus.Build.SourceTree         import (
@@ -21,13 +22,7 @@ from Galacticus.Build.SourceTree         import (
 from Galacticus.Build.SourceTree.Process import register_process, process_tree
 
 
-_TYPE_OPENER_RE = re.compile(
-    r'^\s*type\s*'
-    r'((?:,\s*(?:abstract|public|private|extends\s*\([a-zA-Z0-9_]+\))\s*)*)'
-    r'(?:::)?\s*([a-zA-Z0-9_]+)\s*$',
-    re.IGNORECASE,
-)
-_EXTENDS_ATTR_RE = re.compile(r'extends\(([a-zA-Z0-9_]+)\)', re.IGNORECASE)
+_TYPE_OPENER_RE = type_opener_regex(attributes=TYPE_ATTRIBUTES_TAGGED)
 
 
 # ---------------------------------------------------------------------------
@@ -47,17 +42,7 @@ def _parse_type_opener(opener):
     if not m:
         raise RuntimeError(
             "process_state_storable: unable to parse type definition opener")
-    attrs_text = m.group(1).strip().strip(',').strip()
-    type_name  = m.group(2)
-    extends    = None
-    abstract   = False
-    for attr in re.split(r'\s*,\s*', attrs_text) if attrs_text else []:
-        if attr == 'abstract':
-            abstract = True
-        em = _EXTENDS_ATTR_RE.match(attr)
-        if em:
-            extends = em.group(1)
-    return type_name, extends, abstract
+    return m.group('name'), m.group('extends'), m.group('abstract') is not None
 
 
 def _load_state_storables_xml():

--- a/python/Galacticus/Build/SourceTree/tests/test_type_openers.py
+++ b/python/Galacticus/Build/SourceTree/tests/test_type_openers.py
@@ -1,0 +1,212 @@
+"""Regression tests for derived-type definition opener recognition.
+
+Bug class: the opener pattern omitted `bind(c)` from its attribute
+alternation and admitted no whitespace inside `extends(...)`, so
+`type, bind(c) :: unitType` and `type, extends(hdf5Group             ) ::
+hdf5File` both failed to match.
+
+A missed opener is not merely an unlabelled node.  The unit parser never opens
+a `type` node, so the type's components are absorbed into the enclosing
+scope's declaration node as though they were ordinary variables, and the
+`end type` is stranded as an orphan code node — silently, with nothing
+raised.  Four types in the tree were affected.
+
+The pattern had been copied into eight modules which then drifted apart, so
+these tests also pin every consumer to the shared definition in
+`Fortran.Utils`: fixing one copy previously just moved the failure to the
+next one (`DeepCopyActions` raised "unable to parse type definition opener"
+once the type nodes it had never seen started existing).
+"""
+
+import re
+
+import pytest
+
+from Fortran.Utils import (
+    TYPE_ATTRIBUTES_TAGGED, UNIT_OPENERS, type_opener_regex,
+)
+from Galacticus.Build.SourceTree import parse_code, children, walk_tree
+
+
+TYPE_OPENER = UNIT_OPENERS['type']['regex']
+
+# The four openers in the tree that the old pattern missed, and why.
+MISSED_OPENERS = [
+    ("  type, bind(C) :: unitType",                          'unitType'),
+    ("  type, public, bind(c) :: gsl_sf_result",             'gsl_sf_result'),
+    ("  type, bind(C) :: hdf5VlenC",                         'hdf5VlenC'),
+    ("  type, extends(hdf5Group             ) :: hdf5File",  'hdf5File'),
+]
+
+
+@pytest.mark.parametrize("opener,name", MISSED_OPENERS)
+def test_previously_missed_openers_now_match(opener, name):
+    m = TYPE_OPENER.match(opener)
+    assert m is not None, f"opener not recognized: {opener!r}"
+    assert m.group('name') == name
+
+
+@pytest.mark.parametrize("opener,name", [
+    ("  type :: plain",                             'plain'),
+    ("  type plain",                                'plain'),
+    ("  type, public :: pub",                       'pub'),
+    ("  type, abstract, extends(foo) :: bar",       'bar'),
+    ("  type, extends(foo), abstract :: bar",       'bar'),
+    ("  type, bind( c ) :: spaced",                 'spaced'),
+    ("  TYPE, BIND(C) :: shouty",                   'shouty'),
+])
+def test_opener_forms_match(opener, name):
+    m = TYPE_OPENER.match(opener)
+    assert m is not None, f"opener not recognized: {opener!r}"
+    assert m.group('name') == name
+
+
+@pytest.mark.parametrize("line", [
+    "  type(unitType) :: x",                # a variable, not a definition
+    "  type(c_ptr), pointer :: p",
+    "  type(varying_string), dimension(:) :: names",
+])
+def test_variable_declarations_are_not_openers(line):
+    assert TYPE_OPENER.match(line) is None, \
+        f"variable declaration wrongly claimed as a type opener: {line!r}"
+
+
+def test_bind_c_type_gets_its_own_node_with_its_components():
+    """The whole point of the fix: components stay inside the type.
+
+    Before, `numerator`/`denominator` were recorded as *module-scope*
+    declarations, `unitType` had no node at all, and `end type unitType`
+    survived as a bare code node.
+    """
+    source = (
+        "module demo\n"
+        "  implicit none\n"
+        "  type, bind(c) :: unitType\n"
+        "     integer :: numerator\n"
+        "     integer :: denominator\n"
+        "  end type unitType\n"
+        "  integer :: moduleVariable\n"
+        "end module demo\n"
+    )
+    tree = parse_code(source, name='<test>', instrument=False)
+
+    def declared_names(node):
+        """Every variable declared directly in `node`'s own scope.
+
+        The parser lower-cases variable names (Fortran is case-insensitive),
+        so compare against lower-case expectations.
+        """
+        names = []
+        for child in children(node):
+            if child.get('type') == 'declaration':
+                for declaration in child.get('declarations') or []:
+                    names.extend(declaration.get('variables') or [])
+        return [name.lower() for name in names]
+
+    types = [n for n in walk_tree(tree) if n.get('type') == 'type']
+    assert [n.get('name') for n in types] == ['unitType']
+
+    # The components belong to the type ...
+    assert declared_names(types[0]) == ['numerator', 'denominator']
+
+    # ... and are *not* leaked into the enclosing module, which keeps only its
+    # own variable.  This is the assertion that fails on the unfixed parser.
+    module = next(n for n in walk_tree(tree) if n.get('type') == 'module')
+    assert declared_names(module) == ['modulevariable']
+
+    # `end type` was consumed as the closer, not stranded as orphan code.
+    for node in walk_tree(tree):
+        if node.get('type') == 'code':
+            assert 'end type' not in node.get('content', '').lower(), \
+                "`end type` left as an orphan code node"
+
+
+def test_padded_extends_records_the_parent():
+    """`extends(hdf5Group             )` must yield the parent, not None.
+
+    The padding is what hid `hdf5File` from the parser; a pattern that
+    matched the opener but dropped the parent would silently break the
+    inheritance map instead.
+    """
+    rx = type_opener_regex(attributes=TYPE_ATTRIBUTES_TAGGED)
+    m  = rx.match("  type, extends(hdf5Group             ) :: hdf5File")
+    assert m is not None
+    assert m.group('name')     == 'hdf5File'
+    assert m.group('extends')  == 'hdf5Group'
+    assert m.group('abstract') is None
+
+
+def test_tagged_attributes_capture_abstract_in_any_order():
+    rx = type_opener_regex(attributes=TYPE_ATTRIBUTES_TAGGED)
+    for opener in ("type, abstract, extends(foo) :: bar",
+                   "type, extends(foo), abstract :: bar"):
+        m = rx.match(opener)
+        assert m is not None,               opener
+        assert m.group('abstract')is not None, opener
+        assert m.group('extends') == 'foo', opener
+        assert m.group('name')    == 'bar', opener
+
+
+def test_abstract_is_matched_case_insensitively():
+    """Fortran is case-insensitive; an `ABSTRACT` type is still abstract.
+
+    The hand-rolled attribute splitting this replaced compared with
+    `attr == 'abstract'`, so it silently mis-classified an upper-case
+    `ABSTRACT` type as concrete.
+    """
+    rx = type_opener_regex(attributes=TYPE_ATTRIBUTES_TAGGED)
+    m  = rx.match("TYPE, ABSTRACT, EXTENDS(Foo) :: Bar")
+    assert m is not None
+    assert m.group('abstract') is not None
+
+
+def test_narrowed_name_pattern_captures_the_whole_name():
+    """Callers scanning one functionClass family pass a prefixed name."""
+    rx = type_opener_regex(name=re.escape('massDistribution') + r'[a-z0-9_]+',
+                           attributes=TYPE_ATTRIBUTES_TAGGED)
+    m = rx.match("  type, extends(massDistributionClass) :: massDistributionGaussian")
+    assert m is not None
+    assert m.group('name')    == 'massDistributionGaussian'
+    assert m.group('extends') == 'massDistributionClass'
+    assert rx.match("  type, extends(foo) :: someOtherThing") is None
+
+
+@pytest.mark.parametrize("opener,name", MISSED_OPENERS)
+def test_every_consumer_parses_the_previously_missed_openers(opener, name):
+    """Each site that carried its own copy of the pattern must cope.
+
+    Fixing only the canonical regex broke the build: `DeepCopyActions` and
+    `StateStorable` raise on an opener they cannot parse, and they only began
+    seeing these types once the canonical fix made their nodes exist.
+    """
+    from Galacticus.Build.TypeScan import TYPE_OPENER_RE
+    from Galacticus.Build.SourceTree.Process.DeepCopyActions import (
+        _parse_type_opener as deep_copy_parse,
+    )
+    from Galacticus.Build.SourceTree.Process.StateStorable import (
+        _parse_type_opener as state_store_parse,
+    )
+
+    assert TYPE_OPENER_RE.match(opener) is not None
+
+    # Neither generator may raise; both must agree on the name.
+    assert deep_copy_parse(opener)[0]   == name
+    assert state_store_parse(opener)[0] == name
+
+
+def test_bind_c_types_have_no_parent_and_so_reach_no_generator():
+    """`bind(c)` types are inert for the hierarchy-walking generators.
+
+    A C-interoperable derived type can neither extend another type nor be
+    extended, so it can never join a functionClass / stateStorable /
+    deepCopyActions chain.  That is why making these types visible needs no
+    explicit exclusion — the generators emit code by walking parents, and
+    these have none.
+    """
+    from Galacticus.Build.SourceTree.Process.DeepCopyActions import (
+        _parse_type_opener,
+    )
+    for opener, name in MISSED_OPENERS:
+        parsed = _parse_type_opener(opener)
+        if 'bind' in opener.lower():
+            assert parsed == (name, None, False)

--- a/python/Galacticus/Build/TypeScan.py
+++ b/python/Galacticus/Build/TypeScan.py
@@ -6,21 +6,15 @@ together with the AST nodes carrying a given directive. Historically each
 script carried its own copy; they live here so fixes land once.
 """
 
-import re
-
+from Fortran.Utils              import TYPE_ATTRIBUTES_TAGGED, type_opener_regex
 from Galacticus.Build.SourceTree import walk_tree
 
 __all__ = ['TYPE_OPENER_RE', 'collect_types_and_directives', 'inherits_from']
 
 
-# Matches a derived-type definition opener, capturing (abstract, extends
-# parent, type name).
-TYPE_OPENER_RE = re.compile(
-    r'^\s*type\s*'
-    r'(?:,\s*(?:(abstract)|public|private|extends\s*\(([a-zA-Z0-9_]+)\))\s*)*'
-    r'(?:::)?\s*([a-zA-Z0-9_]+)\s*$',
-    re.IGNORECASE,
-)
+# Matches a derived-type definition opener, capturing the `abstract`,
+# `extends` and `name` groups.
+TYPE_OPENER_RE = type_opener_regex(attributes=TYPE_ATTRIBUTES_TAGGED)
 
 
 def collect_types_and_directives(tree, directive_type):
@@ -45,10 +39,9 @@ def collect_types_and_directives(tree, directive_type):
                     "TypeScan: unable to parse type definition opener: "
                     f"{node.get('opener')!r}"
                 )
-            abstract, extends, name = m.group(1), m.group(2), m.group(3)
-            classes[name] = {
-                'extends':  extends,
-                'abstract': abstract is not None,
+            classes[m.group('name')] = {
+                'extends':  m.group('extends'),
+                'abstract': m.group('abstract') is not None,
             }
     return classes, directives
 

--- a/python/LibraryInterfaces/Hierarchy.py
+++ b/python/LibraryInterfaces/Hierarchy.py
@@ -18,17 +18,17 @@ registered functionClass set.
 import re
 from pathlib import Path
 
-# `type, [optional attrs (abstract, public, private, extends(...))]
-#  [::] <name>` — same shape Fortran.Utils.UNIT_OPENERS['type'] recognises,
-# but with the parent name captured.  Only matches when the `extends(...)`
-# attribute is present; types without it have no parent edge to record.
-_TYPE_EXTENDS_RX = re.compile(
-    r'^\s*type\s*'
-    r'(?:,\s*(?:abstract|public|private|extends\s*\([A-Za-z][A-Za-z0-9_]*\))\s*)*'
-    r',\s*extends\s*\(\s*([A-Za-z][A-Za-z0-9_]*)\s*\)\s*'
-    r'(?:,\s*(?:abstract|public|private)\s*)*'
-    r'(?:::)?\s*([A-Za-z][A-Za-z0-9_]*)\s*$',
-    re.IGNORECASE | re.MULTILINE,
+from Fortran.Utils import TYPE_ATTRIBUTES_TAGGED, type_opener_regex
+
+# `type, [optional attrs (abstract, bind(c), public, private, extends(...))]
+#  [::] <name>` — the shared shape from `Fortran.Utils`, scanned over whole
+# file text rather than a parsed tree, hence `re.MULTILINE`.  The `extends`
+# group is optional in the shared pattern, so the caller skips matches that
+# leave it `None`: a type without a parent has no edge to record.
+_TYPE_EXTENDS_RX = type_opener_regex(
+    name=r'[A-Za-z][A-Za-z0-9_]*',
+    attributes=TYPE_ATTRIBUTES_TAGGED,
+    flags=re.IGNORECASE | re.MULTILINE,
 )
 _MODULE_RX = re.compile(
     r'^\s*module\s+([A-Za-z][A-Za-z0-9_]*)\s*$',
@@ -62,7 +62,9 @@ def build_type_hierarchy(source_dir):
         module_anchors = [(m.start(), m.group(1))
                           for m in _MODULE_RX.finditer(text)]
         for tm in _TYPE_EXTENDS_RX.finditer(text):
-            parent, child = tm.group(1), tm.group(2)
+            parent, child = tm.group('extends'), tm.group('name')
+            if parent is None:
+                continue
             mod = ''
             for off, name in module_anchors:
                 if off < tm.start():

--- a/scripts/aux/staticAnalyzer.py
+++ b/scripts/aux/staticAnalyzer.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
+import os
 import re
 import sys
 
-from Fortran.Utils import type_opener_regex
+# Make the in-tree Python packages importable when run directly, without a
+# `pip install -e .` or an externally-set `PYTHONPATH`.  This script is an aux
+# tool run standalone (and its tests invoke it as a bare subprocess), so it
+# cannot rely on either being in place.
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir, os.pardir, 'python'))
+
+from Fortran.Utils import type_opener_regex                          # noqa: E402
 
 # Perform static analysis of Fortran files.
 # Andrew Benson (28-February-2023)

--- a/scripts/aux/staticAnalyzer.py
+++ b/scripts/aux/staticAnalyzer.py
@@ -2,6 +2,8 @@
 import re
 import sys
 
+from Fortran.Utils import type_opener_regex
+
 # Perform static analysis of Fortran files.
 # Andrew Benson (28-February-2023)
 #
@@ -34,12 +36,7 @@ _VAR_DECL = re.compile(
 )
 
 # Derived-type definition opener: "type [,attrs] [::] name"  (not "type(...)").
-_TYPE_DEF = re.compile(
-    r'^\s*type'
-    r'(?:\s*,\s*(?:abstract|public|private|extends\s*\([^)]+\))\s*)*'
-    r'(?:\s*::)?\s*([a-zA-Z0-9_]+)\s*$',
-    re.IGNORECASE,
-)
+_TYPE_DEF = type_opener_regex()
 _END_TYPE      = re.compile(r'^\s*end\s+type\b',      re.IGNORECASE)
 _INTERFACE     = re.compile(r'^\s*interface\s+([a-zA-Z0-9_]+)\s*$', re.IGNORECASE)
 _END_INTERFACE = re.compile(r'^\s*end\s+interface\b', re.IGNORECASE)
@@ -329,7 +326,7 @@ for line in lines:
     # type definition
     m = _TYPE_DEF.match(line)
     if m and not in_function and not in_subroutine:
-        type_name = m.group(1).lower()
+        type_name = m.group('name').lower()
         known_types.append(type_name)
         in_type_block     = True
         current_type_name = type_name

--- a/scripts/build/moduleDependencies.py
+++ b/scripts/build/moduleDependencies.py
@@ -30,6 +30,7 @@ import sys
 import xml.etree.ElementTree as ET
 
 
+from Fortran.Utils                 import TYPE_ATTRIBUTES_TAGGED, type_opener_regex
 from Galacticus.Build.Directives   import extract_directives
 from Galacticus.Build.ParallelScan import scan as parallel_scan
 from Galacticus.Build.SourceTree   import parse_file, walk_tree
@@ -115,11 +116,9 @@ def _find_function_class_submodules(directive_name, function_class_file,
     directive.
     """
     # Regex is dynamic: the class name is substituted in.
-    type_re = re.compile(
-        r'^\s*type\s*'
-        r'(?:,\s*(?:abstract|public|private|extends\s*\(([a-zA-Z0-9_]+)\))\s*)*'
-        r'(?:::)?\s*' + re.escape(directive_name) + r'([a-z0-9_]+)\s*$',
-        re.IGNORECASE,
+    type_re = type_opener_regex(
+        name=re.escape(directive_name) + r'[a-z0-9_]+',
+        attributes=TYPE_ATTRIBUTES_TAGGED,
     )
 
     tree = parse_file(function_class_file)
@@ -132,9 +131,8 @@ def _find_function_class_submodules(directive_name, function_class_file,
                 classes.setdefault(name, {})['name'] = name
         elif ntype == 'type':
             m = type_re.match(node.get('opener') or '')
-            if m and m.group(1) is not None:
-                class_name = directive_name + m.group(2)
-                classes.setdefault(class_name, {})['extends'] = m.group(1)
+            if m and m.group('extends') is not None:
+                classes.setdefault(m.group('name'), {})['extends'] = m.group('extends')
 
     submodules = []
     # `fileName` must be the stem relative to `source/` (e.g.


### PR DESCRIPTION
Fixes #1381.

## What was wrong

The derived-type opener pattern omitted `bind(c)` from its attribute
alternation and admitted no whitespace inside `extends(...)`, so four types
were never recognized as type definitions:

| Type | File | Cause |
| --- | --- | --- |
| `gsl_sf_result` | `source/interface/GSL/_module.F90` | `bind(c)` |
| `hdf5VlenC` | `source/utility/IO/HDF5/_module.F90` | `bind(c)` |
| `unitType` | `source/utility/units.F90` | `bind(c)` |
| `hdf5File` | `source/utility/IO/HDF5/_module.F90` | padding in `extends(...)` |

A missed opener is not merely an unlabelled node: the unit parser never opens a
`type` node, so the type's components are absorbed into the enclosing scope's
declaration node as ordinary variables and the `end type` is stranded as orphan
code — silently, with nothing raised.

## What changed

The pattern now lives once, in `Fortran.Utils`, as `TYPE_ATTRIBUTE` /
`TYPE_ATTRIBUTES` / `TYPE_ATTRIBUTES_TAGGED` plus a `type_opener_regex()`
builder. All eight sites listed in the issue use it; every hand-rolled copy and
`_EXTENDS_ATTR_RE` is gone.

Groups are **named**, so call sites index by name rather than by position and
are immune to group-numbering drift — which is what made the eight copies
diverge in the first place.

Sharing the definition also let `DeepCopyActions` and `StateStorable` drop
their hand-rolled attribute splitting. That removed a latent bug: both compared
`attr == 'abstract'`, so an upper-case `ABSTRACT` type was mis-classified as
concrete. There is a test pinning this.

## The `bind(c)` design question (issue point 3)

**No exclusion is needed, and none was added.** A C-interoperable derived type
may neither extend another type nor be extended, so it can never appear in a
functionClass / stateStorable / deepCopyActions inheritance chain. Those
generators emit code by walking such chains, so they skip these types
naturally. Adding filter code would have been dead code; the reasoning is
recorded as a comment in `Fortran.Utils` instead.

Corroborating: none of the three affected modules contains a `stateStorable`,
`deepCopyActions` or `functionClass` directive at all. (The `deepCopy` hits in
the HDF5 module are a hand-written type-bound method and its doc block.)

## Verification

| Check | Result |
| --- | --- |
| Tree-wide opener scan, old vs new | exactly the 4 types above change status; 0 regressions; 0 still unmatched |
| Clean rebuild with fix | exit 0, 424 `preprocess.py` runs |
| Generated sources, baseline vs fixed (1791 files) | **0 differences** |
| `quickTest`, `OMP_NUM_THREADS=1` | identical except `/Build/sourceChangeSetDiff` |
| Python test suite | 955 passed, 1 skipped |
| New `test_type_openers.py` | 24 passed |

The single model-output difference is the embedded `git diff` provenance blob,
non-empty only because the working tree had uncommitted changes.

Both generated-source snapshots come from **full clean builds**. An incremental
rebuild is not valid here: the preprocess rules do not list the Python
generator sources as prerequisites, so editing a generator regenerates nothing
and the comparison silently returns a false "no change". That is filed
separately as a build bug; it does not affect this fix, which was re-verified
with a forced clean rebuild.

Note also that `quickTest` is nondeterministic by default — two runs of one
binary differed across 29–36 datasets — so the model comparison above requires
`OMP_NUM_THREADS=1`, under which it is exactly reproducible.

## Notes

The `_is_type_definition` guard in the declaration formatter is unchanged and
kept as a backstop, but its docstring asserted "There are four in the tree,"
which this fix makes false; the docstring is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
