### PR TITLE
perf(launcher): parallelize downloads and publish faster release assets

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -470,7 +470,14 @@ jobs:
           # executable and a stamp matching the required `forutils` version are present. Installs made from
           # the packaged tools (e.g. via PyPI) typically have no Fortran compiler, so a missing stamp turns
           # into a fatal build attempt rather than a simple use of the pre-built binary.
-          tar cfj tools.tar.bz2 \
+          # zstd rather than bzip2. The archive is roughly the same size, but bzip2 decompresses at around
+          # 13 MB/s of compressed input single-threaded, so unpacking the ~1.7 GB archive took over two
+          # minutes on the installing machine -- several times longer than downloading it. zstd unpacks the
+          # same payload in a few seconds. Level 12 is chosen over the slower levels because this payload is
+          # ~9 GB uncompressed: the higher levels buy a few percent of size at the cost of many minutes of
+          # runner time, whereas -12 is both smaller and faster to produce than the bzip2 it replaces.
+          set -o pipefail
+          tar cf - \
             dynamic/CAMB-${cambVersion}/fortran/camb \
             dynamic/CAMB-${cambVersion}/forutils/.galacticusForUtilsVersion_${forutilsVersion} \
             dynamic/axionCAMB-${axioncambVersion}/camb \
@@ -486,12 +493,59 @@ jobs:
             dynamic/fsps-${fspsVersion}/SPECTRA \
             dynamic/fsps-${fspsVersion}/OUTPUTS \
             dynamic/fsps-${fspsVersion}/ISOCHRONES \
-            dynamic/mangle-${mangleVersion}/bin/harmonize
+            dynamic/mangle-${mangleVersion}/bin/harmonize \
+            | zstd -12 -T0 -q -o tools.tar.zst
       - name: Upload tools
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: galacticus-tools
-          path: ./datasets/tools.tar.bz2
+          # Already compressed: re-zipping it in the artifact costs minutes and saves nothing.
+          compression-level: 0
+          path: ./datasets/tools.tar.zst
+      - run: echo "This job's status is ${{ job.status }}."
+  ## Run-time datasets
+  Package-Datasets:
+    # Publish a snapshot of the datasets repository as a release asset.
+    #
+    # Without one, an install has to fetch `galacticusorg/datasets` from GitHub's repository-archive endpoint,
+    # which generates the zip on the fly: it advertises no content length, refuses byte ranges, and is
+    # throttled per connection to a fraction of the rate a release asset is served at. That single download
+    # dominates the wall-clock time of a first install. As a release asset the same data can be split across
+    # connections, verified against the release checksums, and unpacked from zstd rather than deflate.
+    #
+    # It also pins the data: the snapshot is taken at a known commit, recorded in `datasets.ref`, so an
+    # install gets the data this build was tested against instead of whatever `master` has moved on to.
+    # Setting GALACTICUS_DATASETS_REF still asks the launcher for a specific ref via the repository archive.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository datasets
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: galacticusorg/datasets
+          path: datasets
+          # Only the working tree is packaged, so there is no use for the history.
+          fetch-depth: 1
+      - name: Package datasets snapshot
+        run: |
+          set -o pipefail
+          cd datasets
+          git rev-parse HEAD > "${GITHUB_WORKSPACE}/datasets.ref"
+          echo "datasets snapshot at $(cat "${GITHUB_WORKSPACE}/datasets.ref")"
+          # Packed from the root of the tree, with no top-level directory: the launcher unpacks this straight
+          # into GALACTICUS_DATA_PATH, unlike the repository archive whose single `datasets-<ref>/` wrapper
+          # has to be stripped. Level 12 for the same reason as the tools archive -- see `Build-Tools`.
+          tar cf - --exclude=./.git . | zstd -12 -T0 -q -o "${GITHUB_WORKSPACE}/datasets.tar.zst"
+          ls -lh "${GITHUB_WORKSPACE}/datasets.tar.zst"
+      - name: Upload datasets snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: galacticus-datasets
+          # Already compressed: re-zipping it in the artifact costs minutes and saves nothing.
+          compression-level: 0
+          path: |
+            ./datasets.tar.zst
+            ./datasets.ref
       - run: echo "This job's status is ${{ job.status }}."
   ## MacOS
   ### Static executable
@@ -652,6 +706,24 @@ jobs:
           zip -r toolsMacOS.zip "${toolProducts[@]}" \
             -x "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm" \
                "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm.dSYM/*"
+          # The same signed products, packed again as a zstd tar -- which is what the release publishes and
+          # the launcher installs. The zip stays because it is the submission format: `xcrun notarytool
+          # submit` accepts only .zip/.pkg/.dmg, and the signature verification step below reads it too. That
+          # costs nothing at distribution time, because a notarization ticket for loose signed binaries lives
+          # on Apple's servers and is looked up by the code-directory hash of each binary -- it is not stapled
+          # into the archive, so the archive's format is free. The tar wins twice over the zip: it unpacks far
+          # faster, and it records file modes, so the launcher does not have to guess afterwards which of the
+          # unpacked files were meant to be executable.
+          #
+          # COPYFILE_DISABLE stops bsdtar writing AppleDouble `._*` members for extended attributes. Mach-O
+          # code signatures live inside the binaries themselves, so nothing signed is lost; what would be
+          # carried over is quarantine and Finder metadata, which the installed tools have no use for.
+          set -o pipefail
+          COPYFILE_DISABLE=1 tar cf - \
+            --exclude "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm" \
+            --exclude "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm.dSYM*" \
+            "${toolProducts[@]}" \
+            | zstd -12 -T0 -q -o toolsMacOS.tar.zst
       - name: Verify all packaged binaries are code-signed
         uses: ./.github/actions/verifySignedMacOS
         with:
@@ -662,7 +734,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: galacticus-tools-MacOS
-          path: './datasets/toolsMacOS.zip'
+          # Already compressed: re-zipping them in the artifact costs minutes and saves nothing.
+          compression-level: 0
+          path: |
+            ./datasets/toolsMacOS.zip
+            ./datasets/toolsMacOS.tar.zst
   ### Apple Silicon build
   Build-Executable-MacOS-M1:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -817,6 +893,24 @@ jobs:
           zip -r toolsMacOSM1.zip "${toolProducts[@]}" \
             -x "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm" \
                "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm.dSYM/*"
+          # The same signed products, packed again as a zstd tar -- which is what the release publishes and
+          # the launcher installs. The zip stays because it is the submission format: `xcrun notarytool
+          # submit` accepts only .zip/.pkg/.dmg, and the signature verification step below reads it too. That
+          # costs nothing at distribution time, because a notarization ticket for loose signed binaries lives
+          # on Apple's servers and is looked up by the code-directory hash of each binary -- it is not stapled
+          # into the archive, so the archive's format is free. The tar wins twice over the zip: it unpacks far
+          # faster, and it records file modes, so the launcher does not have to guess afterwards which of the
+          # unpacked files were meant to be executable.
+          #
+          # COPYFILE_DISABLE stops bsdtar writing AppleDouble `._*` members for extended attributes. Mach-O
+          # code signatures live inside the binaries themselves, so nothing signed is lost; what would be
+          # carried over is quarantine and Finder metadata, which the installed tools have no use for.
+          set -o pipefail
+          COPYFILE_DISABLE=1 tar cf - \
+            --exclude "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm" \
+            --exclude "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm.dSYM*" \
+            "${toolProducts[@]}" \
+            | zstd -12 -T0 -q -o toolsMacOSM1.tar.zst
       - name: Verify all packaged binaries are code-signed
         uses: ./.github/actions/verifySignedMacOS
         with:
@@ -827,7 +921,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: galacticus-tools-MacOS-M1
-          path: './datasets/toolsMacOSM1.zip'
+          # Already compressed: re-zipping them in the artifact costs minutes and saves nothing.
+          compression-level: 0
+          path: |
+            ./datasets/toolsMacOSM1.zip
+            ./datasets/toolsMacOSM1.tar.zst
   ## Library
   Build-Library-MacOS:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -2502,6 +2600,7 @@ jobs:
              Build-Library-Linux,
              Build-Docker-Linux,
              Build-Tools,
+             Package-Datasets,
              Build-Executable-MacOS,
              Build-Executable-MacOS-M1,
              Build-Library-MacOS,
@@ -2560,11 +2659,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload bleeding-edge ./Galacticus.exe ./libgalacticus.tar.bz2 ./tools.tar.bz2 --clobber
+          gh release upload bleeding-edge ./Galacticus.exe ./libgalacticus.tar.bz2 ./tools.tar.zst --clobber
           # Record the checksums of the assets the launcher downloads and executes, before the local copies are removed. These are
-          # collected across the upload steps of this job and published as a single `SHA256SUMS` asset at the end of it.
-          sha256sum Galacticus.exe tools.tar.bz2 >> "${GITHUB_WORKSPACE}/SHA256SUMS"
-          rm ./Galacticus.exe ./libgalacticus.tar.bz2 ./tools.tar.bz2
+          # collected across the upload steps of this job and published as a single `SHA256SUMS` asset at the end of it. The
+          # launcher also reads this file as the release's asset manifest -- an artefact listed here is one the release carries,
+          # which is how it chooses between the current and the legacy form of an archive without probing for a 404.
+          sha256sum Galacticus.exe tools.tar.zst >> "${GITHUB_WORKSPACE}/SHA256SUMS"
+          rm ./Galacticus.exe ./libgalacticus.tar.bz2 ./tools.tar.zst
+      - name: Download artifacts (datasets)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: galacticus-datasets
+      - name: Upload datasets snapshot to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload bleeding-edge ./datasets.tar.zst ./datasets.ref --clobber
+          sha256sum datasets.tar.zst datasets.ref >> "${GITHUB_WORKSPACE}/SHA256SUMS"
+          rm ./datasets.tar.zst ./datasets.ref
       - name: Download artifacts (executable-macos)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -2601,9 +2713,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload bleeding-edge ./Galacticus_MacOS.exe ./Galacticus_MacOS.zip ./Galacticus_MacOS-M1.exe ./Galacticus_MacOS-M1.zip ./libgalacticusMacOS.zip ./toolsMacOS.zip ./toolsMacOSM1.zip ./debugSymbolsMacOS.zip ./debugSymbolsMacOS-M1.zip ./notarization-requests-*.json --clobber
-          sha256sum Galacticus_MacOS.exe Galacticus_MacOS-M1.exe toolsMacOS.zip toolsMacOSM1.zip >> "${GITHUB_WORKSPACE}/SHA256SUMS"
-          rm -f ./Galacticus_MacOS.exe ./Galacticus_MacOS.zip ./Galacticus_MacOS-M1.exe ./Galacticus_MacOS-M1.zip ./libgalacticusMacOS.zip ./toolsMacOS.zip ./toolsMacOSM1.zip ./debugSymbolsMacOS.zip ./debugSymbolsMacOS-M1.zip ./notarization-requests-*.json
+          # The tools zips are deliberately not published: they exist only as the format `xcrun notarytool
+          # submit` accepts, and the release carries the same signed products as the zstd tars the launcher
+          # installs. Publishing both would add ~4 GB of duplicate assets to every release.
+          gh release upload bleeding-edge ./Galacticus_MacOS.exe ./Galacticus_MacOS.zip ./Galacticus_MacOS-M1.exe ./Galacticus_MacOS-M1.zip ./libgalacticusMacOS.zip ./toolsMacOS.tar.zst ./toolsMacOSM1.tar.zst ./debugSymbolsMacOS.zip ./debugSymbolsMacOS-M1.zip ./notarization-requests-*.json --clobber
+          sha256sum Galacticus_MacOS.exe Galacticus_MacOS-M1.exe toolsMacOS.tar.zst toolsMacOSM1.tar.zst >> "${GITHUB_WORKSPACE}/SHA256SUMS"
+          rm -f ./Galacticus_MacOS.exe ./Galacticus_MacOS.zip ./Galacticus_MacOS-M1.exe ./Galacticus_MacOS-M1.zip ./libgalacticusMacOS.zip ./toolsMacOS.zip ./toolsMacOSM1.zip ./toolsMacOS.tar.zst ./toolsMacOSM1.tar.zst ./debugSymbolsMacOS.zip ./debugSymbolsMacOS-M1.zip ./notarization-requests-*.json
       - name: Download artifacts (perf-darkMatterOnlySubHalos)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -54,7 +54,10 @@ jobs:
         # platformdirs + requests are needed by the galacticus_launcher tests and
         # lxml by the parameter-resolver tests (the third-party deps in the
         # python/ pytest suite); all are small wheels so the job stays fast.
