### PR TITLE
feat(dust): Phase 1 of the unified dust framework — extinction curves, attenuators, and the property extractor

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1649,6 +1649,7 @@ jobs:
                 test-constraint-deterministic-spins.py,
                 test-constraint-mass-function.py,
                 test-halo-mass-functions.py,
+                test-dust-attenuation-parity.py,
                 test-inactive_luminosities.py,
                 test-interoutput-star-formation-rate.py,
                 test-mass-host-maximum.py,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1382,6 +1382,7 @@ jobs:
                       tests.interpolation.2D.exe,
                       tests.interpolation.multiD.exe,
                       tests.dust.attenuation_descriptors.exe,
+                      tests.dust.extinction_curves.exe,
                       tests.make_ranges.exe,
                       tests.tabulations_inverse.exe,
                       tests.cosmology_functions.exe,

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -2556,6 +2556,7 @@
           <xs:enumeration value="densityProfile"/>
           <xs:enumeration value="descendantNode"/>
           <xs:enumeration value="descendants"/>
+          <xs:enumeration value="dustAttenuation"/>
           <xs:enumeration value="excursion"/>
           <xs:enumeration value="finalDescendant"/>
           <xs:enumeration value="fluxFromLuminosity"/>

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -978,6 +978,50 @@
     <xs:anyAttribute processContents="lax"/>
    </xs:complexType>
   </xs:element>
+  <xs:element name="dustAttenuation">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="birthCloud"/>
+          <xs:enumeration value="charlotFall2000"/>
+          <xs:enumeration value="mixedSlab"/>
+          <xs:enumeration value="screen"/>
+          <xs:enumeration value="screenFixed"/>
+          <xs:enumeration value="screenSurfaceDensityMetals"/>
+          <xs:enumeration value="sequence"/>
+          <xs:enumeration value="zero"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="dustExtinctionCurve">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="calzetti2000"/>
+          <xs:enumeration value="cardelli1989"/>
+          <xs:enumeration value="gordon2003"/>
+          <xs:enumeration value="noll2009"/>
+          <xs:enumeration value="powerLaw"/>
+          <xs:enumeration value="prevotBouchet"/>
+          <xs:enumeration value="tabulated"/>
+          <xs:enumeration value="wittGordon2000"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
   <xs:element name="evolveForestsWorkShare">
    <xs:complexType mixed="true">
     <xs:sequence>

--- a/source/dust/attenuation/CharlotFall2000.F90
+++ b/source/dust/attenuation/CharlotFall2000.F90
@@ -1,0 +1,181 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements the two-component dust attenuation model of :cite:t:`charlot_simple_2000`.
+  !!}
+
+  !![
+  <dustAttenuation name="dustAttenuationCharlotFall2000" docformat="rst">
+   <description>
+   The two-component dust attenuation model of :cite:t:`charlot_simple_2000`: young stars are attenuated both by the
+   dust of the birth clouds in which they remain embedded and by the diffuse dust of the interstellar medium, while
+   older stars, having escaped their birth clouds, are attenuated only by the diffuse component.
+
+   This class carries no physics of its own. It is exactly
+
+   .. code-block:: xml
+
+      &lt;dustAttenuation value="sequence"&gt;
+        &lt;dustAttenuation value="birthCloud"&gt;
+          &lt;dustExtinctionCurve value="powerLaw"&gt;&lt;exponent value="0.7"/&gt;&lt;/dustExtinctionCurve&gt;
+        &lt;/dustAttenuation&gt;
+        &lt;dustAttenuation value="screenSurfaceDensityMetals"&gt;
+          &lt;dustExtinctionCurve value="powerLaw"&gt;&lt;exponent value="0.7"/&gt;&lt;/dustExtinctionCurve&gt;
+        &lt;/dustAttenuation&gt;
+      &lt;/dustAttenuation&gt;
+
+   and is provided because that is the combination users most often want and because it pins the canonical parameter
+   values of the model in one place. Anything expressible here is expressible with
+   :galacticus-class:`dustAttenuationSequence`; use that directly to vary the extinction curve of either component
+   independently, or to build a model with more than two components.
+   </description>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationClass) :: dustAttenuationCharlotFall2000
+     !!{RST
+     The two-component dust attenuation model of :cite:t:`charlot_simple_2000`.
+     !!}
+     private
+     type            (dustAttenuationBirthCloud                ) :: birthCloud_
+     type            (dustAttenuationScreenSurfaceDensityMetals) :: screenISM_
+     ! Retained so that the object can describe itself back into a parameter file; the physics is carried entirely by
+     ! the two component attenuators above.
+     double precision                                            :: coefficientBirthCloud, coefficientISM, &
+          &                                                         timescale            , exponent_
+   contains
+     procedure :: transmission => charlotFall2000Transmission
+     procedure :: request      => charlotFall2000Request
+  end type dustAttenuationCharlotFall2000
+
+  interface dustAttenuationCharlotFall2000
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationCharlotFall2000` dust attenuation class.
+     !!}
+     module procedure charlotFall2000ConstructorParameters
+     module procedure charlotFall2000ConstructorInternal
+  end interface dustAttenuationCharlotFall2000
+
+contains
+
+  function charlotFall2000ConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationCharlotFall2000` dust attenuation class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (dustAttenuationCharlotFall2000)                :: self
+    type            (inputParameters               ), intent(inout) :: parameters
+    double precision                                                :: coefficientBirthCloud, coefficientISM, &
+         &                                                             timescale            , exponent_
+
+    !![
+    <inputParameter docformat="rst">
+      <name>coefficientBirthCloud</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>
+      The :math:`V`-band optical depth of a birth cloud of local interstellar medium metallicity.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>coefficientISM</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>
+      A dimensionless multiplicative coefficient applied to the :math:`V`-band optical depth of the diffuse
+      interstellar medium.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>timescale</name>
+      <defaultValue>1.0d-2</defaultValue>
+      <defaultSource>:cite:t:`charlot_simple_2000`</defaultSource>
+      <description>
+      The lifetime of a stellar birth cloud, in Gyr.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>exponent</name>
+      <variable>exponent_</variable>
+      <defaultValue>0.7d0</defaultValue>
+      <defaultSource>:cite:t:`charlot_simple_2000`</defaultSource>
+      <description>
+      The exponent of the power-law extinction curve applied to both components.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=dustAttenuationCharlotFall2000(coefficientBirthCloud,coefficientISM,timescale,exponent_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function charlotFall2000ConstructorParameters
+
+  function charlotFall2000ConstructorInternal(coefficientBirthCloud,coefficientISM,timescale,exponent_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustAttenuationCharlotFall2000` dust attenuation class. Both
+    components are given their own power-law extinction curve of the same exponent.
+    !!}
+    implicit none
+    type            (dustAttenuationCharlotFall2000)                :: self
+    double precision                                , intent(in   ) :: coefficientBirthCloud, coefficientISM, &
+         &                                                             timescale            , exponent_
+    type            (dustExtinctionCurvePowerLaw   )                :: curvePowerLaw
+    !![
+    <constructorAssign variables="coefficientBirthCloud, coefficientISM, timescale, exponent_"/>
+    !!]
+
+    curvePowerLaw   =dustExtinctionCurvePowerLaw              (exponent_                                    )
+    self%birthCloud_=dustAttenuationBirthCloud                (coefficientBirthCloud,timescale,curvePowerLaw)
+    self%screenISM_ =dustAttenuationScreenSurfaceDensityMetals(coefficientISM                 ,curvePowerLaw)
+    return
+  end function charlotFall2000ConstructorInternal
+
+  function charlotFall2000Transmission(self,node,descriptors) result(transmission)
+    !!{RST
+    Return the transmission through both the birth cloud and diffuse interstellar medium components.
+    !!}
+    implicit none
+    class           (dustAttenuationCharlotFall2000), intent(inout)                               :: self
+    type            (treeNode                      ), intent(inout), target                       :: node
+    type            (emissionDescriptor            ), intent(in   ), dimension(:                ) :: descriptors
+    double precision                                               , dimension(size(descriptors)) :: transmission
+
+    transmission=+self%birthCloud_%transmission(node,descriptors) &
+         &       *self%screenISM_ %transmission(node,descriptors)
+    return
+  end function charlotFall2000Transmission
+
+  function charlotFall2000Request(self) result(request)
+    !!{RST
+    Return a decomposition request splitting populations at the birth cloud lifetime, and by component.
+    !!}
+    implicit none
+    type (decompositionRequest          )                :: request
+    class(dustAttenuationCharlotFall2000), intent(inout) :: self
+
+    request=self%birthCloud_%request()
+    return
+  end function charlotFall2000Request

--- a/source/dust/attenuation/CharlotFall2000.F90
+++ b/source/dust/attenuation/CharlotFall2000.F90
@@ -23,6 +23,8 @@
   Implements the two-component dust attenuation model of :cite:t:`charlot_simple_2000`.
   !!}
 
+  use :: Dust_Extinction_Curves, only : dustExtinctionCurvePowerLaw, wavelengthVBand
+
   !![
   <dustAttenuation name="dustAttenuationCharlotFall2000" docformat="rst">
    <description>
@@ -60,7 +62,8 @@
      ! Retained so that the object can describe itself back into a parameter file; the physics is carried entirely by
      ! the two component attenuators above.
      double precision                                            :: coefficientBirthCloud, coefficientISM, &
-          &                                                         timescale            , exponent_
+          &                                                         timescale            , exponent_     , &
+          &                                                         wavelengthReference
    contains
      procedure :: transmission => charlotFall2000Transmission
      procedure :: request      => charlotFall2000Request
@@ -86,7 +89,8 @@ contains
     type            (dustAttenuationCharlotFall2000)                :: self
     type            (inputParameters               ), intent(inout) :: parameters
     double precision                                                :: coefficientBirthCloud, coefficientISM, &
-         &                                                             timescale            , exponent_
+         &                                                             timescale            , exponent_     , &
+         &                                                             wavelengthReference
 
     !![
     <inputParameter docformat="rst">
@@ -125,15 +129,24 @@ contains
       </description>
       <source>parameters</source>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>wavelengthReference</name>
+      <defaultValue>wavelengthVBand</defaultValue>
+      <description>
+      The wavelength, in Å, at which the power-law extinction curve is normalized to unity. Set it to
+      :math:`5500\,`Å to reproduce the ``lmnstyStllrCF2000`` property extractor exactly.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
     !!]
-    self=dustAttenuationCharlotFall2000(coefficientBirthCloud,coefficientISM,timescale,exponent_)
+    self=dustAttenuationCharlotFall2000(coefficientBirthCloud,coefficientISM,timescale,exponent_,wavelengthReference)
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function charlotFall2000ConstructorParameters
 
-  function charlotFall2000ConstructorInternal(coefficientBirthCloud,coefficientISM,timescale,exponent_) result(self)
+  function charlotFall2000ConstructorInternal(coefficientBirthCloud,coefficientISM,timescale,exponent_,wavelengthReference) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`dustAttenuationCharlotFall2000` dust attenuation class. Both
     components are given their own power-law extinction curve of the same exponent.
@@ -141,15 +154,28 @@ contains
     implicit none
     type            (dustAttenuationCharlotFall2000)                :: self
     double precision                                , intent(in   ) :: coefficientBirthCloud, coefficientISM, &
-         &                                                             timescale            , exponent_
-    type            (dustExtinctionCurvePowerLaw   )                :: curvePowerLaw
+         &                                                             timescale            , exponent_     , &
+         &                                                             wavelengthReference
+    class(dustExtinctionCurveClass), pointer :: curvePowerLaw
     !![
-    <constructorAssign variables="coefficientBirthCloud, coefficientISM, timescale, exponent_"/>
+    <constructorAssign variables="coefficientBirthCloud, coefficientISM, timescale, exponent_, wavelengthReference"/>
     !!]
 
-    curvePowerLaw   =dustExtinctionCurvePowerLaw              (exponent_                                    )
+    ! The curve is shared by both components, so it must be a reference-counted heap object rather than a local: each
+    ! component takes a reference to it, and a stack object would be destroyed while those references were still held.
+    ! A freshly allocated object carries no references, so one is established here for the reference this constructor
+    ! itself holds, and released once both components have taken theirs.
+    allocate(dustExtinctionCurvePowerLaw :: curvePowerLaw)
+    select type (curvePowerLaw)
+    type is (dustExtinctionCurvePowerLaw)
+       curvePowerLaw=dustExtinctionCurvePowerLaw(exponent_,wavelengthReference)
+    end select
+    call curvePowerLaw%referenceCountReset()
     self%birthCloud_=dustAttenuationBirthCloud                (coefficientBirthCloud,timescale,curvePowerLaw)
     self%screenISM_ =dustAttenuationScreenSurfaceDensityMetals(coefficientISM                 ,curvePowerLaw)
+    !![
+    <objectDestructor name="curvePowerLaw"/>
+    !!]
     return
   end function charlotFall2000ConstructorInternal
 

--- a/source/dust/attenuation/_class.F90
+++ b/source/dust/attenuation/_class.F90
@@ -1,0 +1,182 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!!{RST
+Contains a module which provides a class implementing attenuation of galactic emission by dust.
+!!}
+
+module Dust_Attenuations
+  !!{RST
+  Provides a class implementing attenuation of galactic emission by dust.
+
+  A ``dustAttenuation`` object answers one question: of the light emitted by a given parcel of a given galaxy, what
+  fraction escapes? It is handed a ``node`` and a list of ``emissionDescriptor`` parcels---each one
+  wavelength, one component, one source type, one age range---and returns a transmission factor in :math:`[0,1]` for
+  each.
+
+  Two design points are worth stating explicitly.
+
+  **Transmission, not magnitudes.** The method returns a multiplicative factor rather than an attenuation in
+  magnitudes or an optical depth. This is unambiguous, composes by multiplication (so a sequence of attenuators is
+  simply a product), and remains well defined for models---such as radiative transfer through a specified
+  geometry---whose result is not proportional to any single optical depth.
+
+  **Vectorized over parcels.** ``transmission`` receives every parcel at once so that an implementation can hoist its
+  per-node work---the :math:`V`-band optical depth of each component, the inclination, interpolation factors in a
+  tabulated atlas---out of the loop over wavelength, without caching state on the object and risking staleness.
+
+  How finely a producer must split its luminosity is negotiated: ``request`` reports the age bin boundaries an
+  attenuator distinguishes and which other axes it depends upon, so that an age-independent screen applied to a
+  broad-band luminosity is handed one parcel per component, rather than one per wavelength, age and metallicity.
+
+  Note that any constant which must be shared between implementations of this class has to be declared here rather
+  than in an implementation file, because each implementation is generated into its own submodule and so cannot see
+  module-level declarations made by its siblings.
+  !!}
+  use :: Dust_Attenuation_Descriptors, only : decompositionRequest, emissionDescriptor
+  use :: Galactic_Structure_Options  , only : componentTypeAll    , enumerationComponentTypeType
+  use :: Galacticus_Nodes            , only : treeNode
+  private
+
+  ! Metallicity of the local interstellar medium, by mass. Dust-to-gas ratios are scaled relative to this value, on
+  ! the assumption that the dust-to-metals ratio is universal. Declared here, rather than in an implementation file,
+  ! because implementations are generated into sibling submodules which can see this module but not each other.
+  double precision, parameter, public :: metallicityISMLocal=2.0d-2
+
+  !![
+  <functionClass docformat="rst">
+   <name>dustAttenuation</name>
+   <descriptiveName>Dust Attenuation</descriptiveName>
+   <description>
+   Class computing the fraction of the emission from a galaxy which is transmitted through its dust.
+   </description>
+   <default>zero</default>
+   <method name="transmission" >
+    <description>
+    Return the fraction of the emission transmitted through dust, in the range :math:`[0,1]`, for each of the given
+    parcels of emission from the given ``node``. A value of unity indicates no attenuation. The result has one element
+    per element of ``descriptors``, in the same order.
+    </description>
+    <type>double precision, dimension(size(descriptors))</type>
+    <pass>yes</pass>
+    <argument>type(treeNode          ), intent(inout), target       :: node       </argument>
+    <argument>type(emissionDescriptor), intent(in   ), dimension(:) :: descriptors</argument>
+   </method>
+   <method name="request" >
+    <description>
+    Return the resolution which a decomposition must have for this attenuator to be applied correctly: the boundaries
+    of the age bins it distinguishes, and whether it depends upon component, metallicity, or radius. A producer of
+    luminosities uses this to split its output no more finely than necessary.
+
+    The default requests no age resolution and no metallicity or radius resolution, but does request splitting by
+    component---which is what any attenuator depending on the properties of an individual component needs.
+    </description>
+    <type>type(decompositionRequest)</type>
+    <pass>yes</pass>
+    <code>
+     !$GLC attributes unused :: self
+     dustAttenuationRequest%resolveComponents =.true.
+     dustAttenuationRequest%resolveMetallicity=.false.
+     dustAttenuationRequest%resolveRadius     =.false.
+    </code>
+   </method>
+   <method name="supportsComponent" >
+    <description>
+    Return true if this attenuator can be applied to emission from the given component.
+
+    The default accepts any individual component but rejects ``componentTypeAll``: different components are attenuated
+    differently, so a luminosity summed over components can not meaningfully be attenuated---it must be decomposed,
+    attenuated, and only then summed. This is checked when the attenuating property extractor is constructed, so that
+    a misconfiguration is reported immediately rather than part way through a run.
+    </description>
+    <type>logical</type>
+    <pass>yes</pass>
+    <argument>type(enumerationComponentTypeType), intent(in   ) :: componentType</argument>
+    <code>
+     !$GLC attributes unused :: self
+     dustAttenuationSupportsComponent=(componentType /= componentTypeAll)
+    </code>
+   </method>
+  </functionClass>
+  !!]
+
+contains
+
+  subroutine componentGasProperties(node,componentType,massGas,radius,metallicity)
+    !!{RST
+    Return the gas mass (:math:`M_\odot`), scale radius (Mpc), and gas-phase metallicity (linear, by mass) of the
+    given component of the given ``node``.
+
+    Attenuators which scale the dust content with the gas content of a component all need these three quantities, so
+    the extraction lives here rather than in any one implementation: each implementation of this class is generated
+    into its own submodule, and while a submodule can see its parent module it can not see its siblings.
+
+    A component with no gas or no size returns zero for all three, which callers should treat as containing no dust.
+    !!}
+    use :: Abundances_Structure      , only : abundances       , metallicityTypeLinearByMass
+    use :: Error                     , only : Error_Report
+    use :: Galactic_Structure_Options, only : componentTypeDisk, componentTypeNuclearStarCluster, componentTypeSpheroid
+    use :: Galacticus_Nodes          , only : nodeComponentDisk, nodeComponentNSC               , nodeComponentSpheroid
+    implicit none
+    type            (treeNode                    ), intent(inout), target  :: node
+    type            (enumerationComponentTypeType), intent(in   )          :: componentType
+    double precision                              , intent(  out)          :: massGas           , radius, &
+         &                                                                    metallicity
+    class           (nodeComponentDisk           )               , pointer :: disk
+    class           (nodeComponentSpheroid       )               , pointer :: spheroid
+    class           (nodeComponentNSC            )               , pointer :: nuclearStarCluster
+    type            (abundances                  )                         :: abundancesGas
+
+    select case (componentType%ID)
+    case (componentTypeDisk              %ID)
+       disk               => node              %disk         ()
+       massGas            =  disk              %massGas      ()
+       radius             =  disk              %radius       ()
+       abundancesGas      =  disk              %abundancesGas()
+    case (componentTypeSpheroid          %ID)
+       spheroid           => node              %spheroid     ()
+       massGas            =  spheroid          %massGas      ()
+       radius             =  spheroid          %radius       ()
+       abundancesGas      =  spheroid          %abundancesGas()
+    case (componentTypeNuclearStarCluster%ID)
+       nuclearStarCluster => node              %NSC          ()
+       massGas            =  nuclearStarCluster%massGas      ()
+       radius             =  nuclearStarCluster%radius       ()
+       abundancesGas      =  nuclearStarCluster%abundancesGas()
+    case default
+       massGas            =  0.0d0
+       radius             =  0.0d0
+       metallicity        =  0.0d0
+       call Error_Report('component can not host dust'//{introspection:location})
+       return
+    end select
+    if (massGas <= 0.0d0 .or. radius <= 0.0d0) then
+       massGas    =0.0d0
+       radius     =0.0d0
+       metallicity=0.0d0
+       return
+    end if
+    call abundancesGas%massToMassFraction(massGas)
+    metallicity=abundancesGas%metallicity(metallicityTypeLinearByMass)
+    return
+  end subroutine componentGasProperties
+
+end module Dust_Attenuations

--- a/source/dust/attenuation/_class.F90
+++ b/source/dust/attenuation/_class.F90
@@ -55,6 +55,10 @@ module Dust_Attenuations
   use :: Galactic_Structure_Options  , only : componentTypeAll    , enumerationComponentTypeType
   use :: Galacticus_Nodes            , only : treeNode
   private
+  ! Made public so that it survives into the object file: it is called only from the submodules into which the
+  ! implementations of this class are generated, never from this module itself, and a private procedure with no
+  ! caller in its own module can be discarded before those submodules are linked against it.
+  public :: componentGasProperties
 
   ! Metallicity of the local interstellar medium, by mass. Dust-to-gas ratios are scaled relative to this value, on
   ! the assumption that the dust-to-metals ratio is universal. Declared here, rather than in an implementation file,

--- a/source/dust/attenuation/birth_cloud.F90
+++ b/source/dust/attenuation/birth_cloud.F90
@@ -1,0 +1,194 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements attenuation of young stellar populations by the dust of their birth clouds.
+  !!}
+
+  !![
+  <dustAttenuation name="dustAttenuationBirthCloud" docformat="rst">
+   <description>
+   Attenuation of stellar populations which remain embedded in the dense clouds from which they formed. Stars younger
+   than ``timescale`` are attenuated by a screen of :math:`V`-band optical depth
+
+   .. math::
+
+      \tau_\mathrm{V} = C \frac{Z}{Z_\mathrm{ISM}},
+
+   proportional to the metallicity :math:`Z` of the gas of the component in which they formed, relative to that of the
+   local interstellar medium; stars older than ``timescale`` are not attenuated at all by this class. This is the
+   birth cloud term of the :cite:t:`charlot_simple_2000` model, in which the coefficient :math:`C` (``coefficient``)
+   is the optical depth of a birth cloud of local interstellar medium metallicity.
+
+   Note that the optical depth depends only on metallicity, not on the surface density of the gas: a birth cloud is a
+   local structure, and its column is not set by the global structure of the galaxy.
+
+   A parcel of emission whose age is unresolved spans all ages, and is therefore treated as old and left unattenuated
+   rather than being attenuated as though it were entirely young. Combine this class with a
+   :galacticus-class:`dustAttenuationScreenClass` through :galacticus-class:`dustAttenuationSequence` to obtain the
+   full two-component model.
+   </description>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationClass) :: dustAttenuationBirthCloud
+     !!{RST
+     Attenuation of young stellar populations by their birth clouds.
+     !!}
+     private
+     class           (dustExtinctionCurveClass), pointer :: dustExtinctionCurve_ => null()
+     double precision                                    :: coefficient                   , timescale
+   contains
+     final     ::                 birthCloudDestructor
+     procedure :: transmission => birthCloudTransmission
+     procedure :: request      => birthCloudRequest
+  end type dustAttenuationBirthCloud
+
+  interface dustAttenuationBirthCloud
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationBirthCloud` dust attenuation class.
+     !!}
+     module procedure birthCloudConstructorParameters
+     module procedure birthCloudConstructorInternal
+  end interface dustAttenuationBirthCloud
+
+contains
+
+  function birthCloudConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationBirthCloud` dust attenuation class which takes a parameter
+    set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (dustAttenuationBirthCloud)                :: self
+    type            (inputParameters          ), intent(inout) :: parameters
+    class           (dustExtinctionCurveClass ), pointer       :: dustExtinctionCurve_
+    double precision                                           :: coefficient         , timescale
+
+    !![
+    <inputParameter docformat="rst">
+      <name>coefficient</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>
+      The :math:`V`-band optical depth of a birth cloud of local interstellar medium metallicity.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>timescale</name>
+      <defaultValue>1.0d-2</defaultValue>
+      <defaultSource>:cite:t:`charlot_simple_2000`</defaultSource>
+      <description>
+      The lifetime of a stellar birth cloud, in Gyr. Stellar populations younger than this are attenuated by their
+      birth cloud; older populations are not.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="dustExtinctionCurve" name="dustExtinctionCurve_" source="parameters"/>
+    !!]
+    self=dustAttenuationBirthCloud(coefficient,timescale,dustExtinctionCurve_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="dustExtinctionCurve_"/>
+    !!]
+    return
+  end function birthCloudConstructorParameters
+
+  function birthCloudConstructorInternal(coefficient,timescale,dustExtinctionCurve_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustAttenuationBirthCloud` dust attenuation class.
+    !!}
+    implicit none
+    type            (dustAttenuationBirthCloud)                        :: self
+    double precision                           , intent(in   )         :: coefficient         , timescale
+    class           (dustExtinctionCurveClass ), intent(in   ), target :: dustExtinctionCurve_
+    !![
+    <constructorAssign variables="coefficient, timescale, *dustExtinctionCurve_"/>
+    !!]
+
+    return
+  end function birthCloudConstructorInternal
+
+  subroutine birthCloudDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`dustAttenuationBirthCloud` dust attenuation class.
+    !!}
+    implicit none
+    type(dustAttenuationBirthCloud), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%dustExtinctionCurve_"/>
+    !!]
+    return
+  end subroutine birthCloudDestructor
+
+  function birthCloudTransmission(self,node,descriptors) result(transmission)
+    !!{RST
+    Return the transmission through the dust of a stellar birth cloud.
+    !!}
+    use :: Galactic_Structure_Options, only : componentTypeMax, componentTypeMin
+    implicit none
+    class           (dustAttenuationBirthCloud), intent(inout)                                               :: self
+    type            (treeNode                 ), intent(inout), target                                       :: node
+    type            (emissionDescriptor       ), intent(in   ), dimension(:                                ) :: descriptors
+    double precision                                          , dimension(size(descriptors)                ) :: transmission
+    double precision                                          , dimension(componentTypeMin:componentTypeMax) :: depthOpticalV
+    logical                                                   , dimension(componentTypeMin:componentTypeMax) :: computed
+    integer                                                                                                  :: i            , indexComponent
+    double precision                                                                                         :: massGas      , radius        , &
+         &                                                                                                      metallicity
+
+    computed=.false.
+    do i=1,size(descriptors)
+       ! Populations older than the birth cloud lifetime have escaped their birth clouds. A parcel whose age is
+       ! unresolved spans all ages and so falls here, and is left unattenuated.
+       if (descriptors(i)%ageMaximum > self%timescale) then
+          transmission(i)=1.0d0
+          cycle
+       end if
+       indexComponent=descriptors(i)%componentType%ID
+       if (.not.computed(indexComponent)) then
+          call componentGasProperties(node,descriptors(i)%componentType,massGas,radius,metallicity)
+          depthOpticalV(indexComponent)=+self%coefficient    &
+               &                        *metallicity         &
+               &                        /metallicityISMLocal
+          computed     (indexComponent)=.true.
+       end if
+       transmission(i)=exp(                                                                          &
+            &              -depthOpticalV(indexComponent)                                            &
+            &              *self%dustExtinctionCurve_%attenuationRelative(descriptors(i)%wavelength) &
+            &             )
+    end do
+    return
+  end function birthCloudTransmission
+
+  function birthCloudRequest(self) result(request)
+    !!{RST
+    Return a decomposition request splitting populations at the birth cloud lifetime.
+    !!}
+    implicit none
+    type (decompositionRequest      )                :: request
+    class(dustAttenuationBirthCloud ), intent(inout) :: self
+
+    request%ageBoundaries    =[self%timescale]
+    request%resolveComponents=.true.
+    return
+  end function birthCloudRequest

