### PR TITLE
refactor(tabulations): migrate the hand-pinned tabulations onto the shared range helper

### DIFF
--- a/source/mass_distributions/_class.F90
+++ b/source/mass_distributions/_class.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
 !!{RST
 Contains a module which implements a class that provides mass distributions.
 !!}
@@ -1384,7 +1386,7 @@ contains
     use            :: Display                , only : displayIndent       , displayUnindent     , displayMessage
     use            :: Error                  , only : Error_Report        , errorStatusSuccess  , GSL_Error_Details
     use            :: Numerical_Integration  , only : integrator
-    use            :: Numerical_Ranges       , only : Make_Range          , rangeTypeLogarithmic
+    use            :: Numerical_Ranges       , only : Range_Pinned        , rangeLattice        , gridSchemePerOctave
     use            :: Table_Labels           , only : extrapolationTypeFix
     use            :: Numerical_Interpolation, only : gsl_interp_linear
     use            :: String_Handling        , only : operator(//)
@@ -1394,9 +1396,10 @@ contains
     double precision                             , intent(in   )              :: radius
     class           (massDistributionClass      ), intent(inout), target      :: massDistribution_               , massDistributionEmbedding
     double precision                                            , parameter   :: radiusTinyFactor        =1.0d-9 , factorDensityLarge       =1.0d+5
-    double precision                                            , parameter   :: countPointsPerOctave    =2.0d0
+    integer                                                     , parameter   :: countPointsPerOctave    =2
     double precision                                            , parameter   :: toleranceFactor         =2.0d0
     double precision                             , dimension(:) , allocatable :: velocityDispersions             , radii
+    type            (rangeLattice               )                             :: lattice
     double precision                                                          :: radiusMinimum                   , radiusMaximum                   , &
          &                                                                       toleranceRelative               , density                         , &
          &                                                                       jeansIntegral                   , radiusOuter_                    , &
@@ -1425,17 +1428,27 @@ contains
        toleranceRelativePrevious=self%toleranceRelativeVelocityDispersion
        ! Find the range of radii at which to compute the velocity dispersion, and construct the arrays.
        call self%solverSet(massDistribution_,massDistributionEmbedding)
-       !! Set an initial range of radii that brackets the requested radius.
-       radiusMinimum=0.5d0*radius
-       radiusMaximum=2.0d0*radius
-       !! Round to the nearest factor of 2.
-       radiusMinimum=2.0d0**floor  (log(radiusMinimum)/log(2.0d0))
-       radiusMaximum=2.0d0**ceiling(log(radiusMaximum)/log(2.0d0))
-       !! Expand to encompass any pre-existing range.
+       !! Find the range of radii to tabulate, pinned to an absolute lattice of whole octaves. This is what the bracketing by a
+       !! factor of two, the rounding to powers of two, and the expansion to encompass any pre-existing range did by hand: the
+       !! default safety margin is a factor of two at each end, and anchoring defaults to whole octaves, so the bounds are the
+       !! same ones - now obtained from the shared helper rather than reproduced here.
        if (allocated(self%velocityDispersionRadialRadius__)) then
-          radiusMinimum=min(radiusMinimum,self%velocityDispersionRadialRadiusMinimum__)
-          radiusMaximum=max(radiusMaximum,self%velocityDispersionRadialRadiusMaximum__)
+          lattice=Range_Pinned(                                                                                       &
+               &                              radius                                                                , &
+               &                              countPointsPerOctave                                                  , &
+               &                              gridSchemePerOctave                                                   , &
+               &               rangeCurrent  =[self%velocityDispersionRadialRadiusMinimum__,                           &
+               &                               self%velocityDispersionRadialRadiusMaximum__]                          &
+               &              )
+       else
+          lattice=Range_Pinned(                                                                                       &
+               &                              radius                                                                , &
+               &                              countPointsPerOctave                                                  , &
+               &                              gridSchemePerOctave                                                     &
+               &              )
        end if
+       radiusMinimum=lattice%minimum()
+       radiusMaximum=lattice%maximum()
        !! Set a suitable outer radius for integration. We require that the density at the outer radius be much smaller than that
        !! at the maximum radius. This should ensure that any constribution to the Jeans integral from beyond this outer radius is
        !! negligible.
@@ -1450,10 +1463,12 @@ contains
           densityOuter_=massDistribution_%density(coordinates)
        end do
        !! Construct arrays.
-       countRadii=nint(log(radiusMaximum/radiusMinimum)/log(2.0d0)*countPointsPerOctave+1.0d0)
+       countRadii=lattice%count
        allocate(radii              (countRadii))
        allocate(velocityDispersions(countRadii))
-       radii=Make_Range(radiusMinimum,radiusMaximum,int(countRadii),rangeTypeLogarithmic)
+       !! Take the abscissae from the lattice rather than by subdividing the range, so that they are bit-identical to those of
+       !! any other tabulation built on the same lattice.
+       radii=lattice%values()
        ! Copy in any usable results from any previous solution.
        !! Assume by default that no previous solutions are usable.
        iMinimum=+huge(0_c_size_t)

--- a/source/mass_distributions/spherical/_class.F90
+++ b/source/mass_distributions/spherical/_class.F90
@@ -564,7 +564,7 @@ contains
     use            :: Numerical_Constants_Astronomical, only : gravitationalConstant_internal
     use            :: Numerical_Integration           , only : integrator
     use            :: Numerical_Comparison            , only : Values_Agree
-    use            :: Numerical_Ranges                , only : Make_Range                    , rangeTypeLogarithmic
+    use            :: Numerical_Ranges                , only : Range_Pinned                  , rangeLattice        , gridSchemePerOctave
     use            :: Table_Labels                    , only : extrapolationTypeExtrapolate
     use            :: Numerical_Interpolation         , only : gsl_interp_linear
     use            :: Error                           , only : Error_Report                  , errorStatusSuccess
@@ -574,7 +574,8 @@ contains
     type            (enumerationStructureErrorCodeType), intent(  out), optional    :: status
     double precision                                   , dimension(:) , allocatable :: potentials                  , radii               , &
          &                                                                             potentials_                 , radii_
-    double precision                                   , parameter                  :: countPointsPerOctave=4.0d+0
+    integer                                            , parameter                  :: countPointsPerOctave=4
+    type            (rangeLattice                     )                              :: lattice
     type            (integrator                       )                             :: integrator_
     integer         (c_size_t                )                                      :: countRadii                  , iMinimum            , &
          &                                                                             iMaximum                    , iPrevious           , &
@@ -590,7 +591,13 @@ contains
     radius            =+coordinates%rSpherical()
     radiusMaximum     =+            radius
     ! Round to the nearest factor of 2.
-    radiusMaximum=2.0d0**ceiling(log(radiusMaximum)/log(2.0d0))
+    ! Round the upper bound up to a whole octave of the absolute lattice. Unlike the enclosed mass tabulation above this one
+    ! takes no factor of two margin at its upper end - the requested radius is its outermost point - so no margin is applied
+    ! here either; the lattice supplies only the rounding. The range spanning the requested radius and half of it is used as the
+    ! target rather than the radius alone: with no margin a single target would give a lattice whose lower and upper bounds
+    ! coincide whenever the radius fell on a whole octave, which is rejected as containing fewer than two points.
+    lattice      =Range_Pinned([0.5d0*radius,radius],countPointsPerOctave,gridSchemePerOctave,marginFactor=1.0d0)
+    radiusMaximum=lattice%maximum()
     ! Determine if the table must be rebuilt.
     remakeTable=.false.
     if (.not.allocated(self%potentialProfilePotential__)) then
@@ -606,20 +613,33 @@ contains
        !! Check the mass at the maximum radius is non-zero.
        massRadiusMaximum=self%massEnclosedBySphere(radiusMaximum)
        if (massRadiusMaximum > 0.0d0) then
-          !! Set an initial range of radii that brackets the requested radii.
-          radiusMinimum=0.5d0*radius
-          !! Round to the nearest factor of 2.
-          radiusMinimum=2.0d0**floor(log(radiusMinimum)/log(2.0d0))
-          !! Expand to encompass any pre-existing range.
+          !! Find the range of radii to tabulate, pinned to the same lattice. The lower bound brackets the requested radius by a
+          !! factor of two and rounds down to a whole octave; the upper bound is the one already rounded up above. Both are
+          !! unioned with any pre-existing range. Again no further margin is applied - the factor of two is supplied here
+          !! explicitly, as the tabulation extends inward from the requested radius but not beyond it.
           if (allocated(self%potentialProfileRadius__)) then
-             radiusMinimum=min(radiusMinimum,self%potentialProfileRadiusMinimum__)
-             radiusMaximum=max(radiusMaximum,self%potentialProfileRadiusMaximum__)
+             lattice=Range_Pinned(                                                                                          &
+                  &                              [0.5d0*radius,radiusMaximum]                                             , &
+                  &                              countPointsPerOctave                                                     , &
+                  &                              gridSchemePerOctave                                                      , &
+                  &               marginFactor  =1.0d0                                                                    , &
+                  &               rangeCurrent  =[self%potentialProfileRadiusMinimum__,self%potentialProfileRadiusMaximum__] &
+                  &              )
+          else
+             lattice=Range_Pinned(                                                                                          &
+                  &                              [0.5d0*radius,radiusMaximum]                                             , &
+                  &                              countPointsPerOctave                                                     , &
+                  &                              gridSchemePerOctave                                                      , &
+                  &               marginFactor  =1.0d0                                                                      &
+                  &              )
           end if
-          !! Construct arrays.
-          countRadii=nint(log(radiusMaximum/radiusMinimum)/log(2.0d0)*countPointsPerOctave+1.0d0)
+          radiusMinimum=lattice%minimum()
+          radiusMaximum=lattice%maximum()
+          !! Construct arrays, taking the abscissae from the lattice.
+          countRadii=lattice%count
           allocate(radii     (countRadii))
           allocate(potentials(countRadii))
-          radii=Make_Range(radiusMinimum,radiusMaximum,int(countRadii),rangeTypeLogarithmic)
+          radii=lattice%values()
           ! Copy in any usable results from any previous solution.
           !! Assume by default that no previous solutions are usable.
           iMinimum=+huge(0_c_size_t)

--- a/source/mass_distributions/spherical/_class.F90
+++ b/source/mass_distributions/spherical/_class.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   Implementation of an abstract mass distribution class for spherically symmetric distributions.
   !!}
