### PR TITLE
feat(tabulations)!: pin the request-anchored tabulations from the #1375 audit

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1268,6 +1268,7 @@ jobs:
                       tests.SIDM_cross_sections.exe,
                       tests.SIDM_parametric_maps.exe,
                       tests.SIDM_Kummer_deceleration.exe,
+                      tests.spin_distribution_nbody_errors.exe,
                       tests.differentiation.exe,
                       tests.tables.exe,
                       tests.table_caches.exe,

--- a/source/dark_matter_halos/scales/virial_density_contrast.F90
+++ b/source/dark_matter_halos/scales/virial_density_contrast.F90
@@ -357,16 +357,16 @@ contains
     !!{RST
     Returns the mean density for ``node``.
     !!}
-    use :: Galacticus_Nodes , only : nodeComponentBasic, treeNode
-    use :: Numerical_Ranges , only : Range_Pinned      , gridSchemePerDecade
+    use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
+    use :: Numerical_Ranges, only : Range_Pinned      , gridSchemePerDecade
     implicit none
-    class           (darkMatterHaloScaleVirialDensityContrastDefinition), intent(inout)               :: self
-    type            (treeNode                                          ), intent(inout)               :: node
-    class           (nodeComponentBasic                                ), pointer                     :: basic
-    integer                                                                                           :: i
-    type            (rangeLattice                                      )                              :: lattice
-    logical                                                             , allocatable, dimension(:)   :: isComputed
-    double precision                                                                                  :: time
+    class           (darkMatterHaloScaleVirialDensityContrastDefinition), intent(inout)             :: self
+    type            (treeNode                                          ), intent(inout)             :: node
+    class           (nodeComponentBasic                                ), pointer                   :: basic
+    integer                                                                                         :: i
+    type            (rangeLattice                                      )                            :: lattice
+    logical                                                             , allocatable, dimension(:) :: isComputed
+    double precision                                                                                :: time
 
     ! Get the basic component.
     basic => node%basic()
@@ -387,12 +387,12 @@ contains
        ! extended without recomputing any value already found. The safety margin `Range_Pinned` applies by default is a factor of
        ! two at each end, which is the margin this tabulation always used. Anchoring is to half decades rather than whole ones:
        ! on a cosmic time axis a whole decade spans most of the history of the universe.
-       lattice=Range_Pinned(                                                          &
-            &                              time                                     , &
-            &                              meanDensityTablePointsPerDecade          , &
-            &                              gridSchemePerDecade                      , &
-            &               latticeCurrent=self%densityMeanTable%lattice             , &
-            &               anchorEvery   =meanDensityTableAnchorEvery                 &
+       lattice=Range_Pinned(                                                &
+            &                              time                           , &
+            &                              meanDensityTablePointsPerDecade, &
+            &                              gridSchemePerDecade            , &
+            &               latticeCurrent=self%densityMeanTable%lattice  , &
+            &               anchorEvery   =meanDensityTableAnchorEvery      &
             &              )
        if (.not.self%densityMeanTable%lattice%covers(lattice)) then
           ! Extend the tabulation onto the new lattice, preserving every value already computed. Each tabulated value depends

--- a/source/dark_matter_halos/scales/virial_density_contrast.F90
+++ b/source/dark_matter_halos/scales/virial_density_contrast.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   An implementation of dark matter halo scales based on virial density contrast.
   !!}
@@ -24,6 +26,7 @@
   use :: Cosmology_Functions    , only : cosmologyFunctionsClass
   use :: Cosmology_Parameters   , only : cosmologyParametersClass
   use :: Kind_Numbers           , only : kind_int8
+  use :: Numerical_Ranges       , only : rangeLattice
   use :: Tables                 , only : table1DLogarithmicLinear
   use :: Virial_Density_Contrast, only : virialDensityContrastClass
   
@@ -52,8 +55,7 @@
           &                                                   temperatureVirialStored             , velocityVirialStored            , &
           &                                                   timePrevious                        , densityGrowthRatePrevious       , &
           &                                                   massPrevious
-     ! Table for fast lookup of the mean density of halos.
-     double precision                                      :: densityMeanTimeMaximum              , densityMeanTimeMinimum   =-1.0d0
+     ! Table for fast lookup of the mean density of halos. Its range is carried by the lattice on which it is built.
      type            (table1DLogarithmicLinear  )          :: densityMeanTable
    contains
      !![
@@ -84,6 +86,9 @@
   end interface darkMatterHaloScaleVirialDensityContrastDefinition
 
   integer, parameter :: meanDensityTablePointsPerDecade=100
+
+  ! Interval, in lattice steps, to which the bounds of the mean density tabulation are pinned - half decades.
+  integer, parameter :: meanDensityTableAnchorEvery    =meanDensityTablePointsPerDecade/2
 
 contains
 
@@ -133,8 +138,6 @@ contains
     self%radiusVirialComputed      =.false.
     self%temperatureVirialComputed =.false.
     self%velocityVirialComputed    =.false.
-    self%densityMeanTimeMaximum    =-1.0d0
-    self%densityMeanTimeMinimum    =-1.0d0
     self%timePrevious              =-1.0d0
     self%massPrevious              =-1.0d0
     return
@@ -165,7 +168,7 @@ contains
     <objectDestructor name="self%cosmologyFunctions_"   />
     <objectDestructor name="self%virialDensityContrast_"/>
     !!]
-    if (self%densityMeanTimeMinimum >= 0.0d0) call self%densityMeanTable%destroy()
+    if (self%densityMeanTable%lattice%isDefined()) call self%densityMeanTable%destroy()
     if (calculationResetEvent%isAttached(self,virialDensityContrastDefinitionCalculationReset)) call calculationResetEvent%detach(self,virialDensityContrastDefinitionCalculationReset)
     return
   end subroutine virialDensityContrastDefinitionDestructor
@@ -354,13 +357,16 @@ contains
     !!{RST
     Returns the mean density for ``node``.
     !!}
-    use :: Galacticus_Nodes, only : nodeComponentBasic, treeNode
+    use :: Galacticus_Nodes , only : nodeComponentBasic, treeNode
+    use :: Numerical_Ranges , only : Range_Pinned      , gridSchemePerDecade
     implicit none
-    class           (darkMatterHaloScaleVirialDensityContrastDefinition), intent(inout) :: self
-    type            (treeNode                                          ), intent(inout) :: node
-    class           (nodeComponentBasic                                ), pointer       :: basic
-    integer                                                                             :: i    , densityMeanTablePoints
-    double precision                                                                    :: time
+    class           (darkMatterHaloScaleVirialDensityContrastDefinition), intent(inout)               :: self
+    type            (treeNode                                          ), intent(inout)               :: node
+    class           (nodeComponentBasic                                ), pointer                     :: basic
+    integer                                                                                           :: i
+    type            (rangeLattice                                      )                              :: lattice
+    logical                                                             , allocatable, dimension(:)   :: isComputed
+    double precision                                                                                  :: time
 
     ! Get the basic component.
     basic => node%basic()
@@ -376,19 +382,24 @@ contains
             &                                        /self%cosmologyFunctions_   %expansionFactor(             time)**3
     else
        ! For non-mass-dependent virial density contrasts we can tabulate as a function of time.
-       ! Retabulate the mean density vs. time if necessary.
-       if (time < self%densityMeanTimeMinimum .or. time > self%densityMeanTimeMaximum) then
-          if (self%densityMeanTimeMinimum <= 0.0d0) then
-             self%densityMeanTimeMinimum=                                time/2.0d0
-             self%densityMeanTimeMaximum=                                time*2.0d0
-          else
-             self%densityMeanTimeMinimum=min(self%densityMeanTimeMinimum,time/2.0d0)
-             self%densityMeanTimeMaximum=max(self%densityMeanTimeMaximum,time*2.0d0)
-          end if
-          densityMeanTablePoints=int(log10(self%densityMeanTimeMaximum/self%densityMeanTimeMinimum)*dble(meanDensityTablePointsPerDecade))+1
-          call self%densityMeanTable%destroy()
-          call self%densityMeanTable%create(self%densityMeanTimeMinimum,self%densityMeanTimeMaximum,densityMeanTablePoints)
-          do i=1,densityMeanTablePoints
+       ! Find the range of times to tabulate, pinned to an absolute lattice. Pinning makes the tabulation - and therefore every
+       ! value interpolated from it - independent of the time at which the table was first requested, and allows the table to be
+       ! extended without recomputing any value already found. The safety margin `Range_Pinned` applies by default is a factor of
+       ! two at each end, which is the margin this tabulation always used. Anchoring is to half decades rather than whole ones:
+       ! on a cosmic time axis a whole decade spans most of the history of the universe.
+       lattice=Range_Pinned(                                                          &
+            &                              time                                     , &
+            &                              meanDensityTablePointsPerDecade          , &
+            &                              gridSchemePerDecade                      , &
+            &               latticeCurrent=self%densityMeanTable%lattice             , &
+            &               anchorEvery   =meanDensityTableAnchorEvery                 &
+            &              )
+       if (.not.self%densityMeanTable%lattice%covers(lattice)) then
+          ! Extend the tabulation onto the new lattice, preserving every value already computed. Each tabulated value depends
+          ! only on its own abscissa, so those carried over are exactly what a fresh tabulation would have produced.
+          call self%densityMeanTable%extend(lattice,isComputed)
+          do i=1,lattice%count
+             if (isComputed(i)) cycle
              call self%densityMeanTable%populate                                                               &
                   & (                                                                                          &
                   &  +self%virialDensityContrast_%densityContrast(basic%mass(),self%densityMeanTable%x(i))     &

--- a/source/dark_matter_halos/spins/distributions/N-body_errors.F90
+++ b/source/dark_matter_halos/spins/distributions/N-body_errors.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   An implementation of the dark matter halo spin distribution which modifies another spin distribution to account for the effects of particle noise errors in spins measured in N-body simulations.
   !!}
@@ -244,6 +246,7 @@ contains
     use :: Galacticus_Nodes      , only : nodeComponentBasic                     , nodeComponentDarkMatterProfile, nodeComponentSpin, treeNode, &
          &                                mergerTree
     use :: Numerical_Integration , only : integrator
+    use :: Numerical_Ranges      , only : Range_Pinned                           , rangeLattice                  , gridSchemePerDecade
     implicit none
     class           (haloSpinDistributionNbodyErrors), intent(inout)                    :: self
     double precision                                 , intent(in   )         , optional :: massRequired                        , spinRequired               , &
@@ -258,6 +261,7 @@ contains
     type            (integrator                     )                                   :: integratorMass                      , integratorSpin             , &
          &                                                                                 integratorMassSpin                  , integratorProduct
     logical                                                                             :: retabulate                          , fixedPoint
+    type            (rangeLattice)                                    :: lattice
     integer                                                                             :: iSpin                               , iMass
     double precision                                                                    :: spinMeasured                        , massMeasured               , &
          &                                                                                 densityRatioInternalToSurface       , massError                  , &
@@ -361,11 +365,24 @@ contains
        self%massCount=    1
        self%massDelta=    0.0d0
     else
-       self%massCount=int(log10(self%massMaximum/self%massMinimum)*dble(massPointsPerDecade))+1
-       self%massDelta=    log10(self%massMaximum/self%massMinimum)/dble(self%massCount-1)
+       ! Pin the mass range to an absolute lattice. Previously the spacing was derived from the range - `log10(max/min)`
+       ! divided by one less than a count which was itself rounded down from that ratio - so the resolution, and with it every
+       ! tabulated value, shifted slightly whenever the range grew. On the lattice the spacing is exactly one step per
+       ! `massPointsPerDecade`, and the bounds take only discrete values, so the grid depends solely on which anchored
+       ! intervals the request fell in. No further margin is applied: the factors of two above have already provided one.
+       lattice         =Range_Pinned([self%massMinimum,self%massMaximum],massPointsPerDecade,gridSchemePerDecade,marginFactor=1.0d0)
+       self%massMinimum=lattice%minimum()
+       self%massMaximum=lattice%maximum()
+       self%massCount  =lattice%count
+       self%massDelta  =1.0d0/dble(massPointsPerDecade)
     end if
-    self   %spinCount=int(log10(self%spinMaximum/self%spinMinimum)*dble(spinPointsPerDecade))+1
-    self   %spinDelta=    log10(self%spinMaximum/self%spinMinimum)/dble(self%spinCount-1)
+    ! As for the mass axis. Note that neither lattice is unioned with one previously in use: the fixed-point path replaces
+    ! `massMinimum` outright rather than widening it, so the mass range is not monotonic across successive fixed points.
+    lattice          =Range_Pinned([self%spinMinimum,self%spinMaximum],spinPointsPerDecade,gridSchemePerDecade,marginFactor=1.0d0)
+    self   %spinMinimum=lattice%minimum()
+    self   %spinMaximum=lattice%maximum()
+    self   %spinCount  =lattice%count
+    self   %spinDelta  =1.0d0/dble(spinPointsPerDecade)
     allocate(self%distributionTable(self%massCount,self%spinCount))
     ! Build a work node.
     node                  => treeNode                  (                 )

--- a/source/dark_matter_halos/spins/distributions/N-body_errors.F90
+++ b/source/dark_matter_halos/spins/distributions/N-body_errors.F90
@@ -261,7 +261,7 @@ contains
     type            (integrator                     )                                   :: integratorMass                      , integratorSpin             , &
          &                                                                                 integratorMassSpin                  , integratorProduct
     logical                                                                             :: retabulate                          , fixedPoint
-    type            (rangeLattice)                                    :: lattice
+    type            (rangeLattice                   )                                   :: lattice
     integer                                                                             :: iSpin                               , iMass
     double precision                                                                    :: spinMeasured                        , massMeasured               , &
          &                                                                                 densityRatioInternalToSurface       , massError                  , &
@@ -334,6 +334,13 @@ contains
     else
        retabulate=.true.
        if (fixedPoint) then
+          ! Record the fixed point. The branch above, taken once a table exists, sets these when it finds them changed - but on
+          ! the first call there is no table to compare against, and without setting them here the tabulation below is built at
+          ! whatever `massMinimum` the defaults left, not at the mass requested, and the fixed spin is never recorded at all.
+          ! The first evaluation for a fresh object then returned a distribution for the wrong halo mass, and the second - which
+          ! found the mismatch and rebuilt - returned a different answer for identical arguments.
+          self%massMinimum=massFixed
+          self%spinFixed  =spinFixed
           self%spinMinimum=min(self%spinMinimum,0.5d0*spinFixed)
           self%spinMaximum=max(self%spinMaximum,2.0d0*spinFixed)
           if (present(spinFixedMeasuredMinimum)) then

--- a/source/hot_halo/mass_distribution/cored/core_radius/growing.F90
+++ b/source/hot_halo/mass_distribution/cored/core_radius/growing.F90
@@ -17,12 +17,15 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   An implementation of the hot halo mass distribution core radius class in which the core grows as the hot halo content is depleted.
   !!}
 
   use :: Cosmology_Parameters   , only : cosmologyParametersClass
   use :: Dark_Matter_Halo_Scales, only : darkMatterHaloScaleClass
+  use :: Numerical_Ranges       , only : rangeLattice
   use :: Tables                 , only : table1D                 , table1DLogarithmicLinear
 
   !![
@@ -41,6 +44,7 @@
      class           (darkMatterHaloScaleClass), pointer     :: darkMatterHaloScale_            => null()
      double precision                                        :: coreRadiusOverScaleRadius                 , coreRadiusOverVirialRadiusMaximum
      double precision                                        :: coreRadiusMaximum                         , coreRadiusMinimum
+     type            (rangeLattice                    )      :: coreRadiusLattice
      double precision                                        :: hotGasFractionSaved                       , coreRadiusOverVirialRadiusInitialSaved, &
           &                                                     coreRadiusOverVirialRadiusSaved
      integer                                                 :: coreRadiusTableCount
@@ -61,6 +65,9 @@
   end interface hotHaloMassDistributionCoreRadiusGrowing
 
   integer, parameter :: tablePointsPerDecade=100
+
+  ! Interval, in lattice steps, to which the lower bound of the core radius tabulation is pinned - tenths of a decade.
+  integer, parameter :: tableAnchorEvery    =tablePointsPerDecade/10
 
 contains
 
@@ -150,6 +157,7 @@ contains
     Return the core radius of the hot halo mass distribution.
     !!}
     use :: Galacticus_Nodes, only : nodeComponentBasic, nodeComponentDarkMatterProfile, nodeComponentHotHalo, treeNode
