### PR TITLE
Report what failed to allocate, and how large it was

### DIFF
--- a/source/error/_module.F90
+++ b/source/error/_module.F90
@@ -33,18 +33,28 @@ module Error
           &                                    GSL_eUndrFlw  , GSL_eZeroDiv, GSL_eMaxIter, GSL_eRound
   implicit none
   private
-  public :: Error_Report               , Error_Handler_Register    , &
-       &    Component_List             , GSL_Error_Handler_Abort_On, &
-       &    GSL_Error_Handler_Abort_Off, GSL_Error_Status          , &
-       &    Warn                       , Error_Wait_Set            , &
-       &    GSL_Error_Details          , signalHandlerDeregister   , &
-       &    signalHandlerRegister      , signalHandlerInterface    , &
-       &    GSL_Error_Handler_Aborting
+  public :: Error_Report               , Error_Handler_Register         , &
+       &    Component_List             , GSL_Error_Handler_Abort_On     , &
+       &    GSL_Error_Handler_Abort_Off, GSL_Error_Status               , &
+       &    Warn                       , Error_Wait_Set                 , &
+       &    GSL_Error_Details          , signalHandlerDeregister        , &
+       &    signalHandlerRegister      , signalHandlerInterface         , &
+       &    GSL_Error_Handler_Aborting , Error_Report_Allocation_Failure 
 
   interface Error_Report
      module procedure Error_Report_Char
      module procedure Error_Report_VarStr
   end interface Error_Report
+
+  interface Error_Report_Allocation_Failure
+     !!{RST
+        Report a failure to allocate memory. The element count is accepted as either a default integer or
+        a ``c_size_t``, since the counts which size such allocations are read from files and so are of
+        both kinds.
+     !!}
+     module procedure Error_Report_Allocation_Failure_Integer
+     module procedure Error_Report_Allocation_Failure_SizeT
+  end interface Error_Report_Allocation_Failure
 
   interface Warn
      module procedure Warn_Char
@@ -120,6 +130,55 @@ module Error
   !$omp threadprivate(signalHandlers,signalHandlerLast,inErrorHandling)
   
 contains
