### PR TITLE
docs: document the pinned-lattice tabulation idiom (#1416)

### DIFF
--- a/aux/words.dict
+++ b/aux/words.dict
@@ -271,6 +271,7 @@ Zeldovich
 Zhang
 Zhao
 Zwaan
+abscissae
 absorptions
 accrete
 accreted
@@ -453,6 +454,7 @@ gfortran
 grainedness
 grasil
 gridded
+gridding
 gsl
 gv
 gyr
@@ -483,6 +485,7 @@ infall
 infalling
 inhomogeneous
 initializer
+inlined
 inout
 inplane
 integrand
@@ -497,6 +500,7 @@ interdependencies
 interoperability
 interoperable
 interparticle
+interpolant
 interpolants
 interpolants
 interpolatable
@@ -544,6 +548,7 @@ memoize
 memoized
 memorylessness
 merchantability
+mergeability
 mergee
 mergees
 metadata
@@ -628,6 +633,7 @@ photoionization
 photoionizations
 photometric
 piecewise
+pointwise
 polycyclic
 polygamma
 polylogarithm
@@ -727,6 +733,7 @@ situ
 smtp
 soliton
 solitonic
+spacings
 sphericalization
 spheroid
 splashback

--- a/aux/words.dict
+++ b/aux/words.dict
@@ -301,6 +301,8 @@ arcminute
 arcminutes
 astrosylva
 asymptotes
+attenuator
+attenuators
 autocorrelation
 axion
 backtrace
@@ -362,6 +364,7 @@ cppcompiler
 cppflags
 cpus
 cryptographic
+cubature
 cumulate
 cumulates
 cumulation
@@ -402,6 +405,7 @@ digamma
 dilogarithm
 dilogarithms
 dima
+dimensionality
 dimensionful
 dimensionfull
 discretization
@@ -445,6 +449,7 @@ fortran
 forutils
 freefall
 functionalities
+functionClass
 galacticus
 galactocentric
 gas
@@ -549,6 +554,7 @@ memoized
 memorylessness
 merchantability
 mergeability
+mergeable
 mergee
 mergees
 metadata
@@ -571,6 +577,7 @@ mpiLaunch
 mpilaunch
 mpirun
 multi
+multilinear
 multinomial
 multistream
 nanometers
@@ -819,6 +826,7 @@ unlinking
 unmap
 unmapped
 unmerged
+unnegotiated
 unnormalized
 unoperators
 unoptimized

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -6,6 +6,7 @@
 /modules.rst
 /workarounds.rst
 /constants.rst
+/nodeComponents.rst
 /manuals/user-guide/contributors.rst
 /_figures/
 /_spelling/

--- a/docs/manuals/developer-guide/growing-a-tabulation.rst
+++ b/docs/manuals/developer-guide/growing-a-tabulation.rst
@@ -1,0 +1,433 @@
+.. _manual-sec-growingATabulation:
+
+Growing a Tabulation
+====================
+
+Many quantities in Galacticus are expensive enough that they are tabulated once
+and interpolated thereafter. The range which must be tabulated is usually not
+known in advance: it is discovered from the values actually requested as a model
+runs. A tabulation therefore has to *grow*, and the question this page answers
+is how to grow one without changing the values it has already returned.
+
+The mechanism is an **absolute lattice**: a set of abscissae fixed once and for
+all by the gridding scheme, entirely independent of which range any particular
+table happens to span. A table built on such a lattice can be extended, and
+every point it already held---and every value interpolated between those
+points---is unchanged, bit for bit. The pieces are ``Range_Pinned`` and
+``rangeLattice`` (in ``Numerical_Ranges``), the ``extend`` methods of the
+``table1D`` and ``table2DLogLogLin`` classes, and, for tabulations expensive
+enough to keep between runs, ``Table_Caches``.
+
+Why a naively-grown tabulation is a problem
+-------------------------------------------
+
+The natural way to grow a table is to widen its bounds until they enclose the
+new request, redistribute the requested number of points over the widened range,
+and paste the previously computed values back in. This does not work, and the
+reason is worth understanding before reaching for the machinery which avoids it.
+
+The bounds so obtained depend on the *history* of the requests. They are grown
+by repeated multiplication by some factor from an origin set by whichever value
+happened to be asked for first, so two runs which end up covering the same range
+of values, but reach it in a different order, tabulate at different abscissae.
+Nothing about the model has changed, yet every interpolated value differs.
+
+Worse, the abscissae pasted back in no longer belong to the table which now
+holds them. Redistributing :math:`N` points over the widened range gives a new
+spacing, but the preserved values retain the abscissae they were computed at, so
+the table becomes a patchwork of spacings which no single interpolation factor
+describes. Where such a table is indexed arithmetically---from a stored inverse
+spacing, rather than by searching---the index computed drifts further from the
+truth with each extension. This is not hypothetical: it is exactly the failure
+which the expansion-factor tabulation in
+``source/cosmology/functions/matter_lambda.F90`` used to suffer, where after
+sufficiently many extensions the computed index fell beyond the end of the
+table.
+
+The absolute lattice
+--------------------
+
+A lattice is specified by a gridding scheme and a density of points,
+``pointsPer`` :math:`=N`. Its points are the :math:`x_j`, for *all* integers
+:math:`j`:
+
+* ``gridSchemePerDecade`` --- :math:`x_j = 10^{j/N}`;
+* ``gridSchemePerOctave`` --- :math:`x_j = 2^{j/N}`;
+* ``gridSchemePerUnit`` --- :math:`x_j = j/N`.
+
+Since :math:`x_j` is a function of :math:`j` and :math:`N` alone, the lattice
+does not know, and cannot depend on, the range over which any particular table
+is built. Two tables built on the same lattice therefore have identical
+abscissae wherever their ranges overlap.
+
+A ``rangeLattice`` object names a contiguous stretch of such a lattice: the
+``count`` points with integer indices ``indexMinimum`` through
+``indexMinimum+count-1``. It carries no abscissae of its own---they are
+regenerated from the integer indices on demand by ``values()`` (or
+``valuesLogarithmic()``), so they are bit-identical to those of any other range
+on the same lattice. Its useful methods are:
+
+* ``isDefined()`` --- is this a usable lattice? A default-initialized
+  ``rangeLattice`` is not, and that is how "nothing is tabulated yet" is
+  represented;
+* ``covers(lattice)`` --- is ``lattice`` on the same lattice as this one, with
+  every one of its points also a point of this one? This is the test for "is the
+  existing tabulation already sufficient?";
+* ``minimum()``, ``maximum()``, ``indexMaximum()``, ``values()``,
+  ``valuesLogarithmic()``;
+* ``step()`` (``perUnit`` only) and ``stepLogarithmic()`` (logarithmic schemes
+  only) --- the spacing of the points.
+
+``step()`` and ``stepLogarithmic()`` are evaluated as pure functions of
+``pointsPer``, and deliberately *not* as the difference of two neighboring
+lattice points: that difference varies in its final bits with position along the
+lattice, so a table which derived its interpolation factor from it would change
+every interpolated value by of order one unit in the last place whenever its
+lower bound moved---defeating the very reuse the lattice exists to provide.
+**Always take the spacing from the lattice.**
+
+Pinning a range to the lattice
+------------------------------
+
+``Range_Pinned`` turns a request---one value, or an array of values, which the
+tabulation must cover---into the ``rangeLattice`` to tabulate:
+
+.. code-block:: fortran
+
+   use :: Numerical_Ranges, only : Range_Pinned, rangeLattice, gridSchemePerDecade
+   ...
+   type(rangeLattice) :: lattice
+   ...
+   lattice=Range_Pinned(                                    &
+        &                              time               , &
+        &                              pointsPerDecade    , &
+        &                              gridSchemePerDecade, &
+        &               marginFactor  =2.0d0              , &
+        &               anchorEvery   =pointsPerDecade/2  , &
+        &               latticeCurrent=self%lattice         &
+        &              )
+
+The bounds are found by, in order:
+
+#. **applying the safety margin** to the range of the requested values: a
+   multiplicative ``marginFactor`` (default :math:`2`) at each end for the
+   logarithmic schemes, or an additive ``marginOffset`` (default :math:`1`) for
+   ``perUnit``. The margin means that a request which creeps outward by a little
+   does not force a retabulation for every step it takes;
+#. **taking the union with** ``rangeCurrent``, if given---a pair of values which
+   the range must span, used where some bound must always be included but is not
+   itself known to lie on the lattice;
+#. **pinning the bounds outward** to lattice points whose index is a multiple of
+   ``anchorEvery``;
+#. **clamping to the hard limits** ``limitMinimum`` and ``limitMaximum``, if
+   given, with the clamped edge snapped *inward* to the lattice so that all
+   points remain lattice points;
+#. **taking the union with** ``latticeCurrent``, if given---in exact integer
+   arithmetic, and after the clamping, so that a lattice already in use is never
+   shrunk and extension of a table built on it can never fail.
+
+``anchorEvery``
+~~~~~~~~~~~~~~~
+
+``anchorEvery`` is the interval, in lattice steps, to which the bounds are
+pinned. It controls only how far beyond the request the table extends, and is
+independent of ``pointsPer``, which controls the accuracy of interpolation
+within it. It defaults to ``pointsPer``---whole decades, octaves, or unit
+intervals---which gives the coarsest set of possible ranges and hence the
+strongest determinism. A value of :math:`1` pins to the lattice points
+themselves.
+
+Intermediate values are for cases where a whole decade of extra tabulation is
+extravagant. On a cosmic time axis a decade spans most of the history of the
+universe, so ``anchorEvery=pointsPer/2`` (half decades, a factor of
+:math:`\sqrt{10}`) is the usual choice there; where each additional point costs
+an ODE integration, ``anchorEvery=1`` may be the only affordable choice.
+Determinism, exact reuse on extension, and the mergeability of cached tables
+hold for *any* choice---only the granularity of the set of possible ranges
+changes.
+
+``rangeCurrent`` versus ``latticeCurrent``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These two look similar and are not interchangeable. The distinction is the most
+common source of error in using ``Range_Pinned``, so it is worth stating
+plainly:
+
+* the **request is the target**, and only the target receives the safety margin;
+* the range **already tabulated** is taken in union through ``latticeCurrent``,
+  after the margin and after the hard limits.
+
+Folding the current bounds into the target instead---taking a ``min``/``max``
+against them before calling ``Range_Pinned``---applies the safety margin to a
+bound to which the margin has already been applied once. The range then ratchets
+outward by another factor on every retabulation, growing without limit.
+``latticeCurrent`` exists precisely so that the current range can be honored
+without the margin being applied to it a second time.
+
+``rangeCurrent`` is for the different case of a bound which must always be
+spanned but does not lie on the lattice: the present day, for a tabulation of
+integrals evaluated to the present day, or the current range of a table which
+was not itself built on a lattice. It is applied *after* the margin, so it
+raises the upper bound without also lowering the lower one.
+
+Deciding whether to retabulate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Test the pinned lattice, not the requested value against the current bounds:
+
+.. code-block:: fortran
+
+   lattice=Range_Pinned(x,pointsPer,scheme,latticeCurrent=self%table%lattice)
+   if (self%table%lattice%covers(lattice)) return
+
+Testing the request against the bounds would apply the safety margin only when
+the request happened to arrive outside them, so the range finally reached would
+depend on the order in which values were asked for---the very dependence pinning
+exists to remove. Pinning first and comparing lattices costs one cheap integer
+comparison and has no such history.
+
+Extending the tabulation
+------------------------
+
+``extend`` grows a table onto a new lattice, creating it if it does not yet
+exist, and returns an ``isComputed`` mask which is true at those points whose
+values were carried over and false at those the caller must now evaluate:
+
+.. code-block:: fortran
+
+   logical, allocatable, dimension(:) :: isComputed
+   ...
+   call self%table%extend(lattice,isComputed)
+   do i=1,lattice%count
+      if (isComputed(i)) cycle
+      call self%table%populate(expensiveFunction(self%table%x(i)),i)
+   end do
+
+Two things to note. Take the abscissae from the table (or from
+``lattice%values()``), never recompute them independently, so that what is
+evaluated is exactly what will later be interpolated. And skipping the computed
+points is the entire purpose of the exercise---the mask is not advisory.
+
+``extend`` and ``x`` are methods of the abstract ``table1D``, but ``populate``
+is defined on the concrete table types. Where the table is held as a
+``class(table1D), allocatable``---as it must be to use ``Table_Caches``---the
+loop therefore needs a ``select type`` around it:
+
+.. code-block:: fortran
+
+   select type (table_ => self%table)
+   type is (table1DLogarithmicLinear)
+      do i=1,lattice%count
+         if (isComputed(i)) cycle
+         call table_%populate(expensiveFunction(table_%x(i)),i)
+      end do
+   end select
+
+The new lattice must be commensurate with (same scheme, same ``pointsPer``) and
+must *contain* the lattice on which the table is currently tabulated; anything
+else is a fatal error. ``Range_Pinned`` guarantees this when it is passed the
+table's current lattice as ``latticeCurrent``.
+
+``extend`` is supported for the table types with uniformly-spaced *internal*
+abscissae---the linear and logarithmic types, with linear or cubic-spline
+interpolation---and is an error for the others. The two-dimensional
+``table2DLogLogLin`` takes a lattice per axis, each pinned independently:
+
+.. code-block:: fortran
+
+   call self%table%extend(latticeX,latticeY,isComputed)
+
+Here the preserved values form a rectangular block, so ``isComputed`` is true
+over that block and false over the L-shaped remainder. Both axes are extended in
+one call because the block preserved is the rectangle common to the two
+tabulations.
+
+Tabulations held in raw arrays
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Not every tabulation lives in a ``table`` object. For a plain rank-1 allocatable
+array, ``Range_Lattice_Extend`` does the whole job:
+
+.. code-block:: fortran
+
+   use :: Numerical_Ranges, only : Range_Lattice_Extend
+   ...
+   call Range_Lattice_Extend(self%lattice,latticeNew,self%values,isComputed)
+   self%lattice=latticeNew
+
+``Range_Lattice_Extend_2D`` does the same for a rank-2 array, extending both
+axes at once. Where the tabulation is of some other rank, or the tabulated axis
+is not the first, use ``Range_Lattice_Offset``: it returns the index offset at
+which the points of the current lattice appear within the new one, and leaves
+the caller to move its own arrays---typically a ``Move_Alloc`` followed by a
+single array-section assignment.
+
+What is, and is not, preserved
+------------------------------
+
+The reuse guarantee is strong, and it is worth being precise about its scope.
+
+**Preserved bit-for-bit.** The abscissae, which are regenerated from integer
+lattice indices rather than carried over, and the tabulated values, which are
+copied into the index window they occupy in the new table. That window is
+computed from the integer lattice indices, so no searching or floating-point
+comparison of abscissae is involved. For a linearly-interpolated table the
+interpolation is local and the spacing comes from the lattice, so every
+interpolated value on the overlap is unchanged too.
+
+This matters to any consumer which integrates across a range of the tabulated
+variable, or compares quantities evaluated either side of a retabulation. Absent
+the guarantee, such a consumer sees the tabulation shift beneath it: a quantity
+computed before the table grew and one computed after are no longer strictly
+comparable, and differences which ought to be zero are not.
+
+**Not preserved: cubic-spline coefficients.** A cubic spline is not local---every
+coefficient depends on every tabulated value---so adding points at either end
+changes the interpolant everywhere. The coefficients are therefore discarded and
+rebuilt. A cubic-spline table preserves its tabulated values exactly, but *not*
+the values it interpolates between them. Callers must accept this; where it is
+unacceptable, use a linearly-interpolated table.
+
+A note on why ``Lattice_Value``, which converts a lattice coordinate back to a
+value, is marked ``noinline``: were it inlined into an array-filling loop the
+compiler would be free to vectorize the exponentiation, and a vectorized
+``pow()`` need not agree in its final bits with the scalar one. The same lattice
+point could then differ between two tables merely because the loops filling them
+had different trip counts. Keeping it an opaque call forces every lattice point,
+everywhere, through the same scalar evaluation.
+
+When carry-over is not valid
+----------------------------
+
+Carrying values over is correct only when each tabulated value depends on its
+own abscissa and on nothing else about the range. That holds for a function
+evaluated pointwise, and for an integral whose limits do not move---an integral
+from each tabulated time to the present day, for instance, is unaffected when
+the earliest time tabulated changes.
+
+It does **not** hold when the values are generated by marching across the table.
+The expansion-factor tabulation in ``matter_lambda.F90`` is the worked example:
+the expansion factor is integrated forward from an initial condition imposed at
+the earliest tabulated epoch, so every value in the table depends on where that
+integration began. Extend the table downward and the initial condition moves;
+every value which was carried over is then the solution of a different initial
+value problem from the one the new table represents.
+
+The idiom for such a case is to discard everything by presenting an *undefined*
+lattice to the extension, which allocates afresh with ``isComputed`` false
+throughout:
+
+.. code-block:: fortran
+
+   carryOver=self%initialized .and. self%lattice%isDefined()
+   if (carryOver) carryOver=latticeNew%indexMinimum == self%lattice%indexMinimum
+   if (.not.carryOver) then
+      if (allocated(self%values)) deallocate(self%values)
+      self%lattice=rangeLattice()
+   end if
+   call Range_Lattice_Extend(self%lattice,latticeNew,self%values,isComputed)
+
+Note that the test is on the integer lattice index of the lower bound, not on
+the value of the bound---exact, and free of any tolerance.
+
+Where a tabulation is of this kind it is worth seeding its lower bound to a
+fixed value rather than letting it follow the request, so that the bound moves
+rarely, if ever, and the discard is rarely triggered.
+
+Persistent caches
+-----------------
+
+Where a tabulation is expensive enough to be worth keeping between runs,
+``Table_Caches`` (``source/objects/tables/caches.F90``) writes it to a file
+under ``pathTypeDataDynamic``. Because the table is built on an absolute
+lattice, a cached file whose range does not cover a new request need not be
+discarded: the cached abscissae are identical to the new ones wherever the two
+overlap, so the file can be *merged* with the table in memory, only the
+genuinely missing points computed, and the union written back. Cache files
+therefore grow monotonically toward the union of every range ever requested,
+rather than thrashing between runs.
+
+The file name comes from ``Table_Cache_File_Name``:
+
+.. code-block:: fortran
+
+   self%fileName   =Table_Cache_File_Name(                                                                                   &
+        &                                 subDirectory    ='intergalacticMedium'                                           , &
+        &                                 objectType      =char(self%objectType      (                                   )), &
+        &                                 hashedDescriptor=char(self%hashedDescriptor(includeSourceDigest         =.true.  , &
+        &                                                                             includeFileModificationTimes=.true.))  &
+        &                                )
+   call Directory_Make(File_Path(self%fileName))
+
+Passing ``includeSourceDigest=.true.`` and
+``includeFileModificationTimes=.true.`` makes the name change whenever either
+the parameters of the object or the source code which generates the tabulation
+changes---so a stale cache is never read back. Build the name with this function
+rather than by hand: doing it by hand is how a discriminator comes to be
+omitted, and two different tabulations come to share a file.
+
+The full idiom is then:
+
+.. code-block:: fortran
+
+   lattice=Range_Pinned(x,pointsPer,scheme,latticeCurrent=self%table%lattice)
+   if (self%table%lattice%covers(lattice)) return
+   ! Merge in any tabulation already cached on disk, then re-evaluate the range required in the light of it.
+   call Table_Cache_Restore(self%table,self%fileName,status)
+   lattice=Range_Pinned(x,pointsPer,scheme,latticeCurrent=self%table%lattice)
+   call self%table%extend(lattice,isComputed)
+   if (any(.not.isComputed)) then
+      ! Compute only the missing points. Note that no lock is held while doing so.
+      select type (table_ => self%table)
+      type is (table1DLogarithmicLinear)
+         do i=1,lattice%count
+            if (isComputed(i)) cycle
+            call table_%populate(expensiveFunction(table_%x(i)),i)
+         end do
+      end select
+      ! Merge with, and write back, the cache file.
+      call Table_Cache_Store(self%table,self%fileName)
+   end if
+
+``Range_Pinned`` is called twice, and must be: restoring the cache may widen the
+table's lattice, and the range finally tabulated must be the union of that with
+the request.
+
+Locking is handled internally, and the important property is what is *not*
+locked. ``Table_Cache_Restore`` takes a shared lock, and ``Table_Cache_Store``
+an exclusive one, but each holds it only for the duration of the file
+input/output---never across the tabulation itself, which is the expensive part.
+``Table_Cache_Store`` re-reads the file under its exclusive lock before writing,
+so a range written by another process since our own read is merged rather than
+overwritten. Note that ``Table_Cache_Store`` may extend the table, since it
+returns holding the union of the cached and in-memory tabulations.
+
+Merging in two dimensions is more restrictive than in one: the union of two
+rectangles is a rectangle only if one contains the other, so unless the cached
+tabulation covers that in memory (in which case it is adopted) or is covered by
+it (in which case there is nothing to do), the cached tabulation is reported and
+ignored.
+
+Checklist
+---------
+
+When adding or converting a tabulation:
+
+#. Store a ``rangeLattice`` alongside the tabulation, or use the ``lattice``
+   component the ``table`` classes already provide.
+#. Pin the range with ``Range_Pinned``, passing the *request* as the target and
+   the current lattice as ``latticeCurrent``. Never fold the current bounds into
+   the target.
+#. Choose ``anchorEvery`` for the cost of over-tabulating, and ``pointsPer`` for
+   the accuracy of interpolation. They are independent.
+#. Return early when ``covers`` says the existing tabulation is sufficient.
+#. Extend, and evaluate only the points for which ``isComputed`` is false.
+#. Take abscissae, and any interpolation spacing, from the lattice or the table.
+#. Check that carry-over is actually valid for the quantity being tabulated; if
+   it is not, discard explicitly by resetting the lattice.
+#. If the tabulation is expensive enough to keep between runs, wrap it in
+   ``Table_Cache_Restore``/``Table_Cache_Store``.
+
+The unit tests in ``source/tests/make_ranges.F90`` and
+``source/tests/table_caches.F90`` exercise all of this, and are a useful source
+of small, concrete examples.

--- a/docs/manuals/developer-guide/index.rst
+++ b/docs/manuals/developer-guide/index.rst
@@ -12,6 +12,7 @@ Developer Guide
    methods
    creating-a-new-class
    traversing-a-merger-tree
+   growing-a-tabulation
    dark-matter-constraint-pipeline
    building-docker-images
    versions-and-releases

--- a/scripts/doc/extractDocsRST.py
+++ b/scripts/doc/extractDocsRST.py
@@ -423,12 +423,21 @@ def scan_source(source_dir: str):
             module_name = mmod.group(1) if mmod else base
             # Module-level description: the !!{RST …!!} block right after the
             # ``module`` line (already RST; not XML-escaped like <description>).
+            # Matched against the rest of the file, not a fixed-size window: the
+            # match is anchored (``re.match`` plus a leading ``\s*``), so it can
+            # still only pick up a block which immediately follows the ``module``
+            # line, but a window would have to reach past the block's *closing*
+            # ``!!}`` for the match to succeed at all — so a header longer than
+            # the window silently dropped its module from the index entirely.
+            # ``dedent`` before ``strip`` so that indentation *within* the block
+            # (code-blocks, nested lists) survives relative to its own margin.
             if mmod:
                 md = re.match(r'\s*!!\{RST\b(.*?)!!\}',
-                              text[mmod.end():mmod.end() + 800], re.DOTALL)
+                              text[mmod.end():], re.DOTALL)
                 if md and md.group(1).strip():
