### PR TITLE
fix(tables): key parameter-independent caches on a source digest, and finish the table cache helper migration

### DIFF
--- a/source/dark_matter_profiles/decaying_dark_matter/utilities.F90
+++ b/source/dark_matter_profiles/decaying_dark_matter/utilities.F90
@@ -336,17 +336,17 @@ contains
 
        f =  \int_{-1}^{+_1} \mathrm{d}\cos\theta \int_{v_\mathrm{min}(\theta)}^{v_\mathrm{max}(\theta)} \mathrm{d}v p(v,\theta|s).
     !!}
-    use :: Display                 , only : displayCounter, displayCounterClear          , displayIndent                , displayUnindent          , &
-         &                                  displayMessage, verbosityLevelStandard
-    use :: ISO_Varying_String      , only : varying_string, operator(//)                 , assignment(=)
+    use :: Display                 , only : displayCounter     , displayCounterClear          , displayIndent                , displayUnindent          , &
+         &                                  displayMessage     , verbosityLevelStandard
+    use :: ISO_Varying_String      , only : varying_string     , operator(//)                 , assignment(=)
     use :: Numerical_Constants_Math, only : Pi
-    use :: Root_Finder             , only : rootFinder    , rangeExpandSignExpectNegative, rangeExpandSignExpectPositive, rangeExpandMultiplicative
+    use :: Root_Finder             , only : rootFinder         , rangeExpandSignExpectNegative, rangeExpandSignExpectPositive, rangeExpandMultiplicative
     use :: Numerical_Integration   , only : integrator
-    use :: Numerical_Ranges        , only : Range_Pinned  , rangeLattice                 , gridSchemePerDecade          , Range_Lattice_Offset
-    use :: File_Utilities          , only : File_Exists   , Directory_Make               , File_Path, File_Lock         , File_Unlock, lockDescriptor
+    use :: Numerical_Ranges        , only : Range_Pinned       , rangeLattice                 , gridSchemePerDecade          , Range_Lattice_Offset
+    use :: File_Utilities          , only : File_Exists        , Directory_Make               , File_Path, File_Lock         , File_Unlock, lockDescriptor
     use :: HDF5_Access             , only : hdf5Access
     use :: IO_HDF5                 , only : hdf5File
-    use :: Input_Paths             , only : inputPath     , pathTypeDataDynamic
+    use :: Input_Paths             , only : inputPath          , pathTypeDataDynamic
     use :: String_Handling         , only : String_C_To_Fortran
     implicit none
     double precision              , intent(inout)               :: velocityEscapeScaleFree
@@ -405,9 +405,9 @@ contains
       end if
       ! Re-evaluate the ranges required in the light of anything restored.
       call rangesRequired()
-      if     (                                                &
+      if     (                                                 &
            &  .not.latticeVelocityEscape%covers(latticeEscape) &
-           &  .or.                                            &
+           &  .or.                                             &
            &  .not.latticeVelocityKick  %covers(latticeKick  ) &
            & ) then
          ! Extend the tabulation onto the new lattices, preserving every solution already found. Both axes may grow, so the

--- a/source/dark_matter_profiles/decaying_dark_matter/utilities.F90
+++ b/source/dark_matter_profiles/decaying_dark_matter/utilities.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
 !!{RST
 Contains a module which implements useful shared utilities for calculations of decaying dark matter.
 !!}
@@ -53,6 +55,14 @@ module Decaying_Dark_Matter
   ! dispersion and essentially all particles are retained. Seeding matters because it guarantees that any two tabulations - built
   ! in different runs, at different requested velocities - overlap, and so can always be merged onto the common lattice.
   double precision                              , parameter   :: velocityKickScaleFreeSeed     =+  1.0d0
+
+  ! Generate a source digest. The tabulation below is a property of the truncated Maxwell-Boltzmann distribution alone, so no
+  ! object's parameters enter it and none belong in its file name. It does depend on the code which generates it - the
+  ! integrands, the integration and root-finding tolerances, and the constants above - so the digest is what its cache file must
+  ! be keyed on. Without it a tabulation computed by an earlier version would be silently reused after the code was changed.
+  !![
+  <sourceDigest name="decayingDarkMatterSourceDigest"/>
+  !!]
 
 contains
 
@@ -337,6 +347,7 @@ contains
     use :: HDF5_Access             , only : hdf5Access
     use :: IO_HDF5                 , only : hdf5File
     use :: Input_Paths             , only : inputPath     , pathTypeDataDynamic
+    use :: String_Handling         , only : String_C_To_Fortran
     implicit none
     double precision              , intent(inout)               :: velocityEscapeScaleFree
     double precision              , intent(in   )               :: velocityKickScaleFree
@@ -375,13 +386,17 @@ contains
       character(len=8         ) :: labelMinimum, labelMaximum
       type     (lockDescriptor) :: fileLock
 
-      fileName=inputPath(pathTypeDataDynamic)//'darkMatter/decayingDarkMatterRetention.hdf5'
+      fileName=inputPath(pathTypeDataDynamic)                     // &
+           &   'darkMatter/decayingDarkMatterRetention_'          // &
+           &   String_C_To_Fortran(decayingDarkMatterSourceDigest)// &
+           &   '.hdf5'
       call Directory_Make(File_Path(fileName))
       ! Adopt any tabulation already cached on disk. Since the tabulation lies on absolute lattices the cached and in-memory
       ! solutions share abscissae wherever they overlap, so the cache is adopted whenever it spans everything we already hold -
       ! rather than, as previously, being read over the top of whatever is in memory, which could discard a wider range. Note
       ! that the file name deliberately carries no descriptor of any object's parameters: the retained fractions and energies are
-      ! a property of the truncated Maxwell-Boltzmann distribution alone, and so are common to every model.
+      ! a property of the truncated Maxwell-Boltzmann distribution alone, and so are common to every model. It is keyed instead
+      ! on this module's source digest, since the code which generates the tabulation is the only thing its values depend on.
       if (File_Exists(fileName)) then
          ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
          call File_Lock(fileName,fileLock,lockIsShared=.true.)

--- a/source/kinematic_distributions/finite-resolution/NFW.F90
+++ b/source/kinematic_distributions/finite-resolution/NFW.F90
@@ -394,11 +394,11 @@ contains
     type (lockDescriptor                           )                :: fileLock
     type (varying_string                           )                :: fileName
 
-    fileName=inputPath(pathTypeDataDynamic)                   // &
-         &   'darkMatter/'                                    // &
-         &   self%objectType      (                          )// &
-         &   'VelocityDispersion_'                            // &
-         &   self%hashedDescriptor(includeSourceDigest=.true.)// &
+    fileName=inputPath(pathTypeDataDynamic)                                                       // &
+         &   'darkMatter/'                                                                        // &
+         &   self%objectType      (                                                              )// &
+         &   'VelocityDispersion_'                                                                // &
+         &   self%hashedDescriptor(includeSourceDigest=.true.,includeFileModificationTimes=.true.)// &
          &   '.hdf5'
     call Directory_Make(File_Path(fileName))
     ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
@@ -447,11 +447,11 @@ contains
     double precision                                           , allocatable, dimension(:  ) :: jeansIntegralStored
     logical                                                                                  :: isUsable
 
-    fileName=inputPath(pathTypeDataDynamic)                   // &
-         &   'darkMatter/'                                    // &
-         &   self%objectType      (                          )// &
-         &   'VelocityDispersion_'                            // &
-         &   self%hashedDescriptor(includeSourceDigest=.true.)// &
+    fileName=inputPath(pathTypeDataDynamic)                                                       // &
+         &   'darkMatter/'                                                                        // &
+         &   self%objectType      (                                                              )// &
+         &   'VelocityDispersion_'                                                                // &
+         &   self%hashedDescriptor(includeSourceDigest=.true.,includeFileModificationTimes=.true.)// &
          &   '.hdf5'
     if (.not.File_Exists(fileName)) return
     ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads. Note that the file is

--- a/source/mass_distributions/Gaussian_ellipsoid.F90
+++ b/source/mass_distributions/Gaussian_ellipsoid.F90
@@ -17,12 +17,21 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   Implementation of a Gaussian ellipsoid mass distribution class.
   !!}
 
   use :: Linear_Algebra, only : matrix
-  
+
+  ! Generate a source digest. The tabulated accelerations are the scale-free solution (a₃ = 1) on grids fixed by the module
+  ! parameters in `gaussianEllipsoidAccelerationTabulate`, so no object's parameters enter their values and none belong in the
+  ! cache file name. They do depend on the code which generates them, so the digest is what that name is keyed on.
+  !![
+  <sourceDigest name="massDistributionGaussianEllipsoidSourceDigest"/>
+  !!]
+
   !![
   <massDistribution name="massDistributionGaussianEllipsoid" docformat="rst">
    <description>
@@ -524,6 +533,7 @@ contains
     use :: Numerical_Constants_Math, only : Pi
     use :: Numerical_Integration   , only : integrator
     use :: Numerical_Ranges        , only : Make_Range           , rangeTypeLogarithmic
+    use :: String_Handling         , only : String_C_To_Fortran
     implicit none
     class           (massDistributionGaussianEllipsoid), intent(inout)       :: self
     double precision                                   , dimension(3) , save :: positionCartesian          , scaleLength
@@ -548,10 +558,12 @@ contains
       type   (lockDescriptor) :: fileLock
       integer                 :: iLock
 
-      ! Construct a file name for the table.
-      fileName=inputPath(pathTypeDataDynamic)// &
-           &   'galacticStructure/'          // &
-           &   self%objectType()             // &
+      ! Construct a file name for the table. The tabulation is the scale-free solution and so carries no descriptor of this
+      ! object's parameters, only the digest of the source which generates it.
+      fileName=inputPath(pathTypeDataDynamic)                                    // &
+           &   'galacticStructure/'                                              // &
+           &   self%objectType()//'_'                                            // &
+           &   String_C_To_Fortran(massDistributionGaussianEllipsoidSourceDigest)// &
            &   '.hdf5'
       call Directory_Make(File_Path(fileName))
       ! Read the table or, if it does not yet exist, build and write it. Two passes are made: the first

--- a/source/mass_distributions/spherical/SIDM/isothermal/_class.F90
+++ b/source/mass_distributions/spherical/SIDM/isothermal/_class.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   Provides a mass distribution implementing the "isothermal" approximation to the effects of SIDM based on the model of :cite:t:`jiang_semi-analytic_2023`.
   !!}
@@ -25,6 +27,14 @@
   use            :: Numerical_Interpolation, only : interpolator
   use            :: Numerical_ODE_Solvers  , only : odeSolver
   use            :: Numerical_Ranges       , only : rangeLattice
+
+  ! Generate a source digest. The tabulation cached by this class carries no descriptor of any object's parameters - see
+  ! `sphericalSIDMIsothermalTabulationExtend` - because its solutions depend on ξ alone. They do depend on the code which
+  ! generates them, including the ODE tolerances and the densities of tabulation points, so the digest is what the cache file is
+  ! keyed on instead.
+  !![
+  <sourceDigest name="massDistributionSIDMIsothermalSourceDigest"/>
+  !!]
 
   !![
   <massDistribution name="massDistributionSphericalSIDMIsothermal" docformat="rst">
@@ -313,6 +323,7 @@ contains
          &                                    gridSchemePerUnit, Range_Lattice_Extend                , Range_Lattice_Offset
     use :: Input_Paths               , only : inputPath        , pathTypeDataDynamic
     use :: Multidimensional_Minimizer, only : multiDMinimizer
+    use :: String_Handling           , only : String_C_To_Fortran
     implicit none
     class           (massDistributionSphericalSIDMIsothermal), intent(inout)                             :: self
     double precision                                         , intent(in   )                             :: xiRequired
@@ -381,10 +392,12 @@ contains
     ! Construct a file name for the table. Note that this deliberately carries no descriptor of the parameters of this object:
     ! the tabulated solutions y₀(ξ) and z₀(ξ), and the dimensionless profiles, depend on ξ alone and so are common to every
     ! halo. Only the extent in ξ differs between users, and that is handled by extending and merging the tabulation rather than
-    ! by separating it into distinct files.
-    fileName=inputPath(pathTypeDataDynamic)// &
-         &   'darkMatter/'                 // &
-         &   self%objectType()             // &
+    ! by separating it into distinct files. It is keyed on this file's source digest instead, so that a tabulation built by
+    ! earlier code is not silently reused.
+    fileName=inputPath(pathTypeDataDynamic)                                 // &
+         &   'darkMatter/'                                                  // &
+         &   self%objectType()//'_'                                         // &
+         &   String_C_To_Fortran(massDistributionSIDMIsothermalSourceDigest)// &
          &   '.hdf5'
     call Directory_Make(File_Path(fileName))
     ! Merge in any tabulation already cached on disk. Since the tabulation lies on an absolute lattice the cached and in-memory

--- a/source/mass_distributions/spherical/SIDM/isothermal/_class.F90
+++ b/source/mass_distributions/spherical/SIDM/isothermal/_class.F90
@@ -312,16 +312,16 @@ contains
     Extend this thread's tabulation of :math:`y_0(\xi)`, :math:`z_0(\xi)`, and of the dimensionless density and mass profiles,
     so that it spans ``xiRequired``, merging with - and writing back to - the copy of it cached on disk.
     !!}
-    use :: Display                   , only : displayIndent    , displayUnindent     , displayMessage, verbosityLevelWorking, &
-         &                                    displayCounter   , displayCounterClear
-    use :: File_Utilities            , only : Directory_Make   , File_Exists         , File_Lock     , File_Path            , &
-         &                                    File_Unlock      , lockDescriptor
+    use :: Display                   , only : displayIndent      , displayUnindent     , displayMessage, verbosityLevelWorking, &
+         &                                    displayCounter     , displayCounterClear
+    use :: File_Utilities            , only : Directory_Make     , File_Exists         , File_Lock     , File_Path            , &
+         &                                    File_Unlock        , lockDescriptor
     use :: HDF5_Access               , only : hdf5Access
     use :: IO_HDF5                   , only : hdf5File
     use :: ISO_Varying_String        , only : char
-    use :: Numerical_Ranges          , only : Make_Range       , rangeTypeLinear     , Range_Pinned  , rangeLattice         , &
-         &                                    gridSchemePerUnit, Range_Lattice_Extend                , Range_Lattice_Offset
-    use :: Input_Paths               , only : inputPath        , pathTypeDataDynamic
+    use :: Numerical_Ranges          , only : Make_Range         , rangeTypeLinear     , Range_Pinned  , rangeLattice         , &
+         &                                    gridSchemePerUnit  , Range_Lattice_Extend                , Range_Lattice_Offset
+    use :: Input_Paths               , only : inputPath          , pathTypeDataDynamic
     use :: Multidimensional_Minimizer, only : multiDMinimizer
     use :: String_Handling           , only : String_C_To_Fortran
     implicit none

--- a/source/objects/tables/caches.F90
+++ b/source/objects/tables/caches.F90
@@ -158,8 +158,8 @@ contains
     integer                             , intent(in   )           :: pointsPer
     type     (rangeLattice             ), intent(  out)           :: lattice
     integer                             , intent(in   ), optional :: countExpected
-    integer                                                       :: schemeStored, pointsPerStored, &
-         &                                                           indexMinimum, countPoints
+    integer                                                       :: schemeStored , pointsPerStored, &
+         &                                                           indexMinimum , countPoints
 
     lattice=rangeLattice()
     if     (                                                  &

--- a/source/objects/tables/caches.F90
+++ b/source/objects/tables/caches.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
 !!{RST
 Contains a module which implements persistent, mergeable caches of tabulated functions.
 !!}
@@ -113,18 +115,20 @@ contains
 
   subroutine Table_Cache_Lattice_Write(file,axisName,lattice)
     !!{RST
-    Record, as attributes of the already-open file ``file``, the ``rangeLattice`` on which an axis of a stored tabulation is
-    built. The attributes are named for that axis, so a file may hold the lattices of any number of axes.
+    Record, as attributes of the already-open ``file``, the ``rangeLattice`` on which an axis of a stored tabulation is
+    built. The attributes are named for that axis, so any number of axes may be recorded alongside one another. ``file`` is
+    anything HDF5 attributes may attach to---a file, a group, or a dataset---so a tabulation stored in a group of its own
+    records its lattices there rather than at the file root.
 
     This is for tabulations held in raw arrays rather than in a :galacticus-class:`table1D`; those are written whole by
     ``Table_Cache_Store``, which records their lattices itself.
     !!}
-    use :: IO_HDF5         , only : hdf5File
+    use :: IO_HDF5         , only : hdf5AttributableObject
     use :: Numerical_Ranges, only : rangeLattice
     implicit none
-    type     (hdf5File    ), intent(inout) :: file
-    character(len=*       ), intent(in   ) :: axisName
-    type     (rangeLattice), intent(in   ) :: lattice
+    class    (hdf5AttributableObject), intent(inout) :: file
+    character(len=*                 ), intent(in   ) :: axisName
+    type     (rangeLattice          ), intent(in   ) :: lattice
 
     call file%writeAttribute(lattice%scheme%ID   ,axisName//'GridScheme'  )
     call file%writeAttribute(lattice%pointsPer   ,axisName//'PointsPer'   )
@@ -133,24 +137,29 @@ contains
     return
   end subroutine Table_Cache_Lattice_Write
 
-  subroutine Table_Cache_Lattice_Read(file,axisName,scheme,pointsPer,lattice)
+  subroutine Table_Cache_Lattice_Read(file,axisName,scheme,pointsPer,lattice,countExpected)
     !!{RST
-    Restore, from the already-open file ``file``, the ``rangeLattice`` on which an axis of a stored tabulation was built. The
+    Restore, from the already-open ``file``, the ``rangeLattice`` on which an axis of a stored tabulation was built. The
     lattice is returned undefined---which the caller must treat as the stored tabulation being unusable---unless the file
     records one which is self-consistent and which uses the gridding scheme and density of points that the caller expects. A
     file written before the lattices were recorded, or with a different grid, therefore reports an undefined lattice rather
-    than being misread.
+    than being misread. As for ``Table_Cache_Lattice_Write``, ``file`` may be a file, a group, or a dataset.
+
+    Where ``countExpected`` is given, the lattice must also hold that many points---the length of the dataset stored alongside
+    it---so that a file whose datasets do not match the lattice recorded with them is rejected rather than misread. It is
+    omitted for a lattice which carries no tabulated points, such as one recorded solely to pin a bound.
     !!}
-    use :: IO_HDF5         , only : hdf5File
-    use :: Numerical_Ranges, only : rangeLattice, enumerationGridSchemeType
+    use :: IO_HDF5         , only : hdf5AttributableObject
+    use :: Numerical_Ranges, only : rangeLattice          , enumerationGridSchemeType
     implicit none
-    type     (hdf5File                 ), intent(inout) :: file
-    character(len=*                    ), intent(in   ) :: axisName
-    type     (enumerationGridSchemeType), intent(in   ) :: scheme
-    integer                             , intent(in   ) :: pointsPer
-    type     (rangeLattice             ), intent(  out) :: lattice
-    integer                                             :: schemeStored, pointsPerStored, &
-         &                                                 indexMinimum, countPoints
+    class    (hdf5AttributableObject   ), intent(inout)           :: file
+    character(len=*                    ), intent(in   )           :: axisName
+    type     (enumerationGridSchemeType), intent(in   )           :: scheme
+    integer                             , intent(in   )           :: pointsPer
+    type     (rangeLattice             ), intent(  out)           :: lattice
+    integer                             , intent(in   ), optional :: countExpected
+    integer                                                       :: schemeStored, pointsPerStored, &
+         &                                                           indexMinimum, countPoints
 
     lattice=rangeLattice()
     if     (                                                  &
@@ -170,6 +179,9 @@ contains
     ! enumeration, so no separate validity test is needed.
     if (enumerationGridSchemeType(schemeStored) /= scheme   ) return
     if (pointsPerStored                         /= pointsPer) return
+    if (present(countExpected)) then
+       if (countPoints /= countExpected) return
+    end if
     lattice=rangeLattice(enumerationGridSchemeType(schemeStored),pointsPerStored,indexMinimum,countPoints)
     if (.not.lattice%isDefined()) lattice=rangeLattice()
     return

--- a/source/satellites/merging/virial_orbits/loss_cone.F90
+++ b/source/satellites/merging/virial_orbits/loss_cone.F90
@@ -1631,14 +1631,14 @@ contains
        ! Place the restored tabulation on its lattice. If the file is not self-consistent---the datasets not matching the lattice
        ! recorded alongside them, or that lattice not one which this object could have built---then discard everything read from
        ! it and retabulate from scratch, rather than leave a partially-restored tabulation behind.
-       if     (                                                                  &
-            &   latticeCached%isDefined  (                 )                     &
-            &  .and.                                                             &
-            &   size(self%mass                      ) == latticeCached%count     &
-            &  .and.                                                             &
-            &   size(self%velocityRadialMeanVirial,1) == latticeCached%count     &
-            &  .and.                                                             &
-            &   size(self%velocityRadialMeanVirial,2) == latticeCached%count     &
+       if     (                                                              &
+            &   latticeCached%isDefined()                                    &
+            &  .and.                                                         &
+            &   size(self%mass                      ) == latticeCached%count &
+            &  .and.                                                         &
+            &   size(self%velocityRadialMeanVirial,1) == latticeCached%count &
+            &  .and.                                                         &
+            &   size(self%velocityRadialMeanVirial,2) == latticeCached%count &
             & ) then
           self%latticeMass=latticeCached
           ! Take the abscissae from the lattice rather than from the file, so that they are bit-identical to those of any other
@@ -1672,7 +1672,7 @@ contains
     !!{RST
     Store the tabulated solution to file.
     !!}
-    use :: File_Utilities    , only : Directory_Make, File_Lock, File_Path, File_Unlock, &
+    use :: File_Utilities    , only : Directory_Make           , File_Lock, File_Path, File_Unlock, &
           &                           lockDescriptor
     use :: HDF5_Access       , only : hdf5Access
     use :: IO_HDF5           , only : hdf5File

--- a/source/satellites/merging/virial_orbits/loss_cone.F90
+++ b/source/satellites/merging/virial_orbits/loss_cone.F90
@@ -1577,18 +1577,17 @@ contains
     !!{RST
     Attempt to restore a table from file.
     !!}
-    use :: File_Utilities    , only : File_Exists              , File_Lock          , File_Unlock, lockDescriptor
+    use :: File_Utilities    , only : File_Exists             , File_Lock, File_Unlock, lockDescriptor
     use :: HDF5_Access       , only : hdf5Access
     use :: IO_HDF5           , only : hdf5File
     use :: ISO_Varying_String, only : char
-    use :: Numerical_Ranges  , only : enumerationGridSchemeType, gridSchemePerDecade
+    use :: Numerical_Ranges  , only : gridSchemePerDecade
+    use :: Table_Caches      , only : Table_Cache_Lattice_Read
     implicit none
     class  (virialOrbitLossCone), intent(inout) :: self
     type   (hdf5File           )                :: file
     type   (lockDescriptor     )                :: fileLock
     type   (rangeLattice       )                :: latticeCached
-    integer                                     :: schemeCached      , pointsPerCached, &
-         &                                         indexMinimumCached, countCached
 
     if (.not.self%fileRead.and.File_Exists(self%fileName)) then
        ! Always obtain the file lock before the hdf5Access lock to avoid deadlocks between OpenMP threads.
@@ -1613,10 +1612,9 @@ contains
        ! it concurrently---which the shared file lock taken above explicitly permits---would fail to open it at all.
        file=hdf5File(self%fileName,overWrite=.false.,readOnly=.true.)
        call file%readAttribute('time'                                ,     self%time                                )
-       call file%readAttribute('massGridScheme'                      ,     schemeCached                             )
-       call file%readAttribute('massPointsPer'                       ,     pointsPerCached                          )
-       call file%readAttribute('massIndexMinimum'                    ,     indexMinimumCached                       )
-       call file%readAttribute('massCount'                           ,     countCached                              )
+       ! Recover the lattice on which the stored tabulation was built. One which the file does not record, or which this object
+       ! would not have built, is returned undefined and so rejected below.
+       call Table_Cache_Lattice_Read(file,'mass',gridSchemePerDecade,self%countMassesPerDecade,latticeCached)
        call file%readDataset  ('mass'                                ,     self%mass                                )
        call file%readDataset  ('velocityRadialMeanVirial'            ,     self%velocityRadialMeanVirial            )
        call file%readDataset  ('velocityRadialDispersionVirial'      ,     self%velocityRadialDispersionVirial      )
@@ -1633,19 +1631,14 @@ contains
        ! Place the restored tabulation on its lattice. If the file is not self-consistent---the datasets not matching the lattice
        ! recorded alongside them, or that lattice not one which this object could have built---then discard everything read from
        ! it and retabulate from scratch, rather than leave a partially-restored tabulation behind.
-       latticeCached=rangeLattice(enumerationGridSchemeType(schemeCached),pointsPerCached,indexMinimumCached,countCached)
-       if     (                                                        &
-            &   latticeCached%isDefined  (                 )           &
-            &  .and.                                                   &
-            &   latticeCached%scheme      ==      gridSchemePerDecade  &
-            &  .and.                                                   &
-            &   pointsPerCached           == self%countMassesPerDecade &
-            &  .and.                                                   &
-            &   size(self%mass                      ) == countCached   &
-            &  .and.                                                   &
-            &   size(self%velocityRadialMeanVirial,1) == countCached   &
-            &  .and.                                                   &
-            &   size(self%velocityRadialMeanVirial,2) == countCached   &
+       if     (                                                                  &
+            &   latticeCached%isDefined  (                 )                     &
+            &  .and.                                                             &
+            &   size(self%mass                      ) == latticeCached%count     &
+            &  .and.                                                             &
+            &   size(self%velocityRadialMeanVirial,1) == latticeCached%count     &
+            &  .and.                                                             &
+            &   size(self%velocityRadialMeanVirial,2) == latticeCached%count     &
             & ) then
           self%latticeMass=latticeCached
           ! Take the abscissae from the lattice rather than from the file, so that they are bit-identical to those of any other
@@ -1684,6 +1677,7 @@ contains
     use :: HDF5_Access       , only : hdf5Access
     use :: IO_HDF5           , only : hdf5File
     use :: ISO_Varying_String, only : char
+    use :: Table_Caches      , only : Table_Cache_Lattice_Write
     implicit none
     class(virialOrbitLossCone), intent(inout) :: self
     type (hdf5File           )                :: file
@@ -1697,10 +1691,7 @@ contains
     call file%writeAttribute(self%time                                ,'time'                                )
     ! Record the lattice, not the bounds: the bounds follow from the lattice, but the converse does not, and it is the lattice
     ! which determines whether a tabulation read back later can be extended to cover a new range without recomputation.
-    call file%writeAttribute(self%latticeMass%scheme%ID               ,'massGridScheme'                      )
-    call file%writeAttribute(self%latticeMass%pointsPer               ,'massPointsPer'                       )
-    call file%writeAttribute(self%latticeMass%indexMinimum            ,'massIndexMinimum'                    )
-    call file%writeAttribute(self%latticeMass%count                   ,'massCount'                           )
+    call Table_Cache_Lattice_Write(file,'mass',self%latticeMass)
     call file%writeDataset  (self%mass                                ,'mass'                                )
     call file%writeDataset  (self%velocityRadialMeanVirial            ,'velocityRadialMeanVirial'            )
     call file%writeDataset  (self%velocityRadialDispersionVirial      ,'velocityRadialDispersionVirial'      )

--- a/source/star_formation/rate_surface_density/disks/Blitz2006.F90
+++ b/source/star_formation/rate_surface_density/disks/Blitz2006.F90
@@ -57,6 +57,15 @@
   integer         , parameter :: anchorEveryFactorBoost           = 3, anchorEveryFactorBoostStellar    = 3, &
        &                         anchorEveryRadius                = 3
 
+  ! Generate a source digest. The tabulated integral depends on only two of this class's parameters, so its file name is built
+  ! from those alone rather than from a full hashed descriptor - see the constructor. But it depends also on the code which
+  ! generates it: the integrand, the integration tolerance and rule, the floors applied to the two boost coefficients, and the
+  ! densities of tabulation points above. None of those are visible to a descriptor of the parameters, so the digest is folded
+  ! into the name to keep a tabulation built by earlier code from being silently reused.
+  !![
+  <sourceDigest name="blitz2006SourceDigest"/>
+  !!]
+
   !![
   <starFormationRateSurfaceDensityDisks name="starFormationRateSurfaceDensityDisksBlitz2006" docformat="rst">
    <description>
@@ -284,6 +293,7 @@ contains
     use :: Numerical_Constants_Prefixes    , only : giga                     , hecto                        , kilo                         , mega
     use :: Root_Finder                     , only : rangeExpandMultiplicative, rangeExpandSignExpectNegative, rangeExpandSignExpectPositive
     use :: Hashes_Cryptographic            , only : Hash_MD5
+    use :: String_Handling                 , only : String_C_To_Fortran
     implicit none
     type            (starFormationRateSurfaceDensityDisksBlitz2006)                :: self
     double precision                                               , intent(in   ) :: velocityDispersionDiskGas          , heightToRadialScaleDisk, &
@@ -333,11 +343,16 @@ contains
     self%radiusScaleFreeMinimum              =+huge(0.0d0)
     self%radiusScaleFreeMaximum              =-huge(0.0d0)
     ! Generate a file name for the table using the two parameters upon which it depends to create a hashed descriptor suffix.
+    ! Deliberately only these two: the tabulated integral is scale free in every other parameter of this class, so including
+    ! them would force the table - which is three-dimensional, and each of whose points is a numerical integral - to be rebuilt
+    ! on changes which cannot affect it. The source digest is included because the tabulated values do depend on the code which
+    ! generates them, which no descriptor of the parameters would capture.
     descriptorString=""
     write (parameterLabel,'(e17.10)') self%pressureExponent
     descriptorString=descriptorString//parameterLabel//" "
     write (parameterLabel,'(e17.10)') self%surfaceDensityExponent
     descriptorString=descriptorString//parameterLabel//" "
+    descriptorString=descriptorString//String_C_To_Fortran(blitz2006SourceDigest)
     self%filenameTable                       =     inputPath  (pathTypeDataDynamic)// &
          &                                    'starFormation/'                     // &
          &                                    self%objectType (                   )// &

--- a/source/structure_formation/cosmological_mass_variance/filtered_power_spectrum.F90
+++ b/source/structure_formation/cosmological_mass_variance/filtered_power_spectrum.F90
@@ -1519,11 +1519,13 @@ contains
     !!{RST
     Read tabulated data on mass variance from file.
     !!}
-    use :: Display       , only : displayMessage           , verbosityLevelWorking
-    use :: File_Utilities, only : File_Exists
-    use :: HDF5_Access   , only : hdf5Access
-    use :: IO_HDF5       , only : hdf5File
-    use :: Tables        , only : table1DLogarithmicCSpline, table1DLogarithmicMonotoneCSpline
+    use :: Display         , only : displayMessage           , verbosityLevelWorking
+    use :: File_Utilities  , only : File_Exists
+    use :: HDF5_Access     , only : hdf5Access
+    use :: IO_HDF5         , only : hdf5File
+    use :: Numerical_Ranges, only : gridSchemePerDecade
+    use :: Table_Caches    , only : Table_Cache_Lattice_Read
+    use :: Tables          , only : table1DLogarithmicCSpline, table1DLogarithmicMonotoneCSpline
     implicit none
     class           (cosmologicalMassVarianceFilteredPower), intent(inout)               :: self
     double precision                                       , dimension(:  ), allocatable :: massTmp        , timesTmp
@@ -1572,8 +1574,11 @@ contains
          ! Recover the lattices on which the stored tabulation was built. A file which does not record them, or which records
          ! lattices incommensurate with those this object would use, is simply ignored - and, since the file name carries a
          ! digest of this source file, such a file can in any case only be one written by a different build.
-         call filteredPowerLatticeRead(dataFile,'mass',pointsPerDecade    ,latticeMass)
-         call filteredPowerLatticeRead(dataFile,'time',timePointsPerDecade,latticeTime)
+         ! Note that an undefined time lattice is a legitimate record - it is what is written where growth is mass-independent
+         ! and sigma(M) is tabulated at a single epoch - so a missing record is told apart from that one through the mass axis,
+         ! which is never undefined in a usable file.
+         call Table_Cache_Lattice_Read(dataFile,'mass',gridSchemePerDecade,pointsPerDecade    ,latticeMass)
+         call Table_Cache_Lattice_Read(dataFile,'time',gridSchemePerDecade,timePointsPerDecade,latticeTime)
          if (latticeMass%isDefined()) then
             call dataFile%readDataset  ('times'             ,     timesTmp             )
             call dataFile%readDataset  ('mass'              ,     massTmp              )
@@ -1669,74 +1674,15 @@ contains
     return
   end subroutine filteredPowerFileRead
 
-  subroutine filteredPowerLatticeWrite(dataFile,axisName,lattice)
-    !!{RST
-    Record the ``rangeLattice`` on which an axis of the stored tabulation is built, as attributes named for that axis. An
-    undefined lattice - as the time axis has where growth is mass-independent, and σ(M) is tabulated at a single epoch - is
-    recorded as such, so that it can be told apart from a file written before the lattices were recorded at all.
-    !!}
-    use :: IO_HDF5, only : hdf5File
-    implicit none
-    type     (hdf5File    ), intent(inout) :: dataFile
-    character(len=*       ), intent(in   ) :: axisName
-    type     (rangeLattice), intent(in   ) :: lattice
-
-    call dataFile%writeAttribute(lattice%scheme%ID   ,axisName//'GridScheme'  )
-    call dataFile%writeAttribute(lattice%pointsPer   ,axisName//'PointsPer'   )
-    call dataFile%writeAttribute(lattice%indexMinimum,axisName//'IndexMinimum')
-    call dataFile%writeAttribute(lattice%count       ,axisName//'Count'       )
-    return
-  end subroutine filteredPowerLatticeWrite
-
-  subroutine filteredPowerLatticeRead(dataFile,axisName,pointsPer,lattice)
-    !!{RST
-    Restore the ``rangeLattice`` on which an axis of the stored tabulation was built. The lattice is returned undefined unless
-    the file records one which is self-consistent and which uses the density of points that this object would use---so that a
-    file written before the lattices were recorded, or with a different grid density, reports an undefined lattice rather than
-    being misread. Note that an undefined lattice is a legitimate record for the time axis, and is distinguished from a missing
-    one by the caller through the mass axis, which is never undefined in a usable file.
-    !!}
-    use :: IO_HDF5         , only : hdf5File
-    use :: Numerical_Ranges, only : enumerationGridSchemeType, gridSchemePerDecade
-    implicit none
-    type     (hdf5File    ), intent(inout) :: dataFile
-    character(len=*       ), intent(in   ) :: axisName
-    integer                , intent(in   ) :: pointsPer
-    type     (rangeLattice), intent(  out) :: lattice
-    integer                                :: schemeStored, pointsPerStored, &
-         &                                    indexMinimum, count_
-
-    lattice=rangeLattice()
-    if     (                                                      &
-         &   .not.dataFile%hasAttribute(axisName//'GridScheme'  ) &
-         &  .or.                                                  &
-         &   .not.dataFile%hasAttribute(axisName//'PointsPer'   ) &
-         &  .or.                                                  &
-         &   .not.dataFile%hasAttribute(axisName//'IndexMinimum') &
-         &  .or.                                                  &
-         &   .not.dataFile%hasAttribute(axisName//'Count'       ) &
-         & ) return
-    call dataFile%readAttribute(axisName//'GridScheme'  ,schemeStored   )
-    call dataFile%readAttribute(axisName//'PointsPer'   ,pointsPerStored)
-    call dataFile%readAttribute(axisName//'IndexMinimum',indexMinimum   )
-    call dataFile%readAttribute(axisName//'Count'       ,count_         )
-    ! Comparing the stored scheme against the one expected is stronger than merely checking that it is a valid member of the
-    ! enumeration, so no separate validity test is needed.
-    if (enumerationGridSchemeType(schemeStored) /= gridSchemePerDecade) return
-    if (pointsPerStored                         /= pointsPer          ) return
-    lattice=rangeLattice(enumerationGridSchemeType(schemeStored),pointsPerStored,indexMinimum,count_)
-    if (.not.lattice%isDefined()) lattice=rangeLattice()
-    return
-  end subroutine filteredPowerLatticeRead
-
   subroutine filteredPowerFileWrite(self)
     !!{RST
     Write tabulated data on mass variance to file.
     !!}
-    use :: Display    , only : displayMessage, verbosityLevelWorking
-    use :: HDF5       , only : hsize_t
-    use :: HDF5_Access, only : hdf5Access
-    use :: IO_HDF5    , only : hdf5File
+    use :: Display     , only : displayMessage           , verbosityLevelWorking
+    use :: HDF5        , only : hsize_t
+    use :: HDF5_Access , only : hdf5Access
+    use :: IO_HDF5     , only : hdf5File
+    use :: Table_Caches, only : Table_Cache_Lattice_Write
     implicit none
     class           (cosmologicalMassVarianceFilteredPower), intent(inout)               :: self
     double precision                                       , dimension(:  ), allocatable :: massTmp
@@ -1815,8 +1761,8 @@ contains
          ! Record the lattices on which the two axes are built. The bounds and interpolating factors which were formerly stored
          ! alongside them are not: each is a function of the lattices and of the epochs, and is recomputed when the file is read,
          ! so that a restored tabulation cannot come to be described differently from a freshly built one.
-         call filteredPowerLatticeWrite(dataFile,'mass',self%latticeMass)
-         call filteredPowerLatticeWrite(dataFile,'time',self%latticeTime)
+         call Table_Cache_Lattice_Write(dataFile,'mass',self%latticeMass)
+         call Table_Cache_Lattice_Write(dataFile,'time',self%latticeTime)
        end block hdf5WriteScope
        !$ call hdf5Access%unset()
     end if

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/_class.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/_class.F90
@@ -1545,6 +1545,7 @@ contains
     use :: ISO_Varying_String, only : operator(//)        , var_str            , varying_string
     use :: Numerical_Ranges  , only : gridSchemePerUnit   , gridSchemePerDecade
     use :: String_Handling   , only : operator(//)
+    use :: Table_Caches      , only : Table_Cache_Lattice_Read
     use :: Table_Labels      , only : extrapolationTypeFix
     implicit none
     class           (excursionSetFirstCrossingFarahi), intent(inout)                   :: self
@@ -1592,8 +1593,8 @@ contains
          ! lattices, or whose lattices do not match the datasets stored alongside them or the grid densities this object would
          ! use, is not usable: everything read from it is discarded and the tabulation is rebuilt, rather than leaving a
          ! partially restored tabulation behind which could neither be extended nor trusted.
-         call farahiLatticeRead(dataGroup,'variance',gridSchemePerUnit  ,self%varianceNumberPerUnitProbability,self%countVariance+1,self%latticeVariance)
-         call farahiLatticeRead(dataGroup,'time'    ,gridSchemePerDecade,self%timeNumberPerDecade             ,self%countTime      ,self%latticeTime    )
+         call Table_Cache_Lattice_Read(dataGroup,'variance',gridSchemePerUnit  ,self%varianceNumberPerUnitProbability,self%latticeVariance,self%countVariance+1)
+         call Table_Cache_Lattice_Read(dataGroup,'time'    ,gridSchemePerDecade,self%timeNumberPerDecade             ,self%latticeTime    ,self%countTime      )
          if (self%latticeVariance%isDefined() .and. self%latticeTime%isDefined()) then
             self%variance        =self%latticeVariance%values ()
             self%time            =self%latticeTime    %values ()
@@ -1683,9 +1684,9 @@ contains
          ! it is discarded. The two transition-spaced axes carry no lattice of their own, so they are checked instead against the
          ! lengths which the pinned bounds imply: were they to disagree, the tabulation could not be extended without moving
          ! points which the stored solutions were computed at.
-         call farahiLatticeRead(dataGroup,'varianceCurrent',gridSchemePerUnit  ,self%varianceNumberPerUnit     ,self%countVarianceCurrentRate+1,self%latticeVarianceCurrentRate)
-         call farahiLatticeRead(dataGroup,'time'           ,gridSchemePerDecade,self%timeNumberPerDecade       ,self%countTimeRate             ,self%latticeTimeRate           )
-         call farahiLatticeRead(dataGroup,'varianceMinimum',gridSchemePerDecade,varianceMinimumAnchorsPerDecade,lattice=self%latticeVarianceMinimumRate                        )
+         call Table_Cache_Lattice_Read(dataGroup,'varianceCurrent',gridSchemePerUnit  ,self%varianceNumberPerUnit     ,self%latticeVarianceCurrentRate,self%countVarianceCurrentRate+1)
+         call Table_Cache_Lattice_Read(dataGroup,'time'           ,gridSchemePerDecade,self%timeNumberPerDecade       ,self%latticeTimeRate           ,self%countTimeRate             )
+         call Table_Cache_Lattice_Read(dataGroup,'varianceMinimum',gridSchemePerDecade,varianceMinimumAnchorsPerDecade,self%latticeVarianceMinimumRate                                )
          if     (                                                  &
               &        self%latticeVarianceCurrentRate%isDefined() &
               &  .and. self%latticeTimeRate           %isDefined() &
@@ -1760,6 +1761,7 @@ contains
     use :: HDF5              , only : hsize_t
     use :: ISO_Varying_String, only : operator(//) , var_str       , varying_string
     use :: String_Handling   , only : operator(//)
+    use :: Table_Caches      , only : Table_Cache_Lattice_Write
     implicit none
     class    (excursionSetFirstCrossingFarahi), intent(inout) :: self
     type     (varying_string                 )                :: message
@@ -1783,8 +1785,8 @@ contains
          call dataGroup%writeDataset(self%firstCrossingProbability,'firstCrossingProbability','The probability of first crossing as a function of variance and time.')
          ! Record the lattices alongside the tabulation. The bounds follow from the lattice, but the converse does not, and it
          ! is the lattice which determines whether what is read back can be extended to cover a new range without recomputation.
-         call farahiLatticeWrite(dataGroup,'variance',self%latticeVariance)
-         call farahiLatticeWrite(dataGroup,'time'    ,self%latticeTime    )
+         call Table_Cache_Lattice_Write(dataGroup,'variance',self%latticeVariance)
+         call Table_Cache_Lattice_Write(dataGroup,'time'    ,self%latticeTime    )
          ! Report.
          message=var_str('write excursion set first crossing probability to: ')//self%fileName
          call displayIndent  (message,verbosityLevelWorking)
@@ -1816,9 +1818,9 @@ contains
          ! Record the lattices alongside the tabulation. Only two of the four axes lie on a lattice; the third lattice carries no
          ! tabulated points at all, and records the pinned lower bound from which the remaining two axes are generated. All three
          ! are needed to establish whether what is read back can be extended without recomputation.
-         call farahiLatticeWrite(dataGroup,'varianceCurrent',self%latticeVarianceCurrentRate)
-         call farahiLatticeWrite(dataGroup,'time'           ,self%latticeTimeRate           )
-         call farahiLatticeWrite(dataGroup,'varianceMinimum',self%latticeVarianceMinimumRate)
+         call Table_Cache_Lattice_Write(dataGroup,'varianceCurrent',self%latticeVarianceCurrentRate)
+         call Table_Cache_Lattice_Write(dataGroup,'time'           ,self%latticeTimeRate           )
+         call Table_Cache_Lattice_Write(dataGroup,'varianceMinimum',self%latticeVarianceMinimumRate)
          ! Report.
          message=var_str('wrote excursion set first crossing rates to: ')//self%fileName
          call displayIndent  (message,verbosityLevelWorking)
@@ -1842,72 +1844,6 @@ contains
     !$ call hdf5Access%unset()
     return
   end subroutine farahiFileWrite
-
-  subroutine farahiLatticeWrite(dataGroup,axisName,lattice)
-    !!{RST
-    Record the ``rangeLattice`` on which an axis of a stored tabulation is built, as attributes named for that axis.
-    !!}
-    use :: IO_HDF5, only : hdf5Group
-    implicit none
-    type     (hdf5Group   ), intent(inout) :: dataGroup
-    character(len=*       ), intent(in   ) :: axisName
-    type     (rangeLattice), intent(in   ) :: lattice
-
-    call dataGroup%writeAttribute(lattice%scheme%ID   ,axisName//'GridScheme'  )
-    call dataGroup%writeAttribute(lattice%pointsPer   ,axisName//'PointsPer'   )
-    call dataGroup%writeAttribute(lattice%indexMinimum,axisName//'IndexMinimum')
-    call dataGroup%writeAttribute(lattice%count       ,axisName//'Count'       )
-    return
-  end subroutine farahiLatticeWrite
-
-  subroutine farahiLatticeRead(dataGroup,axisName,scheme,pointsPer,countExpected,lattice)
-    !!{RST
-    Restore the ``rangeLattice`` on which an axis of a stored tabulation was built. The lattice is returned undefined---which
-    the caller must treat as the tabulation being unusable---unless the file records one, and that lattice is self-consistent,
-    uses the gridding scheme and density of points which this object would use, and has the same number of points as the
-    datasets stored alongside it. Older files, written before the lattices were recorded, therefore report an undefined lattice
-    rather than being misread.
-
-    ``countExpected`` is omitted for a lattice which carries no tabulated points---one recorded solely to pin a bound---since
-    there is then no dataset whose length it should match.
-    !!}
-    use :: IO_HDF5         , only : hdf5Group
-    use :: Numerical_Ranges, only : enumerationGridSchemeType
-    implicit none
-    type     (hdf5Group                ), intent(inout)           :: dataGroup
-    character(len=*                    ), intent(in   )           :: axisName
-    type     (enumerationGridSchemeType), intent(in   )           :: scheme
-    integer                             , intent(in   )           :: pointsPer
-    integer                             , intent(in   ), optional :: countExpected
-    type     (rangeLattice             ), intent(  out)           :: lattice
-    integer                                                       :: schemeStored , pointsPerStored, &
-         &                                                           indexMinimum , count_
-
-    lattice=rangeLattice()
-    if     (                                                       &
-         &   .not.dataGroup%hasAttribute(axisName//'GridScheme'  ) &
-         &  .or.                                                   &
-         &   .not.dataGroup%hasAttribute(axisName//'PointsPer'   ) &
-         &  .or.                                                   &
-         &   .not.dataGroup%hasAttribute(axisName//'IndexMinimum') &
-         &  .or.                                                   &
-         &   .not.dataGroup%hasAttribute(axisName//'Count'       ) &
-         & ) return
-    call dataGroup%readAttribute(axisName//'GridScheme'  ,schemeStored   )
-    call dataGroup%readAttribute(axisName//'PointsPer'   ,pointsPerStored)
-    call dataGroup%readAttribute(axisName//'IndexMinimum',indexMinimum   )
-    call dataGroup%readAttribute(axisName//'Count'       ,count_         )
-    ! Comparing the stored scheme against the one expected is stronger than merely checking that it is a valid member of the
-    ! enumeration, so no separate validity test is needed.
-    if (enumerationGridSchemeType(schemeStored) /= scheme       ) return
-    if (pointsPerStored                         /= pointsPer    ) return
-    if (present(countExpected)) then
-       if (count_                               /= countExpected) return
-    end if
-    lattice=rangeLattice(enumerationGridSchemeType(schemeStored),pointsPerStored,indexMinimum,count_)
-    if (.not.lattice%isDefined()) lattice=rangeLattice()
-    return
-  end subroutine farahiLatticeRead
 
   function farahiVarianceRange(self,rangeMinimum,rangeMaximum,rangeNumber,exponent) result (rangeValues)
     !!{RST

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/_class.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Farahi/_class.F90
@@ -1538,12 +1538,12 @@ contains
     !!{RST
     Read tabulated data on excursion set first crossing probabilities from file.
     !!}
-    use :: Display           , only : displayIndent       , displayMessage     , displayUnindent, verbosityLevelWorking
-    use :: File_Utilities    , only : File_Exists         , File_Name_Expand
+    use :: Display           , only : displayIndent           , displayMessage     , displayUnindent, verbosityLevelWorking
+    use :: File_Utilities    , only : File_Exists             , File_Name_Expand
     use :: HDF5_Access       , only : hdf5Access
-    use :: IO_HDF5           , only : hdf5File            , hdf5Group
-    use :: ISO_Varying_String, only : operator(//)        , var_str            , varying_string
-    use :: Numerical_Ranges  , only : gridSchemePerUnit   , gridSchemePerDecade
+    use :: IO_HDF5           , only : hdf5File                , hdf5Group
+    use :: ISO_Varying_String, only : operator(//)            , var_str            , varying_string
+    use :: Numerical_Ranges  , only : gridSchemePerUnit       , gridSchemePerDecade
     use :: String_Handling   , only : operator(//)
     use :: Table_Caches      , only : Table_Cache_Lattice_Read
     use :: Table_Labels      , only : extrapolationTypeFix
@@ -1756,10 +1756,10 @@ contains
     Write tabulated data on excursion set first crossing probabilities to file.
     !!}
     use :: HDF5_Access       , only : hdf5Access
-    use :: IO_HDF5           , only : hdf5File     , hdf5Group
-    use :: Display           , only : displayIndent, displayMessage, displayUnindent, verbosityLevelWorking
+    use :: IO_HDF5           , only : hdf5File                 , hdf5Group
+    use :: Display           , only : displayIndent            , displayMessage, displayUnindent, verbosityLevelWorking
     use :: HDF5              , only : hsize_t
-    use :: ISO_Varying_String, only : operator(//) , var_str       , varying_string
+    use :: ISO_Varying_String, only : operator(//)             , var_str       , varying_string
     use :: String_Handling   , only : operator(//)
     use :: Table_Caches      , only : Table_Cache_Lattice_Write
     implicit none

--- a/source/structure_formation/halo_mass_function/simulation_variance.F90
+++ b/source/structure_formation/halo_mass_function/simulation_variance.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
 !!{RST
 Implements a dark matter halo mass function class which modifies another mass function by accounting for cosmic variance in a simulation cube.
 !!}
@@ -185,13 +187,13 @@ contains
          self%timePrevious=time
          write (lengthCubeLabel,'(e12.6)') self%lengthSimulationCube
          write (      timeLabel,'(e12.6)')      time
-         fileNameVariance=inputPath(pathTypeDataDynamic)                                  // &
-              &           'largeScaleStructure/'                                          // &
-              &           self%objectType()                                               // &
-              &           'CubeVariance_'                                                 // &
-              &           'lengthSimulationCube_'//trim(lengthCubeLabel)//'_'             // &
-              &           'time_'                //trim(      timeLabel)//'_'             // &
-              &           self%powerSpectrum_%hashedDescriptor(includeSourceDigest=.true.)// &
+         fileNameVariance=inputPath(pathTypeDataDynamic)                                                                      // &
+              &           'largeScaleStructure/'                                                                              // &
+              &           self%objectType()                                                                                   // &
+              &           'CubeVariance_'                                                                                     // &
+              &           'lengthSimulationCube_'//trim(lengthCubeLabel)//'_'                                                 // &
+              &           'time_'                //trim(      timeLabel)//'_'                                                 // &
+              &           self%powerSpectrum_%hashedDescriptor(includeSourceDigest=.true.,includeFileModificationTimes=.true.)// &
               &           '.hdf5'
          !$omp critical(haloMassFunctionSimulationVarianceCache)
          useCache=0

--- a/source/structure_formation/linear_growth/baryons_darkMatter.F90
+++ b/source/structure_formation/linear_growth/baryons_darkMatter.F90
@@ -813,11 +813,13 @@ contains
     !!{RST
     Read tabulated data on linear growth factor from file.
     !!}
-    use :: Display       , only : displayMessage        , verbosityLevelWorking
-    use :: File_Utilities, only : File_Exists
-    use :: HDF5_Access   , only : hdf5Access
-    use :: IO_HDF5       , only : hdf5File
-    use :: Table_Labels  , only : extrapolationTypeAbort, extrapolationTypeFix
+    use :: Display         , only : displayMessage          , verbosityLevelWorking
+    use :: File_Utilities  , only : File_Exists
+    use :: HDF5_Access     , only : hdf5Access
+    use :: IO_HDF5         , only : hdf5File
+    use :: Numerical_Ranges, only : gridSchemePerDecade
+    use :: Table_Caches    , only : Table_Cache_Lattice_Read
+    use :: Table_Labels    , only : extrapolationTypeAbort  , extrapolationTypeFix
     implicit none
     class           (linearGrowthBaryonsDarkMatter), intent(inout)               :: self
     double precision                               , dimension(:,:), allocatable :: growthFactorDarkMatter, growthFactorBaryons
@@ -836,8 +838,8 @@ contains
     dataFile=hdf5File(self%fileName,overWrite=.false.,readOnly=.true.)
     ! Recover the lattices on which the stored tabulation was built. A file which records none, or which records lattices this
     ! object would not use, is ignored - as is one written before the derivatives needed to resume the integration were stored.
-    call baryonsDarkMatterLatticeRead(dataFile,'time'      ,growthTablePointsPerDecadeTime      ,latticeTime      )
-    call baryonsDarkMatterLatticeRead(dataFile,'wavenumber',growthTablePointsPerDecadeWavenumber,latticeWavenumber)
+    call Table_Cache_Lattice_Read(dataFile,'time'      ,gridSchemePerDecade,growthTablePointsPerDecadeTime      ,latticeTime      )
+    call Table_Cache_Lattice_Read(dataFile,'wavenumber',gridSchemePerDecade,growthTablePointsPerDecadeWavenumber,latticeWavenumber)
     if (latticeTime%isDefined() .and. latticeWavenumber%isDefined()) then
        call dataFile%readDataset('growthFactorDarkMatter',growthFactorDarkMatter)
        call dataFile%readDataset('growthFactorBaryons'   ,growthFactorBaryons   )
@@ -904,71 +906,15 @@ contains
     return
   end subroutine baryonsDarkMatterFileRead
 
-  subroutine baryonsDarkMatterLatticeWrite(dataFile,axisName,lattice)
-    !!{RST
-    Record the ``rangeLattice`` on which an axis of the stored tabulation is built, as attributes named for that axis.
-    !!}
-    use :: IO_HDF5, only : hdf5File
-    implicit none
-    type     (hdf5File    ), intent(inout) :: dataFile
-    character(len=*       ), intent(in   ) :: axisName
-    type     (rangeLattice), intent(in   ) :: lattice
-
-    call dataFile%writeAttribute(lattice%scheme%ID   ,axisName//'GridScheme'  )
-    call dataFile%writeAttribute(lattice%pointsPer   ,axisName//'PointsPer'   )
-    call dataFile%writeAttribute(lattice%indexMinimum,axisName//'IndexMinimum')
-    call dataFile%writeAttribute(lattice%count       ,axisName//'Count'       )
-    return
-  end subroutine baryonsDarkMatterLatticeWrite
-
-  subroutine baryonsDarkMatterLatticeRead(dataFile,axisName,pointsPer,lattice)
-    !!{RST
-    Restore the ``rangeLattice`` on which an axis of the stored tabulation was built. The lattice is returned undefined---which
-    the caller must treat as the tabulation being unusable---unless the file records one which is self-consistent and which
-    uses the density of points that this object would use, so that a file written before the lattices were recorded reports an
-    undefined lattice rather than being misread.
-    !!}
-    use :: IO_HDF5         , only : hdf5File
-    use :: Numerical_Ranges, only : enumerationGridSchemeType, gridSchemePerDecade
-    implicit none
-    type     (hdf5File    ), intent(inout) :: dataFile
-    character(len=*       ), intent(in   ) :: axisName
-    integer                , intent(in   ) :: pointsPer
-    type     (rangeLattice), intent(  out) :: lattice
-    integer                                :: schemeStored, pointsPerStored, &
-         &                                    indexMinimum, count_
-
-    lattice=rangeLattice()
-    if     (                                                      &
-         &   .not.dataFile%hasAttribute(axisName//'GridScheme'  ) &
-         &  .or.                                                  &
-         &   .not.dataFile%hasAttribute(axisName//'PointsPer'   ) &
-         &  .or.                                                  &
-         &   .not.dataFile%hasAttribute(axisName//'IndexMinimum') &
-         &  .or.                                                  &
-         &   .not.dataFile%hasAttribute(axisName//'Count'       ) &
-         & ) return
-    call dataFile%readAttribute(axisName//'GridScheme'  ,schemeStored   )
-    call dataFile%readAttribute(axisName//'PointsPer'   ,pointsPerStored)
-    call dataFile%readAttribute(axisName//'IndexMinimum',indexMinimum   )
-    call dataFile%readAttribute(axisName//'Count'       ,count_         )
-    ! Comparing the stored scheme against the one expected is stronger than merely checking that it is a valid member of the
-    ! enumeration, so no separate validity test is needed.
-    if (enumerationGridSchemeType(schemeStored) /= gridSchemePerDecade) return
-    if (pointsPerStored                         /= pointsPer          ) return
-    lattice=rangeLattice(enumerationGridSchemeType(schemeStored),pointsPerStored,indexMinimum,count_)
-    if (.not.lattice%isDefined()) lattice=rangeLattice()
-    return
-  end subroutine baryonsDarkMatterLatticeRead
-
   subroutine baryonsDarkMatterFileWrite(self)
     !!{RST
     Write tabulated data on linear growth factor to file.
     !!}
-    use :: Display    , only : displayMessage, verbosityLevelWorking
-    use :: HDF5       , only : hsize_t
-    use :: HDF5_Access, only : hdf5Access
-    use :: IO_HDF5    , only : hdf5File
+    use :: Display     , only : displayMessage           , verbosityLevelWorking
+    use :: HDF5        , only : hsize_t
+    use :: HDF5_Access , only : hdf5Access
+    use :: IO_HDF5     , only : hdf5File
+    use :: Table_Caches, only : Table_Cache_Lattice_Write
     implicit none
     class(linearGrowthBaryonsDarkMatter), intent(inout) :: self
     type (hdf5File                     )                :: dataFile
@@ -990,8 +936,8 @@ contains
     ! Record the lattices on which the two axes are built. The bounds formerly stored alongside them are not: each is a function
     ! of the lattices, and is recovered from them when the file is read, so that a restored tabulation cannot come to be
     ! described differently from a freshly built one.
-    call baryonsDarkMatterLatticeWrite(dataFile,'time'      ,self%latticeTime      )
-    call baryonsDarkMatterLatticeWrite(dataFile,'wavenumber',self%latticeWavenumber)
+    call Table_Cache_Lattice_Write(dataFile,'time'      ,self%latticeTime      )
+    call Table_Cache_Lattice_Write(dataFile,'wavenumber',self%latticeWavenumber)
     !$ call hdf5Access%unset()
     return
   end subroutine baryonsDarkMatterFileWrite

--- a/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
@@ -47,8 +47,8 @@
    contains
      !![
      <methods docformat="rst">
-       <method description="Get the requested table."                method="getTable"    />
-       <method description="Construct a tabulated solution."         method="tabulate"    />
+       <method description="Get the requested table."        method="getTable"/>
+       <method description="Construct a tabulated solution." method="tabulate"/>
      </methods>
      !!]
      final     ::                          cllsnlssMttCsmlgclCnstntDestructor
@@ -266,9 +266,9 @@ contains
     ! therefore differ from one computed wholly afresh: measured at up to 3e-9 relative, on the restored points only, which is
     ! of order the 1e-9 relative tolerance to which each point's root is found in the first place. Discarding the cache instead
     ! would hide this, at the cost of recomputing every point whenever the requested range grows.
-    if (tableStore) call Table_Cache_Restore(table_,fileName,status)
-    call                 self%tabulate      (time,table_,calculationType)
-    if (tableStore) call Table_Cache_Store  (table_,fileName)
+    if (tableStore) call Table_Cache_Restore(     table_,fileName       ,status)
+    call                 self%tabulate      (time,table_,calculationType       )
+    if (tableStore) call Table_Cache_Store  (     table_,fileName              )
     !$omp critical(sphrclCllpsCllsnlssMttrCsmlgclCnstntCache)
     useCache=0
     if (countCache(calculationType%ID) > 0) then
@@ -988,4 +988,3 @@ contains
     end if
     return
   end function cllsnlssMttCsmlgclCnstntRadiusRoot
-

--- a/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
@@ -48,8 +48,6 @@
      !![
      <methods docformat="rst">
        <method description="Get the requested table."                method="getTable"    />
-       <method description="Restore a tabulated solution from file." method="restoreTable"/>
-       <method description="Store a tabulated solution to file."     method="storeTable"  />
        <method description="Construct a tabulated solution."         method="tabulate"    />
      </methods>
      !!]
@@ -59,8 +57,6 @@
      procedure :: radiusTurnaround      => cllsnlssMttCsmlgclCnstntRadiusTurnaround
      procedure :: linearNonlinearMap    => cllsnlssMttCsmlgclCnstntLinearNonlinearMap
      procedure :: getTable              => cllsnlssMttCsmlgclCnstntGetTable
-     procedure :: restoreTable          => cllsnlssMttCsmlgclCnstntRestoreTable
-     procedure :: storeTable            => cllsnlssMttCsmlgclCnstntStoreTable
      procedure :: tabulate              => cllsnlssMttCsmlgclCnstntTabulate
   end type sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt
 
@@ -205,10 +201,8 @@ contains
     !!{RST
     Get the requested table for collapse for the spherical collapse model---either restoring from cache, from file, or computing as necessary.
     !!}
-    use :: Error         , only : errorStatusSuccess
-    use :: File_Utilities, only : File_Lock         , File_Unlock             , lockDescriptor, Directory_Make, &
-         &                        File_Path
-    use :: Tables        , only : table1D           , table1DLogarithmicLinear
+    use :: Table_Caches, only : Table_Cache_Restore, Table_Cache_Store
+    use :: Tables      , only : table1D            , table1DLogarithmicLinear
     implicit none
     class           (sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt)             , intent(inout) :: self
     double precision                                                               , intent(in   ) :: time
@@ -217,7 +211,6 @@ contains
     type            (enumerationCllsnlssMttCsmlgclCnstntClcltnType   )             , intent(in   ) :: calculationType
     class           (table1D                                         ), allocatable, intent(inout) :: table_
     integer                                                                                        :: status
-    type            (lockDescriptor                                  )                             :: fileLock
     integer                                                                                        :: useCache       , i
     logical                                                           , allocatable, dimension(:)  :: isComputed
 
@@ -257,24 +250,25 @@ contains
     end if
     !$omp end critical(sphrclCllpsCllsnlssMttrCsmlgclCnstntCache)
     if (useCache /=0 ) return
-    if (tableStore) then
-       call     Directory_Make(File_Path(fileName)                              )
-       call     File_Lock     (          fileName ,fileLock,lockIsShared=.true. )
-    end if
-    call       self%restoreTable(time,table_,fileName       ,tableStore,status)
-    if (status /= errorStatusSuccess) then
-       if (tableStore) then
-          call  File_Unlock   (fileLock                    ,sync        =.false.)
-          call  File_Lock     (          fileName ,fileLock,lockIsShared=.false.)
-       end if
-       call    self%restoreTable(time,table_,fileName       ,tableStore,status)
-       if (status /= errorStatusSuccess) then
-          call self%tabulate    (time,table_,calculationType                  )
-          call self%storeTable  (     table_,fileName       ,tableStore       )
-       end if
-    end if
-    if (tableStore) &
-         & call File_Unlock   (fileLock                                                     )
+    ! Merge in whatever is already cached on disk, compute only the points which the request still needs, and write the union
+    ! back. Since each tabulated point is the result of an independent root find - not of an integration carried forward from
+    ! the earliest tabulated epoch - the cached and freshly computed solutions agree wherever they overlap, so a cached file
+    ! whose range does not cover the request can be merged rather than discarded and recomputed wholesale.
+    !
+    ! `Table_Cache_Restore` takes the shared lock and `Table_Cache_Store` the exclusive one, each for the duration of its own
+    ! file access only - never across the tabulation. `Table_Cache_Store` re-reads under its exclusive lock before writing, so a
+    ! range written by another process since our own read is merged rather than overwritten, which is what the second restore
+    ! under an upgraded lock used to guard against.
+    !
+    ! Note one consequence of merging rather than discarding. A restored point keeps the value it was given by the run which
+    ! computed it, and that run may have held a narrower tabulation of the expansion factor than this one does - that tabulation
+    ! is rebuilt, not extended, when its earliest epoch moves, so its values shift slightly when it grows. A merged table can
+    ! therefore differ from one computed wholly afresh: measured at up to 3e-9 relative, on the restored points only, which is
+    ! of order the 1e-9 relative tolerance to which each point's root is found in the first place. Discarding the cache instead
+    ! would hide this, at the cost of recomputing every point whenever the requested range grows.
+    if (tableStore) call Table_Cache_Restore(table_,fileName,status)
+    call                 self%tabulate      (time,table_,calculationType)
+    if (tableStore) call Table_Cache_Store  (table_,fileName)
     !$omp critical(sphrclCllpsCllsnlssMttrCsmlgclCnstntCache)
     useCache=0
     if (countCache(calculationType%ID) > 0) then
@@ -505,6 +499,8 @@ contains
              end select
           end select
        end do
+    class default
+       call Error_Report('tabulation requires a `table1DLogarithmicLinear` table'//{introspection:location})
     end select
     return
   end subroutine cllsnlssMttCsmlgclCnstntTabulate
@@ -993,110 +989,3 @@ contains
     return
   end function cllsnlssMttCsmlgclCnstntRadiusRoot
 
-  subroutine cllsnlssMttCsmlgclCnstntRestoreTable(self,time,restoredTable,fileName,tableStore,status)
-    !!{RST
-    Attempt to restore a table from file. The table is rebuilt on the absolute lattice recorded in the file, so that its
-    abscissae are identical to those of the table which was stored. Files which do not record a lattice (i.e. those written by
-    earlier versions of this code) are rejected, causing the table to be recomputed and stored afresh.
-    !!}
-    use :: Error               , only : errorStatusFail, errorStatusSuccess
-    use :: File_Utilities      , only : File_Exists
-    use :: HDF5_Access         , only : hdf5Access
-    use :: IO_HDF5             , only : hdf5File
-    use :: ISO_Varying_String  , only : char           , varying_string
-    use :: Numerical_Comparison, only : Values_Agree
-    use :: Numerical_Ranges    , only : rangeLattice   , enumerationGridSchemeType
-    use :: Tables              , only : table1D        , table1DLogarithmicLinear
-    implicit none
-    class           (sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt)             , intent(inout) :: self
-    double precision                                                               , intent(in   ) :: time
-    class           (table1D                                         ), allocatable, intent(inout) :: restoredTable
-    type            (varying_string                                  )             , intent(in   ) :: fileName
-    logical                                                                        , intent(in   ) :: tableStore
-    integer                                                                        , intent(  out) :: status
-    type            (hdf5File                                        )                             :: file
-    type            (rangeLattice                                    )                             :: lattice
-    logical                                                           , allocatable, dimension(:)  :: isComputed
-    double precision                                                  , allocatable, dimension(:)  :: timeTable    , valueTable
-    integer                                                                                        :: gridScheme   , pointsPer , &
-         &                                                                                            indexMinimum
-    !$GLC attributes unused :: self
-
-    status=errorStatusFail
-    if (.not.tableStore) return
-    if (File_Exists(fileName)) then
-       !$ call hdf5Access%set()
-       file=hdf5File(fileName,readOnly=.true.)
-       if (file%hasAttribute('gridScheme')) then
-          call file%readDataset('time',timeTable)
-          if     (                                    &
-               &   timeTable(1              ) <= time &
-               &  .and.                               &
-               &   timeTable(size(timeTable)) >= time &
-               & ) then
-             call file%readAttribute('gridScheme'  ,gridScheme  )
-             call file%readAttribute('pointsPer'   ,pointsPer   )
-             call file%readAttribute('indexMinimum',indexMinimum)
-             call file%readDataset  ('value'       ,valueTable  )
-             lattice=rangeLattice(enumerationGridSchemeType(gridScheme),pointsPer,indexMinimum,size(timeTable))
-             ! Guard against a file whose recorded lattice is inconsistent with its stored abscissae - such a file can not be
-             ! restored onto the lattice, so treat it as unusable and allow the table to be recomputed.
-             if     (                                                                          &
-                  &   lattice%isDefined()                                                      &
-                  &  .and.                                                                     &
-                  &   Values_Agree(lattice%minimum(),timeTable(1              ),relTol=1.0d-6) &
-                  &  .and.                                                                     &
-                  &   Values_Agree(lattice%maximum(),timeTable(size(timeTable)),relTol=1.0d-6) &
-                  & ) then
-                ! Deallocate table if currently allocated.
-                if (allocated(restoredTable)) then
-                   call restoredTable%destroy()
-                   deallocate(restoredTable)
-                end if
-                allocate(table1DLogarithmicLinear :: restoredTable)
-                select type (restoredTable)
-                type is (table1DLogarithmicLinear)
-                   call restoredTable%extend  (lattice,isComputed)
-                   call restoredTable%populate(valueTable        )
-                end select
-                status=errorStatusSuccess
-             end if
-          end if
-       end if
-       !$ call hdf5Access%unset()
-    end if
-    return
-  end subroutine cllsnlssMttCsmlgclCnstntRestoreTable
-
-  subroutine cllsnlssMttCsmlgclCnstntStoreTable(self,storeTable,fileName,tableStore)
-    !!{RST
-    Store a table to file, recording the absolute lattice on which it was built so that it can be restored onto exactly the same
-    abscissae.
-    !!}
-    use :: Error             , only : Error_Report
-    use :: File_Utilities    , only : Directory_Make, File_Path
-    use :: HDF5_Access       , only : hdf5Access
-    use :: IO_HDF5           , only : hdf5File
-    use :: ISO_Varying_String, only : char          , varying_string
-    use :: Tables            , only : table1D
-    implicit none
-    class  (sphericalCollapseSolverCllsnlssMttrCsmlgclCnstnt), intent(inout) :: self
-    class  (table1D                                         ), intent(in   ) :: storeTable
-    type   (varying_string                                  ), intent(in   ) :: fileName
-    logical                                                  , intent(in   ) :: tableStore
-    type   (hdf5File                                        )                :: file
-    !$GLC attributes unused :: self
-
-    if (.not.tableStore) return
-    if (.not.storeTable%lattice%isDefined()) call Error_Report('table was not built on an absolute lattice'//{introspection:location})
-    call Directory_Make(File_Path(fileName))
-    !$ call hdf5Access%set()
-    file=hdf5File(fileName,overWrite=.true.,readOnly=.false.)
-    call file%writeDataset  (        storeTable%xs()                     ,'time'        )
-    call file%writeDataset  (reshape(storeTable%ys(),[storeTable%size()]),'value'       )
-    call file%writeAttribute(storeTable%lattice%scheme%ID                ,'gridScheme'  )
-    call file%writeAttribute(storeTable%lattice%pointsPer                ,'pointsPer'   )
-    call file%writeAttribute(storeTable%lattice%indexMinimum             ,'indexMinimum')
-    !$ call hdf5Access%unset()
-    return
-  end subroutine cllsnlssMttCsmlgclCnstntStoreTable

--- a/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation/spherical_collapse/solver/collisionlessMatter_cosmologicalConstant.F90
@@ -178,11 +178,11 @@ contains
          &                             'TurnaroundRadius_'                                                                  // &
          &                             self%hashedDescriptor(includeSourceDigest=.true.,includeFileModificationTimes=.true.)// &
          &                             '.hdf5'
-    self%fileNameNonLinearMap         =inputPath(pathTypeDataDynamic)                   // &
-         &                             'largeScaleStructure/'                           // &
-         &                             self%objectType      (                          )// &
-         &                             'NonLinearMap_'                                  // &
-         &                             self%hashedDescriptor(includeSourceDigest=.true.)// &
+    self%fileNameNonLinearMap         =inputPath(pathTypeDataDynamic)                                                       // &
+         &                             'largeScaleStructure/'                                                               // &
+         &                             self%objectType      (                                                              )// &
+         &                             'NonLinearMap_'                                                                      // &
+         &                             self%hashedDescriptor(includeSourceDigest=.true.,includeFileModificationTimes=.true.)// &
          &                             '.hdf5'
     return
   end function cllsnlssMttCsmlgclCnstntConstructorInternal


### PR DESCRIPTION
Addresses [#1382](https://github.com/galacticusorg/galacticus/issues/1382). Net: **+233 / -457** across 12 files.

Two of that issue's premises turned out to be wrong, so the work it describes is not quite the work here. Both corrections are recorded in a [comment on the issue](https://github.com/galacticusorg/galacticus/issues/1382#issuecomment-5330891171).

## 1. Cache file naming

**Three real defects**, where a name was built from `hashedDescriptor(includeSourceDigest=.true.)` without `includeFileModificationTimes=.true.`, so it did not change when a data file the tabulation depends on did. The `NonLinearMap_` case is the only one of four names built in the same constructor to omit the flag; its three siblings already carry it.

**Four sites where the issue's prescription was backwards.** It proposed standardizing on `objectType() // '_' // hashedDescriptor(...)`. For the decaying dark matter retention table, the SIDM isothermal solutions, the Gaussian ellipsoid accelerations and the Blitz2006 star formation integral, that would be a regression: what those files hold does not depend on the objects' parameters, and naming them mechanically would produce one large file per halo for the per-halo classes — the trap the issue itself warns about. Three of them already carried comments saying so.

What they were missing is the *code* that generates them. Changing an integrand, an integration tolerance or a density of tabulation points left the name unchanged and a stale cache was silently adopted — the same failure mode reached from the other direction. Each now folds in a `<sourceDigest>`, following `intergalactic_medium/state/RecFast.F90`.

`Blitz2006.F90` is worth singling out. Its hand-rolled MD5 looked like a defect but captures exactly the two parameters (`pressureExponent`, `surfaceDensityExponent`) its table actually depends on — verified by tracing every `self%` reference in `blitz2006IntegralPartiallyMolecular`, where the table is built and used. `self%radiusDisk` appears only as `radiusInner/self%radiusDisk`, selecting where the table is read, never what is stored. Replacing that descriptor with a full hashed descriptor would fold in seven parameters that cannot affect the values and force a 3-D tabulation to be rebuilt. It keeps its descriptor and gains a source digest.

The issue's fourth naming item, the `suffix()` variants, needs no change: `tabulated.F90:97-104` documents that the shape parameters are *axes* of those tabulations, interpolated over, so one file correctly serves every parameter value.

## 2. The store/restore helper already existed

The issue's first section proposes extracting it. It was in fact built during #1317 — `source/objects/tables/caches.F90` (`Table_Caches`), with merge-on-miss, the shared → read → exclusive → re-read → write locking protocol, a `formatVersion` guard and `source/tests/table_caches.F90`. What remained was migration, and four sites carried private copies of `Table_Cache_Lattice_Write`/`_Read` identical to the shared ones down to the comment text: `baryons_darkMatter.F90`, `filtered_power_spectrum.F90`, `loss_cone.F90` and `Farahi/_class.F90`. All four now call the helpers — **176 lines of duplicated lattice code removed**.

Two small generalizations made the last two drop-ins:

- the helpers take `class(hdf5AttributableObject)` rather than `type(hdf5File)`, which is the type gathering the attribute methods they use, so a tabulation stored in a group of its own — as Farahi's are — records its lattices there rather than at the file root;
- an optional `countExpected`, which Farahi's copy already had, requiring the lattice to match the length of the dataset stored beside it. Its check and its ordering relative to the scheme and points-per tests are those of the routine it replaces.

## 3. The spherical collapse solver now merges rather than discards

`getTable` implemented the locking protocol by hand, with `restoreTable`/`storeTable` that were near-copies of `Table_Cache_Read_1D`/`Write_1D`. It now calls the helpers — 134 lines removed, 16 added — and since the three solvers form an inheritance chain, this one implementation serves all of them.

**This is a behavior change.** The hand-rolled restore required the cached file to *cover* the request and discarded it otherwise, recomputing every point. The helper merges: each tabulated point is an independent root find, not a value carried forward by integration from the earliest epoch, so the cached and freshly computed solutions agree wherever they overlap. Measured across two processes, a 1501-point cache extended to 3501 carries all 1501 cached values over bit-for-bit and computes only the 2000 new ones.

The second restore under an upgraded lock is gone; `Table_Cache_Store` re-reads under its exclusive lock, covering the race it guarded against.

**One consequence, documented in a comment at the call site.** A restored point keeps the value the run that computed it gave it, and that run may have held a narrower expansion-factor tabulation — which is rebuilt, not extended, when its earliest epoch moves. A merged table can therefore differ from one built wholly afresh: **measured at up to 3e-9 relative, on the restored points only**, which is of order the 1e-9 relative tolerance to which each root is found. Discarding would hide this at the cost of a full retabulation whenever the range grows.

Also adds a `class default` guard to the tabulating `select type`. The table's dynamic type now comes from the cache file rather than being allocated by `restoreTable`, so any other type would previously have fallen through and returned silently with uncomputed points.

## Cache invalidation

Only the spherical collapse change invalidates caches: those files gain the helper's `formatVersion` attribute, so existing ones are ignored and rewritten on first use. The four renamed digest caches are likewise regenerated. Loss cone and Farahi caches are **not** affected — their attribute names are unchanged, confirmed against files on disk.

## Verification

Built and run at each step. `parameters/quickTest.xml` clean throughout; `tests.spherical_collapse.determinism` 30/30, `.flat` 7/7, `.open` 7/7, `.nonlinear` 1/1; `tests.table_caches` 17/17; `tests.excursion_sets` 6/6; `tests.sigma` 5/5, including "σ(M) at tabulated masses is unchanged by extension of the tabulation"; `tests.linear_growth.baryons.EdS` 10/10; `testSuite/test-decayingDM-profile.py` and `testSuite/test-virial-orbit-loss-cone.py` both pass.

Two caveats worth stating rather than leaving implicit:

- **The file-backed merge is not covered by any test in the suite.** `tests.spherical_collapse.determinism` passes `.false.` for `tableStore` at all three call sites, so it never opens a file. The merge was measured with a throwaway program driving the file path across separate processes against an isolated `GALACTICUS_DYNAMIC_DATA_PATH`; that program is not included here. Adding a permanent test would be a reasonable follow-up.
- A narrow-then-wide comparison *within one process* does not isolate this change — the caller carries the table across calls, so the previous code skipped recomputation there too. Only the cross-process comparison does.

The test runs above were made before rebasing onto `b4e94e008`; the three commits picked up share no files with this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