-        run: python -m pip install --upgrade pip pytest platformdirs requests lxml
+        # zstandard supplies zstd where the standard library has none (before
+        # Python 3.14), so the launcher's archive tests do not depend on which
+        # interpreter this job happens to resolve `3.x` to.
+        run: python -m pip install --upgrade pip pytest platformdirs requests lxml zstandard
       - name: Run Python regression tests
         run: |
           cd $GITHUB_WORKSPACE
@@ -439,6 +442,11 @@ jobs:
           echo "GALACTICUS_DATA_PATH=$GITHUB_WORKSPACE/datasets" >> $GITHUB_ENV
           echo "GALACTICUS_FCFLAGS+=\ -static" >> $GITHUB_ENV
           echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
+      - name: "Install archiving tools"
+        # The tools archive is packed with zstd (see the packaging step below), which the build container
+        # does not carry. The other jobs which pack a zstd archive run directly on a runner image, where it
+        # is already present.
+        run: apt-get install --yes zstd || { apt-get update && apt-get install --yes zstd ; }
       - name: Download executables
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,13 +132,22 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          # Both the current and the superseded name of each tools archive are listed. A tag cut before the
+          # next `master` deploy finds only the older names on `bleeding-edge`, and the launcher installs
+          # either -- so mirroring whichever exists keeps such a tag usable, rather than leaving it with no
+          # tools at all. Missing names are warned about and skipped below.
           assets=(
             Galacticus.exe
             Galacticus_MacOS.exe
             Galacticus_MacOS-M1.exe
+            tools.tar.zst
+            toolsMacOS.tar.zst
+            toolsMacOSM1.tar.zst
             tools.tar.bz2
             toolsMacOS.zip
             toolsMacOSM1.zip
+            datasets.tar.zst
+            datasets.ref
             parameters.catalog.json
           )
           mkdir -p release-assets
@@ -148,12 +157,22 @@ jobs:
               --pattern "${asset}" --dir release-assets || \
               echo "WARNING: ${asset} not found on bleeding-edge; skipping."
           done
-          # Pin the datasets version: record the current datasets master HEAD
-          # commit so this release always installs against the same data. The
-          # launcher reads the `datasets.ref` asset; the value is also written
-          # into the release notes for users installing manually (not via pip).
-          datasets_sha=$(git ls-remote https://github.com/galacticusorg/datasets.git HEAD | cut -f1)
-          echo "datasets pinned to ${datasets_sha}"
+          # Pin the datasets version, so this release always installs against the same data. The launcher
+          # reads the `datasets.ref` asset; the value is also written into the release notes for users
+          # installing manually (not via pip).
+          #
+          # The pin has to name the commit the mirrored `datasets.tar.zst` snapshot was taken from, not
+          # whatever `master` happens to be right now -- otherwise the recorded commit and the data actually
+          # published here would disagree. Only when no snapshot was mirrored (a tag cut before the next
+          # `master` deploy) is the current remote HEAD used, which is what the repository-archive fallback
+          # would then fetch anyway.
+          if [ -s release-assets/datasets.ref ]; then
+            datasets_sha=$(cut -d' ' -f1 < release-assets/datasets.ref | tr -d '[:space:]')
+            echo "datasets pinned to ${datasets_sha} (from the mirrored snapshot)"
+          else
+            datasets_sha=$(git ls-remote https://github.com/galacticusorg/datasets.git HEAD | cut -f1)
+            echo "datasets pinned to ${datasets_sha} (no snapshot mirrored; using remote HEAD)"
+          fi
           printf '%s\n' "${datasets_sha}" > release-assets/datasets.ref
           # Create the release (with generated notes) if it does not yet exist.
           gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1 || \

--- a/docs/manuals/user-guide/installation/pip.rst
+++ b/docs/manuals/user-guide/installation/pip.rst
@@ -31,8 +31,10 @@ Running a model
    galacticus run parameters/quickTest.xml
 
 On first use you will see the launcher fetch the executable, datasets, and tools,
-with a progress bar for each download and for unpacking each archive; subsequent
-runs reuse the cached copies. ``galacticus run`` validates the parameter file
+with a progress bar for each download and for unpacking each archive; the
+downloads run concurrently, and each large one is split across several
+connections, so the whole set arrives at roughly the speed of your link rather
+than of one stream. Subsequent runs reuse the cached copies. ``galacticus run`` validates the parameter file
 before dispatching it; pass ``--no-validate`` to skip that, and any other
 arguments (e.g. ``--dry-run``) are passed straight through to the executable.
 ``galacticus <file>`` is shorthand for ``galacticus run <file>``. If you do not
@@ -163,8 +165,17 @@ executable's ``--dry-run``.
 
    The launcher fetches assets from the GitHub release matching the installed
    package version (development installs track the rolling ``bleeding-edge``
-   release). For a versioned release the run-time datasets are pinned to a
-   specific ``datasets`` commit, recorded on the release, so a given package
-   version always installs the same data. ``GALACTICUS_RELEASE_TAG`` and
+   release). The run-time datasets are installed from a snapshot published on
+   the release and pinned to the ``datasets`` commit it was taken from, so a
+   given release always installs the same data — the commit is recorded on the
+   release as ``datasets.ref``. ``GALACTICUS_RELEASE_TAG`` and
    ``GALACTICUS_DATASETS_REF`` override the release tag and datasets ref
-   respectively.
+   respectively; asking for a specific ref fetches that commit from the
+   ``datasets`` repository instead of using the release snapshot, which is
+   slower but is how you track ``master`` or test an unreleased data change.
+
+.. note::
+
+   ``GALACTICUS_DOWNLOAD_CONNECTIONS`` sets how many byte-range requests a
+   single large asset is split across (default 4). Set it to ``1`` if a
+   network or proxy handles ranged requests badly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
     "GitPython",
     "termcolor",
     "platformdirs",
+    # Release archives are zstd-compressed; `compression.zstd` covers this from
+    # Python 3.14 onward, so the package is only needed on earlier versions.
+    "zstandard; python_version < '3.14'",
 ]
 
 [project.optional-dependencies]

--- a/python/galacticus_launcher/download.py
+++ b/python/galacticus_launcher/download.py
@@ -9,7 +9,9 @@ Four components make up a runnable install:
 * **exec**     -- the repository source archive (whole tree), giving
   ``GALACTICUS_EXEC_PATH`` its ``parameters/``, ``aux/`` and ``scripts/``,
   plus the platform executable copied in as ``Galacticus.exe``.
-* **datasets** -- the ``galacticusorg/datasets`` archive (static data root).
+* **datasets** -- the run-time static data root.  Releases publish a snapshot of
+  ``galacticusorg/datasets`` as an asset; older ones are fetched from the
+  repository archive instead (see :func:`_plan_datasets`).
 * **tools**    -- the pre-built run-time tools archive.  Its entries are
   prefixed ``dynamic/`` (the location the un-relocated binary expects); we strip
   that prefix so the contents land directly under ``GALACTICUS_TOOLS_PATH``.
@@ -20,12 +22,23 @@ Four components make up a runnable install:
   parameters used by ``galacticus validate``, downloaded from the release when it
   publishes one and generated from the installed source otherwise.
 
-Archives are staged alongside their destination rather than in the system
-temporary directory, so that unpacking is followed by a rename rather than a
-copy across filesystems, and so that a multi-gigabyte download does not have to
-fit in a (often small, often ``tmpfs``) ``/tmp``.
+A first install moves gigabytes, so the transfer is arranged to keep the link
+busy rather than to be simple:
+
+* Every component's archive is downloaded **concurrently** with the others.  The
+  repository archive endpoint throttles hard per connection, so overlapping the
+  components is worth far more than it costs -- separate connections each get
+  their own share.
+* A single large asset is split across several **byte-range** requests where the
+  server supports them (release assets do; the on-the-fly repository archives do
+  not), which lifts a single-stream transfer to roughly the link rate.
+* Archives are staged alongside their destination rather than in the system
+  temporary directory, so that unpacking is followed by a rename rather than a
+  copy across filesystems, and so that a multi-gigabyte download does not have to
+  fit in a (often small, often ``tmpfs``) ``/tmp``.
 """
 
+import contextlib
 import hashlib
 import json
 import os
@@ -34,8 +47,10 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import threading
 import time
 import zipfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import requests
@@ -46,17 +61,22 @@ DATASETS_REPO = "galacticusorg/datasets"
 # Release asset listing the SHA-256 of each of the other assets, used to verify what we download.
 CHECKSUM_ASSET = "SHA256SUMS"
 
-# Release asset carrying the pre-built parameter catalog (see `_provision_catalog`).
+# Release asset carrying the pre-built parameter catalog (see `_plan_catalog`).
 CATALOG_ASSET = "parameters.catalog.json"
+
+# Release assets carrying the datasets snapshot and the commit it was taken from.
+DATASETS_ASSET = "datasets.tar.zst"
+DATASETS_REF_ASSET = "datasets.ref"
 
 # Sentinel recording that the tools archive is deliberately not wanted.
 TOOLS_SKIPPED = "tools-skipped"
 
 # Tool executables in the pre-built tools archive whose execute bit must be
-# restored after unpacking a zip (macOS tools ship as .zip; tar archives already
-# preserve permissions). This list matches the binaries the CI `Build-Tools`
-# jobs pack into tools.tar.bz2 / toolsMacOS*.zip; tools built at run time and
-# NOT shipped (CosmicEmu's emu.exe, AGN_Spectrum) are intentionally absent.
+# restored after unpacking a zip.  Tar archives -- the current format on every
+# platform -- record the mode themselves, so this only matters when falling back
+# to the macOS `.zip` tools archive published by older releases.  This list
+# matches the binaries the CI `Build-Tools` jobs pack; tools built at run time
+# and NOT shipped (CosmicEmu's emu.exe, AGN_Spectrum) are intentionally absent.
 _TOOL_EXECUTABLE_NAMES = frozenset({
     "camb", "class", "recfast.exe", "cloudy.exe", "autosps.exe", "harmonize",
 })
@@ -68,6 +88,21 @@ _CHUNK = 1 << 20  # 1 MiB
 # directory (see the module docstring), so name them recognizably: an install
 # killed part way through leaves one behind, and it should be obvious what it is.
 _STAGING = ".galacticus-staging-"
+
+# Byte-range requests to split one asset across.  Four is where the measured
+# gain flattens out; `GALACTICUS_DOWNLOAD_CONNECTIONS` overrides it, and 1
+# disables splitting altogether (for a link or proxy which dislikes it).
+_CONNECTIONS = 4
+
+# Ceiling on connections in flight at once across every concurrent download, so
+# that splitting several components at the same time stays polite.
+_MAX_CONNECTIONS = 8
+
+# Assets smaller than this are fetched in one request: splitting them costs more
+# in round trips than it saves in transfer time.
+_SPLIT_THRESHOLD = 64 << 20  # 64 MiB
+
+_CONNECTION_SLOTS = threading.Semaphore(_MAX_CONNECTIONS)
 
 
 def asset_url(tag, asset):
@@ -93,19 +128,18 @@ def datasets_url(ref="master"):
 def resolve_datasets_ref(tag, *, log=print):
     """Resolve which datasets ref to fetch for a release `tag`.
 
