### PR TITLE
fix(parameters): remove the temporary parameter file from the file system

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1530,6 +1530,7 @@ jobs:
                 test-parameters-extract.py,
                 test-parameters-changes.py,
                 test-parameters-default-reporting.py,
+                test-temporary-parameter-file.py,
                 test-output-datasets-suffixes.py,
                 test-star-formation-histories.py,
                 test-star-formation-histories-adaptive.py,

--- a/source/tests/IO/HDF5.F90
+++ b/source/tests/IO/HDF5.F90
@@ -22,13 +22,14 @@ program Tests_IO_HDF5
   Tests the HDF5 I/O module.
   !!}
   use :: Display           , only : displayVerbositySet, verbosityLevelStandard
+  use :: File_Utilities    , only : File_Exists        , File_Name_Temporary   , File_Remove
   use :: Error             , only : Error_Report
   use :: HDF5              , only : HSIZE_T
-  use :: IO_HDF5           , only : IO_HDF5_Is_HDF5    , hdf5File              , hdf5VarDouble       , hdf5VarInteger8  , &
-       &                            hdf5VarDouble2D    , hdf5DataTypeDouble    , hdf5File            , hdf5Group        , &
-       &                            hdf5Dataset        , hdf5DataTypeInteger
-  use :: ISO_Varying_String, only : assignment(=)      , trim                  , varying_string      , var_str          , &
-       &                            char
+  use :: IO_HDF5           , only : IO_HDF5_Is_HDF5    , hdf5DataTypeDouble    , hdf5DataTypeInteger , hdf5Dataset      , &
+  &                                 hdf5File           , hdf5Group             , hdf5VarDouble       , hdf5VarDouble2D  , &
+  &                                 hdf5VarInteger8
+  use :: ISO_Varying_String, only : assignment(=)      , char                  , trim                , var_str          , &
+  &                                 varying_string
   use :: Kind_Numbers      , only : kind_int8
   use :: System_Command    , only : System_Command_Do
   use :: Units_MetaData    , only : unitType
@@ -1107,6 +1108,40 @@ program Tests_IO_HDF5
   call Unit_Tests_Begin_Group("chunk dimensions of large datasets")
   call System_Command_Do("./testSuite/scripts/verify_chunking.py",chunkingStatus)
   call Assert("chunks of large datasets fit within, and tile, their extents (via h5py)",chunkingStatus,0)