--- a/source/dust/attenuation/mixed_slab.F90
+++ b/source/dust/attenuation/mixed_slab.F90
@@ -1,0 +1,185 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a dust attenuation class for dust mixed uniformly with the emitting stars.
+  !!}
+
+  !![
+  <dustAttenuation name="dustAttenuationMixedSlab" docformat="rst">
+   <description>
+   Attenuation by dust mixed uniformly with the emitting stars, rather than lying in a screen in front of them. For a
+   slab in which emitters and absorbers are uniformly interspersed the emergent fraction is
+
+   .. math::
+
+      T = \frac{1-\mathrm{e}^{-\tau}}{\tau},
+
+   which tends to unity as :math:`\tau \rightarrow 0` and, crucially, falls only as :math:`1/\tau` at large optical
+   depth rather than exponentially: stars on the near side of the slab always escape, so a mixed geometry can never
+   extinguish a component completely. This is the qualitative difference from a screen, and it matters whenever the
+   inferred optical depths are large.
+
+   This class is a decorator: it takes the transmission :math:`T_\mathrm{screen}` computed by any other attenuator,
+   recovers the equivalent optical depth :math:`\tau = -\ln T_\mathrm{screen}`, and re-applies it in the mixed
+   geometry. Any prescription for how much dust a galaxy has can therefore be used in either geometry without being
+   reimplemented.
+   </description>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationClass) :: dustAttenuationMixedSlab
+     !!{RST
+     Attenuation by dust mixed uniformly with the emitting stars.
+     !!}
+     private
+     class(dustAttenuationClass), pointer :: dustAttenuation_ => null()
+   contains
+     final     ::                      mixedSlabDestructor
+     procedure :: transmission      => mixedSlabTransmission
+     procedure :: request           => mixedSlabRequest
+     procedure :: supportsComponent => mixedSlabSupportsComponent
+  end type dustAttenuationMixedSlab
+
+  interface dustAttenuationMixedSlab
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationMixedSlab` dust attenuation class.
+     !!}
+     module procedure mixedSlabConstructorParameters
+     module procedure mixedSlabConstructorInternal
+  end interface dustAttenuationMixedSlab
+
+contains
+
+  function mixedSlabConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationMixedSlab` dust attenuation class which takes a parameter
+    set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type (dustAttenuationMixedSlab)                :: self
+    type (inputParameters         ), intent(inout) :: parameters
+    class(dustAttenuationClass    ), pointer       :: dustAttenuation_
+
+    !![
+    <objectBuilder class="dustAttenuation" name="dustAttenuation_" source="parameters"/>
+    !!]
+    self=dustAttenuationMixedSlab(dustAttenuation_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="dustAttenuation_"/>
+    !!]
+    return
+  end function mixedSlabConstructorParameters
+
+  function mixedSlabConstructorInternal(dustAttenuation_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustAttenuationMixedSlab` dust attenuation class.
+    !!}
+    implicit none
+    type (dustAttenuationMixedSlab)                        :: self
+    class(dustAttenuationClass    ), intent(in   ), target :: dustAttenuation_
+    !![
+    <constructorAssign variables="*dustAttenuation_"/>
+    !!]
+
+    return
+  end function mixedSlabConstructorInternal
+
+  subroutine mixedSlabDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`dustAttenuationMixedSlab` dust attenuation class.
+    !!}
+    implicit none
+    type(dustAttenuationMixedSlab), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%dustAttenuation_"/>
+    !!]
+    return
+  end subroutine mixedSlabDestructor
+
+  function mixedSlabTransmission(self,node,descriptors) result(transmission)
+    !!{RST
+    Return the transmission through dust mixed uniformly with the emitting stars.
+    !!}
+    implicit none
+    class           (dustAttenuationMixedSlab), intent(inout)                               :: self
+    type            (treeNode                ), intent(inout), target                       :: node
+    type            (emissionDescriptor      ), intent(in   ), dimension(:                ) :: descriptors
+    double precision                                         , dimension(size(descriptors)) :: transmission
+    ! Below this optical depth the series expansion of [1-exp(-τ)]/τ is used: the direct expression suffers
+    ! cancellation as τ →, where both numerator and denominator vanish.
+    double precision                                         , parameter                    :: depthOpticalSmall=1.0d-6
+    integer                                                                                 :: i
+    double precision                                                                        :: depthOptical
+
+    transmission=self%dustAttenuation_%transmission(node,descriptors)
+    do i=1,size(transmission)
+       if (transmission(i) >= 1.0d0) then
+          ! No attenuation at all.
+          transmission(i)=1.0d0
+       else if (transmission(i) <= 0.0d0) then
+          ! The screen is completely opaque, so the equivalent optical depth is infinite and the mixed transmission
+          ! vanishes -- albeit only as 1/τ.
+          transmission(i)=0.0d0
+       else
+          depthOptical=-log(transmission(i))
+          if (depthOptical < depthOpticalSmall) then
+             transmission(i)=+1.0d0                 &
+                  &          -depthOptical   /2.0d0 &
+                  &          +depthOptical**2/6.0d0
+          else
+             transmission(i)=+(                    &
+                  &            +1.0d0              &
+                  &            -exp(-depthOptical) &
+                  &           )                    &
+                  &          /depthOptical
+          end if
+       end if
+    end do
+    return
+  end function mixedSlabTransmission
+
+  function mixedSlabRequest(self) result(request)
+    !!{RST
+    Return the decomposition request of the wrapped attenuator: changing the geometry does not change which
+    properties the attenuation depends upon.
+    !!}
+    implicit none
+    type (decompositionRequest    )                :: request
+    class(dustAttenuationMixedSlab), intent(inout) :: self
+
+    request=self%dustAttenuation_%request()
+    return
+  end function mixedSlabRequest
+
+  logical function mixedSlabSupportsComponent(self,componentType) result(supportsComponent)
+    !!{RST
+    Return whether the wrapped attenuator supports the given component.
+    !!}
+    implicit none
+    class(dustAttenuationMixedSlab    ), intent(inout) :: self
+    type (enumerationComponentTypeType), intent(in   ) :: componentType
+
+    supportsComponent=self%dustAttenuation_%supportsComponent(componentType)
+    return
+  end function mixedSlabSupportsComponent

--- a/source/dust/attenuation/screen.F90
+++ b/source/dust/attenuation/screen.F90
@@ -1,0 +1,133 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a dust attenuation class describing a uniform screen of dust in front of the emitting stars.
+  !!}
+
+  use :: Dust_Extinction_Curves, only : dustExtinctionCurveClass
+
+  !![
+  <dustAttenuation name="dustAttenuationScreen" abstract="yes" docformat="rst">
+   <description>
+   An abstract dust attenuation class describing a uniform screen of dust lying between the emitting stars and the
+   observer, so that
+
+   .. math::
+
+      T(\lambda) = \exp\left[ -\tau_\mathrm{V} \frac{k(\lambda)}{k_\mathrm{V}} \right],
+
+   where the wavelength dependence :math:`k(\lambda)/k_\mathrm{V}` is supplied by a
+   :galacticus-class:`dustExtinctionCurveClass` object and the normalization :math:`\tau_\mathrm{V}` by the
+   ``depthOpticalV`` method of a concrete subclass. Separating the two means any extinction curve may be combined with
+   any prescription for how much dust a galaxy has.
+
+   A screen is the simplest possible geometry. It attenuates all of the light it is applied to equally, and---unlike a
+   mixed distribution of dust and stars---has no upper limit to the attenuation it can produce.
+   </description>
+  </dustAttenuation>
+  !!]
+
+  ! Note: declared as a concrete type despite `abstract="yes"` above, so that it may carry a finalizer to release the
+  ! extinction curve object; a final subroutine's `self` cannot be declared `type(...)` for an abstract type. The
+  ! `depthOpticalV` method therefore cannot be `deferred`, and instead reports an error if a subclass fails to
+  ! override it -- the same idiom used by `nodePropertyExtractor%decompose`.
+  type, extends(dustAttenuationClass) :: dustAttenuationScreen
+     !!{RST
+     A dust attenuation class describing a uniform screen of dust.
+     !!}
+     private
+     class(dustExtinctionCurveClass), pointer :: dustExtinctionCurve_ => null()
+   contains
+     !![
+     <methods docformat="rst">
+       <method method="depthOpticalV" description="Return the :math:`V`-band optical depth of the screen for one component of one node."/>
+     </methods>
+     !!]
+     final     ::                  screenDestructor
+     procedure :: transmission  => screenTransmission
+     procedure :: depthOpticalV => screenDepthOpticalV
+  end type dustAttenuationScreen
+
+contains
+
+  subroutine screenDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`dustAttenuationScreen` dust attenuation class.
+    !!}
+    implicit none
+    type(dustAttenuationScreen), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%dustExtinctionCurve_"/>
+    !!]
+    return
+  end subroutine screenDestructor
+
+  double precision function screenDepthOpticalV(self,node,componentType) result(depthOpticalV)
+    !!{RST
+    Return the :math:`V`-band optical depth of the screen. The default implementation reports an error: every
+    concrete subclass of :galacticus-class:`dustAttenuationScreen` must override it.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    class(dustAttenuationScreen         ), intent(inout)         :: self
+    type (treeNode                      ), intent(inout), target :: node
+    type (enumerationComponentTypeType  ), intent(in   )         :: componentType
+    !$GLC attributes unused :: self, node, componentType
+
+    depthOpticalV=0.0d0
+    call Error_Report('this screen does not implement depthOpticalV'//{introspection:location})
+    return
+  end function screenDepthOpticalV
+
+  function screenTransmission(self,node,descriptors) result(transmission)
+    !!{RST
+    Return the transmission through a uniform screen of dust.
+
+    The :math:`V`-band optical depth is evaluated once per distinct component appearing in ``descriptors``, rather
+    than once per parcel: a spectrum decomposed at hundreds of wavelengths would otherwise repeat the same structural
+    calculation at each one.
+    !!}
+    use :: Galactic_Structure_Options, only : componentTypeMax, componentTypeMin
+    implicit none
+    class           (dustAttenuationScreen), intent(inout)                                               :: self
+    type            (treeNode             ), intent(inout), target                                       :: node
+    type            (emissionDescriptor   ), intent(in   ), dimension(:                                ) :: descriptors
+    double precision                                      , dimension(size(descriptors)                ) :: transmission
+    double precision                                      , dimension(componentTypeMin:componentTypeMax) :: depthOpticalV
+    logical                                               , dimension(componentTypeMin:componentTypeMax) :: computed
+    integer                                                                                              :: i            , indexComponent
+
+    computed=.false.
+    do i=1,size(descriptors)
+       indexComponent=descriptors(i)%componentType%ID
+       if (.not.computed(indexComponent)) then
+          depthOpticalV(indexComponent)=self%depthOpticalV(node,descriptors(i)%componentType)
+          computed     (indexComponent)=.true.
+       end if
+       transmission(i)=exp(                                                                          &
+            &              -depthOpticalV(indexComponent)                                            &
+            &              *self%dustExtinctionCurve_%attenuationRelative(descriptors(i)%wavelength) &
+            &             )
+    end do
+    return
+  end function screenTransmission

--- a/source/dust/attenuation/screen_fixed.F90
+++ b/source/dust/attenuation/screen_fixed.F90
@@ -1,0 +1,114 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a dust screen of fixed optical depth.
+  !!}
+
+  !![
+  <dustAttenuation name="dustAttenuationScreenFixed" docformat="rst">
+   <description>
+   A uniform dust screen whose :math:`V`-band optical depth is a fixed parameter, independent of the properties of the
+   galaxy. This is the appropriate choice when the optical depth is to be treated as a free parameter---when fitting
+   an observed spectral energy distribution, for example---rather than predicted from a model of the interstellar
+   medium.
+   </description>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationScreen) :: dustAttenuationScreenFixed
+     !!{RST
+     A dust screen of fixed optical depth.
+     !!}
+     private
+     double precision :: depthOpticalV_
+   contains
+     procedure :: depthOpticalV => screenFixedDepthOpticalV
+  end type dustAttenuationScreenFixed
+
+  interface dustAttenuationScreenFixed
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationScreenFixed` dust attenuation class.
+     !!}
+     module procedure screenFixedConstructorParameters
+     module procedure screenFixedConstructorInternal
+  end interface dustAttenuationScreenFixed
+
+contains
+
+  function screenFixedConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationScreenFixed` dust attenuation class which takes a parameter
+    set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (dustAttenuationScreenFixed)                :: self
+    type            (inputParameters           ), intent(inout) :: parameters
+    class           (dustExtinctionCurveClass  ), pointer       :: dustExtinctionCurve_
+    double precision                                            :: depthOpticalV
+
+    !![
+    <inputParameter docformat="rst">
+      <name>depthOpticalV</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>
+      The :math:`V`-band optical depth of the dust screen.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="dustExtinctionCurve" name="dustExtinctionCurve_" source="parameters"/>
+    !!]
+    self=dustAttenuationScreenFixed(depthOpticalV,dustExtinctionCurve_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="dustExtinctionCurve_"/>
+    !!]
+    return
+  end function screenFixedConstructorParameters
+
+  function screenFixedConstructorInternal(depthOpticalV_,dustExtinctionCurve_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustAttenuationScreenFixed` dust attenuation class.
+    !!}
+    implicit none
+    type            (dustAttenuationScreenFixed)                        :: self
+    double precision                            , intent(in   )         :: depthOpticalV_
+    class           (dustExtinctionCurveClass  ), intent(in   ), target :: dustExtinctionCurve_
+    !![
+    <constructorAssign variables="depthOpticalV_, *dustExtinctionCurve_"/>
+    !!]
+
+    return
+  end function screenFixedConstructorInternal
+
+  double precision function screenFixedDepthOpticalV(self,node,componentType) result(depthOpticalV)
+    !!{RST
+    Return the fixed :math:`V`-band optical depth of the screen.
+    !!}
+    implicit none
+    class(dustAttenuationScreenFixed  ), intent(inout)         :: self
+    type (treeNode                    ), intent(inout), target :: node
+    type (enumerationComponentTypeType), intent(in   )         :: componentType
+    !$GLC attributes unused :: node, componentType
+
+    depthOpticalV=self%depthOpticalV_
+    return
+  end function screenFixedDepthOpticalV

--- a/source/dust/attenuation/screen_surface_density_metals.F90
+++ b/source/dust/attenuation/screen_surface_density_metals.F90
@@ -1,0 +1,168 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a dust screen whose optical depth scales with the surface density of metals.
+  !!}
+
+  !![
+  <dustAttenuation name="dustAttenuationScreenSurfaceDensityMetals" docformat="rst">
+   <description>
+   A uniform dust screen whose :math:`V`-band optical depth is proportional to the surface density of metals in the
+   gas of the component being attenuated,
+
+   .. math::
+
+      \tau_\mathrm{V} = C \, \frac{A_\mathrm{V}/E(B-V)}{N_\mathrm{H}/E(B-V)} \, \frac{X_\mathrm{H}}{m_\mathrm{u}} \, \frac{\Sigma_\mathrm{Z}}{Z_\odot} \, \frac{1}{2.5 \log_{10} \mathrm{e}},
+
+   with the ratios :math:`A_\mathrm{V}/E(B-V)=3.1` and :math:`N_\mathrm{H}/E(B-V)=5.8\times10^{21}\,\hbox{atoms cm}^{-2}\,\hbox{mag}^{-1}` from
+   :cite:t:`savage_observed_1979`, and :math:`\Sigma_\mathrm{Z}` the surface density of gas-phase metals. The
+   dimensionless coefficient :math:`C` (``coefficient``) allows the overall normalization to be adjusted.
+
+   The scaling assumes a universal dust-to-metals ratio, so that a galaxy with the metallicity and gas surface density
+   of the local interstellar medium reproduces the Milky Way relation between column density and reddening.
+
+   The surface density is that of an exponential disk or of a spheroid of the same scale radius,
+   :math:`\Sigma_\mathrm{Z} = Z M_\mathrm{gas} / 2\pi r^2`, and is taken to be zero for a component with no gas or no
+   size.
+   </description>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationScreen) :: dustAttenuationScreenSurfaceDensityMetals
+     !!{RST
+     A dust screen whose optical depth scales with the surface density of metals.
+     !!}
+     private
+     double precision :: coefficient
+   contains
+     procedure :: depthOpticalV => screenSurfaceDensityMetalsDepthOpticalV
+  end type dustAttenuationScreenSurfaceDensityMetals
+
+  interface dustAttenuationScreenSurfaceDensityMetals
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationScreenSurfaceDensityMetals` dust attenuation class.
+     !!}
+     module procedure screenSurfaceDensityMetalsConstructorParameters
+     module procedure screenSurfaceDensityMetalsConstructorInternal
+  end interface dustAttenuationScreenSurfaceDensityMetals
+
+contains
+
+  function screenSurfaceDensityMetalsConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationScreenSurfaceDensityMetals` dust attenuation class which
+    takes a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (dustAttenuationScreenSurfaceDensityMetals)                :: self
+    type            (inputParameters                          ), intent(inout) :: parameters
+    class           (dustExtinctionCurveClass                 ), pointer       :: dustExtinctionCurve_
+    double precision                                                           :: coefficient
+
+    !![
+    <inputParameter docformat="rst">
+      <name>coefficient</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>
+      A dimensionless multiplicative coefficient applied to the :math:`V`-band optical depth, allowing the overall
+      normalization of the dust content to be adjusted away from the Milky Way calibration.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="dustExtinctionCurve" name="dustExtinctionCurve_" source="parameters"/>
+    !!]
+    self=dustAttenuationScreenSurfaceDensityMetals(coefficient,dustExtinctionCurve_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="dustExtinctionCurve_"/>
+    !!]
+    return
+  end function screenSurfaceDensityMetalsConstructorParameters
+
+  function screenSurfaceDensityMetalsConstructorInternal(coefficient,dustExtinctionCurve_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustAttenuationScreenSurfaceDensityMetals` dust attenuation class.
+    !!}
+    implicit none
+    type            (dustAttenuationScreenSurfaceDensityMetals)                        :: self
+    double precision                                           , intent(in   )         :: coefficient
+    class           (dustExtinctionCurveClass                 ), intent(in   ), target :: dustExtinctionCurve_
+    !![
+    <constructorAssign variables="coefficient, *dustExtinctionCurve_"/>
+    !!]
+
+    return
+  end function screenSurfaceDensityMetalsConstructorInternal
+
+  double precision function screenSurfaceDensityMetalsDepthOpticalV(self,node,componentType) result(depthOpticalV)
+    !!{RST
+    Return the :math:`V`-band optical depth of a screen scaling with the surface density of metals.
+    !!}
+    use :: Numerical_Constants_Astronomical, only : hydrogenByMassSolar, massSolar, opticalDepthToMagnitudes, parsec
+    use :: Numerical_Constants_Atomic      , only : atomicMassUnit
+    use :: Numerical_Constants_Math        , only : Pi
+    use :: Numerical_Constants_Prefixes    , only : hecto              , mega
+    implicit none
+    class           (dustAttenuationScreenSurfaceDensityMetals), intent(inout)         :: self
+    type            (treeNode                                 ), intent(inout), target :: node
+    type            (enumerationComponentTypeType             ), intent(in   )         :: componentType
+    ! A_V/E(B-V) (Savage & Mathis 1979).
+    double precision                                           , parameter             :: AVToEBV                  =+3.10d+00
+    ! N_H/E(B-V), in atoms/cm²/mag (Savage & Mathis 1979).
+    double precision                                           , parameter             :: NHToEBV                  =+5.80d+21
+    ! Optical depth per unit surface density of metals, in units of (M☉/pc²)⁻¹. Note that the classes replaced
+    ! here derived the optical-depth-to-magnitudes conversion locally as 2.5 log10(e); `opticalDepthToMagnitudes` is
+    ! the algebraically identical 2.5/ln(10), and differs from it by one unit in the last place (2e-16 relative), so
+    ! attenuations computed here differ from those of the originals only at that level.
+    double precision                                           , parameter             :: depthOpticalNormalization=+AVToEBV                  &
+         &                                                                                                          /NHToEBV                  &
+         &                                                                                                          *hydrogenByMassSolar      &
+         &                                                                                                          /atomicMassUnit*massSolar &
+         &                                                                                                          /(                        &
+         &                                                                                                            +parsec                 &
+         &                                                                                                            *hecto                  &
+         &                                                                                                          )**2                      &
+         &                                                                                                          /metallicityISMLocal      &
+         &                                                                                                          /opticalDepthToMagnitudes
+    double precision                                                                   :: massGas                  , radius              , &
+         &                                                                                metallicity              , densitySurfaceMetals
+
+    call componentGasProperties(node,componentType,massGas,radius,metallicity)
+    ! A component with no gas, or no size, has no dust.
+    if (massGas <= 0.0d0 .or. radius <= 0.0d0) then
+       depthOpticalV=0.0d0
+       return
+    end if
+    ! Surface density of metals, in M☉/pc².
+    densitySurfaceMetals=+metallicity          &
+         &               *massGas              &
+         &               /2.0d0                &
+         &               /Pi                   &
+         &               /(                    &
+         &                 +mega               &
+         &                 *radius             &
+         &                )**2
+    depthOpticalV       =+self%coefficient          &
+         &               *depthOpticalNormalization &
+         &               *densitySurfaceMetals
+    return
+  end function screenSurfaceDensityMetalsDepthOpticalV

--- a/source/dust/attenuation/sequence.F90
+++ b/source/dust/attenuation/sequence.F90
@@ -1,0 +1,243 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a dust attenuation class which applies a sequence of other attenuators.
+  !!}
+
+  type, public :: dustAttenuationList
+     class(dustAttenuationClass), pointer :: dustAttenuation_ => null()
+     type (dustAttenuationList ), pointer :: next             => null()
+  end type dustAttenuationList
+
+  !![
+  <dustAttenuation name="dustAttenuationSequence" docformat="rst">
+   <description>
+   A dust attenuation class which applies a sequence of other attenuators, returning the product of their
+   transmissions. Because transmission is multiplicative, this is exactly the result of the light passing through each
+   in turn, and---for pure absorption---the order in which they are listed does not matter.
+
+   The canonical use is to build a two-component model: a :galacticus-class:`dustAttenuationBirthCloud` attenuating
+   young populations, followed by a diffuse interstellar medium screen attenuating everything. See
+   :galacticus-class:`dustAttenuationCharlotFall2000` for that combination pre-assembled.
+
+   The decomposition requested by a sequence is the union of those requested by its members: the age bin boundaries
+   are merged, and an axis is resolved if any member depends upon it. A component is supported only if every member
+   supports it.
+   </description>
+   <linkedList type="dustAttenuationList" variable="dustAttenuations" next="next" object="dustAttenuation_" objectType="dustAttenuationClass"/>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationClass) :: dustAttenuationSequence
+     !!{RST
+     A dust attenuation class which applies a sequence of other attenuators.
+     !!}
+     private
+     type(dustAttenuationList), pointer :: dustAttenuations => null()
+   contains
+     final     ::                      sequenceDestructor
+     procedure :: transmission      => sequenceTransmission
+     procedure :: request           => sequenceRequest
+     procedure :: supportsComponent => sequenceSupportsComponent
+  end type dustAttenuationSequence
+
+  interface dustAttenuationSequence
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationSequence` dust attenuation class.
+     !!}
+     module procedure sequenceConstructorParameters
+     module procedure sequenceConstructorInternal
+  end interface dustAttenuationSequence
+
+contains
+
+  function sequenceConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationSequence` dust attenuation class which takes a parameter set
+    as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type   (dustAttenuationSequence)                :: self
+    type   (inputParameters        ), intent(inout) :: parameters
+    type   (dustAttenuationList    ), pointer       :: dustAttenuation_
+    integer                                         :: i
+
+    self            %dustAttenuations => null()
+    dustAttenuation_                  => null()
+    do i=1,parameters%copiesCount('dustAttenuation',zeroIfNotPresent=.true.)
+       if (associated(dustAttenuation_)) then
+          allocate(dustAttenuation_%next)
+          dustAttenuation_ => dustAttenuation_%next
+       else
+          allocate(self%dustAttenuations)
+          dustAttenuation_ => self%dustAttenuations
+       end if
+       !![
+       <objectBuilder class="dustAttenuation" name="dustAttenuation_%dustAttenuation_" source="parameters" copy="i" />
+       !!]
+    end do
+    !![
+    <inputParametersValidate source="parameters" multiParameters="dustAttenuation"/>
+    !!]
+    return
+  end function sequenceConstructorParameters
+
+  function sequenceConstructorInternal(dustAttenuations) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustAttenuationSequence` dust attenuation class.
+    !!}
+    implicit none
+    type(dustAttenuationSequence)                        :: self
+    type(dustAttenuationList    ), intent(in   ), target :: dustAttenuations
+    type(dustAttenuationList    ), pointer               :: dustAttenuation_
+
+    self            %dustAttenuations => dustAttenuations
+    dustAttenuation_                  => dustAttenuations
+    do while (associated(dustAttenuation_))
+       !![
+       <referenceCountIncrement owner="dustAttenuation_" object="dustAttenuation_"/>
+       !!]
+       dustAttenuation_ => dustAttenuation_%next
+    end do
+    return
+  end function sequenceConstructorInternal
+
+  subroutine sequenceDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`dustAttenuationSequence` dust attenuation class.
+    !!}
+    implicit none
+    type(dustAttenuationSequence), intent(inout) :: self
+    type(dustAttenuationList    ), pointer       :: dustAttenuation_, dustAttenuationNext
+
+    if (associated(self%dustAttenuations)) then
+       dustAttenuation_ => self%dustAttenuations
+       do while (associated(dustAttenuation_))
+          dustAttenuationNext => dustAttenuation_%next
+          !![
+          <objectDestructor name="dustAttenuation_%dustAttenuation_"/>
+          !!]
+          deallocate(dustAttenuation_)
+          dustAttenuation_ => dustAttenuationNext
+       end do
+    end if
+    return
+  end subroutine sequenceDestructor
+
+  function sequenceTransmission(self,node,descriptors) result(transmission)
+    !!{RST
+    Return the product of the transmissions of each attenuator in the sequence.
+    !!}
+    implicit none
+    class           (dustAttenuationSequence), intent(inout)                               :: self
+    type            (treeNode               ), intent(inout), target                       :: node
+    type            (emissionDescriptor     ), intent(in   ), dimension(:)                 :: descriptors
+    double precision                                        , dimension(size(descriptors)) :: transmission
+    type            (dustAttenuationList    ), pointer                                     :: dustAttenuation_
+
+    transmission     =  1.0d0
+    dustAttenuation_ => self%dustAttenuations
+    do while (associated(dustAttenuation_))
+       transmission     =  +transmission                                                     &
+            &              *dustAttenuation_%dustAttenuation_%transmission(node,descriptors)
+       dustAttenuation_ =>  dustAttenuation_%next
+    end do
+    return
+  end function sequenceTransmission
+
+  function sequenceRequest(self) result(request)
+    !!{RST
+    Return the union of the decomposition requests of each attenuator in the sequence: age bin boundaries are merged
+    (sorted, with duplicates removed), and each resolution flag is set if any member sets it.
+    !!}
+    implicit none
+    type            (decompositionRequest   )                            :: request
+    class           (dustAttenuationSequence), intent(inout)             :: self
+    type            (dustAttenuationList    ), pointer                   :: dustAttenuation_
+    type            (decompositionRequest   )                            :: requestMember
+    double precision                         , allocatable, dimension(:) :: boundaries      , boundariesMerged
+    integer                                                              :: countBoundaries , i               , &
+         &                                                                  j
+    double precision                                                     :: boundary
+
+    request%resolveComponents =.false.
+    request%resolveMetallicity=.false.
+    request%resolveRadius     =.false.
+    allocate(boundaries(0))
+    dustAttenuation_ => self%dustAttenuations
+    do while (associated(dustAttenuation_))
+       requestMember=dustAttenuation_%dustAttenuation_%request()
+       request%resolveComponents =request%resolveComponents  .or. requestMember%resolveComponents
+       request%resolveMetallicity=request%resolveMetallicity .or. requestMember%resolveMetallicity
+       request%resolveRadius     =request%resolveRadius      .or. requestMember%resolveRadius
+       if (allocated(requestMember%ageBoundaries)) then
+          boundariesMerged=[boundaries,requestMember%ageBoundaries]
+          call move_alloc(boundariesMerged,boundaries)
+       end if
+       dustAttenuation_ => dustAttenuation_%next
+    end do
+    ! Sort the merged boundaries, then remove duplicates. The arrays here contain at most a handful of entries, so an
+    ! insertion sort is entirely adequate and avoids pulling in a general sorting routine.
+    do i=2,size(boundaries)
+       boundary=boundaries(i)
+       j       =i-1
+       do while (j >= 1)
+          if (boundaries(j) <= boundary) exit
+          boundaries(j+1)=boundaries(j)
+          j              =j-1
+       end do
+       boundaries(j+1)=boundary
+    end do
+    countBoundaries=0
+    do i=1,size(boundaries)
+       if (countBoundaries == 0) then
+          countBoundaries            =1
+          boundaries(countBoundaries)=boundaries(i)
+       else if (boundaries(i) > boundaries(countBoundaries)) then
+          countBoundaries            =countBoundaries+1
+          boundaries(countBoundaries)=boundaries(i)
+       end if
+    end do
+    request%ageBoundaries=boundaries(1:countBoundaries)
+    return
+  end function sequenceRequest
+
+  logical function sequenceSupportsComponent(self,componentType) result(supportsComponent)
+    !!{RST
+    Return true only if every attenuator in the sequence supports the given component.
+    !!}
+    implicit none
+    class(dustAttenuationSequence     ), intent(inout) :: self
+    type (enumerationComponentTypeType), intent(in   ) :: componentType
+    type (dustAttenuationList         ), pointer       :: dustAttenuation_
+
+    supportsComponent=  .true.
+    dustAttenuation_  => self%dustAttenuations
+    do while (associated(dustAttenuation_))
+       if (.not.dustAttenuation_%dustAttenuation_%supportsComponent(componentType)) then
+          supportsComponent=.false.
+          return
+       end if
+       dustAttenuation_ => dustAttenuation_%next
+    end do
+    return
+  end function sequenceSupportsComponent