@@ -244,18 +246,19 @@ contains
     use, intrinsic :: ISO_C_Binding           , only : c_size_t
     use            :: Numerical_Constants_Math, only : Pi
     use            :: Numerical_Integration   , only : integrator
-    use            :: Numerical_Ranges        , only : Make_Range                  , rangeTypeLogarithmic
+    use            :: Numerical_Ranges        , only : Range_Pinned                , rangeLattice        , gridSchemePerOctave
     use            :: Table_Labels            , only : extrapolationTypeExtrapolate
     use            :: Numerical_Interpolation , only : gsl_interp_linear
     use            :: Error                   , only : Error_Report                , errorStatusSuccess
     implicit none
     class           (massDistributionSpherical), intent(inout), target     :: self
     double precision                           , intent(in   )             :: radius
-    double precision                                         , parameter   :: countPointsPerOctave     =4.0d+00
+    integer                                                  , parameter   :: countPointsPerOctave     =4
     double precision                                         , parameter   :: radiusVirialFractionSmall=1.0d-12
     double precision                          , dimension(:) , allocatable :: masses                           , radii              , &
          &                                                                    masses_                          , radii_
     type            (integrator              )                             :: integrator_
+    type            (rangeLattice             )                             :: lattice
     integer         (c_size_t                )                             :: countRadii                       , iMinimum           , &
          &                                                                    iMaximum                         , i                  , &
          &                                                                    iPrevious
