### PR TITLE
fix(satellites): correct the inverted x in the SIDM Kummer2018 satellite models

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1374,6 +1374,7 @@ jobs:
                       tests.SIDM_cross_sections.exe,
                       tests.SIDM_parametric_maps.exe,
                       tests.SIDM_Kummer_deceleration.exe,
+                      tests.SIDM_Kummer_satellites.exe,
                       tests.spin_distribution_nbody_errors.exe,
                       tests.differentiation.exe,
                       tests.tables.exe,

--- a/source/satellites/deceleration_SIDM/Kummer2018.F90
+++ b/source/satellites/deceleration_SIDM/Kummer2018.F90
@@ -17,7 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !+    Contributions to this file made by: Niusha Ahvazi
+  !+    Contributions to this file made by: Niusha Ahvazi, Andrew Benson, Claude.
 
   !!{RST
   Implementation of a satellite deceleration due to dark matter self-interactions using the model of :cite:t:`kummer_effective_2018`.
@@ -42,15 +42,14 @@
      Implementation of a satellite deceleration due to dark matter self-interactions using the model of :cite:t:`kummer_effective_2018`.
      !!}
      private
-     class           (cosmologyParametersClass ), pointer     :: cosmologyParameters_        => null()
-     class           (darkMatterParticleClass  ), pointer     :: darkMatterParticle_         => null()
-     class           (darkMatterHaloScaleClass ), pointer     :: darkMatterHaloScale_        => null()
-     class           (darkMatterProfileDMOClass), pointer     :: darkMatterProfileDMO_       => null()
+     class           (cosmologyParametersClass ), pointer     :: cosmologyParameters_  => null()
+     class           (darkMatterParticleClass  ), pointer     :: darkMatterParticle_   => null()
+     class           (darkMatterHaloScaleClass ), pointer     :: darkMatterHaloScale_  => null()
+     class           (darkMatterProfileDMOClass), pointer     :: darkMatterProfileDMO_ => null()
      type            (interpolator2D           ), allocatable :: decelerationFactor_
-     double precision                                         :: rateScatteringNormalization          , xMaximum       , &
-          &                                                      velocityMinimum                      , velocityMaximum, &
-          &                                                      fractionDarkMatter
-     type            (rangeLattice             )              :: latticeX                             , latticeVelocity
+     double precision                                         :: xMaximum                       , velocityMinimum   , &
+          &                                                      velocityMaximum                , fractionDarkMatter
+     type            (rangeLattice             )              :: latticeX                       , latticeVelocity
    contains
      !![
      <methods docformat="rst">
@@ -156,7 +155,7 @@ contains
     use :: Galactic_Structure_Options      , only : coordinateSystemCartesian                  , radiusLarge                , massTypeDark
     use :: Galacticus_Nodes                , only : nodeComponentSatellite                     , nodeComponentBasic
     use :: Mass_Distributions              , only : massDistributionClass                      , kinematicsDistributionClass
-    use :: Numerical_Constants_Astronomical, only : gravitationalConstant_internal, megaParsec, gigaYear, massSolar
+    use :: Numerical_Constants_Astronomical, only : gravitationalConstant_internal             , megaParsec                 , gigaYear     , massSolar
     use :: Vectors                         , only : Vector_Magnitude
     use :: Dark_Matter_Particles           , only : darkMatterParticleSelfInteractingDarkMatter
     use :: Numerical_Constants_Prefixes    , only : centi                                      , milli                      , kilo
@@ -167,20 +166,20 @@ contains
     class           (nodeComponentSatellite             ), pointer       :: satellite
     class           (nodeComponentBasic                 ), pointer       :: basic
     type            (treeNode                           ), pointer       :: nodeHost
-    class           (massDistributionClass              ), pointer       :: massDistribution_     , massDistributionHost_      , &
+    class           (massDistributionClass              ), pointer       :: massDistribution_          , massDistributionHost_ , &
          &                                                                  massDistributionDark
-    class           (kinematicsDistributionClass        ), pointer       :: kinematics_           , kinematicsHost_
-    double precision                                     , dimension(3)  :: position              , velocity
-    double precision                                                     :: radiusOrbital         , speedOrbital               , &
-         &                                                                  densityHost           , rateScattering             , &
-         &                                                                  massBoundary          , radiusBoundary             , &
-         &                                                                  velocityEscape        , speedHalfMass              , &
-         &                                                                  velocityDispersionHost, velocityDispersionSatellite, &
-         &                                                                  x                     , radiusHalfMass             , &
-         &                                                                  velocityDispersion    , dispersionFactor           , &
-         &                                                                  potentialEscape
-    type            (coordinateSpherical                )                :: coordinates           , coordinatesHost            , &
-         &                                                                  coordinatesBoundary   , coordinatesHalfMass
+    class           (kinematicsDistributionClass        ), pointer       :: kinematics_                , kinematicsHost_
+    double precision                                     , dimension(3)  :: position                   , velocity
+    double precision                                                     :: radiusOrbital              , speedOrbital          , &
+         &                                                                  densityHost                , rateScattering        , &
+         &                                                                  massBoundary               , radiusBoundary        , &
+         &                                                                  velocityEscape             , velocityDispersionHost, &
+         &                                                                  velocityDispersionSatellite, radiusHalfMass        , &
+         &                                                                  velocityDispersion         , dispersionFactor      , &
+         &                                                                  potentialEscape            , speedHalfMass         , &
+         &                                                                  rateScatteringNormalization, x
+    type            (coordinateSpherical                )                :: coordinates                , coordinatesHost       , &
+         &                                                                  coordinatesBoundary        , coordinatesHalfMass
     type            (coordinateCartesian                )                :: coordinatesCartesian
     
     ! Set zero acceleration by default.
@@ -198,20 +197,15 @@ contains
     !![
     <objectDestructor name="massDistributionHost_"/>
     !!]
+    ! If the dark matter particle is not self-interacting there is no scattering, so we can return immediately. The
+    ! normalization of the scattering rate itself can not be evaluated here, as the cross section must be evaluated at the speed
+    ! with which host particles arrive at the half-mass radius of the subhalo, which is not yet known.
     select type (darkMatterParticle_ => self%darkMatterParticle_)
     class is (darkMatterParticleSelfInteractingDarkMatter)
-       ! Compute the normalization of the scattering rate in units such that when multiplied by a velocity in km s⁻¹, and a
-       ! density in units of M⊙ Mpc⁻³, we get a rate in units of Gyr⁻¹.
-       self%rateScatteringNormalization=+darkMatterParticle_%crossSectionSelfInteraction(speedOrbital)*centi**2/milli & ! Convert cross-section from cm² g⁻¹ to m² kg⁻¹.
-            &                           * kilo                       & ! Convert velocity from km s⁻¹ to m s⁻¹.
-            &                           * massSolar   /megaParsec**3 & ! Convert density from M⊙ Mpc⁻³ to kg m⁻³.
-            &                           * gigaYear                     ! Convert rate from s⁻¹ to Gyr⁻¹.
+       ! Self-interacting, so scattering can occur.
     class default
-       ! No scattering.
-       self%rateScatteringNormalization=+0.0d0
+       return
     end select
-    ! If the scattering cross section is zero, we can return immediately.
-    if (self%rateScatteringNormalization == 0.0d0) return
     ! Find the escape velocity from the half-mass radius of the subhalo. This is equal to the potential difference between the
     ! half-mass radius and outer boundary of the subhalo, plus the potential difference from the outer boundary to infinity (for
     ! which we can treat the subhalo as a point mass).
@@ -258,15 +252,17 @@ contains
        <objectDestructor name="massDistribution_"   />
        <objectDestructor name="massDistributionDark"/>
        !!]