--- a/source/dust/attenuation/zero.F90
+++ b/source/dust/attenuation/zero.F90
@@ -1,0 +1,102 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a dust attenuation class in which no attenuation occurs.
+  !!}
+
+  !![
+  <dustAttenuation name="dustAttenuationZero" docformat="rst">
+   <description>
+   A dust attenuation class in which nothing is attenuated: the transmission is unity at all wavelengths, for all
+   components, and at all ages. This is the default, and is useful as a control against which the effect of a dust
+   model can be measured.
+
+   Because it depends on nothing, it requests no decomposition at all---not even by component---so that wrapping a
+   luminosity in this attenuator costs a single parcel per output element.
+   </description>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationClass) :: dustAttenuationZero
+     !!{RST
+     A dust attenuation class in which no attenuation occurs.
+     !!}
+     private
+   contains
+     procedure :: transmission => zeroTransmission
+     procedure :: request      => zeroRequest
+  end type dustAttenuationZero
+
+  interface dustAttenuationZero
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationZero` dust attenuation class.
+     !!}
+     module procedure zeroConstructorParameters
+  end interface dustAttenuationZero
+
+contains
+
+  function zeroConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationZero` dust attenuation class which takes a parameter set as
+    input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type(dustAttenuationZero)                :: self
+    type(inputParameters    ), intent(inout) :: parameters
+
+    self=dustAttenuationZero()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function zeroConstructorParameters
+
+  function zeroTransmission(self,node,descriptors) result(transmission)
+    !!{RST
+    Return unit transmission---no attenuation---for every parcel.
+    !!}
+    implicit none
+    class           (dustAttenuationZero), intent(inout)                               :: self
+    type            (treeNode           ), intent(inout), target                       :: node
+    type            (emissionDescriptor ), intent(in   ), dimension(:                ) :: descriptors
+    double precision                                    , dimension(size(descriptors)) :: transmission
+    !$GLC attributes unused :: self, node, descriptors
+
+    transmission=1.0d0
+    return
+  end function zeroTransmission
+
+  function zeroRequest(self) result(request)
+    !!{RST
+    Return a decomposition request specifying no resolution at all, since the transmission depends on nothing.
+    !!}
+    implicit none
+    type (decompositionRequest)                :: request
+    class(dustAttenuationZero ), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    request%resolveComponents =.false.
+    request%resolveMetallicity=.false.
+    request%resolveRadius     =.false.
+    return
+  end function zeroRequest

--- a/source/dust/extinction_curves/Calzetti2000.F90
+++ b/source/dust/extinction_curves/Calzetti2000.F90
@@ -1,0 +1,155 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements the dust extinction curve of :cite:t:`calzetti_dust_2000`.
+  !!}
+
+  !![
+  <dustExtinctionCurve name="dustExtinctionCurveCalzetti2000" docformat="rst">
+   <description>
+   The dust attenuation curve of :cite:t:`calzetti_dust_2000`, derived empirically from the ultraviolet-to-optical
+   spectra of local starburst galaxies. Equation (4) of that work gives :math:`k(\lambda)`, which is divided here by
+   :math:`R_\mathrm{V}=4.05` (their equation 5) to normalize to the :math:`V`-band.
+
+   The fit is defined only over :math:`0.12\,\mu\mathrm{m} &lt; \lambda \le 2.20\,\mu\mathrm{m}`. Outside that range this
+   implementation returns zero, i.e. *no* attenuation---the behavior of the original ``stellarSpectraDustAttenuation``
+   implementation, retained here for consistency. Note that this is not the same as clamping the curve to its boundary
+   value, and can matter when the curve is evaluated across a broad spectrum rather than through an optical filter;
+   use ``wavelengthRange`` to detect the boundary.
+   </description>
+  </dustExtinctionCurve>
+  !!]
+  type, extends(dustExtinctionCurveClass) :: dustExtinctionCurveCalzetti2000
+     !!{RST
+     The dust extinction curve of :cite:t:`calzetti_dust_2000`.
+     !!}
+     private
+   contains
+     !![
+     <methods docformat="rst">
+       <method method="RvValue" description="Return the total-to-selective extinction ratio assumed by this curve."/>
+     </methods>
+     !!]
+     procedure :: attenuationRelative => calzetti2000AttenuationRelative
+     procedure :: wavelengthRange     => calzetti2000WavelengthRange
+     procedure :: RvValue             => calzetti2000RvValue
+  end type dustExtinctionCurveCalzetti2000
+
+  interface dustExtinctionCurveCalzetti2000
+     !!{RST
+     Constructors for the :galacticus-class:`dustExtinctionCurveCalzetti2000` dust extinction curve class.
+     !!}
+     module procedure calzetti2000ConstructorParameters
+  end interface dustExtinctionCurveCalzetti2000
+
+  ! Range of validity of the fit, in microns (Calzetti et al. 2000; eqn. 4).
+  double precision, parameter :: calzetti2000WavelengthMinimumMicrons=0.12d0
+  double precision, parameter :: calzetti2000WavelengthMaximumMicrons=2.20d0
+  ! Total-to-selective extinction ratio (Calzetti et al. 2000; eqn. 5).
+  double precision, parameter :: calzetti2000Rv                      =4.05d0
+
+contains
+
+  function calzetti2000ConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustExtinctionCurveCalzetti2000` dust extinction curve class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type(dustExtinctionCurveCalzetti2000)                :: self
+    type(inputParameters                ), intent(inout) :: parameters
+
+    self=dustExtinctionCurveCalzetti2000()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function calzetti2000ConstructorParameters
+
+  double precision function calzetti2000AttenuationRelative(self,wavelength) result(attenuationRelative)
+    !!{RST
+    Return the relative dust opacity for the extinction curve of :cite:t:`calzetti_dust_2000`.
+    !!}
+    use :: Numerical_Constants_Units, only : micronsToAngstroms
+    implicit none
+    class           (dustExtinctionCurveCalzetti2000), intent(inout) :: self
+    double precision                                 , intent(in   ) :: wavelength
+    double precision                                                 :: wavelengthMicrons, kappa
+    !$GLC attributes unused :: self
+
+    ! Eqn. (4) of Calzetti et al. (2000).
+    wavelengthMicrons=wavelength/micronsToAngstroms
+    if      (wavelengthMicrons > calzetti2000WavelengthMinimumMicrons .and. wavelengthMicrons <= 0.63d0                             ) then
+       kappa=+2.659d0                                &
+            & *(                                     &
+            &   -2.156d0                             &
+            &   +1.509d0/wavelengthMicrons           &
+            &   -0.198d0/wavelengthMicrons**2        &
+            &   +0.011d0/wavelengthMicrons**3        &
+            &  )                                     &
+            & +calzetti2000Rv
+    else if (wavelengthMicrons > 0.63d0                              .and. wavelengthMicrons <= calzetti2000WavelengthMaximumMicrons) then
+       kappa=+2.659d0                                &
+            & *(                                     &
+            &   -1.857d0                             &
+            &   +1.040d0/wavelengthMicrons           &
+            &  )                                     &
+            & +calzetti2000Rv
+    else
+       ! Outside the range of the fit - see the class description.
+       kappa=+0.0d0
+    end if
+    attenuationRelative=+kappa            &
+         &              /calzetti2000Rv
+    return
+  end function calzetti2000AttenuationRelative
+
+  subroutine calzetti2000WavelengthRange(self,wavelengthMinimum,wavelengthMaximum)
+    !!{RST
+    Return the range of wavelengths over which the :cite:t:`calzetti_dust_2000` extinction curve is defined.
+    !!}
+    use :: Numerical_Constants_Units, only : micronsToAngstroms
+    implicit none
+    class           (dustExtinctionCurveCalzetti2000), intent(inout) :: self
+    double precision                                 , intent(  out) :: wavelengthMinimum, wavelengthMaximum
+    !$GLC attributes unused :: self
+
+    wavelengthMinimum=calzetti2000WavelengthMinimumMicrons*micronsToAngstroms
+    wavelengthMaximum=calzetti2000WavelengthMaximumMicrons*micronsToAngstroms
+    return
+  end subroutine calzetti2000WavelengthRange
+
+  double precision function calzetti2000RvValue(self) result(Rv)
+    !!{RST
+    Return the total-to-selective extinction ratio, :math:`R_\mathrm{V}`, assumed by the
+    :cite:t:`calzetti_dust_2000` curve. Provided as an accessor because each implementation of this class is generated
+    into its own submodule, so a module-level constant declared here is not visible to sibling implementations---and
+    :galacticus-class:`dustExtinctionCurveNoll2009`, which is defined as a modification of this curve, needs it.
+    !!}
+    implicit none
+    class(dustExtinctionCurveCalzetti2000), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    Rv=calzetti2000Rv
+    return
+  end function calzetti2000RvValue

--- a/source/dust/extinction_curves/Cardelli1989.F90
+++ b/source/dust/extinction_curves/Cardelli1989.F90
@@ -1,0 +1,227 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements the dust extinction curve of :cite:t:`cardelli_relationship_1989`.
+  !!}
+
+  !![
+  <dustExtinctionCurve name="dustExtinctionCurveCardelli1989" docformat="rst">
+   <description>
+   The Milky Way dust extinction curve of :cite:t:`cardelli_relationship_1989`. Their equation (1) gives
+   :math:`A(\lambda)/A(\mathrm{V}) = a(x) + b(x)/R_\mathrm{V}` with :math:`x=1/\lambda` in inverse microns, and
+   :math:`a` and :math:`b` the fitting functions of their equations (2)--(5). The parameter ``Rv`` selects the
+   total-to-selective extinction ratio; :math:`R_\mathrm{V}=3.1` is the canonical diffuse interstellar medium value.
+
+   The fit spans :math:`0.3\,\mu\mathrm{m}^{-1} \le x &lt; 8\,\mu\mathrm{m}^{-1}`, i.e. :math:`0.125\,\mu\mathrm{m} &lt;
+   \lambda \le 3.33\,\mu\mathrm{m}$. Outside that range this implementation returns zero, i.e. *no* attenuation ---
+   the behavior of the original ``stellarSpectraDustAttenuation`` implementation, retained here for consistency. Use
+   ``wavelengthRange`` to detect the boundary.
+   </description>
+  </dustExtinctionCurve>
+  !!]
+  type, extends(dustExtinctionCurveClass) :: dustExtinctionCurveCardelli1989
+     !!{RST
+     The dust extinction curve of :cite:t:`cardelli_relationship_1989`.
+     !!}
+     private
+     double precision :: Rv
+   contains
+     !![
+     <methods docformat="rst">
+       <method method="a" description="Return the fitting function :math:`a(x)` of :cite:t:`cardelli_relationship_1989`."/>
+       <method method="b" description="Return the fitting function :math:`b(x)` of :cite:t:`cardelli_relationship_1989`."/>
+     </methods>
+     !!]
+     procedure :: attenuationRelative => cardelli1989AttenuationRelative
+     procedure :: wavelengthRange     => cardelli1989WavelengthRange
+     procedure :: a                   => cardelli1989A
+     procedure :: b                   => cardelli1989B
+  end type dustExtinctionCurveCardelli1989
+
+  interface dustExtinctionCurveCardelli1989
+     !!{RST
+     Constructors for the :galacticus-class:`dustExtinctionCurveCardelli1989` dust extinction curve class.
+     !!}
+     module procedure cardelli1989ConstructorParameters
+     module procedure cardelli1989ConstructorInternal
+  end interface dustExtinctionCurveCardelli1989
+
+  ! Range of validity of the fit, in inverse microns (Cardelli et al. 1989).
+  double precision, parameter :: cardelli1989XMinimum=0.3d0
+  double precision, parameter :: cardelli1989XMaximum=8.0d0
+
+contains
+
+  function cardelli1989ConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustExtinctionCurveCardelli1989` dust extinction curve class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (dustExtinctionCurveCardelli1989)                :: self
+    type            (inputParameters                ), intent(inout) :: parameters
+    double precision                                                 :: Rv
+
+    !![
+    <inputParameter docformat="rst">
+      <name>Rv</name>
+      <defaultValue>3.1d0</defaultValue>
+      <description>
+      The total-to-selective extinction ratio, :math:`R_\mathrm{V}=A(\mathrm{V})/E(B-V)`, in the
+      :cite:t:`cardelli_relationship_1989` extinction curve.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=dustExtinctionCurveCardelli1989(Rv)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function cardelli1989ConstructorParameters
+
+  function cardelli1989ConstructorInternal(Rv) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustExtinctionCurveCardelli1989` dust extinction curve class.
+    !!}
+    implicit none
+    type            (dustExtinctionCurveCardelli1989)                :: self
+    double precision                                 , intent(in   ) :: Rv
+    !![
+    <constructorAssign variables="Rv"/>
+    !!]
+
+    return
+  end function cardelli1989ConstructorInternal
+
+  double precision function cardelli1989AttenuationRelative(self,wavelength) result(attenuationRelative)
+    !!{RST
+    Return the relative dust opacity for the extinction curve of :cite:t:`cardelli_relationship_1989`.
+    !!}
+    use :: Numerical_Constants_Units, only : micronsToAngstroms
+    implicit none
+    class           (dustExtinctionCurveCardelli1989), intent(inout) :: self
+    double precision                                 , intent(in   ) :: wavelength
+    double precision                                                 :: x
+
+    ! Eqn. (1) of Cardelli et al. (1989).
+    x                  =+1.0d0                &
+         &              /(                    &
+         &                +wavelength         &
+         &                /micronsToAngstroms &
+         &               )
+    attenuationRelative=+self%a(x)            &
+         &              +self%b(x)            &
+         &              /self%Rv
+    return
+  end function cardelli1989AttenuationRelative
+
+  subroutine cardelli1989WavelengthRange(self,wavelengthMinimum,wavelengthMaximum)
+    !!{RST
+    Return the range of wavelengths over which the :cite:t:`cardelli_relationship_1989` extinction curve is defined.
+    !!}
+    use :: Numerical_Constants_Units, only : micronsToAngstroms
+    implicit none
+    class           (dustExtinctionCurveCardelli1989), intent(inout) :: self
+    double precision                                 , intent(  out) :: wavelengthMinimum, wavelengthMaximum
+    !$GLC attributes unused :: self
+
+    wavelengthMinimum=micronsToAngstroms/cardelli1989XMaximum
+    wavelengthMaximum=micronsToAngstroms/cardelli1989XMinimum
+    return
+  end subroutine cardelli1989WavelengthRange
+
+  double precision function cardelli1989A(self,x) result(a)
+    !!{RST
+    Return the fitting function :math:`a(x)` for the extinction curve of :cite:t:`cardelli_relationship_1989`.
+    !!}
+    implicit none
+    class           (dustExtinctionCurveCardelli1989), intent(inout) :: self
+    double precision                                 , intent(in   ) :: x
+    double precision                                                 :: y   , Fa
+    !$GLC attributes unused :: self
+
+    a=0.0d0
+    if      (x >= cardelli1989XMinimum .and. x < 1.1d0               ) then
+       a=+0.57400d0*x**1.61d0
+    else if (x >= 1.1d0                .and. x < 3.3d0               ) then
+       y      =x-1.82d0
+       a      =+1.00000d0      &
+            &  +0.17699d0*y    &
+            &  -0.50447d0*y**2 &
+            &  -0.02427d0*y**3 &
+            &  +0.72085d0*y**4 &
+            &  +0.01979d0*y**5 &
+            &  -0.77530d0*y**6 &
+            &  +0.32999d0*y**7
+    else if (x >= 3.3d0                .and. x < cardelli1989XMaximum) then
+       if (x < 5.9d0) then
+          Fa     =+0.0d0
+       else
+          Fa     =-0.044730d0*(x-5.9d0)**2 &
+               &  -0.009779d0*(x-5.9d0)**3
+       end if
+       a         =+1.752d0                         &
+            &     -0.316d0*  x                     &
+            &     -0.104d0/((x-4.67d0)**2+0.341d0) &
+            &     +Fa
+    end if
+    return
+  end function cardelli1989A
+
+  double precision function cardelli1989B(self,x) result(b)
+    !!{RST
+    Return the fitting function :math:`b(x)` for the extinction curve of :cite:t:`cardelli_relationship_1989`.
+    !!}
+    implicit none
+    class           (dustExtinctionCurveCardelli1989), intent(inout) :: self
+    double precision                                 , intent(in   ) :: x
+    double precision                                                 :: y   , Fb
+    !$GLC attributes unused :: self
+
+    b=0.0d0
+    if      (x >= cardelli1989XMinimum .and. x < 1.1d0               ) then
+       b      =-0.52700d0*x**1.61d0
+    else if (x >= 1.1d0                .and. x < 3.3d0               ) then
+       y      =x-1.82d0
+       b      =+1.41338d0*y    &
+            &  +2.28305d0*y**2 &
+            &  +1.07233d0*y**3 &
+            &  -5.38434d0*y**4 &
+            &  -0.62251d0*y**5 &
+            &  +5.30260d0*y**6 &
+            &  -2.09002d0*y**7
+    else if (x >= 3.3d0                .and. x < cardelli1989XMaximum) then
+       if (x < 5.9d0) then
+          Fb     =+0.0d0
+       else
+          Fb     =+0.2130d0*(x-5.9d0)**2 &
+               &  +0.1207d0*(x-5.9d0)**3
+       end if
+       b         =-3.090d0                         &
+            &     +1.825d0*  x                     &
+            &     +1.206d0/((x-4.62d0)**2+0.263d0) &
+            &     +Fb
+    end if
+    return
+  end function cardelli1989B