@@ -283,22 +286,32 @@ contains
        ! Initialize integrator.
        integrator_=integrator(sphericalMassEnclosedBySphereIntegrand,toleranceRelative=1.0d-2)
        ! Find the range of radii at which to compute the enclosed mass, and construct the arrays.
-       !! Set an initial range of radii that brackets the requested radii.
-       radiusMinimum=0.5d0*radius
-       radiusMaximum=2.0d0*radius
-       !! Round to the nearest factor of 2.
-       radiusMinimum=2.0d0**floor  (log(radiusMinimum)/log(2.0d0))
-       radiusMaximum=2.0d0**ceiling(log(radiusMaximum)/log(2.0d0))
-       !! Expand to encompass any pre-existing range.
+       !! Find the range of radii to tabulate, pinned to an absolute lattice of whole octaves. This is what the bracketing by a
+       !! factor of two, the rounding to powers of two, and the expansion to encompass any pre-existing range did by hand: the
+       !! default safety margin is a factor of two at each end, and anchoring defaults to whole octaves, so the bounds are the
+       !! same ones - now obtained from the shared helper rather than reproduced here.
        if (allocated(self%massProfileRadius__)) then
-          radiusMinimum=min(radiusMinimum,self%massProfileRadiusMinimum__)
-          radiusMaximum=max(radiusMaximum,self%massProfileRadiusMaximum__)
+          lattice=Range_Pinned(                                                                                 &
+               &                              radius                                                          , &
+               &                              countPointsPerOctave                                            , &
+               &                              gridSchemePerOctave                                             , &
+               &               rangeCurrent  =[self%massProfileRadiusMinimum__,self%massProfileRadiusMaximum__] &
+               &              )
+       else
+          lattice=Range_Pinned(                                                                                 &
+               &                              radius                                                          , &
+               &                              countPointsPerOctave                                            , &
+               &                              gridSchemePerOctave                                               &
+               &              )
        end if