+                    description = textwrap.dedent(md.group(1)).strip()
                     modules.append({'name': module_name, 'file': path,
-                                    'description': md.group(1).strip()})
+                                    'description': description})
             tmeths = _extract_type_methods(text)
             if tmeths:
                 _derive_type_method_signatures(text, path, tmeths)
@@ -867,15 +876,19 @@ def render_enumerations(enumerations: list[dict], glsmap: dict) -> str:
 
 
 def render_modules(modules: list[dict]) -> str:
-    """A reference index of every documented source module + its summary."""
+    """A reference index of every documented source module + its header docs."""
     out = [_heading('Modules', '='),
            'Every documented Fortran module in the Galacticus source, with the '
-           'summary from its embedded documentation.  Modules implementing a '
+           'documentation embedded in its header.  Modules implementing a '
            'pluggable physics class link to that class.\n']
     for m in modules:
-        desc = re.sub(r'\s*\n\s*', ' ',
-                      textwrap.dedent(m['description']).strip()).strip()
-        body = desc or '—'
+        # Emitted as written, not collapsed onto one line.  Nearly every header
+        # is a single sentence, for which the two are identical; but a handful
+        # carry several paragraphs, and three carry a ``code-block``, which
+        # collapsing folded into the surrounding prose as literal ``.. code-block::``
+        # text.  The body becomes the definition of a definition list, so it is
+        # indented as a whole below.
+        body = m['description'].strip() or '—'
         if m.get('classRef'):
             body += f'\n\nSee :ref:`physics-{m["classRef"]}`.'
         # Emit a stable per-module anchor (``module-<name>``, lower-cased) so