--- a/source/dust/extinction_curves/Gordon2003.F90
+++ b/source/dust/extinction_curves/Gordon2003.F90
@@ -1,0 +1,119 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements the dust extinction curves of :cite:t:`gordon_quantitative_2003`.
+  !!}
+
+  !![
+  <enumeration docformat="rst">
+   <name>gordon2003Sample</name>
+   <description>
+   Enumerates the samples available in the ``gordon2003`` dust extinction curve class.
+   </description>
+   <encodeFunction>yes</encodeFunction>
+   <validator>yes</validator>
+   <visibility>public</visibility>
+   <entry label="SMCBar"/>
+   <entry label="LMC"   />
+  </enumeration>
+  !!]
+
+  !![
+  <dustExtinctionCurve name="dustExtinctionCurveGordon2003" docformat="rst">
+   <description>
+   The dust extinction curves of :cite:t:`gordon_quantitative_2003`, tabulated from their Tables 2 and 3. The
+   ``sample`` parameter selects between the ``SMCBar`` and ``LMC`` sight-line samples; the former is the canonical
+   steep, bumpless curve often adopted for star-forming galaxies at high redshift.
+   </description>
+  </dustExtinctionCurve>
+  !!]
+  type, extends(dustExtinctionCurveTabulated) :: dustExtinctionCurveGordon2003
+     !!{RST
+     The dust extinction curves of :cite:t:`gordon_quantitative_2003`.
+     !!}
+     private
+     type(enumerationGordon2003SampleType) :: sample
+  end type dustExtinctionCurveGordon2003
+
+  interface dustExtinctionCurveGordon2003
+     !!{RST
+     Constructors for the :galacticus-class:`dustExtinctionCurveGordon2003` dust extinction curve class.
+     !!}
+     module procedure gordon2003ConstructorParameters
+     module procedure gordon2003ConstructorInternal
+  end interface dustExtinctionCurveGordon2003
+
+contains
+
+  function gordon2003ConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustExtinctionCurveGordon2003` dust extinction curve class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type(dustExtinctionCurveGordon2003)                :: self
+    type(inputParameters              ), intent(inout) :: parameters
+    type(varying_string               )                :: sample
+
+    !![
+    <inputParameter docformat="rst">
+      <name>sample</name>
+      <defaultValue>var_str('SMCBar')</defaultValue>
+      <description>
+      The name of the sample from :cite:t:`gordon_quantitative_2003` to use---either ``SMCBar`` or ``LMC``.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=dustExtinctionCurveGordon2003(enumerationGordon2003SampleEncode(char(sample),includesPrefix=.false.))
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function gordon2003ConstructorParameters
+
+  function gordon2003ConstructorInternal(sample) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustExtinctionCurveGordon2003` dust extinction curve class. Data
+    are taken directly from Tables 2 and 3 of :cite:t:`gordon_quantitative_2003`.
+    !!}
+    use :: Error       , only : Error_Report
+    use :: Table_Labels, only : extrapolationTypeExtrapolate
+    implicit none
+    type(dustExtinctionCurveGordon2003  )                :: self
+    type(enumerationGordon2003SampleType), intent(in   ) :: sample
+    !![
+    <constructorAssign variables="sample"/>
+    !!]
+
+    if (.not.enumerationGordon2003SampleIsValid(sample)) call Error_Report('invalid sample'//{introspection:location})
+    select case (sample%ID)
+    case (gordon2003SampleSMCBar%ID)
+       call self%attenuationTable%create  ([0.455d0,0.606d0,0.800d0,1.235d0,1.538d0,1.818d0,2.273d0,2.703d0,3.375d0,3.625d0,3.875d0,4.125d0,4.375d0,4.625d0,4.875d0,5.125d0,5.375d0,5.625d0,5.875d0,6.125d0,6.375d0,6.625d0,6.875d0,7.125d0,7.375d0,7.625d0,7.875d0,8.125d0,8.375d0,8.625d0],tableCount=1,extrapolationType=spread(extrapolationTypeExtrapolate,1,2))
+       call self%attenuationTable%populate([0.016d0,0.169d0,0.131d0,0.567d0,0.801d0,1.000d0,1.374d0,1.672d0,2.000d0,2.220d0,2.428d0,2.661d0,2.947d0,3.161d0,3.293d0,3.489d0,3.637d0,3.866d0,4.013d0,4.243d0,4.472d0,4.776d0,5.000d0,5.272d0,5.575d0,5.795d0,6.074d0,6.297d0,6.436d0,6.992d0])
+    case (gordon2003SampleLMC   %ID)
+       call self%attenuationTable%create  ([0.455d0,0.606d0,0.800d0,1.818d0,2.273d0,2.703d0,3.375d0,3.625d0,3.875d0,4.125d0,4.375d0,4.625d0,4.875d0,5.125d0,5.375d0,5.625d0,5.875d0,6.125d0,6.375d0,6.625d0,6.875d0,7.125d0,7.375d0,7.625d0,7.875d0,8.125d0,8.375d0],tableCount=1,extrapolationType=spread(extrapolationTypeExtrapolate,1,2))
+       call self%attenuationTable%populate([0.030d0,0.186d0,0.257d0,1.000d0,1.293d0,1.518d0,1.786d0,1.969d0,2.149d0,2.391d0,2.771d0,2.967d0,2.846d0,2.646d0,2.565d0,2.566d0,2.598d0,2.607d0,2.668d0,2.787d0,2.874d0,2.983d0,3.118d0,3.231d0,3.374d0,3.366d0,3.467d0])
+    end select
+    return
+  end function gordon2003ConstructorInternal

--- a/source/dust/extinction_curves/Noll2009.F90
+++ b/source/dust/extinction_curves/Noll2009.F90
@@ -1,0 +1,172 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements the modified starburst dust attenuation curve of :cite:t:`noll_analysis_2009`.
+  !!}
+
+  !![
+  <dustExtinctionCurve name="dustExtinctionCurveNoll2009" docformat="rst">
+   <description>
+   The modified starburst attenuation curve of :cite:t:`noll_analysis_2009`, which augments the
+   :cite:t:`calzetti_dust_2000` curve with a variable-strength :math:`2175\,`Å absorption bump and an adjustable
+   overall slope:
+
+   .. math::
+
+      \frac{k(\lambda)}{k_\mathrm{V}} = \left[ \frac{k_\mathrm{Cal}(\lambda)}{k_\mathrm{V}} + \frac{D(\lambda)}{R_\mathrm{V}} \right] \left( \frac{\lambda}{\lambda_\mathrm{V}} \right)^\delta,
+
+   where :math:`D(\lambda)` is a Drude profile of amplitude ``bumpStrength``,
+
+   .. math::
+
+      D(\lambda) = \frac{E_\mathrm{b} (\lambda \Delta\lambda)^2}{(\lambda^2-\lambda_0^2)^2 + (\lambda \Delta\lambda)^2},
+
+   with :math:`\lambda_0=2175\,`Å and :math:`\Delta\lambda=350\,`Å. Setting ``bumpStrength`` and ``slope`` to zero
+   recovers :cite:t:`calzetti_dust_2000` exactly. This two-parameter family is the one most commonly varied when
+   fitting attenuation curves to observed spectral energy distributions.
+
+   Because the underlying :cite:t:`calzetti_dust_2000` curve returns zero outside :math:`0.12`--:math:`2.20\,\mu`m,
+   so does this one.
+   </description>
+  </dustExtinctionCurve>
+  !!]
+  type, extends(dustExtinctionCurveClass) :: dustExtinctionCurveNoll2009
+     !!{RST
+     The modified starburst attenuation curve of :cite:t:`noll_analysis_2009`.
+     !!}
+     private
+     type            (dustExtinctionCurveCalzetti2000) :: curveCalzetti2000
+     double precision                                  :: bumpStrength     , slope
+   contains
+     procedure :: attenuationRelative => noll2009AttenuationRelative
+     procedure :: wavelengthRange     => noll2009WavelengthRange
+  end type dustExtinctionCurveNoll2009
+
+  interface dustExtinctionCurveNoll2009
+     !!{RST
+     Constructors for the :galacticus-class:`dustExtinctionCurveNoll2009` dust extinction curve class.
+     !!}
+     module procedure noll2009ConstructorParameters
+     module procedure noll2009ConstructorInternal
+  end interface dustExtinctionCurveNoll2009
+
+  ! Parameters of the Drude profile describing the 2175Å bump (Noll et al. 2009; eqn. 3), in Angstroms.
+  double precision, parameter :: noll2009WavelengthBump=2175.0d0
+  double precision, parameter :: noll2009WidthBump     = 350.0d0
+
+contains
+
+  function noll2009ConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustExtinctionCurveNoll2009` dust extinction curve class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (dustExtinctionCurveNoll2009)                :: self
+    type            (inputParameters            ), intent(inout) :: parameters
+    double precision                                             :: bumpStrength, slope
+
+    !![
+    <inputParameter docformat="rst">
+      <name>bumpStrength</name>
+      <defaultValue>0.0d0</defaultValue>
+      <description>
+      The amplitude :math:`E_\mathrm{b}` of the :math:`2175\,`Å bump in the :cite:t:`noll_analysis_2009` attenuation
+      curve. Zero gives no bump, as in :cite:t:`calzetti_dust_2000`; the Milky Way value is approximately 3.5.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>slope</name>
+      <defaultValue>0.0d0</defaultValue>
+      <description>
+      The slope :math:`\delta` modifying the overall wavelength dependence of the :cite:t:`noll_analysis_2009`
+      attenuation curve. Zero recovers the :cite:t:`calzetti_dust_2000` slope; negative values give a steeper curve.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=dustExtinctionCurveNoll2009(bumpStrength,slope)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function noll2009ConstructorParameters
+
+  function noll2009ConstructorInternal(bumpStrength,slope) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustExtinctionCurveNoll2009` dust extinction curve class.
+    !!}
+    implicit none
+    type            (dustExtinctionCurveNoll2009)                :: self
+    double precision                             , intent(in   ) :: bumpStrength, slope
+    !![
+    <constructorAssign variables="bumpStrength, slope"/>
+    !!]
+
+    self%curveCalzetti2000=dustExtinctionCurveCalzetti2000()
+    return
+  end function noll2009ConstructorInternal
+
+  double precision function noll2009AttenuationRelative(self,wavelength) result(attenuationRelative)
+    !!{RST
+    Return the relative dust opacity for the attenuation curve of :cite:t:`noll_analysis_2009`.
+    !!}
+    implicit none
+    class           (dustExtinctionCurveNoll2009), intent(inout) :: self
+    double precision                             , intent(in   ) :: wavelength
+    double precision                                             :: drude
+
+    ! Eqn. (3) of Noll et al. (2009). The Drude profile is expressed in units of k, so is divided by Rv to bring it
+    ! into the same relative normalization as the Calzetti curve.
+    drude              =+self%bumpStrength                              &
+         &              *(wavelength*noll2009WidthBump)**2              &
+         &              /(                                              &
+         &                +(wavelength**2-noll2009WavelengthBump**2)**2 &
+         &                +(wavelength   *noll2009WidthBump        )**2 &
+         &               )
+    ! Eqn. (5) of Noll et al. (2009).
+    attenuationRelative=+(                                                        &
+         &                +self%curveCalzetti2000%attenuationRelative(wavelength) &
+         &                +drude                                                  &
+         &                /self%curveCalzetti2000%RvValue()                       &
+         &               )                                                        &
+         &              *(                                                        &
+         &                +wavelength                                             &
+         &                /wavelengthVBand                                        &
+         &               )**self%slope
+    return
+  end function noll2009AttenuationRelative
+
+  subroutine noll2009WavelengthRange(self,wavelengthMinimum,wavelengthMaximum)
+    !!{RST
+    Return the range of wavelengths over which the :cite:t:`noll_analysis_2009` attenuation curve is defined, which is
+    that of the underlying :cite:t:`calzetti_dust_2000` curve.
+    !!}
+    implicit none
+    class           (dustExtinctionCurveNoll2009), intent(inout) :: self
+    double precision                             , intent(  out) :: wavelengthMinimum, wavelengthMaximum
+
+    call self%curveCalzetti2000%wavelengthRange(wavelengthMinimum,wavelengthMaximum)
+    return
+  end subroutine noll2009WavelengthRange

--- a/source/dust/extinction_curves/Prevot-Bouchet.F90
+++ b/source/dust/extinction_curves/Prevot-Bouchet.F90
@@ -1,0 +1,100 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements the Small Magellanic Cloud dust extinction curve of :cite:t:`bouchet_visible_1985`.
+  !!}
+
+  !![
+  <dustExtinctionCurve name="dustExtinctionCurvePrevotBouchet" docformat="rst">
+   <description>
+   The Small Magellanic Cloud dust extinction curve of :cite:t:`bouchet_visible_1985`, tabulated from their Table 3.
+   The tabulated quantity is :math:`E(\lambda-\mathrm{V})/E(B-V)`, converted here to :math:`k(\lambda)/k_\mathrm{V}`
+   using the total-to-selective extinction ratio ``Rv``.
+   </description>
+  </dustExtinctionCurve>
+  !!]
+  type, extends(dustExtinctionCurveTabulated) :: dustExtinctionCurvePrevotBouchet
+     !!{RST
+     The dust extinction curve of :cite:t:`bouchet_visible_1985`.
+     !!}
+     private
+     double precision :: Rv
+  end type dustExtinctionCurvePrevotBouchet
+
+  interface dustExtinctionCurvePrevotBouchet
+     !!{RST
+     Constructors for the :galacticus-class:`dustExtinctionCurvePrevotBouchet` dust extinction curve class.
+     !!}
+     module procedure prevotBouchetConstructorParameters
+     module procedure prevotBouchetConstructorInternal
+  end interface dustExtinctionCurvePrevotBouchet
+
+contains
+
+  function prevotBouchetConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustExtinctionCurvePrevotBouchet` dust extinction curve class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (dustExtinctionCurvePrevotBouchet)                :: self
+    type            (inputParameters                 ), intent(inout) :: parameters
+    double precision                                                  :: Rv
+
+    !![
+    <inputParameter docformat="rst">
+      <name>Rv</name>
+      <defaultValue>2.7d0</defaultValue>
+      <description>
+      The total-to-selective extinction ratio, :math:`R_\mathrm{V}=A(\mathrm{V})/E(B-V)`, used to convert the
+      tabulated :math:`E(\lambda-\mathrm{V})/E(B-V)` of :cite:t:`bouchet_visible_1985` to
+      :math:`k(\lambda)/k_\mathrm{V}`.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=dustExtinctionCurvePrevotBouchet(Rv)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function prevotBouchetConstructorParameters
+
+  function prevotBouchetConstructorInternal(Rv) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustExtinctionCurvePrevotBouchet` dust extinction curve class.
+    Data are read directly from Table 3 of :cite:t:`bouchet_visible_1985`.
+    !!}
+    use :: Table_Labels, only : extrapolationTypeExtrapolate
+    implicit none
+    type            (dustExtinctionCurvePrevotBouchet)                               :: self
+    double precision                                  , intent(in   )                :: Rv
+    double precision                                  , parameter    , dimension(27) :: ElambdaVOverEBV=[-2.56d0,-2.40d0,-2.11d0, 0.00d0, 1.00d0, 1.59d0, 2.28d0, 2.61d0, 2.96d0, 3.17d0, 3.49d0, 3.91d0, 4.28d0, 4.60d0, 5.31d0, 5.83d0, 6.40d0, 6.79d0, 6.89d0, 7.16d0, 7.74d0, 8.02d0, 8.53d0, 9.15d0, 9.36d0, 9.90d0,10.80d0]
+    !![
+    <constructorAssign variables="Rv"/>
+    !!]
+
+    call self%attenuationTable%create  ([0.44d0,0.60d0,0.79d0,1.89d0,2.32d0,2.68d0,3.19d0,3.31d0,3.41d0,3.55d0,3.72d0,3.89d0,4.07d0,4.24d0,4.46d0,4.68d0,4.93d0,5.20d0,5.31d0,5.45d0,5.63d0,5.83d0,6.02d0,6.22d0,6.44d0,6.66d0,6.93d0],tableCount=1,extrapolationType=spread(extrapolationTypeExtrapolate,1,2))
+    call self%attenuationTable%populate(ElambdaVOverEBV/Rv+1.0d0)
+    return
+  end function prevotBouchetConstructorInternal

--- a/source/dust/extinction_curves/WittGordon2000.F90
+++ b/source/dust/extinction_curves/WittGordon2000.F90
@@ -1,0 +1,125 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements the dust attenuation curves of :cite:t:`witt_multiple_2000`.
+  !!}
+
+  !![
+  <enumeration docformat="rst">
+   <name>wittGordon2000Model</name>
+   <description>
+   Enumerates the models available in the ``wittGordon2000`` dust extinction curve class.
+   </description>
+   <encodeFunction>yes</encodeFunction>
+   <validator>yes</validator>
+   <visibility>public</visibility>
+   <entry label="milkyWayShellTau3"/>
+   <entry label="SMCShellTau3"     />
+  </enumeration>
+  !!]
+
+  !![
+  <dustExtinctionCurve name="dustExtinctionCurveWittGordon2000" docformat="rst">
+   <description>
+   The dust curves of :cite:t:`witt_multiple_2000`, for a shell geometry of :math:`V`-band optical depth 3 with either
+   Milky Way or Small Magellanic Cloud dust.
+
+   Note that these are *attenuation* curves rather than extinction curves: they are the outcome of a radiative
+   transfer calculation through a specified geometry, including scattering back into the line of sight, and so already
+   embed an assumption about how dust and stars are distributed. Combining one with a ``dustAttenuation`` object that
+   itself models a geometry therefore double counts that geometry. They are provided here for continuity with the
+   models this class replaces.
+   </description>
+  </dustExtinctionCurve>
+  !!]
+  type, extends(dustExtinctionCurveTabulated) :: dustExtinctionCurveWittGordon2000
+     !!{RST
+     The dust attenuation curves of :cite:t:`witt_multiple_2000`.
+     !!}
+     private
+     type(enumerationWittGordon2000ModelType) :: model
+  end type dustExtinctionCurveWittGordon2000
+
+  interface dustExtinctionCurveWittGordon2000
+     !!{RST
+     Constructors for the :galacticus-class:`dustExtinctionCurveWittGordon2000` dust extinction curve class.
+     !!}
+     module procedure wittGordon2000ConstructorParameters
+     module procedure wittGordon2000ConstructorInternal
+  end interface dustExtinctionCurveWittGordon2000
+
+contains
+
+  function wittGordon2000ConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustExtinctionCurveWittGordon2000` dust extinction curve class which takes
+    a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type(dustExtinctionCurveWittGordon2000)                :: self
+    type(inputParameters                  ), intent(inout) :: parameters
+    type(varying_string                   )                :: model
+
+    !![
+    <inputParameter docformat="rst">
+      <name>model</name>
+      <defaultValue>var_str('MilkyWayShellTau3.0')</defaultValue>
+      <description>
+      The name of the model from :cite:t:`witt_multiple_2000` to use.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=dustExtinctionCurveWittGordon2000(enumerationWittGordon2000ModelEncode(char(model),includesPrefix=.false.))
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function wittGordon2000ConstructorParameters
+
+  function wittGordon2000ConstructorInternal(model) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustExtinctionCurveWittGordon2000` dust extinction curve class.
+    !!}
+    use :: Array_Utilities                 , only : Array_Reverse
+    use :: Error                           , only : Error_Report
+    use :: Numerical_Constants_Astronomical, only : opticalDepthToMagnitudes
+    use :: Numerical_Constants_Units       , only : micronsToAngstroms
+    use :: Table_Labels                    , only : extrapolationTypeExtrapolate
+    implicit none
+    type(dustExtinctionCurveWittGordon2000  )                :: self
+    type(enumerationWittGordon2000ModelType ), intent(in   ) :: model
+    !![
+    <constructorAssign variables="model"/>
+    !!]
+
+    if (.not.enumerationWittGordon2000ModelIsValid(model)) call Error_Report('invalid model'//{introspection:location})
+    call self%attenuationTable%create(micronsToAngstroms/Array_Reverse([ 1000.0d0,   1142.0d0,   1285.0d0,   1428.0d0,   1571.0d0,  1714.0d0,  1857.0d0,  2000.0d0,   2142.0d0,  2285.0d0,   2428.0d0,   2571.0d0,   2714.0d0,   2857.0d0,   3000.0d0,   3776.0d0,   4754.0d0,   5985.0d0,   7535.0d0,   9487.0d0,  11943.0d0,  15036.0d0,  18929.0d0,  23830.0d0,  30001.0d0]),tableCount=1,extrapolationType=spread(extrapolationTypeExtrapolate,1,2))
+    select case (model%ID)
+    case (wittGordon2000ModelMilkyWayShellTau3%ID)
+       call self%attenuationTable%populate(opticalDepthToMagnitudes*Array_Reverse([ 15.714d0,  11.754d0,   9.546d0,   8.340d0,   7.752d0,   7.527d0,   7.683d0,   8.529d0,   9.570d0,   8.730d0,   7.416d0,   6.582d0,   6.066d0,   5.715d0,   5.454d0,   4.581d0,   3.597d0,   2.727d0,   2.001d0,   1.320d0,   0.912d0,   0.630d0,   0.435d0,   0.300d0,   0.207d0]))
+    case (wittGordon2000ModelSMCShellTau3     %ID)
+       call self%attenuationTable%populate(opticalDepthToMagnitudes*Array_Reverse([ 29.025d0,  22.320d0,  18.204d0,  15.501d0,  13.608d0,  12.222d0,  11.100d0,  10.137d0,   9.303d0,   8.571d0,   7.926d0,   7.356d0,   6.846d0,   6.399d0,   6.093d0,   4.830d0,   3.663d0,   2.640d0,   1.890d0,   1.290d0,   0.816d0,   0.498d0,   0.333d0,   0.225d0,   0.099d0]))
+    end select
+    return
+  end function wittGordon2000ConstructorInternal

--- a/source/dust/extinction_curves/_class.F90
+++ b/source/dust/extinction_curves/_class.F90
@@ -1,0 +1,101 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!!{RST
+Contains a module which provides a class implementing dust extinction curves.
+!!}
+
+module Dust_Extinction_Curves
+  !!{RST
+  Provides a class implementing dust extinction curves---the wavelength dependence of the opacity of interstellar
+  dust, normalized to its value in the :math:`V`-band.
+
+  An extinction curve carries no information about *how much* dust lies along a line of sight, only about the relative
+  efficiency with which dust absorbs and scatters light as a function of wavelength. The normalization is supplied
+  separately by a ``dustAttenuation`` object, which multiplies the curve by a :math:`V`-band optical depth computed
+  from the properties of a galaxy. Keeping the two apart means any curve can be combined with any normalization.
+
+  Curves are normalized to their value in the :math:`V`-band, so that for a simple screen the transmission is
+
+  .. math::
+
+     T(\lambda) = \exp\left[-\tau_\mathrm{V} \frac{k(\lambda)}{k_\mathrm{V}}\right].
+
+  Note that the normalization is only approximate for the empirically fit curves. Each published fit anchors its
+  :math:`V`-band normalization at its own nominal wavelength---:cite:t:`cardelli_relationship_1989` at
+  :math:`x=1.82\,\mu\mathrm{m}^{-1}`, i.e. :math:`0.5495\,\mu\mathrm{m}`---which differs slightly from the
+  :math:`5504.6\,`Å effective wavelength of the Buser :math:`V` filter that Galacticus uses, and the fitting functions
+  do not evaluate to exactly unity even there. The residual is a few parts in a thousand (0.14% for
+  :cite:t:`calzetti_dust_2000`, 0.21% for :cite:t:`cardelli_relationship_1989`). The curves are deliberately *not*
+  renormalized to remove it, both because doing so would depart from the published fits and because it would change
+  the results of existing models.
+
+  Many published curves are fit only over a limited range of wavelengths. The ``wavelengthRange`` method reports that
+  range, and the description of each implementation states what it does outside it---several return zero, which is to
+  say *no* attenuation rather than clamped attenuation, and that distinction matters when a curve is evaluated over a
+  broad spectrum rather than through an optical filter.
+  !!}
+  implicit none
+  private
+  public :: wavelengthVBand
+
+  ! Effective wavelength of the Buser V-band filter, in Angstroms. Extinction curves are normalized to unity here.
+  double precision, parameter :: wavelengthVBand=5504.61227375652d0
+
+  !![
+  <functionClass docformat="rst">
+   <name>dustExtinctionCurve</name>
+   <descriptiveName>Dust Extinction Curves</descriptiveName>
+   <description>
+   Class providing the wavelength dependence of dust opacity, normalized to unity in the :math:`V`-band.
+   </description>
+   <default>calzetti2000</default>
+   <method name="attenuationRelative" >
+    <description>
+    Return the opacity of dust at the given rest-frame ``wavelength`` (in Å), relative to its value in the
+    :math:`V`-band; that is, :math:`k(\lambda)/k_\mathrm{V}`. The result is dimensionless, and is approximately (but,
+    for the empirically fit curves, not exactly) unity at the :math:`V`-band effective wavelength---see the discussion
+    of normalization in the class description.
+    </description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>double precision, intent(in   ) :: wavelength</argument>
+   </method>
+   <method name="wavelengthRange" >
+    <description>
+    Return the range of rest-frame wavelengths (in Å) over which this curve is defined. The default is unbounded;
+    implementations fit over a limited range override it. Callers which evaluate a curve across a broad spectrum---the
+    dust emission calculations in particular---should consult this rather than assume the curve is meaningful
+    everywhere.
+    </description>
+    <type>void</type>
+    <pass>yes</pass>
+    <argument>double precision, intent(  out) :: wavelengthMinimum, wavelengthMaximum</argument>
+    <code>
+     !$GLC attributes unused :: self
+     wavelengthMinimum=0.0d0
+     wavelengthMaximum=huge(0.0d0)
+    </code>
+   </method>
+  </functionClass>
+  !!]
+
+end module Dust_Extinction_Curves

--- a/source/dust/extinction_curves/power_law.F90
+++ b/source/dust/extinction_curves/power_law.F90
@@ -1,0 +1,116 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a power-law dust extinction curve.
+  !!}
+
+  !![
+  <dustExtinctionCurve name="dustExtinctionCurvePowerLaw" docformat="rst">
+   <description>
+   A power-law dust extinction curve, :math:`k(\lambda)/k_\mathrm{V} = (\lambda/\lambda_\mathrm{V})^{-\alpha}`, where
+   :math:`\lambda_\mathrm{V}` is the :math:`V`-band effective wavelength. The default exponent, :math:`\alpha=0.7`, is
+   that adopted by :cite:t:`charlot_simple_2000` for both the diffuse interstellar medium and stellar birth clouds.
+
+   The curve is defined at all wavelengths, and diverges as :math:`\lambda \rightarrow 0`; it should not be used far
+   into the ultraviolet without consideration of whether a power law remains appropriate there.
+   </description>
+  </dustExtinctionCurve>
+  !!]
+  type, extends(dustExtinctionCurveClass) :: dustExtinctionCurvePowerLaw
+     !!{RST
+     A power-law dust extinction curve.
+     !!}
+     private
+     double precision :: exponent_
+   contains
+     procedure :: attenuationRelative => powerLawAttenuationRelative
+  end type dustExtinctionCurvePowerLaw
+
+  interface dustExtinctionCurvePowerLaw
+     !!{RST
+     Constructors for the :galacticus-class:`dustExtinctionCurvePowerLaw` dust extinction curve class.
+     !!}
+     module procedure powerLawConstructorParameters
+     module procedure powerLawConstructorInternal
+  end interface dustExtinctionCurvePowerLaw
+
+contains
+
+  function powerLawConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustExtinctionCurvePowerLaw` dust extinction curve class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (dustExtinctionCurvePowerLaw)                :: self
+    type            (inputParameters            ), intent(inout) :: parameters
+    double precision                                             :: exponent_
+
+    !![
+    <inputParameter docformat="rst">
+      <name>exponent</name>
+      <variable>exponent_</variable>
+      <defaultValue>0.7d0</defaultValue>
+      <defaultSource>:cite:t:`charlot_simple_2000`</defaultSource>
+      <description>
+      The exponent :math:`\alpha` of the power-law dust extinction curve,
+      :math:`k(\lambda)/k_\mathrm{V}=(\lambda/\lambda_\mathrm{V})^{-\alpha}`.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=dustExtinctionCurvePowerLaw(exponent_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function powerLawConstructorParameters
+
+  function powerLawConstructorInternal(exponent_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustExtinctionCurvePowerLaw` dust extinction curve class.
+    !!}
+    implicit none
+    type            (dustExtinctionCurvePowerLaw)                :: self
+    double precision                             , intent(in   ) :: exponent_
+    !![
+    <constructorAssign variables="exponent_"/>
+    !!]
+
+    return
+  end function powerLawConstructorInternal
+
+  double precision function powerLawAttenuationRelative(self,wavelength) result(attenuationRelative)
+    !!{RST
+    Return the relative dust opacity for a power-law extinction curve.
+    !!}
+    implicit none
+    class           (dustExtinctionCurvePowerLaw), intent(inout) :: self
+    double precision                             , intent(in   ) :: wavelength
+
+    attenuationRelative=+(                    &
+         &                +wavelength         &
+         &                /wavelengthVBand    &
+         &               )**(-self%exponent_)
+    return
+  end function powerLawAttenuationRelative