-       !! Construct arrays.
-       countRadii=nint(log(radiusMaximum/radiusMinimum)/log(2.0d0)*countPointsPerOctave+1.0d0)
+       radiusMinimum=lattice%minimum()
+       radiusMaximum=lattice%maximum()
+       !! Construct arrays, taking the abscissae from the lattice rather than by subdividing the range so that they are
+       !! bit-identical to those of any other tabulation built on the same lattice.
+       countRadii=lattice%count
        allocate(radii (countRadii))
        allocate(masses(countRadii))
-       radii=Make_Range(radiusMinimum,radiusMaximum,int(countRadii),rangeTypeLogarithmic)
+       radii=lattice%values()
        ! Copy in any usable results from any previous solution.
        !! Assume by default that no previous solutions are usable.
        iMinimum=+huge(0_c_size_t)

--- a/source/structure_formation/critical_overdensity/spherical_collapse_baryons_darkMatter_darkEnergy.F90
+++ b/source/structure_formation/critical_overdensity/spherical_collapse_baryons_darkMatter_darkEnergy.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   An implementation of critical overdensity for collapse based on spherical collapse accounting for non-clustering of baryons.
   !!}
@@ -46,8 +48,6 @@
      !!}
      private
      logical                                                                           :: tableInitialized                  =  .false.
-     double precision                                                                  :: tableClusteredTimeMinimum                   , tableClusteredTimeMaximum                    , &
-          &                                                                               tableUnclusteredTimeMinimum                 , tableUnclusteredTimeMaximum
      double precision                                                                  :: normalization
      double precision                                                                  :: perturbationSmall
      integer                                                                           :: tablePointsPerOctave
@@ -253,7 +253,17 @@ contains
 
     ! Check if we need to recompute our table.
     if (self%tableInitialized) then