-    ``GALACTICUS_DATASETS_REF`` overrides everything. Otherwise a versioned
-    release pins datasets to the commit recorded in its ``datasets.ref`` asset
-    (written by the publish workflow), so a given package version always fetches
-    the same data. Dev/bleeding-edge installs, or a release with no pin, track
-    datasets ``master``.
+    ``GALACTICUS_DATASETS_REF`` overrides everything. Otherwise a release pins
+    datasets to the commit recorded in its ``datasets.ref`` asset (written by the
+    workflow which publishes the snapshot), so a given release always installs
+    the same data. A release with no pin tracks datasets ``master``.
     """
     override = os.environ.get("GALACTICUS_DATASETS_REF")
     if override:
         return override
+    pinned = _read_remote_text(asset_url(tag, DATASETS_REF_ASSET))
+    if pinned:
+        return pinned.strip().split()[0]
     if tag and tag != "bleeding-edge":
-        pinned = _read_remote_text(asset_url(tag, "datasets.ref"))
-        if pinned:
-            return pinned.strip().split()[0]
         log(f"  no datasets pin on release {tag}; using datasets master.")
     return "master"
 
@@ -130,6 +164,10 @@ def load_checksums(tag, *, log=print):
     actually received are the ones that release published, so a corrupted, truncated, or substituted asset is caught rather than
     being executed. Releases published before this file existed simply have no checksums; that is reported and provisioning
     continues, since refusing would break every existing install.
+
+    It doubles as the manifest of what a release carries: an asset listed here is
+    one the release has, which is how provisioning chooses between the current
+    and the legacy form of an artefact without probing for a 404.
     """
     body = _read_remote_text(asset_url(tag, CHECKSUM_ASSET))
     if not body:
@@ -141,6 +179,11 @@ def load_checksums(tag, *, log=print):
             digest, name = fields
             checksums[name.lstrip("*")] = digest.lower()
     return checksums or None
+
+
+def _publishes(checksums, asset):
+    """True if release `checksums` list `asset` -- i.e. the release carries it."""
+    return checksums is not None and asset in checksums
 
 
 def _sha256(path):
@@ -176,6 +219,38 @@ def _verify(path, name, checksums, *, log=print):
     log(f"  verified {name} (SHA-256).")
 
 
+class _Plan:
+    """What one component needs: files to download, then how to install them.
+
+    Provisioning is split in two so that the slow part can be overlapped.  Each
+    component's planner registers its downloads with the shared :class:`_Fetcher`
+    and returns the callable which unpacks them; every download then runs
+    concurrently, and the unpack callables run afterwards, in component order.
+    """
+
+    def __init__(self, name, unpack):
+        self.name = name
+        self.unpack = unpack
+
+
+class _Context:
+    """Everything a component planner needs, gathered once per `provision` call."""
+
+    def __init__(self, *, install, checksums, force, log, fetcher, stack):
+        self.install = install
+        self.checksums = checksums
+        self.force = force
+        self.log = log
+        self.fetcher = fetcher
+        self.stack = stack
+
+    def workspace(self, beside):
+        """A staging directory next to `beside`, removed when provisioning ends."""
+        beside.mkdir(parents=True, exist_ok=True)
+        return Path(self.stack.enter_context(
+            tempfile.TemporaryDirectory(dir=beside.parent, prefix=_STAGING)))
+
+
 def provision(install, *, force=False, log=print, tools=None):
     """Download and unpack any missing components of a managed `install`.
 
@@ -192,7 +267,6 @@ def provision(install, *, force=False, log=print, tools=None):
     if install.assets is None:  # pragma: no cover - managed always has assets
         raise ValueError("managed install is missing platform assets")
 
-    done = []
     for path in (install.exec_path, install.data_path, install.tools_path,
                  install.dynamic_path):
         path.mkdir(parents=True, exist_ok=True)
@@ -203,15 +277,22 @@ def provision(install, *, force=False, log=print, tools=None):
         log(f"  note: release {install.tag} publishes no {CHECKSUM_ASSET}; "
             "downloaded artefacts can not be verified against it.")
 
-    if _provision_exec(install, force=force, log=log, checksums=checksums):
-        done.append("exec")
-    if _provision_datasets(install, force=force, log=log):
-        done.append("datasets")
-    if _tools_wanted(install, tools, log=log) and \
-            _provision_tools(install, force=force, log=log, checksums=checksums):
-        done.append("tools")
-    if _provision_catalog(install, force=force, log=log, checksums=checksums):
-        done.append("parameter catalog")
+    done = []
+    fetcher = _Fetcher(log=log)
+    with contextlib.ExitStack() as stack:
+        context = _Context(install=install, checksums=checksums, force=force,
+                           log=log, fetcher=fetcher, stack=stack)
+        plans = [plan for plan in (_plan_exec(context),
+                                   _plan_datasets(context),
+                                   _plan_tools(context, tools),
+                                   _plan_catalog(context))
+                 if plan is not None]
+        if not plans:
+            return done
+        fetcher.run()
+        for plan in plans:
+            if plan.unpack() is not False:
+                done.append(plan.name)
     return done
 
 
@@ -249,7 +330,7 @@ def _tools_wanted(install, tools, *, log):
     return False
 
 
-def _provision_catalog(install, *, force, log, checksums=None):
+def _plan_catalog(context):
     """Install the parameter catalog used by ``galacticus validate``.
 
     The catalog is not a committed artifact -- it is derived from the source
@@ -261,39 +342,50 @@ def _provision_catalog(install, *, force, log, checksums=None):
     is best effort: without a catalog, validation falls back to the executable's
     ``--dry-run``.
     """
+    install, log = context.install, context.log
     catalog = Path(install.exec_path) / CATALOG_ASSET
-    if catalog.is_file() and not force:
-        return False
-    if _fetch_catalog(install, catalog, log=log, checksums=checksums):
-        return True
-    return _generate_catalog(install, catalog, log=log)
-
-
-def _fetch_catalog(install, catalog, *, log, checksums):
-    """Download the pre-built parameter catalog published by the release.
-
-    Returns True if `catalog` was written.  Every failure mode -- the release
-    publishing no catalog, a download error, a checksum mismatch, or a file which
-    is not valid JSON -- returns False so the caller can generate one instead.
-    Unlike the executable and the tools, the catalog is data and is never run, so
-    a bad copy is a reason to fall back rather than to abort the install; the
-    generator reproduces the same catalog from the source tree just installed.
-    """
-    log("Fetching parameter catalog ...")
+    if catalog.is_file() and not context.force:
+        return None
     staged = Path(str(catalog) + ".part-download")
+    job = None
+    if context.checksums is None or CATALOG_ASSET in context.checksums:
+        log("Fetching parameter catalog ...")
+        # Optional: the catalog can be rebuilt from the source tree, so neither
+        # a release which does not publish one nor a failure to fetch it may
+        # abort an install whose other components succeeded.
+        job = context.fetcher.enqueue(asset_url(install.tag, CATALOG_ASSET), staged,
+                                      label=CATALOG_ASSET, missing_ok=True,
+                                      optional=True)
+    else:
+        log(f"  release {install.tag} publishes no {CATALOG_ASSET}.")
+
+    def unpack():
+        if job is not None and job.present and _accept_catalog(
+                staged, context.checksums, log=log):
+            staged.replace(catalog)
+            return True
+        staged.unlink(missing_ok=True)
+        return _generate_catalog(install, catalog, log=log)
+
+    return _Plan("parameter catalog", unpack)
+
+
+def _accept_catalog(staged, checksums, *, log):
+    """True if the downloaded catalog at `staged` is fit to install.
+
+    Every failure mode -- a checksum mismatch, a file which is not valid JSON --
+    returns False so the caller can generate one instead.  Unlike the executable
+    and the tools, the catalog is data and is never run, so a bad copy is a reason
+    to fall back rather than to abort the install; the generator reproduces the
+    same catalog from the source tree just installed.
+    """
     try:
-        if not _download(asset_url(install.tag, CATALOG_ASSET), staged, log=log,
-                         missing_ok=True):
-            log(f"  release {install.tag} publishes no {CATALOG_ASSET}.")
-            return False
         _verify(staged, CATALOG_ASSET, checksums, log=log)
         with open(staged) as handle:
             json.load(handle)
     except (RuntimeError, OSError, ValueError) as error:
         log(f"  could not use the published parameter catalog ({error}).")
-        staged.unlink(missing_ok=True)
         return False
-    staged.replace(catalog)
     return True
 
 
@@ -319,90 +411,270 @@ def _sentinel(directory, name):
     return Path(directory) / f".galacticus-{name}"
 
 
-def _provision_exec(install, *, force, log, checksums=None):
+def _plan_exec(context):
+    install, log = context.install, context.log
     sentinel = _sentinel(install.exec_path, "exec")
-    if sentinel.exists() and not force:
-        return False
+    if sentinel.exists() and not context.force:
+        return None
     log(f"Fetching Galacticus source ({install.tag}) ...")
-    with tempfile.TemporaryDirectory(dir=install.exec_path.parent, prefix=_STAGING) as work:
-        archive = Path(work) / "source.zip"
-        _download(source_url(install.tag), archive, log=log)
+    work = context.workspace(install.exec_path)
+    archive = work / "source.zip"
+    # The executable is staged beside the archive rather than downloaded straight
+    # into `exec_path`, because unpacking the source tree into that directory
+    # happens afterwards and replaces whatever it finds under each of its own
+    # top-level names.
+    staged_binary = work / "Galacticus.exe"
+    context.fetcher.enqueue(source_url(install.tag), archive, label="source.zip")
+    context.fetcher.enqueue(asset_url(install.tag, install.assets.binary),
+                            staged_binary, label=install.assets.binary)
+
+    def unpack():
         _extract_strip_top(archive, install.exec_path, log=log)
-    log(f"Fetching executable {install.assets.binary} ...")
-    binary = install.exec_path / "Galacticus.exe"
-    _download(asset_url(install.tag, install.assets.binary), binary, log=log)
-    # Verify before making the file executable, so that a file which fails the check is never left runnable.
-    _verify(binary, install.assets.binary, checksums, log=log)
-    binary.chmod(0o755)
-    sentinel.write_text(install.tag)
-    return True
+        # Verify before making the file executable, so that a file which fails the check is never left runnable.
+        _verify(staged_binary, install.assets.binary, context.checksums, log=log)
+        binary = install.exec_path / "Galacticus.exe"
+        binary.unlink(missing_ok=True)
+        shutil.move(str(staged_binary), str(binary))
+        binary.chmod(0o755)
+        sentinel.write_text(install.tag)
+        return True
+
+    return _Plan("exec", unpack)
 
 
-def _provision_datasets(install, *, force, log):
+def _plan_datasets(context):
+    """Install the static data root, preferring the snapshot the release publishes.
+
+    The datasets repository archive is generated on the fly by GitHub and served
+    from a throttled endpoint which supports neither byte ranges nor a content
+    length, so it is the slowest artefact of an install by a wide margin.  A
+    release which publishes a `datasets.tar.zst` snapshot is used instead: it is a
+    release asset like any other, so it can be split across connections, verified
+    against the release checksums, and unpacked far faster than a zip.  It also
+    pins the data to the commit the release was built against rather than to
+    whatever ``master`` happens to be, which is why the sentinel records the
+    snapshot's own ref.  Setting ``GALACTICUS_DATASETS_REF`` asks for a specific
+    ref and so always takes the repository-archive path.
+    """
+    install, log = context.install, context.log
     sentinel = _sentinel(install.data_path, "datasets")
-    if sentinel.exists() and not force:
-        return False
+    if sentinel.exists() and not context.force:
+        return None
+    override = os.environ.get("GALACTICUS_DATASETS_REF")
+    if not override and _publishes(context.checksums, DATASETS_ASSET):
+        log(f"Fetching datasets snapshot ({install.tag}) ...")
+        work = context.workspace(install.data_path)
+        archive = work / DATASETS_ASSET
+        context.fetcher.enqueue(asset_url(install.tag, DATASETS_ASSET), archive,
+                                label=DATASETS_ASSET)
+
+        def unpack():
+            _verify(archive, DATASETS_ASSET, context.checksums, log=log)
+            log(f"Unpacking {DATASETS_ASSET} ...")
+            # The snapshot is packed from the root of the datasets tree, so there
+            # is no top-level directory to strip -- but it is still unpacked to
+            # one side and moved in, so that re-provisioning replaces each
+            # top-level entry outright instead of merging into a stale tree.
+            staging = work / "unpacked"
+            _extract(archive, staging, "tar.zst", log=log)
+            _replace_children(staging, install.data_path)
+            sentinel.write_text(_snapshot_ref(install.tag) or install.tag)
+            return True
+
+        return _Plan("datasets", unpack)
+
     ref = resolve_datasets_ref(install.tag, log=log)
     log(f"Fetching datasets ({ref}) ...")
-    with tempfile.TemporaryDirectory(dir=install.data_path.parent, prefix=_STAGING) as work:
-        archive = Path(work) / "datasets.zip"
-        _download(datasets_url(ref), archive, log=log)
+    work = context.workspace(install.data_path)
+    archive = work / "datasets.zip"
+    context.fetcher.enqueue(datasets_url(ref), archive, label="datasets.zip")
+
+    def unpack():
         _extract_strip_top(archive, install.data_path, log=log)
-    sentinel.write_text(ref)
-    return True
+        sentinel.write_text(ref)
+        return True
+
+    return _Plan("datasets", unpack)
 
 
-def _provision_tools(install, *, force, log, checksums=None):
+def _snapshot_ref(tag):
+    """The datasets commit a release's snapshot was taken from, or None."""
+    pinned = _read_remote_text(asset_url(tag, DATASETS_REF_ASSET))
+    return pinned.strip().split()[0] if pinned else None
+
+
+def _tools_archive(install, checksums):
+    """Return the (asset name, format) of the tools archive to fetch.
+
+    Releases cut before the switch to zstd carry only the older archive, and it
+    can not be regenerated for them, so the choice is made from what the release
+    actually publishes rather than from the platform alone.
+    """
+    assets = install.assets
+    legacy = (assets.tools_legacy, assets.tools_legacy_format)
+    current = (assets.tools, assets.tools_format)
+    if checksums is None:
+        # Old enough to publish no checksums at all is old enough to predate the
+        # current archive; try the legacy name, which is all such a release has.
+        return legacy if assets.tools_legacy else current
+    if assets.tools in checksums:
+        return current
+    if assets.tools_legacy in checksums:
+        return legacy
+    return current      # published neither: ask for the current one and fail loudly
+
+
+def _plan_tools(context, tools):
+    install, log = context.install, context.log
+    if not _tools_wanted(install, tools, log=log):
+        return None
     sentinel = _sentinel(install.tools_path, "tools")