--- a/source/dust/extinction_curves/power_law.F90
+++ b/source/dust/extinction_curves/power_law.F90
@@ -40,7 +40,7 @@
      A power-law dust extinction curve.
      !!}
      private
-     double precision :: exponent_
+     double precision :: exponent_, wavelengthReference
    contains
      procedure :: attenuationRelative => powerLawAttenuationRelative
   end type dustExtinctionCurvePowerLaw
@@ -64,7 +64,7 @@ contains
     implicit none
     type            (dustExtinctionCurvePowerLaw)                :: self
     type            (inputParameters            ), intent(inout) :: parameters
-    double precision                                             :: exponent_
+    double precision                                             :: exponent_ , wavelengthReference
 
     !![
     <inputParameter docformat="rst">
@@ -78,23 +78,34 @@ contains
       </description>
       <source>parameters</source>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>wavelengthReference</name>
+      <defaultValue>wavelengthVBand</defaultValue>
+      <description>
+      The wavelength, in Å, at which the power law is normalized to unity. The default is the effective wavelength of
+      the Buser :math:`V` filter, which is the definition used throughout this framework. Set it to
+      :math:`5500\,`Å to reproduce results from the ``lmnstyStllrCF2000`` property extractor, which adopted that
+      round value instead.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
     !!]
-    self=dustExtinctionCurvePowerLaw(exponent_)
+    self=dustExtinctionCurvePowerLaw(exponent_,wavelengthReference)
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
   end function powerLawConstructorParameters
 
-  function powerLawConstructorInternal(exponent_) result(self)
+  function powerLawConstructorInternal(exponent_,wavelengthReference) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`dustExtinctionCurvePowerLaw` dust extinction curve class.
     !!}
     implicit none
     type            (dustExtinctionCurvePowerLaw)                :: self
-    double precision                             , intent(in   ) :: exponent_
+    double precision                             , intent(in   ) :: exponent_, wavelengthReference
     !![
-    <constructorAssign variables="exponent_"/>
+    <constructorAssign variables="exponent_, wavelengthReference"/>
     !!]
 
     return
@@ -108,9 +119,9 @@ contains
     class           (dustExtinctionCurvePowerLaw), intent(inout) :: self
     double precision                             , intent(in   ) :: wavelength
 
-    attenuationRelative=+(                    &
-         &                +wavelength         &
-         &                /wavelengthVBand    &
+    attenuationRelative=+(                          &
+         &                +     wavelength          &
+         &                /self%wavelengthReference &
          &               )**(-self%exponent_)
     return
   end function powerLawAttenuationRelative

--- a/source/dust/extinction_curves/tabulated.F90
+++ b/source/dust/extinction_curves/tabulated.F90
@@ -1,0 +1,103 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a dust extinction curve read from a tabulation.
+  !!}
+
+  use :: Tables, only : table1DGeneric
+
+  !![
+  <dustExtinctionCurve name="dustExtinctionCurveTabulated" abstract="yes" docformat="rst">
+   <description>
+   An abstract dust extinction curve given by a tabulation of :math:`k(\lambda)` against inverse wavelength,
+   :math:`x=1/\lambda` in inverse microns---the variable in which such curves are conventionally published.
+
+   Unlike the analytic curves, a tabulated curve is normalized by *its own* interpolated value at the :math:`V`-band
+   effective wavelength, so it returns exactly unity there by construction.
+   </description>
+  </dustExtinctionCurve>
+  !!]
+  ! Note: declared as a concrete type despite `abstract="yes"` in the directive above. The directive keeps the class
+  ! out of the set which can be built from a parameter file, while leaving the Fortran type concrete so that it may
+  ! carry a finalizer -- a final subroutine's `self` cannot be declared `type(...)` for an abstract type. This mirrors
+  ! `stellarSpectraDustAttenuationTabulated`, the class replaced here.
+  type, extends(dustExtinctionCurveClass) :: dustExtinctionCurveTabulated
+     !!{RST
+     A dust extinction curve given by a tabulation.
+     !!}
+     private
+     type(table1DGeneric) :: attenuationTable
+   contains
+     final     ::                        tabulatedDestructor
+     procedure :: attenuationRelative => tabulatedAttenuationRelative
+     procedure :: wavelengthRange     => tabulatedWavelengthRange
+  end type dustExtinctionCurveTabulated
+
+contains
+
+  subroutine tabulatedDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`dustExtinctionCurveTabulated` dust extinction curve class.
+    !!}
+    implicit none
+    type(dustExtinctionCurveTabulated), intent(inout) :: self
+
+    call self%attenuationTable%destroy()
+    return
+  end subroutine tabulatedDestructor
+
+  double precision function tabulatedAttenuationRelative(self,wavelength) result(attenuationRelative)
+    !!{RST
+    Return the relative dust opacity for a tabulated extinction curve.
+    !!}
+    use :: Numerical_Constants_Units, only : micronsToAngstroms
+    implicit none
+    class           (dustExtinctionCurveTabulated), intent(inout) :: self
+    double precision                              , intent(in   ) :: wavelength
+    double precision                              , parameter     :: xV        =1.0d0/(wavelengthVBand/micronsToAngstroms)
+    double precision                                              :: x
+
+    x                  =+1.0d0                                 &
+         &              /(                                     &
+         &                +wavelength                          &
+         &                /micronsToAngstroms                  &
+         &               )
+    attenuationRelative=+self%attenuationTable%interpolate(x ) &
+         &              /self%attenuationTable%interpolate(xV)
+    return
+  end function tabulatedAttenuationRelative
+
+  subroutine tabulatedWavelengthRange(self,wavelengthMinimum,wavelengthMaximum)
+    !!{RST
+    Return the range of wavelengths spanned by the tabulation. Note that these curves are constructed with
+    extrapolating tables, so they return a value outside this range rather than zero---but that value is an
+    extrapolation of the published data, not a fit to it.
+    !!}
+    use :: Numerical_Constants_Units, only : micronsToAngstroms
+    implicit none
+    class           (dustExtinctionCurveTabulated), intent(inout) :: self
+    double precision                              , intent(  out) :: wavelengthMinimum, wavelengthMaximum
+
+    wavelengthMinimum=micronsToAngstroms/self%attenuationTable%x(-1)
+    wavelengthMaximum=micronsToAngstroms/self%attenuationTable%x(+1)
+    return
+  end subroutine tabulatedWavelengthRange

--- a/source/nodes/property_extractor/dust_attenuation.F90
+++ b/source/nodes/property_extractor/dust_attenuation.F90
@@ -475,8 +475,7 @@ contains
     double precision                                      , intent(in   )               :: time
     double precision                                      , allocatable  , dimension(:) :: unitsChild
     type            (multiExtractorList                  ), pointer                     :: extractor_
-    integer                                                                             :: offset     , countChild, &
-         &                                                                                 i
+    integer                                                                             :: offset     , countChild
 
     allocate(unitsInSI(self%elementCount(elementType,time)))
     if (elementType /= elementTypeDouble) return

--- a/source/nodes/property_extractor/dust_attenuation.F90
+++ b/source/nodes/property_extractor/dust_attenuation.F90
@@ -1,0 +1,578 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a property extractor which applies dust attenuation to the luminosities of other extractors.
+  !!}
+
+  use :: Dust_Attenuations, only : dustAttenuationClass
+
+  !![
+  <nodePropertyExtractor name="nodePropertyExtractorDustAttenuation" docformat="rst">
+   <description>
+   A property extractor which applies dust attenuation to the luminosities produced by other property extractors.
+
+   Each child extractor is asked to decompose its luminosity into parcels of emission---one wavelength, one component,
+   one range of stellar population ages---at a resolution which the ``[dustAttenuation]`` object itself specifies. The
+   attenuator returns a transmission factor for each parcel, and the child recombines the attenuated parcels into its
+   own output. A child which can not decompose its output, or whose component the attenuator refuses, is rejected.
+
+   Attenuated properties are named for the child with ``:dustAttenuated:`` and the name of the attenuator appended, so
+   they may coexist with their unattenuated counterparts. Setting ``[outputUnattenuated]`` emits those counterparts
+   alongside, which is the usual way to measure the effect of the dust model. Setting ``[outputSum]`` additionally
+   emits the sum of the attenuated luminosities of all children: dust must be applied to each component separately,
+   since components are attenuated differently, so recovering a galaxy-wide total requires summing afterwards, and
+   this does that in one place rather than in post-processing.
+
+   Only children producing scalar or tuple properties are supported at present. Extractors returning arrays---spectral
+   energy distributions in particular---will be supported once they implement decomposition.
+   </description>
+  </nodePropertyExtractor>
+  !!]
+  type, extends(nodePropertyExtractorMulti) :: nodePropertyExtractorDustAttenuation
+     !!{RST
+     A property extractor which applies dust attenuation to the luminosities of other extractors.
+     !!}
+     private
+     class  (dustAttenuationClass), pointer :: dustAttenuation_   => null()
+     logical                                :: outputUnattenuated          , outputSum
+   contains
+     !![
+     <methods docformat="rst">
+       <method method="countChildElements" description="Return the number of properties produced by a child extractor."/>
+       <method method="attenuate"          description="Return the attenuated properties of a child extractor."        />
+     </methods>
+     !!]
+     final     ::                       dustAttenuationDestructor
+     procedure :: countChildElements => dustAttenuationCountChildElements
+     procedure :: attenuate          => dustAttenuationAttenuate
+     procedure :: elementCount       => dustAttenuationElementCount
+     procedure :: extractDouble      => dustAttenuationExtractDouble
+     procedure :: names              => dustAttenuationNames
+     procedure :: descriptions       => dustAttenuationDescriptions
+     procedure :: unitsInSI          => dustAttenuationUnitsInSI
+     procedure :: units              => dustAttenuationUnits
+     procedure :: ranks              => dustAttenuationRanks
+  end type nodePropertyExtractorDustAttenuation
+
+  interface nodePropertyExtractorDustAttenuation
+     !!{RST
+     Constructors for the :galacticus-class:`nodePropertyExtractorDustAttenuation` property extractor class.
+     !!}
+     module procedure dustAttenuationConstructorParameters
+     module procedure dustAttenuationConstructorInternal
+  end interface nodePropertyExtractorDustAttenuation
+
+contains
+
+  function dustAttenuationConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`nodePropertyExtractorDustAttenuation` property extractor class which takes
+    a parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type   (nodePropertyExtractorDustAttenuation)                :: self
+    type   (inputParameters                     ), intent(inout) :: parameters
+    class  (dustAttenuationClass                ), pointer       :: dustAttenuation_
+    logical                                                      :: outputUnattenuated, outputSum
+
+    self%nodePropertyExtractorMulti=nodePropertyExtractorMulti(parameters)
+    !![
+    <inputParameter docformat="rst">
+      <name>outputUnattenuated</name>
+      <defaultValue>.false.</defaultValue>
+      <description>
+      If true, the unattenuated properties of each child extractor are emitted alongside the attenuated ones.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>outputSum</name>
+      <defaultValue>.false.</defaultValue>
+      <description>
+      If true, the sum of the attenuated properties over all child extractors is emitted as an additional property.
+      Useful for recovering a galaxy-wide total from luminosities which had to be attenuated component by component.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="dustAttenuation" name="dustAttenuation_" source="parameters"/>
+    <inputParametersValidate source="parameters" multiParameters="nodePropertyExtractor"/>
+    !!]
+    self%dustAttenuation_   => dustAttenuation_
+    !![
+    <referenceCountIncrement owner="self" object="dustAttenuation_"/>
+    !!]
+    self%outputUnattenuated =  outputUnattenuated
+    self%outputSum          =  outputSum
+    call dustAttenuationValidate(self)
+    !![
+    <objectDestructor name="dustAttenuation_"/>
+    !!]
+    return
+  end function dustAttenuationConstructorParameters
+
+  function dustAttenuationConstructorInternal(dustAttenuation_,outputUnattenuated,outputSum,extractors) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`nodePropertyExtractorDustAttenuation` property extractor class.
+    !!}
+    implicit none
+    type   (nodePropertyExtractorDustAttenuation)                        :: self
+    class  (dustAttenuationClass                ), intent(in   ), target :: dustAttenuation_
+    logical                                      , intent(in   )         :: outputUnattenuated, outputSum
+    type   (multiExtractorList                  ), intent(in   )         :: extractors
+    !![
+    <constructorAssign variables="outputUnattenuated, outputSum, *dustAttenuation_"/>
+    !!]
+
+    self%nodePropertyExtractorMulti=nodePropertyExtractorMulti(extractors)
+    call dustAttenuationValidate(self)
+    return
+  end function dustAttenuationConstructorInternal
+
+  subroutine dustAttenuationValidate(self)
+    !!{RST
+    Check that every child extractor can be attenuated, reporting any that can not at construction rather than part
+    way through a run.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    type (nodePropertyExtractorDustAttenuation), intent(inout) :: self
+    type (multiExtractorList                  ), pointer       :: extractor_
+
+    extractor_ => self%extractors
+    do while (associated(extractor_))
+       if (.not.extractor_%extractor_%supportsAttenuation())                                                   &
+            & call Error_Report(                                                                               &
+            &                   'property extractor "'                                                      // &
+            &                   extractor_%extractor_%objectType()                                          // &
+            &                   '" does not support dust attenuation - it can not decompose its output into'// &
+            &                   ' parcels of emission'                                                      // &
+            &                   {introspection:location}                                                       &
+            &                  )
+       select type (child => extractor_%extractor_)
+       class is (nodePropertyExtractorScalar)
+          ! Supported.
+       class is (nodePropertyExtractorTuple )
+          ! Supported.
+       class default
+          call Error_Report(                                                                                       &
+               &            'property extractor "'                                                              // &
+               &            extractor_%extractor_%objectType()                                                  // &
+               &            '" produces properties of a rank which dust attenuation does not yet support - only'// &
+               &            ' scalar and tuple extractors may be attenuated'                                    // &
+               &            {introspection:location}                                                               &
+               &           )
+       end select
+       extractor_ => extractor_%next
+    end do
+    return
+  end subroutine dustAttenuationValidate
+
+  subroutine dustAttenuationDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`nodePropertyExtractorDustAttenuation` property extractor class.
+    !!}
+    implicit none
+    type(nodePropertyExtractorDustAttenuation), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%dustAttenuation_"/>
+    !!]
+    return
+  end subroutine dustAttenuationDestructor
+
+  integer function dustAttenuationCountChildElements(self,extractor_,time) result(countElements)
+    !!{RST
+    Return the number of properties produced by a child extractor.
+    !!}
+    implicit none
+    class           (nodePropertyExtractorDustAttenuation), intent(inout) :: self
+    class           (nodePropertyExtractorClass          ), intent(inout) :: extractor_
+    double precision                                      , intent(in   ) :: time
+    !$GLC attributes unused :: self
+
+    countElements=0
+    select type (extractor_)
+    class is (nodePropertyExtractorScalar)
+       countElements=1
+    class is (nodePropertyExtractorTuple )
+       countElements=extractor_%elementCount(time)
+    end select
+    return
+  end function dustAttenuationCountChildElements
+
+  integer function dustAttenuationElementCount(self,elementType,time) result(elementCount)
+    !!{RST
+    Return the number of properties emitted, counting attenuated properties, optionally their unattenuated
+    counterparts, and optionally their sum.
+    !!}
+    implicit none
+    class           (nodePropertyExtractorDustAttenuation), intent(inout) :: self
+    type            (enumerationElementTypeType          ), intent(in   ) :: elementType
+    double precision                                      , intent(in   ) :: time
+    type            (multiExtractorList                  ), pointer       :: extractor_
+    integer                                                               :: countChild
+
+    elementCount=0
+    ! Only double-precision properties are produced.
+    if (elementType /= elementTypeDouble) return
+    extractor_ => self%extractors
+    do while (associated(extractor_))
+       countChild  =self%countChildElements(extractor_%extractor_,time)
+       elementCount=elementCount+countChild
+       if (self%outputUnattenuated) elementCount=elementCount+countChild
+       extractor_  => extractor_%next
+    end do
+    if (self%outputSum) elementCount=elementCount+1
+    return
+  end function dustAttenuationElementCount
+
+  function dustAttenuationAttenuate(self,extractor_,node,time,instance) result(values)
+    !!{RST
+    Return the attenuated properties of a child extractor: decompose its luminosity into parcels, attenuate each, and
+    let the child recombine them.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    double precision                                      , allocatable  , dimension(:) :: values
+    class           (nodePropertyExtractorDustAttenuation), intent(inout)               :: self
+    class           (nodePropertyExtractorClass          ), intent(inout), target       :: extractor_
+    type            (treeNode                            ), intent(inout), target       :: node
+    double precision                                      , intent(in   )               :: time
+    type            (multiCounter                        ), intent(inout), optional     :: instance
+    type            (luminosityDecomposition             )                              :: decomposition
+    double precision                                      , allocatable  , dimension(:) :: transmission
+    integer                                                                             :: i
+    !$GLC attributes unused :: instance
+
+    decomposition=extractor_%decompose(node,time,self%dustAttenuation_%request())
+    ! The attenuator may refuse the component a parcel came from -- most refuse a luminosity summed over components,
+    ! which can not be attenuated meaningfully. The child's component is not visible until it decomposes, so this is
+    ! checked here rather than at construction.
+    do i=1,decomposition%countTerms()
+       if (.not.self%dustAttenuation_%supportsComponent(decomposition%descriptors(i)%componentType))                &
+            & call Error_Report(                                                                                    &
+            &                   'the dust attenuation model refuses the component of a parcel of emission from "'// &
+            &                   extractor_%objectType()                                                          // &
+            &                   '" - a luminosity summed over components can not be attenuated'                  // &
+            &                   {introspection:location}                                                            &
+            &                  )
+    end do
+    allocate(transmission(decomposition%countTerms()))
+    if (decomposition%countTerms() > 0) transmission=self%dustAttenuation_%transmission(node,decomposition%descriptors)
+    call extractor_%recompose(decomposition,transmission,values)
+    return
+  end function dustAttenuationAttenuate
+
+  function dustAttenuationExtractDouble(self,node,time,instance,ranks) result(properties)
+    !!{RST
+    Extract the attenuated properties.
+    !!}
+    use :: Error     , only : Error_Report
+    use :: Poly_Ranks, only : polyRankDouble
+    implicit none
+    type            (polyRankDouble                      )                         , allocatable, dimension(:) :: properties
+    class           (nodePropertyExtractorDustAttenuation), intent(inout)                                      :: self
+    type            (treeNode                            ), intent(inout)                                      :: node
+    double precision                                      , intent(in   )                                      :: time
+    type            (multiCounter                        ), intent(inout), optional                            :: instance
+    integer                                               , intent(  out), optional, allocatable, dimension(:) :: ranks
+    type            (multiExtractorList                  ), pointer                                            :: extractor_
+    double precision                                                               , allocatable, dimension(:) :: valuesAttenuated, valuesRaw
+    integer                                                                                                    :: offset          , countChild, &
+         &                                                                                                        i
+    double precision                                                                                           :: sumAttenuated
+
+    allocate(properties(self%elementCount(elementTypeDouble,time)))
+    if (present(ranks)) then
+       allocate(ranks(self%elementCount(elementTypeDouble,time)))
+       ranks=0
+    end if
+    offset        =  0
+    sumAttenuated =  0.0d0
+    extractor_    => self%extractors
+    do while (associated(extractor_))
+       countChild=self%countChildElements(extractor_%extractor_,time)
+       if (self%outputUnattenuated) then
+          select type (child => extractor_%extractor_)
+          class is (nodePropertyExtractorScalar)
+             allocate(valuesRaw(1))
+             valuesRaw(1)=child%extract(node,     instance)
+          class is (nodePropertyExtractorTuple )
+             valuesRaw   =child%extract(node,time,instance)
+          end select
+          do i=1,countChild
+             properties(offset+i)=polyRankDouble(valuesRaw(i))
+          end do
+          offset=offset+countChild
+          deallocate(valuesRaw)
+       end if
+       valuesAttenuated=self%attenuate(extractor_%extractor_,node,time,instance)
+       if (size(valuesAttenuated) /= countChild)                                       &
+            & call Error_Report(                                                       &
+            &                   'the number of attenuated properties returned by "' // &
+            &                   extractor_%extractor_%objectType()                  // &
+            &                   '" does not match the number of properties it emits'// &
+            &                   {introspection:location}                               &
+            &                  )
+       do i=1,countChild
+          properties(offset+i)=polyRankDouble(valuesAttenuated(i))
+          sumAttenuated       =sumAttenuated+valuesAttenuated(i)
+       end do
+       offset=offset+countChild
+       deallocate(valuesAttenuated)
+       extractor_ => extractor_%next
+    end do
+    if (self%outputSum) then
+       offset            =offset+1
+       properties(offset)=polyRankDouble(sumAttenuated)
+    end if
+    return
+  end function dustAttenuationExtractDouble
+
+  subroutine dustAttenuationNames(self,elementType,time,names)
+    !!{RST
+    Return the names of the properties emitted. Attenuated properties take the name of the property they attenuate,
+    with the name of the attenuator appended, so that the two may coexist in the same output.
+    !!}
+    implicit none
+    class           (nodePropertyExtractorDustAttenuation), intent(inout)                            :: self
+    type            (enumerationElementTypeType          ), intent(in   )                            :: elementType
+    double precision                                      , intent(in   )                            :: time
+    type            (varying_string                      ), intent(inout), dimension(:), allocatable :: names
+    type            (varying_string                      )               , dimension(:), allocatable :: namesChild
+    type            (multiExtractorList                  ), pointer                                  :: extractor_
+    type            (varying_string                      )                                           :: suffix
+    integer                                                                                          :: offset     , countChild, &
+         &                                                                                               i
+
+    allocate(names(self%elementCount(elementType,time)))
+    if (elementType /= elementTypeDouble) return
+    suffix     =  ":dustAttenuated:"//self%dustAttenuation_%objectType(short=.true.)
+    offset     =  0
+    extractor_ => self%extractors
+    do while (associated(extractor_))
+       countChild=self%countChildElements(extractor_%extractor_,time)
+       call dustAttenuationChildNames(self,extractor_%extractor_,time,namesChild)
+       if (self%outputUnattenuated) then
+          do i=1,countChild
+             names(offset+i)=namesChild(i)
+          end do
+          offset=offset+countChild
+       end if
+       do i=1,countChild
+          names(offset+i)=namesChild(i)//suffix
+       end do
+       offset=offset+countChild
+       deallocate(namesChild)
+       extractor_ => extractor_%next
+    end do
+    if (self%outputSum) then
+       offset       =offset+1
+       names(offset)="luminosityTotal"//suffix
+    end if
+    return
+  end subroutine dustAttenuationNames
+
+  subroutine dustAttenuationChildNames(self,extractor_,time,names)
+    !!{RST
+    Return the names of the properties of a child extractor.
+    !!}
+    implicit none
+    type            (nodePropertyExtractorDustAttenuation), intent(inout)                            :: self
+    class           (nodePropertyExtractorClass          ), intent(inout)                            :: extractor_
+    double precision                                      , intent(in   )                            :: time
+    type            (varying_string                      ), intent(inout), dimension(:), allocatable :: names
+    !$GLC attributes unused :: self
+
+    select type (extractor_)
+    class is (nodePropertyExtractorScalar)
+       allocate(names(1))
+       names(1)=extractor_%name()
+    class is (nodePropertyExtractorTuple )
+       call extractor_%names(time,names)
+    end select
+    return
+  end subroutine dustAttenuationChildNames
+
+  subroutine dustAttenuationDescriptions(self,elementType,time,descriptions)
+    !!{RST
+    Return descriptions of the properties emitted.
+    !!}
+    implicit none
+    class           (nodePropertyExtractorDustAttenuation), intent(inout)                            :: self
+    type            (enumerationElementTypeType          ), intent(in   )                            :: elementType
+    double precision                                      , intent(in   )                            :: time
+    type            (varying_string                      ), intent(inout), dimension(:), allocatable :: descriptions
+    type            (varying_string                      )               , dimension(:), allocatable :: descriptionsChild
+    type            (multiExtractorList                  ), pointer                                  :: extractor_
+    type            (varying_string                      )                                           :: suffix
+    integer                                                                                          :: offset           , countChild, &
+         &                                                                                              i
+
+    allocate(descriptions(self%elementCount(elementType,time)))
+    if (elementType /= elementTypeDouble) return
+    suffix     =  ", attenuated by dust using the '"//self%dustAttenuation_%objectType(short=.true.)//"' model"
+    offset     =  0
+    extractor_ => self%extractors
+    do while (associated(extractor_))
+       countChild=self%countChildElements(extractor_%extractor_,time)
+       select type (child => extractor_%extractor_)
+       class is (nodePropertyExtractorScalar)
+          allocate(descriptionsChild(1))
+          descriptionsChild(1)=child%description()
+       class is (nodePropertyExtractorTuple )
+          call child%descriptions(time,descriptionsChild)
+       end select
+       if (self%outputUnattenuated) then
+          do i=1,countChild
+             descriptions(offset+i)=descriptionsChild(i)
+          end do
+          offset=offset+countChild
+       end if
+       do i=1,countChild
+          descriptions(offset+i)=descriptionsChild(i)//suffix
+       end do
+       offset=offset+countChild
+       deallocate(descriptionsChild)
+       extractor_ => extractor_%next
+    end do
+    if (self%outputSum) then
+       offset            =offset+1
+       descriptions(offset)="Sum over all child extractors of the luminosity"//suffix
+    end if
+    return
+  end subroutine dustAttenuationDescriptions
+
+  function dustAttenuationUnitsInSI(self,elementType,time) result(unitsInSI)
+    !!{RST
+    Return the units, in the SI system, of the properties emitted. Attenuation is dimensionless, so an attenuated
+    property carries the units of the property it attenuates.
+    !!}
+    implicit none
+    double precision                                      , allocatable  , dimension(:) :: unitsInSI
+    class           (nodePropertyExtractorDustAttenuation), intent(inout)               :: self
+    type            (enumerationElementTypeType          ), intent(in   )               :: elementType
+    double precision                                      , intent(in   )               :: time
+    double precision                                      , allocatable  , dimension(:) :: unitsChild
+    type            (multiExtractorList                  ), pointer                     :: extractor_
+    integer                                                                             :: offset     , countChild, &
+         &                                                                                 i
+
+    allocate(unitsInSI(self%elementCount(elementType,time)))
+    if (elementType /= elementTypeDouble) return
+    offset     =  0
+    extractor_ => self%extractors
+    do while (associated(extractor_))
+       countChild=self%countChildElements(extractor_%extractor_,time)
+       select type (child => extractor_%extractor_)
+       class is (nodePropertyExtractorScalar)
+          allocate(unitsChild(1))
+          unitsChild(1)=child%unitsInSI()
+       class is (nodePropertyExtractorTuple )
+          unitsChild   =child%unitsInSI(time)
+       end select
+       if (self%outputUnattenuated) then
+          unitsInSI(offset+1:offset+countChild)=unitsChild
+          offset                               =offset+countChild
+       end if
+       unitsInSI(offset+1:offset+countChild)=unitsChild
+       offset                               =offset+countChild
+       deallocate(unitsChild)
+       extractor_ => extractor_%next
+    end do
+    ! The summed property takes the units of the first child, all children being luminosities in the same units.
+    if (self%outputSum) then
+       offset           =offset+1
+       if (offset > 1) then
+          unitsInSI(offset)=unitsInSI(offset-1)
+       else
+          unitsInSI(offset)=1.0d0
+       end if
+    end if
+    return
+  end function dustAttenuationUnitsInSI
+
+  function dustAttenuationUnits(self,elementType,time) result(units)
+    !!{RST
+    Return metadata describing the units of the properties emitted.
+    !!}
+    implicit none
+    type            (unitType                            ), allocatable  , dimension(:) :: units
+    class           (nodePropertyExtractorDustAttenuation), intent(inout)               :: self
+    type            (enumerationElementTypeType          ), intent(in   )               :: elementType
+    double precision                                      , intent(in   )               :: time
+    type            (unitType                            ), allocatable  , dimension(:) :: unitsChild
+    type            (multiExtractorList                  ), pointer                     :: extractor_
+    integer                                                                             :: offset     , countChild, &
+         &                                                                                 i
+
+    allocate(units(self%elementCount(elementType,time)))
+    if (elementType /= elementTypeDouble) return
+    offset     =  0
+    extractor_ => self%extractors
+    do while (associated(extractor_))
+       countChild=self%countChildElements(extractor_%extractor_,time)
+       ! `units` is defined on the rank-specific extractor classes rather than on the base class, and with differing
+       ! signatures, so the child's class must be resolved before it can be called.
+       select type (child => extractor_%extractor_)
+       class is (nodePropertyExtractorScalar)
+          allocate(unitsChild(1))
+          unitsChild(1)=child%units(    )
+       class is (nodePropertyExtractorTuple )
+          unitsChild   =child%units(time)
+       end select
+       if (self%outputUnattenuated) then
+          do i=1,countChild
+             units(offset+i)=unitsChild(i)
+          end do
+          offset=offset+countChild
+       end if
+       do i=1,countChild
+          units(offset+i)=unitsChild(i)
+       end do
+       offset=offset+countChild
+       deallocate(unitsChild)
+       extractor_ => extractor_%next
+    end do
+    if (self%outputSum) then
+       offset      =offset+1
+       if (offset > 1) units(offset)=units(offset-1)
+    end if
+    return
+  end function dustAttenuationUnits
+
+  function dustAttenuationRanks(self,elementType,time) result(ranks)
+    !!{RST
+    Return the ranks of the properties emitted. Only scalar and tuple children are supported, so every property is of
+    rank zero.
+    !!}
+    implicit none
+    integer                                               , allocatable  , dimension(:) :: ranks
+    class           (nodePropertyExtractorDustAttenuation), intent(inout)               :: self
+    type            (enumerationElementTypeType          ), intent(in   )               :: elementType
+    double precision                                      , intent(in   )               :: time
+
+    allocate(ranks(self%elementCount(elementType,time)))
+    ranks=0
+    return
+  end function dustAttenuationRanks

--- a/source/nodes/property_extractor/luminosity_stellar/_class.F90
+++ b/source/nodes/property_extractor/luminosity_stellar/_class.F90
@@ -91,6 +91,7 @@ contains
     type            (varying_string                        ), allocatable  , dimension(:) :: postprocessChains
     double precision                                                                      :: redshiftBand
     logical                                                                               :: redshiftBandIsPresent, postprocessChainIsPresent
+    integer                                                                               :: countChains
 
     redshiftBandIsPresent    =parameters%isPresent('redshiftBand'    )
     postprocessChainIsPresent=parameters%isPresent('postprocessChain')
@@ -108,21 +109,6 @@ contains
       <description>
       The filter type (rest or observed) to select.
       </description>
-    </inputParameter>
-    <inputParameter docformat="rst">
-      <name>postprocessChains</name>
-      <defaultValue>[var_str('')]</defaultValue>
-      <description>
-      The names of the postprocessing chains to use when resolving this luminosity into bins of stellar population
-      age, as required when applying a dust model which attenuates young and old populations differently. Each named
-      chain must already be defined by the ``[stellarPopulationSpectraPostprocessorBuilder]``, and a luminosity using
-      it must be tracked for this filter.
-
-      The age range spanned by each chain is obtained from the chain itself, not declared here, so it can not drift
-      out of step with the chain's configuration. Leave this unset---the default---for a dust model which does not
-      distinguish populations by age.
-      </description>
-      <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
       <name>component</name>
@@ -153,6 +139,28 @@ contains
          <source>parameters</source>
          <description>
          The postprocessing chain to use.
+         </description>
+       </inputParameter>
+       !!]
+    end if
+    ! The age-resolving chains are read only if given: a deferred-shape parameter can not be read into an unallocated
+    ! array, so its extent is established first.
+    countChains=parameters%count('postprocessChains',zeroIfNotPresent=.true.)
+    allocate(postprocessChains(countChains))
+    if (countChains > 0) then
+       !![
+       <inputParameter docformat="rst">
+         <name>postprocessChains</name>
+         <source>parameters</source>
+         <description>
+         The names of the postprocessing chains to use when resolving this luminosity into bins of stellar population
+         age, as required when applying a dust model which attenuates young and old populations differently. Each
+         named chain must already be defined by the ``[stellarPopulationSpectraPostprocessorBuilder]``, and a
+         luminosity using it must be tracked for this filter.
+
+         The age range spanned by each chain is obtained from the chain itself, not declared here, so it can not drift
+         out of step with the chain's configuration. Leave this unset---the default---for a dust model which does not
+         distinguish populations by age.
          </description>
        </inputParameter>
        !!]

