### PR TITLE
Improve the MPI universal-event guards, and document the valgrind leak filters

### DIFF
--- a/source/radiation/intergalactic_background/internal.F90
+++ b/source/radiation/intergalactic_background/internal.F90
@@ -245,14 +245,14 @@ contains
     ! suspended while the others catch up, and suspending a tree is not supported under MPI. The guard is placed here, rather than
     ! being left to the point at which a tree must first be suspended, so that the run fails immediately with a message naming the
     ! parameter responsible rather than partway through evolution naming an internal mechanism.
-    call Error_Report(                                                                                                &
-         &            'the internal intergalactic background radiation field is not supported under MPI'  //char(10)// &
-         &            displayGreen()//'HELP:'//displayReset()                                                       // &
-         &            ' this radiation field is evolved self-consistently with the galaxy population, which requires' // &
-         &            ' suspending trees that reach a universal event before the others, and that is not supported'   // &
-         &            ' under MPI. Either select a different `radiationField`, or run as a single process using'      // &
-         &            ' OpenMP threads, which is unaffected'                                                          // &
-         &            {introspection:location}                                                                         &
+    call Error_Report(                                                                                                  &
+         &            'the internal intergalactic background radiation field is not supported under MPI'//char(10)   // &
+         &            displayGreen()//'HELP:'//displayReset()                                                        // &
+         &            ' this radiation field is evolved self-consistently with the galaxy population, which requires'// &
+         &            ' suspending trees that reach a universal event before the others, and that is not supported'  // &
+         &            ' under MPI. Either select a different `radiationField`, or run as a single process using'     // &
+         &            ' OpenMP threads, which is unaffected'                                                         // &
+         &            {introspection:location}                                                                          &
          &           )
 #endif
     ! Build tables of wavelength and time for cosmic background radiation.

--- a/source/radiation/intergalactic_background/internal.F90
+++ b/source/radiation/intergalactic_background/internal.F90
@@ -216,6 +216,10 @@ contains
     !!}
     use :: Numerical_Ranges, only : Make_Range          , rangeTypeLogarithmic
     use :: Table_Labels    , only : extrapolationTypeFix, extrapolationTypeZero
+#ifdef USEMPI
+    use :: Display         , only : displayGreen        , displayReset
+    use :: Error           , only : Error_Report
+#endif
     implicit none
     type            (radiationFieldIntergalacticBackgroundInternal)                        :: self
     integer                                                        , intent(in   )         :: wavelengthCountPerDecade          , timeCountPerDecade
@@ -235,6 +239,22 @@ contains
     <constructorAssign variables="wavelengthMinimum, wavelengthMaximum, wavelengthCountPerDecade, redshiftMinimum, redshiftMaximum, timeCountPerDecade, *cosmologyParameters_, *cosmologyFunctions_, *intergalacticMediumState_, *atomicCrossSectionIonizationPhoto_, *accretionDiskSpectra_, *starFormationRateDisks_, *starFormationRateSpheroids_, *stellarPopulationSelector_, *outputTimes_"/>
     !!]
 