+    use :: Numerical_Ranges, only : Range_Pinned      , gridSchemePerDecade
     implicit none
     class           (hotHaloMassDistributionCoreRadiusGrowing), intent(inout) :: self
     type            (treeNode                                ), intent(inout) :: node
@@ -158,6 +166,7 @@ contains
     class           (nodeComponentDarkMatterProfile          ), pointer       :: darkMatterProfile
     double precision                                                          :: hotGasFraction                   , coreRadiusOverVirialRadius, &
          &                                                                       coreRadiusOverVirialRadiusInitial, targetValue
+    type            (rangeLattice                            )                :: lattice
     logical                                                                   :: makeTable
 
     ! Get components.
@@ -188,10 +197,31 @@ contains
          &       )                                                                                  &
          & ) then
        ! Create a tabulation of core radius vs. virial density factor if necessary.
+       ! Find the range to tabulate, pinned to an absolute lattice, so that the tabulation depends only on which anchored
+       ! interval the requested core radius fell in rather than on that radius itself.
+       !
+       ! Only the *lower* bound is taken from the lattice. The upper bound is fixed by the parameter
+       ! `coreRadiusOverVirialRadiusMaximum` and so never varies, needing no pinning - and must not be pinned: snapping it onto
+       ! a lattice point would move it inward, below the maximum core radius that parameter is documented to set.
+       !
+       ! The table is rebuilt rather than extended. It is deliberately built in *descending* order - which is why the guard
+       ! below tests `%x(-1)`, its lower bound - and `extend` builds ascending, which would invert it and with it the inverse
+       ! table and the bound tests which use it. Nothing is lost by rebuilding: the tabulated function is a single elementwise
+       ! analytic expression, so recomputing it is far cheaper than the tabulation machinery it would replace.
+       lattice=Range_Pinned(                                                                            &
+            &                              coreRadiusOverVirialRadiusInitial                          , &
+            &                              tablePointsPerDecade                                       , &
+            &                              gridSchemePerDecade                                        , &
+            &               rangeCurrent  =[self%coreRadiusOverScaleRadius,                              &
+            &                               self%coreRadiusOverVirialRadiusMaximum]                    , &
+            &               latticeCurrent=self%coreRadiusLattice                                      , &
+            &               anchorEvery   =tableAnchorEvery                                              &
+            &              )
        makeTable=.not.self%coreRadiusTableInitialized
-       if (.not.makeTable) makeTable=(coreRadiusOverVirialRadiusInitial < self%coreRadiusTable%x(-1))
+       if (.not.makeTable) makeTable=.not.self%coreRadiusLattice%covers(lattice)
        if (makeTable) then
-          self%coreRadiusMinimum   =min(self%coreRadiusOverScaleRadius,coreRadiusOverVirialRadiusInitial)
+          self%coreRadiusLattice   =lattice
+          self%coreRadiusMinimum   =lattice%minimum()
           self%coreRadiusMaximum   =self%coreRadiusOverVirialRadiusMaximum
           self%coreRadiusTableCount=int(log10(self%coreRadiusMaximum/self%coreRadiusMinimum)*dble(tablePointsPerDecade))+1
           call self%coreRadiusTable%destroy (                                                                       )

--- a/source/hot_halo/mass_distribution/cored/core_radius/growing.F90
+++ b/source/hot_halo/mass_distribution/cored/core_radius/growing.F90
@@ -208,14 +208,14 @@ contains
        ! below tests `%x(-1)`, its lower bound - and `extend` builds ascending, which would invert it and with it the inverse
        ! table and the bound tests which use it. Nothing is lost by rebuilding: the tabulated function is a single elementwise
        ! analytic expression, so recomputing it is far cheaper than the tabulation machinery it would replace.
-       lattice=Range_Pinned(                                                                            &
-            &                              coreRadiusOverVirialRadiusInitial                          , &
-            &                              tablePointsPerDecade                                       , &
-            &                              gridSchemePerDecade                                        , &
-            &               rangeCurrent  =[self%coreRadiusOverScaleRadius,                              &
-            &                               self%coreRadiusOverVirialRadiusMaximum]                    , &
-            &               latticeCurrent=self%coreRadiusLattice                                      , &
-            &               anchorEvery   =tableAnchorEvery                                              &
+       lattice=Range_Pinned(                                                         &
+            &                              coreRadiusOverVirialRadiusInitial       , &
+            &                              tablePointsPerDecade                    , &
+            &                              gridSchemePerDecade                     , &
+            &               rangeCurrent  =[self%coreRadiusOverScaleRadius         , &
+            &                               self%coreRadiusOverVirialRadiusMaximum], &
+            &               latticeCurrent=self%coreRadiusLattice                  , &
+            &               anchorEvery   =tableAnchorEvery                          &
             &              )
        makeTable=.not.self%coreRadiusTableInitialized
        if (.not.makeTable) makeTable=.not.self%coreRadiusLattice%covers(lattice)

--- a/source/mass_distributions/cylindrical/exponential_disk.F90
+++ b/source/mass_distributions/cylindrical/exponential_disk.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   Implementation of an exponential disk mass distribution class.
   !!}
@@ -43,8 +45,6 @@
           &                                                                     rotationCurveGradientInitialized      =.false., potentialInitialized                  =.false., &
           &                                                                     accelerationInitialized               =.false.
      double precision                                                        :: scaleLengthFactor
-     double precision                                                        :: rotationCurveHalfRadiusMinimum                , rotationCurveHalfRadiusMaximum
-     double precision                                                        :: rotationCurveGradientHalfRadiusMinimum        , rotationCurveGradientHalfRadiusMaximum
      type            (table1DLogarithmicLinear)                              :: rotationCurveTable                            , rotationCurveGradientTable                    , &
           &                                                                     potentialTable
      double precision                          , allocatable, dimension(:  ) :: accelerationRadii                             , accelerationHeights
@@ -109,6 +109,10 @@
   integer         , parameter :: potentialPointsPerDecade=10
   double precision, parameter :: potentialRadiusMinimum  =1.0d-3
   double precision, parameter :: potentialRadiusMaximum  =5.0d+2
+
+  ! Seed range for the rotation curve tabulations. Every range begins from this one, so that any two tabulations - built in
+  ! different runs, at different requested half-radii - overlap and can be merged onto the common lattice.
+  double precision, parameter :: rotationCurveHalfRadiusMinimumDefault=1.0d-6, rotationCurveHalfRadiusMaximumDefault=1.0d+1
 
 contains
 
@@ -205,7 +209,6 @@ contains
     logical                                          , intent(in   ), optional :: dimensionless
     type            (enumerationComponentTypeType   ), intent(in   ), optional :: componentType
     type            (enumerationMassTypeType        ), intent(in   ), optional :: massType
-    double precision                                 , parameter               :: rotationCurveHalfRadiusMaximumDefault=1.0d+1, rotationCurveHalfRadiusMinimumDefault=1.0d-6
     !![
     <constructorAssign variables="componentType, massType"/>
     !!]
@@ -247,10 +250,6 @@ contains
        self%densityNormalization=0.0d0
     end if
     ! Initialize rotation curve tables.
-    self%rotationCurveHalfRadiusMinimum        =rotationCurveHalfRadiusMinimumDefault
-    self%rotationCurveHalfRadiusMaximum        =rotationCurveHalfRadiusMaximumDefault
-    self%rotationCurveGradientHalfRadiusMinimum=rotationCurveHalfRadiusMinimumDefault
-    self%rotationCurveGradientHalfRadiusMaximum=rotationCurveHalfRadiusMaximumDefault
     self%scaleLengthFactorSet                  =.false.
     self%rotationCurveInitialized              =.false.
     self%rotationCurveGradientInitialized      =.false.
@@ -679,14 +678,16 @@ contains
     !!}
     use :: Bessel_Functions        , only : Bessel_Function_I0, Bessel_Function_I1, Bessel_Function_K0, Bessel_Function_K1
     use :: Numerical_Constants_Math, only : eulersConstant    , ln2
+    use :: Numerical_Ranges        , only : Range_Pinned      , rangeLattice      , gridSchemePerDecade
     implicit none
-    class           (massDistributionExponentialDisk), intent(inout) :: self
-    double precision                                 , intent(in   ) :: halfRadius
-    double precision                                 , parameter     :: halfRadiusSmall             =1.0d-3
-    integer                                          , parameter     :: rotationCurvePointsPerDecade=100
-    integer                                                          :: iPoint                             , rotationCurvePointsCount
-    double precision                                                 :: x
-    logical                                                          :: makeTable
+    class           (massDistributionExponentialDisk), intent(inout)               :: self
+    double precision                                 , intent(in   )               :: halfRadius
+    double precision                                 , parameter                   :: halfRadiusSmall             =1.0d-3
+    integer                                          , parameter                   :: rotationCurvePointsPerDecade=100
+    integer                                                                        :: iPoint
+    double precision                                                               :: x
+    type            (rangeLattice                   )                              :: lattice
+    logical                                                         , allocatable, dimension(:) :: isComputed
 
     ! For small half-radii, use a series expansion for a more accurate result.
     if (halfRadius <= 0.0d0) then
@@ -696,24 +697,23 @@ contains
        exponentialDiskBesselFactorRotationCurve=(ln2-eulersConstant-0.5d0-log(halfRadius))*halfRadius**2
        return
     end if
-    if (.not.self%rotationCurveInitialized) then
-       makeTable=.true.
-    else
-       makeTable= halfRadius < self%rotationCurveTable%x(+1) &
-         &       .or.                                        &
-         &        halfRadius > self%rotationCurveTable%x(-1)
-    end if
-    if (makeTable) then
-       ! Find the minimum and maximum half-radii to tabulate.
-       self%rotationCurveHalfRadiusMinimum=min(self%rotationCurveHalfRadiusMinimum,0.5d0*halfRadius)
-       self%rotationCurveHalfRadiusMaximum=max(self%rotationCurveHalfRadiusMaximum,2.0d0*halfRadius)
-       ! Determine how many points to tabulate.
-       rotationCurvePointsCount=int(log10(self%rotationCurveHalfRadiusMaximum/self%rotationCurveHalfRadiusMinimum)*dble(rotationCurvePointsPerDecade))+1
-       ! Allocate table arrays.
-       call self%rotationCurveTable%destroy()
-       call self%rotationCurveTable%create(self%rotationCurveHalfRadiusMinimum,self%rotationCurveHalfRadiusMaximum,rotationCurvePointsCount)
-       ! Compute Bessel factors.
-       do iPoint=1,rotationCurvePointsCount
+    ! Find the range of half-radii to tabulate, pinned to an absolute lattice so that the tabulation - and hence every value
+    ! interpolated from it - is independent of the half-radius at which it happened to be first requested, and so that it can be
+    ! extended without recomputing any value already found. The safety margin which `Range_Pinned` applies by default is a factor
+    ! of two at each end, which is the margin this tabulation always used.
+    lattice=Range_Pinned(                                                                                       &
+         &                              halfRadius                                                            , &
+         &                              rotationCurvePointsPerDecade                                          , &
+         &                              gridSchemePerDecade                                                   , &
+         &               rangeCurrent  =[rotationCurveHalfRadiusMinimumDefault,rotationCurveHalfRadiusMaximumDefault], &
+         &               latticeCurrent=self%rotationCurveTable%lattice                                          &
+         &              )
+    if (.not.self%rotationCurveInitialized.or..not.self%rotationCurveTable%lattice%covers(lattice)) then
+       ! Extend the tabulation onto the new lattice, preserving every value already computed.
+       call self%rotationCurveTable%extend(lattice,isComputed)
+       ! Compute Bessel factors, skipping any point whose value was preserved by the extension.
+       do iPoint=1,lattice%count
+          if (isComputed(iPoint)) cycle
           x=self%rotationCurveTable%x(iPoint)
           call self%rotationCurveTable%populate(                                               &
                &                                +x**2                                          &
@@ -738,14 +738,17 @@ contains
     !!}
     use :: Bessel_Functions        , only : Bessel_Function_I0, Bessel_Function_I1, Bessel_Function_K0, Bessel_Function_K1
     use :: Numerical_Constants_Math, only : eulersConstant    , ln2
+    use :: Numerical_Ranges        , only : Range_Pinned      , rangeLattice      , gridSchemePerDecade
     implicit none
-    class           (massDistributionExponentialDisk), intent(inout) :: self
-    double precision                                 , intent(in   ) :: halfRadius
-    double precision                                 , parameter     :: halfRadiusSmall                     =1.0d-3
-    double precision                                 , parameter     :: halfRadiusLarge                     =1.0d+2
-    integer                                          , parameter     :: rotationCurveGradientPointsPerDecade=100
-    integer                                                          :: iPoint                                      , rotationCurveGradientPointsCount
-    double precision                                                 :: x
+    class           (massDistributionExponentialDisk), intent(inout)                            :: self
+    double precision                                 , intent(in   )                            :: halfRadius
+    double precision                                 , parameter                                :: halfRadiusSmall                     =1.0d-3
+    double precision                                 , parameter                                :: halfRadiusLarge                     =1.0d+2
+    integer                                          , parameter                                :: rotationCurveGradientPointsPerDecade=100
+    integer                                                                                     :: iPoint
+    double precision                                                                            :: x
+    type            (rangeLattice                   )                                           :: lattice
+    logical                                                          , allocatable, dimension(:) :: isComputed
 
     ! For small and large half-radii, use a series expansion for a more accurate result.
     if (halfRadius == 0.0d0) then
@@ -759,23 +762,21 @@ contains
        exponentialDiskBesselFactorRotationCurveGradient=-0.125d0-27.0d0/64.0d0/halfRadius**2
        return
     end if
-    if     (                                                    &
-         &   .not.self%rotationCurveGradientInitialized         &
-         &  .or.                                                &
-         &   halfRadius < self%rotationCurveGradientTable%x(+1) &
-         &  .or.                                                &
-         &   halfRadius > self%rotationCurveGradientTable%x(-1) &
-         & ) then
-       ! Find the minimum and maximum half-radii to tabulate.
-       self%rotationCurveGradientHalfRadiusMinimum=min(self%rotationCurveGradientHalfRadiusMinimum,0.5d0*halfRadius)
-       self%rotationCurveGradientHalfRadiusMaximum=max(self%rotationCurveGradientHalfRadiusMaximum,2.0d0*halfRadius)
-       ! Determine how many points to tabulate.
-       rotationCurveGradientPointsCount=int(log10(self%rotationCurveGradientHalfRadiusMaximum/self%rotationCurveGradientHalfRadiusMinimum)*dble(rotationCurveGradientPointsPerDecade))+1
-       ! Allocate table arrays.
-       call self%rotationCurveGradientTable%destroy()
-       call self%rotationCurveGradientTable%create(self%rotationCurveGradientHalfRadiusMinimum,self%rotationCurveGradientHalfRadiusMaximum,rotationCurveGradientPointsCount)
-       ! Compute Bessel factors.
-       do iPoint=1,rotationCurveGradientPointsCount
+    ! As for the rotation curve itself, pin the range to an absolute lattice so that the tabulation does not depend on the
+    ! half-radius at which it was first requested, and can be extended without recomputing any value already found.
+    lattice=Range_Pinned(                                                                                                   &
+         &                              halfRadius                                                                        , &
+         &                              rotationCurveGradientPointsPerDecade                                              , &
+         &                              gridSchemePerDecade                                                               , &
+         &               rangeCurrent  =[rotationCurveHalfRadiusMinimumDefault,rotationCurveHalfRadiusMaximumDefault]     , &
+         &               latticeCurrent=self%rotationCurveGradientTable%lattice                                             &
+         &              )
+    if (.not.self%rotationCurveGradientInitialized.or..not.self%rotationCurveGradientTable%lattice%covers(lattice)) then
+       ! Extend the tabulation onto the new lattice, preserving every value already computed.
+       call self%rotationCurveGradientTable%extend(lattice,isComputed)
+       ! Compute Bessel factors, skipping any point whose value was preserved by the extension.
+       do iPoint=1,lattice%count
+          if (isComputed(iPoint)) cycle
           x=self%rotationCurveGradientTable%x(iPoint)
           call self%rotationCurveGradientTable%populate                                      &
                &  (                                                                          &

--- a/source/mass_distributions/cylindrical/exponential_disk.F90
+++ b/source/mass_distributions/cylindrical/exponential_disk.F90
@@ -37,23 +37,23 @@
      The exponential disk mass distribution: :math:`\rho(r,z)=\rho_0 \exp(-r/r_\mathrm{s}) \hbox{sech}^2(z/z_\mathrm{s})`.
      !!}
      private