--- a/source/nodes/property_extractor/luminosity_stellar/_class.F90
+++ b/source/nodes/property_extractor/luminosity_stellar/_class.F90
@@ -37,21 +37,33 @@ Implements a stellar mass output analysis property extractor class.
      A stellar luminosity output analysis property extractor class.
      !!}
      private
-     type            (varying_string              )                            :: filterName                , filterType, &
-          &                                                                       postprocessChain          , name_     , &
-          &                                                                       description_
-     type            (enumerationComponentTypeType)                            :: component
-     double precision                                                          :: redshiftBand
-     integer                                       , allocatable, dimension(:) :: luminosityIndex
-     class           (outputTimesClass            ), pointer                   :: outputTimes_     => null()
+     type            (varying_string              )                              :: filterName                   , filterType, &
+          &                                                                         postprocessChain             , name_     , &
+          &                                                                         description_
+     type            (enumerationComponentTypeType)                              :: component
+     double precision                                                            :: redshiftBand
+     integer                                       , allocatable, dimension(:  ) :: luminosityIndex
+     ! Names of the postprocessing chains used to resolve this luminosity into bins of stellar population age, and the
+     ! index of the corresponding luminosity at each output time. Empty unless age resolution has been requested.
+     type            (varying_string              ), allocatable, dimension(:  ) :: postprocessChains
+     integer                                       , allocatable, dimension(:,:) :: luminosityIndexChain
+     class           (outputTimesClass            ), pointer                     :: outputTimes_         => null()
    contains
      final     ::                luminosityStellarDestructor
-     procedure :: extract     => luminosityStellarExtract
-     procedure :: quantity    => luminosityStellarQuantity
-     procedure :: name        => luminosityStellarName
-     procedure :: description => luminosityStellarDescription
-     procedure :: unitsInSI   => luminosityStellarUnitsInSI
-     procedure :: units       => luminosityStellarUnits
+     procedure :: extract             => luminosityStellarExtract
+     procedure :: supportsAttenuation => luminosityStellarSupportsAttenuation
+     procedure :: decompose           => luminosityStellarDecompose
+     !![
+     <methods docformat="rst">
+       <method method="luminosityValue" description="Return the luminosity of this extractor's component for a given entry in the stellar luminosities structure."/>
+     </methods>
+     !!]
+     procedure :: luminosityValue => luminosityStellarLuminosityValue
+     procedure :: quantity        => luminosityStellarQuantity
+     procedure :: name            => luminosityStellarName
+     procedure :: description     => luminosityStellarDescription
+     procedure :: unitsInSI       => luminosityStellarUnitsInSI
+     procedure :: units           => luminosityStellarUnits
   end type nodePropertyExtractorLuminosityStellar
 
   interface nodePropertyExtractorLuminosityStellar
@@ -71,13 +83,14 @@ contains
     use :: Galactic_Structure_Options, only : enumerationComponentTypeEncode
     use :: Input_Parameters          , only : inputParameter                , inputParameters
     implicit none
-    type            (nodePropertyExtractorLuminosityStellar)                :: self
-    type            (inputParameters                       ), intent(inout) :: parameters
-    class           (outputTimesClass                      ), pointer       :: outputTimes_
-    type            (varying_string                        )                :: filterName           , filterType               , &
-         &                                                                     postprocessChain     , component
-    double precision                                                        :: redshiftBand
-    logical                                                                 :: redshiftBandIsPresent, postprocessChainIsPresent
+    type            (nodePropertyExtractorLuminosityStellar)                              :: self
+    type            (inputParameters                       ), intent(inout)               :: parameters
+    class           (outputTimesClass                      ), pointer                     :: outputTimes_
+    type            (varying_string                        )                              :: filterName           , filterType               , &
+         &                                                                                   postprocessChain     , component
+    type            (varying_string                        ), allocatable  , dimension(:) :: postprocessChains
+    double precision                                                                      :: redshiftBand
+    logical                                                                               :: redshiftBandIsPresent, postprocessChainIsPresent
 
     redshiftBandIsPresent    =parameters%isPresent('redshiftBand'    )
     postprocessChainIsPresent=parameters%isPresent('postprocessChain')
@@ -95,6 +108,21 @@ contains
       <description>
       The filter type (rest or observed) to select.
       </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>postprocessChains</name>
+      <defaultValue>[var_str('')]</defaultValue>
+      <description>
+      The names of the postprocessing chains to use when resolving this luminosity into bins of stellar population
+      age, as required when applying a dust model which attenuates young and old populations differently. Each named
+      chain must already be defined by the ``[stellarPopulationSpectraPostprocessorBuilder]``, and a luminosity using
+      it must be tracked for this filter.
+
+      The age range spanned by each chain is obtained from the chain itself, not declared here, so it can not drift
+      out of step with the chain's configuration. Leave this unset---the default---for a dust model which does not
+      distinguish populations by age.
+      </description>
+      <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
       <name>component</name>
@@ -134,15 +162,15 @@ contains
     !!]
     if (redshiftBandIsPresent) then
        if (postprocessChainIsPresent) then
-          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,redshiftBand=redshiftBand,postprocessChain=char(postprocessChain))
+          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,postprocessChains=postprocessChains,redshiftBand=redshiftBand,postprocessChain=char(postprocessChain))
        else
-          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,redshiftBand=redshiftBand                                        )
+          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,postprocessChains=postprocessChains,redshiftBand=redshiftBand                                        )
        end if
     else
        if (postprocessChainIsPresent) then
-          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,                          postprocessChain=char(postprocessChain))
+          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,postprocessChains=postprocessChains,                          postprocessChain=char(postprocessChain))
        else
-          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_                                                                  )
+          self=nodePropertyExtractorLuminosityStellar(char(filterName),char(filterType),enumerationComponentTypeEncode(char(component),includesPrefix=.false.),outputTimes_,postprocessChains=postprocessChains                                                                  )
        end if
     end if
     !![
@@ -152,7 +180,7 @@ contains
     return
   end function luminosityStellarConstructorParameters
 
-  function luminosityStellarConstructorInternal(filterName,filterType,component,outputTimes_,redshiftBand,postprocessChain,outputMask) result(self)
+  function luminosityStellarConstructorInternal(filterName,filterType,component,outputTimes_,redshiftBand,postprocessChain,postprocessChains,outputMask) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`nodePropertyExtractorLuminosityStellar` property extractor class.
     !!}
@@ -169,7 +197,9 @@ contains
     character       (len=*                                 ), intent(in   ), optional               :: postprocessChain
     double precision                                        , intent(in   ), optional               :: redshiftBand
     logical                                                 , intent(in   ), dimension(:), optional :: outputMask
+    type            (varying_string                        ), intent(in   ), dimension(:), optional :: postprocessChains
     integer         (c_size_t                              )                                        :: i