--- a/scripts/doc/tests/test_extractDocsRST.py
+++ b/scripts/doc/tests/test_extractDocsRST.py
@@ -312,3 +312,78 @@ end module Test_Computed
     # carried into the rendered text so the reader learns what it means.
     rendered = extractDocsRST.render_parameter(param, {})
     assert "I_1/I_2" in rendered
+
+
+# A module header long enough that its closing `!!}` falls outside any modest
+# fixed-size window, carrying several paragraphs and a code-block.  Three real
+# module headers look like this (`Table_Caches`, `Tabulations_Inverse`,
+# `Benchmark_Utilities`); nine exceed the 800-character window that `scan_source`
+# used to match within.
+_LONG_MODULE_FIXTURE = """\
+module Test_Long_Header
+  !!{RST
+  Implements a thing.
+
+  %s
+
+  The intended usage is:
+
+  .. code-block:: fortran
+
+     lattice=Range_Pinned(x,pointsPer,scheme)
+     call table_%%extend(lattice,isComputed)
+
+  Trailing paragraph.
+  !!}
+  implicit none
+end module Test_Long_Header
+""" % (("Filler prose. " * 70).strip(),)
+
+
+def test_long_module_header_is_not_dropped(tmp_path):
+    # `re.match` against a fixed-size window fails outright when the closing
+    # `!!}` lies beyond it, so an over-long header used to remove its module from
+    # the index entirely - silently, and indistinguishably from a module with no
+    # header at all.
+    (tmp_path / "longHeader.F90").write_text(_LONG_MODULE_FIXTURE)
+    *_head, _enums, modules, _components, _workarounds = \
+        extractDocsRST.scan_source(str(tmp_path))
+    assert [m["name"] for m in modules] == ["Test_Long_Header"]
+    assert len(modules[0]["description"]) > 800
+
+
+def test_module_header_structure_survives_rendering(tmp_path):
+    # The body is emitted as written rather than collapsed onto a single line:
+    # collapsing folded a `code-block` directive into the surrounding prose,
+    # where it rendered as literal `.. code-block::` text.
+    (tmp_path / "longHeader.F90").write_text(_LONG_MODULE_FIXTURE)
+    *_head, _enums, modules, _components, _workarounds = \
+        extractDocsRST.scan_source(str(tmp_path))
+    rendered = extractDocsRST.render_modules(modules)
+    # The directive stands alone on its own line, indented as the definition of
+    # the definition list whose term is the module name.
+    assert "\n   .. code-block:: fortran\n" in rendered
+    # ...and the literal block it introduces keeps its indentation relative to it.
+    assert "\n      lattice=Range_Pinned(x,pointsPer,scheme)\n" in rendered
+    # Paragraph breaks are preserved, not run together.
+    assert "\n   Implements a thing.\n\n" in rendered
+
+
+def test_module_header_is_dedented_to_its_own_margin(tmp_path):
+    # Every line of a module-level header carries the two-space indent of the
+    # `!!{RST` block, except the first, which `strip` has already removed it
+    # from.  `textwrap.dedent` must therefore be applied before stripping, or
+    # the common margin is not detected and every continuation line renders as
+    # an unintended block quote.
+    (tmp_path / "indented.F90").write_text("""\
+module Test_Indented
+  !!{RST
+  First line.
+
+  Second paragraph.
+  !!}
+end module Test_Indented
+""")
+    *_head, _enums, modules, _components, _workarounds = \
+        extractDocsRST.scan_source(str(tmp_path))
+    assert modules[0]["description"] == "First line.\n\nSecond paragraph."