+
+  subroutine Error_Report_Allocation_Failure_Integer(name,elementCount,location)
+    !!{RST
+    Report a failure to allocate memory, for an element count given as a default integer.
+    !!}
+    use, intrinsic :: ISO_C_Binding, only : c_size_t
+    implicit none
+    character(len=*), intent(in   ) :: name        , location
+    integer         , intent(in   ) :: elementCount
+
+    call Error_Report_Allocation_Failure_SizeT(name,int(elementCount,kind=c_size_t),location)
+    return
+  end subroutine Error_Report_Allocation_Failure_Integer
+
+  subroutine Error_Report_Allocation_Failure_SizeT(name,elementCount,location)
+    !!{RST
+    Report a failure to allocate memory.
+
+    An ``allocate`` which fails without ``stat=`` aborts the process with no indication of what was
+    being allocated, which is of no help at all in deciding what to do about it. This reports the
+    name of the object and the number of elements requested.
+
+    It exists so that the cost at each call site is a scalar integer and one branch: the message is
+    built here, on the failing branch, and not in the caller where the machinery to build it would be
+    constructed and destroyed on every call including the overwhelming majority which succeed.
+    !!}
+    use            :: Display      , only : displayGreen, displayReset
+    use, intrinsic :: ISO_C_Binding, only : c_size_t
+    implicit none
+    character(len=*        ), intent(in   )              :: name        , location
+    integer  (c_size_t     ), intent(in   )              :: elementCount
+    character(len=32       )                             :: countLabel
+    character(len=:        ), allocatable                :: message
+
+    ! The message is assembled before being reported, rather than being built in the call to
+    ! `Error_Report`, because the location is supplied by the caller here: a call which builds its
+    ! message from literals is required to append `{introspection:location}` itself, and check 5 of
+    ! `staticAnalyzer.py` enforces that.
+    write (countLabel,'(i0)') elementCount
+    message='unable to allocate `'//name//'` ('//trim(countLabel)//' elements)'//char(10)        // &
+         &  displayGreen()//'HELP:'//displayReset()                                              // &
+         &  ' the run needs more memory than is available to it. Reduce the size of the problem' // &
+         &  ' (for example, the number of trees or particles being processed), reduce the number'// &
+         &  ' of OpenMP threads, since each holds its own copy of much of the state, or run'     // &
+         &  ' where more memory is available'                                                    // &
+         &  location
+    call Error_Report(message)
+    return
+  end subroutine Error_Report_Allocation_Failure_SizeT
 
   subroutine Error_Report_VarStr(message)
     !!{RST

--- a/source/merger_trees/construct/read/importer/galacticus.F90
+++ b/source/merger_trees/construct/read/importer/galacticus.F90
@@ -689,7 +689,7 @@ contains
     !!{RST
     Read the tree indices.
     !!}
-    use :: Error                           , only : Error_Report
+    use :: Error                           , only : Error_Report, Error_Report_Allocation_Failure
     use :: HDF5                            , only : HSIZE_T
     use :: HDF5_Access                     , only : hdf5Access
     use :: Numerical_Constants_Astronomical, only : gigaYear
@@ -698,13 +698,13 @@ contains
     class           (mergerTreeImporterGalacticus), intent(inout)             :: self
     type            (hdf5Group                   )                            :: treeIndexGroup
     integer         (kind=kind_int8              ), allocatable, dimension(:) :: descendantIndex
-    double precision                              , allocatable, dimension(:) :: nodeMass           , treeMass    , &
-         &                                                                       nodeTime           , treeTime
-    integer         (kind=HSIZE_T                )             , dimension(1) :: firstNodeIndex     , nodeCount
+    double precision                              , allocatable, dimension(:) :: nodeMass        , treeMass   , &
+         &                                                                       nodeTime        , treeTime
+    integer         (kind=HSIZE_T                )             , dimension(1) :: firstNodeIndex  , nodeCount
     integer         (kind=c_size_t               ), allocatable, dimension(:) :: sortOrder
-    integer                                                                   :: i
+    integer                                                                   :: i               , allocErr
     integer         (c_size_t                    )                            :: iNode
-    double precision                                                          :: massMinimum        , massMaximum
+    double precision                                                          :: massMinimum     , massMaximum
     logical                                                                   :: hasForestWeights
 
     if (self%forestIndicesRead) return
@@ -726,9 +726,12 @@ contains
           firstNodeIndex(1)=self%firstNodes(i)+1
           nodeCount     (1)=self%nodeCounts(i)
           ! Allocate the nodes array.
-          allocate(descendantIndex(nodeCount(1)))
-          allocate(nodeMass       (nodeCount(1)))
-          allocate(nodeTime       (nodeCount(1)))
+          allocate(descendantIndex(nodeCount(1)),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('descendantIndex',nodeCount(1),{introspection:location})
+          allocate(nodeMass       (nodeCount(1)),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('nodeMass'       ,nodeCount(1),{introspection:location})
+          allocate(nodeTime       (nodeCount(1)),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('nodeTime'       ,nodeCount(1),{introspection:location})
           call self%forestHalos%readDatasetStatic("descendantIndex",descendantIndex,firstNodeIndex,nodeCount)
           call self%forestHalos%readDatasetStatic("nodeMass"       ,nodeMass       ,firstNodeIndex,nodeCount)
           if      (self%forestHalos%hasDataset("time"           )) then
@@ -1022,10 +1025,10 @@ contains
     !!{RST
     Import the :math:`i^\mathrm{th}` merger tree.
     !!}
-    use :: Error                           , only : Error_Report       , Warn
+    use :: Error                           , only : Error_Report    , Warn     , Error_Report_Allocation_Failure
     use :: HDF5                            , only : hsize_t
     use :: HDF5_Access                     , only : hdf5Access
-    use :: Numerical_Constants_Astronomical, only : gigaYear           , massSolar      , megaParsec
+    use :: Numerical_Constants_Astronomical, only : gigaYear        , massSolar, megaParsec
     use :: Numerical_Constants_Prefixes    , only : kilo
     use :: Vectors                         , only : Vector_Magnitude
     implicit none
@@ -1041,6 +1044,7 @@ contains
     integer         (hsize_t                     )                            , dimension(1  ) :: firstNodeIndex         , nodeCount
     integer         (c_size_t                    )                                             :: iNode
     integer         (c_size_t                    )               , allocatable, dimension(:  ) :: nodeSubsetOffset
+    integer                                                                                    :: allocErr
     double precision                                             , allocatable, dimension(:,:) :: angularMomentum3D      , position             , &
          &                                                                                        velocity               , spin3D
     double precision                                             , allocatable, dimension(:  ) :: namedReal
@@ -1066,9 +1070,11 @@ contains
     end if
     ! Allocate the nodes array.
     if (present(structureOnly).and.structureOnly) then
-       allocate(nodeDataMinimal    :: nodes(nodeCount(1)))
+       allocate(nodeDataMinimal    :: nodes(nodeCount(1)),stat=allocErr)
+       if (allocErr /= 0) call Error_Report_Allocation_Failure('nodes',nodeCount(1),{introspection:location})
     else
-       allocate(nodeDataGalacticus :: nodes(nodeCount(1)))
+       allocate(nodeDataGalacticus :: nodes(nodeCount(1)),stat=allocErr)
+       if (allocErr /= 0) call Error_Report_Allocation_Failure('nodes',nodeCount(1),{introspection:location})
     end if
     !$ call hdf5Access%set()
     if (useNodeSubset) then

--- a/source/nBody/import/GadgetBinary.F90
+++ b/source/nBody/import/GadgetBinary.F90
@@ -188,20 +188,22 @@ contains
     !!}
     use, intrinsic :: ISO_Fortran_Env                 , only : int32
     use, intrinsic :: ISO_C_Binding                   , only : c_size_t
-    use            :: Display                         , only : displayIndent                 , displayUnindent               , verbosityLevelStandard
+    use            :: Display                         , only : displayIndent                  , displayUnindent               , verbosityLevelStandard
     use            :: Cosmology_Parameters            , only : hubbleUnitsLittleH
     use            :: File_Utilities                  , only : File_Exists
-    use            :: Dictionaries                    , only : rank1IntegerSizeTPtrDictionary, rank2IntegerSizeTPtrDictionary, rank1DoublePtrDictionary    , rank2DoublePtrDictionary, &
-         &                                                     doubleDictionary              , varyingStringDictionary       , integerSizeTDictionary      , genericDictionary
-    use            :: Numerical_Constants_Astronomical, only : massSolar               , megaParsec
+    use            :: Dictionaries                    , only : rank1IntegerSizeTPtrDictionary , rank2IntegerSizeTPtrDictionary, rank1DoublePtrDictionary    , rank2DoublePtrDictionary, &
+         &                                                     doubleDictionary               , varyingStringDictionary       , integerSizeTDictionary      , genericDictionary
+    use            :: Numerical_Constants_Astronomical, only : massSolar                      , megaParsec
     use            :: Numerical_Constants_Prefixes    , only : kilo
+    use            :: Error                           , only : Error_Report_Allocation_Failure
     implicit none
     class           (nbodyImporterGadgetBinary), intent(inout)                                 :: self
     type            (nBodyData                ), intent(  out), allocatable  , dimension( :  ) :: simulations
     integer                                                                  , dimension( 6  ) :: numberParticleType     , numberParticleTypeFile
     integer                                                                                    :: numberParticleTotal    , numberParticleTotalFile, &
          &                                                                                        numberParticleTotalRead, numberParticleStartRead, &
-         &                                                                                        numberMassStartRead    , numberTypeAssigned
+         &                                                                                        numberMassStartRead    , numberTypeAssigned     , &
+         &                                                                                        allocErr
     real                                                      , allocatable  , dimension( :,:) :: position               , velocity
     double precision                                          , pointer      , dimension( :,:) :: position_              , velocity_
     double precision                                                         , dimension( 6  ) :: massParticleType
@@ -270,13 +272,19 @@ contains
              massesDiffer       =    massParticleType(self%particleType+1) == 0.0d0 
           end if
           readMasses=massesDiffer .and. any(massParticleType == 0.0d0)
-          allocate       (position_(3,numberParticleTotal))
-          allocate       (velocity_(3,numberParticleTotal))
-          allocate       (id_      (  numberParticleTotal))
-          if (     massesDiffer   )                         &
-               & allocate(mass_    (  numberParticleTotal))
+          allocate       (position_(3,numberParticleTotal),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('position_',3*numberParticleTotal,{introspection:location})
+          allocate       (velocity_(3,numberParticleTotal),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('velocity_',3*numberParticleTotal,{introspection:location})
+          allocate       (id_      (  numberParticleTotal),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('id_'      ,  numberParticleTotal,{introspection:location})
+          if (massesDiffer) then
+             allocate(mass_(  numberParticleTotal),stat=allocErr)
+             if (allocErr /= 0) call Error_Report_Allocation_Failure('mass_' ,  numberParticleTotal,{introspection:location})
+          end if
           if (self%setParticleType) then
-             allocate    (type_    (  numberParticleTotal))
+             allocate    (type_    (  numberParticleTotal),stat=allocErr)
+             if (allocErr /= 0) call Error_Report_Allocation_Failure('type_' ,  numberParticleTotal,{introspection:location})
           else
              allocate    (type_    (                    0))
           end if
@@ -292,11 +300,16 @@ contains
              numberParticleStartRead=0
           end if
        end if
-       allocate       (position(3,sum(numberParticleTypeFile                               )))
-       allocate       (velocity(3,sum(numberParticleTypeFile                               )))
-       allocate       (id      (  sum(numberParticleTypeFile                               )))
-       if (readMasses)                                                                         &
-            & allocate(mass    (  sum(numberParticleTypeFile,mask=massParticleType == 0.0d0)))
+       allocate       (position(3,sum(numberParticleTypeFile)),stat=allocErr)
+       if (allocErr /= 0) call Error_Report_Allocation_Failure('position',3*sum(numberParticleTypeFile                               ),{introspection:location})
+       allocate       (velocity(3,sum(numberParticleTypeFile)),stat=allocErr)
+       if (allocErr /= 0) call Error_Report_Allocation_Failure('velocity',3*sum(numberParticleTypeFile                               ),{introspection:location})
+       allocate       (id      (  sum(numberParticleTypeFile)),stat=allocErr)
+       if (allocErr /= 0) call Error_Report_Allocation_Failure('id'      ,  sum(numberParticleTypeFile                               ),{introspection:location})
+       if (readMasses) then
+          allocate(mass(  sum(numberParticleTypeFile,mask=massParticleType == 0.0d0)),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('mass' ,  sum(numberParticleTypeFile,mask=massParticleType == 0.0d0),{introspection:location})
+       end if
        read        (file) recordMarker,position,recordMarker
        read        (file) recordMarker,velocity,recordMarker
        read        (file) recordMarker,id      ,recordMarker

--- a/source/nBody/import/GadgetHDF5.F90
+++ b/source/nBody/import/GadgetHDF5.F90
@@ -180,10 +180,10 @@ contains
     Import data from a Gadget HDF5 file.
     !!}
     use :: Cosmology_Parameters            , only : hubbleUnitsLittleH
-    use :: Error                           , only : Error_Report
-    use :: Dictionaries                    , only : rank1IntegerSizeTPtrDictionary, rank2IntegerSizeTPtrDictionary, rank1DoublePtrDictionary, rank2DoublePtrDictionary, &
-         &                                          doubleDictionary              , varyingStringDictionary       , integerSizeTDictionary  , genericDictionary
-    use :: Numerical_Constants_Astronomical, only : massSolar               , megaParsec
+    use :: Error                           , only : Error_Report                  , Error_Report_Allocation_Failure
+    use :: Dictionaries                    , only : rank1IntegerSizeTPtrDictionary, rank2IntegerSizeTPtrDictionary , rank1DoublePtrDictionary, rank2DoublePtrDictionary, &
+         &                                          doubleDictionary              , varyingStringDictionary        , integerSizeTDictionary  , genericDictionary
+    use :: Numerical_Constants_Astronomical, only : massSolar                     , megaParsec
     use :: Numerical_Constants_Prefixes    , only : kilo
     implicit none
     class           (nbodyImporterGadgetHDF5), intent(inout)                              :: self
@@ -195,6 +195,7 @@ contains
     integer         (c_size_t               )               , pointer    , dimension(:,:) :: boundStatus
     integer         (c_size_t               )               , pointer    , dimension(:  ) :: particleID
     integer         (c_size_t               )                                             :: countParticles       , countBootstrapSample
+    integer                                                                               :: allocErr
     character       (len=9                  )                                             :: particleGroupName
     type            (hdf5Group              )                                             :: header
     type            (hdf5Dataset            )                                             :: dataset
@@ -233,9 +234,12 @@ contains
     ! the bound status of particles.
     dataset=simulations(1)%analysis%openDataset('ParticleIDs')
     countParticles=dataset%size(1)
-    allocate(particleID(  countParticles))
-    allocate(position  (3,countParticles))
-    allocate(velocity  (3,countParticles))
+    allocate(particleID(  countParticles),stat=allocErr)
+    if (allocErr /= 0) call Error_Report_Allocation_Failure('particleID',  countParticles,{introspection:location})
+    allocate(position  (3,countParticles),stat=allocErr)
+    if (allocErr /= 0) call Error_Report_Allocation_Failure('position'  ,3*countParticles,{introspection:location})
+    allocate(velocity  (3,countParticles),stat=allocErr)
+    if (allocErr /= 0) call Error_Report_Allocation_Failure('velocity'  ,3*countParticles,{introspection:location})
     call simulations(1)%analysis%readDatasetStatic('Coordinates',position  )
     call simulations(1)%analysis%readDatasetStatic('Velocities' ,velocity  )
     call simulations(1)%analysis%readDatasetStatic('ParticleIDs',particleID)
@@ -250,9 +254,12 @@ contains
     if (simulations(1)%analysis%hasDataset('selfBoundStatus')) then
        dataset=simulations(1)%analysis%openDataset('selfBoundStatus')
        countBootstrapSample=dataset%size(2)
-       allocate(boundStatus (countParticles,countBootstrapSample))
-       allocate(sampleWeight(countParticles,countBootstrapSample))
-       allocate(weight      (countParticles,countBootstrapSample))
+       allocate(boundStatus (countParticles,countBootstrapSample),stat=allocErr)
+       if (allocErr /= 0) call Error_Report_Allocation_Failure('boundStatus' ,countParticles*countBootstrapSample,{introspection:location})
+       allocate(sampleWeight(countParticles,countBootstrapSample),stat=allocErr)
+       if (allocErr /= 0) call Error_Report_Allocation_Failure('sampleWeight',countParticles*countBootstrapSample,{introspection:location})
+       allocate(weight      (countParticles,countBootstrapSample),stat=allocErr)
+       if (allocErr /= 0) call Error_Report_Allocation_Failure('weight'      ,countParticles*countBootstrapSample,{introspection:location})
        call simulations(1)%analysis%readDatasetStatic('selfBoundStatus',boundStatus )
        call simulations(1)%analysis%readDatasetStatic('weight'         ,weight      )
        sampleWeight=dble(weight)

--- a/source/nBody/import/IRATE.F90
+++ b/source/nBody/import/IRATE.F90
@@ -161,12 +161,13 @@ contains
     !!{RST
     Import data from a IRATE file.
     !!}
-    use :: Display     , only : displayIndent          , displayUnindent               , verbosityLevelStandard
-    use :: Error       , only : errorStatusSuccess
-    use :: Dictionaries, only : doubleDictionary       , integerSizeTDictionary        , rank1DoublePtrDictionary    , rank1IntegerSizeTPtrDictionary, &
-          &                    rank2DoublePtrDictionary, rank2IntegerSizeTPtrDictionary, varyingStringDictionary     , genericDictionary
+    use :: Display     , only : displayIndent           , displayUnindent                , verbosityLevelStandard
+    use :: Error       , only : errorStatusSuccess      , Error_Report_Allocation_Failure
+    use :: Dictionaries, only : doubleDictionary        , integerSizeTDictionary         , rank1DoublePtrDictionary, rank1IntegerSizeTPtrDictionary, &
+          &                     rank2DoublePtrDictionary, rank2IntegerSizeTPtrDictionary , varyingStringDictionary , genericDictionary
     use :: HDF5_Access , only : hdf5Access
-    use :: IO_HDF5     , only : H5T_NATIVE_DOUBLES     , H5T_NATIVE_INTEGERS           , hdf5File, hdf5Group, hdf5Dataset
+    use :: IO_HDF5     , only : H5T_NATIVE_DOUBLES      , H5T_NATIVE_INTEGERS            , hdf5File                , hdf5Group                     , &
+         &                      hdf5Dataset
     use :: IO_IRATE    , only : irate
     implicit none
     class           (nbodyImporterIRATE), intent(inout)                              :: self
@@ -179,7 +180,8 @@ contains
     type            (hdf5Group         )                                             :: snapshotGroup
     type            (hdf5Dataset       )                                             :: dataset
     character       (len=13            )                                             :: snapshotLabel
-    integer                                                                          :: i              , status
+    integer                                                                          :: i              , status     , &
+         &                                                                              allocErr
     double precision                                                                 :: boxSize
 
     call displayIndent('import simulation from IRATE file',verbosityLevelStandard)
@@ -225,14 +227,16 @@ contains
        dataset=simulations(1)%analysis%openDataset(char(datasetNames(i)))
        call dataset%assertDatasetType(H5T_NATIVE_INTEGERS,1,status)
        if (status == errorStatusSuccess) then
-          allocate(propertyInteger(dataset%size(1)))
+          allocate(propertyInteger(dataset%size(1)),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('propertyInteger',dataset%size(1),{introspection:location})
           call dataset       %readDatasetStatic    (                datasetValue=propertyInteger)
           call simulations(1)%propertiesInteger%set(datasetNames(i),             propertyInteger)
           nullify(propertyInteger)
        end if
        call dataset%assertDatasetType(H5T_NATIVE_DOUBLES ,1,status)
        if (status == errorStatusSuccess) then
-          allocate(propertyReal   (dataset%size(1)))
+          allocate(propertyReal   (dataset%size(1)),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('propertyReal',dataset%size(1),{introspection:location})
           call dataset       %readDatasetStatic    (                datasetValue=propertyReal   )
           call simulations(1)%propertiesReal   %set(datasetNames(i),             propertyReal   )
           nullify(propertyReal   )

--- a/source/nBody/import/Millennium_CSV.F90
+++ b/source/nBody/import/Millennium_CSV.F90
@@ -154,13 +154,13 @@ contains
     Import data from a MillenniumCSV file.
     !!}
     use :: Cosmology_Parameters, only : hubbleUnitsLittleH
-    use :: Display             , only : displayCounter          , displayCounterClear           , displayIndent          , displayUnindent         , &
+    use :: Display             , only : displayCounter          , displayCounterClear            , displayIndent           , displayUnindent               , &
           &                             verbosityLevelStandard
-    use :: Error               , only : Error_Report
+    use :: Error               , only : Error_Report            , Error_Report_Allocation_Failure
     use :: File_Utilities      , only : Count_Lines_in_File
-    use :: Dictionaries        , only : rank1DoublePtrDictionary, rank1IntegerSizeTPtrDictionary, rank2DoublePtrDictionary, rank2IntegerSizeTPtrDictionary, &
-         &                              doubleDictionary        , integerSizeTDictionary        , varyingStringDictionary , genericDictionary
-    use :: String_Handling     , only : String_Count_Words    , String_Split_Words
+    use :: Dictionaries        , only : rank1DoublePtrDictionary, rank1IntegerSizeTPtrDictionary , rank2DoublePtrDictionary, rank2IntegerSizeTPtrDictionary, &
+         &                              doubleDictionary        , integerSizeTDictionary         , varyingStringDictionary , genericDictionary
+    use :: String_Handling     , only : String_Count_Words      , String_Split_Words
     implicit none
     class           (nbodyImporterMillenniumCSV), intent(inout)                              :: self
     type            (nBodyData                 ), intent(  out), dimension(  :), allocatable :: simulations
@@ -174,7 +174,8 @@ contains
     integer         (c_size_t                  )                                             :: countPoints             , i
     integer                                                                                  :: status                  , file        , &
          &                                                                                      j                       , countColumns, &
-         &                                                                                      countReal               , countInteger
+         &                                                                                      countReal               , countInteger, &
+         &                                                                                      allocErr
     character       (len=1024                  )                                             :: line
     logical                                                                                  :: isComment               , readHeader  , &
          &                                                                                      gotPositionX            , gotPositionY, &
@@ -189,9 +190,12 @@ contains
     ! Count lines in file. (Subtract 1 since one lines gives the column headers.)
     countPoints=Count_Lines_In_File(self%fileName,comment_char="#")-1_c_size_t
     ! Allocate storage
-    allocate(position  (3_c_size_t,countPoints))
-    allocate(velocity  (3_c_size_t,countPoints))
-    allocate(particleID(           countPoints))
+    allocate(position  (3_c_size_t,countPoints),stat=allocErr)
+    if (allocErr /= 0) call Error_Report_Allocation_Failure('position'  ,3_c_size_t*countPoints,{introspection:location})
+    allocate(velocity  (3_c_size_t,countPoints),stat=allocErr)
+    if (allocErr /= 0) call Error_Report_Allocation_Failure('velocity'  ,3_c_size_t*countPoints,{introspection:location})
+    allocate(particleID(           countPoints),stat=allocErr)
+    if (allocErr /= 0) call Error_Report_Allocation_Failure('particleID',           countPoints,{introspection:location})
     allocate(propertiesReal   (0))
     allocate(propertiesInteger(0))
     ! Initialize status.
@@ -266,10 +270,12 @@ contains
              allocate(propertiesReal   (countReal   ))
              allocate(propertiesInteger(countInteger))
              do j=1,countReal
-                allocate(propertiesReal   (j)%property(countPoints))
+                allocate(propertiesReal   (j)%property(countPoints),stat=allocErr)
+                if (allocErr /= 0) call Error_Report_Allocation_Failure('propertiesReal'   ,countPoints,{introspection:location})
              end do
              do j=1,countInteger
-                allocate(propertiesInteger(j)%property(countPoints))
+                allocate(propertiesInteger(j)%property(countPoints),stat=allocErr)
+                if (allocErr /= 0) call Error_Report_Allocation_Failure('propertiesInteger',countPoints,{introspection:location})
              end do
              readHeader=.true.
           else

--- a/source/nBody/import/Rockstar.F90
+++ b/source/nBody/import/Rockstar.F90
@@ -336,12 +336,12 @@ contains
     Import data from a Rockstar file.
     !!}
     use :: Cosmology_Parameters        , only : hubbleUnitsLittleH
-    use :: Display                     , only : displayCounter          , displayCounterClear           , displayIndent           , displayUnindent         , &
+    use :: Display                     , only : displayCounter          , displayCounterClear            , displayIndent           , displayUnindent               , &
           &                                     verbosityLevelStandard
-    use :: Error                       , only : Error_Report
+    use :: Error                       , only : Error_Report            , Error_Report_Allocation_Failure
     use :: File_Utilities              , only : Count_Lines_in_File
-    use :: Dictionaries                , only : doubleDictionary        , integerSizeTDictionary        , rank1DoublePtrDictionary, rank1IntegerSizeTPtrDictionary, &
-          &                                     rank2DoublePtrDictionary, rank2IntegerSizeTPtrDictionary, varyingStringDictionary , genericDictionary
+    use :: Dictionaries                , only : doubleDictionary        , integerSizeTDictionary         , rank1DoublePtrDictionary, rank1IntegerSizeTPtrDictionary, &
+          &                                     rank2DoublePtrDictionary, rank2IntegerSizeTPtrDictionary , varyingStringDictionary , genericDictionary
     use :: Numerical_Constants_Prefixes, only : kilo
     use :: String_Handling             , only : String_Split_Words      , String_Count_Words
     implicit none
@@ -359,7 +359,7 @@ contains
     integer                                                                                     :: status           , j         , &
          &                                                                                         file             , jInteger  , &
          &                                                                                         jReal            , columnMap , &
-         &                                                                                         lineStatus
+         &                                                                                         lineStatus       , allocErr
     character       (len=1024                  )                                                :: line
     character       (len=64                    )                                                :: columnName
     logical                                                                                     :: isComment
@@ -373,7 +373,8 @@ contains
     countTrees=                                                    0_c_size_t    
     ! Allocate storage
     if (self%expansionFactorNeeded) then
-       allocate(expansionFactor(countHalos))
+       allocate(expansionFactor(countHalos),stat=allocErr)
+       if (allocErr /= 0) call Error_Report_Allocation_Failure('expansionFactor',countHalos,{introspection:location})
     else
        allocate(expansionFactor(         0))
     end if
@@ -381,10 +382,12 @@ contains
        allocate(propertiesInteger(self%readColumnsIntegerCount))
        allocate(propertiesReal   (self%readColumnsRealCount   ))
        do i=1,self%readColumnsIntegerCount
-          allocate(propertiesInteger(i)%property(countHalos))
+          allocate(propertiesInteger(i)%property(countHalos),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('propertiesInteger',countHalos,{introspection:location})
        end do
        do i=1,self%readColumnsRealCount
-          allocate(propertiesReal   (i)%property(countHalos))
+          allocate(propertiesReal   (i)%property(countHalos),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('propertiesReal'   ,countHalos,{introspection:location})
        end do
     else
        allocate(propertiesInteger(0                           ))
@@ -644,8 +647,14 @@ contains
     simulations(1)%propertiesIntegerRank1=rank2IntegerSizeTPtrDictionary()
     simulations(1)%propertiesRealRank1   =rank2DoublePtrDictionary      ()
     if (allocated(self%readColumns)) then
-       if (self%havePosition) allocate(position(3,countHalos))
-       if (self%haveVelocity) allocate(velocity(3,countHalos))
+       if (self%havePosition) then
+          allocate(position(3,countHalos),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('position',3*countHalos,{introspection:location})
+       end if
+       if (self%haveVelocity) then
+          allocate(velocity(3,countHalos),stat=allocErr)
+          if (allocErr /= 0) call Error_Report_Allocation_Failure('velocity',3*countHalos,{introspection:location})
+       end if
        jInteger                        =0
        jReal                           =0
        do j=1,size(self%readColumns)

--- a/source/nBody/import/merge.F90
+++ b/source/nBody/import/merge.F90
@@ -144,10 +144,10 @@ contains
     !!{RST
     Merge data from multiple importers.
     !!}
-    use :: Display        , only : displayIndent           , displayUnindent               , verbosityLevelStandard  , displayMessage
-    use :: Error          , only : Error_Report
-    use :: Dictionaries   , only : doubleDictionary        , integerSizeTDictionary        , rank1DoublePtrDictionary, rank1IntegerSizeTPtrDictionary, &
-          &                        rank2DoublePtrDictionary, rank2IntegerSizeTPtrDictionary, varyingStringDictionary , genericDictionary
+    use :: Display        , only : displayIndent           , displayUnindent                , verbosityLevelStandard  , displayMessage
+    use :: Error          , only : Error_Report            , Error_Report_Allocation_Failure
+    use :: Dictionaries   , only : doubleDictionary        , integerSizeTDictionary         , rank1DoublePtrDictionary, rank1IntegerSizeTPtrDictionary, &
+          &                        rank2DoublePtrDictionary, rank2IntegerSizeTPtrDictionary , varyingStringDictionary , genericDictionary
     use :: String_Handling, only : operator(//)
     implicit none
     class           (nbodyImporterMerge), intent(inout)                              :: self
@@ -158,7 +158,7 @@ contains
     integer         (c_size_t          )               , pointer    , dimension(:,:) :: propertyIntegerRank1, propertyIntegerRank1Merged
     double precision                                   , pointer    , dimension(:,:) :: propertyRealRank1   , propertyRealRank1Merged
     integer                                                                          :: j                   , k                         , &
-         &                                                                              i
+         &                                                                              i                   , allocErr
     integer         (c_size_t          )                                             :: countObjects        , countObjectsMerged
     logical                                                                          :: propertiesFound
     
@@ -295,7 +295,10 @@ contains
           if (importer_%simulations(1)%propertiesInteger%size() > 0) then
              do j=1,size(importer_%simulations)
                 propertyInteger                                                                =>  importer_%simulations(j)%propertiesInteger%value(k)
-                if (.not.associated(propertyIntegerMerged)) allocate(propertyIntegerMerged(countObjectsMerged))
+                if (.not.associated(propertyIntegerMerged)) then
+                   allocate(propertyIntegerMerged(countObjectsMerged),stat=allocErr)
+                   if (allocErr /= 0) call Error_Report_Allocation_Failure('propertyIntegerMerged',countObjectsMerged,{introspection:location})
+                end if
                 propertyIntegerMerged(countObjects+1:countObjects+size(propertyInteger,dim=1)) =   propertyInteger
                 countObjects                                                                   =  +countObjects                &
                      &                                                                            +size(propertyInteger,dim=1)
@@ -316,7 +319,10 @@ contains
           if (importer_%simulations(1)%propertiesReal%size() > 0) then
              do j=1,size(importer_%simulations)
                 propertyReal                                                             =>  importer_%simulations(j)%propertiesReal%value(k)
-                if (.not.associated(propertyRealMerged)) allocate(propertyRealMerged(countObjectsMerged))
+                if (.not.associated(propertyRealMerged)) then
+                   allocate(propertyRealMerged(countObjectsMerged),stat=allocErr)
+                   if (allocErr /= 0) call Error_Report_Allocation_Failure('propertyRealMerged',countObjectsMerged,{introspection:location})
+                end if
                 propertyRealMerged(countObjects+1:countObjects+size(propertyReal,dim=1)) =   propertyReal
                 countObjects                                                             =  +countObjects                &
                      &                                                                      +size(propertyReal,dim=1)
@@ -337,7 +343,10 @@ contains
           if (importer_%simulations(1)%propertiesIntegerRank1%size() > 0) then
              do j=1,size(importer_%simulations)
                 propertyIntegerRank1                                                                       =>  importer_%simulations(j)%propertiesIntegerRank1%value(k)
-                if (.not.associated(propertyIntegerRank1Merged)) allocate(propertyIntegerRank1Merged(size(propertyIntegerRank1,dim=1),countObjectsMerged))
+                if (.not.associated(propertyIntegerRank1Merged)) then
+                   allocate(propertyIntegerRank1Merged(size(propertyIntegerRank1,dim=1),countObjectsMerged),stat=allocErr)
+                   if (allocErr /= 0) call Error_Report_Allocation_Failure('propertyIntegerRank1Merged',size(propertyIntegerRank1,dim=1)*countObjectsMerged,{introspection:location})
+                end if
                 propertyIntegerRank1Merged(:,countObjects+1:countObjects+size(propertyIntegerRank1,dim=2)) =   propertyIntegerRank1
                 countObjects                                                                               =  +countObjects                     &
                      &                                                                                        +size(propertyIntegerRank1,dim=2)
@@ -358,7 +367,10 @@ contains
           if (importer_%simulations(1)%propertiesRealRank1%size() > 0) then
              do j=1,size(importer_%simulations)
                 propertyRealRank1                                                                    =>  importer_%simulations(j)%propertiesRealRank1%value(k)
-                if (.not.associated(propertyRealRank1Merged)) allocate(propertyRealRank1Merged(size(propertyRealRank1,dim=1),countObjectsMerged))
+                if (.not.associated(propertyRealRank1Merged)) then
+                   allocate(propertyRealRank1Merged(size(propertyRealRank1,dim=1),countObjectsMerged),stat=allocErr)
+                   if (allocErr /= 0) call Error_Report_Allocation_Failure('propertyRealRank1Merged',size(propertyRealRank1,dim=1)*countObjectsMerged,{introspection:location})
+                end if
                 propertyRealRank1Merged(:,countObjects+1:countObjects+size(propertyRealRank1,dim=2)) =   propertyRealRank1
                 countObjects                                                                         =  +countObjects                     &
                      &                                                                                  +size(propertyRealRank1,dim=2)

--- a/source/nBody/import/random.F90
+++ b/source/nBody/import/random.F90
@@ -141,21 +141,26 @@ contains
     !!{RST
     Import data from a Random file.
     !!}
-    use :: Display     , only : displayIndent           , displayUnindent         , verbosityLevelStandard
-    use :: Dictionaries, only : rank1DoublePtrDictionary, rank1IntegerSizeTPtrDictionary, rank2DoublePtrDictionary    , rank2IntegerSizeTPtrDictionary, &
-         &                      doubleDictionary        , integerSizeTDictionary        , varyingStringDictionary     , genericDictionary
+    use :: Display     , only : displayIndent                  , displayUnindent               , verbosityLevelStandard
+    use :: Error       , only : Error_Report_Allocation_Failure
+    use :: Dictionaries, only : rank1DoublePtrDictionary       , rank1IntegerSizeTPtrDictionary, rank2DoublePtrDictionary, rank2IntegerSizeTPtrDictionary, &
+         &                      doubleDictionary               , integerSizeTDictionary        , varyingStringDictionary , genericDictionary
     implicit none
     class           (nbodyImporterRandom), intent(inout)                              :: self
     type            (nBodyData          ), intent(  out), dimension(  :), allocatable :: simulations
     double precision                                    , dimension(:,:), pointer     :: position   , velocity
     integer         (c_size_t           )               , dimension(  :), pointer     :: particleID
     integer         (c_size_t           )                                             :: i
+    integer                                                                           :: allocErr
 
     call displayIndent('import simulation from Random file',verbosityLevelStandard)
     allocate(simulations(1                 ))
-    allocate(particleID (  self%countPoints))
-    allocate(position   (3,self%countPoints))
-    allocate(velocity   (3,self%countPoints))
+    allocate(particleID (  self%countPoints),stat=allocErr)
+    if (allocErr /= 0) call Error_Report_Allocation_Failure('particleID',  self%countPoints,{introspection:location})
+    allocate(position   (3,self%countPoints),stat=allocErr)
+    if (allocErr /= 0) call Error_Report_Allocation_Failure('position'  ,3*self%countPoints,{introspection:location})
+    allocate(velocity   (3,self%countPoints),stat=allocErr)
+    if (allocErr /= 0) call Error_Report_Allocation_Failure('velocity'  ,3*self%countPoints,{introspection:location})
     simulations(1)%label='random'
     simulations(1)%propertiesInteger     =rank1IntegerSizeTPtrDictionary()
     simulations(1)%propertiesReal        =rank1DoublePtrDictionary      ()


### PR DESCRIPTION
Addresses item 4 of #1353.

An `allocate` which fails without `stat=` aborts the process with no indication of what was being allocated or how large it was — an uninformative kill, precisely when the user most needs to know what to change. Of **5741** `allocate` statements in the source, **two** passed `stat=`.

> A note on the issue's numbers: it records "7,932 `allocate` statements and only 81 uses of `stat=`". The 81 counts every occurrence of `stat=` in the source, nearly all of them `iostat=` on I/O statements; only two are on an `allocate`. The baseline is therefore starker than described.

### Scope

The allocations worth guarding and the hot paths are disjoint, which is what makes this safe to bound. Those guarded here are sized by a count read at run time — the number of particles in a simulation file, of halos in a catalog, or of nodes in a merger tree file — and each runs once per file read. They are the allocations large enough to exhaust memory, and none is near a hot path. The small metadata allocations sitting alongside them, sized by a number of columns or properties, are deliberately left alone.

**39 sites**, across the N-body import layer (GadgetBinary 9, GadgetHDF5 6, Rockstar 5, Millennium_CSV 5, merge 4, random 3, IRATE 2) and the merger tree importer (5).

### One helper, not a message at each site

Each site costs a scalar integer and one branch:

```fortran
allocate(position  (3,countParticles),stat=allocErr)
if (allocErr /= 0) call Error_Report_Allocation_Failure('position'  ,3*countParticles,{introspection:location})
```

The message is built inside the helper, on the failing branch. That matters: building it at the call site would mean constructing and destroying a `varying_string` on every call, including the overwhelming majority which succeed. A `block` gated on the failure would also avoid that cost, but a helper additionally keeps the wording — and the `HELP:` hint, which is identical everywhere — in one place rather than repeated 39 times.

The helper is generic over the element count being a default `integer` or a `c_size_t`, since the counts which size these allocations are of both kinds; that keeps the call sites free of conversions and of the `c_size_t` import which would come with them.

A failure now reports:

```
unable to allocate `particleID` (1000000000000 elements)
HELP: the run needs more memory than is available to it. Reduce the size of the problem (for
example, the number of trees or particles being processed), reduce the number of OpenMP threads,
since each holds its own copy of much of the state, or run where more memory is available
 Occurred at:
   subroutine:randomImport
         file:nBody/import/random.F90   [line 159]
```

That is a real run, provoked by requesting an impossible number of points — not a mock-up.

### Verification

Full build clean; `quickTest`; 1029 Python unit tests; `test-merger-tree-read-ties.py`, which exercises the five merger-tree importer sites; an N-body `random` importer run exercising three sites on the success path; and the deliberate allocation failure above exercising the guard path end to end.

**A gap worth knowing about independently of this change:** the N-body import layer has **no test coverage in the repository** — no parameter file under `testSuite/` or `parameters/` references `nbodyImporter` — so CI never exercises it either. Thirty-one of the thirty-nine sites are therefore compile-verified only; reaching them needs real simulation files. The `random` importer and the merger tree importer are the two that can be exercised without input data, and both are.

### Note

The helper assembles its message into a variable before reporting it, rather than building it in the call to `Error_Report`. It receives the location from its caller, and check 5 of `staticAnalyzer.py` — added in #1378 — requires a call which builds its message from literals to append `{introspection:location}` itself. The check flagged the helper on its first draft, which is the "wrapper where the location comes from elsewhere" case #1353 anticipated; restructuring satisfies it honestly rather than suppressing it.

The *Source formatting* hook reports the touched files as differing from house style; they already did so on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