-    if sentinel.exists() and not force:
-        return False
-    log(f"Fetching tools {install.assets.tools} ...")
-    with tempfile.TemporaryDirectory(dir=install.tools_path.parent, prefix=_STAGING) as work:
-        archive = Path(work) / install.assets.tools
-        _download(asset_url(install.tag, install.assets.tools), archive, log=log)
+    if sentinel.exists() and not context.force:
+        return None
+    name, fmt = _tools_archive(install, context.checksums)
+    log(f"Fetching tools {name} ...")
+    work = context.workspace(install.tools_path)
+    archive = work / name
+    context.fetcher.enqueue(asset_url(install.tag, name), archive, label=name)
+
+    def unpack():
         # Verify before unpacking: this archive contains executables which are later run.
-        _verify(archive, install.assets.tools, checksums, log=log)
-        staging = Path(work) / "unpacked"
-        log(f"Unpacking {install.assets.tools} ...")
-        _extract(archive, staging, install.assets.tools_format, log=log)
+        _verify(archive, name, context.checksums, log=log)
+        staging = work / "unpacked"
+        log(f"Unpacking {name} ...")
+        _extract(archive, staging, fmt, log=log)
         # Tools archives are rooted at "dynamic/"; lift that subtree up so the
         # contents sit directly under GALACTICUS_TOOLS_PATH.
         root = staging / "dynamic"
-        source = root if root.is_dir() else staging
-        for child in source.iterdir():
-            destination = install.tools_path / child.name
-            if destination.exists():
-                shutil.rmtree(destination) if destination.is_dir() else destination.unlink()
-            shutil.move(str(child), str(destination))
-    _restore_executable_bits(install.tools_path)
-    sentinel.write_text(install.tag)
-    return True
+        _replace_children(root if root.is_dir() else staging, install.tools_path)
+        if fmt == "zip":
+            _restore_executable_bits(install.tools_path)
+        sentinel.write_text(install.tag)
+        return True
+
+    return _Plan("tools", unpack)
 
 
-def _download(url, dest, *, log=print, retries=4, missing_ok=False):
-    """Stream `url` to `dest` with exponential-backoff retries and progress.
+class _Job:
+    """One queued download, and whether it turned out to be there.
+
+    `optional` marks an artefact the install can do without.  Such a job records
+    a failure rather than raising it, because the components are fetched together
+    and a failure escaping the fetch phase discards every staging directory --
+    losing gigabytes which did arrive over one small artefact which did not.
+    """
+
+    def __init__(self, url, dest, label, missing_ok, optional):
+        self.url = url
+        self.dest = dest
+        self.label = label
+        self.missing_ok = missing_ok
+        self.optional = optional
+        self.present = False
+        self.error = None
+
+
+class _Fetcher:
+    """Collect the downloads a provisioning run needs, then run them together.
+
+    The components are independent, and the repository archive endpoint throttles
+    each connection rather than the account, so fetching them at the same time is
+    close to free: the slowest component sets the wall clock instead of the sum.
+    """
+
+    def __init__(self, *, log=print):
+        self._jobs = []
+        self._log = log
+
+    def enqueue(self, url, dest, *, label, missing_ok=False, optional=False):
+        job = _Job(url, dest, label, missing_ok, optional)
+        self._jobs.append(job)
+        return job
+
+    def run(self):
+        if not self._jobs:
+            return
+        with _display(log=self._log) as display:
+            if len(self._jobs) == 1:
+                self._fetch(self._jobs[0], display)
+                return
+            with ThreadPoolExecutor(len(self._jobs)) as pool:
+                # `map` is consumed eagerly so that the first failure is raised
+                # here, once every job has been given its chance to finish.
+                list(pool.map(lambda job: self._fetch(job, display), self._jobs))
+
+    def _fetch(self, job, display):
+        progress = display.add(job.label)
+        try:
+            job.present = _download(job.url, job.dest, log=self._log,
+                                    missing_ok=job.missing_ok, progress=progress)
+        except (RuntimeError, OSError) as error:
+            if not job.optional:
+                raise
+            job.error = error
+            self._log(f"  could not fetch {job.label} ({error}).")
+        finally:
+            progress.finish()
+
+
+def _connections():
+    """How many byte-range requests to split one large asset across."""
+    try:
+        value = int(os.environ.get("GALACTICUS_DOWNLOAD_CONNECTIONS", _CONNECTIONS))
+    except ValueError:
+        return _CONNECTIONS
+    return max(1, min(value, _MAX_CONNECTIONS))
+
+
+def _download(url, dest, *, log=print, retries=4, missing_ok=False, progress=None):
+    """Fetch `url` to `dest`, splitting it across connections where that helps.
 
     Returns True once `dest` is written.  With `missing_ok`, a 404 -- the release
     simply does not publish this asset -- returns False immediately instead of
     retrying an absence through the full backoff schedule.
+
+    The first request asks for ``bytes=0-``: a server which honours byte ranges
+    answers 206 and states the total size, which is the signal that the transfer
+    can be split (and, for a large enough asset, it then is).  One which does not
+    -- GitHub's on-the-fly repository archives -- answers 200, and its response is
+    the transfer, so nothing is wasted probing.
     """
+    own_display = None
+    if progress is None:
+        own_display = _Display(log=log)
+        progress = own_display.add(Path(dest).name)
+    try:
+        return _fetch(url, dest, progress=progress, log=log, retries=retries,
+                      missing_ok=missing_ok)
+    finally:
+        if own_display is not None:
+            progress.finish()
+            own_display.close()
+
+
+def _fetch(url, dest, *, progress, log, retries, missing_ok):
     last_error = None
     for attempt in range(retries):
         try:
-            with requests.get(url, stream=True, timeout=60) as response:
-                if missing_ok and response.status_code == 404:
-                    return False
-                response.raise_for_status()
-                total = _content_length(response)
-                tmp = Path(str(dest) + ".part")
-                progress = _Progress(total, log=log)
-                with open(tmp, "wb") as handle:
-                    for chunk in response.iter_content(chunk_size=_CHUNK):
-                        if chunk:
-                            handle.write(chunk)
-                            progress.update(len(chunk))
-                progress.finish()
-                tmp.replace(dest)
+            with _CONNECTION_SLOTS:
+                response = requests.get(url, stream=True, timeout=60,
+                                        headers={"Range": "bytes=0-"})
+                with response:
+                    if missing_ok and response.status_code == 404:
+                        return False
+                    response.raise_for_status()
+                    total = _total_length(response)
+                    progress.set_total(total)
+                    splittable = (response.status_code == 206
+                                  and total is not None
+                                  and total >= _SPLIT_THRESHOLD
+                                  and _connections() > 1)
+                    if not splittable:
+                        _stream_to(response, dest, progress)
+                        return True
+            # Splittable: the probe response is closed (and its connection slot
+            # released) before the range workers ask for slots of their own.
+            _fetch_split(url, dest, total, progress=progress, retries=retries)
             return True
         except (requests.RequestException, OSError) as error:  # pragma: no cover - network
             last_error = error
@@ -410,12 +682,81 @@ def _download(url, dest, *, log=print, retries=4, missing_ok=False):
                 break
             wait = 2 ** (attempt + 1)
             log(f"  download failed ({error}); retrying in {wait}s ...")
+            progress.reset()
             time.sleep(wait)
     raise RuntimeError(f"failed to download {url}: {last_error}")
 
 
-def _content_length(response):
-    """Total size in bytes from the response headers, or None if not advertised."""
+def _stream_to(response, dest, progress):
+    """Write the body of `response` to `dest` through a `.part` file."""
+    tmp = Path(str(dest) + ".part")
+    with open(tmp, "wb") as handle:
+        for chunk in response.iter_content(chunk_size=_CHUNK):
+            if chunk:
+                handle.write(chunk)
+                progress.update(len(chunk))
+    tmp.replace(dest)
+
+
+def _fetch_split(url, dest, total, *, progress, retries):
+    """Fetch `url` as several byte ranges written into one preallocated file.
+
+    Each worker owns a disjoint span and writes it at its own offset, so no
+    reassembly step is needed.  A worker which is cut off resumes from where it
+    stopped rather than restarting its span, which keeps both the transfer and
+    the progress total honest across a retry.
+    """
+    connections = _connections()
+    tmp = Path(str(dest) + ".part")
+    with open(tmp, "wb") as handle:
+        handle.truncate(total)
+    span = -(-total // connections)         # ceiling division
+    spans = [(start, min(start + span, total) - 1)
+             for start in range(0, total, span)]
+    with ThreadPoolExecutor(len(spans)) as pool:
+        list(pool.map(lambda bounds: _fetch_span(url, tmp, *bounds,
+                                                 progress=progress, retries=retries),
+                      spans))
+    tmp.replace(dest)
+
+
+def _fetch_span(url, path, start, end, *, progress, retries):
+    position = start
+    last_error = None
+    for attempt in range(retries):
+        try:
+            with _CONNECTION_SLOTS:
+                headers = {"Range": f"bytes={position}-{end}"}
+                with requests.get(url, stream=True, timeout=60, headers=headers) as response:
+                    response.raise_for_status()
+                    with open(path, "r+b") as handle:
+                        handle.seek(position)
+                        for chunk in response.iter_content(chunk_size=_CHUNK):
+                            if chunk:
+                                handle.write(chunk)
+                                position += len(chunk)
+                                progress.update(len(chunk))
+            if position > end:
+                return
+            last_error = OSError(f"stream ended at byte {position}, short of {end}")
+        except (requests.RequestException, OSError) as error:  # pragma: no cover - network
+            last_error = error
+        if attempt < retries - 1:
+            time.sleep(2 ** (attempt + 1))
+    raise RuntimeError(f"failed to download bytes {start}-{end} of {url}: {last_error}")
+
+
+def _total_length(response):
+    """Total size of the resource in bytes, or None if it is not advertised.
+
+    A 206 states the total after the ``/`` of ``Content-Range``; a 200 states it
+    in ``Content-Length`` (which on a 206 would be the length of the range only).
+    """
+    content_range = response.headers.get("Content-Range")
+    if content_range and "/" in content_range:
+        total = content_range.rsplit("/", 1)[1].strip()
+        if total.isdigit():
+            return int(total)
     value = response.headers.get("Content-Length")
     try:
         return int(value) if value is not None else None
@@ -424,69 +765,144 @@ def _content_length(response):
 
 
 class _Progress:
-    """Render download progress.
+    """One labelled bar's worth of state; rendered by its :class:`_Display`."""
 