+    integer                                                                                         :: j                , countChains
     character       (len=7                                 )                                        :: label
     !![
     <constructorAssign variables="filterName, filterType, component, redshiftBand, postprocessChain, *outputTimes_"/>
@@ -197,6 +227,31 @@ contains
           self%luminosityIndex(i)=unitStellarLuminosities%index(filterName,filterType,self%outputTimes_%redshift(i),redshiftBand,postprocessChain)
        end if
     end do
+    ! Resolve the luminosity index of each age-resolving chain, at each output time. A chain named here must already
+    ! be tracked as a luminosity for this filter; `unitStellarLuminosities%index` reports helpfully if it is not.
+    countChains=0
+    if (present(postprocessChains)) then
+       do j=1,size(postprocessChains)
+          if (len_trim(postprocessChains(j)) > 0) countChains=countChains+1
+       end do
+    end if
+    allocate(self%postprocessChains   (countChains                          ))
+    allocate(self%luminosityIndexChain(countChains,self%outputTimes_%count()))
+    if (countChains > 0) then
+       countChains=0
+       do j=1,size(postprocessChains)
+          if (len_trim(postprocessChains(j)) == 0) cycle
+          countChains                        =countChains+1
+          self%postprocessChains(countChains)=postprocessChains(j)
+          do i=1,self%outputTimes_%count()
+             if (present(outputMask).and..not.outputMask(i)) then
+                self%luminosityIndexChain(countChains,i)=-1
+             else
+                self%luminosityIndexChain(countChains,i)=unitStellarLuminosities%index(filterName,filterType,self%outputTimes_%redshift(i),redshiftBand,char(postprocessChains(j)))
+             end if
+          end do
+       end do
+    end if
     self%name_       ="luminosityStellar:"//filterName//":"//filterType
     if (component == componentTypeAll) then
        self%description_="Total stellar luminosity in the "//filterType//"-frame "//filterName//" filter"
@@ -323,3 +378,218 @@ contains
     units=unitType(self%unitsInSI(),description='AB-magnitude zero point',quantity='4.465920e17 W/Hz')
     return
   end function luminosityStellarUnits
+
+  logical function luminosityStellarSupportsAttenuation(self) result(supportsAttenuation)
+    !!{RST
+    Return true: a stellar luminosity can be decomposed for attenuation by dust.
+    !!}
+    implicit none
+    class(nodePropertyExtractorLuminosityStellar), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    supportsAttenuation=.true.
+    return
+  end function luminosityStellarSupportsAttenuation
+
+  function luminosityStellarDecompose(self,node,time,request) result(decomposition)
+    !!{RST
+    Decompose this luminosity into parcels of emission which may be attenuated separately.
+
+    When no age resolution is requested the whole luminosity is a single parcel. When it is, the luminosity of each
+    age bin is recovered from the luminosities computed with the postprocessing chains named by
+    ``[postprocessChains]``, whose age windows are read from the chains themselves. Two arrangements of those chains
+    are understood:
+
+    *Cumulative*
+       Every chain admits ages from zero, each to a different upper limit---the usual case, in which a ``recent`` chain
+       restricted to young populations sits alongside an unrestricted ``default`` chain. The luminosity of a bin is
+       then the difference between successive chains.
+
+    *Disjoint*
+       Each chain admits a range beginning where the previous one ended, so the luminosity of a bin is that of its
+       chain directly.
+
+    Anything else, a chain whose age window is not sharp, or a requested age boundary which no chain provides, is
+    reported as an error rather than approximated: silently splitting a luminosity at the wrong age would produce
+    plausible but wrong colours.
+    !!}
+    use :: Dust_Attenuation_Descriptors  , only : emissionSourceStellar
+    use :: Error                         , only : Error_Report
+    use :: Galactic_Structure_Options    , only : componentTypeAll       , enumerationComponentTypeDecode
+    use :: Galacticus_Nodes              , only : nodeComponentBasic
+    use :: ISO_Varying_String            , only : operator(//)           , var_str
+    use :: Numerical_Comparison          , only : Values_Agree
+    use :: Stellar_Luminosities_Structure, only : unitStellarLuminosities
+    use :: String_Handling               , only : operator(//)
+    implicit none
+    type            (luminosityDecomposition               )                              :: decomposition
+    class           (nodePropertyExtractorLuminosityStellar), intent(inout), target       :: self
+    type            (treeNode                              ), intent(inout), target       :: node
+    double precision                                        , intent(in   )               :: time
+    type            (decompositionRequest                  ), intent(in   )               :: request
+    class           (nodeComponentBasic                    )               , pointer      :: basic
+    double precision                                        , allocatable  , dimension(:) :: ageMinimum   , ageMaximum   , &
+         &                                                                                   luminosity
+    integer                                                 , allocatable  , dimension(:) :: order
+    integer         (c_size_t                              )                              :: indexTime
+    integer                                                                               :: countChains  , i            , &
+         &                                                                                   j            , indexSwap    , &
+         &                                                                                   countBins
+    logical                                                                               :: isSharp      , isCumulative , &
+         &                                                                                   isDisjoint   , found
+    double precision                                                                      :: wavelength   , ageLower     , &
+         &                                                                                   luminosityBin
+    character       (len=12                                )                              :: labelAge
+
+    ! Dust can not be applied to a luminosity summed over components, since components are attenuated differently.
+    if (self%component == componentTypeAll)                                                                       &
+         & call Error_Report(                                                                                     &
+         &                   'this luminosity is summed over all components, and so can not be attenuated; set'// &
+         &                   ' [component] to an individual component'                                         // &
+         &                   {introspection:location}                                                             &
+         &                  )
+    basic     => node             %basic(                               )
+    indexTime =  self%outputTimes_%index(basic%time(),findClosest=.true.)
+    ! With no age resolution requested, the luminosity is a single parcel spanning all ages.
+    if (request%countAgeBins() == 1) then
+       call decomposition%initialize(1,1)
+       decomposition%luminosities(1)              =self%luminosityValue(node,self%luminosityIndex(indexTime))
+       decomposition%elementIndex(1)              =1
+       decomposition%descriptors (1)%wavelength   =unitStellarLuminosities%wavelengthRestFrame(self%luminosityIndex(indexTime))
+       decomposition%descriptors (1)%componentType=self%component
+       decomposition%descriptors (1)%sourceType   =emissionSourceStellar
+       return
+    end if
+    ! Age resolution has been requested, so the age-resolving chains are needed.
+    countChains=size(self%postprocessChains)
+    if (countChains == 0)                                                                                              &
+         & call Error_Report(                                                                                          &
+         &                   'the dust model requires this luminosity to be resolved by stellar population age, but'// &
+         &                   ' no age-resolving postprocessing chains are given; set [postprocessChains]'           // &
+         &                   {introspection:location}                                                                  &
+         &                  )
+    allocate(ageMinimum(countChains))
+    allocate(ageMaximum(countChains))
+    allocate(luminosity(countChains))
+    allocate(order     (countChains))
+    do i=1,countChains
+       call unitStellarLuminosities%ageWindow(self%luminosityIndexChain(i,indexTime),ageMinimum(i),ageMaximum(i),isSharp)
+       if (.not.isSharp)                                                                                                  &
+            & call Error_Report(                                                                                          &
+            &                   var_str('postprocessing chain "')//self%postprocessChains(i)//'" does not have a sharp'// &
+            &                   ' age window, so it can not be used to isolate the light of a range of ages'           // &
+            &                   {introspection:location}                                                                  &
+            &                  )
+       if (ageMaximum(i) <= ageMinimum(i))                                                                                &
+            & call Error_Report(                                                                                          &
+            &                   var_str('postprocessing chain "')//self%postprocessChains(i)//'" admits no ages at all'// &
+            &                   {introspection:location}                                                                  &
+            &                  )
+       luminosity(i)=self%luminosityValue(node,self%luminosityIndexChain(i,indexTime))
+       order     (i)=i
+    end do
+    ! Order the chains by increasing upper age limit.
+    do i=2,countChains
+       indexSwap=order(i)
+       j        =i-1
+       do while (j >= 1)
+          if (ageMaximum(order(j)) <= ageMaximum(indexSwap)) exit
+          order(j+1)=order(j)
+          j         =j-1
+       end do
+       order(j+1)=indexSwap
+    end do
+    ! Classify the arrangement of the chains.
+    isCumulative=.true.
+    isDisjoint  =.true.
+    do i=1,countChains
+       if (ageMinimum(order(i)) > 0.0d0) isCumulative=.false.
+       if (i == 1) then
+          if (ageMinimum(order(i)) > 0.0d0) isDisjoint=.false.
+       else if (.not.Values_Agree(ageMinimum(order(i)),ageMaximum(order(i-1)),relTol=1.0d-6,absTol=1.0d-12)) then
+          isDisjoint=.false.
+       end if
+    end do
+    if (.not.(isCumulative.or.isDisjoint))                                                                                 &
+         & call Error_Report(                                                                                              &
+         &                   'the age windows of [postprocessChains] are neither cumulative (all beginning at zero age)'// &
+         &                   ' nor disjoint (each beginning where the previous ends), so the luminosity of each age bin'// &
+         &                   ' can not be determined'                                                                   // &
+         &                   {introspection:location}                                                                      &
+         &                  )
+    ! The highest chain must extend to all ages, or light older than its limit is simply missing.
+    if (ageMaximum(order(countChains)) < huge(0.0d0))                                                                     &
+         & call Error_Report(                                                                                             &
+         &                   'no chain in [postprocessChains] admits the oldest populations, so part of the luminosity'// &
+         &                   ' would be discarded; include an unrestricted chain'                                      // &
+         &                   {introspection:location}                                                                     &
+         &                  )
+    ! Every age boundary the dust model asks for must be one that the chains provide.
+    do i=1,request%countAgeBins()-1
+       found=.false.
+       do j=1,countChains-1
+          if (Values_Agree(request%ageBoundaries(i),ageMaximum(order(j)),relTol=1.0d-6,absTol=1.0d-12)) then
+             found=.true.
+             exit
+          end if
+       end do
+       if (.not.found) then
+          write (labelAge,'(e12.6)') request%ageBoundaries(i)
+          call Error_Report(                                                                              &
+               &            var_str('the dust model requires the luminosity to be split at an age of ')// &
+               &            trim(adjustl(labelAge))                                                    // &
+               &            ' Gyr, but no chain in [postprocessChains] has that upper age limit'       // &
+               &            {introspection:location}                                                      &
+               &           )
+       end if
+    end do
+    ! Build one parcel per age bin. All parcels contribute to the single output element of this scalar extractor.
+    countBins =countChains
+    wavelength=unitStellarLuminosities%wavelengthRestFrame(self%luminosityIndexChain(order(countChains),indexTime))
+    call decomposition%initialize(countBins,1)
+    ageLower=0.0d0
+    do i=1,countBins
+       if (isCumulative) then
+          if (i == 1) then
+             luminosityBin=luminosity(order(i))
+          else
+             luminosityBin=luminosity(order(i))-luminosity(order(i-1))
+          end if
+       else
+          luminosityBin=luminosity(order(i))
+       end if
+       decomposition%luminosities(i)              =luminosityBin
+       decomposition%elementIndex(i)              =1
+       decomposition%descriptors (i)%wavelength   =wavelength
+       decomposition%descriptors (i)%componentType=self%component
+       decomposition%descriptors (i)%sourceType   =emissionSourceStellar
+       decomposition%descriptors (i)%ageMinimum   =ageLower
+       decomposition%descriptors (i)%ageMaximum   =ageMaximum(order(i))
+       ageLower                                   =ageMaximum(order(i))
+    end do
+    return
+  end function luminosityStellarDecompose
+
+  double precision function luminosityStellarLuminosityValue(self,node,index) result(luminosity)
+    !!{RST
+    Return the luminosity of this extractor's component for the given entry in the stellar luminosities structure.
+    !!}
+    use :: Galactic_Structure_Options, only : massTypeStellar      , weightByLuminosity
+    use :: Mass_Distributions        , only : massDistributionClass
+    implicit none
+    class  (nodePropertyExtractorLuminosityStellar), intent(inout) :: self
+    type   (treeNode                              ), intent(inout) :: node
+    integer                                        , intent(in   ) :: index
+    class  (massDistributionClass                 ), pointer       :: massDistribution_
+
+    if (index < 0) then
+       luminosity=0.0d0
+       return
+    end if
+    massDistribution_ => node             %massDistribution(componentType=self%component,massType=massTypeStellar,weightBy=weightByLuminosity,weightIndex=index)
+    luminosity        =  massDistribution_%massTotal       (                                                                                                   )
+    !![
+    <objectDestructor name="massDistribution_"/>
+    !!]
+    return
+  end function luminosityStellarLuminosityValue

--- a/source/objects/stellar_luminosities/structure.F90
+++ b/source/objects/stellar_luminosities/structure.F90
@@ -110,6 +110,7 @@ module Stellar_Luminosities_Structure
        <method description="Return the effective wavelength (in Å, in the frame of the filter) of a luminosity specified by index." method="wavelengthEffective" />
        <method description="Return the redshift to which the filter of a luminosity specified by index is shifted (zero for rest-frame filters)." method="bandRedshift" />
        <method description="Return the rest-frame effective wavelength (in Å) of a luminosity specified by index." method="wavelengthRestFrame" />
+       <method description="Return the range of stellar population ages contributing to a luminosity specified by index, and whether that range is a sharp window." method="ageWindow" />
        <method description="Truncate the number of stellar luminosities stored to match that in the given ``templateLuminosities``." method="truncate" />
        <method description="Returns the size of any non-static components of the type." method="nonStaticSizeOf" />
      </methods>
@@ -152,6 +153,7 @@ module Stellar_Luminosities_Structure
      procedure, nopass :: wavelengthEffective   => Stellar_Luminosities_Wavelength_Effective
      procedure, nopass :: bandRedshift          => Stellar_Luminosities_Band_Redshift
      procedure, nopass :: wavelengthRestFrame   => Stellar_Luminosities_Wavelength_Rest_Frame
+     procedure, nopass :: ageWindow             => Stellar_Luminosities_Age_Window
      procedure         :: truncate              => Stellar_Luminosities_Truncate
   end type stellarLuminosities
   
@@ -934,6 +936,37 @@ contains
          &                                      )
     return
   end function Stellar_Luminosities_Wavelength_Rest_Frame
+
+  subroutine Stellar_Luminosities_Age_Window(index,ageMinimum,ageMaximum,isSharp)
+    !!{RST
+    Return the range of stellar population ages (in Gyr) which contribute to the specified entry in the stellar
+    luminosities structure, together with whether that range is a *sharp* window---that is, whether the postprocessing
+    chain applied to this luminosity suppresses ages outside the range while leaving the age dependence within it
+    untouched.
+
+    The range is that reported by the postprocessing chain itself, so it stays correct if the chain is reconfigured.
+    Only a sharp window may be used to isolate the light of a range of ages by differencing luminosities computed with
+    different chains; ``isSharp`` must therefore be tested before the range is relied upon. An empty window, signalled
+    by ``ageMaximum`` :math:`\le` ``ageMinimum``, means that the chain suppresses emission at every age.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    integer                       , intent(in   ) :: index
+    double precision              , intent(  out) :: ageMinimum, ageMaximum
+    logical                       , intent(  out) :: isSharp
+
+    ! Check for index in range.
+    if (index > 0 .and. index <= luminosityCount) then
+       call luminosityPostprocessor(index)%stellarPopulationSpectraPostprocessor_%ageRange(ageMinimum,ageMaximum)
+       isSharp=luminosityPostprocessor(index)%stellarPopulationSpectraPostprocessor_%ageWindowIsSharp()
+    else
+       ageMinimum=0.0d0
+       ageMaximum=0.0d0
+       isSharp   =.false.
+       call Error_Report('index out of range'//{introspection:location})
+    end if
+    return
+  end subroutine Stellar_Luminosities_Age_Window
 
   subroutine Stellar_Luminosities_Create(self)
     !!{RST

--- a/source/stellar_populations/spectra/postprocess/_class.F90
+++ b/source/stellar_populations/spectra/postprocess/_class.F90
@@ -44,6 +44,47 @@ module Stellar_Population_Spectra_Postprocess
     <pass>yes</pass>
     <argument>double precision, intent(in   ) :: wavelength, age, redshift</argument>
    </method>
+   <method name="ageRange" >
+    <description>
+    Return the range of stellar population ages, in Gyr, over which this postprocessor's multiplier is non-zero. The
+    default is unbounded; postprocessors which suppress emission outside a range of ages override it.
+
+    This is what allows a consumer to discover which of a set of named postprocessing chains corresponds to which
+    range of ages---so that, for example, a luminosity computed with a chain restricted to young populations can be
+    subtracted from one computed with an unrestricted chain to isolate the light of old populations---rather than
+    requiring the user to declare that correspondence and keep it consistent by hand.
+    </description>
+    <type>void</type>
+    <pass>yes</pass>
+    <argument>double precision, intent(  out) :: ageMinimum, ageMaximum</argument>
+    <code>
+     !$GLC attributes unused :: self
+     ageMinimum=0.0d0
+     ageMaximum=huge(0.0d0)
+    </code>
+   </method>
+   <method name="ageWindowIsSharp" >
+    <description>
+    Return true if the age dependence of this postprocessor's multiplier is a sharp window: that is, if the multiplier
+    is independent of age within the range reported by ``ageRange`` and zero outside it.
+
+    Postprocessors which have no age dependence at all satisfy this trivially, and so the default is true. Those which
+    taper---:galacticus-class:`stellarPopulationSpectraPostprocessorBirthCloudsLacey2016`, which declines linearly
+    between one and two birth cloud lifetimes, and
+    :galacticus-class:`stellarPopulationSpectraPostprocessorUnescaped`, which decays exponentially with age---do not,
+    and must return false.
+
+    The distinction matters because only a sharp window lets a luminosity be split cleanly into age bins by
+    differencing chains. Applying that construction to a tapering postprocessor would silently mis-apportion light
+    between the bins, so a consumer must check this before relying on ``ageRange``.
+    </description>
+    <type>logical</type>
+    <pass>yes</pass>
+    <code>
+     !$GLC attributes unused :: self
+     stellarPopulationSpectraPostprocessorAgeWindowIsSharp=.true.
+    </code>
+   </method>
    <method name="isRedshiftDependent" >
     <description>
     Return true if this postprocessor's correction factor depends on the source redshift, allowing the ODE solver to determine whether the luminosity must be recomputed when the redshift changes rather than using a cached value.

--- a/source/stellar_populations/spectra/postprocess/age_window.F90
+++ b/source/stellar_populations/spectra/postprocess/age_window.F90
@@ -36,6 +36,7 @@
      double precision :: ageMinimum, ageMaximum
    contains
      procedure :: multiplier          => ageWindowMultiplier
+     procedure :: ageRange            => ageWindowAgeRange
      procedure :: isRedshiftDependent => ageWindowIsRedshiftDependent
   end type stellarPopulationSpectraPostprocessorAgeWindow
 
@@ -128,3 +129,16 @@ contains
     isRedshiftDependent=.false.
     return
   end function ageWindowIsRedshiftDependent
+
+  subroutine ageWindowAgeRange(self,ageMinimum,ageMaximum)
+    !!{RST
+    Return the range of ages retained by an age window postprocessor.
+    !!}
+    implicit none
+    class           (stellarPopulationSpectraPostprocessorAgeWindow), intent(inout) :: self
+    double precision                                                , intent(  out) :: ageMinimum, ageMaximum
+
+    ageMinimum=self%ageMinimum
+    ageMaximum=self%ageMaximum
+    return
+  end subroutine ageWindowAgeRange

--- a/source/stellar_populations/spectra/postprocess/birth_clouds/Lacey2016.F90
+++ b/source/stellar_populations/spectra/postprocess/birth_clouds/Lacey2016.F90
@@ -36,6 +36,8 @@
      double precision :: timescale
    contains
      procedure :: multiplier          => birthCloudsLacey2016Multiplier
+     procedure :: ageRange            => birthCloudsLacey2016AgeRange
+     procedure :: ageWindowIsSharp    => birthCloudsLacey2016AgeWindowIsSharp
      procedure :: isRedshiftDependent => birthCloudsLacey2016IsRedshiftDependent
   end type stellarPopulationSpectraPostprocessorBirthCloudsLacey2016
 
@@ -122,3 +124,30 @@ contains
     isRedshiftDependent=.false.
     return
   end function birthCloudsLacey2016IsRedshiftDependent
+
+  subroutine birthCloudsLacey2016AgeRange(self,ageMinimum,ageMaximum)
+    !!{RST
+    Return the range of ages over which emission is retained. Equation (A5) of :cite:t:`lacey_unified_2016` declines
+    linearly from one to two birth cloud lifetimes, and vanishes beyond.
+    !!}
+    implicit none
+    class           (stellarPopulationSpectraPostprocessorBirthCloudsLacey2016), intent(inout) :: self
+    double precision                                                           , intent(  out) :: ageMinimum, ageMaximum
+
+    ageMinimum=0.0d0
+    ageMaximum=2.0d0*self%timescale
+    return
+  end subroutine birthCloudsLacey2016AgeRange
+
+  logical function birthCloudsLacey2016AgeWindowIsSharp(self) result(ageWindowIsSharp)
+    !!{RST
+    Return false: the multiplier tapers linearly between one and two birth cloud lifetimes rather than switching
+    sharply, so this chain can not be used to define an age bin for decomposition.
+    !!}
+    implicit none
+    class(stellarPopulationSpectraPostprocessorBirthCloudsLacey2016), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    ageWindowIsSharp=.false.
+    return
+  end function birthCloudsLacey2016AgeWindowIsSharp

--- a/source/stellar_populations/spectra/postprocess/recent.F90
+++ b/source/stellar_populations/spectra/postprocess/recent.F90
@@ -36,6 +36,7 @@
      double precision :: timeLimit
    contains
      procedure :: multiplier          => recentMultiplier
+     procedure :: ageRange            => recentAgeRange
      procedure :: isRedshiftDependent => recentIsRedshiftDependent
   end type stellarPopulationSpectraPostprocessorRecent
 
@@ -119,3 +120,16 @@ contains
     isRedshiftDependent=.false.
     return
   end function recentIsRedshiftDependent
+
+  subroutine recentAgeRange(self,ageMinimum,ageMaximum)
+    !!{RST
+    Return the range of ages retained by a recent postprocessor.
+    !!}
+    implicit none
+    class           (stellarPopulationSpectraPostprocessorRecent), intent(inout) :: self
+    double precision                                             , intent(  out) :: ageMinimum, ageMaximum
+
+    ageMinimum=0.0d0
+    ageMaximum=self%timeLimit
+    return
+  end subroutine recentAgeRange

--- a/source/stellar_populations/spectra/postprocess/sequence.F90
+++ b/source/stellar_populations/spectra/postprocess/sequence.F90
@@ -43,6 +43,8 @@ Implements a stellar population spectra postprocessor class which applies a sequ
    contains
      final     ::                        sequenceDestructor
      procedure :: multiplier          => sequenceMultiplier
+     procedure :: ageRange            => sequenceAgeRange
+     procedure :: ageWindowIsSharp    => sequenceAgeWindowIsSharp
      procedure :: isRedshiftDependent => sequenceIsRedshiftDependent
   end type stellarPopulationSpectraPostprocessorSequence
 
@@ -168,3 +170,72 @@ contains
     end do
     return
   end function sequenceIsRedshiftDependent
+
+  subroutine sequenceAgeRange(self,ageMinimum,ageMaximum)
+    !!{RST
+    Return the range of ages retained by a sequence of postprocessors, which is the *intersection* of the ranges
+    retained by its members---the multiplier of a sequence being the product of those of its members, emission
+    survives only if it survives every one.
+
+    Because each member's range is a single interval, and the intersection of intervals is an interval, the result can
+    never contain a gap. Members whose ranges do not overlap at all intersect to nothing, which is reported as an
+    empty range: **on return, ``ageMaximum`` :math:`\le` ``ageMinimum`` means that no age survives the sequence, and
+    consumers must test for this** rather than treating the result as a narrow but usable window. Such a sequence
+    suppresses all emission at every age, and is almost always a misconfiguration.
+    !!}
+    implicit none
+    class           (stellarPopulationSpectraPostprocessorSequence), intent(inout) :: self
+    double precision                                               , intent(  out) :: ageMinimum      , ageMaximum
+    type            (postprocessorList                            ), pointer       :: postprocessor_
+    double precision                                                               :: ageMinimumMember, ageMaximumMember
+
+    ageMinimum     =  0.0d0
+    ageMaximum     =  huge(0.0d0)
+    postprocessor_ => self%postprocessors
+    do while (associated(postprocessor_))
+       call postprocessor_%postprocessor_%ageRange(ageMinimumMember,ageMaximumMember)
+       ageMinimum     =  max(ageMinimum,ageMinimumMember)
+       ageMaximum     =  min(ageMaximum,ageMaximumMember)
+       postprocessor_ => postprocessor_%next
+    end do
+    ! An empty intersection retains nothing. Report it as a zero-width range rather than an inverted one, so that the
+    ! test `ageMaximum <= ageMinimum` identifies the empty case whichever way it arose.
+    if (ageMaximum < ageMinimum) ageMaximum=ageMinimum
+    return
+  end subroutine sequenceAgeRange
+
+  logical function sequenceAgeWindowIsSharp(self) result(ageWindowIsSharp)
+    !!{RST
+    Return true only if every member of the sequence has a sharp age window.
+
+    Sharpness composes: writing a sharp member's multiplier as :math:`c_i(\lambda,z)` within its window and zero
+    outside, the product over members is :math:`\prod_i c_i(\lambda,z)` throughout the intersection---still
+    independent of age---and zero outside it, since at least one factor vanishes there. Note that "sharp" means
+    independent of age within the window, *not* equal to unity, so members with differing multipliers still compose to
+    a sharp window; that is precisely why a wavelength-dependent but age-independent member such as
+    :galacticus-class:`stellarPopulationSpectraPostprocessorInoue2014` cancels when two chains differing only in an
+    age window are divided.
+
+    The test is sufficient but not necessary, and so is conservative. A tapering member whose taper lies entirely
+    outside the intersection contributes only its flat part, and the product is then sharp despite this method
+    reporting otherwise---for example
+    :galacticus-class:`stellarPopulationSpectraPostprocessorBirthCloudsLacey2016` combined with a
+    :galacticus-class:`stellarPopulationSpectraPostprocessorRecent` whose limit is below one birth cloud lifetime.
+    Erring this way causes a consumer to decline to split a luminosity it could in fact have split, rather than to
+    split one it should not have.
+    !!}
+    implicit none
+    class(stellarPopulationSpectraPostprocessorSequence), intent(inout) :: self
+    type (postprocessorList                            ), pointer       :: postprocessor_
+
+    ageWindowIsSharp =  .true.
+    postprocessor_   => self%postprocessors
+    do while (associated(postprocessor_))
+       if (.not.postprocessor_%postprocessor_%ageWindowIsSharp()) then
+          ageWindowIsSharp=.false.
+          return
+       end if
+       postprocessor_ => postprocessor_%next
+    end do
+    return
+  end function sequenceAgeWindowIsSharp

--- a/source/stellar_populations/spectra/postprocess/unescaped.F90
+++ b/source/stellar_populations/spectra/postprocess/unescaped.F90
@@ -36,6 +36,7 @@
      double precision :: timescale
    contains
      procedure :: multiplier          => unescapedMultiplier
+     procedure :: ageWindowIsSharp    => unescapedAgeWindowIsSharp
      procedure :: isRedshiftDependent => unescapedIsRedshiftDependent
   end type stellarPopulationSpectraPostprocessorUnescaped
 
@@ -115,3 +116,16 @@ contains
     isRedshiftDependent=.false.
     return
   end function unescapedIsRedshiftDependent
+
+  logical function unescapedAgeWindowIsSharp(self) result(ageWindowIsSharp)
+    !!{RST
+    Return false: the multiplier decays exponentially with age and is never exactly zero, so this chain can not be
+    used to define an age bin for decomposition.
+    !!}
+    implicit none
+    class(stellarPopulationSpectraPostprocessorUnescaped), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    ageWindowIsSharp=.false.
+    return
+  end function unescapedAgeWindowIsSharp

--- a/source/tests/dust/extinction_curves.F90
+++ b/source/tests/dust/extinction_curves.F90
@@ -1,0 +1,187 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!!{RST
+Contains a program to test dust extinction curves.
+!!}
+
+program Test_Dust_Extinction_Curves
+  !!{RST
+  Tests the ``dustExtinctionCurve`` class against the ``stellarSpectraDustAttenuation`` implementations which it
+  replaces.
+
+  The old class returned ``vBandAttenuation`` multiplied by the shape of the extinction curve, so with a unit
+  ``vBandAttenuation`` it returned exactly the quantity the new class returns from ``attenuationRelative``. Every
+  curve must therefore agree to round-off, which is what pins the ports as faithful.
+  !!}
+  use :: Display                          , only : displayVerbositySet                      , verbosityLevelStandard
+  use :: Dust_Extinction_Curves           , only : dustExtinctionCurveCalzetti2000          , dustExtinctionCurveCardelli1989          , dustExtinctionCurveGordon2003               , dustExtinctionCurveNoll2009              , &
+       &                                           dustExtinctionCurvePowerLaw              , dustExtinctionCurvePrevotBouchet         , dustExtinctionCurveWittGordon2000           , gordon2003SampleLMC                      , &
+       &                                           gordon2003SampleSMCBar                   , wavelengthVBand                          , wittGordon2000ModelMilkyWayShellTau3        , wittGordon2000ModelSMCShellTau3
+  ! Both modules declare enumerations of the same name for the Gordon et al. samples and the Witt & Gordon models --
+  ! they are distinct types in distinct modules. Rename the old module's on import so that each constructor is handed
+  ! the enumeration belonging to its own module. The collision disappears when the old class is retired.
+  use :: Stellar_Spectra_Dust_Attenuations, only : stellarSpectraDustAttenuationCalzetti2000   , stellarSpectraDustAttenuationCardelli1989          , stellarSpectraDustAttenuationCharlotFall2000, stellarSpectraDustAttenuationGordon2003, &
+       &                                           stellarSpectraDustAttenuationPrevotBouchet  , stellarSpectraDustAttenuationWittGordon2000        , &
+       &                                           oldGordon2003SampleSMCBar=>gordon2003SampleSMCBar                                                , oldGordon2003SampleLMC=>gordon2003SampleLMC , &
+       &                                           oldWittGordon2000ModelMilkyWay=>wittGordon2000ModelMilkyWayShellTau3                             , oldWittGordon2000ModelSMC=>wittGordon2000ModelSMCShellTau3
+  use :: Unit_Tests                       , only : Assert                                   , Unit_Tests_Begin_Group                    , Unit_Tests_End_Group       , Unit_Tests_Finish
+  implicit none
+  type            (dustExtinctionCurveCalzetti2000             )               :: curveCalzetti2000
+  type            (dustExtinctionCurveCardelli1989             )               :: curveCardelli1989
+  type            (dustExtinctionCurvePowerLaw                 )               :: curvePowerLaw
+  type            (dustExtinctionCurveGordon2003               )               :: curveGordon2003SMC   , curveGordon2003LMC
+  type            (dustExtinctionCurvePrevotBouchet            )               :: curvePrevotBouchet
+  type            (dustExtinctionCurveWittGordon2000           )               :: curveWittGordon2000MW, curveWittGordon2000SMC
+  type            (dustExtinctionCurveNoll2009                 )               :: curveNoll2009Plain   , curveNoll2009Bump
+  type            (stellarSpectraDustAttenuationCalzetti2000   )               :: oldCalzetti2000
+  type            (stellarSpectraDustAttenuationCardelli1989   )               :: oldCardelli1989
+  type            (stellarSpectraDustAttenuationCharlotFall2000)               :: oldCharlotFall2000
+  type            (stellarSpectraDustAttenuationGordon2003     )               :: oldGordon2003SMC     , oldGordon2003LMC
+  type            (stellarSpectraDustAttenuationPrevotBouchet  )               :: oldPrevotBouchet
+  type            (stellarSpectraDustAttenuationWittGordon2000 )               :: oldWittGordon2000MW  , oldWittGordon2000SMC
+  ! Wavelengths spanning the ultraviolet to the near-infrared, in Angstroms, plus points outside the fitted ranges.
+  double precision                                              , dimension(9) :: wavelengths      =[1.0d3,1.5d3,2.5d3,3.5d3,wavelengthVBand,7.0d3,1.0d4,2.0d4,3.0d4]
+  double precision                                                             :: new                  , old
+  double precision                                                             :: excessBump           , excessWing
+  integer                                                                      :: i
+  character       (len=32                                      )               :: label
+
+  ! Set verbosity level.
+  call displayVerbositySet(verbosityLevelStandard)
+
+  ! Begin unit tests.
+  call Unit_Tests_Begin_Group("Dust extinction curves")
+
+  ! Every curve must be normalized to approximately unity in the V-band. The empirically fit curves are not exactly
+  ! unity at the Buser V effective wavelength: each anchors its own normalization at a slightly different nominal
+  ! wavelength (Cardelli et al. at x=1.82 inverse microns, i.e. 0.5495 microns) and the fitting functions do not
+  ! evaluate to exactly one even there. The residual is a few parts in a thousand, and is deliberately not removed --
+  ! see the class description -- so a loose tolerance here is checking normalization, not fit accuracy.
+  call Unit_Tests_Begin_Group("normalization in the V-band")
+  curveCalzetti2000=dustExtinctionCurveCalzetti2000(     )
+  curveCardelli1989=dustExtinctionCurveCardelli1989(3.1d0)
+  curvePowerLaw    =dustExtinctionCurvePowerLaw    (0.7d0)
+  call Assert("calzetti2000",curveCalzetti2000%attenuationRelative(wavelengthVBand),1.0d0,relTol=3.0d-3)
+  call Assert("cardelli1989",curveCardelli1989%attenuationRelative(wavelengthVBand),1.0d0,relTol=3.0d-3)
+  ! The power law is exactly unity by construction.
+  call Assert("powerLaw"    ,curvePowerLaw    %attenuationRelative(wavelengthVBand),1.0d0,relTol=1.0d-12)
+  ! The tabulated curves normalize by their own interpolated V-band value, so they are exactly unity there.
+  curveGordon2003SMC   =dustExtinctionCurveGordon2003    (gordon2003SampleSMCBar              )
+  curvePrevotBouchet   =dustExtinctionCurvePrevotBouchet (2.7d0                               )
+  curveWittGordon2000MW=dustExtinctionCurveWittGordon2000(wittGordon2000ModelMilkyWayShellTau3)
+  call Assert("gordon2003"    ,curveGordon2003SMC   %attenuationRelative(wavelengthVBand),1.0d0,relTol=1.0d-12)
+  call Assert("prevotBouchet" ,curvePrevotBouchet   %attenuationRelative(wavelengthVBand),1.0d0,relTol=1.0d-12)
+  call Assert("wittGordon2000",curveWittGordon2000MW%attenuationRelative(wavelengthVBand),1.0d0,relTol=1.0d-12)
+  call Unit_Tests_End_Group()
+
+  ! Each port must reproduce the class it replaces, evaluated with a unit V-band attenuation.
+  call Unit_Tests_Begin_Group("agreement with stellarSpectraDustAttenuation")
+  oldCalzetti2000   =stellarSpectraDustAttenuationCalzetti2000   (                        )
+  oldCardelli1989   =stellarSpectraDustAttenuationCardelli1989   (3.1d0                   )
+  ! The Charlot & Fall class is a power law in wavelength; with the birth cloud optical depth equal to zero and an age
+  ! beyond the birth cloud lifetime it reduces to the bare power-law curve.
+  oldCharlotFall2000=stellarSpectraDustAttenuationCharlotFall2000(0.7d0,1.0d-2,1.0d0,1.0d0)
+  curveGordon2003LMC    =dustExtinctionCurveGordon2003              (gordon2003SampleLMC            )
+  curveWittGordon2000SMC=dustExtinctionCurveWittGordon2000          (wittGordon2000ModelSMCShellTau3)
+  oldGordon2003SMC      =stellarSpectraDustAttenuationGordon2003    (oldGordon2003SampleSMCBar      )
+  oldGordon2003LMC      =stellarSpectraDustAttenuationGordon2003    (oldGordon2003SampleLMC         )
+  oldPrevotBouchet      =stellarSpectraDustAttenuationPrevotBouchet (2.7d0                          )
+  oldWittGordon2000MW   =stellarSpectraDustAttenuationWittGordon2000(oldWittGordon2000ModelMilkyWay )
+  oldWittGordon2000SMC  =stellarSpectraDustAttenuationWittGordon2000(oldWittGordon2000ModelSMC      )
+  do i=1,size(wavelengths)
+     write (label,'(a,f9.1,a)') "lambda=",wavelengths(i)," A"
+     new=curveCalzetti2000%attenuationRelative(wavelengths(i))
+     old=oldCalzetti2000  %attenuation        (wavelengths(i),1.0d0,1.0d0)
+     call Assert("calzetti2000 "//trim(label),new,old,absTol=1.0d-12)
+     new=curveCardelli1989%attenuationRelative(wavelengths(i))
+     old=oldCardelli1989  %attenuation        (wavelengths(i),1.0d0,1.0d0)
+     call Assert("cardelli1989 "//trim(label),new,old,absTol=1.0d-12)
+     new=curvePowerLaw    %attenuationRelative(wavelengths(i))
+     old=oldCharlotFall2000%attenuation       (wavelengths(i),1.0d0,1.0d0)
+     call Assert("powerLaw "    //trim(label),new,old,absTol=1.0d-12)
+     new=curveGordon2003SMC   %attenuationRelative(wavelengths(i))
+     old=oldGordon2003SMC     %attenuation        (wavelengths(i),1.0d0,1.0d0)
+     call Assert("gordon2003 SMCBar "        //trim(label),new,old,absTol=1.0d-12)
+     new=curveGordon2003LMC   %attenuationRelative(wavelengths(i))
+     old=oldGordon2003LMC     %attenuation        (wavelengths(i),1.0d0,1.0d0)
+     call Assert("gordon2003 LMC "           //trim(label),new,old,absTol=1.0d-12)
+     new=curvePrevotBouchet   %attenuationRelative(wavelengths(i))
+     old=oldPrevotBouchet     %attenuation        (wavelengths(i),1.0d0,1.0d0)
+     call Assert("prevotBouchet "            //trim(label),new,old,absTol=1.0d-12)
+     new=curveWittGordon2000MW%attenuationRelative(wavelengths(i))
+     old=oldWittGordon2000MW  %attenuation        (wavelengths(i),1.0d0,1.0d0)
+     call Assert("wittGordon2000 MilkyWay "  //trim(label),new,old,absTol=1.0d-12)
+     new=curveWittGordon2000SMC%attenuationRelative(wavelengths(i))
+     old=oldWittGordon2000SMC  %attenuation       (wavelengths(i),1.0d0,1.0d0)
+     call Assert("wittGordon2000 SMC "       //trim(label),new,old,absTol=1.0d-12)
+  end do
+  call Unit_Tests_End_Group()
+
+  ! With no bump and no slope modification, Noll et al. reduces exactly to Calzetti et al.; with a bump it must exceed
+  ! it near 2175A and match it far from the bump.
+  call Unit_Tests_Begin_Group("noll2009 reduces to calzetti2000")
+  curveNoll2009Plain=dustExtinctionCurveNoll2009(0.0d0,0.0d0)
+  curveNoll2009Bump =dustExtinctionCurveNoll2009(3.5d0,0.0d0)
+  do i=1,size(wavelengths)
+     write (label,'(a,f9.1,a)') "lambda=",wavelengths(i)," A"
+     call Assert("no bump, no slope "//trim(label),curveNoll2009Plain%attenuationRelative(wavelengths(i)),curveCalzetti2000%attenuationRelative(wavelengths(i)),absTol=1.0d-12)
+  end do
+  ! The Drude profile is a Lorentzian, so it has power-law wings: the bump is strongly peaked at 2175A but does not
+  ! vanish in the optical. Check that it dominates at the bump and is small -- but explicitly *not* zero -- far away.
+  excessBump =+curveNoll2009Bump %attenuationRelative(2175.0d0) &
+       &      /curveCalzetti2000 %attenuationRelative(2175.0d0) &
+       &      -1.0d0
+  excessWing =+curveNoll2009Bump %attenuationRelative(7000.0d0) &
+       &      /curveCalzetti2000 %attenuationRelative(7000.0d0) &
+       &      -1.0d0
+  call Assert("bump dominates at 2175A"        ,excessBump > 2.0d-1                                     ,.true.)
+  call Assert("wing present but small at 7000A",excessWing > 0.0d0             .and. excessWing < 1.0d-2,.true.)
+  call Assert("wing far weaker than the bump " ,excessWing < 1.0d-1*excessBump                          ,.true.)
+  call Unit_Tests_End_Group()
+
+  ! Curves fit over a limited range must report that range, and must return zero outside it.
+  call Unit_Tests_Begin_Group("wavelength ranges")
+  call assertRange(curveCalzetti2000%attenuationRelative(1.0d3),"calzetti2000 below range")
+  call assertRange(curveCalzetti2000%attenuationRelative(3.0d4),"calzetti2000 above range")
+  call assertRange(curveCardelli1989%attenuationRelative(1.0d3),"cardelli1989 below range")
+  call assertRange(curveCardelli1989%attenuationRelative(4.0d4),"cardelli1989 above range")
+  call Unit_Tests_End_Group()
+
+  ! End unit tests.
+  call Unit_Tests_End_Group()
+  call Unit_Tests_Finish()
+
+contains
+
+  subroutine assertRange(value,label)
+    !!{RST
+    Assert that a curve returns zero outside of the range over which it is fit.
+    !!}
+    implicit none
+    double precision       , intent(in   ) :: value
+    character       (len=*), intent(in   ) :: label
+
+    call Assert(label,value,0.0d0,absTol=1.0d-12)
+    return
+  end subroutine assertRange
+
+end program Test_Dust_Extinction_Curves

--- a/source/tests/dust/extinction_curves.F90
+++ b/source/tests/dust/extinction_curves.F90
@@ -79,7 +79,9 @@ program Test_Dust_Extinction_Curves
   call Unit_Tests_Begin_Group("normalization in the V-band")
   curveCalzetti2000=dustExtinctionCurveCalzetti2000(     )
   curveCardelli1989=dustExtinctionCurveCardelli1989(3.1d0)
-  curvePowerLaw    =dustExtinctionCurvePowerLaw    (0.7d0)
+  ! The reference wavelength is given explicitly: the curve is compared below against
+  ! `stellarSpectraDustAttenuationCharlotFall2000`, which normalizes at the Buser V effective wavelength.
+  curvePowerLaw    =dustExtinctionCurvePowerLaw    (0.7d0,wavelengthVBand)
   call Assert("calzetti2000",curveCalzetti2000%attenuationRelative(wavelengthVBand),1.0d0,relTol=3.0d-3)
   call Assert("cardelli1989",curveCardelli1989%attenuationRelative(wavelengthVBand),1.0d0,relTol=3.0d-3)
   ! The power law is exactly unity by construction.

--- a/testSuite/parameters/dustAttenuationParity.xml
+++ b/testSuite/parameters/dustAttenuationParity.xml
@@ -1,0 +1,370 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Default parameters for Galacticus v0.9.4 -->
+
+<!-- 30-October-2011                          -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="f62df0c3b1d868c052eedef79c20488955a738c9" time="2026-08-12T22:48:39"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard">
+    <starveSatellites value="false"/>
+  </componentHotHalo>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <ratioAngularMomentumScaleRadius value="0.5"/>
+    <efficiencyEnergeticOutflow value="1.0e-2"/>
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeSeeds value="random"/>
+  <mergerTreeConstructor value="build"/>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="sampledDistributionUniform">
+    <massTreeMinimum value="1.0e10"/>
+    <massTreeMaximum value="1.0e13"/>
+    <treesPerDecade value="2"/>
+  </mergerTreeBuildMasses>
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="gao2008"/>
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="simple">
+    <redshiftReionization value="10.5"/>
+    <velocitySuppressionReionization value="35.0"/>
+  </accretionHalo>
+
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="5.0"/>
+  </hotHaloOutflowReincorporation>
+  <hotHaloOutflowStripping value="standard">
+     <efficiency value="0.1"/>
+  </hotHaloOutflowStripping>
+  <coolingInfallTorque value="fixed">
+     <fractionLossAngularMomentum value="0.3"/>
+  </coolingInfallTorque>
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0"/>
+  </coolingTimeAvailable>
+  <circumgalacticMediumHeating value="AGNFeedback"/>
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <!-- Galactic structure solver options -->
+  <galacticStructureSolver value="equilibrium"/>
+  <darkMatterProfile value="adiabaticGnedin2004">
+    <A value="0.73"/>
+    <omega value="0.7"/>
+  </darkMatterProfile>
+  <!-- Star formation rate options -->
+  <starFormationRateDisks value="intgrtdSurfaceDensity"/>
+  <starFormationRateSurfaceDensityDisks value="krumholz2009">
+    <frequencyStarFormation value="0.385"/>
+    <clumpingFactorMolecularComplex value="5.000"/>
+    <molecularFractionFast value="true"/>
+  </starFormationRateSurfaceDensityDisks>
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.04"/>
+      <exponentVelocity value="2.0"/>
+      <timescaleMinimum value="0.001"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="instantaneous"/>
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+
+  <initialMassFunction value="chabrier2001"/>
+  <stellarPopulation value="standard">
+    <recycledFraction value="0.46"/>
+    <metalYield value="0.035"/>
+  </stellarPopulation>
+
+  <!-- AGN feedback options -->
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
+  <!-- Accretion disk properties -->
+  <accretionDisks value="switched">
+    <accretionRateThinDiskMaximum value="0.30"/>
+    <accretionRateThinDiskMinimum value="0.01"/>
+    <scaleADAFRadiativeEfficiency value="true"/>
+    <accretionDisksShakuraSunyaev value="shakuraSunyaev"/>
+    <accretionDisksADAF value="ADAF">
+      <efficiencyRadiationType value="thinDisk"/>
+      <adiabaticIndex value="1.444"/>
+      <energyOption value="pureADAF"/>
+      <efficiencyRadiation value="0.01"/>
+      <viscosityOption value="fit"/>
+    </accretionDisksADAF>
+  </accretionDisks>
+
+  <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+  </blackHoleAccretionRate>
+  <blackHoleBinaryMerger value="rezzolla2008"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="benson2005"/>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"/>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+    <nodeOperator value="starFormationSpheroids"/>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="250.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="100.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <!-- Bar instability in galactic disks -->
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="0.7"/>
+	<stabilityThresholdStellar value="1.1"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <!-- Black hole physics -->
+    <nodeOperator value="blackHolesSeed">
+      <blackHoleSeeds value="fixed">
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
+    </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <!-- CGM physics -->
+    <nodeOperator value="CGMAccretion">
+      <allowNegativeCGMMass value="true"/>
+      <angularMomentumAlwaysGrows value="false"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOutflowReincorporation">
+      <includeSatellites value="true"/>
+    </nodeOperator>
+    <nodeOperator value="CGMCoolingHeating">
+      <component value="disk"/>
+      <coolingFrom value="currentNode"/>
+      <excessHeatDrivesOutflow value="true"/>
+      <rateMaximumExpulsion value="1.0"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+
+  <!-- Dust attenuation parity test
+       Compares the `dustAttenuation` property extractor, applying `charlotFall2000` to per-component luminosities
+       decomposed by stellar population age, against `lmnstyStllrCF2000`, the class it replaces. Rest-frame filters
+       only: the old class evaluates its extinction curve at the observed filter wavelength without correcting to the
+       rest frame, so the two agree exactly only where those coincide.
+  -->
+
+  <outputTimes value="list">
+    <redshifts value="0.0"/>
+  </outputTimes>
+
+  <!-- Each luminosity is tracked twice: once unrestricted, once restricted to populations younger than the birth
+       cloud lifetime. Differencing the two isolates the light of old stars. -->
+  <luminosityFilter         value="SDSS_r  SDSS_r"/>
+  <luminosityType           value="rest    rest  "/>
+  <luminosityRedshift       value="0.0     0.0   "/>
+  <luminosityPostprocessSet value="default recent"/>
+
+  <stellarPopulationSpectraPostprocessorBuilder value="lookup">
+    <names value="default recent"/>
+    <stellarPopulationSpectraPostprocessor value="identity"/>
+    <stellarPopulationSpectraPostprocessor value="recent">
+      <timeLimit value="1.0e-2"/>
+    </stellarPopulationSpectraPostprocessor>
+  </stellarPopulationSpectraPostprocessorBuilder>
+
+  <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="lmnstyStllrCF2000">
+      <filterName                    value="SDSS_r"/>
+      <filterType                    value="rest"  />
+      <depthOpticalISMCoefficient    value="1.0"   />
+      <depthOpticalCloudsCoefficient value="1.0"   />
+      <wavelengthExponent            value="0.7"   />
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="dustAttenuation">
+      <outputUnattenuated value="true"/>
+      <outputSum          value="true"/>
+      <dustAttenuation value="charlotFall2000">
+        <coefficientBirthCloud value="1.0e0" />
+        <coefficientISM        value="1.0e0" />
+        <timescale             value="1.0e-2"/>
+        <exponent              value="0.7e0" />
+        <!-- The class being compared against normalizes its power law at a round 5500A rather than at the Buser V
+             effective wavelength, so match it here to isolate every other difference. -->
+        <wavelengthReference   value="5500.0"/>
+      </dustAttenuation>
+      <nodePropertyExtractor value="luminosityStellar">
+        <filterName        value="SDSS_r"        />
+        <filterType        value="rest"          />
+        <component         value="disk"          />
+        <postprocessChains value="default recent"/>
+      </nodePropertyExtractor>
+      <nodePropertyExtractor value="luminosityStellar">
+        <filterName        value="SDSS_r"        />
+        <filterType        value="rest"          />
+        <component         value="spheroid"      />
+        <postprocessChains value="default recent"/>
+      </nodePropertyExtractor>
+    </nodePropertyExtractor>
+  </nodePropertyExtractor>
+
+  <outputFileName value="testSuite/outputs/dustAttenuationParity.hdf5"/>
+
+</parameters>

--- a/testSuite/test-dust-attenuation-parity.py
+++ b/testSuite/test-dust-attenuation-parity.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Check that the dust attenuation framework reproduces the class it replaces.
+
+`nodePropertyExtractorDustAttenuation`, applying `charlotFall2000` to per-component stellar luminosities decomposed
+by stellar population age, must reproduce `nodePropertyExtractorLmnstyStllrCF2000` -- the class it is intended to
+retire -- when configured equivalently.
+
+Two configuration details make the comparison exact rather than approximate:
+
+* The old class normalizes its power-law extinction curve at a round 5500 A, whereas the framework normalizes at the
+  effective wavelength of the Buser V filter, as the stellar spectra classes do. The parameter file sets
+  `wavelengthReference` to 5500 A so that this known difference is removed; leaving it at the default shifts
+  luminosities by a few parts in ten thousand.
+* Rest-frame filters only. The old class evaluates its extinction curve at the observed filter wavelength without
+  correcting to the rest frame, so for observed-frame filters the two differ by construction -- the framework being
+  the correct one.
+
+Also checked: `outputSum` must equal the sum of the per-component attenuated luminosities exactly, since dust has to
+be applied component by component and the total recovered afterwards.
+
+Andrew Benson, with assistance from Claude.
+"""
+import os
+import subprocess
+import sys
+
+import h5py
+import numpy as np
+
+# Tolerance on the comparison. The two codes are algebraically identical once the reference wavelength is matched,
+# but derive the optical-depth-to-magnitudes conversion through different expressions whose values differ in the last
+# place, so agreement is to a few ulp rather than exactly zero.
+TOLERANCE = 1.0e-12
+
+# This script runs with the working directory set to testSuite/, while the model is run from the repository root, so
+# the two need different paths to the same file. Getting this wrong would leave a stale output in place and let a
+# failed model run be scored against the previous run's results.
+parameterFile = "testSuite/parameters/dustAttenuationParity.xml"
+outputFile    = "testSuite/outputs/dustAttenuationParity.hdf5"
+outputPath    = os.path.join("..", outputFile)
+
+os.makedirs("outputs", exist_ok=True)
+if os.path.exists(outputPath):
+    os.remove(outputPath)
+
+status = subprocess.run(f"cd ..; ./Galacticus.exe {parameterFile}", shell=True, capture_output=True)
+log = status.stdout.decode() + status.stderr.decode()
+if status.returncode != 0 or not os.path.exists(outputPath):
+    print("FAILED: the dust attenuation parity model did not run")
+    print(log[-2000:])
+    sys.exit(0)
+
+with h5py.File(outputPath, "r") as f:
+    nodes = f["Outputs/Output1/nodeData"]
+    try:
+        old      = nodes["luminosityStellar:SDSS_r:rest:dustCharlotFall2000"][:]
+        disk     = nodes["luminosityStellar:SDSS_r:rest:disk:dustAttenuated:charlotFall2000"][:]
+        spheroid = nodes["luminosityStellar:SDSS_r:rest:spheroid:dustAttenuated:charlotFall2000"][:]
+        total    = nodes["luminosityTotal:dustAttenuated:charlotFall2000"][:]
+    except KeyError as e:
+        print(f"FAILED: expected dataset missing from the output: {e}")
+        sys.exit(0)
+
+new       = disk + spheroid
+comparable = (old > 0.0) & (new > 0.0)
+countGalaxies = int(comparable.sum())
+
+if countGalaxies == 0:
+    print("FAILED: no galaxy has a non-zero luminosity in both the old and new extractors")
+    sys.exit(0)
+
+# The summed output must equal the sum of its parts exactly -- it is formed from the same numbers.
+differenceSum = float(np.nanmax(np.abs(total - new)))
+if differenceSum > 0.0:
+    print(f"FAILED: outputSum differs from the sum of the per-component luminosities by {differenceSum:.3e}")
+    sys.exit(0)
+print(f"SUCCESS: outputSum equals the sum of the per-component attenuated luminosities exactly")
+
+difference = np.abs(new[comparable] - old[comparable]) / old[comparable]
+worst      = float(difference.max())
+if worst > TOLERANCE:
+    print(f"FAILED: dust attenuation framework differs from lmnstyStllrCF2000 by up to {worst:.3e}"
+          f" (tolerance {TOLERANCE:.1e}) over {countGalaxies} galaxies")
+    sys.exit(0)
+
+print(f"SUCCESS: dust attenuation framework reproduces lmnstyStllrCF2000 to {worst:.3e}"
+      f" over {countGalaxies} galaxies")
+sys.exit(0)


### PR DESCRIPTION
## Summary

Phase 1 of the dust attenuation framework of #893, following the Phase 0 groundwork in #1337. This is the first point
at which dust attenuation can actually be applied to an output, and it reproduces the class it is intended to retire
exactly.

The framework separates three things the existing code conflates:

* **`dustExtinctionCurve`** — the wavelength dependence of dust opacity, normalized to the :math:`V`-band, carrying no
  information about how much dust is present. `powerLaw`, `calzetti2000`, `cardelli1989`, `gordon2003`,
  `prevotBouchet`, `wittGordon2000`, and `noll2009` (Calzetti with a variable 2175 Å bump and adjustable slope, the
  flexible curve SED fitting generally wants).
* **`dustAttenuation`** — node properties to a transmission factor. `zero`, `screenFixed`,
  `screenSurfaceDensityMetals`, `birthCloud`, `sequence`, `mixedSlab`, and `charlotFall2000`.
* **`nodePropertyExtractorDustAttenuation`** — applies an attenuator to the luminosity of any extractor that can
  decompose its output.

### Design points worth review

**Transmission, not magnitudes.** The class being replaced returned a quantity read as magnitudes by one caller
(`SED_fit.F90`) and as an optical depth by another (`Panuzzo2003.F90`); it worked only because every implementation
happened to be proportional to `vBandAttenuation`. A transmission factor is unambiguous, composes by multiplication,
and stays well defined for models whose result is not proportional to any optical depth — which is what the atlas and
compendium models of Phase 3 will be.

**Negotiated decomposition.** An attenuator states the age bin boundaries it distinguishes and which other axes it
depends on, and the producer splits its luminosity no more finely than that. An age-independent screen on a broad-band
luminosity gets one parcel per component rather than one per (wavelength, age, metallicity).

**Age windows are read from the postprocessors, not declared.** `L(old) = L(default) − L(recent)` is valid only where
the chain's age window is *sharp*, and two postprocessors are not: `birthCloudsLacey2016` tapers linearly between one
and two birth cloud lifetimes, and `unescaped` decays exponentially and is never zero. Both now report
`ageWindowIsSharp() = .false.`, and `decompose` refuses them. Without that check the light would be mis-apportioned
between age bins with no error raised.

**`decompose` refuses rather than approximates.** A component summed over all components, a chain that is not sharp or
admits no ages, chains neither cumulative nor disjoint, no chain reaching the oldest populations, or a requested age
boundary no chain provides — each is an error naming the problem.

**De-duplication.** `screenSurfaceDensityMetals` is now the single home of the Savage & Mathis normalization
previously copied into `CharlotFall2000.F90`, `Panuzzo2003.F90` and implicitly `SED_fit.F90`; the V-band effective
wavelength, previously in three files, lives in `Dust_Extinction_Curves`; and `opticalDepthToMagnitudes` is taken from
`Numerical_Constants_Astronomical` rather than re-derived.

### One deliberate change in results

`lmnstyStllrCF2000` normalizes its power-law curve at a round **5500 Å**, while the `stellarSpectraDustAttenuation`
classes — and this framework — use the effective wavelength of the Buser :math:`V` filter, **5504.61 Å**. The old code
disagreed with itself. The framework follows the spectra classes, which shifts luminosities from the old extractor by
a few parts in ten thousand. `powerLaw` gains a `wavelengthReference` parameter so published results can be
reproduced, and the parity test sets it to 5500 Å to isolate every other difference.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test

```bash
export GALACTICUS_EXEC_PATH=`pwd`
make -jN Galacticus.exe tests.dust.extinction_curves.exe tests.dust.attenuation_descriptors.exe
./tests.dust.extinction_curves.exe
cd testSuite && python3 test-dust-attenuation-parity.py
```

## Checklist
- [x] I ran relevant tests (or explain why not):
  - `testSuite/test-dust-attenuation-parity.py` — **maximum relative difference 0.000e+00** against
    `lmnstyStllrCF2000`, and `outputSum` equals the sum of the per-component attenuated luminosities exactly. With the
    birth cloud term disabled the residual is 2.0e-16, precisely the one unit in the last place by which
    `opticalDepthToMagnitudes` differs from the expression the old classes derived locally.
  - `tests.dust.extinction_curves.exe` — 94/94, including every ported curve against the class it replaces at 1e-12
    across nine wavelengths
  - `tests.dust.attenuation_descriptors.exe` — 28/28; `tests.interpolation.multiD.exe` — 27/27
  - full build; `quickTest.xml`; `python -m pytest` — 1047 passed, 1 skipped
  - **Unrelated failure, fixed elsewhere:** `test_resolve_datasets_ref_bleeding` fails both locally and in the
    `Test-Preprocessor` job. It is not caused by this branch, which touches nothing under
    `python/galacticus_launcher/`: the test resolves the datasets pin over the network, so whether it passes depends
    on the environment rather than on the source. #1409 stubs that lookup and fixes it.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

## Limitations

* Only scalar and tuple children can be attenuated. Array children — spectral energy distributions — are rejected with
  a message saying so; the convention for flattening a rank-two output into the parcel list is better settled against a
  real case in Phase 2 than guessed at now.
* A child whose component the attenuator refuses is rejected on first extraction rather than at construction, because
  the component is not visible until the child decomposes.
* The parity comparison covers three galaxies with non-zero luminosity, spanning effective optical depths of 0.11 to
  0.21. Exact agreement is strong evidence, but the range exercised is narrow.

Part of #893.