-       ! Get the speed of a host particle at the half-mass radius of the subhalo - this is the sum of the kinetic energy or host
-       ! particles in the rest-frame of the subhalo, plus the energy they gain by falling in to the half-mass radius of the
-       ! subhalo.
-       speedHalfMass=+sqrt(                   &
-            &              +speedOrbital  **2 &
-            &              +velocityEscape**2 &
-            &             )
-       x            =+      speedHalfMass     &
-            &        /      speedOrbital
+       ! Evaluate the ratio, x, of the escape velocity from the subhalo to the speed of the subhalo relative to the host. Note
+       ! that the relative speed here is the speed far from the subhalo - the boost which host particles acquire as they fall
+       ! in to the half-mass radius, arriving with speed √(speedOrbital²+velocityEscape²), is already accounted for within the
+       ! definitions of the critical scattering angle and of the deceleration factor, both of which are functions of this x. To
+       ! see this, note that a particle leaving the scattering with speed √(speedOrbital²+velocityEscape²) cos(θ/2) escapes the
+       ! subhalo only for θ < θ_c = cos⁻¹([x²-1]/[x²+1]), which is precisely the θ_c tabulated in `kummer2018Tabulate`.
+       ! Expanding that tabulated integral at large x for a constant cross section reproduces the asymptotic form
+       ! 1-8/3x²+16/5x⁴ used in `kummer2018DecelerationFactor`, which fixes the sense of x: large x is a deeply bound subhalo
+       ! from which nothing escapes, so that momentum transfer is complete and χ_d → 1.
+       x            =+velocityEscape &
+            &        /speedOrbital
        ! Find the combined velocity dispersion of satellite and host, and evaluate the correction factor given in Appendix A of
        ! Kummer et al. (2018).
        massDistribution_           =>  self                 %darkMatterProfileDMO_%get                   (node           )
@@ -286,7 +282,7 @@ contains
             &                           +1.0d0                &
             &                           +(                    &
             &                             +velocityDispersion &
-            &                             /speedHalfMass      &
+            &                             /speedOrbital       &
             &                            )**3                 &
             &                          )
        !![
@@ -295,14 +291,37 @@ contains
        <objectDestructor name="kinematics_"          />
        <objectDestructor name="kinematicsHost_"      />
        !!]
-       ! Evaluate the scattering rate and acceleration.
-       rateScattering               =  +     speedOrbital                       &
-            &                          *     densityHost                        &
-            &                          *self%rateScatteringNormalization
-       kummer2018Acceleration       =  -     velocity                           &
-            &                          *     rateScattering                     &
-            &                          *self%decelerationFactor(x,speedOrbital) &
-            &                          *     dispersionFactor
+       ! Find the speed with which host particles arrive at the half-mass radius of the subhalo: the speed of the subhalo
+       ! relative to the host, broadened by the velocity dispersion and boosted by the energy the particles gain in falling in.
+       ! This is the typical speed of the particles which actually scatter, and so is the speed at which the cross section -
+       ! which may be velocity dependent - is evaluated, both here and in the tabulation of the deceleration factor. Note that
+       ! this is distinct from the speed which enters x and the dispersion correction factor above: those are functions of the
+       ! orbital speed alone, with the infall boost and the dispersion accounted for within their own definitions.
+       speedHalfMass                =  +sqrt(                       &
+            &                                +speedOrbital      **2 &
+            &                                +velocityEscape    **2 &
+            &                                +velocityDispersion**2 &
+            &                               )
+       ! Compute the normalization of the scattering rate in units such that when multiplied by a velocity in km s⁻¹, and a
+       ! density in units of M⊙ Mpc⁻³, we get a rate in units of Gyr⁻¹.
+       rateScatteringNormalization  =  +0.0d0
+       select type (darkMatterParticle_ => self%darkMatterParticle_)
+       class is (darkMatterParticleSelfInteractingDarkMatter)
+          rateScatteringNormalization=+darkMatterParticle_%crossSectionSelfInteraction(speedHalfMass) &
+               &                      *centi    **2/milli                                            & ! Convert cross-section from cm² g⁻¹ to m² kg⁻¹.
+               &                      *kilo                                                          & ! Convert velocity from km s⁻¹ to m s⁻¹.
+               &                      *massSolar   /megaParsec**3                                    & ! Convert density from M⊙ Mpc⁻³ to kg m⁻³.
+               &                      *gigaYear                                                        ! Convert rate from s⁻¹ to Gyr⁻¹.
+       end select
+       ! Evaluate the scattering rate and acceleration. Note that the flux of host particles through the subhalo is set by the
+       ! speed with which the subhalo moves through its host, not by the speed at the point of scattering.
+       rateScattering               =  +speedOrbital                             &
+            &                          *densityHost                              &
+            &                          *rateScatteringNormalization
+       kummer2018Acceleration       =  -velocity                                 &
+            &                          *rateScattering                           &
+            &                          *self%decelerationFactor(x,speedHalfMass) &
+            &                          *dispersionFactor
     end if
     return
   end function kummer2018Acceleration
@@ -405,7 +424,7 @@ contains
 
   end subroutine kummer2018Tabulate
   
-  double precision function kummer2018DecelerationFactor(self,x,speedOrbital)
+  double precision function kummer2018DecelerationFactor(self,x,velocityRelative)
     !!{RST
     Compute the deceleration factor, :math:`\chi_\mathrm{d}`, as defined by :cite:t:`kummer_effective_2018`.
     !!}