-       remakeTable=(time < self%tableClusteredTimeMinimum .or. time > self%tableClusteredTimeMaximum .or. time < self%tableUnclusteredTimeMinimum .or. time > self%tableUnclusteredTimeMaximum)
+       ! Test the request against the tabulations' own bounds - see the collisionless matter variant of this class for why a
+       ! copy of them is not kept here.
+       remakeTable=(                                                                &
+            &        time < self%overdensityCriticalClustered  %x(+1)               &
+            &       .or.                                                            &
+            &        time > self%overdensityCriticalClustered  %x(-1)               &
+            &       .or.                                                            &
+            &        time < self%overdensityCriticalUnclustered%x(+1)               &
+            &       .or.                                                            &
+            &        time > self%overdensityCriticalUnclustered%x(-1)               &
+            &      )
     else
        remakeTable=.true.
     end if
@@ -261,10 +271,6 @@ contains
        call self%sphericalCollapseSolverUnclustered_%criticalOverdensity(time,self%tableStore,self%overdensityCriticalUnclustered)
        call self%sphericalCollapseSolverClustered_  %criticalOverdensity(time,self%tableStore,self%overdensityCriticalClustered  )
        self%tableInitialized           =.true.
-       self%tableClusteredTimeMinimum  =self%overdensityCriticalClustered  %x(+1)
-       self%tableClusteredTimeMaximum  =self%overdensityCriticalClustered  %x(-1)
-       self%tableUnclusteredTimeMinimum=self%overdensityCriticalUnclustered%x(+1)
-       self%tableUnclusteredTimeMaximum=self%overdensityCriticalUnclustered%x(-1)
     end if
     return
   end subroutine sphericalCollapseBrynsDrkMttrDrkEnrgyRetabulate

--- a/source/structure_formation/critical_overdensity/spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation/critical_overdensity/spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   An implementation of critical overdensity for collapse based on spherical collapse in a matter plus cosmological constant universe.
   !!}
@@ -38,7 +40,6 @@
      !!}
      private
      logical                                                                         :: tableInitialized         = .false.
-     double precision                                                                :: tableTimeMinimum                  , tableTimeMaximum
      double precision                                                                :: normalization
      logical                                                                         :: tableStore
      class           (table1D                                         ), allocatable :: overdensityCritical
@@ -201,16 +202,17 @@ contains
     logical                                                                                       :: remakeTable
 
     ! Check if we need to recompute our table.
+    ! Test the request against the tabulation's own bounds. The solver pins those to an absolute lattice, so they take only
+    ! discrete values and this test is stable; keeping a copy of them here only created a second place for them to be recorded,
+    ! and one which could fall out of step with the table it describes.
     if (self%tableInitialized) then
-       remakeTable=(time < self%tableTimeMinimum .or. time > self%tableTimeMaximum)
+       remakeTable=(time < self%overdensityCritical%x(+1) .or. time > self%overdensityCritical%x(-1))
     else
        remakeTable=.true.
     end if
     if (remakeTable) then
        call self%sphericalCollapseSolver_%criticalOverdensity(time,self%tableStore,self%overdensityCritical)
        self%tableInitialized=.true.
-       self%tableTimeMinimum=self%overdensityCritical%x(+1)
-       self%tableTimeMaximum=self%overdensityCritical%x(-1)
     end if
     return
   end subroutine sphericalCollapseClsnlssMttrCsmlgclCnstntRetabulate

--- a/source/structure_formation/virial_density_contrast/spherical_collapse_baryons_darkMatter_darkEnergy.F90
+++ b/source/structure_formation/virial_density_contrast/spherical_collapse_baryons_darkMatter_darkEnergy.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   An implementation of dark matter halo virial density contrasts based on spherical collapse in a matter plus cosmological constant universe.
   !!}
@@ -46,10 +48,6 @@
      !!}
      private
      logical                                                                           :: tableInitialized                  =  .false., turnaroundInitialized              =  .false.