-    On an interactive terminal a single carriage-return-updated bar is drawn to
-    stderr.  Otherwise (logs, pipes, non-default ``log``) progress is emitted as
-    occasional milestone lines, so it stays readable without a TTY.  Dependency
+    def __init__(self, label, total, *, display):
+        self.label = label
+        self._total = total if total and total > 0 else None
+        self._display = display
+        self._done = 0
+        self._next_milestone = _Display.MILESTONE
+
+    def set_total(self, total):
+        """Record the size once the response headers state it."""
+        with self._display.lock:
+            self._total = total if total and total > 0 else None
+
+    def reset(self):
+        """Start counting again, after a failed attempt is retried."""
+        with self._display.lock:
+            self._done = 0
+            self._next_milestone = _Display.MILESTONE
+
+    def update(self, count):
+        with self._display.lock:
+            self._done += count
+            milestone = self._milestone()
+        self._display.touch(self, milestone)
+
+    def set_position(self, position):
+        """Advance to an absolute `position`, in bytes; never moves backwards."""
+        with self._display.lock:
+            if position <= self._done:
+                return
+            self._done = position
+            milestone = self._milestone()
+        self._display.touch(self, milestone)
+
+    def finish(self):
+        self._display.touch(self, None, force=True)
+
+    def _milestone(self):
+        """The percentage to report as a line, or None; caller holds the lock."""
+        if self._total is None:
+            return None
+        fraction = self._done / self._total
+        if fraction < self._next_milestone:
+            return None
+        while self._next_milestone <= fraction:
+            self._next_milestone += _Display.MILESTONE
+        return f"{int(fraction * 100)}% ({_human(self._done)} / {_human(self._total)})"
+
+    def render(self):
+        """The bar as a single line of text; caller holds the lock."""
+        if self._total is None:
+            return f"  {self.label}: {_human(self._done)}"
+        fraction = min(1.0, self._done / self._total)
+        filled = int(_Display.BAR_WIDTH * fraction)
+        bar = "#" * filled + "-" * (_Display.BAR_WIDTH - filled)
+        return (f"  [{bar}] {int(fraction * 100):3d}% "
+                f"{_human(self._done)} / {_human(self._total)}  {self.label}")
+
+
+class _Display:
+    """Render progress for one or more transfers at once.
+
+    On an interactive terminal each item gets a line, and the whole block is
+    redrawn in place; otherwise progress is emitted as occasional milestone lines
+    tagged with the item's label, so a log or a pipe stays readable.  Dependency
     free -- no ``tqdm`` -- to keep the launcher's footprint minimal.
     """
 
-    _BAR_WIDTH = 30
-    _MILESTONE = 0.10  # log every 10% when not a TTY
+    BAR_WIDTH = 30
+    MILESTONE = 0.10  # log every 10% when not a TTY
+    INTERVAL = 0.1    # seconds between redraws
 
-    def __init__(self, total, *, log=print):
-        self._total = total if total and total > 0 else None
+    def __init__(self, *, log=print):
         self._log = log
-        self._done = 0
+        self._items = []
+        self._drawn = 0
         self._last_render = 0.0
-        self._next_milestone = self._MILESTONE
+        self.lock = threading.RLock()
         self._tty = (
             log is print
             and hasattr(sys.stderr, "isatty")
             and sys.stderr.isatty()
         )
-        self._active = False
 
-    def update(self, count):
-        self._done += count
+    def add(self, label, total=None):
+        item = _Progress(label, total, display=self)
+        with self.lock:
+            self._items.append(item)
+        return item
+
+    def touch(self, item, milestone, *, force=False):
+        """Note that `item` advanced; redraw, or log its `milestone` if given."""
         if self._tty:
-            self._render_bar()
-        elif self._total is not None:
-            fraction = self._done / self._total
-            if fraction >= self._next_milestone:
-                while self._next_milestone <= fraction:
-                    self._next_milestone += self._MILESTONE
-                self._log(f"  ... {int(fraction * 100)}% "
-                          f"({_human(self._done)} / {_human(self._total)})")
+            self._render(force=force)
+        elif milestone is not None:
+            self._log(f"  ... {item.label} {milestone}")
 
-    def set_position(self, position):
-        """Advance to an absolute `position`, in bytes; never moves backwards."""
-        if position > self._done:
-            self.update(position - self._done)
-
-    def finish(self):
-        if self._tty and self._active:
-            self._render_bar(force=True)
-            sys.stderr.write("\n")
+    def _render(self, *, force=False):
+        with self.lock:
+            now = time.monotonic()
+            if not force and now - self._last_render < self.INTERVAL:
+                return
+            self._last_render = now
+            text = ""
+            if self._drawn:
+                text += f"\033[{self._drawn}A"    # back to the top of the block
+            for item in self._items:
+                text += f"\r\033[K{item.render()}\n"
+            self._drawn = len(self._items)
+            sys.stderr.write(text)
             sys.stderr.flush()
 
-    def _render_bar(self, *, force=False):
-        now = time.monotonic()
-        if not force and now - self._last_render < 0.1:
-            return
-        self._last_render = now
-        self._active = True
-        if self._total is not None:
-            fraction = min(1.0, self._done / self._total)
-            filled = int(self._BAR_WIDTH * fraction)
-            bar = "#" * filled + "-" * (self._BAR_WIDTH - filled)
-            text = (f"\r  [{bar}] {int(fraction * 100):3d}% "
-                    f"{_human(self._done)} / {_human(self._total)}")
-        else:
-            text = f"\r  {_human(self._done)} downloaded"
-        sys.stderr.write(text)
-        sys.stderr.flush()
+    def close(self):
+        """Leave the final state on screen and stop drawing over it."""
+        with self.lock:
+            if self._tty and self._items:
+                self._render(force=True)
+            self._items = []
+            self._drawn = 0
+
+
+@contextlib.contextmanager
+def _display(*, log=print):
+    display = _Display(log=log)
+    try:
+        yield display
+    finally:
+        display.close()
+
+
+@contextlib.contextmanager
+def _bar(label, total, *, log=print):
+    """A single progress bar, closed when the block ends."""
+    with _display(log=log) as display:
+        progress = display.add(label, total)
+        yield progress
+        progress.finish()
 
 
 def _human(num_bytes):
@@ -498,7 +914,7 @@ def _human(num_bytes):
 
 
 def _extract(archive, dest, fmt, *, log=print):
-    """Unpack `archive` (`fmt` in {'zip','tar.bz2','tar.gz'}) into `dest`.
+    """Unpack `archive` (`fmt` in {'zip','tar.zst','tar.bz2','tar.gz'}) into `dest`.
 
     Tar archives are unpacked with the ``data`` filter, which refuses members whose paths would escape `dest` (via an absolute
     path, a ``..`` component, or a symlink pointing outside the destination). Without it, unpacking a tar archive lets the archive
@@ -513,7 +929,7 @@ def _extract(archive, dest, fmt, *, log=print):
     if fmt == "zip":
         _extract_zip(archive, dest, log=log)
     else:
-        _extract_tar(archive, dest, "r:bz2" if fmt == "tar.bz2" else "r:gz", log=log)
+        _extract_tar(archive, dest, fmt, log=log)
 
 
 def _extract_zip(archive, dest, *, log=print):
@@ -526,14 +942,33 @@ def _extract_zip(archive, dest, *, log=print):
     """
     with zipfile.ZipFile(archive) as zf:
         members = zf.infolist()
-        progress = _Progress(sum(member.file_size for member in members), log=log)
-        for member in members:
-            zf.extract(member, dest)
-            progress.update(member.file_size)
-        progress.finish()
+        total = sum(member.file_size for member in members)
+        with _bar(Path(archive).name, total, log=log) as progress:
+            for member in members:
+                zf.extract(member, dest)
+                progress.update(member.file_size)
 
 
-def _extract_tar(archive, dest, mode, *, log=print):
+def _zstd_stream(handle):
+    """A file-like object decompressing zstd from the open file `handle`."""
+    try:
+        from compression.zstd import ZstdFile        # Python 3.14 and later
+    except ImportError:
+        pass
+    else:
+        return ZstdFile(handle, "rb")
+    try:
+        import zstandard
+    except ImportError as error:                     # pragma: no cover - packaging
+        raise RuntimeError(
+            "unpacking this archive needs zstd support, which this interpreter "
+            "does not have: install it with `pip install zstandard`, or use "
+            "Python 3.14 or later."
+        ) from error
+    return zstandard.ZstdDecompressor().stream_reader(handle)
+
+
+def _extract_tar(archive, dest, fmt, *, log=print):
     """Unpack a compressed tar with the ``data`` filter, reporting progress.
 
     Progress is measured by how far into the *compressed* file the reader has
@@ -542,18 +977,29 @@ def _extract_tar(archive, dest, mode, *, log=print):
     paying for the expensive part twice.  Members are pulled through a generator
     so the offset can be sampled as each one is reached, while ``extractall``
     still applies the extraction filter to every member.
