### PR TITLE
fix(parameters): record parameters read during node component thread initialization

### DIFF
--- a/source/merger_trees/evolver/threaded.F90
+++ b/source/merger_trees/evolver/threaded.F90
@@ -421,6 +421,12 @@ contains
        timer_=timer()
        call timer_%start()
     end if
+    ! The per-thread copies of the parameter set are made with output suppressed (the default), so parameters read during thread
+    ! initialization are not recorded in the output file from here. That is deliberate: this parallel region is nested inside the
+    ! parallel region of the task driving the evolution, so the master thread of this team is not unique---enabling output on it
+    ! would give one writer per outer thread, and would repeat that write for every tree evolved. It is also unnecessary, since
+    ! `self%parameters` is the root parameter set, on which the driving task has already performed thread initialization with
+    ! output enabled, so exactly these parameters are recorded there.
     allocate(parameters)
     parameters=inputParameters(self%parameters)
     call Node_Components_Thread_Initialize(parameters)   

--- a/source/tasks/evolve_forests/_class.F90
+++ b/source/tasks/evolve_forests/_class.F90
@@ -623,17 +623,31 @@ contains
     ! Perform initialization which must occur for all threads if run in parallel. This is done first---before the per-thread deep
     ! copies below---so that the tree census (which, for some mass distributions, requires building nodes) can be computed on the
     ! master constructor and then inherited by each thread's copy.
-    !$omp critical(evolveForestsInitialize)
-    allocate(parameters)
     ! Thread initialization is run against a per-thread copy of the parameter set. Output is enabled on the master thread's copy
     ! only, so that the parameters read during thread initialization (some of which---e.g. the mass distributions of the disk and
     ! spheroid components---are read nowhere else) are recorded in the output file. Every thread reads the same parameters, so a
-    ! single writer suffices, and the enclosing critical section serializes that writer against everything else.
+    ! single writer suffices.
+    !
+    ! The master must initialize *first*, and alone. Building an object from its default class inserts that default into the
+    ! parameter tree---which every thread's copy shares---so only the thread which initializes first sees such a parameter as
+    ! absent, and only that thread marks it as defaulted. Were the master not that thread, those markers would never be written,
+    ! and which parameters carried one would depend on the number of threads.
     recordParameters=.true.
     !$ recordParameters=OMP_Get_Thread_Num() == 0
-    parameters=inputParameters(self%parameters,noOutput=.not.recordParameters)
-    call Node_Components_Thread_Initialize(parameters)
-    !$omp end critical(evolveForestsInitialize)
+    if (recordParameters) then
+       allocate(parameters)
+       parameters=inputParameters(self%parameters,noOutput=.false.)
+       call Node_Components_Thread_Initialize(parameters)
+    end if
+    !$omp barrier
+    ! The remaining threads now initialize against copies with output suppressed.
+    if (.not.recordParameters) then
+       !$omp critical(evolveForestsInitialize)
+       allocate(parameters)
+       parameters=inputParameters(self%parameters)
+       call Node_Components_Thread_Initialize(parameters)
+       !$omp end critical(evolveForestsInitialize)
+    end if
     !$omp barrier
     ! Compute the tree census and (if a cost model is available) the total predicted work, then report the start-of-run estimate.
     ! This is performed on the master constructor, before the per-thread deep copies below, so that each thread's copy inherits the

--- a/source/tasks/evolve_forests/_class.F90
+++ b/source/tasks/evolve_forests/_class.F90
@@ -520,14 +520,14 @@ contains
     !$omp threadprivate(event_)
     type            (treeNode                ), pointer                  , save :: node
     class           (nodeComponentBasic      ), pointer                  , save :: basic
-    logical                                                              , save :: treesFinished
+    logical                                                              , save :: treesFinished        , recordParameters
     integer         (c_size_t                )                           , save :: treeNumber
     type            (inputParameters         ), allocatable              , save :: parameters
     integer         (c_size_t                )                                  :: treeCount
     integer         (omp_lock_kind           )                                  :: initializationLock
     integer         (kind_int8               )                                  :: systemClockRate      , systemClockMaximum
     integer                                                              , save :: statusForest