--- a/source/cooling/cooling_rate/_class.F90
+++ b/source/cooling/cooling_rate/_class.F90
@@ -33,7 +33,7 @@ module Cooling_Rates
    <name>coolingRate</name>
    <descriptiveName>Cooling Rates</descriptiveName>
    <description>
-   Class providing models of the mass cooling rate (in :math:`\mathrm{M}_\odot` Gyr\ :math:`^{-1}`) at which gas cools out of the hot atmosphere of a dark matter halo and becomes available for accretion onto the central galaxy. The cooling rate drives the supply of cold gas for star formation and sets the growth rate of the galaxy disc. Implementations typically account for the interplay between the cooling time, the freefall time, the cooling radius, and the available mass of hot gas, following the two-regime picture of GalacticuswhiteFrenk1991 and subsequent refinements.
+   Class providing models of the mass cooling rate (in :math:`\mathrm{M}_\odot` Gyr\ :math:`^{-1}`) at which gas cools out of the hot atmosphere of a dark matter halo and becomes available for accretion onto the central galaxy. The cooling rate drives the supply of cold gas for star formation and sets the growth rate of the galaxy disc. Implementations typically account for the interplay between the cooling time, the freefall time, the cooling radius, and the available mass of hot gas, following the two-regime picture of :cite:t:`white_galaxy_1991` and subsequent refinements.
    </description>
    <default>whiteFrenk1991</default>
    <method name="rate" >