+#ifdef USEMPI
+    ! This class evolves the background radiation field self-consistently with the galaxy population, which requires that every
+    ! tree be evolved to a common cosmic time before the field can be updated. Trees which reach that time first must therefore be
+    ! suspended while the others catch up, and suspending a tree is not supported under MPI. The guard is placed here, rather than
+    ! being left to the point at which a tree must first be suspended, so that the run fails immediately with a message naming the
+    ! parameter responsible rather than partway through evolution naming an internal mechanism.
+    call Error_Report(                                                                                                &
+         &            'the internal intergalactic background radiation field is not supported under MPI'  //char(10)// &
+         &            displayGreen()//'HELP:'//displayReset()                                                       // &
+         &            ' this radiation field is evolved self-consistently with the galaxy population, which requires' // &
+         &            ' suspending trees that reach a universal event before the others, and that is not supported'   // &
+         &            ' under MPI. Either select a different `radiationField`, or run as a single process using'      // &
+         &            ' OpenMP threads, which is unaffected'                                                          // &
+         &            {introspection:location}                                                                         &
+         &           )
+#endif
     ! Build tables of wavelength and time for cosmic background radiation.
     self%timeMaximum=self%cosmologyFunctions_%cosmicTime                 (                      &
          &           self%cosmologyFunctions_%expansionFactorFromRedshift (                     &

--- a/source/tasks/evolve_forests/_class.F90
+++ b/source/tasks/evolve_forests/_class.F90
@@ -1366,15 +1366,15 @@ contains
     ! never asks for a tree to be suspended directly, so the message names the classes which create such events instead: those are
     ! the parameters that can be changed. Each of those classes also guards against MPI itself, so reaching here means one has been
     ! added without such a guard.
-    call Error_Report(                                                                                                &
-         &            'evolution requires suspending a tree, which is not supported under MPI'            //char(10)// &
-         &            displayGreen()//'HELP:'//displayReset()                                                       // &
-         &            ' a tree must be suspended when its evolution is limited by an event which requires all trees'  // &
-         &            ' to reach a common cosmic time. Such events are created by the self-consistent intergalactic'  // &
-         &            ' medium state evolver (`universeOperator`) and by the internal intergalactic background'       // &
-         &            ' radiation field (`radiationField`). Either select alternatives for those, or run as a single' // &
-         &            ' process using OpenMP threads, which is unaffected'                                            // &
-         &            {introspection:location}                                                                         &
+    call Error_Report(                                                                                                  &
+         &            'evolution requires suspending a tree, which is not supported under MPI'//char(10)             // &
+         &            displayGreen()//'HELP:'//displayReset()                                                        // &
+         &            ' a tree must be suspended when its evolution is limited by an event which requires all trees' // &
+         &            ' to reach a common cosmic time. Such events are created by the self-consistent intergalactic' // &
+         &            ' medium state evolver (`universeOperator`) and by the internal intergalactic background'      // &
+         &            ' radiation field (`radiationField`). Either select alternatives for those, or run as a single'// &
+         &            ' process using OpenMP threads, which is unaffected'                                           // &
+         &            {introspection:location}                                                                          &
          &           )
 #endif
     ! If the tree is to be suspended to file do so now.

--- a/source/tasks/evolve_forests/_class.F90
+++ b/source/tasks/evolve_forests/_class.F90
@@ -1346,6 +1346,7 @@ contains
     Suspend processing of a tree.
     !!}
 #ifdef USEMPI
+    use :: Display                 , only : displayGreen        , displayReset
     use :: Error                   , only : Error_Report
 #endif
     use :: ISO_Varying_String      , only : operator(//)        , varying_string
@@ -1360,7 +1361,21 @@ contains
     type   (varying_string   )                         :: fileName
 
 #ifdef USEMPI
-    call Error_Report('suspending trees is not supported under MPI'//{introspection:location})
+    ! A tree is suspended when its evolution is limited by a *universal* event - one which requires every tree to reach a common
+    ! cosmic time before it can be performed. Trees reaching that time first are suspended while the others catch up. The user
+    ! never asks for a tree to be suspended directly, so the message names the classes which create such events instead: those are
+    ! the parameters that can be changed. Each of those classes also guards against MPI itself, so reaching here means one has been
+    ! added without such a guard.
+    call Error_Report(                                                                                                &
+         &            'evolution requires suspending a tree, which is not supported under MPI'            //char(10)// &
+         &            displayGreen()//'HELP:'//displayReset()                                                       // &
+         &            ' a tree must be suspended when its evolution is limited by an event which requires all trees'  // &
+         &            ' to reach a common cosmic time. Such events are created by the self-consistent intergalactic'  // &
+         &            ' medium state evolver (`universeOperator`) and by the internal intergalactic background'       // &
+         &            ' radiation field (`radiationField`). Either select alternatives for those, or run as a single' // &
+         &            ' process using OpenMP threads, which is unaffected'                                            // &
+         &            {introspection:location}                                                                         &
+         &           )
 #endif
     ! If the tree is to be suspended to file do so now.
     if (.not.self%suspendToRAM) then

--- a/testSuite/test-memory-leaks.py
+++ b/testSuite/test-memory-leaks.py
@@ -83,6 +83,11 @@ for model in models:
 
         for error in root.findall("error"):
             kind = error.findtext("kind", "")
+            # Consider only the two kinds which indicate a leak of memory that can no longer be
+            # reached. `Leak_StillReachable` is excluded because a pointer to the allocation still
+            # exists at exit, which is the normal state of anything allocated once and held for the
+            # lifetime of the run; `Leak_IndirectlyLost` is excluded because it is a consequence of
+            # some `Leak_DefinitelyLost` block which is itself reported.
             if kind not in ("Leak_PossiblyLost", "Leak_DefinitelyLost"):
                 continue
 
@@ -94,11 +99,35 @@ for model in models:
                     obj = frame.findtext("obj", "")
                     if frameFinal is None and "Galacticus.exe" in obj:
                         frameFinal = frame
+                    # Ignore possibly-lost allocations made beneath libgomp.
+                    #
+                    # Read this filter as broader than it looks. Under gfortran the body of an
+                    # `!$omp parallel` region is *outlined* into a separate function (`..._omp_fn.N`)
+                    # which is invoked through `GOMP_parallel`, and worker threads run beneath
+                    # `gomp_thread_start` — both of which live in libgomp. Essentially every
+                    # allocation made inside any parallel region therefore carries a libgomp frame in
+                    # its allocation stack, not merely the threadprivate allocations this filter was
+                    # presumably introduced for. In effect, then, *no* possibly-lost allocation made
+                    # by parallel code is reported.
+                    #
+                    # That is not necessarily wrong: "possibly lost" means valgrind found only an
+                    # interior pointer to the block, which is routine for the descriptors gfortran
+                    # builds for threadprivate and allocatable data, so the reports it suppresses are
+                    # largely false positives. What matters is knowing the extent of it, and that the
+                    # check is gated on `kind`, so `Leak_DefinitelyLost` inside parallel regions is
+                    # still reported and genuine leaks are not hidden wholesale.
                     if kind == "Leak_PossiblyLost" and "libgomp" in obj:
                         ignore = True
+                    # Ignore anything allocated beneath the MPI library. Note that, unlike the
+                    # libgomp filter above, this one is *not* gated on `kind`, so it suppresses
+                    # definitely-lost reports as well as possibly-lost ones.
                     if "libmpi" in obj:
                         ignore = True
 
+            # `frameFinal` is the innermost frame within Galacticus itself, used to report where the
+            # allocation was made. A leak whose stack contains no Galacticus frame at all — one made
+            # entirely within a library — is therefore skipped rather than reported against an
+            # unknown location.
             if ignore or frameFinal is None:
                 continue
 


### PR DESCRIPTION
Addresses items 6 and 7 of #1353. Two independent changes, one commit each.

### The MPI universal-event guards now say what went wrong

A user who selects the internal intergalactic background radiation field and launches under MPI was told only:

```
suspending trees is not supported under MPI
```

They never asked for a tree to be suspended. Suspension is reached when a tree's evolution is limited by a *universal* event — one requiring every tree to reach a common cosmic time — so trees arriving first are suspended while the others catch up. The message named that internal mechanism rather than the parameter which caused it, and offered no remedy.

Exactly two classes create universal events: the self-consistent intergalactic medium state evolver, and the internal intergalactic background radiation field. The first already guarded against MPI with a self-describing message. The second **had no guard at all** — no `USEMPI` reference anywhere in the file — and relied entirely on the `suspendTree` guard firing later, which is why its diagnosis was the message above.

It now guards in its own constructor, where every construction path converges, so the run fails at start-up naming the parameter the user set. The `suspendTree` message names both classes and the remedy, with a `HELP:` hint following the convention added in #1406:

```
evolution requires suspending a tree, which is not supported under MPI
HELP: a tree must be suspended when its evolution is limited by an event which requires all
trees to reach a common cosmic time. Such events are created by the self-consistent
intergalactic medium state evolver (`universeOperator`) and by the internal intergalactic
background radiation field (`radiationField`). Either select alternatives for those, or run
as a single process using OpenMP threads, which is unaffected
```

With both classes guarding directly, reaching the `suspendTree` guard now means a third such class has been added *without* a guard — a more useful invariant than a vague catch-all, and its comment records that.

### The valgrind leak filters are explained

`test-memory-leaks.py` narrows valgrind's output in **four** ways, none of which were explained. Two are broader than they appear, and neither is the one the issue anticipated on its own:

* The **libgomp** filter reads as though it excluded only threadprivate allocations. Under gfortran the body of an `!$omp parallel` region is outlined into a separate function invoked through `GOMP_parallel`, and worker threads run beneath `gomp_thread_start`, so essentially *every* allocation made inside *any* parallel region carries a libgomp frame — and no possibly-lost allocation made by parallel code is reported at all. That is defensible (an interior pointer to a gfortran descriptor is exactly what "possibly lost" means here) and definitely-lost coverage is unaffected because the check is gated on `kind`. It simply needed recording, so a later reader does not assume possibly-lost is covered in parallel regions when it is not.
* The **libmpi** filter is *not* gated on `kind`, so unlike the libgomp filter it suppresses definitely-lost reports as well. The issue does not mention this filter.

The other two: only possibly- and definitely-lost kinds are considered, and a leak whose stack contains no Galacticus frame is skipped rather than reported against an unknown location.

No behavior change.

### Verification

Non-MPI build clean; `quickTest`; 1029 Python unit tests.

Two things could not be checked locally, and are called out because CI covers them and I could not:

* **Both guard blocks are inside `#ifdef USEMPI`**, and there is no MPI toolchain on the machine this was written on, so the normal build compiles neither. They were checked as far as possible by preprocessing both files to confirm `{introspection:location}` expands, then extracting the *generated* `Error_Report` calls verbatim into standalone programs and compiling and running them — both render correctly. `Build-Executables-MPI-Linux` is the real check.
* **Valgrind is unusable on that machine** — it hung on a trivial non-OpenMP Fortran program, so the slowness is valgrind itself and not an OpenMP interaction. The outlining behavior described above was therefore confirmed from the symbols of a compiled OpenMP binary (`MAIN__._omp_fn.0`, and `GOMP_parallel` as an undefined symbol resolved from libgomp) rather than from a valgrind trace.

The *Source formatting* hook reports both touched Fortran files as differing from house style; both already did so on `master`, before these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