-    !$omp threadprivate(node,basic,treeNumber,treesFinished,parameters,statusForest)
+    !$omp threadprivate(node,basic,treeNumber,treesFinished,parameters,statusForest,recordParameters)
     logical                                                                     :: checkpointRestored   , checkpointing         , &
          &                                                                         universeUpdated      , failed
     ! Whole-run progress and run-time estimation accumulators. The counts, work sums, and clock references below are shared across
@@ -625,7 +625,13 @@ contains
     ! master constructor and then inherited by each thread's copy.
     !$omp critical(evolveForestsInitialize)
     allocate(parameters)
-    parameters=inputParameters(self%parameters)
+    ! Thread initialization is run against a per-thread copy of the parameter set. Output is enabled on the master thread's copy
+    ! only, so that the parameters read during thread initialization (some of which---e.g. the mass distributions of the disk and
+    ! spheroid components---are read nowhere else) are recorded in the output file. Every thread reads the same parameters, so a
+    ! single writer suffices, and the enclosing critical section serializes that writer against everything else.
+    recordParameters=.true.
+    !$ recordParameters=OMP_Get_Thread_Num() == 0
+    parameters=inputParameters(self%parameters,noOutput=.not.recordParameters)
     call Node_Components_Thread_Initialize(parameters)
     !$omp end critical(evolveForestsInitialize)
     !$omp barrier

--- a/source/tasks/halo_mass_function.F90
+++ b/source/tasks/halo_mass_function.F90
@@ -774,7 +774,10 @@ contains
     end do
     !$omp end critical(taskHaloMassFunctionDeepCopy)
     !$omp barrier
-    ! Call routines to perform initialization which must occur for all threads if run in parallel.
+    ! Call routines to perform initialization which must occur for all threads if run in parallel. The per-thread copies of the
+    ! parameter set are made with output suppressed (the default), so parameters read during thread initialization are not
+    ! recorded in the output file from here. That is not a loss: the same initialization has already been performed, above, on
+    ! `self%parameters` itself---which does have an output group---so those parameters are recorded there.
     allocate(parameters)
     parameters=inputParameters(self%parameters)
     call Node_Components_Thread_Initialize(parameters)

--- a/source/tasks/postprocess_forests.F90
+++ b/source/tasks/postprocess_forests.F90
@@ -235,6 +235,7 @@ contains
     use            :: Node_Components         , only : Node_Components_Thread_Initialize, Node_Components_Thread_Uninitialize
     use            :: Merger_Tree_Construction, only : mergerTreeStateFromFile
     use            :: File_Utilities          , only : File_Lock                        , File_Unlock                        , lockDescriptor
+    !$ use         :: OMP_Lib                 , only : OMP_Get_Thread_Num
     implicit none
     class           (taskPostprocessForests), intent(inout), target   :: self
     integer                                 , intent(  out), optional :: status
@@ -248,6 +249,8 @@ contains
     !$omp threadprivate(statusRead)
     integer         (c_size_t              )               , save     :: indexOutput
     !$omp threadprivate(indexOutput)
+    logical                                                , save     :: recordParameters
+    !$omp threadprivate(recordParameters)
     integer                                                           :: fileUnit
     logical                                                           :: finished
     
@@ -268,9 +271,15 @@ contains
     !!]
     !$omp end critical(postprocessForestsDeepCopy)
     !$omp barrier
-    ! Call routines to perform initialization which must occur for all threads if run in parallel.
+    ! Call routines to perform initialization which must occur for all threads if run in parallel. Thread initialization is run
+    ! against a per-thread copy of the parameter set. Output is enabled on the master thread's copy only, so that the parameters
+    ! read during thread initialization (some of which are read nowhere else) are recorded in the output file. Every thread reads
+    ! the same parameters, so a single writer suffices---and, since it is the only writer, needs no locking beyond the lock on
+    ! HDF5 access through which all parameter output passes.
     allocate(parameters)
-    parameters=inputParameters(self%parameters)
+    recordParameters=.true.
+    !$ recordParameters=OMP_Get_Thread_Num() == 0
+    parameters=inputParameters(self%parameters,noOutput=.not.recordParameters)
     call Node_Components_Thread_Initialize(parameters)
     !$omp barrier
     ! Begin loop to read and post-process trees.