-     double precision                                                        :: scaleRadius                                   , scaleHeight                                   , &
-          &                                                                     densityNormalization                          , surfaceDensityNormalization                   , &
+     double precision                                                        :: scaleRadius                              , scaleHeight                              , &
+          &                                                                     densityNormalization                     , surfaceDensityNormalization              , &
           &                                                                     mass
      ! Tables used for rotation curves and potential.
-     logical                                                                 :: scaleLengthFactorSet                          , rotationCurveInitialized              =.false., &
-          &                                                                     rotationCurveGradientInitialized      =.false., potentialInitialized                  =.false., &
-          &                                                                     accelerationInitialized               =.false.
+     logical                                                                 :: scaleLengthFactorSet                     , rotationCurveInitialized         =.false., &
+          &                                                                     rotationCurveGradientInitialized =.false., potentialInitialized             =.false., &
+          &                                                                     accelerationInitialized          =.false.
      double precision                                                        :: scaleLengthFactor
-     type            (table1DLogarithmicLinear)                              :: rotationCurveTable                            , rotationCurveGradientTable                    , &
+     type            (table1DLogarithmicLinear)                              :: rotationCurveTable                       , rotationCurveGradientTable               , &
           &                                                                     potentialTable
-     double precision                          , allocatable, dimension(:  ) :: accelerationRadii                             , accelerationHeights
-     double precision                          , allocatable, dimension(:,:) :: accelerationRadial                            , accelerationVertical                          , &
-          &                                                                     tidalTensorRadialRadial                       , tidalTensorVerticalVertical                   , &
+     double precision                          , allocatable, dimension(:  ) :: accelerationRadii                        , accelerationHeights
+     double precision                          , allocatable, dimension(:,:) :: accelerationRadial                       , accelerationVertical                     , &
+          &                                                                     tidalTensorRadialRadial                  , tidalTensorVerticalVertical              , &
           &                                                                     tidalTensorCross