+
+    zstd archives are read as a stream (``r|``) layered on a decompressor, since
+    the standard library's tar reader has no zstd mode of its own; bzip2 and gzip
+    it opens directly.
     """
     total = Path(archive).stat().st_size
-    progress = _Progress(total, log=log)
-    with open(archive, "rb") as handle:
-        with tarfile.open(fileobj=handle, mode=mode) as tf:
-            def members():
-                for member in tf:
-                    progress.set_position(handle.tell())
-                    yield member
-            tf.extractall(dest, members=members(), filter="data")
-    progress.set_position(total)
-    progress.finish()
+    with _bar(Path(archive).name, total, log=log) as progress:
+        with open(archive, "rb") as handle:
+            with contextlib.ExitStack() as stack:
+                if fmt == "tar.zst":
+                    stream = stack.enter_context(contextlib.closing(_zstd_stream(handle)))
+                    tf = stack.enter_context(tarfile.open(fileobj=stream, mode="r|"))
+                else:
+                    mode = "r:bz2" if fmt == "tar.bz2" else "r:gz"
+                    tf = stack.enter_context(tarfile.open(fileobj=handle, mode=mode))
+
+                def members():
+                    for member in tf:
+                        progress.set_position(handle.tell())
+                        yield member
+
+                tf.extractall(dest, members=members(), filter="data")
+        progress.set_position(total)
 
 
 def _extract_strip_top(archive, dest, *, log=print):
@@ -571,11 +1017,20 @@ def _extract_strip_top(archive, dest, *, log=print):
         _extract_zip(archive, Path(work), log=log)
         entries = [child for child in Path(work).iterdir()]
         top = entries[0] if len(entries) == 1 and entries[0].is_dir() else Path(work)
-        for child in top.iterdir():
-            destination = dest / child.name
-            if destination.exists():
-                shutil.rmtree(destination) if destination.is_dir() else destination.unlink()
-            shutil.move(str(child), str(destination))
+        _replace_children(top, dest)
+
+
+def _replace_children(source, dest):
+    """Move each entry of `source` into `dest`, replacing any of the same name.
+
+    The staging directory always sits on the same filesystem as `dest`, so each
+    move is a rename rather than a copy of the subtree.
+    """
+    for child in Path(source).iterdir():
+        destination = Path(dest) / child.name
+        if destination.exists():
+            shutil.rmtree(destination) if destination.is_dir() else destination.unlink()
+        shutil.move(str(child), str(destination))
 
 
 def _restore_executable_bits(tools_path):

--- a/python/galacticus_launcher/platforms.py
+++ b/python/galacticus_launcher/platforms.py
@@ -11,12 +11,23 @@ import platform
 from collections import namedtuple
 
 # Describes the release assets for one platform.
-#   binary       -- name of the executable asset (e.g. "Galacticus.exe").
-#   tools        -- name of the run-time tools archive asset.
-#   tools_format -- "tar.bz2" or "zip"; how to unpack `tools`.
-#   key          -- short human label for the platform (used in messages).
+#   binary        -- name of the executable asset (e.g. "Galacticus.exe").
+#   tools         -- name of the run-time tools archive asset.
+#   tools_format  -- "tar.zst", "tar.bz2", or "zip"; how to unpack `tools`.
+#   tools_legacy  -- name of the tools archive published by releases predating
+#                    the switch to zstd, or None if there is no earlier name.
+#   tools_legacy_format -- how to unpack `tools_legacy`.
+#   key           -- short human label for the platform (used in messages).
+#
+# Two tools archives are named per platform because a release only ever carries
+# the format that was current when it was cut: releases published before the
+# switch have `tools_legacy` and nothing else, and those assets can not be
+# regenerated after the fact.  Provisioning therefore prefers `tools` and falls
+# back to `tools_legacy` (see `download._tools_archive`), which keeps every
+# already-published version tag installable.
 PlatformAssets = namedtuple(
-    "PlatformAssets", ["binary", "tools", "tools_format", "key"]
+    "PlatformAssets",
+    ["binary", "tools", "tools_format", "tools_legacy", "tools_legacy_format", "key"],
 )
 
 
@@ -41,7 +52,10 @@ def detect(system=None, machine=None):
 
     if system == "Linux":
         if machine in ("x86_64", "amd64"):
-            return PlatformAssets("Galacticus.exe", "tools.tar.bz2", "tar.bz2", "Linux x86-64")
+            return PlatformAssets("Galacticus.exe",
+                                  "tools.tar.zst", "tar.zst",
+                                  "tools.tar.bz2", "tar.bz2",
+                                  "Linux x86-64")
         raise UnsupportedPlatform(
             f"Galacticus provides no pre-built Linux binary for machine '{machine}'. "
             "Build from source: https://galacticus.readthedocs.io/en/latest/"
@@ -49,9 +63,15 @@ def detect(system=None, machine=None):
         )
     if system == "Darwin":
         if machine in ("x86_64", "amd64"):
-            return PlatformAssets("Galacticus_MacOS.exe", "toolsMacOS.zip", "zip", "macOS x86-64")
+            return PlatformAssets("Galacticus_MacOS.exe",
+                                  "toolsMacOS.tar.zst", "tar.zst",
+                                  "toolsMacOS.zip", "zip",
+                                  "macOS x86-64")
         if machine in ("arm64", "aarch64"):
-            return PlatformAssets("Galacticus_MacOS-M1.exe", "toolsMacOSM1.zip", "zip", "macOS Apple Silicon")
+            return PlatformAssets("Galacticus_MacOS-M1.exe",
+                                  "toolsMacOSM1.tar.zst", "tar.zst",
+                                  "toolsMacOSM1.zip", "zip",
+                                  "macOS Apple Silicon")
         raise UnsupportedPlatform(
             f"Galacticus provides no pre-built macOS binary for machine '{machine}'."
         )

--- a/python/galacticus_launcher/tests/test_launcher.py
+++ b/python/galacticus_launcher/tests/test_launcher.py
@@ -21,17 +21,20 @@ from galacticus_launcher import platforms, paths, cli, download, macos
 
 # --- platform mapping ------------------------------------------------------
 
-@pytest.mark.parametrize("system,machine,binary,fmt", [
-    ("Linux", "x86_64", "Galacticus.exe", "tar.bz2"),
-    ("Linux", "AMD64", "Galacticus.exe", "tar.bz2"),
-    ("Darwin", "x86_64", "Galacticus_MacOS.exe", "zip"),
-    ("Darwin", "arm64", "Galacticus_MacOS-M1.exe", "zip"),
-    ("Darwin", "aarch64", "Galacticus_MacOS-M1.exe", "zip"),
+@pytest.mark.parametrize("system,machine,binary,tools,legacy", [
+    ("Linux", "x86_64", "Galacticus.exe", "tools.tar.zst", "tools.tar.bz2"),
+    ("Linux", "AMD64", "Galacticus.exe", "tools.tar.zst", "tools.tar.bz2"),
+    ("Darwin", "x86_64", "Galacticus_MacOS.exe", "toolsMacOS.tar.zst", "toolsMacOS.zip"),
+    ("Darwin", "arm64", "Galacticus_MacOS-M1.exe", "toolsMacOSM1.tar.zst", "toolsMacOSM1.zip"),
+    ("Darwin", "aarch64", "Galacticus_MacOS-M1.exe", "toolsMacOSM1.tar.zst", "toolsMacOSM1.zip"),
 ])
-def test_detect_supported(system, machine, binary, fmt):
+def test_detect_supported(system, machine, binary, tools, legacy):
     assets = platforms.detect(system, machine)
     assert assets.binary == binary
-    assert assets.tools_format == fmt
+    # Every platform now ships tools as a zstd tar; the archive each release
+    # published before that switch is still named, so old tags stay installable.
+    assert (assets.tools, assets.tools_format) == (tools, "tar.zst")
+    assert assets.tools_legacy == legacy
 
 
 @pytest.mark.parametrize("system,machine", [
@@ -76,7 +79,8 @@ def _clear_galacticus_env(monkeypatch):
 def test_resolve_managed(monkeypatch):
     _clear_galacticus_env(monkeypatch)
     monkeypatch.setattr(platforms, "detect",
-                        lambda: platforms.PlatformAssets("Galacticus.exe", "tools.tar.bz2", "tar.bz2", "test"))
+                        lambda: platforms.PlatformAssets("Galacticus.exe", "tools.tar.zst", "tar.zst",
+                                                        "tools.tar.bz2", "tar.bz2", "test"))
     install = paths.resolve("1.2.3")
     assert install.source == paths.SOURCE_MANAGED
     assert install.managed
@@ -132,7 +136,8 @@ def test_resolve_environment_separated_tools(monkeypatch, tmp_path):
 def test_resolve_environment_without_binary_falls_through(monkeypatch, tmp_path):
     _clear_galacticus_env(monkeypatch)
     monkeypatch.setattr(platforms, "detect",
-                        lambda: platforms.PlatformAssets("Galacticus.exe", "tools.tar.bz2", "tar.bz2", "test"))
+                        lambda: platforms.PlatformAssets("Galacticus.exe", "tools.tar.zst", "tar.zst",
+                                                        "tools.tar.bz2", "tar.bz2", "test"))
     monkeypatch.setenv("GALACTICUS_EXEC_PATH", str(tmp_path / "nope"))
     monkeypatch.setenv("GALACTICUS_DATA_PATH", str(tmp_path / "datasets"))
     install = paths.resolve("1.2.3")
@@ -288,21 +293,24 @@ def test_resolve_parameter_file_absolute_untouched(tmp_path):
 
 def test_progress_milestones_non_tty(capsys):
     lines = []
-    progress = download._Progress(1000, log=lines.append)
-    assert not progress._tty  # custom log is never treated as a TTY
+    display = download._Display(log=lines.append)
+    assert not display._tty  # custom log is never treated as a TTY
+    progress = display.add("asset", 1000)
     for _ in range(10):
         progress.update(100)
     progress.finish()
-    # Milestone lines report percentage as the download advances.
+    # Milestone lines report percentage as the download advances, and name the
+    # item they belong to -- several downloads report into one display at once.
     assert any("100%" in line for line in lines)
     assert any("50%" in line for line in lines)
+    assert all("asset" in line for line in lines)
 
 
 def test_progress_set_position_never_moves_backwards():
     """Unpacking reports an absolute offset into the archive; a sample that has
     not advanced (or has gone backwards) must not rewind the bar."""
     lines = []
-    progress = download._Progress(1000, log=lines.append)
+    progress = download._Display(log=lines.append).add("archive", 1000)
     progress.set_position(600)
     progress.set_position(500)
     progress.set_position(1000)
@@ -312,9 +320,25 @@ def test_progress_set_position_never_moves_backwards():
 
 def test_progress_unknown_total_no_crash():
     lines = []
-    progress = download._Progress(None, log=lines.append)
+    display = download._Display(log=lines.append)
+    progress = display.add("asset")
     progress.update(500)
     progress.finish()  # must not raise when the total is unknown
+    # A size learned from the response headers starts the bar reporting.
+    progress.set_total(1000)
+    progress.update(500)
+    assert any("100%" in line for line in lines)
+
+
+def test_progress_reset_restarts_after_a_failed_attempt():
+    """A retried download starts its bar again rather than counting on top."""
+    lines = []
+    progress = download._Display(log=lines.append).add("asset", 1000)
+    progress.update(400)
+    progress.reset()
+    progress.update(1000)
+    assert progress._done == 1000
+    assert any("100%" in line for line in lines)
 
 
 def test_download_human_readable():

--- a/python/galacticus_launcher/tests/test_provision.py
+++ b/python/galacticus_launcher/tests/test_provision.py
@@ -2,10 +2,12 @@
 
 Network-free: `_download` is replaced by a copy out of a locally built fixture
 "release", so the component selection logic, the ``--no-tools`` choice and its
-persistence, and the parameter-catalog download/generate fallback are all
-exercised against real archives on disk.
+persistence, the choice between an artefact's current and legacy form, and the
+parameter-catalog download/generate fallback are all exercised against real
+archives on disk.
 """
 
+import io
 import json
 import tarfile
 import zipfile
@@ -50,11 +52,35 @@ def release(tmp_path):
     (tools / "camb").write_text("#!/bin/sh\n")
     with tarfile.open(assets / "tools.tar.bz2", "w:bz2") as archive:
         archive.add(tools, arcname="dynamic")
+    _tar_zst(assets / "tools.tar.zst",
+             lambda archive: archive.add(tools, arcname="dynamic"))
+
+    # The datasets snapshot is packed from the root of the datasets tree, so it
+    # has no top-level directory to strip (unlike the repository archive above).
+    _tar_zst(assets / "datasets.tar.zst",
+             lambda archive: archive.add(data, arcname="static"))
 
     (assets / "Galacticus.exe").write_text("#!/bin/true\n")
     (assets / "parameters.catalog.json").write_text(
         json.dumps({"source": "published"}))
     return assets