-     double precision                                                                  :: tableClusteredTimeMinimum                   , tableClusteredTimeMaximum                    , &
-          &                                                                               tableUnclusteredTimeMinimum                 , tableUnclusteredTimeMaximum                  , &
-          &                                                                               turnaroundClusteredTimeMinimum              , turnaroundClusteredTimeMaximum               , &
-          &                                                                               turnaroundUnclusteredTimeMinimum            , turnaroundUnclusteredTimeMaximum
      integer                                                                           :: tablePointsPerOctave
      double precision                                                                  :: perturbationSmall
      logical                                                                           :: tableStore
@@ -216,7 +214,17 @@ contains
 
     ! Check if we need to recompute our table.
     if (self%tableInitialized) then
-       remakeTable=(time < self%tableClusteredTimeMinimum .or. time > self%tableClusteredTimeMaximum .or. time < self%tableUnclusteredTimeMinimum .or. time > self%tableUnclusteredTimeMaximum)
+       ! Test the request against the tabulations' own bounds - see the critical overdensity variant of this class for why a
+       ! copy of them is not kept here.
+       remakeTable=(                                                                &
+            &        time < self%deltaVirialClustered  %x(+1)&
+            &       .or.                                                            &
+            &        time > self%deltaVirialClustered  %x(-1)&
+            &       .or.                                                            &
+            &        time < self%deltaVirialUnclustered%x(+1)&
+            &       .or.                                                            &
+            &        time > self%deltaVirialUnclustered%x(-1)&
+            &      )
     else
        remakeTable=.true.
     end if
@@ -224,10 +232,6 @@ contains
        call self%sphericalCollapseSolverUnclustered_%virialDensityContrast(time,self%tableStore,self%deltaVirialUnclustered)
        call self%sphericalCollapseSolverClustered_  %virialDensityContrast(time,self%tableStore,self%deltaVirialClustered  )
        self%tableInitialized=.true.
-       self%tableClusteredTimeMinimum  =self%deltaVirialClustered  %x(+1)
-       self%tableClusteredTimeMaximum  =self%deltaVirialClustered  %x(-1)
-       self%tableUnclusteredTimeMinimum=self%deltaVirialUnclustered%x(+1)
-       self%tableUnclusteredTimeMaximum=self%deltaVirialUnclustered%x(-1)
     end if
     return
   end subroutine sphericalCollapseBrynsDrkMttrDrkEnrgyRetabulate
@@ -300,7 +304,15 @@ contains
 
     ! Check if we need to recompute our table.
     if (self%turnaroundInitialized) then
-       remakeTable=(time < self%turnaroundClusteredTimeMinimum .or. time > self%turnaroundClusteredTimeMaximum .or. time < self%turnaroundUnclusteredTimeMinimum .or. time > self%turnaroundUnclusteredTimeMaximum)
+       remakeTable=(                                                                &
+            &        time < self%turnaroundClustered  %x(+1)&
+            &       .or.                                                            &
+            &        time > self%turnaroundClustered  %x(-1)&
+            &       .or.                                                            &
+            &        time < self%turnaroundUnclustered%x(+1)&
+            &       .or.                                                            &
+            &        time > self%turnaroundUnclustered%x(-1)&
+            &      )
     else
        remakeTable=.true.
     end if
@@ -308,10 +320,6 @@ contains
        call self%sphericalCollapseSolverUnclustered_%radiusTurnaround(time,self%tableStore,self%turnaroundUnclustered)
        call self%sphericalCollapseSolverClustered_  %radiusTurnaround(time,self%tableStore,self%turnaroundClustered  )
        self%turnaroundInitialized=.true.
-       self%turnaroundClusteredTimeMinimum  =self%turnaroundClustered  %x(+1)
-       self%turnaroundClusteredTimeMaximum  =self%turnaroundClustered  %x(-1)
-       self%turnaroundUnclusteredTimeMinimum=self%turnaroundUnclustered%x(+1)
-       self%turnaroundUnclusteredTimeMaximum=self%turnaroundUnclustered%x(-1)
     end if
     return
   end subroutine sphericalCollapseBrynsDrkMttrDrkEnrgyRetabulateTurnaround

