### PR TITLE
Add an error-handling page to the developer guide

### DIFF
--- a/aux/words.dict
+++ b/aux/words.dict
@@ -378,6 +378,7 @@ declinations
 decrementing
 decorrelated
 decrement
+deduplicated
 dereference
 dereferenced
 deregister
@@ -668,6 +669,7 @@ recalibration
 recombination
 recomputations
 recouple
+recoverably
 redshift
 redshifted
 redshifting

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -674,6 +674,8 @@ For this reason the dispatch block uses ``countLockless()`` instead, which reads
 
 Code that genuinely requires a serialized, consistent snapshot of the hook count (for example, logic internal to ``attach``/``detach`` themselves) should continue to use the locked ``count()``; ``countLockless()`` is intended only for hot, read-only dispatch paths that satisfy the static-hooks invariant described above.
 
+.. _manual-sec-conditionalCall:
+
 Conditional Call
 ~~~~~~~~~~~~~~~~
 

--- a/docs/manuals/developer-guide/error-handling.rst
+++ b/docs/manuals/developer-guide/error-handling.rst
@@ -92,12 +92,12 @@ convention is the literal text ``HELP:`` in green, followed by the advice:
 
    use :: Display, only : displayGreen, displayReset
    ...
-   call Error_Report(                                                                        &
-        &            'Unable to find data file "'//char(fileName)//'"'           //char(10)// &
-        &            displayGreen()//'HELP:'//displayReset()                              // &
-        &            ' this file is provided by the Galacticus datasets repository. If the' // &
-        &            ' path above begins with "./" then the `GALACTICUS_DATA_PATH`'         // &
-        &            ' environment variable is not set'                                     // &
+   call Error_Report(                                                                         &
+        &            'Unable to find data file "'//char(fileName)//'"'//char(10)           // &
+        &            displayGreen()//'HELP:'//displayReset()                               // &
+        &            ' this file is provided by the Galacticus datasets repository. If the'// &
+        &            ' path above begins with "./" then the `GALACTICUS_DATA_PATH`'        // &
+        &            ' environment variable is not set'                                    // &
         &            {introspection:location}                                                 &
         &           )
 
@@ -126,7 +126,7 @@ returns a status code instead when it is present. The canonical form is:
       status=errorStatusUnderflow
       return
    else
-      call Error_Report  ('ODE integration failed '//{introspection:location})
+      call Error_Report('ODE integration failed '//{introspection:location})
    end if
 
 Two properties of this idiom matter. Existing callers are unaffected, since they
@@ -244,8 +244,8 @@ This costs a scalar integer and one branch. Note what it deliberately does *not*
 do: it does not build a message reporting the size requested, because doing so
 requires a ``type(varying_string)`` local, which is then constructed and
 destroyed on every call rather than only on the failure that never normally
-happens. Where the size is worth reporting, it belongs in a helper called only
-on the failing branch.
+happens. Where the size is worth reporting, it belongs in a ``block`` or a helper
+called only on the failing branch.
 
 .. _manual-sec-errorHandlingSignals:
 

--- a/docs/manuals/developer-guide/error-handling.rst
+++ b/docs/manuals/developer-guide/error-handling.rst
@@ -1,0 +1,265 @@
+.. _manual-sec-errorHandling:
+
+Error Handling
+==============
+
+Galacticus distinguishes two kinds of failure, and the distinction determines
+almost everything else on this page:
+
+* A **fatal error** is a condition from which the run cannot continue: a
+  parameter file that asks for something impossible, a data file that is not
+  where it should be, an internal inconsistency that indicates a bug. These are
+  reported with ``Error_Report``, which prints the message and aborts.
+
+* A **recoverable failure** is one that a caller further up the stack is
+  expected to handle. The canonical case is the failure to evolve a single
+  merger tree: with ``<tolerateFailures value="true"/>`` that tree is abandoned
+  and the remaining trees are evolved as usual. These are reported by setting an
+  optional ``status`` argument, and returning.
+
+Most code needs only ``Error_Report``. Adding a ``status`` argument is
+worthwhile only where a caller genuinely exists that can do something other than
+abort.
+
+.. _manual-sec-errorHandlingFatal:
+
+Reporting a fatal error
+-----------------------
+
+``Error_Report`` takes the message to report, to which the location at which the
+error was raised **must** be appended:
+
+.. code-block:: fortran
+
+   use :: Error, only : Error_Report
+   ...
+   if (radius <= 0.0d0) call Error_Report('non-positive radius'//{introspection:location})
+
+``{introspection:location}`` is expanded by the preprocessor into the name of
+the enclosing function or subroutine, the source file, and the line number.
+Without it the user is left with only the message and a backtrace into the
+*preprocessed* sources under ``work/build/``, whose line numbers do not
+correspond to those of the file being edited.
+
+This is checked mechanically. Check 5 of ``scripts/aux/staticAnalyzer.py``
+reports any ``Error_Report`` call which builds its message from a string literal
+and does not append the location; it runs both in the *Fortran-Static-Analysis*
+CI job and in the pre-commit hook. Only literal-built messages are checked,
+because a message passed as a bare variable may have had the location appended
+where that variable was assigned:
+
+.. code-block:: fortran
+
+   ! Checked - the message is a literal, so the location must be appended here.
+   call Error_Report('unrecognized option'//{introspection:location})
+
+   ! Not checked - the location may already be part of `message`.
+   call Error_Report(message)
+
+Writing a good message
+~~~~~~~~~~~~~~~~~~~~~~
+
+The message should say what went wrong in terms the user can act on. Two
+conventions help:
+
+**Name the values involved.** An error that reports only that something was
+wrong, without saying what was expected or what was found, forces the reader
+into the source to learn anything at all. Where an object is not of the expected
+class, name both classes: every ``functionClass`` has an ``objectType`` method
+returning the name of its concrete class, and it is declared on the
+``functionClass`` base type, so the name can be obtained through any
+``class(functionClass)`` reference:
+
+.. code-block:: fortran
+
+   select type (self)
+   type is (galacticStructureSolverLinear)
+      call self%solve(node)
+   class is (functionClass)
+      call Error_Report('object is not of [galacticStructureSolverLinear] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
+   class default
+      call Error_Report('object is not of [galacticStructureSolverLinear] class'//{introspection:location})
+   end select
+
+The ``class default`` branch is kept as the genuine catch-all, so an object
+which is not a ``functionClass`` at all still raises an error rather than
+falling through.
+
+**Say how to fix it.** Where a remedy exists, append a ``HELP:`` hint. The
+convention is the literal text ``HELP:`` in green, followed by the advice:
+
+.. code-block:: fortran
+
+   use :: Display, only : displayGreen, displayReset
+   ...
+   call Error_Report(                                                                        &
+        &            'Unable to find data file "'//char(fileName)//'"'           //char(10)// &
+        &            displayGreen()//'HELP:'//displayReset()                              // &
+        &            ' this file is provided by the Galacticus datasets repository. If the' // &
+        &            ' path above begins with "./" then the `GALACTICUS_DATA_PATH`'         // &
+        &            ' environment variable is not set'                                     // &
+        &            {introspection:location}                                                 &
+        &           )
+
+A hint is most valuable on the errors users meet most often --- a parameter that
+is absent, a value out of range, a data file that cannot be found --- and least
+valuable on internal consistency checks, which a user cannot act on in any case.
+Where the error corresponds to a section of the
+:doc:`troubleshooting guide <../user-guide/troubleshooting/run-time-errors>`, phrase the
+message so that the two agree: a user searching for the message text should find
+the section.
+
+.. _manual-sec-errorHandlingStatus:
+
+Reporting a recoverable failure
+-------------------------------
+
+A procedure which can fail recoverably takes an ``optional``, ``intent(out)``
+``status`` argument. The convention is that the procedure behaves as it always
+did when ``status`` is absent --- that is, it reports a fatal error --- and
+returns a status code instead when it is present. The canonical form is:
+
+.. code-block:: fortran
+
+   if (present(status)) then
+      call displayMessage('ODE integration failed')
+      status=errorStatusUnderflow
+      return
+   else
+      call Error_Report  ('ODE integration failed '//{introspection:location})
+   end if
+
+Two properties of this idiom matter. Existing callers are unaffected, since they
+do not pass ``status``; and a failure is never silent, because the caller which
+*does* pass ``status`` has explicitly taken responsibility for it. A procedure
+with a ``status`` argument should set it to ``errorStatusSuccess`` on entry, so
+that every path which returns normally reports success without having to say so.
+
+The status codes are declared in ``source/error/_module.F90``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Code
+     - Meaning
+   * - ``errorStatusSuccess``
+     - No error.
+   * - ``errorStatusFail``
+     - Generic failure, where no more specific code applies.
+   * - ``errorStatusInputDomain``
+     - An argument was outside the domain on which the procedure is defined.
+   * - ``errorStatusRound``
+     - Failure due to rounding error.
+   * - ``errorStatusOutOfRange``
+     - The result was outside the representable range.
+   * - ``errorStatusDivideByZero``
+     - Division by zero.
+   * - ``errorStatusUnderflow``
+     - Floating point underflow.
+   * - ``errorStatusMaxIterations``
+     - An iterative method did not converge within its iteration limit.
+   * - ``errorStatusXCPU``
+     - A CPU or wall time limit was exceeded.
+   * - ``errorStatusNotExist``
+     - The entity requested does not exist.
+
+Those which have a natural GSL counterpart are defined *as* the corresponding
+GSL code, so that a status returned by a GSL routine can be propagated without
+translation. The remainder take values above 1024, chosen so that they cannot
+collide with a GSL code.
+
+Passing ``status`` onward
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A procedure which itself calls a procedure with an optional ``status`` argument
+must pass its own ``status`` on only when it has one. Passing an absent optional
+argument onward is legal, but the two-branch form is often clearer, and where the
+call has several such arguments the combinations multiply. The
+:ref:`conditionalCall directive <manual-sec-conditionalCall>` generates the
+combinations from a single written form, and exists largely for this case.
+
+.. _manual-sec-errorHandlingWarnings:
+
+Warnings
+--------
+
+``Warn`` reports something the user should know about but which does not stop the
+run:
+
+.. code-block:: fortran
+
+   use :: Error, only : Warn
+   ...
+   call Warn('tabulated data required extrapolation beyond its range')
+
+A warning behaves differently depending on the verbosity in force. At
+``verbosityLevel="warn"`` or above it is displayed as it is issued. Below that
+level it is *accumulated* instead, and the accumulated warnings are replayed if
+the run subsequently ends in a fatal error --- so that a user who sees only the
+error still sees the warnings that preceded it.
+
+That replay is a bounded resource, and this is the constraint that governs what
+should be a warning at all. Warnings are deduplicated on their message text, and
+at most ``warningsUniqueMaximum`` (100) distinct messages are retained; once the
+limit is reached, further *distinct* warnings are counted but not recorded.
+
+.. warning::
+
+   Do not use ``Warn`` to report something which happens as a matter of course.
+   Because the retained set is filled in the order warnings are issued, a routine
+   condition arising during start-up will exhaust the limit before evolution
+   begins, and genuine warnings issued later can then never appear in the replay
+   at all.
+
+   Reporting the use of a default parameter value was once such a case: a small
+   model defaults of order a hundred parameters, which filled the replay
+   completely. That reporting was removed, and the information is instead
+   recorded in the output file, where each defaulted parameter carries a
+   ``{defaulted}`` marker alongside its value in the ``Parameters`` group.
+
+The test for something that belongs in a warning is whether it indicates that
+the *model* may not be what the user intended. Anything which is merely a record
+of what the code did belongs in the output file, or at
+``verbosityLevelInfo``, not in the warning channel.
+
+.. _manual-sec-errorHandlingAllocation:
+
+Allocation failures
+-------------------
+
+An ``allocate`` which fails without ``stat=`` aborts the process with no
+indication of what was being allocated. For the large allocations --- those
+whose size is set by a count read at run time, rather than by a fixed dimension
+--- pass ``stat=`` and report:
+
+.. code-block:: fortran
+
+   integer :: allocErr
+   ...
+   allocate(self,stat=allocErr)
+   if (allocErr /= 0) call Error_Report('unable to allocate node'//{introspection:location})
+
+This costs a scalar integer and one branch. Note what it deliberately does *not*
+do: it does not build a message reporting the size requested, because doing so
+requires a ``type(varying_string)`` local, which is then constructed and
+destroyed on every call rather than only on the failure that never normally
+happens. Where the size is worth reporting, it belongs in a helper called only
+on the failing branch.
+
+.. _manual-sec-errorHandlingSignals:
+
+Signals and crash context
+-------------------------
+
+Handlers registered with ``signalHandlerRegister`` are called when the process
+receives ``SIGSEGV``, ``SIGFPE``, ``SIGBUS``, ``SIGILL`` or ``SIGXCPU``, and are
+passed the signal number. They exist so that a crash can dump context which would
+otherwise be lost --- the posterior-sampling likelihood, for example, registers a
+handler which writes the parameter set being evaluated to a file, so that a crash
+can be reproduced.
+
+Handlers are ``threadprivate``, so a crash dumps the context of the thread which
+crashed, and that thread only. A handler must be careful to do as little as
+possible: it runs in a process which has already failed, and anything it does
+which itself fails will replace the original diagnosis with its own.

--- a/docs/manuals/developer-guide/index.rst
+++ b/docs/manuals/developer-guide/index.rst
@@ -7,6 +7,7 @@ Developer Guide
    development
    editor-setup
    coding
+   error-handling
    continuous-integration
    methods
    creating-a-new-class


### PR DESCRIPTION
Addresses item 2 of #1353.

There was no error-handling section in the developer guide, and `coding.rst` mentions errors only incidentally, so the conventions were recorded nowhere. Meanwhile the source carries over a thousand `Error_Report` calls and a hundred and fifty optional `status` arguments, with no written contract for either — which is how the convention came to drift in the first place.

The page is structured around the distinction that determines everything else: a **fatal error**, reported with `Error_Report`, against a **recoverable failure**, reported by setting an optional `status` argument. It says plainly that most code needs only the former, and that a `status` argument is worth adding only where a caller genuinely exists that can do something other than abort — the merger-tree evolution spine, reached via `<tolerateFailures value="true"/>`, being the case that motivates it.

Within that frame it covers:

* the requirement to append `{introspection:location}`, and check 5 of `staticAnalyzer.py` which now enforces it — including why only messages built from a string literal are checked;
* how to write a message worth reading: naming both classes in a mismatch through `objectType`, and appending a `HELP:` hint where a remedy exists, with the guidance that hints belong on the errors users actually meet and not on internal consistency checks;
* the canonical dual-mode `present(status)` idiom, quoted from the node evolver, and why it leaves existing callers unaffected;
* the `errorStatus*` codes, and why some are defined *as* their GSL counterparts while the rest take values above 1024;
* `conditionalCall`, cross-referenced rather than duplicated, with the note that passing `status` onward is largely why it exists;
* allocation failures, and why the idiom deliberately does not report the size requested;
* the signal handlers, what they are for, and the constraint that they run in a process which has already failed.

### The warnings section

This is the part most worth reading, because it records a constraint that is easy to violate without noticing. The warnings replayed on a fatal error are a **bounded** resource — one hundred distinct messages, filled in the order they are issued — so a warning reporting something routine exhausts the limit during start-up, and genuine warnings issued later can then never appear in the replay at all.

The reporting of default parameter values is given as the worked example, since that is exactly what it did: a small model defaults of order a hundred parameters, which filled the replay completely, leaving it with no genuine warnings in it whatsoever.

### Notes

`conditionalCall` was already documented in `coding.rst`, so it is cross-referenced rather than restated; a label is added to that section so it can be. `deduplicated` and `recoverably` are added to `aux/words.dict`.

Verified by building the documentation locally, both `-b spelling` and `-b html`: the page spell-checks clean and both of its cross-references resolve. The Sphinx warnings that remain are pre-existing and in other files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