--- a/source/dark_matter_profiles/structure/scale/Johnson2021.F90
+++ b/source/dark_matter_profiles/structure/scale/Johnson2021.F90
@@ -45,7 +45,7 @@
     <description>
     A dark matter profile scale radius class that computes scale radii based on the energy conservation approach of :cite:t:`johnson_random_2021`, with some modifications and improvements.
 
-    Specifically, for "well-resolved" halos (see below for discussion of this point), the concentration is found by computing the total energy of the halo as the sum over the energies (internal and orbital) of its progenitor halos. The halo is assumed to have virialized at this energy, and the scale radius is then solved for such that the energy of the assumed density profile (e.g. Galacticusnfw) is equal to the computed energy of the halo.
+    Specifically, for "well-resolved" halos (see below for discussion of this point), the concentration is found by computing the total energy of the halo as the sum over the energies (internal and orbital) of its progenitor halos. The halo is assumed to have virialized at this energy, and the scale radius is then solved for such that the energy of the assumed density profile (e.g. :term:`NFW`) is equal to the computed energy of the halo.
 
     In detail, the energy, :math:`E_\mathrm{int}`, of a node is assumed to be given by:
 

--- a/source/numerical/integration_nD.F90
+++ b/source/numerical/integration_nD.F90
@@ -38,7 +38,7 @@ module Numerical_Integration_nD
   error estimate costs nothing extra.
 
   Regions are refined adaptively: the region of largest error estimate is repeatedly bisected, as the one-dimensional