--- a/source/structure_formation/virial_density_contrast/spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation/virial_density_contrast/spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   An implementation of dark matter halo virial density contrasts based on spherical collapse in a matter plus cosmological constant universe.
   !!}
@@ -38,8 +40,6 @@
      !!}
      private
      logical                                                                         :: tableInitialized        =  .false., turnaroundInitialized=.false.
-     double precision                                                                :: tableTimeMinimum                  , tableTimeMaximum             , &
-          &                                                                             turnaroundTimeMinimum             , turnaroundTimeMaximum
      logical                                                                         :: tableStore
      class           (table1D                                         ), allocatable :: deltaVirial                       , turnaround
      class           (cosmologyFunctionsClass                         ), pointer     :: cosmologyFunctions_      => null()
@@ -154,15 +154,15 @@ contains
 
     ! Check if we need to recompute our table.
     if (self%tableInitialized) then
-       remakeTable=(time < self%tableTimeMinimum .or. time > self%tableTimeMaximum)
+       ! Test the request against the tabulation's own bounds - see the critical overdensity variant of this class for why a
+       ! copy of them is not kept here.
+       remakeTable=(time < self%deltaVirial%x(+1) .or. time > self%deltaVirial%x(-1))
     else
        remakeTable=.true.
     end if
     if (remakeTable) then
        call self%sphericalCollapseSolver_%virialDensityContrast(time,self%tableStore,self%deltaVirial)
        self%tableInitialized=.true.
-       self%tableTimeMinimum=self%deltaVirial%x(+1)
-       self%tableTimeMaximum=self%deltaVirial%x(-1)
     end if
     return
   end subroutine sphericalCollapseClsnlssMttrCsmlgclCnstntRetabulate
@@ -263,15 +263,13 @@ contains
     call self%cosmologyFunctions_%epochValidate(time,expansionFactor,collapsing,timeOut=time_)
     ! Check if we need to recompute our table.
     if (self%turnaroundInitialized) then
-       remakeTable=(time_ < self%turnaroundTimeMinimum .or. time_ > self%turnaroundTimeMaximum)
+       remakeTable=(time_ < self%turnaround%x(+1) .or. time_ > self%turnaround%x(-1))
     else
        remakeTable=.true.
     end if
     if (remakeTable) then
        call self%sphericalCollapseSolver_%radiusTurnaround(time_,self%tableStore,self%turnaround)
        self%turnaroundInitialized=.true.
-       self%turnaroundTimeMinimum=self%turnaround%x(+1)
-       self%turnaroundTimeMaximum=self%turnaround%x(-1)
     end if
     ! Interpolate to get the ratio.
     sphericalCollapseClsnlssMttrCsmlgclCnstntTrnrndVrlRd=self%turnaround%interpolate(time_)

--- a/source/tests/mass_distributions.F90
+++ b/source/tests/mass_distributions.F90
@@ -1093,6 +1093,20 @@ program Test_Mass_Distributions
   deallocate(massDistribution_)
   call Unit_Tests_End_Group()
 
+  ! The potential tabulation rounds its bounds outward to whole octaves of an absolute lattice. A radius which already lies on
+  ! one is the case where those bounds can coincide, which is rejected as a range of fewer than two points - so evaluate there.
+  call Unit_Tests_Begin_Group("Potential at a radius on a whole octave")
+  block
+    type            (massDistributionHernquist) :: hernquist_
+    type            (coordinateSpherical      ) :: coordinatesOctave
+    double precision                            :: potentialOctave
+    hernquist_       =massDistributionHernquist(mass=1.0d0,scaleLength=1.0d0)
+    coordinatesOctave=[1.0d0,0.0d0,0.0d0]
+    potentialOctave  =hernquist_%potential(coordinatesOctave)
+    call Assert("the potential is finite at a radius lying on a whole octave",potentialOctave < 0.0d0,.true.)
+  end block
+  call Unit_Tests_End_Group()
+
   ! End unit tests.
   call Unit_Tests_End_Group()
   call Unit_Tests_Finish()