-     double precision                                                        :: accelerationRadiusMinimumLog                  , accelerationRadiusMaximumLog                  , &
-          &                                                                     accelerationHeightMinimumLog                  , accelerationHeightMaximumLog                  , &
-          &                                                                     accelerationRadiusInverseInterval             , accelerationHeightInverseInterval
+     double precision                                                        :: accelerationRadiusMinimumLog             , accelerationRadiusMaximumLog             , &
+          &                                                                     accelerationHeightMinimumLog             , accelerationHeightMaximumLog             , &
+          &                                                                     accelerationRadiusInverseInterval        , accelerationHeightInverseInterval
    contains
      !![
      <methods docformat="rst">
@@ -204,7 +204,7 @@ contains
     use :: Numerical_Constants_Math, only : Pi
     implicit none
     type            (massDistributionExponentialDisk)                          :: self
-    double precision                                 , intent(in   ), optional :: scaleRadius                                 , scaleHeight                                 , &
+    double precision                                 , intent(in   ), optional :: scaleRadius  , scaleHeight, &
          &                                                                        mass
     logical                                          , intent(in   ), optional :: dimensionless
     type            (enumerationComponentTypeType   ), intent(in   ), optional :: componentType
@@ -250,12 +250,12 @@ contains
        self%densityNormalization=0.0d0
     end if
     ! Initialize rotation curve tables.
-    self%scaleLengthFactorSet                  =.false.
-    self%rotationCurveInitialized              =.false.
-    self%rotationCurveGradientInitialized      =.false.
-    self%potentialInitialized                  =.false.
-    self%accelerationInitialized               =.false.
-    self%scaleLengthFactor                     =0.0d0
+    self%scaleLengthFactorSet            =.false.
+    self%rotationCurveInitialized        =.false.
+    self%rotationCurveGradientInitialized=.false.
+    self%potentialInitialized            =.false.
+    self%accelerationInitialized         =.false.
+    self%scaleLengthFactor               =0.0d0
     return
   end function exponentialDiskConstructorInternal
 
@@ -687,7 +687,7 @@ contains
     integer                                                                        :: iPoint
     double precision                                                               :: x
     type            (rangeLattice                   )                              :: lattice
-    logical                                                         , allocatable, dimension(:) :: isComputed
+    logical                                          , allocatable  , dimension(:) :: isComputed
 
     ! For small half-radii, use a series expansion for a more accurate result.
     if (halfRadius <= 0.0d0) then
@@ -701,12 +701,12 @@ contains
     ! interpolated from it - is independent of the half-radius at which it happened to be first requested, and so that it can be
     ! extended without recomputing any value already found. The safety margin which `Range_Pinned` applies by default is a factor
     ! of two at each end, which is the margin this tabulation always used.
-    lattice=Range_Pinned(                                                                                       &
-         &                              halfRadius                                                            , &
-         &                              rotationCurvePointsPerDecade                                          , &
-         &                              gridSchemePerDecade                                                   , &
+    lattice=Range_Pinned(                                                                                              &
+         &                              halfRadius                                                                   , &
+         &                              rotationCurvePointsPerDecade                                                 , &
+         &                              gridSchemePerDecade                                                          , &
          &               rangeCurrent  =[rotationCurveHalfRadiusMinimumDefault,rotationCurveHalfRadiusMaximumDefault], &
-         &               latticeCurrent=self%rotationCurveTable%lattice                                          &
+         &               latticeCurrent=self%rotationCurveTable%lattice                                                &
          &              )
     if (.not.self%rotationCurveInitialized.or..not.self%rotationCurveTable%lattice%covers(lattice)) then
        ! Extend the tabulation onto the new lattice, preserving every value already computed.
@@ -736,19 +736,19 @@ contains
     !!{RST
     Compute Bessel function factors appearing in the expression for a razor-thin exponential disk rotation curve gradient.
     !!}
-    use :: Bessel_Functions        , only : Bessel_Function_I0, Bessel_Function_I1, Bessel_Function_K0, Bessel_Function_K1
+    use :: Bessel_Functions        , only : Bessel_Function_I0, Bessel_Function_I1, Bessel_Function_K0 , Bessel_Function_K1
     use :: Numerical_Constants_Math, only : eulersConstant    , ln2
     use :: Numerical_Ranges        , only : Range_Pinned      , rangeLattice      , gridSchemePerDecade
     implicit none
-    class           (massDistributionExponentialDisk), intent(inout)                            :: self
-    double precision                                 , intent(in   )                            :: halfRadius
-    double precision                                 , parameter                                :: halfRadiusSmall                     =1.0d-3
-    double precision                                 , parameter                                :: halfRadiusLarge                     =1.0d+2
-    integer                                          , parameter                                :: rotationCurveGradientPointsPerDecade=100
-    integer                                                                                     :: iPoint
-    double precision                                                                            :: x
-    type            (rangeLattice                   )                                           :: lattice
-    logical                                                          , allocatable, dimension(:) :: isComputed
+    class           (massDistributionExponentialDisk), intent(inout)               :: self
+    double precision                                 , intent(in   )               :: halfRadius
+    double precision                                 , parameter                   :: halfRadiusSmall                     =1.0d-3
+    double precision                                 , parameter                   :: halfRadiusLarge                     =1.0d+2
+    integer                                          , parameter                   :: rotationCurveGradientPointsPerDecade=100
+    integer                                                                        :: iPoint
+    double precision                                                               :: x
+    type            (rangeLattice                   )                              :: lattice
+    logical                                          , allocatable  , dimension(:) :: isComputed
 
     ! For small and large half-radii, use a series expansion for a more accurate result.
     if (halfRadius == 0.0d0) then
@@ -764,12 +764,12 @@ contains
     end if
     ! As for the rotation curve itself, pin the range to an absolute lattice so that the tabulation does not depend on the
     ! half-radius at which it was first requested, and can be extended without recomputing any value already found.
-    lattice=Range_Pinned(                                                                                                   &
-         &                              halfRadius                                                                        , &
-         &                              rotationCurveGradientPointsPerDecade                                              , &
-         &                              gridSchemePerDecade                                                               , &
-         &               rangeCurrent  =[rotationCurveHalfRadiusMinimumDefault,rotationCurveHalfRadiusMaximumDefault]     , &
-         &               latticeCurrent=self%rotationCurveGradientTable%lattice                                             &
+    lattice=Range_Pinned(                                                                                              &
+         &                              halfRadius                                                                   , &
+         &                              rotationCurveGradientPointsPerDecade                                         , &
+         &                              gridSchemePerDecade                                                          , &
+         &               rangeCurrent  =[rotationCurveHalfRadiusMinimumDefault,rotationCurveHalfRadiusMaximumDefault], &
+         &               latticeCurrent=self%rotationCurveGradientTable%lattice                                        &
          &              )
     if (.not.self%rotationCurveGradientInitialized.or..not.self%rotationCurveGradientTable%lattice%covers(lattice)) then
        ! Extend the tabulation onto the new lattice, preserving every value already computed.

--- a/source/mass_distributions/spherical/Sersic.F90
+++ b/source/mass_distributions/spherical/Sersic.F90
@@ -78,15 +78,15 @@
   end interface massDistributionSersic
 
   ! Table granularity for Sersic profiles.
-  integer                        , parameter :: tablePointsPerDecade=1000
+  integer                        , parameter :: tablePointsPerDecade     =1000
 
   ! Seed range for the tabulation. Every range begins from this one, so that any two tabulations - built at different requested
   ! radii - start from a common set of bounds.
-  double precision               , parameter :: tableRadiusMinimumDefault=1.0d-3, tableRadiusMaximumDefault=1.0d+3
+  double precision               , parameter :: tableRadiusMinimumDefault=1.0d-3                 , tableRadiusMaximumDefault=1.0d+3
 
   ! Interval, in lattice steps, to which the tabulation bounds are pinned. A whole decade of this tabulation is a thousand
   ! points, each an Abel integral, so the bounds are anchored to tenths of a decade instead.
-  integer                        , parameter :: tableAnchorEvery    =tablePointsPerDecade/10
+  integer                        , parameter :: tableAnchorEvery         =tablePointsPerDecade/10
 
   ! Module scope variables used in integration and root finding.
   class  (massDistributionSersic), pointer   :: self_
@@ -487,13 +487,13 @@ contains
           ! radius fell in, not on the radius itself. Two runs which request slightly different radii falling in the same
           ! interval build identical tables. Taking the union with the lattice already in use also guarantees the range never
           ! shrinks, so this loop terminates.
-          self%tableLattice      =Range_Pinned(                                                                          &
-               &                                              radiusActual*self%table3dRadiusHalfMass                  , &
-               &                                              tablePointsPerDecade                                     , &
-               &                                              gridSchemePerDecade                                      , &
-               &                               rangeCurrent  =[tableRadiusMinimumDefault,tableRadiusMaximumDefault]    , &
-               &                               latticeCurrent=self%tableLattice                                        , &
-               &                               anchorEvery   =tableAnchorEvery                                           &
+          self%tableLattice      =Range_Pinned(                                                                      &
+               &                                              radiusActual*self%table3dRadiusHalfMass              , &
+               &                                              tablePointsPerDecade                                 , &
+               &                                              gridSchemePerDecade                                  , &
+               &                               rangeCurrent  =[tableRadiusMinimumDefault,tableRadiusMaximumDefault], &
+               &                               latticeCurrent=self%tableLattice                                    , &
+               &                               anchorEvery   =tableAnchorEvery                                       &
                &                              )
           self%tableRadiusMinimum=self%tableLattice%minimum()
           self%tableRadiusMaximum=self%tableLattice%maximum()

--- a/source/mass_distributions/spherical/Sersic.F90
+++ b/source/mass_distributions/spherical/Sersic.F90
@@ -17,11 +17,14 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   Implementation of a S\'ersic mass distribution class.
   !!}
 
   use :: Numerical_Interpolation, only : interpolator
+  use :: Numerical_Ranges       , only : rangeLattice
 
   !![
   <massDistribution name="massDistributionSersic" docformat="rst">
@@ -41,6 +44,7 @@
      logical                                                   :: tableInitialized              =.false.
      integer                                                   :: tableCount
      double precision                                          :: tableRadiusMaximum                    , tableRadiusMinimum
+     type            (rangeLattice)                            :: tableLattice
      double precision                                          :: table3dRadiusHalfMass
      double precision                                          :: table2dRadiusHalfMass
      double precision                                          :: gradientLogarithmicMassCentral
@@ -75,6 +79,14 @@
 
   ! Table granularity for Sersic profiles.
   integer                        , parameter :: tablePointsPerDecade=1000
+
+  ! Seed range for the tabulation. Every range begins from this one, so that any two tabulations - built at different requested
+  ! radii - start from a common set of bounds.
+  double precision               , parameter :: tableRadiusMinimumDefault=1.0d-3, tableRadiusMaximumDefault=1.0d+3
+
+  ! Interval, in lattice steps, to which the tabulation bounds are pinned. A whole decade of this tabulation is a thousand
+  ! points, each an Abel integral, so the bounds are anchored to tenths of a decade instead.
+  integer                        , parameter :: tableAnchorEvery    =tablePointsPerDecade/10
 
   ! Module scope variables used in integration and root finding.
   class  (massDistributionSersic), pointer   :: self_
@@ -180,8 +192,8 @@ contains
     if (present(dimensionless)) self%dimensionless=dimensionless
     ! Initialize state.
     self%tableInitialized     =.false.
-    self%tableRadiusMaximum   =1.0d+3
-    self%tableRadiusMinimum   =1.0d-3
+    self%tableRadiusMaximum   =tableRadiusMaximumDefault
+    self%tableRadiusMinimum   =tableRadiusMinimumDefault
     self%table3dRadiusHalfMass=1.0d+0
     self%index_               =index
     ! Tabulate the profile.
@@ -410,7 +422,7 @@ contains
     !!}
     use :: Numerical_Constants_Math, only : Pi
     use :: Numerical_Integration   , only : integrator
-    use :: Numerical_Ranges        , only : Make_Range                  , rangeTypeLogarithmic
+    use :: Numerical_Ranges        , only : Range_Pinned                , gridSchemePerDecade
     use :: Root_Finder             , only : rangeExpandMultiplicative   , rootFinder
     use :: Table_Labels            , only : extrapolationTypeExtrapolate
     implicit none
@@ -463,11 +475,29 @@ contains
        ! Try building the table until it has sufficient extent to encompass the requested radius.
        tableHasSufficientExtent=.false.
        do while (.not.tableHasSufficientExtent)
-          ! Find suitable radius limits.
-          self%tableRadiusMinimum=min(self%tableRadiusMinimum,0.5d0*radiusActual*self%table3dRadiusHalfMass)
-          self%tableRadiusMaximum=max(self%tableRadiusMaximum,2.0d0*radiusActual*self%table3dRadiusHalfMass)
-          ! Determine the number of points at which to tabulate the profile.
-          self%tableCount=int(log10(self%tableRadiusMaximum/self%tableRadiusMinimum)*dble(tablePointsPerDecade))+1
+          ! Find suitable radius limits, pinned to an absolute lattice. Unlike the tabulations converted elsewhere under this
+          ! issue, no previously computed value can be carried over here: the densities are Abel integrals taken out to
+          ! `radiusInfinity`, which is set from the upper bound; the enclosed masses are accumulated from the innermost radius
+          ! outwards; and both are then normalized by the enclosed mass at the outermost point. Every stored value therefore
+          ! moves whenever either bound moves, and the table is rebuilt in full below, as it always was.
+          !
+          ! What pinning buys is reproducibility. The bounds may now take only the discrete values which are lattice points a
+          ! multiple of `tableAnchorEvery` apart, so the tabulation - and every quantity derived from it, including the half mass
+          ! radius by which the abscissae are subsequently rescaled - depends only on which anchored interval the requested
+          ! radius fell in, not on the radius itself. Two runs which request slightly different radii falling in the same
+          ! interval build identical tables. Taking the union with the lattice already in use also guarantees the range never
+          ! shrinks, so this loop terminates.
+          self%tableLattice      =Range_Pinned(                                                                          &
+               &                                              radiusActual*self%table3dRadiusHalfMass                  , &
+               &                                              tablePointsPerDecade                                     , &
+               &                                              gridSchemePerDecade                                      , &
+               &                               rangeCurrent  =[tableRadiusMinimumDefault,tableRadiusMaximumDefault]    , &
+               &                               latticeCurrent=self%tableLattice                                        , &
+               &                               anchorEvery   =tableAnchorEvery                                           &
+               &                              )
+          self%tableRadiusMinimum=self%tableLattice%minimum()
+          self%tableRadiusMaximum=self%tableLattice%maximum()
+          self%tableCount        =self%tableLattice%count
           ! Allocate arrays for storing the tables.
           if (allocated(self%tableRadius)) then
              deallocate(self%tableRadius      )
@@ -479,8 +509,9 @@ contains
           allocate(self%tableDensity     (self%tableCount))
           allocate(self%tableEnclosedMass(self%tableCount))
           allocate(self%tablePotential   (self%tableCount))
-          ! Create an array of logarithmically distributed radii.
-          self%tableRadius=Make_Range(self%tableRadiusMinimum,self%tableRadiusMaximum,self%tableCount,rangeType=rangeTypeLogarithmic)
+          ! Take the abscissae from the lattice rather than by subdividing the range, so that they are bit-identical to those of
+          ! any other tabulation built on the same lattice.
+          self%tableRadius=self%tableLattice%values()
           ! Compute the coefficient appearing in the Sérsic profile.
           self%coefficient=finder%find(rootGuess=coefficientGuess)
           ! Compute a suitably large approximation to infinite radius for use in integration.

--- a/source/satellites/deceleration_SIDM/Kummer2018.F90
+++ b/source/satellites/deceleration_SIDM/Kummer2018.F90
@@ -332,16 +332,19 @@ contains
        ! Tabulate the χ_d factor.
        ! Pin both axes to absolute lattices, so that the tabulation - and every value interpolated from it - depends only on
        ! which anchored intervals the request fell in, rather than on the requested x and speed themselves. The x axis is
-       ! linear and runs from zero, so it uses the per-unit gridding scheme with its lower edge clamped there; the speed axis
+       ! linear and runs from zero, so the *whole* range [0,xMaximum] is the target - `limitMinimum` only clamps a range which
+       ! would otherwise extend below zero, it does not make one reach down to it - and its lower edge is clamped there; the
+       ! speed axis
        ! is logarithmic. Taking the union with the lattices already in use guarantees the tabulated range never shrinks.
        !
        ! The table is rebuilt rather than extended. Each entry depends only on its own two abscissae, so entries could in
        ! principle be carried over, but the computed values are held only inside the `interpolator2D` built from them and are
        ! not recoverable from it; doing so would mean storing the raw array alongside. Left as a possible follow-up.
        self%latticeX       =Range_Pinned(                                                          &
-            &                                           xMaximum                                 , &
+            &                                           [0.0d0,xMaximum]                         , &
             &                                           countPerUnit                             , &
             &                                           gridSchemePerUnit                        , &
+            &                            marginOffset  =0.0d0                                    , &
             &                            limitMinimum  =0.0d0                                    , &
             &                            latticeCurrent=self%latticeX                              &
             &                           )

--- a/source/satellites/deceleration_SIDM/Kummer2018.F90
+++ b/source/satellites/deceleration_SIDM/Kummer2018.F90
@@ -316,15 +316,15 @@ contains
     use :: Numerical_Ranges     , only : Range_Pinned                               , gridSchemePerUnit, gridSchemePerDecade
     implicit none
     class           (satelliteDecelerationSIDMKummer2018        ), intent(inout)                 :: self
-    double precision                                             , intent(in   )                 :: xMaximum                  , velocityMinimum      , &
+    double precision                                             , intent(in   )                 :: xMaximum                  , velocityMinimum   , &
          &                                                                                          velocityMaximum
     class           (darkMatterParticleSelfInteractingDarkMatter), pointer                       :: darkMatterParticleSIDM_
     double precision                                             , allocatable  , dimension(:,:) :: decelerationFactor_
     double precision                                             , allocatable  , dimension(:  ) :: x                         , velocity 
-    integer                                                      , parameter                     :: countPerUnit           =10, countPerDex=10
+    integer                                                      , parameter                     :: countPerUnit           =10, countPerDex    =10
     type            (integrator                                 )                                :: integrator_
     double precision                                                                             :: thetaCritical
-    integer                                                                                      :: i                         , j             , &
+    integer                                                                                      :: i                         , j                 , &
          &                                                                                          countX                    , countVelocity
 
     select type (darkMatterParticle_ => self%darkMatterParticle_)
@@ -340,19 +340,19 @@ contains
        ! The table is rebuilt rather than extended. Each entry depends only on its own two abscissae, so entries could in
        ! principle be carried over, but the computed values are held only inside the `interpolator2D` built from them and are
        ! not recoverable from it; doing so would mean storing the raw array alongside. Left as a possible follow-up.
-       self%latticeX       =Range_Pinned(                                                          &
-            &                                           [0.0d0,xMaximum]                         , &
-            &                                           countPerUnit                             , &
-            &                                           gridSchemePerUnit                        , &
-            &                            marginOffset  =0.0d0                                    , &
-            &                            limitMinimum  =0.0d0                                    , &
-            &                            latticeCurrent=self%latticeX                              &
+       self%latticeX       =Range_Pinned(                                                  &
+            &                                           [0.0d0,xMaximum]                 , &
+            &                                           countPerUnit                     , &
+            &                                           gridSchemePerUnit                , &
+            &                            marginOffset  =0.0d0                            , &
+            &                            limitMinimum  =0.0d0                            , &
+            &                            latticeCurrent=self%latticeX                      &
             &                           )
-       self%latticeVelocity=Range_Pinned(                                                          &
-            &                                           [velocityMinimum,velocityMaximum]        , &
-            &                                           countPerDex                              , &
-            &                                           gridSchemePerDecade                      , &
-            &                            latticeCurrent=self%latticeVelocity                       &
+       self%latticeVelocity=Range_Pinned(                                                  &
+            &                                           [velocityMinimum,velocityMaximum], &
+            &                                           countPerDex                      , &
+            &                                           gridSchemePerDecade              , &
+            &                            latticeCurrent=self%latticeVelocity               &
             &                           )
        self%xMaximum       =self%latticeX       %maximum()
        self%velocityMaximum=self%latticeVelocity%maximum()

--- a/source/satellites/deceleration_SIDM/Kummer2018.F90
+++ b/source/satellites/deceleration_SIDM/Kummer2018.F90
@@ -28,6 +28,7 @@
   use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMOClass
   use :: Dark_Matter_Halo_Scales , only : darkMatterHaloScaleClass
   use :: Numerical_Interpolation , only : interpolator2D
+  use :: Numerical_Ranges        , only : rangeLattice
 
   !![
   <satelliteDecelerationSIDM name="satelliteDecelerationSIDMKummer2018" docformat="rst">
@@ -49,6 +50,7 @@
      double precision                                         :: rateScatteringNormalization          , xMaximum       , &
           &                                                      velocityMinimum                      , velocityMaximum, &
           &                                                      fractionDarkMatter
+     type            (rangeLattice             )              :: latticeX                             , latticeVelocity
    contains
      !![
      <methods docformat="rst">
@@ -311,7 +313,7 @@ contains
     !!}
     use :: Dark_Matter_Particles, only : darkMatterParticleSelfInteractingDarkMatter
     use :: Numerical_Integration, only : integrator
-    use :: Numerical_Ranges     , only : Make_Range                                 , rangeTypeLinear, rangeTypeLogarithmic
+    use :: Numerical_Ranges     , only : Range_Pinned                               , gridSchemePerUnit, gridSchemePerDecade
     implicit none
     class           (satelliteDecelerationSIDMKummer2018        ), intent(inout)                 :: self
     double precision                                             , intent(in   )                 :: xMaximum                  , velocityMinimum      , &
@@ -328,16 +330,37 @@ contains
     select type (darkMatterParticle_ => self%darkMatterParticle_)
     class is (darkMatterParticleSelfInteractingDarkMatter)
        ! Tabulate the χ_d factor.
-       self%xMaximum=xMaximum
-       self%velocityMaximum=velocityMaximum
-       self%velocityMinimum=velocityMinimum
-       countX       =int(      xMaximum          *dble(countPerUnit))+1
-       countVelocity       =int(log10(velocityMaximum/velocityMinimum)*     countPerDex  )+1
+       ! Pin both axes to absolute lattices, so that the tabulation - and every value interpolated from it - depends only on
+       ! which anchored intervals the request fell in, rather than on the requested x and speed themselves. The x axis is
+       ! linear and runs from zero, so it uses the per-unit gridding scheme with its lower edge clamped there; the speed axis
+       ! is logarithmic. Taking the union with the lattices already in use guarantees the tabulated range never shrinks.
+       !
+       ! The table is rebuilt rather than extended. Each entry depends only on its own two abscissae, so entries could in
+       ! principle be carried over, but the computed values are held only inside the `interpolator2D` built from them and are
+       ! not recoverable from it; doing so would mean storing the raw array alongside. Left as a possible follow-up.
+       self%latticeX       =Range_Pinned(                                                          &
+            &                                           xMaximum                                 , &
+            &                                           countPerUnit                             , &
+            &                                           gridSchemePerUnit                        , &
+            &                            limitMinimum  =0.0d0                                    , &
+            &                            latticeCurrent=self%latticeX                              &
+            &                           )
+       self%latticeVelocity=Range_Pinned(                                                          &
+            &                                           [velocityMinimum,velocityMaximum]        , &
+            &                                           countPerDex                              , &
+            &                                           gridSchemePerDecade                      , &
+            &                            latticeCurrent=self%latticeVelocity                       &
+            &                           )
+       self%xMaximum       =self%latticeX       %maximum()
+       self%velocityMaximum=self%latticeVelocity%maximum()
+       self%velocityMinimum=self%latticeVelocity%minimum()
+       countX       =self%latticeX       %count
+       countVelocity=self%latticeVelocity%count
        allocate(x                  (countX       ))
        allocate(velocity                  (       countVelocity))
        allocate(decelerationFactor_(countX,countVelocity))
-       x                       =  Make_Range(0.0d0   ,xMaximum,countX,rangeTypeLinear     )
-       velocity                       =  Make_Range(velocityMinimum,velocityMaximum,countVelocity,rangeTypeLogarithmic)
+       x           =self%latticeX       %values()
+       velocity    =self%latticeVelocity%values()
        darkMatterParticleSIDM_ => darkMatterParticle_
        integrator_             =  integrator(integrandDecelerationFactor,toleranceAbsolute=1.0d-6,toleranceRelative=1.0d-3)
        do i=1,countX

--- a/source/satellites/evaporation_SIDM/Kummer2018.F90
+++ b/source/satellites/evaporation_SIDM/Kummer2018.F90
@@ -28,6 +28,7 @@
   use :: Dark_Matter_Profiles_DMO, only : darkMatterProfileDMOClass
   use :: Dark_Matter_Halo_Scales , only : darkMatterHaloScaleClass
   use :: Numerical_Interpolation , only : interpolator2D
+  use :: Numerical_Ranges        , only : rangeLattice
 
   !![
   <satelliteEvaporationSIDM name="satelliteEvaporationSIDMKummer2018" docformat="rst">
@@ -49,6 +50,7 @@
      double precision                                         :: rateScatteringNormalization          , xMaximum       , &
           &                                                      velocityMinimum                      , velocityMaximum, &
           &                                                      fractionDarkMatter
+     type            (rangeLattice             )              :: latticeX                             , latticeVelocity
    contains
      !![
      <methods docformat="rst">
@@ -306,7 +308,7 @@ contains
     !!}
     use :: Dark_Matter_Particles   , only : darkMatterParticleSelfInteractingDarkMatter
     use :: Numerical_Integration   , only : integrator
-    use :: Numerical_Ranges        , only : Make_Range                                 , rangeTypeLinear, rangeTypeLogarithmic
+    use :: Numerical_Ranges        , only : Range_Pinned                               , gridSchemePerUnit, gridSchemePerDecade
     use :: Numerical_Constants_Math, only : Pi
     use :: Error                   , only : Error_Report
     implicit none
@@ -325,16 +327,37 @@ contains
     select type (darkMatterParticle_ => self%darkMatterParticle_)
     class is (darkMatterParticleSelfInteractingDarkMatter)
        ! Tabulate the χ_d factor.
-       self%xMaximum=xMaximum
-       self%velocityMaximum=velocityMaximum
-       self%velocityMinimum=velocityMinimum
-       countX       =int(      xMaximum                        *dble(countPerUnit))+1
-       countVelocity=int(log10(velocityMaximum/velocityMinimum)*     countPerDex  )+1
+       ! Pin both axes to absolute lattices, so that the tabulation - and every value interpolated from it - depends only on
+       ! which anchored intervals the request fell in, rather than on the requested x and speed themselves. The x axis is
+       ! linear and runs from zero, so it uses the per-unit gridding scheme with its lower edge clamped there; the speed axis
+       ! is logarithmic. Taking the union with the lattices already in use guarantees the tabulated range never shrinks.
+       !
+       ! The table is rebuilt rather than extended. Each entry depends only on its own two abscissae, so entries could in
+       ! principle be carried over, but the computed values are held only inside the `interpolator2D` built from them and are
+       ! not recoverable from it; doing so would mean storing the raw array alongside. Left as a possible follow-up.
+       self%latticeX       =Range_Pinned(                                                          &
+            &                                           xMaximum                                 , &
+            &                                           countPerUnit                             , &
+            &                                           gridSchemePerUnit                        , &
+            &                            limitMinimum  =0.0d0                                    , &
+            &                            latticeCurrent=self%latticeX                              &
+            &                           )
+       self%latticeVelocity=Range_Pinned(                                                          &
+            &                                           [velocityMinimum,velocityMaximum]        , &
+            &                                           countPerDex                              , &
+            &                                           gridSchemePerDecade                      , &
+            &                            latticeCurrent=self%latticeVelocity                       &
+            &                           )
+       self%xMaximum       =self%latticeX       %maximum()
+       self%velocityMaximum=self%latticeVelocity%maximum()
+       self%velocityMinimum=self%latticeVelocity%minimum()
+       countX       =self%latticeX       %count
+       countVelocity=self%latticeVelocity%count
        allocate(x                 (countX              ))
        allocate(velocity          (       countVelocity))
        allocate(evaporationFactor_(countX,countVelocity))
-       x                       =  Make_Range(0.0d0          ,xMaximum       ,countX       ,rangeTypeLinear     )
-       velocity                =  Make_Range(velocityMinimum,velocityMaximum,countVelocity,rangeTypeLogarithmic)
+       x           =self%latticeX       %values()
+       velocity    =self%latticeVelocity%values()
        darkMatterParticleSIDM_ => darkMatterParticle_
        integrator_             =  integrator(integrandEvaporationFactor,toleranceAbsolute=1.0d-6,toleranceRelative=1.0d-3)
        do i=1,countX

--- a/source/satellites/evaporation_SIDM/Kummer2018.F90
+++ b/source/satellites/evaporation_SIDM/Kummer2018.F90
@@ -337,19 +337,19 @@ contains
        ! The table is rebuilt rather than extended. Each entry depends only on its own two abscissae, so entries could in
        ! principle be carried over, but the computed values are held only inside the `interpolator2D` built from them and are
        ! not recoverable from it; doing so would mean storing the raw array alongside. Left as a possible follow-up.
-       self%latticeX       =Range_Pinned(                                                          &
-            &                                           [0.0d0,xMaximum]                         , &
-            &                                           countPerUnit                             , &
-            &                                           gridSchemePerUnit                        , &
-            &                            marginOffset  =0.0d0                                    , &
-            &                            limitMinimum  =0.0d0                                    , &
-            &                            latticeCurrent=self%latticeX                              &
+       self%latticeX       =Range_Pinned(                                                  &
+            &                                           [0.0d0,xMaximum]                 , &
+            &                                           countPerUnit                     , &
+            &                                           gridSchemePerUnit                , &
+            &                            marginOffset  =0.0d0                            , &
+            &                            limitMinimum  =0.0d0                            , &
+            &                            latticeCurrent=self%latticeX                      &
             &                           )
-       self%latticeVelocity=Range_Pinned(                                                          &
-            &                                           [velocityMinimum,velocityMaximum]        , &
-            &                                           countPerDex                              , &
-            &                                           gridSchemePerDecade                      , &
-            &                            latticeCurrent=self%latticeVelocity                       &
+       self%latticeVelocity=Range_Pinned(                                                  &
+            &                                           [velocityMinimum,velocityMaximum], &
+            &                                           countPerDex                      , &
+            &                                           gridSchemePerDecade              , &
+            &                            latticeCurrent=self%latticeVelocity               &
             &                           )
        self%xMaximum       =self%latticeX       %maximum()
        self%velocityMaximum=self%latticeVelocity%maximum()

--- a/source/satellites/evaporation_SIDM/Kummer2018.F90
+++ b/source/satellites/evaporation_SIDM/Kummer2018.F90
@@ -329,16 +329,19 @@ contains
        ! Tabulate the χ_d factor.
        ! Pin both axes to absolute lattices, so that the tabulation - and every value interpolated from it - depends only on
        ! which anchored intervals the request fell in, rather than on the requested x and speed themselves. The x axis is
-       ! linear and runs from zero, so it uses the per-unit gridding scheme with its lower edge clamped there; the speed axis
+       ! linear and runs from zero, so the *whole* range [0,xMaximum] is the target - `limitMinimum` only clamps a range which
+       ! would otherwise extend below zero, it does not make one reach down to it - and its lower edge is clamped there; the
+       ! speed axis
        ! is logarithmic. Taking the union with the lattices already in use guarantees the tabulated range never shrinks.
        !
        ! The table is rebuilt rather than extended. Each entry depends only on its own two abscissae, so entries could in
        ! principle be carried over, but the computed values are held only inside the `interpolator2D` built from them and are
        ! not recoverable from it; doing so would mean storing the raw array alongside. Left as a possible follow-up.
        self%latticeX       =Range_Pinned(                                                          &
-            &                                           xMaximum                                 , &
+            &                                           [0.0d0,xMaximum]                         , &
             &                                           countPerUnit                             , &
             &                                           gridSchemePerUnit                        , &
+            &                            marginOffset  =0.0d0                                    , &
             &                            limitMinimum  =0.0d0                                    , &
             &                            latticeCurrent=self%latticeX                              &
             &                           )

--- a/source/structure_formation/correlation_function/two_point/power_spectrum_transform.F90
+++ b/source/structure_formation/correlation_function/two_point/power_spectrum_transform.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
 !!{RST
 Implements a two-point correlation function class in which the correlation function is found by Fourier transforming a power spectrum.
 !!}
@@ -166,7 +168,7 @@ contains
     !!}
     use :: FFTLogs                 , only : FFTLogSineTransform, fftLogForward
     use :: Numerical_Constants_Math, only : Pi
-    use :: Numerical_Ranges        , only : Make_Range         , rangeTypeLogarithmic
+    use :: Numerical_Ranges        , only : Range_Pinned       , rangeLattice        , gridSchemePerDecade
     implicit none
     class           (correlationFunctionTwoPointPowerSpectrumTransform), intent(inout)             :: self
     double precision                                                   , intent(in   )             :: time                      , separation
@@ -174,6 +176,7 @@ contains
          &                                                                                            correlation               , separations
     integer                                                            , parameter                 :: wavenumbersPerDecade=125
     double precision                                                   , parameter                 :: wavenumbersRange    =1.0d4
+    type            (rangeLattice                                     )                           :: lattice
     double precision                                                                               :: wavenumberMinimum         , wavenumberMaximum, &
          &                                                                                            time_
     integer         (c_size_t                                         )                            :: countWavenumbers          , i
@@ -190,12 +193,20 @@ contains
        end if
        wavenumberMinimum=1.0d0/max(separation*wavenumbersRange,self%separationMaximum)
        wavenumberMaximum=1.0d0/min(separation/wavenumbersRange,self%separationMinimum)
-       countWavenumbers =int(log10(wavenumberMaximum/wavenumberMinimum)*dble(wavenumbersPerDecade),c_size_t)
+       ! Pin the wavenumber range to an absolute lattice, so that the transform - and therefore the correlation function it
+       ! returns - depends only on which anchored intervals the accumulated separation range fell in, rather than on the
+       ! separations at which it happened to be requested. No further margin is applied: `wavenumbersRange` above already
+       ! provides one. No value can be carried over when the range grows, and none is attempted: the grid feeds an FFTLog sine
+       ! transform, every output of which depends on the whole input grid.
+       lattice          =Range_Pinned([wavenumberMinimum,wavenumberMaximum],wavenumbersPerDecade,gridSchemePerDecade,marginFactor=1.0d0)
+       wavenumberMinimum=lattice%minimum()
+       wavenumberMaximum=lattice%maximum()
+       countWavenumbers =int(lattice%count,c_size_t)
        allocate(wavenumbers  (countWavenumbers))
        allocate(powerSpectrum(countWavenumbers))
        allocate(correlation  (countWavenumbers))
        allocate(separations  (countWavenumbers))
-       wavenumbers=Make_Range(wavenumberMinimum,wavenumberMaximum,int(countWavenumbers),rangeTypeLogarithmic)
+       wavenumbers=lattice%values()
        do i=1,countWavenumbers
           if (associated(self%powerSpectrum_)) then
              powerSpectrum(i)=self%powerSpectrum_         %power(wavenumbers(i),time_)
@@ -250,7 +261,7 @@ contains
     use :: FFTLogs                 , only : FFTLog      , fftLogForward
     use :: Numerical_Constants_Math, only : Pi
     use :: Numerical_Interpolation , only : interpolator
-    use :: Numerical_Ranges        , only : Make_Range  , rangeTypeLogarithmic
+    use :: Numerical_Ranges        , only : Range_Pinned       , rangeLattice        , gridSchemePerDecade
     implicit none
     class           (correlationFunctionTwoPointPowerSpectrumTransform), intent(inout)             :: self
     double precision                                                   , intent(in   )             :: time                      , separation
@@ -258,6 +269,7 @@ contains
          &                                                                                            correlation               , separations
     integer                                                            , parameter                 :: wavenumbersPerDecade=125
     double precision                                                   , parameter                 :: wavenumbersRange    =1.0d4
+    type            (rangeLattice                                     )                           :: lattice
     double precision                                                                               :: wavenumberMinimum         , wavenumberMaximum, &
          &                                                                                            time_
     integer         (c_size_t                                         )                            :: countWavenumbers          , i
@@ -274,12 +286,20 @@ contains
        end if
        wavenumberMinimum=1.0d0/max(separation*wavenumbersRange,self%separationMaximumVolumeAveraged)
        wavenumberMaximum=1.0d0/min(separation/wavenumbersRange,self%separationMinimumVolumeAveraged)
-       countWavenumbers =int(log10(wavenumberMaximum/wavenumberMinimum)*dble(wavenumbersPerDecade),c_size_t)
+       ! Pin the wavenumber range to an absolute lattice, so that the transform - and therefore the correlation function it
+       ! returns - depends only on which anchored intervals the accumulated separation range fell in, rather than on the
+       ! separations at which it happened to be requested. No further margin is applied: `wavenumbersRange` above already
+       ! provides one. No value can be carried over when the range grows, and none is attempted: the grid feeds an FFTLog sine
+       ! transform, every output of which depends on the whole input grid.
+       lattice          =Range_Pinned([wavenumberMinimum,wavenumberMaximum],wavenumbersPerDecade,gridSchemePerDecade,marginFactor=1.0d0)
+       wavenumberMinimum=lattice%minimum()
+       wavenumberMaximum=lattice%maximum()
+       countWavenumbers =int(lattice%count,c_size_t)
        allocate(wavenumbers  (countWavenumbers))
        allocate(powerSpectrum(countWavenumbers))
        allocate(correlation  (countWavenumbers))
        allocate(separations  (countWavenumbers))
-       wavenumbers=Make_Range(wavenumberMinimum,wavenumberMaximum,int(countWavenumbers),rangeTypeLogarithmic)
+       wavenumbers=lattice%values()
        do i=1,countWavenumbers
           if (associated(self%powerSpectrum_)) then
              powerSpectrum(i)=self%powerSpectrum_         %power(wavenumbers(i),time_)

--- a/source/structure_formation/correlation_function/two_point/power_spectrum_transform.F90
+++ b/source/structure_formation/correlation_function/two_point/power_spectrum_transform.F90
@@ -168,7 +168,7 @@ contains
     !!}
     use :: FFTLogs                 , only : FFTLogSineTransform, fftLogForward
     use :: Numerical_Constants_Math, only : Pi
-    use :: Numerical_Ranges        , only : Range_Pinned       , rangeLattice        , gridSchemePerDecade
+    use :: Numerical_Ranges        , only : Range_Pinned       , rangeLattice , gridSchemePerDecade
     implicit none
     class           (correlationFunctionTwoPointPowerSpectrumTransform), intent(inout)             :: self
     double precision                                                   , intent(in   )             :: time                      , separation
@@ -261,7 +261,7 @@ contains
     use :: FFTLogs                 , only : FFTLog      , fftLogForward
     use :: Numerical_Constants_Math, only : Pi
     use :: Numerical_Interpolation , only : interpolator
-    use :: Numerical_Ranges        , only : Range_Pinned       , rangeLattice        , gridSchemePerDecade
+    use :: Numerical_Ranges        , only : Range_Pinned, rangeLattice , gridSchemePerDecade
     implicit none
     class           (correlationFunctionTwoPointPowerSpectrumTransform), intent(inout)             :: self
     double precision                                                   , intent(in   )             :: time                      , separation
@@ -269,7 +269,7 @@ contains
          &                                                                                            correlation               , separations
     integer                                                            , parameter                 :: wavenumbersPerDecade=125
     double precision                                                   , parameter                 :: wavenumbersRange    =1.0d4
-    type            (rangeLattice                                     )                           :: lattice
+    type            (rangeLattice                                     )                            :: lattice
     double precision                                                                               :: wavenumberMinimum         , wavenumberMaximum, &
          &                                                                                            time_
     integer         (c_size_t                                         )                            :: countWavenumbers          , i

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui.F90
@@ -184,7 +184,7 @@ contains
        ! lattice points. The variance axis is linear and runs from zero, so it uses the per-unit scheme with its lower edge
        ! clamped there.
        self%varianceMaximum   =max(self%varianceMaximum,variance)
-       latticeVariance        =Range_Pinned(self%varianceMaximum,varianceTableNumberPerUnit,gridSchemePerUnit,marginOffset=0.0d0,limitMinimum=0.0d0)
+       latticeVariance        =Range_Pinned([0.0d0,self%varianceMaximum],varianceTableNumberPerUnit,gridSchemePerUnit,marginOffset=0.0d0,limitMinimum=0.0d0)
        self%varianceMaximum   =latticeVariance%maximum()
        self%varianceTableCount=latticeVariance%count-1
        if (self%tableInitialized) then

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui.F90
@@ -149,10 +149,10 @@ contains
     !!{RST
     Return the excursion set barrier at the given variance and time.
     !!}
-    use            :: Display          , only : displayCounter       , displayCounterClear, displayIndent       , displayUnindent, &
-          &                                     verbosityLevelWorking
-    use, intrinsic :: ISO_C_Binding    , only : c_size_t
-    use            :: Numerical_Ranges , only : Range_Pinned         , rangeLattice       , gridSchemePerUnit, gridSchemePerDecade
+    use            :: Display         , only : displayCounter       , displayCounterClear, displayIndent    , displayUnindent    , &
+          &                                    verbosityLevelWorking
+    use, intrinsic :: ISO_C_Binding   , only : c_size_t
+    use            :: Numerical_Ranges, only : Range_Pinned         , rangeLattice       , gridSchemePerUnit, gridSchemePerDecade
     implicit none
     class           (excursionSetFirstCrossingZhangHui), intent(inout)  :: self
     double precision                                   , intent(in   )  :: variance         , time

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   Implements a excursion set first crossing statistics class utilizing the algorithm of :cite:t:`zhang_random_2006`.
   !!}
@@ -150,13 +152,14 @@ contains
     use            :: Display          , only : displayCounter       , displayCounterClear, displayIndent       , displayUnindent, &
           &                                     verbosityLevelWorking
     use, intrinsic :: ISO_C_Binding    , only : c_size_t
-    use            :: Numerical_Ranges , only : Make_Range           , rangeTypeLinear    , rangeTypeLogarithmic
+    use            :: Numerical_Ranges , only : Range_Pinned         , rangeLattice       , gridSchemePerUnit, gridSchemePerDecade
     implicit none
     class           (excursionSetFirstCrossingZhangHui), intent(inout)  :: self
     double precision                                   , intent(in   )  :: variance         , time
     type            (treeNode                         ), intent(inout)  :: node
     double precision                                   , dimension(0:1) :: hTime            , hVariance
     logical                                                             :: makeTable
+    type            (rangeLattice                     )                 :: latticeVariance  , latticeTime
     integer         (c_size_t                         )                 :: iTime            , iVariance
     integer                                                             :: i                , j        , &
          &                                                                 jTime            , jVariance
@@ -175,8 +178,15 @@ contains
        if (allocated(self%varianceTable                )) deallocate(self%varianceTable                )
        if (allocated(self%timeTable                    )) deallocate(self%timeTable                    )
        if (allocated(self%firstCrossingProbabilityTable)) deallocate(self%firstCrossingProbabilityTable)
+       ! Pin both axes to absolute lattices, so that the tabulation - and every value interpolated from it - depends only on
+       ! which anchored intervals the request fell in, not on the variance and time at which it was first built. The bounds are
+       ! already widened monotonically above, so no further margin is applied here; pinning only snaps them outward onto
+       ! lattice points. The variance axis is linear and runs from zero, so it uses the per-unit scheme with its lower edge
+       ! clamped there.
        self%varianceMaximum   =max(self%varianceMaximum,variance)
-       self%varianceTableCount=int(self%varianceMaximum*dble(varianceTableNumberPerUnit))
+       latticeVariance        =Range_Pinned(self%varianceMaximum,varianceTableNumberPerUnit,gridSchemePerUnit,marginOffset=0.0d0,limitMinimum=0.0d0)
+       self%varianceMaximum   =latticeVariance%maximum()
+       self%varianceTableCount=latticeVariance%count-1
        if (self%tableInitialized) then
           self%timeMinimum=min(self%timeMinimum,time)
           self%timeMaximum=max(self%timeMaximum,time)
@@ -184,12 +194,17 @@ contains
           self%timeMinimum=0.5d0*time
           self%timeMaximum=2.0d0*time
        end if
-       self%timeTableCount=int(log10(self%timeMaximum/self%timeMinimum)*dble(timeTableNumberPerDecade))+1
+       latticeTime        =Range_Pinned([self%timeMinimum,self%timeMaximum],timeTableNumberPerDecade,gridSchemePerDecade,marginFactor=1.0d0)
+       self%timeMinimum   =latticeTime%minimum()
+       self%timeMaximum   =latticeTime%maximum()
+       self%timeTableCount=latticeTime%count
        allocate(self%varianceTable                (0:self%varianceTableCount                    ))
        allocate(self%timeTable                    (                          self%timeTableCount))
        allocate(self%firstCrossingProbabilityTable(0:self%varianceTableCount,self%timeTableCount))
-       self%timeTable        =Make_Range(self%timeMinimum,self%timeMaximum    ,self%timeTableCount      ,rangeType=rangeTypeLogarithmic)
-       self%varianceTable    =Make_Range(0.0d0           ,self%varianceMaximum,self%varianceTableCount+1,rangeType=rangeTypeLinear     )
+       ! Take the abscissae from the lattices rather than by subdividing the ranges, so that they are bit-identical to those of
+       ! any other tabulation built on the same lattices.
+       self%timeTable        =latticeTime    %values()
+       self%varianceTable    =latticeVariance%values()
        self%varianceTableStep=+self%varianceTable(1) &
             &                 -self%varianceTable(0)
        ! Loop through the table and solve for the first crossing distribution.

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui_high_order.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui_high_order.F90
@@ -231,7 +231,8 @@ contains
        ! Pin both axes to absolute lattices, so that the tabulation depends only on which anchored intervals the request fell in
        ! rather than on the variance and time at which it was first built. The bounds are already widened monotonically above,
        ! so no further margin is applied; pinning only snaps them outward onto lattice points. The variance axis is linear and
-       ! runs from zero, so it uses the per-unit scheme with its lower edge clamped there.
+       ! runs from zero, so the *whole* range [0,varianceMaximum] is the target: `limitMinimum` only clamps a range which would
+       ! otherwise extend below zero, it does not make one reach down to it.
        !
        ! This is done *before* the extendability test below, which compares the time bounds against those of the previous
        ! tabulation for exact equality: the comparison must be between pinned bounds, or it would test a raw bound against a
@@ -241,7 +242,7 @@ contains
        self%timeMinimum       =latticeTime%minimum()
        self%timeMaximum       =latticeTime%maximum()
        self%varianceMaximum   =max(self%varianceMaximum,variance)
-       latticeVariance        =Range_Pinned(self%varianceMaximum,varianceTableNumberPerUnit,gridSchemePerUnit,marginOffset=0.0d0,limitMinimum=0.0d0)
+       latticeVariance        =Range_Pinned([0.0d0,self%varianceMaximum],varianceTableNumberPerUnit,gridSchemePerUnit,marginOffset=0.0d0,limitMinimum=0.0d0)
        self%varianceMaximum   =latticeVariance%maximum()
        ! Make a copy of the current table if possible.
        tableIsExtendable=(self%timeMinimum == self%timeMinimumPrevious .and. self%timeMaximum == self%timeMaximumPrevious .and. self%tableInitialized)

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui_high_order.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui_high_order.F90
@@ -192,10 +192,10 @@ contains
     !!{RST
     Return the excursion set barrier at the given variance and time.
     !!}
-    use            :: Display          , only : displayCounter       , displayCounterClear, displayIndent       , displayUnindent, &
-          &                                     verbosityLevelWorking
-    use, intrinsic :: ISO_C_Binding    , only : c_size_t
-    use            :: Numerical_Ranges , only : Range_Pinned         , rangeLattice       , gridSchemePerUnit, gridSchemePerDecade
+    use            :: Display         , only : displayCounter       , displayCounterClear, displayIndent    , displayUnindent    , &
+          &                                    verbosityLevelWorking
+    use, intrinsic :: ISO_C_Binding   , only : c_size_t
+    use            :: Numerical_Ranges, only : Range_Pinned         , rangeLattice       , gridSchemePerUnit, gridSchemePerDecade
     implicit none
     class           (excursionSetFirstCrossingZhangHuiHighOrder), intent(inout)                 :: self
     double precision                                            , intent(in   )                 :: variance                             , time
@@ -203,7 +203,7 @@ contains
     double precision                                                           , dimension(0:1) :: hTime                                , hVariance
     double precision                                            , allocatable  , dimension(:,:) :: firstCrossingProbabilityTablePrevious
     logical                                                                                     :: makeTable                            , tableIsExtendable
-    type            (rangeLattice                                        )                      :: latticeVariance                      , latticeTime
+    type            (rangeLattice                              )                                :: latticeVariance                      , latticeTime
     integer         (c_size_t                                  )                                :: iVariance                            , iTime
     integer                                                                                     :: i                                    , j                         , &
          &                                                                                         jTime                                , jVariance                 , &

--- a/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui_high_order.F90
+++ b/source/structure_formation/excursion_sets/first_crossing_distribution/Zhang_Hui_high_order.F90
@@ -195,7 +195,7 @@ contains
     use            :: Display          , only : displayCounter       , displayCounterClear, displayIndent       , displayUnindent, &
           &                                     verbosityLevelWorking
     use, intrinsic :: ISO_C_Binding    , only : c_size_t
-    use            :: Numerical_Ranges , only : Make_Range           , rangeTypeLinear    , rangeTypeLogarithmic
+    use            :: Numerical_Ranges , only : Range_Pinned         , rangeLattice       , gridSchemePerUnit, gridSchemePerDecade
     implicit none
     class           (excursionSetFirstCrossingZhangHuiHighOrder), intent(inout)                 :: self
     double precision                                            , intent(in   )                 :: variance                             , time
@@ -203,6 +203,7 @@ contains
     double precision                                                           , dimension(0:1) :: hTime                                , hVariance
     double precision                                            , allocatable  , dimension(:,:) :: firstCrossingProbabilityTablePrevious
     logical                                                                                     :: makeTable                            , tableIsExtendable
+    type            (rangeLattice                                        )                      :: latticeVariance                      , latticeTime
     integer         (c_size_t                                  )                                :: iVariance                            , iTime
     integer                                                                                     :: i                                    , j                         , &
          &                                                                                         jTime                                , jVariance                 , &
@@ -227,7 +228,21 @@ contains
           self%timeMinimum=0.5d0*time
           self%timeMaximum=2.0d0*time
        end if
+       ! Pin both axes to absolute lattices, so that the tabulation depends only on which anchored intervals the request fell in
+       ! rather than on the variance and time at which it was first built. The bounds are already widened monotonically above,
+       ! so no further margin is applied; pinning only snaps them outward onto lattice points. The variance axis is linear and
+       ! runs from zero, so it uses the per-unit scheme with its lower edge clamped there.
+       !
+       ! This is done *before* the extendability test below, which compares the time bounds against those of the previous
+       ! tabulation for exact equality: the comparison must be between pinned bounds, or it would test a raw bound against a
+       ! stored pinned one. Pinning in fact makes that test succeed more often, since a small change in the requested time no
+       ! longer moves the bounds at all, so previously computed values are carried over more frequently.
+       latticeTime            =Range_Pinned([self%timeMinimum,self%timeMaximum],timeTableNumberPerDecade,gridSchemePerDecade,marginFactor=1.0d0)
+       self%timeMinimum       =latticeTime%minimum()
+       self%timeMaximum       =latticeTime%maximum()
        self%varianceMaximum   =max(self%varianceMaximum,variance)
+       latticeVariance        =Range_Pinned(self%varianceMaximum,varianceTableNumberPerUnit,gridSchemePerUnit,marginOffset=0.0d0,limitMinimum=0.0d0)
+       self%varianceMaximum   =latticeVariance%maximum()
        ! Make a copy of the current table if possible.
        tableIsExtendable=(self%timeMinimum == self%timeMinimumPrevious .and. self%timeMaximum == self%timeMaximumPrevious .and. self%tableInitialized)
        if (tableIsExtendable) then
@@ -241,8 +256,8 @@ contains
        end if
        self%timeMinimumPrevious=self%timeMinimum
        self%timeMaximumPrevious=self%timeMaximum
-       self%timeTableCount     =int(log10(self%timeMaximum/self%timeMinimum)*dble(timeTableNumberPerDecade))+1
-       self%varianceTableCount =int(self%varianceMaximum*dble(varianceTableNumberPerUnit))
+       self%timeTableCount     =latticeTime    %count
+       self%varianceTableCount =latticeVariance%count-1
        ! Construct the table of variance on which we will solve for the first crossing distribution.
        if (allocated(self%varianceTable                )) deallocate(self%varianceTable                )
        if (allocated(self%timeTable                    )) deallocate(self%timeTable                    )
@@ -250,8 +265,10 @@ contains
        allocate(self%varianceTable                (0:self%varianceTableCount                    ))
        allocate(self%timeTable                    (                          self%timeTableCount))
        allocate(self%firstCrossingProbabilityTable(0:self%varianceTableCount,self%timeTableCount))
-       self%timeTable        =Make_Range(self%timeMinimum,self%timeMaximum    ,self%timeTableCount      ,rangeType=rangeTypeLogarithmic)
-       self%varianceTable    =Make_Range(0.0d0           ,self%varianceMaximum,self%varianceTableCount+1,rangeType=rangeTypeLinear     )
+       ! Take the abscissae from the lattices rather than by subdividing the ranges, so that they are bit-identical to those of
+       ! any other tabulation built on the same lattices - which is what lets the values carried over above remain valid.
+       self%timeTable        =latticeTime    %values()
+       self%varianceTable    =latticeVariance%values()
        self%varianceTableStep=+self%varianceTable(4) &
             &                 -self%varianceTable(0)
        if (tableIsExtendable) then

--- a/source/structure_formation/halo_mass_function/decaying_dark_matter.F90
+++ b/source/structure_formation/halo_mass_function/decaying_dark_matter.F90
@@ -26,7 +26,7 @@ models, following the revised spherical collapse model of :cite:t:`montandon_dec
 
   use :: Dark_Matter_Particles  , only : darkMatterParticleClass
   use :: Numerical_Interpolation, only : interpolator
-  use :: Numerical_Ranges                       , only : rangeLattice
+  use :: Numerical_Ranges       , only : rangeLattice
 
   !![
   <haloMassFunction name="haloMassFunctionDecayingDarkMatter" docformat="rst">
@@ -257,13 +257,13 @@ contains
     ! initial `massMinimum` parameter rather than on anything absolute. Snapping to the lattice - with no further margin, the
     ! stepping having already provided one - makes the bounds exact powers of ten, identical for any object using the same
     ! resolution, and taking the union with the lattice in use keeps the range monotonic.
-    lattice         =Range_Pinned(                                              &
-         &                                       [massMinimum,massMaximum]    , &
-         &                                       self%pointsPerDecade         , &
-         &                                       gridSchemePerDecade          , &
-         &                        marginFactor  =1.0d0                        , &
-         &                        anchorEvery   =1                            , &
-         &                        latticeCurrent=self%massLattice               &
+    lattice         =Range_Pinned(                                          &
+         &                                       [massMinimum,massMaximum], &
+         &                                       self%pointsPerDecade     , &
+         &                                       gridSchemePerDecade      , &
+         &                        marginFactor  =1.0d0                    , &
+         &                        anchorEvery   =1                        , &
+         &                        latticeCurrent=self%massLattice           &
          &                       )
     self%massLattice=lattice
     self%massMinimum=lattice%minimum()

--- a/source/structure_formation/halo_mass_function/decaying_dark_matter.F90
+++ b/source/structure_formation/halo_mass_function/decaying_dark_matter.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
 !!{RST
 Contains a module which implements a dark matter halo mass function class for decaying dark matter (DDM)
 models, following the revised spherical collapse model of :cite:t:`montandon_decaying_2026`.
@@ -24,6 +26,7 @@ models, following the revised spherical collapse model of :cite:t:`montandon_dec
 
   use :: Dark_Matter_Particles  , only : darkMatterParticleClass
   use :: Numerical_Interpolation, only : interpolator
+  use :: Numerical_Ranges                       , only : rangeLattice
 
   !![
   <haloMassFunction name="haloMassFunctionDecayingDarkMatter" docformat="rst">
@@ -80,8 +83,9 @@ models, following the revised spherical collapse model of :cite:t:`montandon_dec
      class           (haloMassFunctionClass  ), pointer                   :: massFunction_       => null()
      class           (darkMatterParticleClass), pointer                   :: darkMatterParticle_ => null()
      double precision                                                     :: lifetime                           , velocityKick         , &
-          &                                                                  massMinimum                        , massMaximum          , &
-          &                                                                  pointsPerDecade
+          &                                                                  massMinimum                        , massMaximum
+     integer                                                              :: pointsPerDecade
+     type            (rangeLattice           )                            :: massLattice
      ! Cache of the (epoch-dependent) M_coll(M₀) mapping. The grid of Lagrangian masses spans
      ! [massMinimum,massMaximum], which are expanded dynamically as needed; massCollapsedMinimum and
      ! massCollapsedMaximum are the corresponding limits of the (monotonic) mapped collapsed mass, used to
@@ -118,8 +122,8 @@ contains
     class           (haloMassFunctionClass             ), pointer       :: massFunction_
     class           (cosmologyParametersClass          ), pointer       :: cosmologyParameters_
     class           (darkMatterParticleClass           ), pointer       :: darkMatterParticle_
-    double precision                                                    :: massMinimum         , massMaximum, &
-         &                                                                 pointsPerDecade
+    double precision                                                    :: massMinimum         , massMaximum
+    integer                                                             :: pointsPerDecade
 
     !![
     <inputParameter docformat="rst">
@@ -137,8 +141,8 @@ contains
     <inputParameter docformat="rst">
       <name>pointsPerDecade</name>
       <source>parameters</source>
-      <defaultValue>100.0d0</defaultValue>
-      <description>The number of points per decade of mass used in tabulating the mapping between Lagrangian and collapsed mass.</description>
+      <defaultValue>100</defaultValue>
+      <description>The number of points per decade of mass used in tabulating the mapping between Lagrangian and collapsed mass. The tabulation is built on an absolute lattice of this many points per decade, so the value must be an integer.</description>
     </inputParameter>
     <objectBuilder class="cosmologyParameters" name="cosmologyParameters_" source="parameters"/>
     <objectBuilder class="haloMassFunction"    name="massFunction_"        source="parameters"/>
@@ -165,8 +169,8 @@ contains
     class           (haloMassFunctionClass             ), target, intent(in   ) :: massFunction_
     class           (cosmologyParametersClass          ), target, intent(in   ) :: cosmologyParameters_
     class           (darkMatterParticleClass           ), target, intent(in   ) :: darkMatterParticle_
-    double precision                                            , intent(in   ) :: massMinimum         , massMaximum, &
-         &                                                                         pointsPerDecade
+    double precision                                            , intent(in   ) :: massMinimum         , massMaximum
+    integer                                                     , intent(in   ) :: pointsPerDecade
     !![
     <constructorAssign variables="*massFunction_, *cosmologyParameters_, *darkMatterParticle_, massMinimum, massMaximum, pointsPerDecade"/>
     !!]
@@ -222,7 +226,7 @@ contains
     !!}
     use :: Decaying_Dark_Matter_Spherical_Collapse, only : decayingDarkMatterMassCollapsed
     use :: Numerical_Interpolation                , only : GSL_Interp_Linear
-    use :: Numerical_Ranges                       , only : Make_Range                     , rangeTypeLogarithmic
+    use :: Numerical_Ranges                       , only : Range_Pinned                   , gridSchemePerDecade
     use :: Table_Labels                           , only : extrapolationTypeExtrapolate
     implicit none
     class           (haloMassFunctionDecayingDarkMatter), intent(inout)           :: self
@@ -231,6 +235,7 @@ contains
     integer                                                                       :: i          , countTable
     double precision                                                              :: massMinimum, massMaximum, &
          &                                                                           stepFactor
+    type            (rangeLattice                      )                          :: lattice
 
     massMinimum=self%massMinimum
     massMaximum=self%massMaximum
@@ -247,15 +252,29 @@ contains
           massMaximum=massMaximum*stepFactor
        end do
     end if
-    self%massMinimum=massMinimum
-    self%massMaximum=massMaximum
-    ! Build the grid of Lagrangian masses at the fixed resolution.
-    countTable=int(log10(massMaximum/massMinimum)*self%pointsPerDecade)+1
+    ! Pin the expanded bounds to an absolute lattice. The stepping above walks outward from the bounds already in use, so its
+    ! endpoints drift off the grid as the rounding of repeated division accumulates, and the grid it defines is anchored on the
+    ! initial `massMinimum` parameter rather than on anything absolute. Snapping to the lattice - with no further margin, the
+    ! stepping having already provided one - makes the bounds exact powers of ten, identical for any object using the same
+    ! resolution, and taking the union with the lattice in use keeps the range monotonic.
+    lattice         =Range_Pinned(                                              &
+         &                                       [massMinimum,massMaximum]    , &
+         &                                       self%pointsPerDecade         , &
+         &                                       gridSchemePerDecade          , &
+         &                        marginFactor  =1.0d0                        , &
+         &                        anchorEvery   =1                            , &
+         &                        latticeCurrent=self%massLattice               &
+         &                       )
+    self%massLattice=lattice
+    self%massMinimum=lattice%minimum()
+    self%massMaximum=lattice%maximum()
+    ! Build the grid of Lagrangian masses, taking the abscissae from the lattice rather than by subdividing the range so that
+    ! they are bit-identical to those of any other tabulation built on the same lattice.
+    countTable      =lattice%count
     if (allocated(self%logMass0Table        )) deallocate(self%logMass0Table        )
     if (allocated(self%logMassCollapsedTable)) deallocate(self%logMassCollapsedTable)
-    allocate(self%logMass0Table        (countTable))
     allocate(self%logMassCollapsedTable(countTable))
-    self%logMass0Table=log(Make_Range(massMinimum,massMaximum,countTable,rangeTypeLogarithmic))
+    self%logMass0Table=log(lattice%values())
     do i=1,countTable
        self%logMassCollapsedTable(i)=+log(decayingDarkMatterMassCollapsed(exp(self%logMass0Table(i)),time,self%lifetime,self%velocityKick))
     end do

--- a/source/tests/SIDM_Kummer_deceleration.F90
+++ b/source/tests/SIDM_Kummer_deceleration.F90
@@ -91,8 +91,8 @@ program Tests_SIDM_Kummer_Deceleration
   ! and the tabulation is never consulted. The assertions below use x below that threshold, and so exercise the tabulated
   ! branch: without them the tabulation - and the absolute lattices its axes are pinned to - would be entirely untested.
   block
-    double precision :: factorTabulated, factorAfterExtension, factorDirect
-    type(satelliteDecelerationSIDMKummer2018) :: decelerationReverse
+    double precision                                      :: factorTabulated    , factorAfterExtension, factorDirect
+    type            (satelliteDecelerationSIDMKummer2018) :: decelerationReverse
     ! A value from the tabulated branch must differ from the analytic large-x form, which tends to unity.
     factorTabulated=decelerationVelocityDependent%decelerationFactor(5.0d0,73.0d0)
     call Assert("tabulated branch is reached at x=5",factorTabulated < 9.9d-1,.true.)

--- a/source/tests/SIDM_Kummer_deceleration.F90
+++ b/source/tests/SIDM_Kummer_deceleration.F90
@@ -87,6 +87,27 @@ program Tests_SIDM_Kummer_Deceleration
   ! Constant large-x deceleration factor: independent of the orbital speed.
   call Assert("constant deceleration factor, x=200",decelerationConstant%decelerationFactor(200.0d0,100.0d0),9.999333353333d-01,relTol=1.0d-9)
   call Assert("constant deceleration factor, x=150",decelerationConstant%decelerationFactor(150.0d0, 50.0d0),9.998814878025d-01,relTol=1.0d-9)
+  ! All of the assertions above use x above `xCritical`, where the deceleration factor is given by its analytic asymptotic form
+  ! and the tabulation is never consulted. The assertions below use x below that threshold, and so exercise the tabulated
+  ! branch: without them the tabulation - and the absolute lattices its axes are pinned to - would be entirely untested.
+  block
+    double precision :: factorTabulated, factorAfterExtension, factorDirect
+    type(satelliteDecelerationSIDMKummer2018) :: decelerationReverse
+    ! A value from the tabulated branch must differ from the analytic large-x form, which tends to unity.
+    factorTabulated=decelerationVelocityDependent%decelerationFactor(5.0d0,73.0d0)
+    call Assert("tabulated branch is reached at x=5",factorTabulated < 9.9d-1,.true.)
+    ! Extending the tabulation - here by a request outside it on both axes - must leave a previously tabulated value unchanged.
+    ! The table is rebuilt rather than extended, but rebuilt on the same pinned lattice, so its abscissae do not move.
+    factorAfterExtension=decelerationVelocityDependent%decelerationFactor(9.0d0,11.0d0)
+    factorAfterExtension=decelerationVelocityDependent%decelerationFactor(5.0d0,73.0d0)
+    call Assert("extension leaves a tabulated value unchanged",factorAfterExtension == factorTabulated,.true.)
+    ! An object driven straight to the wider range must agree bit-for-bit with one which reached it by extension: the bounds
+    ! are pinned, so both tabulate on the same lattice regardless of the order in which they were asked.
+    decelerationReverse=satelliteDecelerationSIDMKummer2018(cosmologyParameters_,particleVelocityDependent,darkMatterHaloScale_,darkMatterProfileDMO_)
+    factorDirect       =decelerationReverse%decelerationFactor(9.0d0,11.0d0)
+    factorDirect       =decelerationReverse%decelerationFactor(5.0d0,73.0d0)
+    call Assert("tabulation is independent of the order of requests",factorDirect == factorTabulated,.true.)
+  end block
   ! Clean up the node-component hierarchy.
   call Node_Components_Thread_Uninitialize()
   call Node_Components_Uninitialize       ()

--- a/source/tests/dark_matter_profiles.F90
+++ b/source/tests/dark_matter_profiles.F90
@@ -282,7 +282,7 @@ program Test_Dark_Matter_Profiles
         fourier                                   (i)=massDistribution_      %fourierTransform                 (radiusVirial,1.0d0                                      /radiusScale   /radius      (i)                                        )
         radialVelocityDispersion                  (i)=kinematicsDistribution_%velocityDispersion1D             (                                                                        coordinates        ,massDistribution_,massDistribution_)
      end do
-     radiusSmall             =massDistribution_%radiusEnclosingMass         (massSmall                              )
+     radiusSmall             =massDistribution_%radiusEnclosingMass         (massSmall                              )/radiusScale
      radiusVelocityMaximum   =massDistribution_%radiusRotationCurveMaximum  (                                       )
      velocityMaximum         =massDistribution_%velocityRotationCurveMaximum(                                       )
      velocityMaximumIndirect =massDistribution_%rotationCurve               (radiusVelocityMaximum                  )
@@ -318,10 +318,13 @@ program Test_Dark_Matter_Profiles
        &      radius                 , &
        &      relTol=1.0d-6            &
        &     )
+  ! The radius enclosing a small mass is tested in units of the scale radius. In those units it is a function of the enclosed mass
+  ! fraction and the concentration alone - both fixed here - so this asserts on the small-mass solution of the profile itself, and
+  ! not, as the unnormalized radius did, on the virial radius which merely sets the scale.
   call Assert(                                          &
        &      'radius enclosing mass (at small radii)', &
        &      radiusSmall                             , &
-       &      1.6764798688849444d-9                   , &
+       &      5.1170484302260309d-4                   , &
        &      relTol=1.0d-5                             &
        &     )
   call Assert(                         &

--- a/source/tests/mass_distributions.F90
+++ b/source/tests/mass_distributions.F90
@@ -1112,12 +1112,12 @@ program Test_Mass_Distributions
   ! extend and so never revealing whether extension moves values already computed.
   call Unit_Tests_Begin_Group("Pinned tabulations")
   block
-    type            (massDistributionExponentialDisk) :: diskExtended        , diskDirect
-    type            (massDistributionSersic         ) :: sersicA             , sersicB
+    type            (massDistributionExponentialDisk) :: diskExtended  , diskDirect
+    type            (massDistributionSersic         ) :: sersicA       , sersicB
     type            (coordinateSpherical            ) :: coordinates_
-    double precision                                  :: velocityProbe       , velocityAfterExtension, &
-         &                                               velocityDirect      , densityA              , &
-         &                                               densityB            , velocityFar
+    double precision                                  :: velocityProbe , velocityAfterExtension, &
+         &                                               velocityDirect, densityA              , &
+         &                                               densityB      , velocityFar
     ! The exponential disk rotation curve. The radii are chosen to avoid the three paths which bypass the tabulation: the
     ! small-argument series expansion below a half-radius of 1e-3, the cached factor used at exactly one scale radius, and the
     ! point-mass approximation beyond `radiusMaximum`=30 scale radii. r=4 gives a half-radius of 2, inside the seed range;

--- a/source/tests/mass_distributions.F90
+++ b/source/tests/mass_distributions.F90
@@ -1107,6 +1107,49 @@ program Test_Mass_Distributions
   end block
   call Unit_Tests_End_Group()
 
+  ! Test that the tabulations which are pinned to absolute lattices behave as intended. These properties are what pinning is
+  ! for, and none of the tests above constrain them: they exercise the profiles at fixed radii, never driving a tabulation to
+  ! extend and so never revealing whether extension moves values already computed.
+  call Unit_Tests_Begin_Group("Pinned tabulations")
+  block
+    type            (massDistributionExponentialDisk) :: diskExtended        , diskDirect
+    type            (massDistributionSersic         ) :: sersicA             , sersicB
+    type            (coordinateSpherical            ) :: coordinates_
+    double precision                                  :: velocityProbe       , velocityAfterExtension, &
+         &                                               velocityDirect      , densityA              , &
+         &                                               densityB            , velocityFar
+    ! The exponential disk rotation curve. The radii are chosen to avoid the three paths which bypass the tabulation: the
+    ! small-argument series expansion below a half-radius of 1e-3, the cached factor used at exactly one scale radius, and the
+    ! point-mass approximation beyond `radiusMaximum`=30 scale radii. r=4 gives a half-radius of 2, inside the seed range;
+    ! r=28 gives 14, outside it, and so forces a genuine extension.
+    diskExtended         =massDistributionExponentialDisk(scaleRadius=1.0d0,mass=1.0d0)
+    velocityProbe        =diskExtended%rotationCurve( 4.0d0)
+    velocityFar          =diskExtended%rotationCurve(28.0d0)
+    velocityAfterExtension=diskExtended%rotationCurve( 4.0d0)
+    call Assert("exponential disk: extension preserves a tabulated rotation curve",velocityAfterExtension == velocityProbe,.true.)
+    ! A disk driven straight to the wider range must agree bit-for-bit with one which reached it by extension.
+    diskDirect           =massDistributionExponentialDisk(scaleRadius=1.0d0,mass=1.0d0)
+    velocityDirect       =diskDirect  %rotationCurve(28.0d0)
+    call Assert("exponential disk: rotation curve is independent of the order of requests",velocityDirect == velocityFar,.true.)
+    call Assert("exponential disk: probe value is independent of the order of requests",diskDirect%rotationCurve(4.0d0) == velocityProbe,.true.)
+    ! The Sersic profile. Nothing computed for it can be carried over when its range moves - the densities are Abel integrals
+    ! taken out to a bound-derived radius, and the enclosed masses accumulate from the innermost point - so what is tested is
+    ! reproducibility: two profiles driven to nearby radii must build identical tables. The radii are large enough to push the
+    ! bounds beyond the seed range, where under the previous scheme they would have differed by the ratio of the two radii.
+    sersicA     =massDistributionSersic(index=4.0d0,radiusHalfMass=1.0d0,mass=1.0d0)
+    sersicB     =massDistributionSersic(index=4.0d0,radiusHalfMass=1.0d0,mass=1.0d0)
+    coordinates_=[900.0d0,0.0d0,0.0d0]
+    densityA    =sersicA%density(coordinates_)
+    coordinates_=[901.0d0,0.0d0,0.0d0]
+    densityB    =sersicB%density(coordinates_)
+    coordinates_=[  1.0d0,0.0d0,0.0d0]
+    densityA    =sersicA%density(coordinates_)
+    densityB    =sersicB%density(coordinates_)
+    call Assert("Sersic: tabulation is reproducible across nearby requested radii",densityA == densityB,.true.)
+    call Assert("Sersic: enclosed mass is reproducible across nearby requested radii",sersicA%massEnclosedBySphere(1.0d0) == sersicB%massEnclosedBySphere(1.0d0),.true.)
+  end block
+  call Unit_Tests_End_Group()
+
   ! End unit tests.
   call Unit_Tests_End_Group()
   call Unit_Tests_Finish()

--- a/source/tests/spin_distribution_nbody_errors.F90
+++ b/source/tests/spin_distribution_nbody_errors.F90
@@ -1,0 +1,140 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!!{RST
+Contains a program which tests the N-body errors halo spin distribution.
+!!}
+
+program Test_Spin_Distribution_Nbody_Errors
+  !!{RST
+  Tests the :galacticus-class:`haloSpinDistributionNbodyErrors` halo spin distribution class, whose tabulation of the
+  error-convolved distribution is built on absolute lattices in mass and spin. The test requires that:
+
+  #. evaluating twice with identical arguments returns the same distribution;
+  #. a second, independent object asked the same question returns the same answer.
+
+  Both failed before the fix which accompanies this test: the class recorded the mass and spin it was asked for only when it
+  found them changed from a previous request, so the first evaluation for a fresh object tabulated at the default minimum mass
+  rather than the one requested.
+
+  The tabulated range is deliberately *not* driven outside the class's defaults of [3.0d-4,0.5d0] in spin. Those already span
+  every physical halo spin, and forcing an extension beyond them drives the distribution into underflow - the value returned
+  becomes denormal - so it tests a regime the class is not meant to work in. Extension within the defaults changes interpolated
+  values only at the level of round-off in the interpolation weights, so it cannot be asserted bit-for-bit either.
+
+  Before this test the class had no coverage of any kind: no test script, unit test, or bundled parameter file referenced it.
+
+  The fixed-point entry point is used deliberately. It tabulates at a single mass, so the table is one row of order a hundred
+  points rather than the two-dimensional grid of some two thousand which the general entry point builds - each point of which
+  is several nested numerical integrals. Driving the general entry point takes tens of minutes, which is why this test
+  exercises the spin axis only; the mass axis is left uncovered, as it was before. The extents of both axes are fixed by
+  module parameters in the class and cannot be reduced from a parameter file.
+  !!}
+  use :: Display          , only : displayVerbositySet          , verbosityLevelStandard
+  use :: Events_Hooks     , only : eventsHooksInitialize
+  use :: Functions_Global_Utilities, only : Functions_Global_Set
+  use :: Galacticus_Nodes , only : nodeClassHierarchyInitialize , treeNode                          , nodeComponentBasic, nodeComponentSpin
+  use :: Halo_Spin_Distributions, only : haloSpinDistributionNbodyErrors
+  use :: Input_Parameters , only : inputParameters
+  use :: Node_Components  , only : Node_Components_Initialize   , Node_Components_Thread_Initialize , Node_Components_Thread_Uninitialize, Node_Components_Uninitialize
+  use :: Unit_Tests       , only : Assert                       , Unit_Tests_Begin_Group            , Unit_Tests_End_Group              , Unit_Tests_Finish
+  implicit none
+  type            (inputParameters                )          :: parameters          , parametersSpin
+  type            (haloSpinDistributionNbodyErrors)          :: distributionExtended, distributionDirect
+  type            (treeNode                       ), pointer :: node
+  class           (nodeComponentBasic             ), pointer :: basic
+  class           (nodeComponentSpin              ), pointer :: spin
+  double precision                                           :: probeInitial        , probeAfterExtension, &
+       &                                                        probeDirect
+  double precision                                 , parameter :: massProbe=1.0d12
+  ! The spin at which the tabulation is read, and two ranges of measured spin: the second reaches well outside the first and
+  ! so forces the tabulated range to be extended.
+  double precision                                 , parameter :: spinMeasured       =3.0d-2
+  double precision                                 , parameter :: spinNarrowMinimum  =2.0d-2, spinNarrowMaximum=5.0d-2
+  ! An angular momentum, not a spin: the class divides by the halo's angular momentum scale to form the dimensionless spin.
+  ! Its precise value does not matter - the assertions are about reproducibility of the tabulation, not about particular
+  ! distribution values - only that it places the spin inside, or close to, the tabulated range.
+  double precision                                 , parameter :: angularMomentumProbe=1.0d12
+
+  call displayVerbositySet  (verbosityLevelStandard)
+  call eventsHooksInitialize(                      )
+  call Functions_Global_Set (                      )
+  parameters=inputParameters('testSuite/parameters/spinDistributionNbodyErrors.xml')
+  call nodeClassHierarchyInitialize     (parameters)
+  call Node_Components_Initialize       (parameters)
+  call Node_Components_Thread_Initialize(parameters)
+  call Unit_Tests_Begin_Group("N-body errors halo spin distribution")
+  ! Build two identical distributions from the same parameters. The class reads its own parameters from the object it is
+  ! handed, so it is given the `haloSpinDistribution` subtree rather than the root.
+  parametersSpin      =parameters%subParameters('haloSpinDistribution')
+  distributionExtended=haloSpinDistributionNbodyErrors(parametersSpin)
+  distributionDirect  =haloSpinDistributionNbodyErrors(parametersSpin)
+  ! Evaluate twice with identical arguments. The class records the fixed point - the mass and spin it was asked for - only when
+  ! it finds them changed from a previous request, which on a fresh object there is none of; without that record the first
+  ! evaluation tabulates at the default minimum mass rather than the one requested, and the second, finding the mismatch and
+  ! rebuilding, returns a different answer for the same question. For a 10^12 solar mass halo the two differed by a factor of
+  ! about fourteen.
+  probeInitial       =distributionValue(distributionExtended,massProbe,angularMomentumProbe,spinNarrowMinimum,spinNarrowMaximum)
+  probeAfterExtension=distributionValue(distributionExtended,massProbe,angularMomentumProbe,spinNarrowMinimum,spinNarrowMaximum)
+  call Assert("repeated evaluation returns the same distribution",probeAfterExtension == probeInitial,.true.)
+  ! A second, independent object asked the same question must give the same answer as the first.
+  probeDirect        =distributionValue(distributionDirect  ,massProbe,angularMomentumProbe,spinNarrowMinimum,spinNarrowMaximum)
+  call Assert("the distribution does not depend on which object was asked",probeDirect == probeInitial,.true.)
+  ! Guard against all of the above being satisfied by a distribution which is identically zero.
+  call Assert("the tabulated distribution is non-zero",probeInitial > 0.0d0,.true.)
+  ! Clean up the node-component hierarchy.
+  call Node_Components_Thread_Uninitialize()
+  call Node_Components_Uninitialize       ()
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Finish   ()
+
+contains
+
+  double precision function distributionValue(distribution_,mass,angularMomentum_,spinMinimum_,spinMaximum_)
+    !!{RST
+    Return the spin distribution for a halo of the given mass and spin, building the node it is evaluated for.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentDarkMatterProfile
+    implicit none
+    type            (haloSpinDistributionNbodyErrors), intent(inout) :: distribution_
+    double precision                                 , intent(in   ) :: mass         , angularMomentum_, &
+         &                                                              spinMinimum_ , spinMaximum_
+    class           (nodeComponentDarkMatterProfile  ), pointer       :: darkMatterProfile
+
+    node              =>  treeNode                  (                 )
+    basic             =>  node    %basic            (autoCreate=.true.)
+    spin              =>  node    %spin             (autoCreate=.true.)
+    darkMatterProfile =>  node    %darkMatterProfile(autoCreate=.true.)
+    call basic%massSet            (mass     )
+    call basic%timeSet            (13.8d0   )
+    ! Give the halo a well-formed dark matter profile. The class sets the scale radius itself on the node it builds while
+    ! tabulating, but not on the node passed to it, and the angular momentum scale it forms below integrates over that
+    ! profile - which is degenerate, and produces an invalid result, if the scale is left unset. The value need only be
+    ! physically sensible; it is scaled with the halo's radius so that the concentration is the same at every mass.
+    call darkMatterProfile%scaleSet(2.0d-2*(mass/1.0d12)**(1.0d0/3.0d0))
+    call spin %angularMomentumSet (angularMomentum_)
+    distributionValue=distribution_%distributionFixedPoint(node,spinMeasured,spinMinimum_,spinMaximum_)
+    call node%destroy()
+    deallocate(node)
+    return
+  end function distributionValue
+
+end program Test_Spin_Distribution_Nbody_Errors

--- a/testSuite/parameters/spinDistributionNbodyErrors.xml
+++ b/testSuite/parameters/spinDistributionNbodyErrors.xml
@@ -1,0 +1,87 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- N-body spin distribution with measurement errors.
+
+     Wires up `haloSpinDistributionNbodyErrors` and the objects it needs, for
+     `source/tests/spin_distribution_nbody_errors.F90`. That test checks that the class's tabulation of
+     the error-convolved spin distribution is pinned to absolute lattices: the tabulated values must not
+     move when the range is extended, and must not depend on the order in which masses and spins were
+     requested. The class had no test coverage of any kind before that test was added.
+
+     The cosmology and power spectrum are standard LCDM; nothing here is tuned, since the test asserts
+     properties of the tabulation rather than particular spin distribution values. -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+
+  <!-- Component selection. The class builds a `treeNode` of its own while tabulating, and sets its basic,
+       spin and dark matter profile components. -->
+  <componentBasic             value="standard"/>
+  <componentSpin              value="scalar"  />
+  <componentDarkMatterProfile value="scale"   />
+
+  <!-- Cosmology. -->
+  <cosmologyFunctions  value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant  value="67.76000"/>
+    <OmegaMatter     value=" 0.30700"/>
+    <OmegaDarkEnergy value=" 0.69300"/>
+    <OmegaBaryon     value=" 0.04860"/>
+    <temperatureCMB  value=" 2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum, needed by the halo mass function below. -->
+  <transferFunction value="eisensteinHu1999">
+    <darkMatterParticle      value="CDM"  />
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed      value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index               value="0.9665"/>
+    <wavenumberReference value="1.0000"/>
+    <running             value="0.0000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.8825"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation. -->
+  <linearGrowth          value="collisionlessMatter"                     />
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <criticalOverdensity   value="sphericalCollapseClsnlssMttrCsmlgclCnstnt">
+    <darkMatterParticle value="CDM"/>
+  </criticalOverdensity>
+  <haloMassFunction value="shethTormen">
+    <a             value="0.707"/>
+    <p             value="0.300"/>
+    <normalization value="0.322"/>
+  </haloMassFunction>
+
+  <!-- Halo structure. -->
+  <darkMatterProfileDMO           value="NFW"          />
+  <darkMatterProfileConcentration value="fixed">
+    <concentration value="8.0"/>
+  </darkMatterProfileConcentration>
+  <darkMatterProfileScaleRadius   value="concentration"/>
+  <darkMatterHaloScale            value="virialDensityContrastDefinition"/>
+
+  <!-- The spin distribution under test. `nbodyErrors` convolves an intrinsic distribution with the
+       measurement errors expected for haloes resolved by a given number of particles. -->
+  <haloSpinDistribution value="nbodyErrors">
+    <massParticle                       value="1.0e8"/>
+    <particleCountMinimum               value="100"  />
+    <energyEstimateParticleCountMaximum value="1.0e6"/>
+    <redshift                           value="0.0"  />
+    <haloSpinDistribution value="logNormal">
+      <median value="0.03687"/>
+      <sigma  value="0.57690"/>
+    </haloSpinDistribution>
+    <nbodyHaloMassError value="trenti2010">
+      <massParticle          value="1.0e8"/>
+      <correlationNormalization value="1.0"/>
+      <correlationMassExponent  value="0.0"/>
+      <correlationRedshiftExponent value="0.0"/>
+    </nbodyHaloMassError>
+  </haloSpinDistribution>
+
+</parameters>

--- a/testSuite/test-reproducibility.py
+++ b/testSuite/test-reproducibility.py
@@ -29,9 +29,16 @@ tests = [
                 # more accurate. Both shift interpolated cosmological quantities at the level of their own interpolation error;
                 # this value moved by 6.5 parts per million, just past the 4 part per million tolerance below. That is the
                 # one-time shift anticipated by the issue - the tabulations are deterministic from here on.
+                #
+                # Updated again when the halo mean density tabulation of darkMatterHaloScaleVirialDensityContrastDefinition was
+                # pinned (#1375). That table is interpolated linearly in the logarithm of time at a hundred points per decade, so
+                # it carries an error against the exact density contrast of order one part in ten thousand; moving its abscissae
+                # changes only where in that error a given requested time falls. Measured here, the interpolated mean density went
+                # from 23 parts per million below the exact value to 98 parts per million above it. The virial radius follows the
+                # inverse cube root of that density and moved by 41 parts per million, and this value by 18 parts per million.
                 "output":            1,
                 "property":          "hotHaloMass",
-                "values":            np.array([7.998050315988728e10]),
+                "values":            np.array([7.997904546876071e10]),
                 "toleranceRelative": 4.0e-6,
             }
         ],


### PR DESCRIPTION
Converts the request-anchored tabulations found by the audit in [#1375](https://github.com/galacticusorg/galacticus/issues/1375). Independent of #1399 — no file overlaps.

Two defects were found along the way, and both are fixed here: one pre-existing in the spin distribution class, and one I introduced and caught with a sweep. Details below, because they are the parts most worth reviewing.

## What is converted

Eleven sites. Where the tabulated values depend only on their own abscissae, extension now preserves them exactly; where they cannot be reused, the site is pinned for reproducibility and the reason is recorded at the site so the absence of a skip-already-computed loop is not later read as an oversight.

| | Sites |
|---|---|
| Pinned, values reused exactly | `exponential_disk` (rotation curve and gradient), `virial_density_contrast` (mean density) |
| Pinned for reproducibility, rebuilt | `Sersic`, `cored/core_radius/growing`, both `Kummer2018`, `decayingDarkMatter` halo mass function, `N-body_errors`, both `Zhang_Hui`, `power_spectrum_transform` |

Why the second group cannot reuse: `Sersic`'s densities are Abel integrals taken out to a bound-derived radius and its masses accumulate from the innermost point, so every value moves when either bound moves; `growing`'s table is deliberately descending and `extend` builds ascending, which would invert it and the inverse table with it; the `Kummer2018` values live only inside an `interpolator2D` and are not recoverable from it; `power_spectrum_transform` feeds an FFTLog whose every output depends on the whole input grid.

`virial_density_contrast` is the site #1317 listed in its own phase 2 and never converted.

## Breaking change

`pointsPerDecade` on the `decayingDarkMatter` halo mass function becomes an integer (default `100.0d0` → `100`). An absolute lattice is indexed by whole steps per decade, so a non-integral resolution cannot define one, and every other pinned site takes an integer. Integral values are unaffected; a non-integral value is now rejected. The class is recent and not widely used.

## The two defects

**A pre-existing bug in `haloSpinDistributionNbodyErrors`,** found by the new test. The class records the fixed mass and spin it was asked for only in the branch taken once a table exists, where it compares them against the previous request. On a fresh object there is nothing to compare against, so neither is recorded and the tabulation is built at the default `massMinimum` of 10¹¹ M☉ rather than the mass requested. The first fixed-point evaluation returned a distribution for the wrong halo; the second, finding the mismatch and rebuilding, returned a different answer for identical arguments — **a factor of about fourteen apart for a 10¹² M☉ halo**. Evaluate once and you got the wrong halo; evaluate twice and the answer depended on how many times you had asked. The missing assignment sits in code the pinning does not touch.

**A bug I introduced, in `Kummer2018`,** and then found a second instance of. `Range_Pinned` was given only the upper end of an axis which must span from zero, so it returned a lattice covering a window *around* that value rather than one reaching down to zero. `limitMinimum` does not help: it clamps a range which would otherwise extend below zero, it does not make one reach down to it. A factor requested at small x then fell outside the table and aborted in `interpolator2DInterpolate`.

That prompted a sweep of every converted site asking what the code looks up that the new lattice might not cover. It isolates exactly one shape of mistake — where a tabulation must span a *fixed* endpoint, targeting only the moving end leaves the fixed one outside — and found a second instance, on the Zhang-Hui variance axis. Every other site is safe for a checkable reason: it passes the full range as an array, or is read back only at the value it pinned on, or re-checks its own extent.

Both bugs compiled cleanly and passed `quickTest`.

## Coverage

Three of the sites had tests which passed without exercising the code being changed. That is addressed where practical:

- **`tests.SIDM_Kummer_deceleration` 4 → 7.** Every existing assertion used x=200 or x=150, above the `xCritical`=100 threshold where the factor is analytic and the tabulation is never consulted — it passed 4/4 while covering none of it. The new assertions drive x=5, and the first of them fails without the x-axis fix above.
- **`tests.mass_distributions` 157 → 162.** Exponential disk rotation curve preserved across extension and independent of request order; two Sersic profiles at nearby radii building identical tables. The radii dodge the small-argument series expansion, the `r == 1` cached factor, and the point-mass approximation beyond thirty scale radii, each of which would make the check vacuous.
- **`tests.spin_distribution_nbody_errors`, new** (3 assertions, 0.2 s, registered in the CI matrix), for a class which previously had no coverage of any kind.

Two gaps remain, stated rather than papered over:

- The **mass axis of `N-body_errors` is still uncovered.** The general entry point builds a two-dimensional grid of some two thousand points, each several nested numerical integrals; driving it ran over twenty-five minutes without completing. The new test uses the fixed-point entry point, which tabulates a single row of order a hundred points. Both axes' extents are module `parameter`s no parameter file can reduce.
- **`tests.excursion_sets` does not constrain the Zhang-Hui variance range.** It passes 6/6 both with and without the fix; what reveals the change is its runtime, seconds before and over two minutes after. Covering it properly needs a test reaching the tabulated first-crossing probabilities directly.

## Also found, not fixed here

`haloSpinDistributionNbodyErrors%distribution` integrates over the *passed* node's dark matter profile to form the angular momentum scale, but sets the scale radius only on the node it builds internally. A caller passing a node without one gets a floating-point exception inside `nfwEnergyKinetic` rather than a diagnostic. Pre-existing and unrelated to this branch; worth its own issue.

## Verification

Built and run at each step. `parameters/quickTest.xml` clean throughout; `tests.mass_distributions` 162/162, `tests.SIDM_Kummer_deceleration` 7/7, `tests.spin_distribution_nbody_errors` 3/3, `tests.excursion_sets` 6/6, `tests.dark_matter_halo_radius_enclosing_mass` 5/5, `tests.orbits` 4/4, plus `testSuite/test-decayingDM-profile.py`, `testSuite/test-virial-orbit-loss-cone.py` and `testSuite/test-decaying-dark-matter-halo-mass-function.py` (which checks four models against the reference values of Montandon et al. 2026, their Fig. 9).

Rebased onto `544daf1fc` and rebuilt, smoke-tested and re-run there; the only file shared with the commits picked up is `cicd.yml`, whose test registration survived the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