@@ -414,24 +433,24 @@ contains
     implicit none
     class           (satelliteDecelerationSIDMKummer2018), intent(inout) :: self
     double precision                                     , intent(in   ) :: x
-    double precision                                     , intent(in   ) :: speedOrbital
-    double precision                                     , parameter     :: xCritical   =100.0d0
-    double precision                                                     :: q                   , velocityCharacteristic
+    double precision                                     , intent(in   ) :: velocityRelative
+    double precision                                     , parameter     :: xCritical       =100.0d0
+    double precision                                                     :: q                       , velocityCharacteristic
 
     if (x < xCritical) then
-       if     (                                                         &
-            &   x            > self%xMaximum                            &
-            &  .or.                                                     &
-            &   speedOrbital > self%velocityMaximum                            &
-            &  .or.                                                     &
-            &   speedOrbital < self%velocityMinimum                            &
-            & )                                                         &
-            & call self%tabulate(                                       &
-            &                    x+1.0d0                              , &
-            &                    min(0.5d0*speedOrbital,self%velocityMinimum), &
-            &                    max(2.0d0*speedOrbital,self%velocityMaximum)  &
+       if     (                                                                    &
+            &   x                > self%xMaximum                                   &
+            &  .or.                                                                &
+            &   velocityRelative > self%velocityMaximum                            &
+            &  .or.                                                                &
+            &   velocityRelative < self%velocityMinimum                            &
+            & )                                                                    &
+            & call self%tabulate(                                                  &
+            &                    x+1.0d0                                         , &
+            &                    min(0.5d0*velocityRelative,self%velocityMinimum), &
+            &                    max(2.0d0*velocityRelative,self%velocityMaximum)  &
             &                   )
-       kummer2018DecelerationFactor=self%decelerationFactor_%interpolate(x,speedOrbital)
+       kummer2018DecelerationFactor=self%decelerationFactor_%interpolate(x,velocityRelative)
     else
        ! Large-x (x > xCritical) regime: use the analytic asymptotic form of the deceleration factor. The form is
        ! cross-section-model specific, so dispatch on the dark matter particle class.
@@ -439,7 +458,7 @@ contains
        type is (darkMatterParticleSIDMVelocityDependent)
           ! Velocity-dependent cross section: read the characteristic velocity scale, v_c, from the particle.
           velocityCharacteristic      = darkMatterParticle_%velocityCharacteristic()
-          q                           =+speedOrbital           &
+          q                           =+velocityRelative       &
                &                       /velocityCharacteristic
           kummer2018DecelerationFactor=+1.0d0                                &
                &                       -sqrt(2.0d0     )                     &

--- a/source/satellites/evaporation_SIDM/Kummer2018.F90
+++ b/source/satellites/evaporation_SIDM/Kummer2018.F90
@@ -17,7 +17,7 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
-  !+    Contributions to this file made by: Niusha Ahvazi
+  !+    Contributions to this file made by: Niusha Ahvazi, Andrew Benson, Claude.
 
   !!{RST
   Implementation of a satellite evaporation due to dark matter self-interactions using the model of :cite:t:`kummer_effective_2018`.
@@ -42,15 +42,14 @@
      Implementation of a satellite evaporation due to dark matter self-interactions using the model of :cite:t:`kummer_effective_2018`.
      !!}
      private
-     class           (cosmologyParametersClass ), pointer     :: cosmologyParameters_        => null()
-     class           (darkMatterParticleClass  ), pointer     :: darkMatterParticle_         => null()
-     class           (darkMatterHaloScaleClass ), pointer     :: darkMatterHaloScale_        => null()
-     class           (darkMatterProfileDMOClass), pointer     :: darkMatterProfileDMO_       => null()
+     class           (cosmologyParametersClass ), pointer     :: cosmologyParameters_  => null()
+     class           (darkMatterParticleClass  ), pointer     :: darkMatterParticle_   => null()
+     class           (darkMatterHaloScaleClass ), pointer     :: darkMatterHaloScale_  => null()
+     class           (darkMatterProfileDMOClass), pointer     :: darkMatterProfileDMO_ => null()
      type            (interpolator2D           ), allocatable :: evaporationFactor_
-     double precision                                         :: rateScatteringNormalization          , xMaximum       , &
-          &                                                      velocityMinimum                      , velocityMaximum, &
-          &                                                      fractionDarkMatter
-     type            (rangeLattice             )              :: latticeX                             , latticeVelocity
+     double precision                                         :: xMaximum                       , velocityMinimum   , &
+          &                                                      velocityMaximum                , fractionDarkMatter
+     type            (rangeLattice             )              :: latticeX                       , latticeVelocity
    contains
      !![
      <methods docformat="rst">
@@ -173,10 +172,11 @@ contains
     double precision                                                    :: radiusOrbital         , speedOrbital               , &
          &                                                                 densityHost           , rateScattering             , &
          &                                                                 massBoundary          , radiusBoundary             , &
-         &                                                                 velocityEscape        , speedHalfMass              , &
+         &                                                                 velocityEscape        , speedRelative              , &
          &                                                                 velocityDispersionHost, velocityDispersionSatellite, &
          &                                                                 x                     , radiusHalfMass             , &
-         &                                                                 velocityDispersion    , potentialEscape
+         &                                                                 velocityDispersion    , potentialEscape            , &
+         &                                                                 speedHalfMass         , rateScatteringNormalization
     type            (coordinateSpherical                )                :: coordinates          , coordinatesHost            , &
          &                                                                  coordinatesBoundary  , coordinatesHalfMass
     type            (coordinateCartesian                )                :: coordinatesCartesian
@@ -196,22 +196,15 @@ contains
     !![
     <objectDestructor name="massDistributionHost_"/>
     !!]
-    ! repositioned select block + if-expersion
+    ! If the dark matter particle is not self-interacting there is no scattering, so we can return immediately. The
+    ! normalization of the scattering rate itself can not be evaluated here, as the cross section must be evaluated at the speed
+    ! with which host particles arrive at the half-mass radius of the subhalo, which is not yet known.
     select type (darkMatterParticle_ => self%darkMatterParticle_)
     class is (darkMatterParticleSelfInteractingDarkMatter)
-       ! Compute the normalization of the scattering rate in units such that when multiplied by a velocity in km s⁻¹, and a
-       ! density in units of M⊙ Mpc⁻³, we get a rate in units of Gyr⁻¹.
-       self%rateScatteringNormalization=+darkMatterParticle_%crossSectionSelfInteraction(speedOrbital) &
-            &                           *centi    **2/milli                                            & ! Convert cross-section from cm² g⁻¹ to m² kg⁻¹.
-            &                           *kilo                                                          & ! Convert velocity from km s⁻¹ to m s⁻¹.
-            &                           *massSolar   /megaParsec**3                                    & ! Convert density from M⊙ Mpc⁻³ to kg m⁻³.
-            &                           *gigaYear                                                        ! Convert rate from s⁻¹ to Gyr⁻¹.
+       ! Self-interacting, so scattering can occur.
     class default
-       ! No scattering.
-       self%rateScatteringNormalization=+0.0d0
+       return
     end select
-    ! If the scattering cross section is zero, we can return immediately.
-    if (self%rateScatteringNormalization == 0.0d0) return
     ! Find the escape velocity from the half-mass radius of the subhalo. This is equal to the potential difference between the
     ! half-mass radius and outer boundary of the subhalo, plus the potential difference from the outer boundary to infinity (for
     ! which we can treat the subhalo as a point mass).
@@ -277,26 +270,55 @@ contains
        <objectDestructor name="kinematics_"          />
        <objectDestructor name="kinematicsHost_"      />
        !!]
-       ! Get the speed of a host particle at the half-mass radius of the subhalo - this is the sum of the kinetic energy of host
-       ! particles in the rest-frame of the subhalo, plus the energy they gain by falling in to the half-mass radius of the
-       ! subhalo. We include the correction factor of the velocity dispersion as suggested in equation (A4) of Kummer et
-       ! al. (2018).
-       speedHalfMass=+sqrt(                       &
+       ! Find the effective speed of the subhalo relative to the host - this is the speed of host particles in the rest frame of
+       ! the subhalo far from the subhalo, broadened by the velocity dispersion as suggested in equation (A4) of Kummer et
+       ! al. (2018). Host particles reaching the half-mass radius of the subhalo are further boosted by the energy they gain in
+       ! falling in, arriving with speed √(speedRelative²+velocityEscape²).
+       speedRelative=+sqrt(                       &
             &              +speedOrbital      **2 &
-            &              +velocityEscape    **2 &
             &              +velocityDispersion**2 &
             &             )
-       x            =+      speedHalfMass         &
-            &        /      speedOrbital
+       ! Evaluate the ratio, x, of the escape velocity from the subhalo to that relative speed. Note that x is defined in terms
+       ! of the relative speed far from the subhalo, and *not* the speed at the point of scattering: the infall boost is already
+       ! accounted for within the definitions of the critical scattering angle and of the evaporation factor, both of which are
+       ! functions of this x. To see this, note that a subhalo particle recoiling with speed √(speedRelative²+velocityEscape²)
+       ! sin(θ/2) escapes the subhalo only for θ > π-θ_c, while the scattered host particle escapes only for θ < θ_c, where
+       ! θ_c = cos⁻¹([x²-1]/[x²+1]) is the critical angle tabulated in `kummer2018Tabulate`. Net evaporation therefore requires
+       ! π-θ_c < θ < θ_c - the range integrated over in that tabulation - which is non-empty only for x < 1. For a constant
+       ! cross section the tabulated integral is χ_e = (1-x²)/(1+x²), the closed form given by Kummer et al. (2018), which fixes
+       ! the sense of x: small x is a weakly bound subhalo moving quickly through its host, from which every scattering
+       ! evaporates a particle.
+       x            =+velocityEscape &
+            &        /speedRelative
        ! Evaporation occurs for x<1.
-       if (x < 1.0d0) then 
-          ! Evaluate the scattering rate and mass loss rate.
-          rateScattering               =  +     speedOrbital                     &
-               &                          *     densityHost                      &
-               &                          *self%rateScatteringNormalization
-          kummer2018MassLossRate       =  -     massBoundary                     &
-               &                          *     rateScattering                   &
-               &                          *self%evaporationFactor(x,speedOrbital)
+       if (x < 1.0d0) then
+          ! Find the speed with which host particles arrive at the half-mass radius of the subhalo: the effective relative speed,
+          ! boosted by the energy they gain in falling in. This is the typical speed of the particles which actually scatter, and
+          ! so is the speed at which the cross section - which may be velocity dependent - is evaluated, both here and in the
+          ! tabulation of the evaporation factor.
+          speedHalfMass=+sqrt(                   &
+               &              +speedRelative **2 &
+               &              +velocityEscape**2 &
+               &             )
+          ! Compute the normalization of the scattering rate in units such that when multiplied by a velocity in km s⁻¹, and a
+          ! density in units of M⊙ Mpc⁻³, we get a rate in units of Gyr⁻¹.
+          rateScatteringNormalization=0.0d0
+          select type (darkMatterParticle_ => self%darkMatterParticle_)
+          class is (darkMatterParticleSelfInteractingDarkMatter)
+             rateScatteringNormalization=+darkMatterParticle_%crossSectionSelfInteraction(speedHalfMass) &
+                  &                      *centi    **2/milli                                             & ! Convert cross-section from cm² g⁻¹ to m² kg⁻¹.
+                  &                      *kilo                                                           & ! Convert velocity from km s⁻¹ to m s⁻¹.
+                  &                      *massSolar   /megaParsec**3                                     & ! Convert density from M⊙ Mpc⁻³ to kg m⁻³.
+                  &                      *gigaYear                                                         ! Convert rate from s⁻¹ to Gyr⁻¹.
+          end select
+          ! Evaluate the scattering rate and mass loss rate. Note that the flux of host particles through the subhalo is set by
+          ! the speed with which the subhalo moves through its host, not by the speed at the point of scattering.
+          rateScattering        =+speedOrbital                             &
+               &                 *densityHost                              &
+               &                 *rateScatteringNormalization
+          kummer2018MassLossRate=-massBoundary                             &
+               &                 *rateScattering                           &
+               &                 *self%evaporationFactor(x,speedHalfMass)
        end if
     end if
     return
@@ -396,32 +418,32 @@ contains
 
   end subroutine kummer2018Tabulate
   
-  double precision function kummer2018EvaporationFactor(self,x,speedOrbital)
+  double precision function kummer2018EvaporationFactor(self,x,velocityRelative)
     !!{RST
     Evaluate the evaporation factor from :cite:t:`kummer_effective_2018`.
     !!}
     implicit none
     class           (satelliteEvaporationSIDMKummer2018), intent(inout) :: self
     double precision                                    , intent(in   ) :: x
-    double precision                                    , intent(in   ) :: speedOrbital
-    double precision                                                    :: xCritical   =1.0d0
+    double precision                                    , intent(in   ) :: velocityRelative
+    double precision                                    , parameter     :: xCritical       =1.0d0
 
-    if     (                                                                   &
-         &   x            > self%xMaximum                                      &
-         &  .or.                                                               &
-         &   speedOrbital > self%velocityMaximum                               &
-         &  .or.                                                               &
-         &   speedOrbital < self%velocityMinimum                               &
-         & ) then 
-       if (x < xCritical)                                                      &
-            & call self%tabulate(                                              &
-            &                    x+1.0d0                                     , &
-            &                    min(0.5d0*speedOrbital,self%velocityMinimum), &
-            &                    max(2.0d0*speedOrbital,self%velocityMaximum)  &
+    if     (                                         &
+         &   x                > self%xMaximum        &
+         &  .or.                                     &
+         &   velocityRelative > self%velocityMaximum &
+         &  .or.                                     &
+         &   velocityRelative < self%velocityMinimum &
+         & ) then
+       if (x < xCritical)                                                          &
+            & call self%tabulate(                                                  &
+            &                    x+1.0d0                                         , &
+            &                    min(0.5d0*velocityRelative,self%velocityMinimum), &
+            &                    max(2.0d0*velocityRelative,self%velocityMaximum)  &
             &                   )
     end if
     if (x < xCritical) then
-       kummer2018EvaporationFactor=self%evaporationFactor_%interpolate(x,speedOrbital)
+       kummer2018EvaporationFactor=self%evaporationFactor_%interpolate(x,velocityRelative)
     else
        kummer2018EvaporationFactor=0.0d0
     end if

--- a/source/tests/SIDM_Kummer_satellites.F90
+++ b/source/tests/SIDM_Kummer_satellites.F90
@@ -1,0 +1,252 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+  !+    Contributions to this file made by: Andrew Benson, Claude.
+
+!!{RST
+Tests of the :cite:t:`kummer_effective_2018` self-interacting dark matter satellite evaporation and deceleration models, as
+applied to an explicitly constructed satellite/host pair. (The deceleration factor, :math:`\chi_\mathrm{d}`, is tested in
+isolation by ``tests.SIDM_Kummer_deceleration.exe``.)
+
+First, the tabulated evaporation factor, :math:`\chi_\mathrm{e}`, is compared against the closed form
+:math:`\chi_\mathrm{e}=(1-x^2)/(1+x^2)` which it takes for an isotropic, constant cross section. The mass loss rate and
+acceleration computed for the satellite are then used to pin the construction of :math:`x` itself. Since
+:math:`x=v_\mathrm{esc}/v_\mathrm{rel}`, in the limit of arbitrarily large orbital speed :math:`x \rightarrow 0`, so that the
+evaporation factor implied by the mass loss rate must approach unity while that implied by the acceleration must approach
+:math:`\chi_\mathrm{d}(0)=-1`; and for a satellite bound deeply enough that :math:`v_\mathrm{esc} > v_\mathrm{rel}`
+evaporation must switch off entirely while the drag must remain a genuine deceleration.
+!!}
+
+program Tests_SIDM_Kummer_Satellites
+  use :: Coordinates                     , only : coordinateCartesian                               , assignment(=)
+  use :: Cosmology_Parameters            , only : cosmologyParametersSimple
+  use :: Cosmology_Functions             , only : cosmologyFunctionsMatterLambda
+  use :: Dark_Matter_Halo_Scales         , only : darkMatterHaloScaleVirialDensityContrastDefinition
+  use :: Dark_Matter_Particles           , only : darkMatterParticleCDM                             , darkMatterParticleSelfInteractingDarkMatterConstant
+  use :: Dark_Matter_Profiles_DMO        , only : darkMatterProfileDMONFW
+  use :: Display                         , only : displayVerbositySet                               , verbosityLevelStandard
+  use :: Events_Hooks                    , only : eventsHooksInitialize
+  use :: Functions_Global_Utilities      , only : Functions_Global_Set
+  use :: Galacticus_Nodes                , only : mergerTree                                        , nodeClassHierarchyInitialize                       , nodeComponentBasic    , nodeComponentDarkMatterProfile, &
+       &                                          nodeComponentSatellite                            , treeNode
+  use :: Input_Parameters                , only : inputParameters
+  use :: Mass_Distributions              , only : massDistributionClass
+  use :: Node_Components                 , only : Node_Components_Initialize                        , Node_Components_Thread_Initialize                  , Node_Components_Thread_Uninitialize, Node_Components_Uninitialize
+  use :: Numerical_Constants_Astronomical, only : gigaYear                                          , massSolar                                          , megaParsec
+  use :: Numerical_Constants_Prefixes    , only : centi                                             , kilo                                               , milli
+  use :: Satellite_Deceleration_SIDM     , only : satelliteDecelerationSIDMKummer2018
+  use :: Satellite_Evaporation_SIDM      , only : satelliteEvaporationSIDMKummer2018
+  use :: Unit_Tests                      , only : Assert                                            , Unit_Tests_Begin_Group                             , Unit_Tests_End_Group  , Unit_Tests_Finish
+  use :: Virial_Density_Contrast         , only : virialDensityContrastBryanNorman1998
+  implicit none
+  type            (inputParameters                                    )               :: parameters
+  type            (cosmologyParametersSimple                          ), pointer      :: cosmologyParameters_
+  type            (cosmologyFunctionsMatterLambda                     ), pointer      :: cosmologyFunctions_
+  type            (virialDensityContrastBryanNorman1998               ), pointer      :: virialDensityContrast_
+  type            (darkMatterHaloScaleVirialDensityContrastDefinition ), pointer      :: darkMatterHaloScale_
+  type            (darkMatterProfileDMONFW                            ), pointer      :: darkMatterProfileDMO_
+  type            (darkMatterParticleCDM                              ), pointer      :: darkMatterParticleCDM_
+  type            (darkMatterParticleSelfInteractingDarkMatterConstant), pointer      :: particleConstant
+  type            (satelliteEvaporationSIDMKummer2018                 )               :: evaporation
+  type            (satelliteDecelerationSIDMKummer2018                )               :: deceleration
+  type            (mergerTree                                         )               :: tree
+  type            (treeNode                                           ), pointer      :: node                        , nodeHost                    , &
+       &                                                                                 nodeDense
+  class           (nodeComponentBasic                                 ), pointer      :: basic                       , basicHost                   , &
+       &                                                                                 basicDense
+  class           (nodeComponentDarkMatterProfile                     ), pointer      :: darkMatterProfile           , darkMatterProfileHost       , &
+       &                                                                                 darkMatterProfileDense
+  class           (nodeComponentSatellite                             ), pointer      :: satellite                   , satelliteDense
+  class           (massDistributionClass                              ), pointer      :: massDistributionHost_
+  double precision                                                     , parameter    :: crossSectionConstant=10.0d0                                   ! [cm² g⁻¹]
+  double precision                                                     , parameter    :: massHost            = 1.0d12, radiusScaleHost      =2.0d-2, & ! [M☉], [Mpc]
+       &                                                                                 massSatellite       = 1.0d09, radiusScaleSatellite =2.0d-3, & ! [M☉], [Mpc]
+       &                                                                                 massSatelliteDense  = 1.0d11, radiusScaleDense     =1.0d-3    ! [M☉], [Mpc]
+  double precision                                                     , parameter    :: radiusOrbital       = 5.0d-2                                  ! [Mpc]
+  double precision                                                     , parameter    :: speedOrbitalDense   = 1.0d1                                   ! [km/s]
+  double precision                                                     , dimension(7) :: xTabulated          =[0.10d0,0.30d0,0.50d0,0.70d0,0.90d0,1.05d0,2.00d0]
+  double precision                                                     , dimension(7) :: factorTabulated             , factorAnalytic
+  double precision                                                     , dimension(3) :: speedOrbital        =[5.0d1,2.0d2,5.0d3]                      ! [km/s]
+  double precision                                                     , dimension(3) :: factorEvaporation           , factorDeceleration
+  double precision                                                     , dimension(3) :: acceleration
+  type            (coordinateCartesian                                )               :: coordinates
+  double precision                                                                    :: densityHost                 , rateNormalization         , &
+       &                                                                                 massLossRate                , massBoundary              , &
+       &                                                                                 fractionDarkMatter          , massLossRateDense         , &
+       &                                                                                 factorDecelerationDense
+  integer                                                                             :: i
+
+  ! Set verbosity level and initialize the minimal global state needed to construct the objects.
+  call displayVerbositySet  (verbosityLevelStandard)
+  call eventsHooksInitialize(                      )
+  call Functions_Global_Set (                      )
+  ! Initialize the node-component hierarchy. The basic and dark matter profile components supply the mass, time, and scale radius
+  ! of each halo, while the orbiting satellite component carries the position and velocity of the satellite relative to its host.
+  parameters=inputParameters('testSuite/parameters/nodes/nodes_SIDM_Kummer.xml')
+  call nodeClassHierarchyInitialize     (parameters)
+  call Node_Components_Initialize       (parameters)
+  call Node_Components_Thread_Initialize(parameters)
+  ! Begin unit tests.
+  call Unit_Tests_Begin_Group("SIDM Kummer (2018) satellite evaporation and deceleration")
+  ! Build the dependency stack. These must match the objects built from the parameter file by the dark matter profile component,
+  ! so that the mass distributions seen by the evaporation object and by the nodes are the same.
+  allocate(cosmologyParameters_  )
+  allocate(cosmologyFunctions_   )
+  allocate(virialDensityContrast_)
+  allocate(darkMatterHaloScale_  )
+  allocate(darkMatterProfileDMO_ )
+  allocate(darkMatterParticleCDM_)
+  allocate(particleConstant      )
+  cosmologyParameters_  =cosmologyParametersSimple                          (OmegaMatter=0.2815d0,OmegaBaryon=0.0465d0,OmegaDarkEnergy=0.7185d0,temperatureCMB=2.78d0,HubbleConstant=70.0d0)
+  cosmologyFunctions_   =cosmologyFunctionsMatterLambda                     (cosmologyParameters_=cosmologyParameters_)
+  virialDensityContrast_=virialDensityContrastBryanNorman1998               (allowUnsupportedCosmology=.false.,cosmologyParameters_=cosmologyParameters_,cosmologyFunctions_=cosmologyFunctions_)
+  darkMatterHaloScale_  =darkMatterHaloScaleVirialDensityContrastDefinition (cosmologyParameters_=cosmologyParameters_,cosmologyFunctions_=cosmologyFunctions_,virialDensityContrast_=virialDensityContrast_)
+  darkMatterProfileDMO_ =darkMatterProfileDMONFW                            (velocityDispersionUseSeriesExpansion=.false.,darkMatterHaloScale_=darkMatterHaloScale_)
+  darkMatterParticleCDM_=darkMatterParticleCDM                              ()
+  particleConstant      =darkMatterParticleSelfInteractingDarkMatterConstant(crossSectionSelfInteraction=crossSectionConstant,darkMatterParticle_=darkMatterParticleCDM_)
+  evaporation           =satelliteEvaporationSIDMKummer2018                 (cosmologyParameters_,particleConstant,darkMatterHaloScale_,darkMatterProfileDMO_)
+  deceleration          =satelliteDecelerationSIDMKummer2018                (cosmologyParameters_,particleConstant,darkMatterHaloScale_,darkMatterProfileDMO_)
+  ! For an isotropic, constant cross section the tabulated integral over the range of scattering angles which result in net
+  ! evaporation, ∫dσ/dθ dθ from π-θ_c to θ_c with θ_c=acos([x²-1]/[x²+1]), has the closed form (1-x²)/(1+x²) given by Kummer et
+  ! al. (2018). Evaporation switches off for x≥1, where that range of angles is empty. The x values tested fall on the pinned
+  ! lattice on which the factor is tabulated, so that this tests the tabulated integral itself and not the linear interpolation
+  ! between lattice points.
+  do i=1,size(xTabulated)
+     factorTabulated(i)=evaporation%evaporationFactor(xTabulated(i),1.0d2)
+     if (xTabulated(i) < 1.0d0) then
+        factorAnalytic(i)=+(1.0d0-xTabulated(i)**2) &
+             &            /(1.0d0+xTabulated(i)**2)
+     else
+        factorAnalytic(i)=+0.0d0
+     end if
+  end do
+  call Assert("evaporation factor matches the analytic (1-x²)/(1+x²)",factorTabulated,factorAnalytic,absTol=1.0d-6)
+  ! Construct a satellite orbiting within a host halo, and evaluate the mass loss rate. Since the only quantity in that rate
+  ! which is not directly known here is the evaporation factor itself, it can be recovered from the rate, and used to pin the
+  ! construction of x.
+  nodeHost              => treeNode                                    (hostTree=tree    )
+  node                  => treeNode                                    (hostTree=tree    )
+  tree%nodeBase         => nodeHost
+  nodeHost%firstChild   => node
+  node    %parent       => nodeHost
+  basicHost             => nodeHost%basic            (autoCreate=.true.)
+  basic                 => node    %basic            (autoCreate=.true.)
+  darkMatterProfileHost => nodeHost%darkMatterProfile(autoCreate=.true.)
+  darkMatterProfile     => node    %darkMatterProfile(autoCreate=.true.)
+  satellite             => node    %satellite        (autoCreate=.true.)
+  call basicHost            %massSet (massHost                       )
+  call basicHost            %timeSet (cosmologyFunctions_%cosmicTime(1.0d0))
+  call basic                %massSet (massSatellite                  )
+  call basic                %timeSet (cosmologyFunctions_%cosmicTime(1.0d0))
+  call darkMatterProfileHost%scaleSet(radiusScaleHost                )
+  call darkMatterProfile    %scaleSet(radiusScaleSatellite           )
+  call satellite            %boundMassSet(massSatellite              )
+  call satellite            %positionSet ([radiusOrbital,0.0d0,0.0d0])
+  ! Evaluate the factors, other than the evaporation factor itself, which enter the mass loss rate.
+  fractionDarkMatter=+(                                    &
+       &               +cosmologyParameters_%OmegaMatter() &
+       &               -cosmologyParameters_%OmegaBaryon() &
+       &              )                                    &
+       &             /  cosmologyParameters_%OmegaMatter()
+  massBoundary      =+massSatellite      &
+       &             *fractionDarkMatter
+  coordinates           =  [radiusOrbital,0.0d0,0.0d0]
+  massDistributionHost_ => nodeHost             %massDistribution(           )
+  densityHost           =  massDistributionHost_%density         (coordinates)
+  !![
+  <objectDestructor name="massDistributionHost_"/>
+  !!]
+  rateNormalization=+crossSectionConstant       & ! [cm² g⁻¹]
+       &            *centi    **2/milli         & ! Convert cross-section from cm² g⁻¹ to m² kg⁻¹.
+       &            *kilo                       & ! Convert velocity from km s⁻¹ to m s⁻¹.
+       &            *massSolar   /megaParsec**3 & ! Convert density from M☉ Mpc⁻³ to kg m⁻³.
+       &            *gigaYear                     ! Convert rate from s⁻¹ to Gyr⁻¹.
+  ! Recover the evaporation factor from the mass loss rate at each of a range of orbital speeds.
+  do i=1,size(speedOrbital)
+     call satellite%velocitySet([0.0d0,speedOrbital(i),0.0d0])
+     massLossRate         =evaporation %massLossRate(node)
+     acceleration         =deceleration%acceleration(node)
+     factorEvaporation (i)=-massLossRate         &
+          &                /massBoundary         &
+          &                /speedOrbital     (i) &
+          &                /densityHost          &
+          &                /rateNormalization
+     ! Recover the product of the deceleration factor and the velocity dispersion correction factor. The acceleration returned
+     ! is -v χ_d f_σ (ρ σ v), so the orbital speed appears in it twice, and must be divided out twice: once as the velocity
+     ! vector which sets the direction of the drag, and once as the flux factor within the scattering rate. The velocity is
+     ! directed along the y-axis, so only that component of the acceleration is non-zero.
+     factorDeceleration(i)=-acceleration     (2) &
+          &                /speedOrbital     (i) & ! The velocity which the drag acts along.
+          &                /speedOrbital     (i) & ! The flux factor within the scattering rate.
+          &                /densityHost          &
+          &                /rateNormalization
+  end do
+  ! Evaporation must occur at every one of these speeds: the satellite here is far more weakly bound than the speed at which it
+  ! moves through its host. Prior to the fix of the inverted definition of x, the constructed x was bounded below by unity and so
+  ! the mass loss rate was identically zero.
+  call Assert("mass loss rate is non-zero for a weakly bound satellite"           ,all(factorEvaporation      > 0.0d0                 ),.true.)
+  ! The evaporation factor must increase with orbital speed: x=v_esc/v_rel decreases as the satellite moves more quickly, and
+  ! χ_e=(1-x²)/(1+x²) decreases with x. Were x inverted, the ordering would be reversed.
+  call Assert("evaporation factor increases with orbital speed"                   ,all(factorEvaporation(2:3) > factorEvaporation(1:2)),.true.)
+  ! In the limit of an arbitrarily large orbital speed x→0 and hence χ_e→1: every scattering evaporates a particle. This fixes
+  ! the normalization and the sense of x without reference to the details of either halo.
+  call Assert("evaporation factor tends to unity at large orbital speed"          ,factorEvaporation(3) , 1.0d0,absTol=5.0d-3)
+  ! The same limit fixes the deceleration factor. As x→0 the velocity dispersion correction factor of Appendix A of Kummer et
+  ! al. (2018) also tends to unity, since it depends on the dispersion only through its ratio to the orbital speed, so the
+  ! product recovered from the acceleration must tend to χ_d(0)=-1. For a weakly bound subhalo the scattered particles carry
+  ! away more momentum than they bring in, and the sign of the drag reverses.
+  call Assert("deceleration factor tends to -1 at large orbital speed"            ,factorDeceleration(3),-1.0d0,absTol=5.0d-3)
+  ! Finally, a satellite bound deeply enough that its escape velocity exceeds the speed at which it moves relative to its host
+  ! must suffer no evaporation at all: every scattering which ejects one of its own particles also captures a host particle. A
+  ! second node is built for this, rather than the properties of the first being changed: mass distributions are memoized
+  ! against the unique ID of the node, so a node modified in place can be seen with a stale mass distribution.
+  nodeDense                  => treeNode                   (hostTree=tree    )
+  nodeHost  %firstChild      => nodeDense
+  nodeDense %sibling         => node
+  nodeDense %parent          => nodeHost
+  basicDense                 => nodeDense%basic            (autoCreate=.true.)
+  darkMatterProfileDense     => nodeDense%darkMatterProfile(autoCreate=.true.)
+  satelliteDense             => nodeDense%satellite        (autoCreate=.true.)
+  call basicDense            %massSet     (massSatelliteDense                   )
+  call basicDense            %timeSet     (cosmologyFunctions_%cosmicTime(1.0d0))
+  call darkMatterProfileDense%scaleSet    (radiusScaleDense                     )
+  call satelliteDense        %boundMassSet(massSatelliteDense                   )
+  call satelliteDense        %positionSet ([radiusOrbital,0.0d0,0.0d0]          )
+  call satelliteDense        %velocitySet ([0.0d0,speedOrbitalDense,0.0d0]      )
+  massLossRateDense=evaporation%massLossRate(nodeDense)
+  call Assert("mass loss rate is zero for a deeply bound, slowly moving satellite",massLossRateDense,0.0d0)
+  ! In that same regime the drag must be a genuine deceleration: nothing escapes the subhalo, so momentum transfer from the host
+  ! is complete and χ_d is positive.
+  acceleration           =deceleration%acceleration(nodeDense)
+  factorDecelerationDense=-acceleration     (2) &
+       &                  /speedOrbitalDense    & ! The velocity which the drag acts along.
+       &                  /speedOrbitalDense    & ! The flux factor within the scattering rate.
+       &                  /densityHost          &
+       &                  /rateNormalization
+  call Assert("deceleration is a drag for a deeply bound, slowly moving satellite",factorDecelerationDense > 0.0d0,.true.)
+  ! Clean up.
+  call node     %destroy()
+  call nodeDense%destroy()
+  call nodeHost %destroy()
+  call Node_Components_Thread_Uninitialize()
+  call Node_Components_Uninitialize       ()
+  ! End unit tests.
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Finish   ()
+end program Tests_SIDM_Kummer_Satellites

--- a/testSuite/parameters/nodes/nodes_SIDM_Kummer.xml
+++ b/testSuite/parameters/nodes/nodes_SIDM_Kummer.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Parameter file used by the SIDM Kummer (2018) satellite unit test (source/tests/SIDM_Kummer_satellites.F90).       -->
+<!-- It enables the basic, dark matter profile (with a settable scale radius), and orbiting satellite (which carries the   -->
+<!-- position and velocity of the satellite relative to its host) components, and pins the objects which those components -->
+<!-- build so that they match those constructed directly by the test.                                                     -->
+
+<parameters>
+  <lastModified revision="0f386049a46fce7fce1c459a8c53cd79fa5e8c0b" time="2026-08-20T18:06:17"/>
+  <formatVersion>2</formatVersion>
+
+  <componentBasic             value="standard"/>
+  <componentDarkMatterProfile value="scale"   />
+  <componentSatellite         value="orbiting"/>
+
+  <cosmologyParameters value="simple">
+    <OmegaMatter     value="0.2815"/>
+    <OmegaBaryon     value="0.0465"/>
+    <OmegaDarkEnergy value="0.7185"/>
+    <temperatureCMB  value="2.78"  />
+    <HubbleConstant  value="70.0"  />
+  </cosmologyParameters>
+  <cosmologyFunctions    value="matterLambda"                   />
+  <virialDensityContrast value="bryanNorman1998"                />
+  <darkMatterHaloScale   value="virialDensityContrastDefinition"/>
+  <darkMatterProfile     value="darkMatterOnly"                 />
+  <darkMatterProfileDMO  value="NFW">
+    <velocityDispersionUseSeriesExpansion value="false"/>
+  </darkMatterProfileDMO>
+</parameters>


### PR DESCRIPTION
Fixes the prerequisite bug identified in §5 of the assessment on #175: the `x` variable is inverted in both SIDM satellite classes.

`x` was constructed as `speedHalfMass/speedOrbital` = √(1+[v_esc/v_rel]²), which is bounded below by unity. The `x < 1` branch of `kummer2018MassLossRate` was therefore unreachable and it **returned zero for every satellite**, while `kummer2018Acceleration` evaluated χ_d at √(1+x²) rather than at x.

Adding the host^N terms of #175 to a sum which is identically zero would not have been a useful change, so this is sequenced first.

### The correct definition

:cite:`kummer_effective_2018` define x as the ratio of the escape velocity from the subhalo to the speed of the subhalo relative to its host *far from the subhalo*. The boost host particles acquire in falling in to the half-mass radius is already accounted for within the definitions of the critical scattering angle and of both χ factors. Three independent checks of the existing code fix that reading:

* the coded θ_c = acos([x²−1]/[x²+1]) follows from the escape condition `w cos(θ/2) > v_esc` only under this definition, given `w² = v_rel²+v_esc²`;
* the coded χ_e integral evaluates to the published closed form (1−x²)/(1+x²);
* expanding the coded χ_d integral at large x reproduces the hard-coded asymptote 1−8/3x²+16/5x⁴ — 0.999733365330 against 0.999733365333 at x=100.

All of the above were verified against the paper by hand.

### Changes

* **evaporation**: `x = v_esc/√(v_orb²+σ²)`, retaining the dispersion broadening of equation (A4).
* **deceleration**: `x = v_esc/v_orb`, with the dispersion left to the empirical correction factor, which now takes σ/v_orb rather than σ/`speedHalfMass`.
* The self-interaction cross section — and the velocity axis of both tabulations — is now evaluated at √(v_orb²+v_esc²+σ²), the typical relative speed of the particles which actually scatter, rather than at the orbital speed. The flux factor within the scattering rate remains the orbital speed. This required moving the rate normalization below the point at which the escape velocity and dispersion are known, and makes it a local variable rather than a component of the class, where it was only ever per-call scratch state.
* Each definition is accompanied by a comment deriving why that particular speed is the right one, so that the three distinct speeds now in play do not get conflated again.

At v_esc/v_orb = 0.25 this takes χ_e from 0 to 0.882 and χ_d from −0.157 to −0.934.

### Testing

Neither class had any regression coverage — nothing under `parameters/` or `testSuite/` instantiated either one, which is why this went unnoticed. `tests.SIDM_Kummer_satellites.exe` applies both to an explicitly constructed satellite/host pair and asserts that:

* the tabulated χ_e reproduces (1−x²)/(1+x²) for a constant cross section, tested on the pinned lattice so that the tabulated integral is tested rather than the interpolation between lattice points;
* the mass loss rate is non-zero for a weakly bound satellite, and grows with orbital speed;
* as the orbital speed is made arbitrarily large x → 0, so the factors implied by the mass loss rate and by the acceleration tend to χ_e = 1 and χ_d = −1 — parameter-free limits which fix both the normalization and the sense of x without reference to the details of either halo;
* a satellite bound deeply enough that v_esc > v_rel suffers no evaporation, while its drag remains a genuine deceleration.

Reverting only the definition of x fails three of the seven assertions. `tests.SIDM_Kummer_deceleration.exe` (χ_d in isolation) is unaffected and still passes 7/7.

**Known gap:** these tests use the constant cross-section particle class, for which the cross section and its angular dependence are velocity independent, so they do not exercise the speed at which the cross section is evaluated. Covering that needs the velocity-dependent class and either duplicating the escape-velocity and dispersion calculation in the test or reducing it to a self-consistency check; that choice currently rests on the source comments instead.

### Notes

* No bundled parameter file or test instantiated either class before this, so no existing results change.
* Neither the orbit integration nor Chandrasekhar dynamical friction includes host^N, so the consistency caveat raised in §3 of the assessment on #175 still stands for the follow-up work there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