+
+
+def _tar_zst(path, add):
+    """Write a zstd-compressed tar built by `add`, as the release assets are."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        add(archive)
+    path.write_bytes(_zstd(buffer.getvalue()))
+
+
+def _zstd(data):
+    try:
+        from compression.zstd import compress        # Python 3.14 and later
+    except ImportError:
+        import zstandard
+        return zstandard.ZstdCompressor().compress(data)
+    return compress(data)
 
 
 def _zip(path, root):
@@ -71,8 +97,9 @@ def install(tmp_path):
         exec_path=root / "exec", data_path=root / "datasets",
         tools_path=root / "tools", dynamic_path=tmp_path / "cache" / "dynamic",
         binary=root / "exec" / "Galacticus.exe",
-        assets=platforms.PlatformAssets("Galacticus.exe", "tools.tar.bz2",
-                                        "tar.bz2", "test"),
+        assets=platforms.PlatformAssets("Galacticus.exe",
+                                        "tools.tar.zst", "tar.zst",
+                                        "tools.tar.bz2", "tar.bz2", "test"),
     )
 
 
@@ -81,7 +108,8 @@ def fetched(monkeypatch, release):
     """Serve `_download` from the fixture release; record every URL requested."""
     requested = []
 
-    def _fake_download(url, dest, *, log=print, retries=4, missing_ok=False):
+    def _fake_download(url, dest, *, log=print, retries=4, missing_ok=False,
+                       progress=None):
         requested.append(url)
         # Both repository archives are `.../archive/...zip`, so key on the repo;
         # every other URL is named for the release asset it carries.
@@ -103,6 +131,9 @@ def fetched(monkeypatch, release):
     monkeypatch.setattr(download, "load_checksums", lambda tag, log=print: None)
     monkeypatch.setattr(download, "resolve_datasets_ref",
                         lambda tag, log=print: "master")
+    # Nothing may reach the network: the small text assets (the datasets pin)
+    # are read through this, and a release which publishes none is the default.
+    monkeypatch.setattr(download, "_read_remote_text", lambda url: None)
     return requested
 
 
@@ -192,4 +223,95 @@ def test_bad_catalog_checksum_falls_back_to_generating_one(install, fetched,
 def test_malformed_catalog_falls_back_to_generating_one(install, fetched, release):
     (release / "parameters.catalog.json").write_text("{ not json")
     download.provision(install, log=_quiet)
+    assert _catalog(install) == {"source": "generated"}
+
+
+# --- choosing between an artefact's current and legacy form ----------------
+
+def _checksums(*assets):
+    """A release asset listing, with digests no test verifies against."""
+    return {asset: "" for asset in assets}
+
+
+def test_tools_come_from_the_zstd_archive_when_the_release_publishes_one(
+        install, fetched, monkeypatch):
+    monkeypatch.setattr(download, "load_checksums",
+                        lambda tag, log=print: _checksums("tools.tar.zst"))
+    monkeypatch.setattr(download, "_verify", lambda *a, **k: None)
+    assert "tools" in download.provision(install, log=_quiet)
+    assert any(url.endswith("tools.tar.zst") for url in fetched)
+    assert not any(url.endswith("tools.tar.bz2") for url in fetched)
+    assert (install.tools_path / "camb").is_file()
+
+
+def test_tools_fall_back_to_the_archive_an_older_release_published(
+        install, fetched, monkeypatch):
+    """A release cut before the switch to zstd carries only the older archive,
+    and it can not be regenerated, so its name has to remain reachable."""
+    monkeypatch.setattr(download, "load_checksums",
+                        lambda tag, log=print: _checksums("tools.tar.bz2"))
+    monkeypatch.setattr(download, "_verify", lambda *a, **k: None)
+    assert "tools" in download.provision(install, log=_quiet)
+    assert any(url.endswith("tools.tar.bz2") for url in fetched)
+    assert not any(url.endswith("tools.tar.zst") for url in fetched)
+    assert (install.tools_path / "camb").is_file()
+
+
+# --- the datasets snapshot -------------------------------------------------
+
+def test_datasets_come_from_the_release_snapshot_when_published(
+        install, fetched, monkeypatch):
+    monkeypatch.setattr(download, "load_checksums",
+                        lambda tag, log=print: _checksums("datasets.tar.zst"))
+    monkeypatch.setattr(download, "_verify", lambda *a, **k: None)
+    monkeypatch.setattr(download, "_snapshot_ref", lambda tag: "abc123")
+    assert "datasets" in download.provision(install, log=_quiet)
+    assert any(url.endswith("datasets.tar.zst") for url in fetched)
+    assert not any(f"/{download.DATASETS_REPO}/archive/" in url for url in fetched)
+    assert (install.data_path / "static" / "table.txt").is_file()
+    # The sentinel records the commit the snapshot was taken from, so that
+    # `galacticus info` and a later `update` can tell which data is installed.
+    assert (install.data_path / ".galacticus-datasets").read_text() == "abc123"
+
+
+def test_datasets_fall_back_to_the_repository_archive(install, fetched,
+                                                      monkeypatch):
+    monkeypatch.setattr(download, "load_checksums",
+                        lambda tag, log=print: _checksums("Galacticus.exe"))
+    monkeypatch.setattr(download, "_verify", lambda *a, **k: None)
+    assert "datasets" in download.provision(install, log=_quiet)
+    assert any(f"/{download.DATASETS_REPO}/archive/" in url for url in fetched)
+    assert (install.data_path / "static" / "table.txt").is_file()
+
+
+def test_an_explicit_datasets_ref_bypasses_the_snapshot(install, fetched,
+                                                        monkeypatch):
+    """`GALACTICUS_DATASETS_REF` asks for a specific commit, which the release's
+    own snapshot can not satisfy -- so that request must reach the repository."""
+    monkeypatch.setenv("GALACTICUS_DATASETS_REF", "somebranch")
+    monkeypatch.setattr(download, "load_checksums",
+                        lambda tag, log=print: _checksums("datasets.tar.zst"))
+    monkeypatch.setattr(download, "_verify", lambda *a, **k: None)
+    download.provision(install, log=_quiet)
+    assert any(f"/{download.DATASETS_REPO}/archive/" in url for url in fetched)
+    assert not any(url.endswith("datasets.tar.zst") for url in fetched)
+
+
+def test_a_failed_catalog_download_does_not_abort_the_install(install, fetched,
+                                                              monkeypatch):
+    """The catalog is the one artefact provisioning can rebuild itself, so a
+    transfer failure has to fall back to generating it -- not discard the
+    components which already downloaded."""
+    real = download._download
+
+    def failing(url, dest, **kwargs):
+        if url.endswith(download.CATALOG_ASSET):
+            raise RuntimeError("connection reset by peer")
+        return real(url, dest, **kwargs)
+
+    monkeypatch.setattr(download, "_download", failing)
+    done = download.provision(install, log=_quiet)
+    assert done == ["exec", "datasets", "tools", "parameter catalog"]
+    assert (install.exec_path / "parameters" / "quickTest.xml").is_file()
+    assert (install.tools_path / "camb").is_file()
     assert _catalog(install) == {"source": "generated"}

--- a/python/galacticus_launcher/tests/test_transfer.py
+++ b/python/galacticus_launcher/tests/test_transfer.py
@@ -1,0 +1,240 @@
+"""Unit tests for how the launcher moves bytes: byte-range splitting, the
+choice not to split, and running several downloads at once.
+
+Network-free: ``requests.get`` is replaced by a fake origin server which serves
+one byte string and honours ``Range`` the way GitHub's release assets do (or
+refuses to, the way its on-the-fly repository archives do).
+"""
+
+import threading
+
+import pytest
+
+pytest.importorskip("requests")
+
+import requests
+
+from galacticus_launcher import download
+
+
+class _FakeResponse:
+    """Just enough of `requests.Response` for the download path."""
+
+    def __init__(self, status_code, body, headers):
+        self.status_code = status_code
+        self.headers = headers
+        self._body = body
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+    def iter_content(self, chunk_size=1):
+        for start in range(0, len(self._body), chunk_size):
+            yield self._body[start:start + chunk_size]
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+def _origin(body, *, ranges=True, missing=False):
+    """A fake ``requests.get`` serving `body`, recording the ranges asked for."""
+    asked = []
+
+    def get(url, stream=False, timeout=None, headers=None):
+        requested = (headers or {}).get("Range")
+        asked.append(requested)
+        if missing:
+            return _FakeResponse(404, b"", {})
+        if ranges and requested:
+            span = requested.split("=", 1)[1]
+            start_text, _, end_text = span.partition("-")
+            start = int(start_text)
+            end = int(end_text) if end_text else len(body) - 1
+            end = min(end, len(body) - 1)
+            chunk = body[start:end + 1]
+            return _FakeResponse(206, chunk, {
+                "Content-Range": f"bytes {start}-{end}/{len(body)}",
+                "Content-Length": str(len(chunk)),
+            })
+        # A server which does not do ranges answers the whole body, whatever was
+        # asked for -- which is exactly what makes the "ask for bytes=0-" probe
+        # free: this response *is* the transfer.
+        return _FakeResponse(200, body, {"Content-Length": str(len(body))})
+
+    return get, asked
+
+
+@pytest.fixture
+def quiet_progress():
+    return download._Display(log=lambda message: None).add("asset")
+
+
+# --- reading the size off the response --------------------------------------
+
+def test_total_length_prefers_the_content_range_total():
+    """On a 206, Content-Length is the length of the *range*; only Content-Range
+    states the size of the whole resource."""
+    response = _FakeResponse(206, b"", {"Content-Range": "bytes 0-9/1000",
+                                        "Content-Length": "10"})
+    assert download._total_length(response) == 1000
+
+
+def test_total_length_falls_back_to_content_length():
+    assert download._total_length(_FakeResponse(200, b"", {"Content-Length": "42"})) == 42
+
+
+def test_total_length_is_none_when_unadvertised():
+    assert download._total_length(_FakeResponse(200, b"", {})) is None
+
+
+# --- splitting a large asset across connections -----------------------------
+
+def test_a_large_asset_is_split_and_reassembled(tmp_path, monkeypatch,
+                                                quiet_progress):
+    body = bytes(range(256)) * 400                       # 102 400 bytes
+    get, asked = _origin(body)
+    monkeypatch.setattr(download.requests, "get", get)
+    monkeypatch.setattr(download, "_SPLIT_THRESHOLD", 1024)
+    monkeypatch.setenv("GALACTICUS_DOWNLOAD_CONNECTIONS", "4")
+
+    dest = tmp_path / "asset.bin"
+    assert download._download("https://example/asset", dest,
+                              progress=quiet_progress) is True
+    assert dest.read_bytes() == body
+    # One probe, then one request per span; together the spans cover the file
+    # exactly once, with no overlap and nothing left out.
+    spans = [request for request in asked if request != "bytes=0-"]
+    assert len(spans) == 4
+    bounds = sorted(tuple(int(value) for value in span.split("=")[1].split("-"))
+                    for span in spans)
+    assert bounds[0][0] == 0 and bounds[-1][1] == len(body) - 1
+    for (_, end), (start, _) in zip(bounds, bounds[1:]):
+        assert start == end + 1
+
+
+def test_a_small_asset_is_not_split(tmp_path, monkeypatch, quiet_progress):
+    body = b"small payload"
+    get, asked = _origin(body)
+    monkeypatch.setattr(download.requests, "get", get)
+    monkeypatch.setattr(download, "_SPLIT_THRESHOLD", 1024)
+
+    dest = tmp_path / "asset.bin"
+    download._download("https://example/asset", dest, progress=quiet_progress)
+    assert dest.read_bytes() == body
+    assert asked == ["bytes=0-"]      # the probe response was the transfer
+
+
+def test_a_server_without_ranges_is_streamed(tmp_path, monkeypatch,
+                                             quiet_progress):
+    """The repository archives are generated on the fly and answer 200 to a
+    range request; the body of that answer has to be used, not discarded."""
+    body = bytes(range(256)) * 400
+    get, asked = _origin(body, ranges=False)
+    monkeypatch.setattr(download.requests, "get", get)
+    monkeypatch.setattr(download, "_SPLIT_THRESHOLD", 1024)
+
+    dest = tmp_path / "asset.bin"
+    download._download("https://example/asset", dest, progress=quiet_progress)
+    assert dest.read_bytes() == body
+    assert asked == ["bytes=0-"]
+
+
+def test_splitting_can_be_turned_off(tmp_path, monkeypatch, quiet_progress):
+    body = bytes(range(256)) * 400
+    get, asked = _origin(body)
+    monkeypatch.setattr(download.requests, "get", get)
+    monkeypatch.setattr(download, "_SPLIT_THRESHOLD", 1024)
+    monkeypatch.setenv("GALACTICUS_DOWNLOAD_CONNECTIONS", "1")
+
+    dest = tmp_path / "asset.bin"
+    download._download("https://example/asset", dest, progress=quiet_progress)
+    assert dest.read_bytes() == body
+    assert asked == ["bytes=0-"]
+
+
+def test_connections_are_clamped(monkeypatch):
+    monkeypatch.setenv("GALACTICUS_DOWNLOAD_CONNECTIONS", "0")
+    assert download._connections() == 1
+    monkeypatch.setenv("GALACTICUS_DOWNLOAD_CONNECTIONS", "1000")
+    assert download._connections() == download._MAX_CONNECTIONS
+    monkeypatch.setenv("GALACTICUS_DOWNLOAD_CONNECTIONS", "not a number")
+    assert download._connections() == download._CONNECTIONS
+    monkeypatch.delenv("GALACTICUS_DOWNLOAD_CONNECTIONS")
+    assert download._connections() == download._CONNECTIONS
+
+
+def test_a_missing_asset_is_reported_rather_than_retried(tmp_path, monkeypatch,
+                                                         quiet_progress):
+    get, asked = _origin(b"", missing=True)
+    monkeypatch.setattr(download.requests, "get", get)
+    assert download._download("https://example/absent", tmp_path / "x",
+                              missing_ok=True, progress=quiet_progress) is False
+    assert len(asked) == 1            # a 404 is an answer, not a failure to retry
+
+
+# --- running the components' downloads together -----------------------------
+
+def test_fetcher_runs_its_jobs_concurrently(tmp_path, monkeypatch):
+    """The components are downloaded at the same time; the endpoint throttles
+    each connection, so overlapping them is what makes an install quick."""
+    started = threading.Barrier(3, timeout=10)
+
+    def fake_download(url, dest, *, log=print, missing_ok=False, progress=None):
+        started.wait()                # only returns once all three are in flight
+        dest.write_text(url)
+        return True
+
+    monkeypatch.setattr(download, "_download", fake_download)
+    fetcher = download._Fetcher(log=lambda message: None)
+    jobs = [fetcher.enqueue(f"https://example/{index}", tmp_path / str(index),
+                            label=str(index)) for index in range(3)]
+    fetcher.run()                     # would time out if the jobs were serial
+    assert all(job.present for job in jobs)
+    assert (tmp_path / "1").read_text() == "https://example/1"
+
+
+def test_fetcher_reports_a_failed_job(tmp_path, monkeypatch):
+    def fake_download(url, dest, *, log=print, missing_ok=False, progress=None):
+        if url.endswith("2"):
+            raise RuntimeError("no such asset")
+        return True
+
+    monkeypatch.setattr(download, "_download", fake_download)
+    fetcher = download._Fetcher(log=lambda message: None)
+    for index in range(3):
+        fetcher.enqueue(f"https://example/{index}", tmp_path / str(index),
+                        label=str(index))
+    with pytest.raises(RuntimeError, match="no such asset"):
+        fetcher.run()
+
+
+def test_an_optional_job_that_fails_does_not_sink_the_others(tmp_path,
+                                                             monkeypatch):
+    """The components are fetched together into staging directories which are
+    torn down if the fetch phase raises. An artefact the install can rebuild for
+    itself must therefore not raise -- otherwise one small failed download
+    discards the gigabytes which did arrive."""
+    def fake_download(url, dest, *, log=print, missing_ok=False, progress=None):
+        if url.endswith("optional"):
+            raise RuntimeError("connection reset")
+        dest.write_text(url)
+        return True
+
+    monkeypatch.setattr(download, "_download", fake_download)
+    messages = []
+    fetcher = download._Fetcher(log=messages.append)
+    needed = fetcher.enqueue("https://example/needed", tmp_path / "needed",
+                             label="needed")
+    spare = fetcher.enqueue("https://example/optional", tmp_path / "spare",
+                            label="optional", optional=True)
+    fetcher.run()
+    assert needed.present and (tmp_path / "needed").is_file()
+    assert not spare.present and isinstance(spare.error, RuntimeError)
+    assert any("could not fetch optional" in message for message in messages)

--- a/python/galacticus_launcher/tests/test_validate_resolve.py
+++ b/python/galacticus_launcher/tests/test_validate_resolve.py
@@ -6,6 +6,7 @@ in-repo `Galacticus.Parameters` tree via a stub install whose `exec_path` is the
 repository root.
 """
 
