### PR TITLE
fix(tests): prune duplicated parameters from the outdated test suite files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -183,10 +183,10 @@ likely to be useful when working in this repo:
   (with `GALACTICUS_EXEC_PATH` set); walks `parameters/`, `constraints/`, and
   `testSuite/` and runs `scripts/aux/parametersMigrate.py` in place on every XML
   parameter file. Use this after a change that renames/restructures parameters,
-  rather than editing the bundled parameter files one at a time. It also resets
-  the `lastModified revision` in `testSuite/.../strictOutdated.xml` and
-  `unstrictOutdated.xml`, which intentionally exercise the "outdated parameter
-  file" paths.
+  rather than editing the bundled parameter files one at a time. It skips
+  `testSuite/.../strictOutdated.xml` and `unstrictOutdated.xml`, which must stay
+  out of date to exercise the "outdated parameter file" paths - do not migrate
+  them by hand either.
 - **`deltaTestCaseReducer/delta.sh`** — wrapper around the
   [Delta](https://github.com/dsw/delta) debugging tool; reduces a source file to
   a minimal case that still reproduces an error (compiler ICE, runtime crash,

--- a/testSuite/parameters/strictOutdated.xml
+++ b/testSuite/parameters/strictOutdated.xml
@@ -1,11 +1,9 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- A parameter file with an outdated revision and strict compliance requested    -->
-
 <!-- 02-December-2025                                                              -->
-
 <parameters>
-  <lastModified revision="262562000c251ee5b935019673f606a8a8c47c10" time="2026-07-28T17:29:21" strict="true"/>
   <formatVersion>2</formatVersion>
+  <lastModified revision="262562000c251ee5b935019673f606a8a8c47c10" time="2025-10-22T21:34:03" strict="true"/>
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
@@ -20,23 +18,6 @@
   <componentHotHalo value="standard">
     <starveSatellites value="false"/>
   </componentHotHalo>
-  <hotHaloOutflowStripping value="standard">
-  <efficiency value="0.1"/></hotHaloOutflowStripping>
-  <coolingInfallTorque value="fixed">
-    <fractionLossAngularMomentum value="0.3"/>
-  </coolingInfallTorque>
-  <hotHaloOutflowStripping value="standard">
-    <efficiency value="0.1"/>
-  </hotHaloOutflowStripping>
-  <coolingInfallTorque value="fixed">
-    <fractionLossAngularMomentum value="0.3"/>
-  </coolingInfallTorque>
-  <hotHaloOutflowStripping value="standard">
-    <efficiency value="0.1"/>
-  </hotHaloOutflowStripping>
-  <coolingInfallTorque value="fixed">
-    <fractionLossAngularMomentum value="0.3"/>
-  </coolingInfallTorque>
   <componentSatellite value="standard"/>
   <componentSpheroid value="standard">
     <ratioAngularMomentumScaleRadius value="0.5"/>
@@ -301,26 +282,6 @@
       <excessHeatDrivesOutflow value="true"/>
       <rateMaximumExpulsion value="1.0"/>
     </nodeOperator>
-    <nodeOperator value="CGMCoolingHeating">
-      <component value="disk"/>
-      <coolingFrom value="currentNode"/>
-      <excessHeatDrivesOutflow value="true"/>
-    <rateMaximumExpulsion value="1.0"/></nodeOperator>
-    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
-    <nodeOperator value="CGMCoolingHeating">
-      <component value="disk"/>
-      <coolingFrom value="currentNode"/>
-      <excessHeatDrivesOutflow value="true"/>
-      <rateMaximumExpulsion value="1.0"/>
-    </nodeOperator>
-    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
-    <nodeOperator value="CGMCoolingHeating">
-      <component value="disk"/>
-      <coolingFrom value="currentNode"/>
-      <excessHeatDrivesOutflow value="true"/>
-      <rateMaximumExpulsion value="1.0"/>
-    </nodeOperator>
-    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
   </nodeOperator>
 
   <!-- Numerical tolerances -->

--- a/testSuite/parameters/unstrictOutdated.xml
+++ b/testSuite/parameters/unstrictOutdated.xml
@@ -1,11 +1,9 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- A parameter file with an outdated revision but no strict compliance requested -->
-
 <!-- 02-December-2025                                                              -->
-
 <parameters>
-  <lastModified revision="262562000c251ee5b935019673f606a8a8c47c10" time="2026-07-28T17:29:21"/>
   <formatVersion>2</formatVersion>
+  <lastModified revision="262562000c251ee5b935019673f606a8a8c47c10" time="2025-10-22T21:34:03" strict="false"/>
 
   <!-- Component selection -->
   <componentBasic value="standard"/>
@@ -20,26 +18,6 @@
   <componentHotHalo value="standard">
     <starveSatellites value="false"/>
   </componentHotHalo>
-  <hotHaloOutflowStripping value="standard">
-    <efficiency value="0.1"/>
-  </hotHaloOutflowStripping>
-  <coolingInfallTorque value="fixed">
-    <fractionLossAngularMomentum value="0.3"/>
-  </coolingInfallTorque>
-  <hotHaloOutflowStripping value="standard">
-    <efficiency value="0.1"/>
-  </hotHaloOutflowStripping>
-  <coolingInfallTorque value="fixed">
-    <fractionLossAngularMomentum value="0.3"/>
-  </coolingInfallTorque>
-  <hotHaloOutflowStripping value="standard">
-
-  <efficiency value="0.1"/></hotHaloOutflowStripping>
-
-  <coolingInfallTorque value="fixed">
-
-  <fractionLossAngularMomentum value="0.3"/></coolingInfallTorque>
-
   <componentSatellite value="standard"/>
   <componentSpheroid value="standard">
     <ratioAngularMomentumScaleRadius value="0.5"/>
@@ -304,28 +282,8 @@
       <excessHeatDrivesOutflow value="true"/>
       <rateMaximumExpulsion value="1.0"/>
     </nodeOperator>
-    <nodeOperator value="CGMCoolingHeating">
-      <component value="disk"/>
-      <coolingFrom value="currentNode"/>
-      <excessHeatDrivesOutflow value="true"/>
-    <rateMaximumExpulsion value="1.0"/></nodeOperator>
-    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
-    <nodeOperator value="CGMCoolingHeating">
-      <component value="disk"/>
-      <coolingFrom value="currentNode"/>
-      <excessHeatDrivesOutflow value="true"/>
-      <rateMaximumExpulsion value="1.0"/>
-    </nodeOperator>
-    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
-    <nodeOperator value="CGMCoolingHeating">
-      <component value="disk"/>
-      <coolingFrom value="currentNode"/>
-      <excessHeatDrivesOutflow value="true"/>
-      <rateMaximumExpulsion value="1.0"/>
-    </nodeOperator>
-    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
   </nodeOperator>
-  
+
   <!-- Numerical tolerances -->
   <mergerTreeNodeEvolver value="standard">
     <odeToleranceAbsolute value="0.01"/>


### PR DESCRIPTION
## Summary

`testSuite/parameters/strictOutdated.xml` and `unstrictOutdated.xml` are migrated by `migrateAllParameterFiles.py` and then have their `lastModified revision` rewound, so every bulk-migration run replays all migrations since `262562000c` against a body which already has them applied. Each run appended a further copy of any element which a migration inserts:

| commit | date | copies of `<hotHaloOutflowStripping value=...>` |
|---|---|---|
| `83d695722` | 2025-12-03 | 1 |
| `088ed790e` | 2026-04-02 | 2 |
| `ab1cbecd8` | 2026-05-18 | 3 |
| `607b9a301` | 2026-07-28 | 4 |

`coolingInfallTorque` and the `CGMCoolingHeating` node operator track it exactly, and several of the inserted blocks are badly formatted, e.g.

```xml
  <hotHaloOutflowStripping value="standard">

  <efficiency value="0.1"/></hotHaloOutflowStripping>
```

## Changes

- Both files are restored to their content at `83d695722` - the last revision before the duplication began - pruning each element back to the single copy the files are meant to carry, and recovering the hand-maintained formatting the migration rewrites had mangled. The `strict="true"` attribute and the corrected header comment introduced in 599ad99d5b are retained, as those were deliberate fixes rather than migration damage; the files otherwise differ from `HEAD` only in the duplicated blocks and in migration formatting artefacts.
- `.claude/CLAUDE.md` is updated to describe the tool's new behaviour.

## The underlying bug

Fixed in galacticusorg/galacticusDevTools#3: `migrateAllParameterFiles.py` now skips these two files entirely rather than migrating them and rewinding the label afterwards, so the duplication cannot recur.

## Testing

Not run locally - this checkout has no built executable, and `test-strict-parameters.py` exercises the two `*Outdated` models only where `libgit2` is available. The CI checks cover it: `strictOutdated` must fail and `unstrictOutdated` must succeed, and the outdated revision is unchanged by this PR, so the outcome under test is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)