+  call Unit_Tests_End_Group()
+
+  ! Test the handling of temporary files. A temporary file must be removed from the file system when it is closed, and a file
+  ! removed from the file system while it is still open must remain fully usable (this is the create-open-unlink idiom used for
+  ! the temporary parameter file - see issue #1391).
+  call Unit_Tests_Begin_Group("temporary files")
+  block
+    type(varying_string) :: fileNameTemporary
+    fileNameTemporary=File_Name_Temporary("test.IO.HDF5.temporary",'testSuite/outputs')
+    block
+      type(hdf5File ) :: fileObject
+      type(hdf5Group) :: groupObject
+      fileObject =hdf5File(char(fileNameTemporary),isTemporary=.true.)
+      groupObject=fileObject%openGroup("myGroup")
+      call Assert("file object reports the name of the file which contains it" ,char(fileObject %fileName()),char(fileNameTemporary))
+      call Assert("group object reports the name of the file which contains it",char(groupObject%fileName()),char(fileNameTemporary))
+      call Assert("temporary file exists while it is open"                     ,File_Exists(fileNameTemporary),.true.               )
+    end block
+    call Assert("temporary file is removed when it is closed",File_Exists(fileNameTemporary),.false.)
+  end block
+  block
+    type(varying_string) :: fileNameTemporary
+    fileNameTemporary=File_Name_Temporary("test.IO.HDF5.unlinked",'testSuite/outputs')
+    block
+      type(hdf5File) :: fileObject
+      fileObject=hdf5File(char(fileNameTemporary))
+      call File_Remove(fileObject%fileName())
+      call Assert("file removed while open no longer exists in the file system",File_Exists(fileNameTemporary),.false.)
+      integerValue=42
+      call fileObject%writeAttribute(integerValue,"integerAttribute")
+      call fileObject%readAttribute ("integerAttribute",integerValueReread)
+      call Assert("file removed while open remains readable and writable",integerValue,integerValueReread)
+    end block
+  end block
   call Unit_Tests_End_Group()
 
   ! End unit tests.

--- a/source/utility/IO/HDF5/_module.F90
+++ b/source/utility/IO/HDF5/_module.F90
@@ -747,7 +747,7 @@ contains
           message="unable to close file object '"//self%objectFile//"'"
           call Error_Report(message//{introspection:location})
        end if
-       if (self%isTemporary) call File_Remove(char(self%objectName))
+       if (self%isTemporary) call File_Remove(char(self%objectFile))
        ! Uninitialize the HDF5 library (will only uninitialize if this is the last file to be closed).
        call IO_HDF5_Uninitialize()
     end if
@@ -977,18 +977,13 @@ contains
     !!{RST
     Returns the name of the file containing ``self``.
     !!}
-    use :: ISO_Varying_String, only : operator(//)
     implicit none
-    class(hdf5Object    ), intent(in   ), target  :: self
-    type (varying_string)                         :: fileName
-    class(hdf5Object    )               , pointer :: parent
+    class(hdf5Object    ), intent(in   ) :: self
+    type (varying_string)                :: fileName
 
-    ! Walk up the chain of parent objects to the file, which is the unique object with no parent (its ``parentObject`` is null).
-    parent  => self
-    do while (associated(parent%parentObject))
-       parent => parent%parentObject
-    end do
-    fileName=parent%objectName
+    ! Every object records the name of the file which contains it - a file object records it when the file is opened, and all
+    ! other objects inherit it from their parent object.
+    fileName=self%objectFile
     return
   end function IO_HDF5_File_Name
 
@@ -1279,25 +1274,25 @@ contains
     ! Create an access list.
     call h5pcreate_f(H5P_FILE_ACCESS_F,accessList,errorCode)
     if (errorCode /= 0) then
-       message="failed to create file access list HDF5 file '"//self%objectName//"'"
+       message="failed to create file access list HDF5 file '"//self%objectFile//"'"
        call Error_Report(message//self%locationReport()//{introspection:location})
     end if
     call h5pset_fclose_degree_f(accessList,H5F_CLOSE_SEMI_F,errorCode)
     if (errorCode /= 0) then
-       message="failed to set close degree for HDF5 file '"//self%objectName//"'"
+       message="failed to set close degree for HDF5 file '"//self%objectFile//"'"
        call Error_Report(message//self%locationReport()//{introspection:location})
     end if
     ! Specify file driver (buffered I/O).
     call h5pset_fapl_stdio_f(accessList,errorCode)
     if (errorCode /= 0) then
-       message="failed to set I/O driver for HDF5 file '"//self%objectName//"'"
+       message="failed to set I/O driver for HDF5 file '"//self%objectFile//"'"
        call Error_Report(message//self%locationReport()//{introspection:location})
     end if
     ! Set sieve buffer size.
     if (present(sieveBufferSize)) then
        call h5pset_sieve_buf_size_f(accessList,sieveBufferSize,errorCode)
        if (errorCode /= 0) then
-          message="failed to set sieve buffer size for HDF5 file '"//self%objectName//"'"
+          message="failed to set sieve buffer size for HDF5 file '"//self%objectFile//"'"
           call Error_Report(message//self%locationReport()//{introspection:location})
        end if
     end if
@@ -1312,14 +1307,14 @@ contains
           call h5pset_libver_bounds_f(accessList,H5F_LIBVER_V18_F   ,H5F_LIBVER_V114_F  ,errorCode)
        end if
        if (errorCode /= 0) then
-          message="failed to set file format for HDF5 file '"//self%objectName//"'"
+          message="failed to set file format for HDF5 file '"//self%objectFile//"'"
           call Error_Report(message//self%locationReport()//{introspection:location})
        end if
     else
        call    h5pset_libver_bounds_f(accessList,H5F_LIBVER_V18_F   ,H5F_LIBVER_V114_F  ,errorCode)
     end if
     if (errorCode /= 0) then
-       message="failed to set file format for HDF5 file '"//self%objectName//"'"
+       message="failed to set file format for HDF5 file '"//self%objectFile//"'"
        call Error_Report(message//{introspection:location})
     end if
     if (present(cacheElementsCount).or.present(cacheSizeBytes)) then
@@ -1366,7 +1361,7 @@ contains
        ! If read only was specified, creating the file is not allowed.
        if (present(readOnly)) then
           if (readOnly) then
-             message="can not create/overwrite read only file '"//self%objectName//"'"
+             message="can not create/overwrite read only file '"//self%objectFile//"'"
              call Error_Report(message//self%locationReport()//{introspection:location})
           end if
        end if
@@ -1380,7 +1375,7 @@ contains
     ! Finished with our property list.
     call h5pclose_f(accessList,errorCode)
     if (errorCode /= 0) then
-       message="failed to close access property list for HDF5 file '"//self%objectName//"'"
+       message="failed to close access property list for HDF5 file '"//self%objectFile//"'"
        call Error_Report(message//self%locationReport()//{introspection:location})
     end if
     ! Store the file ID.
@@ -1540,6 +1535,9 @@ contains
     self%objectFile    =self%parentObject%objectFile
     self%objectLocation=self%parentObject%pathTo    (includeFileName=.false.)
     self%objectName    =trim(groupName)
+    ! Inherit the temporary status of the containing file - whichever object holds the final reference to the file is the
+    ! one which closes it, and so the one which must remove it from the file system (see `IO_HDF5_Finalize_Shared`).
+    self%isTemporary   =self%parentObject%isTemporary
 
     ! Set the chunk size if provided.
     if (present(chunkSize)) then
@@ -1759,6 +1757,9 @@ contains
     self%objectFile    =self%parentObject%objectFile
     self%objectLocation=self%parentObject%pathTo    (includeFileName=.false.)
     self%objectName    =trim(attributeName)
+    ! Inherit the temporary status of the containing file - whichever object holds the final reference to the file is the
+    ! one which closes it, and so the one which must remove it from the file system (see `IO_HDF5_Finalize_Shared`).
+    self%isTemporary   =self%parentObject%isTemporary
 
     ! Mark whether attribute is overwritable.
     if (present(isOverwritable)) then
@@ -3708,6 +3709,9 @@ attributeValue=trim(attributeValue)
     self%objectFile    =self%parentObject%objectFile
     self%objectLocation=self%parentObject%pathTo    (includeFileName=.false.)
     self%objectName    =trim(datasetName)
+    ! Inherit the temporary status of the containing file - whichever object holds the final reference to the file is the
+    ! one which closes it, and so the one which must remove it from the file system (see `IO_HDF5_Finalize_Shared`).
+    self%isTemporary   =self%parentObject%isTemporary
     ! Check if the dataset exists.
     if (inObject%hasDataset(datasetName)) then
        ! Open the dataset.

--- a/source/utility/files.F90
+++ b/source/utility/files.F90
@@ -774,6 +774,9 @@ contains
     character(len=*), intent(in   ) :: fileName
     integer  (c_int)                :: status
 
+    ! An empty file name is always an error - it can never name a file to remove, so silently accepting it would hide the bug in
+    ! the caller (as it did in the case of issue #1391).
+    if (len_trim(fileName) == 0) call Error_Report('no file name given'//{introspection:location})
     if (File_Exists(fileName)) then
        status=unlink_C(trim(fileName)//char(0))
        if (status /= 0) call Error_Report('failed to remove file "'//trim(fileName)//'"'//{introspection:location})

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -913,7 +913,9 @@ contains
        !![
        </workaround>
        !!]
-       call File_Remove(self%outputParametersContainer%name())
+       ! Immediately remove the temporary file. The file remains accessible to us (as it is open), but will be automatically
+       ! removed from the file system once we close it - even if this run is killed before it can close the file cleanly.
+       call File_Remove(self%outputParametersContainer%fileName())
     end if
     ! Get allowed parameter names.
     if (.not.allocated(allowedParameterNamesGlobal)) &

--- a/testSuite/parameters/temporaryParameterFile.xml
+++ b/testSuite/parameters/temporaryParameterFile.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Changes applied to `parameters/quickTest.xml` for `test-temporary-parameter-file.py`.        -->
+<!-- Only the output file is changed - the model itself is irrelevant to the test, which cares    -->
+<!-- solely about the temporary file used to accumulate the output parameter set.                 -->
+<changes>
+
+  <change type="replaceOrAppend" path="outputFileName">
+    <outputFileName value="testSuite/outputs/temporaryParameterFile.hdf5"/>
+  </change>
+
+</changes>

--- a/testSuite/test-output-datasets-suffixes.py
+++ b/testSuite/test-output-datasets-suffixes.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import subprocess
+import sys
 import h5py
 import re
 

--- a/testSuite/test-parameters-extract.py
+++ b/testSuite/test-parameters-extract.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import subprocess
+import sys
 import h5py
 import re
 import filecmp

--- a/testSuite/test-temporary-parameter-file.py
+++ b/testSuite/test-temporary-parameter-file.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Test that the temporary parameter file is removed from the file system (issue #1391).
+
+Every run accumulates its output parameter set in a temporary HDF5 file,
+`glcTmpPar.<pid>.<n>`, placed on a memory-backed file system (`/dev/shm`, or
+`/tmp` on macOS) and copied into the output file at the end of the run. The file
+is removed from the file system as soon as it has been opened - it remains fully
+usable through the open file handle, but has no name in the file system, so it
+cannot outlive the run even if the run is killed.
+
+When this failed to happen the files accumulated silently, one per run, until the
+file system was full - after which *every* subsequent run died at startup while
+closing the temporary file, an error which gives no hint that its cause is the
+leftovers of earlier runs.
+
+This test runs a model and requires that it leave no temporary parameter file of
+its own behind.
+
+Andrew Benson
+"""
+
+import glob
+import os
+import platform
+import subprocess
+import sys
+
+# The temporary path and file name root must match those used in
+# `inputParametersConstructorNode` in `source/utility/input_parameters.F90`.
+temporaryPath     = "/tmp" if platform.system() == "Darwin" else "/dev/shm"
+temporaryRootName = "glcTmpPar"
+temporaryPattern  = os.path.join(temporaryPath,temporaryRootName+".*")
+
+parameterFile = "parameters/quickTest.xml"
+changeFile    = "testSuite/parameters/temporaryParameterFile.xml"
+outputFile    = "outputs/temporaryParameterFile.hdf5"
+logFileName   = "outputs/test-temporary-parameter-file.log"
+
+# Change to the testSuite directory.
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+subprocess.run("mkdir -p outputs",shell=True)
+subprocess.run(f"rm -f {outputFile}",shell=True)
+
+failed = False
+
+# Run the model, recording the temporary files present before and after. The model is run without an intervening shell so that
+# the process ID we see is that of the model itself - the temporary file is named for it, which lets us distinguish files left by
+# this run from any belonging to other runs sharing the same machine.
+filesBefore = set(glob.glob(temporaryPattern))
+print("Running model...")
+with open(logFileName,"w") as logFile:
+    process = subprocess.Popen(
+        ["./Galacticus.exe",parameterFile,changeFile],
+        cwd="..", stdout=logFile, stderr=subprocess.STDOUT,
+    )
+    returnCode = process.wait()
+print("...done")
+filesAfter = set(glob.glob(temporaryPattern))
+
+
+def processID(fileName):
+    """Return the process ID recorded in the name of a temporary parameter file."""
+    fields = os.path.basename(fileName).split(".")
+    return fields[1] if len(fields) > 1 else None
+
+
+filesNew    = filesAfter-filesBefore
+filesLeaked = [fileName for fileName in filesNew if processID(fileName) == str(process.pid)]
+filesOther  = filesNew-set(filesLeaked)
+
+if returnCode != 0:
+    print(f"FAILED: model did not run to completion (return code {returnCode}) - see {logFileName}")
+    failed = True
+elif not os.path.exists(outputFile):
+    print(f"FAILED: output file {outputFile} was not produced")
+    failed = True
+
+if filesLeaked:
+    print(f"FAILED: the model left {len(filesLeaked)} temporary parameter file(s) of its own in {temporaryPath}: {sorted(filesLeaked)}")
+    failed = True
+    # Do not leave our own mess behind, even on failure.
+    for fileName in filesLeaked:
+        os.remove(fileName)
+else:
+    print(f"SUCCESS: the model left no temporary parameter file of its own in {temporaryPath}")
+
+# Files appearing during the run but belonging to some other process are not evidence of a problem here - they are simply other
+# models running on the same machine - so they are reported but not judged.
+if filesOther:
+    print(f"NOTE: {len(filesOther)} temporary parameter file(s) belonging to other processes appeared in {temporaryPath} during this test; these are not the responsibility of this run")
+
+# The output parameter set must survive the removal of the temporary file which carried it.
+if not failed:
+    import h5py
+    with h5py.File(outputFile,"r") as outputFileHDF5:
+        if "Parameters" not in outputFileHDF5:
+            print("FAILED: the output file contains no `Parameters` group, so the content of the temporary file was lost")
+            failed = True
+        elif len(outputFileHDF5["Parameters"].attrs) == 0:
+            print("FAILED: the `Parameters` group in the output file is empty, so the content of the temporary file was lost")
+            failed = True
+        else:
+            print("SUCCESS: the parameter set accumulated in the temporary file was copied to the output file")
+
+# Failure is signaled by the text above, not by the exit status.
+if failed:
+    print("FAILED: temporary parameter file handling")
+else:
+    print("SUCCESS: temporary parameter file handling")
+sys.exit(0)


### PR DESCRIPTION
Fixes #1391.

## The bug

Each run accumulates its output parameter set in a temporary HDF5 file, `glcTmpPar.<pid>.<n>`, on `/dev/shm` (`/tmp` on macOS). Both attempts to remove it passed `objectName`, which an `hdf5File` leaves empty — it stores the path in `objectFile` — so both were `File_Remove("")` and the file survived. The files accumulated, one per run, until `/dev/shm` was full, after which *every* subsequent run died at startup while closing its own temporary file, with an error giving no hint that the leftovers of earlier runs were the cause.

## The fix

- `source/utility/input_parameters.F90` — the create-open-unlink now passes the real path, so the file leaves the file system as soon as it has been opened and cannot outlive the run even if the run is killed.
- `source/utility/IO/HDF5/_module.F90`
  - `IO_HDF5_Finalize_Shared` removes the file by `objectFile` on close.
  - `IO_HDF5_File_Name` returned the same empty `objectName`; it now returns `objectFile`.
  - `isTemporary` is inherited by groups, datasets, and attributes. Without this, a file whose last reference was held by a child object was closed by an object which did not know the file was temporary, and so was never removed.
  - Eight error messages in the `hdf5File` constructor also printed the empty `objectName`, and now print the path.
- `source/utility/files.F90` — `File_Remove` reports an empty file name as an error rather than silently accepting it, which is what let all of this pass unnoticed.

## Tests

- `source/tests/IO/HDF5.F90` — a new *temporary files* group: `fileName()` on a file and on a group, the file existing while open, its removal on close, and that a file unlinked while open remains readable and writable.
- `testSuite/test-temporary-parameter-file.py` (+ its change file, + an entry in the CI matrix) — runs a model and requires that it leave no `glcTmpPar.<pid>.*` of its own, and that the parameter set still reaches the output file.

## Verification

- `tests.IO.HDF5.exe`: 217/217 pass, including the six new assertions.
- `test-temporary-parameter-file.py`, `test-parameters-default-reporting.py`, `test-parameters-extract.py`, `test-output-datasets-suffixes.py`: all SUCCESS.
- `/dev/shm` held the same number of files before and after roughly eight model runs; previously each run added one. A run `kill -9`'d during startup also leaves nothing behind.

## Second commit

`fix(testSuite): import sys …` is unrelated to #1391 and can be dropped if you would rather it went separately. `test-parameters-extract.py` and `test-output-datasets-suffixes.py` call `sys.exit(0)` on their model-failure paths without importing `sys`, so each died with a `NameError` before printing its `FAILED` line — and since the harness judges a test by grepping for `FAIL`, a failed model run was recorded as a pass.

## Note

The commit hook reports that the Fortran files touched here deviate from the house formatting style; that is pre-existing (the same files fail `--check` on `master`) and is left for a separate reformatting commit, as the hook suggests. The lines added here do round-trip through both formatters unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