-  integrators of :galacticus-mod:`Numerical_Integration2` bisect intervals, with two differences.
+  integrators of :ref:`Numerical_Integration2 <module-numerical_integration2>` bisect intervals, with two differences.
 
   #. A region is split along a single coordinate rather than into :math:`2^d` children. Splitting into :math:`2^d` children
      multiplies the region count by eight in three dimensions at every refinement, and spends effort in directions along which
@@ -131,7 +131,7 @@ contains
   function genzMalikNDConstructor(countDimensions,integrand,toleranceAbsolute,toleranceRelative,countEvaluationsMaximum) result(self)
     !!{RST
     Constructor for the :galacticus-class:`integratorGenzMalikND` class. ``countDimensions`` is the dimensionality of the integral,
-    which must be at least two---in one dimension the integrators of :galacticus-mod:`Numerical_Integration2` should be used
+    which must be at least two---in one dimension the integrators of :ref:`Numerical_Integration2 <module-numerical_integration2>` should be used
     instead. At least one of ``toleranceAbsolute`` and ``toleranceRelative`` must be given. ``countEvaluationsMaximum`` limits the number
     of integrand evaluations performed before the integration is abandoned.
     !!}

--- a/source/numerical/interpolation/multiD.F90
+++ b/source/numerical/interpolation/multiD.F90
@@ -33,7 +33,7 @@ module Numerical_Interpolation_MultiD
   the enclosing hypercube. That pattern is mechanical but fiddly to write out by hand for each new table, and is easy
   to get subtly wrong. This class factors it out.
 