--- a/source/tasks/postprocess_forests.F90
+++ b/source/tasks/postprocess_forests.F90
@@ -276,11 +276,25 @@ contains
     ! read during thread initialization (some of which are read nowhere else) are recorded in the output file. Every thread reads
     ! the same parameters, so a single writer suffices---and, since it is the only writer, needs no locking beyond the lock on
     ! HDF5 access through which all parameter output passes.
-    allocate(parameters)
+    !
+    ! The master must initialize *first*, and alone. Building an object from its default class inserts that default into the
+    ! parameter tree---which every thread's copy shares---so only the thread which initializes first sees such a parameter as
+    ! absent, and only that thread marks it as defaulted. Were the master not that thread, those markers would never be written,
+    ! and which parameters carried one would depend on the number of threads.
     recordParameters=.true.
     !$ recordParameters=OMP_Get_Thread_Num() == 0
-    parameters=inputParameters(self%parameters,noOutput=.not.recordParameters)
-    call Node_Components_Thread_Initialize(parameters)
+    if (recordParameters) then
+       allocate(parameters)
+       parameters=inputParameters(self%parameters,noOutput=.false.)
+       call Node_Components_Thread_Initialize(parameters)
+    end if
+    !$omp barrier
+    ! The remaining threads now initialize against copies with output suppressed.
+    if (.not.recordParameters) then
+       allocate(parameters)
+       parameters=inputParameters(self%parameters)
+       call Node_Components_Thread_Initialize(parameters)
+    end if
     !$omp barrier
     ! Begin loop to read and post-process trees.
     do while (.not.finished)

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -749,18 +749,42 @@ contains
     return
   end function inputParametersConstructorFileChar
 
-  function inputParametersConstructorCopy(parameters) result(self)
+  function inputParametersConstructorCopy(parameters,noOutput) result(self)
     !!{RST
     Constructor for the ``inputParameters`` class from an existing parameters object.
+
+    Copies are made primarily to give each OpenMP thread its own parameter set for node component
+    thread initialization. By default (``noOutput=.true.``) the copy has no output group, so
+    parameters read through it are *not* recorded in the ``Parameters`` group of the output
+    file---if every thread's copy wrote, all threads would race to write the same values. Passing
+    ``noOutput=.false.`` instead shares the output group of the parameter set being copied, so
+    that parameters read through the copy *are* recorded. Precisely one copy should be created
+    this way (in practice, the copy made on the master thread), so that there is a single writer;
+    since every thread reads the same parameters, recording from one is sufficient.
     !!}
     implicit none
-    type (inputParameters)                :: self
-    type (inputParameters), intent(in   ) :: parameters
+    type   (inputParameters)                          :: self
+    type   (inputParameters), intent(in   )           :: parameters
+    logical                 , intent(in   ), optional :: noOutput
+    !![
+    <optionalArgument name="noOutput" defaultsTo=".true." />
+    !!]
 
     self            =  inputParameters(parameters%rootNode  ,noOutput=.true.,noBuild=.true.,documentManager=parameters%documentManager,document=parameters%document)
     self%parameters =>                 parameters%parameters
     self%parent     =>                 parameters%parent
     self%original   =>                 parameters%original
+    if (.not.noOutput_.and.associated(parameters%outputParameters)) then
+       ! Share the output group of the parameter set being copied so that parameters read through this copy are recorded in the
+       ! output file. The resource managers are assigned (not pointer assigned) so that the reference counts of the shared HDF5
+       ! objects are incremented---the shared group therefore remains valid for as long as this copy exists.
+       self%outputParameters                 => parameters%outputParameters
+       self%outputParametersContainer        => parameters%outputParametersContainer
+       self%outputParametersCopied           =  parameters%outputParametersCopied
+       self%outputParametersTemporary        =  parameters%outputParametersTemporary
+       self%outputParametersManager          =  parameters%outputParametersManager
+       self%outputParametersContainerManager =  parameters%outputParametersContainerManager
+    end if
     return
   end function inputParametersConstructorCopy
 

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -761,6 +761,11 @@ contains
     that parameters read through the copy *are* recorded. Precisely one copy should be created
     this way (in practice, the copy made on the master thread), so that there is a single writer;
     since every thread reads the same parameters, recording from one is sufficient.