+import contextlib
 import json
 from pathlib import Path
 
@@ -155,6 +156,21 @@ def _fake_generator(exec_path):
     return gen
 
 
+def _provision_catalog(install, *, force, log):
+    """Plan and run the catalog component against a release publishing none.
+
+    The empty checksum map stands in for a release whose asset list does not
+    include a catalog, which is what sends the planner down the generate path --
+    and keeps these tests free of any network access.
+    """
+    with contextlib.ExitStack() as stack:
+        context = download._Context(install=install, checksums={}, force=force,
+                                    log=log, fetcher=download._Fetcher(log=log),
+                                    stack=stack)
+        plan = download._plan_catalog(context)
+        return False if plan is None else plan.unpack()
+
+
 def test_provision_catalog_generates_when_missing(tmp_path, monkeypatch):
     _fake_generator(tmp_path)
     captured = {}
@@ -164,8 +180,8 @@ def test_provision_catalog_generates_when_missing(tmp_path, monkeypatch):
         Path(cmd[3]).write_text("{}")        # the generator writes the catalog
     monkeypatch.setattr(download.subprocess, "run", fake_run)
 
-    assert download._provision_catalog(_install_at(tmp_path), force=False,
-                                       log=lambda *a: None) is True
+    assert _provision_catalog(_install_at(tmp_path), force=False,
+                              log=lambda *a: None) is True
     assert (tmp_path / "parameters.catalog.json").is_file()
     assert captured["cmd"][2:] == [str(tmp_path), str(tmp_path / "parameters.catalog.json")]
 
@@ -175,19 +191,19 @@ def test_provision_catalog_skips_when_present(tmp_path, monkeypatch):
     (tmp_path / "parameters.catalog.json").write_text("{}")
     ran = []
     monkeypatch.setattr(download.subprocess, "run", lambda *a, **k: ran.append(a))
-    assert download._provision_catalog(_install_at(tmp_path), force=False,
-                                       log=lambda *a: None) is False
+    assert _provision_catalog(_install_at(tmp_path), force=False,
+                              log=lambda *a: None) is False
     assert ran == []                         # not regenerated
     # ... but force=True regenerates.
     monkeypatch.setattr(download.subprocess, "run",
                         lambda cmd, **k: Path(cmd[3]).write_text("{}"))
-    assert download._provision_catalog(_install_at(tmp_path), force=True,
-                                       log=lambda *a: None) is True
+    assert _provision_catalog(_install_at(tmp_path), force=True,
+                              log=lambda *a: None) is True
 
 
 def test_provision_catalog_without_source_is_noop(tmp_path):
-    assert download._provision_catalog(_install_at(tmp_path), force=False,
-                                       log=lambda *a: None) is False
+    assert _provision_catalog(_install_at(tmp_path), force=False,
+                              log=lambda *a: None) is False
 
 
 def test_find_catalog_locations(tmp_path, monkeypatch):
@@ -217,6 +233,6 @@ def test_provision_catalog_failure_is_best_effort(tmp_path, monkeypatch):
         raise download.subprocess.CalledProcessError(1, "parameterCatalog.py")
     monkeypatch.setattr(download.subprocess, "run", boom)
     messages = []
-    assert download._provision_catalog(_install_at(tmp_path), force=False,
-                                       log=messages.append) is False
+    assert _provision_catalog(_install_at(tmp_path), force=False,
+                              log=messages.append) is False
     assert any("could not generate" in m for m in messages)


### PR DESCRIPTION
A first managed install fetched its four components serially, and ~96% of its
wall clock was spent waiting on transfers. Measured on a 1 Gbit link, an
`--no-tools` install took ~80 s, of which the datasets archive alone was ~56 s:
GitHub generates that zip on the fly, so it advertises no content length,
refuses byte ranges, and is throttled to ~8 MB/s per connection.

| step | size | before |
|---|---|---|
| datasets zip download | 1257 MB | **55.6 s** (22.6 MB/s) |
| source zip download | 100 MB | 12.3 s (8.0 MB/s) |
| `Galacticus.exe` download | 290 MB | 7.4 s (39 MB/s) |
| datasets unzip | 1814 MB out | 3.6 s |
| source unzip | 221 MB out | 0.6 s |

Separately, the pre-built tools archive took **longer to unpack than to
download**: Python's `bz2` decompresses at ~13 MB/s of compressed input, so the
~1.7 GB Linux archive cost over two minutes of single-core CPU.

## What this does

**Publishes the datasets as a release asset.** A new `Package-Datasets` job
packs a snapshot of `galacticusorg/datasets` as `datasets.tar.zst`, turning the
slowest component into a range-splittable, checksum-verified asset instead of a
throttled repository archive. It also pins the data to the commit the release
was built against, recorded as `datasets.ref`, so a release installs the data it
was tested with. `GALACTICUS_DATASETS_REF` still fetches a named ref from the
repository.

**Switches the tools archives to zstd.** Level 12 is both smaller and faster to
produce than the bzip2 it replaces, and unpacks roughly twenty times faster. The
higher levels would cost many minutes of runner time on a ~9 GB payload for a
few percent of size.

On macOS the `.zip` remains, because `xcrun notarytool submit` accepts only
`.zip`/`.pkg`/`.dmg` — but it is now a workflow artifact rather than a published
asset. A notarization ticket for loose signed binaries is looked up by each
binary's code-directory hash rather than stapled into the archive, so the
distribution format is free. Tar also records file modes, so the execute-bit
fixup is now needed only for the legacy zip.

**Downloads every component concurrently.** The archive endpoint throttles per
connection rather than per account — two concurrent pulls each got the full
per-connection rate — so overlapping the components is close to free.

**Splits a single large asset across byte ranges** where the server supports
them (release assets do; the repository archives do not), measured at
39 → 82 MB/s on `Galacticus.exe`. The first request asks for `bytes=0-`, so a
server which refuses ranges answers 200 and that response *is* the transfer;
nothing is spent probing. `GALACTICUS_DOWNLOAD_CONNECTIONS` tunes it, and a
semaphore caps total connections in flight.

Progress reporting became a multi-bar display: one line per concurrent transfer
on a terminal, label-tagged milestone lines otherwise.

## Backward compatibility

Releases published before this change carry only the older archives, and those
assets cannot be regenerated. So `platforms.py` names both forms per platform,
and `SHA256SUMS` doubles as the release's asset manifest: provisioning picks
whichever form the release actually lists, without probing for a 404. Checked
against the live `bleeding-edge` release, which still resolves to
`tools.tar.bz2` and the repository datasets archive — nothing breaks before the
next deploy. `publish.yml` mirrors both the current and superseded names, so a
tag cut before the next `master` deploy is still usable.

## Three decisions worth a second look

1. **`bleeding-edge` datasets are now pinned** to the snapshot from the last
   `master` deploy rather than tracking `datasets` master live. This matches the
   data to the executable it was tested against; `GALACTICUS_DATASETS_REF=master`
   still gets live master.
2. **The macOS tools `.zip` is no longer published on the release.** Publishing
   both forms would add ~4 GB of duplicate assets per release.
3. **`zstandard` is a new dependency** for Python < 3.14 (3.14+ uses the stdlib
   `compression.zstd`). Both paths are exercised.

## Testing

- 1034 unit tests pass, including a new `test_transfer.py` covering range
  splitting, the no-split and no-ranges paths, connection clamping, and
  concurrent fetching, plus new cases for archive-form selection and the
  datasets snapshot.
- End-to-end provisioning against a local server mimicking GitHub's two
  endpoints; an 80 MiB split download reassembles byte-identically.
- The exact CI `tar ... --exclude ... | zstd` command was round-tripped through
  the unpacker: exclusions honored, modes preserved.
- Both workflows parse, and every non-templated `run:` block passes `bash -n`.
- **Not exercised locally:** the macOS `bsdtar` invocation, and the CI jobs
  themselves.

## Expected effect

A `--no-tools` first install should go from ~80 s to ~25 s, and the tools
component from ~180 s to ~27 s.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