-  Each dimension is described by an ordinary :galacticus-class:`interpolator` object, so extrapolation behaviour is
+  Each dimension is described by an ordinary :galacticus-class:`interpolator` object, so extrapolation behavior is
   specified per-dimension in the usual way, and a dimension which should be interpolated logarithmically is handled
   by constructing its interpolator on---and evaluating it at---the logarithm of the coordinate.
 

--- a/source/numerical/ranges.F90
+++ b/source/numerical/ranges.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
 !!{RST
 Contains a module which implements construction of numerical ranges.
 !!}
@@ -24,6 +26,10 @@ Contains a module which implements construction of numerical ranges.
 module Numerical_Ranges
   !!{RST
   Implements construction of numerical ranges.
+
+  In addition to the simple ranges built by ``Make_Range``, this module provides the absolute lattices used by tabulations
+  which must grow as a model runs---``rangeLattice``, ``Range_Pinned``, and the ``Range_Lattice_*`` extension primitives. See
+  :ref:`manual-sec-growingATabulation` in the developer guide for how these are used, and why.
   !!}
   implicit none
   private

--- a/source/objects/nodes/components/nuclear_star_cluster/standard/_class.F90
+++ b/source/objects/nodes/components/nuclear_star_cluster/standard/_class.F90
@@ -20,12 +20,12 @@
   !+    Contributions to this file made by: Matías Liempi
 
 !!{RST
-Contains a module which implements the standard Galacticusnsc node component.
+Contains a module which implements the standard :term:`NSC` node component.
 !!}
 
 module Node_Component_NSC_Standard
   !!{RST
-  Implements the standard Galacticusnsc node component.
+  Implements the standard :term:`NSC` node component.
   !!}
   use :: Dark_Matter_Halo_Scales         , only : darkMatterHaloScaleClass
   use :: Histories                       , only : history