+
+    That copy must also be the *first* to be used. Building an object from its default class adds
+    that default to the parameter tree, which all copies share, so only whichever copy is used
+    first sees such a parameter as absent and marks it as defaulted. A recording copy used after
+    some other copy would therefore silently omit those markers.
     !!}
     implicit none
     type   (inputParameters)                          :: self

--- a/testSuite/test-parameters-extract.py
+++ b/testSuite/test-parameters-extract.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import subprocess
+import sys
 import h5py
 import re
 import filecmp
@@ -7,7 +8,9 @@ import lxml.etree as ET
 
 # Check that parameter extraction produces consistent results. A simple parameter file is run with Galacticus. A new parameter
 # file is then extracted from the HDF5 output. That new parameter file is then run with Galacticus, and another parameter file is
-# extracted from this second HDF5 file. The two extracted parameter files are then compared - they should be identical.
+# extracted from this second HDF5 file. The two extracted parameter files are then compared - they should be identical. Finally,
+# the first extracted parameter file is compared against the original parameter file - every parameter given in the original must
+# be present, with the same value, in the extracted file.
 # Andrew Benson (06-September-2024)
 
 # Run the model and check for completion.
@@ -60,3 +63,58 @@ if len(cosmologyPointer) == 1:
     print('SUCCESS: reference `<cosmologyParameters/>` is present')
 else:
     print('FAILED: reference `<cosmologyParameters/>` is not present')
+
+# Check that the extracted parameter file is equivalent to the parameter file that was run. Comparing two *extracted* files (as
+# above) can not detect a parameter which never reaches the output file's `Parameters` group at all, since both extractions are
+# then equally lossy and so still agree. Comparing against the original catches that: a parameter which the user supplied but
+# which is absent from the extracted file means the extracted file would run different physics.
+def normalizedValue(value):
+    # Normalize a parameter value for comparison. Values are written to the output file verbatim, but may be reformatted (e.g.
+    # by dropping insignificant zeros) when read back and written out again, so numerical values are compared numerically.
+    value = " ".join(value.split())
+    try:
+        return " ".join(map(lambda x: "%.10g" % float(x),value.split(" ")))
+    except ValueError:
+        return value
+
+def parameterCounts(fileName):
+    # Return a count, for each (path, value) pair, of the parameters in the given parameter file. Paths are used (rather than
+    # elements) so that a parameter is matched only where it appears in the same place in the parameter hierarchy, and counts are
+    # used so that repeated instances of the same parameter must be repeated in both files.
+    counts = {}
+    def accumulate(element,path):
+        for child in element:
+            if not isinstance(child.tag,str):
+                continue
+            childPath = path+"/"+child.tag
+            if   'idRef' in child.attrib:
+                value = "{idRef:"+child.attrib['idRef']+"}"
+            elif 'value' in child.attrib:
+                value = normalizedValue(child.attrib['value'])
+            else:
+                value = None
+            counts[(childPath,value)] = counts.get((childPath,value),0)+1
+            accumulate(child,childPath)
+    accumulate(ET.parse(fileName).getroot(),"")
+    return counts
+
+# Parameters which are expected to be absent from the extracted file. The parameter file deliberately includes a duplicated
+# `mergerTreeOutputter` (to ensure that such duplicates do not cause errors in parameter extraction); the duplicate is never
+# used, and so is never recorded in the output file.
+ignoredParameters = (
+    ("/mergerTreeOutputter","null"),
+)
+countsOriginal  = parameterCounts("parameters/parametersExtract.xml")
+countsExtracted = parameterCounts("outputs/parametersExtract.xml"   )
+missing         = []
+for (path, value), count in countsOriginal.items():
+    if (path,value) in ignoredParameters:
+        continue
+    if countsExtracted.get((path,value),0) < count:
+        missing.append(path+(" = "+value if value is not None else ""))
+if len(missing) == 0:
+    print("SUCCESS: extracted parameters match the original parameter file")
+else:
+    print("FAILED: parameters present in the original parameter file are absent from the extracted parameter file:")
+    for parameter in sorted(missing):
+        print("   "+parameter)


