### PR TITLE
test(launcher): stub the datasets pin lookup for bleeding-edge

### DIFF
--- a/python/galacticus_launcher/tests/test_launcher.py
+++ b/python/galacticus_launcher/tests/test_launcher.py
@@ -183,8 +183,22 @@ def test_resolve_datasets_ref_env_override(monkeypatch):
 
 def test_resolve_datasets_ref_bleeding(monkeypatch):
     monkeypatch.delenv("GALACTICUS_DATASETS_REF", raising=False)
-    # bleeding-edge tracks master and never hits the network for a pin.
-    assert download.resolve_datasets_ref("bleeding-edge") == "master"
+    # `bleeding-edge` is pinned by its own `datasets.ref` asset exactly as a tagged release is: the
+    # snapshot published alongside it is the data that build was tested against. The fetch is stubbed
+    # because asserting against the live release would make this test depend on what is published at
+    # the moment it runs.
+    monkeypatch.setattr(download, "_read_remote_text", lambda url: "abc123def\n")
+    assert download.resolve_datasets_ref("bleeding-edge") == "abc123def"
+
+
+def test_resolve_datasets_ref_bleeding_unpinned(monkeypatch):
+    monkeypatch.delenv("GALACTICUS_DATASETS_REF", raising=False)
+    monkeypatch.setattr(download, "_read_remote_text", lambda url: None)
+    # With no pin published, datasets `master` is used - and, unlike a tagged release, the absence of
+    # a pin is not reported, since it is unremarkable for a rolling build.
+    logged = []
+    assert download.resolve_datasets_ref("bleeding-edge", log=logged.append) == "master"
+    assert logged == []
 
 
 def test_resolve_datasets_ref_pinned(monkeypatch):


### PR DESCRIPTION
`test_resolve_datasets_ref_bleeding` is failing on `master`, and so on every open branch. It is not a regression in the launcher — it is a test which was only ever passing by accident, and which the latest release stopped propping up.

### What happened

The test asserted that `bleeding-edge` *"tracks master and never hits the network for a pin"*:

```python
monkeypatch.delenv("GALACTICUS_DATASETS_REF", raising=False)
assert download.resolve_datasets_ref("bleeding-edge") == "master"
```

`resolve_datasets_ref` has never special-cased `bleeding-edge` — it fetches the `datasets.ref` asset of whatever tag it is given. This was the only test in the file not to stub `_read_remote_text` (its three siblings all do), so it reached the live release and passed only for as long as that asset happened to 404.

75d7fdf14 (#1405) added

```
gh release upload bleeding-edge ./datasets.tar.zst ./datasets.ref --clobber
```

to the Deploy job, so from the first Deploy run to carry it the request succeeds:

```
$ curl -sL https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/datasets.ref
8e0e6bdc8411a4ce2ff33352c5186172d095b7fd
```

which is exactly the SHA in the assertion failure.

### Why the test is wrong rather than the function

Pinning `bleeding-edge` is the documented intent, in three places:

* the `Package-Datasets` job records the snapshot commit so that *"an install gets the data this build was tested against instead of whatever `master` has moved on to"*;
* `_plan_datasets` documents the same, and prefers the published snapshot over the repository archive;
* `_snapshot_ref` reads that same asset to write the sentinel.

A rolling build wants the data it was tested against just as a tagged release does. So this corrects the test to the actual contract rather than the function to the test.

### Changes

* `test_resolve_datasets_ref_bleeding` stubs `_read_remote_text` and asserts the pin is honored, so the result no longer depends on what is published at the moment it runs.
* Adds `test_resolve_datasets_ref_bleeding_unpinned`, covering the one thing genuinely special about `bleeding-edge` here, which the old test never reached: with no pin published the datasets `master` fallback is used *without* reporting the absence of a pin, which would be noise for a rolling build.

Test-only; no launcher behavior changes.

### Verification

Reproduced on a clean `master` worktree before the change. Afterwards the full Python suite passes (1049 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