--- a/source/objects/tables/caches.F90
+++ b/source/objects/tables/caches.F90
@@ -57,6 +57,10 @@ module Table_Caches
   it holds only for the duration of the file input/output---never across the tabulation itself. ``Table_Cache_Store`` re-reads
   the file under that exclusive lock before writing, so that a range written by another process since our own read is merged
   rather than overwritten.
+
+  See :ref:`manual-sec-growingATabulation` in the developer guide for the whole idiom of which this module is a part---the
+  absolute lattice, pinning a range to it with ``Range_Pinned``, extending a tabulation onto it, and the conditions under which
+  previously computed values may be carried over.
   !!}
   use :: ISO_Varying_String, only : varying_string
   implicit none


### PR DESCRIPTION
## Summary
- Adds `docs/manuals/developer-guide/growing-a-tabulation.rst`, a developer-guide page for the pinned-lattice tabulation idiom — the absolute lattice, `Range_Pinned`, the `extend`/`isComputed` loop, the bit-for-bit reuse guarantee, when carry-over is *not* valid, and `Table_Caches`. Closes #1416.
- Fixes a bug in `scripts/doc/extractDocsRST.py` which was silently dropping **nine** modules from the generated module index — including `Table_Caches`, whose header was the idiom's only previous documentation.
- Repairs four `\glc{...}` references mangled in embedded docstrings, plus one British spelling.

Documentation and doc-tooling only — no functional change to the model.

Three self-contained commits, reviewable independently:

| Commit | What |
|---|---|
| `docs(numerical):` | the new developer-guide page + cross-links from the `Table_Caches` and `Numerical_Ranges` module headers |
| `fix(docs):` | the module-index extractor fix + regression tests |
| `docs:` | the `\glc{...}` docstring repairs |

### The module-index bug

`scan_source` matched a module's `!!{RST … !!}` header against a fixed 800-character *slice* of the file. The slice was taken before the match, so the closing `!!}` of a longer header lay outside it and `re.match` failed outright — not truncating the description, but returning no match at all, so the module never reached the index. Silent, and indistinguishable from a module with no header.

Dropped: `Numerical_Integration_nD`, `Table_Caches`, `Tabulations_Inverse`, `Dust_Extinction_Curves`, `Dust_Attenuations`, `Dust_Attenuation_Descriptors`, `Johnson2021_Statistics`, `Numerical_Interpolation_MultiD`, `Coordinates`. The index now lists 421 modules rather than 412.

The fix also stops `render_modules` collapsing the body onto one line, which folded a `code-block` directive into the surrounding prose as literal `.. code-block::` text — visible today in `Benchmark_Utilities`, which was short enough to render and still came out mangled.

Un-dropping `Numerical_Integration_nD` surfaced a latent `:galacticus-mod:` role that has never been defined, and which became a hard docutils error the moment the module rendered; both uses are rewritten to the `:ref:`Name <module-name>`` idiom already used elsewhere in the source. Defining a proper `:galacticus-mod:` role in `conf.py`, parallel to `:galacticus-class:`, would be the nicer long-term answer — deliberately left out of scope here.

### The `\glc{...}` repairs

`\glc` is the macro for the word "Galacticus" and takes no argument, so `\glc{nsc}` rendered as "Galacticus" followed by a bare group — "Galacticusnsc" in the LaTeX docs, carried over verbatim by the RST migration. `\gls` was meant. The pre-migration tree contains exactly four such uses, in three files, all repaired: `:term:`NSC``, `:term:`NFW``, and — where no glossary key of that name exists and the reference is to the paper — `:cite:t:`white_galaxy_1991``.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Docs / tooling
- [ ] Other:

## How to test

```bash
export GALACTICUS_EXEC_PATH=`pwd`
PYTHONPATH=$(pwd)/python python3 scripts/doc/extractDocsRST.py source docs
python3 -m sphinx -b html docs /tmp/docsbuild            # new page renders; warnings unchanged
SPHINX_SPELLING=1 python3 -m sphinx -b spelling docs /tmp/spell
python3 -m pytest -q python scripts/doc/tests
```

The new page is at `manuals/developer-guide/growing-a-tabulation.html`; `modules.rst` should now carry a `Table_Caches` entry with its code-block rendered as a literal block.

## Checklist
- [x] I ran relevant tests (or explain why not): `948 passed, 1 skipped`. The HTML build emits exactly the same five warnings as `master` (all pre-existing, in the dust `<description>` blocks); the spelling build is clean for the new page and for the newly-rendered module headers, with the technical terms they introduce added to `aux/words.dict`. No model run is involved — nothing here compiles into `Galacticus.exe`.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

---

Note: the pre-commit hook reports house-style deviations (`formatDeclarations.py` / `formatModuleUses.py`) in several of the touched Fortran files. These are pre-existing on `master` — verified by running both formatters against the `master` copies — and are not introduced here; all Fortran edits in this PR are inside comments. Left for the separate reformatting commit the hook itself suggests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