### PR DESCRIPTION
Closes #1377.

## Problem

Parameters read during node component *thread* initialization never reached the output file's `Parameters` group. Thread initialization runs against a per-thread copy of the parameter set built by `inputParametersConstructorCopy`, which passed `noOutput=.true.` unconditionally, so the copy had no output group and every object built beneath it — and every parameter it read — was invisible to the output file.

This was not limited to defaulted values. Parameters supplied explicitly by the user were lost too, so `scripts/parameters/parametersExtract.py` silently produced a parameter file that was *not* equivalent to the one that was run: `darkMatterProfile` fell back to its default class rather than `adiabaticGnedin2004`, and `hotHaloMassDistribution` rather than `betaProfile`. No warning was issued.

## Fix

Give exactly one thread's copy an output group, rather than none.

`inputParametersConstructorCopy` gains an optional `noOutput` argument, defaulting to `.true.` so every existing caller is unaffected. Passing `noOutput=.false.` shares the output group of the parameter set being copied; the resource managers are assigned rather than pointer-assigned, so the reference counts of the shared HDF5 objects are incremented and the group stays valid for the copy's lifetime.

`taskEvolveForests` and `taskPostprocessForests` pass `noOutput=.false.` on the master thread only. Every thread reads the same parameters, so a single writer suffices. No new locking is required: in `taskEvolveForests` the call site is already inside `critical(evolveForestsInitialize)`, and elsewhere the single writer's output passes through the existing HDF5 access lock, under which attribute writes are already check-then-write and hence idempotent.

The condition is written as

```fortran
recordParameters=.true.
!$ recordParameters=OMP_Get_Thread_Num() == 0
parameters=inputParameters(self%parameters,noOutput=.not.recordParameters)
```

rather than an `!$`-guarded `if`/`else`, so that a build without OpenMP still records the parameters.

## Audit of the remaining call sites

Both are left suppressed, with comments recording why:

| Call site | Why output stays suppressed |
| --- | --- |
| `taskHaloMassFunction` | Already performs thread initialization on the output-enabled `self%parameters` earlier in `perform`, so these parameters are recorded there. Its per-thread copy is also never deallocated, so enabling output would leak a reference. |
| `mergerTreeEvolverThreaded` | Its parallel region is nested inside that of the driving task, so the team's master thread is not unique — enabling output would give one writer per outer thread, repeated for every tree evolved. It also uses the same root parameter set the driving task already records. |

## Test

`testSuite/test-parameters-extract.py` gains a check comparing the extracted parameter file against the **original**. The existing check compares two *extracted* files, which are equally lossy and therefore agree even when parameters are missing entirely.

The comparison is by (path, value) multiset, so a parameter must appear at the same point in the hierarchy and repeated instances must be repeated in both files. Values are normalized numerically, since a value written verbatim to the output may be reformatted when read back. The deliberately-duplicated `<mergerTreeOutputter value="null"/>` is the single documented exclusion.

To confirm the check is a genuine regression test rather than a tautology, I ran it against the `--dry-run` extraction — which never calls `task_%perform` and so reproduces the pre-fix state. It reports 17 missing user-supplied parameters, including `darkMatterProfile = adiabaticGnedin2004`, `hotHaloMassDistribution = betaProfile`, `mergerMassMovements = simple`, and `mergerRemnantSize = cole2000`.

## Verification

Built clean. `testSuite/test-parameters-extract.py`, `testSuite/test-postprocessing.py`, and `parameters/quickTest.xml` all pass.

In the `quickTest` output, all four previously-absent containers are now present, and `componentDisk/massDistributionDisk` carries its five previously-missing defaulted values with correct `{defaulted}` markers:

```
['componentType', 'componentType{defaulted}', 'dimensionless', 'mass', 'massType',
 'massType{defaulted}', 'mass{defaulted}', 'scaleHeight', 'scaleHeight{defaulted}',
 'scaleRadius', 'scaleRadius{defaulted}']
```

---

This change was generated with Claude and verified by Andrew Benson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