### PR DESCRIPTION
Completes the helper-migration group of [#1375](https://github.com/galacticusorg/galacticus/issues/1375) — the sites already pinned correctly by hand, but reproducing the pinning rather than using the shared helper. Independent of #1399 and #1400; no file overlaps with either.

Behaviour-preserving cleanup, with one exception: a crash I introduced and then fixed, described below, because it is the part most worth reviewing.

## What changes

**The four spherical collapse wrappers** each kept their own copy of the bounds of the tabulation they hold — read back from the table's abscissae on the line after building it — and tested later requests against the copy rather than against the table. They now test the tabulations directly, and **twelve fields go**: two from each collisionless-matter class, four from each baryons-plus-dark-matter-plus-dark-energy class, which hold a clustered and an unclustered tabulation apiece. Every copy was assigned from exactly the abscissae now tested, so nothing changes but the number of places the bounds are recorded.

**The three hand-pinned tabulations** — velocity dispersion in `mass_distributions/_class.F90`, enclosed mass and potential in `mass_distributions/spherical/_class.F90` — bracketed the requested radius by a factor of two, rounded each bound to a power of two with `2**floor` and `2**ceiling`, expanded to encompass any pre-existing range with `min`/`max`, sized the grid from a base-two logarithm and built it with `Make_Range`. #1317 cites them as the prior art for the pinning it went on to provide. They now call `Range_Pinned`, whose default margin is a factor of two, whose default anchoring is to whole octaves, and whose `rangeCurrent` performs the union — the same lattice, obtained from the helper rather than reproduced. Abscissae come from the lattice rather than from subdividing the range, so they are bit-identical to those of any other tabulation built on it. `countPointsPerOctave` becomes an integer in both files, having been a whole number held in a double.

The potential tabulation keeps its shape rather than being flattened into the same form as the other two: its upper bound is still established *before* the guard which decides whether to rebuild, because the mass enclosed within it decides whether a tabulation is possible at all, and the factor of two at its lower end is supplied explicitly because this tabulation extends inward from the requested radius but not beyond it.

## The crash, and the test added for it

My first version of the potential change pinned the upper bound from a **scalar** target with `marginFactor=1.0d0`. `Range_Pinned` then sets `coordinateMinimum` and `coordinateMaximum` from that same value (`ranges.F90:254-255`), and when the radius lies on a whole octave both round to the same anchor, tripping `if (indexMaximum <= indexMinimum) call Error_Report('pinned range contains fewer than two points ...')` at `ranges.F90:291`. **Every radius on a whole octave — 0.5, 1.0, 2.0, 4.0 — would have aborted.**

The build, `parameters/quickTest.xml`, `tests.mass_distributions`, `tests.mass_distributions.tabulated` and `tests.dark_matter_profiles` all passed with it in place: none of them evaluates a potential at such a radius.

Fixed by targeting the range spanning the requested radius and half of it, which gives the same rounded maximum and cannot be degenerate. A test evaluating a Hernquist potential at exactly r=1 is added, since nothing covered it.

## Deliberately not done

The carry-over of previously computed values, in all three tabulations, still identifies the overlapping block by index arithmetic on the octave grid rather than with `Range_Lattice_Offset`. Expressing it properly means storing the lattice as a `functionClass` `<data>` component, and **no such component is a derived type anywhere in the code at present**, so it would exercise the generated deep-copy and state-store paths for the first time. That is real risk for no correctness gain on code which is already right. Noted here so the remaining hand-rolled arithmetic is not read as an oversight.

## Verification

`Galacticus.exe` built and `parameters/quickTest.xml` run clean at each step, plus `tests.spherical_collapse.determinism` (30/30), `.flat` (7/7), `.dark_energy.EdS` (14/14), `tests.mass_distributions` (158/158, up from 157 with the new assertion), `tests.mass_distributions.tabulated` (27/27), `tests.dark_matter_profiles` (100/100) and `tests.kinematic_distributions.NFW` (1/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
