### PR TITLE
Dust framework phase 3: per-galaxy inclination and the Ferrara et al. (1999) atlas

### DIFF
--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -986,6 +986,7 @@
        <xs:attribute name="value" use="optional">
         <xs:simpleType>
          <xs:restriction base="xs:string">
+          <xs:enumeration value="atlasFerrara2000"/>
           <xs:enumeration value="birthCloud"/>
           <xs:enumeration value="charlotFall2000"/>
           <xs:enumeration value="inclinationAveraged"/>
@@ -4416,6 +4417,22 @@
          <xs:restriction base="xs:string">
           <xs:enumeration value="bett2007"/>
           <xs:enumeration value="logNormal"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="dust">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="milkyWay"/>
+          <xs:enumeration value="smallMagellanicCloud"/>
          </xs:restriction>
         </xs:simpleType>
        </xs:attribute>

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -1189,6 +1189,24 @@
     <xs:anyAttribute processContents="lax"/>
    </xs:complexType>
   </xs:element>
+  <xs:element name="galacticInclination">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="null"/>
+          <xs:enumeration value="random"/>
+          <xs:enumeration value="spinVector"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
   <xs:element name="galacticStructureSolver">
    <xs:complexType mixed="true">
     <xs:sequence>
@@ -2457,6 +2475,7 @@
           <xs:enumeration value="haloAxisRatiosMenkerBenson2022"/>
           <xs:enumeration value="hierarchy"/>
           <xs:enumeration value="impulsiveOutflowEnergy"/>
+          <xs:enumeration value="inclinationRandom"/>
           <xs:enumeration value="indexBranchTip"/>
           <xs:enumeration value="indexLastHost"/>
           <xs:enumeration value="indexShift"/>
@@ -2576,6 +2595,7 @@
           <xs:enumeration value="haloEnvironment"/>
           <xs:enumeration value="hierarchy"/>
           <xs:enumeration value="hostNode"/>
+          <xs:enumeration value="inclination"/>
           <xs:enumeration value="indexBranchTip"/>
           <xs:enumeration value="indexLastHost"/>
           <xs:enumeration value="indicesHost"/>
@@ -4615,6 +4635,22 @@
          <xs:restriction base="xs:string">
           <xs:enumeration value="luminosity"/>
           <xs:enumeration value="size"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="lineOfSight">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="lightcone"/>
          </xs:restriction>
         </xs:simpleType>
        </xs:attribute>

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -988,6 +988,7 @@
          <xs:restriction base="xs:string">
           <xs:enumeration value="birthCloud"/>
           <xs:enumeration value="charlotFall2000"/>
+          <xs:enumeration value="inclinationAveraged"/>
           <xs:enumeration value="mixedSlab"/>
           <xs:enumeration value="screen"/>
           <xs:enumeration value="screenFixed"/>

--- a/source/dust/attenuation/CharlotFall2000.F90
+++ b/source/dust/attenuation/CharlotFall2000.F90
@@ -187,8 +187,8 @@ contains
     class           (dustAttenuationCharlotFall2000), intent(inout)                               :: self
     type            (treeNode                      ), intent(inout), target                       :: node
     type            (emissionDescriptor            ), intent(in   ), dimension(:                ) :: descriptors
-    double precision                                    , intent(in   ), optional                 :: inclination
     double precision                                               , dimension(size(descriptors)) :: transmission
+    double precision                                , intent(in   ), optional                     :: inclination
     !$GLC attributes unused :: inclination
 
     transmission=+self%birthCloud_%transmission(node,descriptors) &

--- a/source/dust/attenuation/CharlotFall2000.F90
+++ b/source/dust/attenuation/CharlotFall2000.F90
@@ -179,7 +179,7 @@ contains
     return
   end function charlotFall2000ConstructorInternal
 
-  function charlotFall2000Transmission(self,node,descriptors) result(transmission)
+  function charlotFall2000Transmission(self,node,descriptors,inclination) result(transmission)
     !!{RST
     Return the transmission through both the birth cloud and diffuse interstellar medium components.
     !!}
@@ -187,7 +187,9 @@ contains
     class           (dustAttenuationCharlotFall2000), intent(inout)                               :: self
     type            (treeNode                      ), intent(inout), target                       :: node
     type            (emissionDescriptor            ), intent(in   ), dimension(:                ) :: descriptors
+    double precision                                    , intent(in   ), optional                 :: inclination
     double precision                                               , dimension(size(descriptors)) :: transmission
+    !$GLC attributes unused :: inclination
 
     transmission=+self%birthCloud_%transmission(node,descriptors) &
          &       *self%screenISM_ %transmission(node,descriptors)

--- a/source/dust/attenuation/_class.F90
+++ b/source/dust/attenuation/_class.F90
@@ -29,8 +29,8 @@ module Dust_Attenuations
 
   A ``dustAttenuation`` object answers one question: of the light emitted by a given parcel of a given galaxy, what
   fraction escapes? It is handed a ``node`` and a list of ``emissionDescriptor`` parcels---each one
-  wavelength, one component, one source type, one age range---and returns a transmission factor in :math:`[0,1]` for
-  each.
+  wavelength, one component, one source type, one age range---and returns the fraction of that light which reaches an
+  observer.
 
   Two design points are worth stating explicitly.
 
@@ -75,9 +75,17 @@ module Dust_Attenuations
    <default>zero</default>
    <method name="transmission" >
     <description>
-    Return the fraction of the emission transmitted through dust, in the range :math:`[0,1]`, for each of the given
-    parcels of emission from the given ``node``. A value of unity indicates no attenuation. The result has one element
-    per element of ``descriptors``, in the same order.
+    Return the fraction of the emission transmitted through dust, for each of the given parcels of emission from the
+    given ``node``. A value of unity indicates no attenuation. The result has one element per element of
+    ``descriptors``, in the same order.
+
+    The value is non-negative, and is normally at most unity---but not necessarily. This is a *directional*
+    transmission, the fraction reaching an observer in one particular direction, and where dust scatters light it can
+    redirect more into that direction than it removes from it, leaving the galaxy brighter at that angle than it
+    would be with no dust at all. Radiative transfer calculations show this at low optical depth and low inclination:
+    the atlas of :cite:t:`ferrara_atlas_1999` exceeds unity by up to 3% there. Consumers must therefore not assume an
+    upper bound of one. Energy is still conserved, since what is gained along one line of sight is lost along
+    others---a constraint on the average over orientation, not on any single direction.
 
     ``inclination`` overrides the angle at which an orientation-dependent attenuator is evaluated, in radians. It is
     how :galacticus-class:`dustAttenuationInclinationAveraged` drives its quadrature: the wrapped attenuator is

--- a/source/dust/attenuation/_class.F90
+++ b/source/dust/attenuation/_class.F90
@@ -78,11 +78,18 @@ module Dust_Attenuations
     Return the fraction of the emission transmitted through dust, in the range :math:`[0,1]`, for each of the given
     parcels of emission from the given ``node``. A value of unity indicates no attenuation. The result has one element
     per element of ``descriptors``, in the same order.
+
+    ``inclination`` overrides the angle at which an orientation-dependent attenuator is evaluated, in radians. It is
+    how :galacticus-class:`dustAttenuationInclinationAveraged` drives its quadrature: the wrapped attenuator is
+    asked for the transmission at each angle in turn, without any shared state being mutated, so the arrangement is
+    safe under threading. An implementation which does not depend on orientation ignores it; one which does falls
+    back to its own ``galacticInclination`` object when it is absent.
     </description>
     <type>double precision, dimension(size(descriptors))</type>
     <pass>yes</pass>
     <argument>type(treeNode          ), intent(inout), target       :: node       </argument>
     <argument>type(emissionDescriptor), intent(in   ), dimension(:) :: descriptors</argument>
+    <argument>double precision        , intent(in   ), optional     :: inclination</argument>
    </method>
    <method name="request" >
     <description>

--- a/source/dust/attenuation/atlas_Ferrara2000.F90
+++ b/source/dust/attenuation/atlas_Ferrara2000.F90
@@ -96,6 +96,11 @@
      double precision                                 , allocatable, dimension(:,:,:  ) :: transmissionDisk
      double precision                                 , allocatable, dimension(:,:,:,:) :: transmissionSpheroid
      type            (interpolatorMultiD             )                                  :: interpolatorDisk     , interpolatorSpheroid
+     ! The axis interpolators are retained as well as being handed to the multilinear interpolators above. Only the
+     ! wavelength changes between the parcels of a galaxy, so bracketing the other axes once per galaxy and reusing
+     ! the result saves that work on every parcel.
+     type            (interpolator                   )                                  :: interpolatorWavelength  , interpolatorInclination, &
+          &                                                                                interpolatorDepthOptical, interpolatorRadiusSpheroid
    contains
      final     ::                      atlasFerrara2000Destructor
      procedure :: transmission      => atlasFerrara2000Transmission
@@ -240,8 +245,12 @@ contains
     interpolatorsSpheroid(2)=interpolatorsDisk(1)
     interpolatorsSpheroid(3)=interpolatorsDisk(2)
     interpolatorsSpheroid(4)=interpolatorsDisk(3)
-    self%interpolatorDisk    =interpolatorMultiD(interpolatorsDisk    )
-    self%interpolatorSpheroid=interpolatorMultiD(interpolatorsSpheroid)
+    self%interpolatorDisk        =interpolatorMultiD(interpolatorsDisk    )
+    self%interpolatorSpheroid    =interpolatorMultiD(interpolatorsSpheroid)
+    self%interpolatorDepthOptical=interpolatorsDisk    (1)
+    self%interpolatorInclination =interpolatorsDisk    (2)
+    self%interpolatorWavelength  =interpolatorsDisk    (3)
+    self%interpolatorRadiusSpheroid=interpolatorsSpheroid(1)
     return
   end function atlasFerrara2000ConstructorInternal
 
@@ -266,6 +275,7 @@ contains
     The optical depth and the inclination are properties of the galaxy rather than of a parcel, so both are obtained
     once here and reused across every parcel, as is the spheroid size if any parcel needs it.
     !!}
+    use, intrinsic :: ISO_C_Binding             , only : c_size_t
     use :: Error                           , only : Error_Report
     use :: Galactic_Structure_Options      , only : componentTypeDisk    , componentTypeSpheroid
     use :: Numerical_Constants_Astronomical, only : degreesToRadians
@@ -280,6 +290,13 @@ contains
          &                                                                                            inclinationDegrees
     logical                                                                                        :: radiusSpheroidComputed
     integer                                                                                        :: i
+    ! Bracketing indices and linear weights, per dimension, in the order the tables are laid out: for the disk
+    ! (optical depth, inclination, wavelength), and for the spheroid (spheroid size, optical depth, inclination,
+    ! wavelength). Only the wavelength entry changes between parcels.
+    integer         (c_size_t                       )                , dimension(  3)              :: indicesDisk
+    double precision                                                 , dimension(0:1,3)            :: weightsDisk
+    integer         (c_size_t                       )                , dimension(  4)              :: indicesSpheroid
+    double precision                                                 , dimension(0:1,4)            :: weightsSpheroid
 
     ! The dust lies in the disk in this model, and a spheroid is reddened by the disk's dust, so the optical depth is
     ! always that of the disk.
@@ -303,9 +320,17 @@ contains
     logDepth              =log(depthOptical)
     radiusSpheroidComputed=.false.
     radiusSpheroid        =0.0d0
+    ! Bracket the axes which are properties of the galaxy rather than of a parcel, once.
+    call self%interpolatorDepthOptical%linearFactors(logDepth          ,indicesDisk(1),weightsDisk(:,1))
+    call self%interpolatorInclination %linearFactors(inclinationDegrees,indicesDisk(2),weightsDisk(:,2))
+    indicesSpheroid(2:3)=indicesDisk(1:2)
+    weightsSpheroid(:,2:3)=weightsDisk(:,1:2)
     do i=1,size(descriptors)
+       call self%interpolatorWavelength%linearFactors(log(descriptors(i)%wavelength),indicesDisk(3),weightsDisk(:,3))
+       indicesSpheroid(4  )=indicesDisk(3  )
+       weightsSpheroid(:,4)=weightsDisk(:,3)
        if      (descriptors(i)%componentType == componentTypeDisk    ) then
-          transmission(i)=self%interpolatorDisk    %interpolate(self%transmissionDisk    ,[logDepth,inclinationDegrees,log(descriptors(i)%wavelength)])
+          transmission(i)=self%interpolatorDisk    %interpolateFactors(self%transmissionDisk    ,indicesDisk    ,weightsDisk    )
        else if (descriptors(i)%componentType == componentTypeSpheroid) then
           if (.not.radiusSpheroidComputed) then
              ! Clamp into the tabulated range before taking a logarithm. A galaxy may have no spheroid, or no disk
@@ -313,8 +338,9 @@ contains
              ! values at the boundary in any case, so nothing is lost by clamping here rather than there.
              radiusSpheroid        =max(atlasFerrara2000RadiusSpheroid(node),minval(self%radiusSpheroid))
              radiusSpheroidComputed=.true.
+             call self%interpolatorRadiusSpheroid%linearFactors(log(radiusSpheroid),indicesSpheroid(1),weightsSpheroid(:,1))
           end if
-          transmission(i)=self%interpolatorSpheroid%interpolate(self%transmissionSpheroid,[log(radiusSpheroid),logDepth,inclinationDegrees,log(descriptors(i)%wavelength)])
+          transmission(i)=self%interpolatorSpheroid%interpolateFactors(self%transmissionSpheroid,indicesSpheroid,weightsSpheroid)
        else
           transmission(i)=1.0d0
           call Error_Report('this atlas tabulates only disk and spheroid components'//{introspection:location})

--- a/source/dust/attenuation/atlas_Ferrara2000.F90
+++ b/source/dust/attenuation/atlas_Ferrara2000.F90
@@ -406,8 +406,8 @@ contains
     else which varies within a component.
     !!}
     implicit none
-    type (decompositionRequest              )                :: request
-    class(dustAttenuationAtlasFerrara2000   ), intent(inout) :: self
+    type (decompositionRequest           )                :: request
+    class(dustAttenuationAtlasFerrara2000), intent(inout) :: self
     !$GLC attributes unused :: self
 
     request%resolveComponents =.true.

--- a/source/dust/attenuation/atlas_Ferrara2000.F90
+++ b/source/dust/attenuation/atlas_Ferrara2000.F90
@@ -308,7 +308,10 @@ contains
           transmission(i)=self%interpolatorDisk    %interpolate(self%transmissionDisk    ,[logDepth,inclinationDegrees,log(descriptors(i)%wavelength)])
        else if (descriptors(i)%componentType == componentTypeSpheroid) then
           if (.not.radiusSpheroidComputed) then
-             radiusSpheroid        =atlasFerrara2000RadiusSpheroid(node)
+             ! Clamp into the tabulated range before taking a logarithm. A galaxy may have no spheroid, or no disk
+             ! to measure one against, giving a ratio of zero whose logarithm would trap; and the interpolator holds
+             ! values at the boundary in any case, so nothing is lost by clamping here rather than there.
+             radiusSpheroid        =max(atlasFerrara2000RadiusSpheroid(node),minval(self%radiusSpheroid))
              radiusSpheroidComputed=.true.
           end if
           transmission(i)=self%interpolatorSpheroid%interpolate(self%transmissionSpheroid,[log(radiusSpheroid),logDepth,inclinationDegrees,log(descriptors(i)%wavelength)])

--- a/source/dust/attenuation/atlas_Ferrara2000.F90
+++ b/source/dust/attenuation/atlas_Ferrara2000.F90
@@ -1,0 +1,386 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+  !!{RST
+  Implements a dust attenuation class using the atlas of Ferrara et al. (1999).
+  !!}
+
+  use :: Galactic_Inclinations         , only : galacticInclinationClass
+  use :: Numerical_Interpolation       , only : interpolator
+  use :: Numerical_Interpolation_MultiD, only : interpolatorMultiD
+
+  !![
+  <enumeration docformat="rst">
+   <name>ferrara2000Dust</name>
+   <description>
+   Enumerates the dust types tabulated in the atlas of :cite:t:`ferrara_atlas_1999`.
+   </description>
+   <encodeFunction>yes</encodeFunction>
+   <validator>yes</validator>
+   <visibility>public</visibility>
+   <entry label="milkyWay"            />
+   <entry label="smallMagellanicCloud"/>
+  </enumeration>
+  !!]
+
+  !![
+  <dustAttenuation name="dustAttenuationAtlasFerrara2000" docformat="rst">
+   <description>
+   Dust attenuation from the radiative transfer atlas of :cite:t:`ferrara_atlas_1999`, which tabulates the fraction
+   of light escaping a galaxy as a function of wavelength, inclination, optical depth, and---for the spheroid---the
+   size of the spheroid relative to the disk.
+
+   This is a *non-separable* attenuator. The tabulated escape fraction is the result of a radiative transfer
+   calculation through a specified geometry, and is not the exponential of a single optical depth times a
+   wavelength-dependent curve, so it takes no ``dustExtinctionCurve``---the wavelength dependence is in the table,
+   which is the point of tabulating it. It also means the transmission can slightly exceed unity at low optical
+   depth and low inclination, where scattering redirects more light into the line of sight than the dust removes
+   from it.
+
+   The tabulation is selected by two parameters: ``dust``, the extinction curve of the grains, either ``milkyWay``
+   or ``smallMagellanicCloud``; and ``heightRatio``, the ratio of the dust scale height to the stellar scale height,
+   one of 0.4, 1.0, or 2.5.
+
+   Two quantities are supplied per galaxy rather than tabulated:
+
+   * The optical depth, obtained from a :galacticus-class:`dustAttenuationScreen` object through its
+     ``depthOpticalV`` method. Delegating this keeps the Milky Way calibration of
+     :galacticus-class:`dustAttenuationScreenSurfaceDensityMetals` as the single home of that normalization, and
+     lets a fixed depth be substituted for testing. It is *always* evaluated for the disk, whichever component is
+     being attenuated: in this model the dust lies in the disk and a spheroid is reddened by the disk's dust, so
+     asking for a spheroid's own optical depth would compute a surface density of a component holding no dust here.
+
+     The atlas defines its optical depth as that through the center of the galaxy perpendicular to the plane, in the
+     :math:`V` band. For an exponential disk :math:`\Sigma_0 = M/2\pi r_\mathrm{d}^2`, which is what
+     ``screenSurfaceDensityMetals`` computes, so the definitions agree.
+
+   * The inclination, from a :galacticus-class:`galacticInclinationClass` object, or from the ``inclination``
+     argument when one is imposed, as :galacticus-class:`dustAttenuationInclinationAveraged` does. One or the other
+     must be available, and an error is reported if neither is.
+   </description>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationClass) :: dustAttenuationAtlasFerrara2000
+     !!{RST
+     A dust attenuation class using the atlas of :cite:t:`ferrara_atlas_1999`.
+     !!}
+     private
+     class           (galacticInclinationClass       ), pointer                       :: galacticInclination_   => null()
+     class           (dustAttenuationScreen          ), pointer                       :: dustAttenuation_       => null()
+     type            (enumerationFerrara2000DustType )                                :: dust
+     double precision                                                                 :: heightRatio
+     logical                                                                          :: inclinationAvailable
+     ! Grid axes. Wavelengths are in Angstroms and inclinations in degrees, as tabulated; the spheroid axis is the
+     ! spheroid half-mass radius in units of the disk scale length.
+     double precision                                 , allocatable, dimension(:      ) :: wavelength           , inclination        , &
+          &                                                                                depthOptical         , radiusSpheroid
+     ! Tabulated transmission. The datasets are written (wavelength, inclination, opticalDepth[, radius]) as a
+     ! row-major reader sees them, so the Fortran dimensions are the reverse of that.
+     double precision                                 , allocatable, dimension(:,:,:  ) :: transmissionDisk
+     double precision                                 , allocatable, dimension(:,:,:,:) :: transmissionSpheroid
+     type            (interpolatorMultiD             )                                  :: interpolatorDisk     , interpolatorSpheroid
+   contains
+     final     ::                      atlasFerrara2000Destructor
+     procedure :: transmission      => atlasFerrara2000Transmission
+     procedure :: request           => atlasFerrara2000Request
+     procedure :: supportsComponent => atlasFerrara2000SupportsComponent
+  end type dustAttenuationAtlasFerrara2000
+
+  interface dustAttenuationAtlasFerrara2000
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationAtlasFerrara2000` dust attenuation class.
+     !!}
+     module procedure atlasFerrara2000ConstructorParameters
+     module procedure atlasFerrara2000ConstructorInternal
+  end interface dustAttenuationAtlasFerrara2000
+
+contains
+
+  function atlasFerrara2000ConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationAtlasFerrara2000` dust attenuation class which takes a
+    parameter set as input.
+    !!}
+    use :: Error             , only : Error_Report
+    use :: Input_Parameters  , only : inputParameter, inputParameters
+    use :: ISO_Varying_String, only : char          , var_str       , varying_string
+    implicit none
+    type            (dustAttenuationAtlasFerrara2000)                :: self
+    type            (inputParameters                ), intent(inout) :: parameters
+    class           (galacticInclinationClass       ), pointer       :: galacticInclination_
+    class           (dustAttenuationClass           ), pointer       :: dustAttenuation_
+    class           (dustAttenuationScreen          ), pointer       :: dustAttenuationScreen_
+    type            (varying_string                 )                :: dust
+    double precision                                                 :: heightRatio
+
+    !![
+    <inputParameter docformat="rst">
+      <name>dust</name>
+      <defaultValue>var_str('milkyWay')</defaultValue>
+      <description>
+      The extinction curve of the dust grains: ``milkyWay`` or ``smallMagellanicCloud``.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>heightRatio</name>
+      <defaultValue>1.0d0</defaultValue>
+      <description>
+      The ratio of the dust scale height to the stellar scale height. Tabulations exist for 0.4, 1.0, and 2.5.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="galacticInclination" name="galacticInclination_" source="parameters"/>
+    <objectBuilder class="dustAttenuation"     name="dustAttenuation_"     source="parameters"/>
+    !!]
+    ! The optical depth is taken from a screen attenuator, so that its calibration lives in one place.
+    select type (dustAttenuation_)
+    class is (dustAttenuationScreen)
+       dustAttenuationScreen_ => dustAttenuation_
+    class default
+       call Error_Report('the `dustAttenuation` supplied must be a `screen` class: it is used only as a source of the V-band optical depth'//{introspection:location})
+    end select
+    self=dustAttenuationAtlasFerrara2000(enumerationFerrara2000DustEncode(char(dust),includesPrefix=.false.),heightRatio,galacticInclination_,dustAttenuationScreen_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="galacticInclination_"/>
+    <objectDestructor name="dustAttenuation_"    />
+    !!]
+    return
+  end function atlasFerrara2000ConstructorParameters
+
+  function atlasFerrara2000ConstructorInternal(dust,heightRatio,galacticInclination_,dustAttenuation_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustAttenuationAtlasFerrara2000` dust attenuation class. The
+    tabulation is read once, here, and interpolators built over it.
+    !!}
+    use :: Error                   , only : Error_Report
+    use :: HDF5_Access             , only : hdf5Access
+    use :: Input_Paths             , only : inputPath                , pathTypeDataStatic
+    use :: IO_HDF5                 , only : hdf5File
+    use :: ISO_Varying_String      , only : char                     , operator(//)     , varying_string
+    use :: Table_Labels            , only : extrapolationTypeFix
+    implicit none
+    type            (dustAttenuationAtlasFerrara2000)                        :: self
+    type            (enumerationFerrara2000DustType ), intent(in   )         :: dust
+    double precision                                 , intent(in   )         :: heightRatio
+    class           (galacticInclinationClass       ), intent(in   ), target :: galacticInclination_
+    class           (dustAttenuationScreen          ), intent(in   ), target :: dustAttenuation_
+    type            (hdf5File                       )                        :: file
+    type            (varying_string                 )                        :: fileName             , labelDust
+    character       (len=3                          )                        :: labelRatio
+    type            (interpolator                   ), dimension(3)          :: interpolatorsDisk
+    type            (interpolator                   ), dimension(4)          :: interpolatorsSpheroid
+    !![
+    <constructorAssign variables="dust, heightRatio, *galacticInclination_, *dustAttenuation_"/>
+    !!]
+
+    ! An inclination must be available, either per galaxy or imposed by an attenuator averaging over orientation.
+    self%inclinationAvailable=self%galacticInclination_%isAvailable()
+    ! Select the tabulation.
+    select case (self%dust%ID)
+    case (ferrara2000DustMilkyWay            %ID)
+       labelDust='MilkyWay'
+    case (ferrara2000DustSmallMagellanicCloud%ID)
+       labelDust='SmallMagellanicCloud'
+    case default
+       labelDust=''
+       call Error_Report('unrecognized dust type'//{introspection:location})
+    end select
+    if      (abs(self%heightRatio-0.4d0) < 1.0d-3) then
+       labelRatio='0.4'
+    else if (abs(self%heightRatio-1.0d0) < 1.0d-3) then
+       labelRatio='1.0'
+    else if (abs(self%heightRatio-2.5d0) < 1.0d-3) then
+       labelRatio='2.5'
+    else
+       labelRatio='   '
+       call Error_Report('`heightRatio` must be one of the tabulated values 0.4, 1.0, or 2.5'//{introspection:location})
+    end if
+    fileName=inputPath(pathTypeDataStatic)//'dust/atlasFerrara2000/attenuations_'//labelDust//'_dustHeightRatio'//labelRatio//'.hdf5'
+    !$ call hdf5Access%set()
+    file=hdf5File(char(fileName),readOnly=.true.)
+    call file%readDataset('wavelength'         ,self%wavelength          )
+    call file%readDataset('inclination'        ,self%inclination         )
+    call file%readDataset('opticalDepth'       ,self%depthOptical        )
+    call file%readDataset('spheroidScaleRadial',self%radiusSpheroid      )
+    call file%readDataset('attenuationDisk'    ,self%transmissionDisk    )
+    call file%readDataset('attenuationSpheroid',self%transmissionSpheroid)
+    !$ call hdf5Access%unset()
+    ! Check that the tables have the shape the axes imply. A transposed read would otherwise show up much later as
+    ! quietly wrong attenuation.
+    if (any(shape(self%transmissionDisk    ) /= [size(self%depthOptical),size(self%inclination),size(self%wavelength)                      ])) &
+         & call Error_Report('`attenuationDisk` does not have the shape implied by the axes'    //{introspection:location})
+    if (any(shape(self%transmissionSpheroid) /= [size(self%radiusSpheroid),size(self%depthOptical),size(self%inclination),size(self%wavelength)])) &
+         & call Error_Report('`attenuationSpheroid` does not have the shape implied by the axes'//{introspection:location})
+    ! Build interpolators, ordered from the most rapidly varying dimension of the table outward. Optical depth and
+    ! spheroid size are interpolated logarithmically, being tabulated on geometric grids; wavelength likewise. Values
+    ! outside the tabulated ranges are held at the boundary.
+    interpolatorsDisk    (1)=interpolator(log(self%depthOptical  ),extrapolationType=extrapolationTypeFix)
+    interpolatorsDisk    (2)=interpolator(    self%inclination    ,extrapolationType=extrapolationTypeFix)
+    interpolatorsDisk    (3)=interpolator(log(self%wavelength    ),extrapolationType=extrapolationTypeFix)
+    interpolatorsSpheroid(1)=interpolator(log(self%radiusSpheroid),extrapolationType=extrapolationTypeFix)
+    interpolatorsSpheroid(2)=interpolatorsDisk(1)
+    interpolatorsSpheroid(3)=interpolatorsDisk(2)
+    interpolatorsSpheroid(4)=interpolatorsDisk(3)
+    self%interpolatorDisk    =interpolatorMultiD(interpolatorsDisk    )
+    self%interpolatorSpheroid=interpolatorMultiD(interpolatorsSpheroid)
+    return
+  end function atlasFerrara2000ConstructorInternal
+
+  subroutine atlasFerrara2000Destructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`dustAttenuationAtlasFerrara2000` dust attenuation class.
+    !!}
+    implicit none
+    type(dustAttenuationAtlasFerrara2000), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%galacticInclination_"  />
+    <objectDestructor name="self%dustAttenuation_"      />
+    !!]
+    return
+  end subroutine atlasFerrara2000Destructor
+
+  function atlasFerrara2000Transmission(self,node,descriptors,inclination) result(transmission)
+    !!{RST
+    Return the transmission of each parcel, interpolated in the atlas.
+
+    The optical depth and the inclination are properties of the galaxy rather than of a parcel, so both are obtained
+    once here and reused across every parcel, as is the spheroid size if any parcel needs it.
+    !!}
+    use :: Error                           , only : Error_Report
+    use :: Galactic_Structure_Options      , only : componentTypeDisk    , componentTypeSpheroid
+    use :: Numerical_Constants_Astronomical, only : degreesToRadians
+    implicit none
+    class           (dustAttenuationAtlasFerrara2000), intent(inout)                               :: self
+    type            (treeNode                       ), intent(inout), target                       :: node
+    type            (emissionDescriptor             ), intent(in   ), dimension(:                ) :: descriptors
+    double precision                                 , intent(in   ), optional                     :: inclination
+    double precision                                                , dimension(size(descriptors)) :: transmission
+    double precision                                                                               :: depthOptical      , inclination_, &
+         &                                                                                            radiusSpheroid    , logDepth    , &
+         &                                                                                            inclinationDegrees
+    logical                                                                                        :: radiusSpheroidComputed
+    integer                                                                                        :: i
+
+    ! The dust lies in the disk in this model, and a spheroid is reddened by the disk's dust, so the optical depth is
+    ! always that of the disk.
+    depthOptical=self%dustAttenuation_%depthOpticalV(node,componentTypeDisk)
+    if (present(inclination)) then
+       inclination_=inclination
+    else if (self%inclinationAvailable) then
+       inclination_=self%galacticInclination_%inclination(node)
+    else
+       inclination_=0.0d0
+       call Error_Report('this attenuator depends on orientation, but no inclination is available: either set `galacticInclination` to a class which supplies one, or wrap this attenuator in `inclinationAveraged`'//{introspection:location})
+    end if
+    ! The atlas is tabulated in degrees, and interpolated logarithmically in optical depth. A galaxy with no dust at
+    ! all transmits everything, so guard the logarithm rather than letting it overflow.
+    inclinationDegrees=+inclination_     &
+         &             /degreesToRadians
+    if (depthOptical <= 0.0d0) then
+       transmission=1.0d0
+       return
+    end if
+    logDepth              =log(depthOptical)
+    radiusSpheroidComputed=.false.
+    radiusSpheroid        =0.0d0
+    do i=1,size(descriptors)
+       if      (descriptors(i)%componentType == componentTypeDisk    ) then
+          transmission(i)=self%interpolatorDisk    %interpolate(self%transmissionDisk    ,[logDepth,inclinationDegrees,log(descriptors(i)%wavelength)])
+       else if (descriptors(i)%componentType == componentTypeSpheroid) then
+          if (.not.radiusSpheroidComputed) then
+             radiusSpheroid        =atlasFerrara2000RadiusSpheroid(node)
+             radiusSpheroidComputed=.true.
+          end if
+          transmission(i)=self%interpolatorSpheroid%interpolate(self%transmissionSpheroid,[log(radiusSpheroid),logDepth,inclinationDegrees,log(descriptors(i)%wavelength)])
+       else
+          transmission(i)=1.0d0
+          call Error_Report('this atlas tabulates only disk and spheroid components'//{introspection:location})
+       end if
+    end do
+    return
+  end function atlasFerrara2000Transmission
+
+  double precision function atlasFerrara2000RadiusSpheroid(node) result(radiusSpheroid)
+    !!{RST
+    Return the size of the spheroid in the units the atlas is tabulated against: its half-mass radius, in units of
+    the disk scale length.
+
+    :cite:t:`ferrara_atlas_1999` model spheroids as Jaffe profiles and tabulate against the spheroid effective
+    radius. For a Jaffe profile the enclosed mass is :math:`M(r)/M = (r/r_0)/(1+r/r_0)`, so the half-mass radius is
+    exactly the scale radius :math:`r_0`; the tabulated axis is therefore a half-mass radius. A model galaxy's
+    spheroid will in general follow some other profile, so it is matched on that same physical radius rather than on
+    a scale radius, whose meaning differs between profiles.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Galacticus_Nodes, only : nodeComponentDisk, nodeComponentSpheroid
+    implicit none
+    type            (treeNode             ), intent(inout), target :: node
+    class           (nodeComponentDisk    )               , pointer :: disk
+    class           (nodeComponentSpheroid)               , pointer :: spheroid
+    double precision                                                :: radiusDisk
+
+    disk       => node    %disk  ()
+    spheroid   => node    %spheroid()
+    radiusDisk =  disk    %radius()
+    if (radiusDisk <= 0.0d0) then
+       ! With no disk there is no scale to measure the spheroid against, and no dust either, so the value is
+       ! immaterial: return the smallest tabulated size.
+       radiusSpheroid=0.0d0
+       return
+    end if
+    radiusSpheroid=+spheroid%radius() &
+         &         /         radiusDisk
+    return
+  end function atlasFerrara2000RadiusSpheroid
+
+  function atlasFerrara2000Request(self) result(request)
+    !!{RST
+    Return the decomposition required: the attenuation differs between disk and spheroid, but depends on nothing
+    else which varies within a component.
+    !!}
+    implicit none
+    type (decompositionRequest              )                :: request
+    class(dustAttenuationAtlasFerrara2000   ), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    request%resolveComponents =.true.
+    request%resolveMetallicity=.false.
+    request%resolveRadius     =.false.
+    return
+  end function atlasFerrara2000Request
+
+  logical function atlasFerrara2000SupportsComponent(self,componentType) result(supportsComponent)
+    !!{RST
+    Return true only for the disk and spheroid, which are the components this atlas tabulates.
+    !!}
+    use :: Galactic_Structure_Options, only : componentTypeDisk, componentTypeSpheroid
+    implicit none
+    class(dustAttenuationAtlasFerrara2000), intent(inout) :: self
+    type (enumerationComponentTypeType   ), intent(in   ) :: componentType
+    !$GLC attributes unused :: self
+
+    supportsComponent=  componentType == componentTypeDisk     &
+         &            .or.                                     &
+         &              componentType == componentTypeSpheroid
+    return
+  end function atlasFerrara2000SupportsComponent

--- a/source/dust/attenuation/atlas_Ferrara2000.F90
+++ b/source/dust/attenuation/atlas_Ferrara2000.F90
@@ -19,7 +19,7 @@
 
 !+    Contributions to this file made by: Andrew Benson, Claude.
   !!{RST
-  Implements a dust attenuation class using the atlas of Ferrara et al. (1999).
+  Implements a dust attenuation class using the atlas of :cite:t:`ferrara_atlas_1999`.
   !!}
 
   use :: Galactic_Inclinations         , only : galacticInclinationClass
@@ -82,25 +82,25 @@
      A dust attenuation class using the atlas of :cite:t:`ferrara_atlas_1999`.
      !!}
      private
-     class           (galacticInclinationClass       ), pointer                       :: galacticInclination_   => null()
-     class           (dustAttenuationScreen          ), pointer                       :: dustAttenuation_       => null()
-     type            (enumerationFerrara2000DustType )                                :: dust
-     double precision                                                                 :: heightRatio
-     logical                                                                          :: inclinationAvailable
+     class           (galacticInclinationClass       ), pointer                         :: galacticInclination_     => null()
+     class           (dustAttenuationScreen          ), pointer                         :: dustAttenuation_         => null()
+     type            (enumerationFerrara2000DustType )                                  :: dust
+     double precision                                                                   :: heightRatio
+     logical                                                                            :: inclinationAvailable
      ! Grid axes. Wavelengths are in Angstroms and inclinations in degrees, as tabulated; the spheroid axis is the
      ! spheroid half-mass radius in units of the disk scale length.
-     double precision                                 , allocatable, dimension(:      ) :: wavelength           , inclination        , &
-          &                                                                                depthOptical         , radiusSpheroid
+     double precision                                 , allocatable, dimension(:      ) :: wavelength                        , inclination               , &
+          &                                                                                depthOptical                      , radiusSpheroid
      ! Tabulated transmission. The datasets are written (wavelength, inclination, opticalDepth[, radius]) as a
      ! row-major reader sees them, so the Fortran dimensions are the reverse of that.
      double precision                                 , allocatable, dimension(:,:,:  ) :: transmissionDisk
      double precision                                 , allocatable, dimension(:,:,:,:) :: transmissionSpheroid
-     type            (interpolatorMultiD             )                                  :: interpolatorDisk     , interpolatorSpheroid
+     type            (interpolatorMultiD             )                                  :: interpolatorDisk                  , interpolatorSpheroid
      ! The axis interpolators are retained as well as being handed to the multilinear interpolators above. Only the
      ! wavelength changes between the parcels of a galaxy, so bracketing the other axes once per galaxy and reusing
      ! the result saves that work on every parcel.
-     type            (interpolator                   )                                  :: interpolatorWavelength  , interpolatorInclination, &
-          &                                                                                interpolatorDepthOptical, interpolatorRadiusSpheroid
+     type            (interpolator                   )                                  :: interpolatorWavelength            , interpolatorInclination   , &
+          &                                                                                interpolatorDepthOptical          , interpolatorRadiusSpheroid
    contains
      final     ::                      atlasFerrara2000Destructor
      procedure :: transmission      => atlasFerrara2000Transmission
@@ -176,12 +176,12 @@ contains
     Internal constructor for the :galacticus-class:`dustAttenuationAtlasFerrara2000` dust attenuation class. The
     tabulation is read once, here, and interpolators built over it.
     !!}
-    use :: Error                   , only : Error_Report
-    use :: HDF5_Access             , only : hdf5Access
-    use :: Input_Paths             , only : inputPath                , pathTypeDataStatic
-    use :: IO_HDF5                 , only : hdf5File
-    use :: ISO_Varying_String      , only : char                     , operator(//)     , varying_string
-    use :: Table_Labels            , only : extrapolationTypeFix
+    use :: Error             , only : Error_Report
+    use :: HDF5_Access       , only : hdf5Access
+    use :: Input_Paths       , only : inputPath           , pathTypeDataStatic
+    use :: IO_HDF5           , only : hdf5File
+    use :: ISO_Varying_String, only : char                , operator(//)      , varying_string
+    use :: Table_Labels      , only : extrapolationTypeFix
     implicit none
     type            (dustAttenuationAtlasFerrara2000)                        :: self
     type            (enumerationFerrara2000DustType ), intent(in   )         :: dust
@@ -231,26 +231,26 @@ contains
     !$ call hdf5Access%unset()
     ! Check that the tables have the shape the axes imply. A transposed read would otherwise show up much later as
     ! quietly wrong attenuation.
-    if (any(shape(self%transmissionDisk    ) /= [size(self%depthOptical),size(self%inclination),size(self%wavelength)                      ])) &
+    if (any(shape(self%transmissionDisk    ) /= [size(self%depthOptical  ),size(self%inclination )                       ,size(self%wavelength)])) &
          & call Error_Report('`attenuationDisk` does not have the shape implied by the axes'    //{introspection:location})
     if (any(shape(self%transmissionSpheroid) /= [size(self%radiusSpheroid),size(self%depthOptical),size(self%inclination),size(self%wavelength)])) &
          & call Error_Report('`attenuationSpheroid` does not have the shape implied by the axes'//{introspection:location})
     ! Build interpolators, ordered from the most rapidly varying dimension of the table outward. Optical depth and
     ! spheroid size are interpolated logarithmically, being tabulated on geometric grids; wavelength likewise. Values
     ! outside the tabulated ranges are held at the boundary.
-    interpolatorsDisk    (1)=interpolator(log(self%depthOptical  ),extrapolationType=extrapolationTypeFix)
-    interpolatorsDisk    (2)=interpolator(    self%inclination    ,extrapolationType=extrapolationTypeFix)
-    interpolatorsDisk    (3)=interpolator(log(self%wavelength    ),extrapolationType=extrapolationTypeFix)
-    interpolatorsSpheroid(1)=interpolator(log(self%radiusSpheroid),extrapolationType=extrapolationTypeFix)
-    interpolatorsSpheroid(2)=interpolatorsDisk(1)
-    interpolatorsSpheroid(3)=interpolatorsDisk(2)
-    interpolatorsSpheroid(4)=interpolatorsDisk(3)
-    self%interpolatorDisk        =interpolatorMultiD(interpolatorsDisk    )
-    self%interpolatorSpheroid    =interpolatorMultiD(interpolatorsSpheroid)
-    self%interpolatorDepthOptical=interpolatorsDisk    (1)
-    self%interpolatorInclination =interpolatorsDisk    (2)
-    self%interpolatorWavelength  =interpolatorsDisk    (3)
-    self%interpolatorRadiusSpheroid=interpolatorsSpheroid(1)
+    interpolatorsDisk              (1)=interpolator(log(self%depthOptical  ),extrapolationType=extrapolationTypeFix)
+    interpolatorsDisk              (2)=interpolator(    self%inclination    ,extrapolationType=extrapolationTypeFix)
+    interpolatorsDisk              (3)=interpolator(log(self%wavelength    ),extrapolationType=extrapolationTypeFix)
+    interpolatorsSpheroid          (1)=interpolator(log(self%radiusSpheroid),extrapolationType=extrapolationTypeFix)
+    interpolatorsSpheroid          (2)=interpolatorsDisk(1)
+    interpolatorsSpheroid          (3)=interpolatorsDisk(2)
+    interpolatorsSpheroid          (4)=interpolatorsDisk(3)
+    self%interpolatorDisk             =interpolatorMultiD(interpolatorsDisk    )
+    self%interpolatorSpheroid         =interpolatorMultiD(interpolatorsSpheroid)
+    self%interpolatorDepthOptical     =interpolatorsDisk    (1)
+    self%interpolatorInclination      =interpolatorsDisk    (2)
+    self%interpolatorWavelength       =interpolatorsDisk    (3)
+    self%interpolatorRadiusSpheroid   =interpolatorsSpheroid(1)
     return
   end function atlasFerrara2000ConstructorInternal
 
@@ -262,8 +262,8 @@ contains
     type(dustAttenuationAtlasFerrara2000), intent(inout) :: self
 
     !![
-    <objectDestructor name="self%galacticInclination_"  />
-    <objectDestructor name="self%dustAttenuation_"      />
+    <objectDestructor name="self%galacticInclination_"/>
+    <objectDestructor name="self%dustAttenuation_"    />
     !!]
     return
   end subroutine atlasFerrara2000Destructor
@@ -275,18 +275,18 @@ contains
     The optical depth and the inclination are properties of the galaxy rather than of a parcel, so both are obtained
     once here and reused across every parcel, as is the spheroid size if any parcel needs it.
     !!}
-    use, intrinsic :: ISO_C_Binding             , only : c_size_t
-    use :: Error                           , only : Error_Report
-    use :: Galactic_Structure_Options      , only : componentTypeDisk    , componentTypeSpheroid
-    use :: Numerical_Constants_Astronomical, only : degreesToRadians
+    use, intrinsic :: ISO_C_Binding                   , only : c_size_t
+    use            :: Error                           , only : Error_Report
+    use            :: Galactic_Structure_Options      , only : componentTypeDisk, componentTypeSpheroid
+    use            :: Numerical_Constants_Astronomical, only : degreesToRadians
     implicit none
     class           (dustAttenuationAtlasFerrara2000), intent(inout)                               :: self
     type            (treeNode                       ), intent(inout), target                       :: node
     type            (emissionDescriptor             ), intent(in   ), dimension(:                ) :: descriptors
     double precision                                 , intent(in   ), optional                     :: inclination
     double precision                                                , dimension(size(descriptors)) :: transmission
-    double precision                                                                               :: depthOptical      , inclination_, &
-         &                                                                                            radiusSpheroid    , logDepth    , &
+    double precision                                                                               :: depthOptical          , inclination_, &
+         &                                                                                            radiusSpheroid        , logDepth    , &
          &                                                                                            inclinationDegrees
     logical                                                                                        :: radiusSpheroidComputed
     integer                                                                                        :: i
@@ -363,21 +363,21 @@ contains
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : nodeComponentDisk, nodeComponentSpheroid
     implicit none
-    type            (treeNode             ), intent(inout), target :: node
+    type            (treeNode             ), intent(inout), target  :: node
     class           (nodeComponentDisk    )               , pointer :: disk
     class           (nodeComponentSpheroid)               , pointer :: spheroid
     double precision                                                :: radiusDisk
 
-    disk       => node    %disk  ()
-    spheroid   => node    %spheroid()
-    radiusDisk =  disk    %radius()
+    disk       => node%disk    ()
+    spheroid   => node%spheroid()
+    radiusDisk =  disk%radius  ()
     if (radiusDisk <= 0.0d0) then
        ! With no disk there is no scale to measure the spheroid against, and no dust either, so the value is
        ! immaterial: return the smallest tabulated size.
        radiusSpheroid=0.0d0
        return
     end if
-    radiusSpheroid=+spheroid%radius() &
+    radiusSpheroid=+spheroid%radius    () &
          &         /         radiusDisk
     return
   end function atlasFerrara2000RadiusSpheroid

--- a/source/dust/attenuation/atlas_Ferrara2000.F90
+++ b/source/dust/attenuation/atlas_Ferrara2000.F90
@@ -356,29 +356,47 @@ contains
 
     :cite:t:`ferrara_atlas_1999` model spheroids as Jaffe profiles and tabulate against the spheroid effective
     radius. For a Jaffe profile the enclosed mass is :math:`M(r)/M = (r/r_0)/(1+r/r_0)`, so the half-mass radius is
-    exactly the scale radius :math:`r_0`; the tabulated axis is therefore a half-mass radius. A model galaxy's
-    spheroid will in general follow some other profile, so it is matched on that same physical radius rather than on
-    a scale radius, whose meaning differs between profiles.
+    exactly the scale radius :math:`r_0`, and the tabulated axis is therefore a half-mass radius.
+
+    A model galaxy's spheroid will in general follow some other profile, for which the scale radius is *not* the
+    half-mass radius---for a Hernquist profile the latter is :math:`(1+\sqrt{2})` times the former---so the
+    half-mass radius is taken from the stellar mass distribution of the spheroid rather than from its scale radius.
+    That is the radius which means the same thing whatever profile either side assumes, and matching on it is what
+    makes the atlas applicable to a spheroid it was not computed for.
+
+    The disk is measured by its scale radius, which is what :cite:t:`ferrara_atlas_1999` normalize to, and which is
+    what the disk component's radius already is for an exponential profile.
     !!}
-    use :: Error           , only : Error_Report
-    use :: Galacticus_Nodes, only : nodeComponentDisk, nodeComponentSpheroid
+    use :: Error                     , only : Error_Report
+    use :: Galactic_Structure_Options, only : componentTypeSpheroid, massTypeStellar
+    use :: Galacticus_Nodes          , only : nodeComponentDisk
+    use :: Mass_Distributions        , only : massDistributionClass, massDistributionSpherical
     implicit none
     type            (treeNode             ), intent(inout), target  :: node
     class           (nodeComponentDisk    )               , pointer :: disk
-    class           (nodeComponentSpheroid)               , pointer :: spheroid
+    class           (massDistributionClass)               , pointer :: massDistributionSpheroid
     double precision                                                :: radiusDisk
 
-    disk       => node%disk    ()
-    spheroid   => node%spheroid()
-    radiusDisk =  disk%radius  ()
+    disk       => node%disk  ()
+    radiusDisk =  disk%radius()
+    ! With no disk there is no scale to measure the spheroid against, and no dust either, so the value is
+    ! immaterial: return zero, which the caller clamps into the tabulated range.
     if (radiusDisk <= 0.0d0) then
-       ! With no disk there is no scale to measure the spheroid against, and no dust either, so the value is
-       ! immaterial: return the smallest tabulated size.
        radiusSpheroid=0.0d0
        return
     end if
-    radiusSpheroid=+spheroid%radius    () &
-         &         /         radiusDisk
+    massDistributionSpheroid => node%massDistribution(componentTypeSpheroid,massTypeStellar)
+    select type (massDistributionSpheroid)
+    class is (massDistributionSpherical)
+       radiusSpheroid=+massDistributionSpheroid%radiusHalfMass() &
+            &         /                         radiusDisk
+    class default
+       radiusSpheroid=0.0d0
+       call Error_Report('a half-mass radius is needed for the spheroid, which requires a spherical mass distribution'//{introspection:location})
+    end select
+    !![
+    <objectDestructor name="massDistributionSpheroid"/>
+    !!]
     return
   end function atlasFerrara2000RadiusSpheroid
 

--- a/source/dust/attenuation/birth_cloud.F90
+++ b/source/dust/attenuation/birth_cloud.F90
@@ -149,7 +149,7 @@ contains
     class           (dustAttenuationBirthCloud), intent(inout)                                               :: self
     type            (treeNode                 ), intent(inout), target                                       :: node
     type            (emissionDescriptor       ), intent(in   ), dimension(:                                ) :: descriptors
-    double precision                                    , intent(in   ), optional                            :: inclination
+    double precision                           , intent(in   ), optional                                     :: inclination
     double precision                                          , dimension(size(descriptors)                ) :: transmission
     double precision                                          , dimension(componentTypeMin:componentTypeMax) :: depthOpticalV
     logical                                                   , dimension(componentTypeMin:componentTypeMax) :: computed

--- a/source/dust/attenuation/birth_cloud.F90
+++ b/source/dust/attenuation/birth_cloud.F90
@@ -140,7 +140,7 @@ contains
     return
   end subroutine birthCloudDestructor
 
-  function birthCloudTransmission(self,node,descriptors) result(transmission)
+  function birthCloudTransmission(self,node,descriptors,inclination) result(transmission)
     !!{RST
     Return the transmission through the dust of a stellar birth cloud.
     !!}
@@ -149,12 +149,14 @@ contains
     class           (dustAttenuationBirthCloud), intent(inout)                                               :: self
     type            (treeNode                 ), intent(inout), target                                       :: node
     type            (emissionDescriptor       ), intent(in   ), dimension(:                                ) :: descriptors
+    double precision                                    , intent(in   ), optional                            :: inclination
     double precision                                          , dimension(size(descriptors)                ) :: transmission
     double precision                                          , dimension(componentTypeMin:componentTypeMax) :: depthOpticalV
     logical                                                   , dimension(componentTypeMin:componentTypeMax) :: computed
     integer                                                                                                  :: i            , indexComponent
     double precision                                                                                         :: massGas      , radius        , &
          &                                                                                                      metallicity
+    !$GLC attributes unused :: inclination
 
     computed=.false.
     do i=1,size(descriptors)

--- a/source/dust/attenuation/inclination_averaged.F90
+++ b/source/dust/attenuation/inclination_averaged.F90
@@ -1,0 +1,258 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+  !!{RST
+  Implements a dust attenuation class which averages another over orientation.
+  !!}
+
+  !![
+  <dustAttenuation name="dustAttenuationInclinationAveraged" docformat="rst">
+   <description>
+   A dust attenuation class which averages the transmission of another attenuator over orientation, for models in
+   which no inclination is available for each galaxy---which is the default, see
+   :galacticus-class:`galacticInclinationNull`.
+
+   Orientations are isotropic, so uniform in :math:`\cos i`, and the average is
+
+   .. math::
+
+      \bar{T}(\lambda) = \int_0^1 T(\lambda,i) \, \mathrm{d}\cos i.
+
+   It is the *transmission* which is averaged, not the optical depth. Those are not the same thing: attenuation is
+   exponential in optical depth, so a galaxy seen at a range of orientations transmits more light than one seen at
+   the mean optical depth, and averaging the depth instead would systematically over-attenuate. What an observer
+   averaging over an orientation-blind sample measures is the mean flux, which is the mean transmission.
+
+   The wrapped attenuator is evaluated at each abscissa through the optional ``inclination`` argument of its
+   ``transmission`` method, so nothing is mutated and the arrangement is safe under threading. Wrapping a
+   :galacticus-class:`dustAttenuationSequence` averages the sequence as a whole---the product of its members
+   evaluated at a common orientation---rather than the product of separately averaged members, which is a different
+   and incorrect quantity.
+
+   The integral is evaluated by Gauss-Legendre quadrature of order ``order``. Fixed-order quadrature is used in
+   preference to an adaptive rule because the integrand is smooth and bounded in :math:`[0,1]`, so it converges
+   quickly, and because the cost of the average multiplies the cost of every luminosity: a fixed order makes that
+   cost predictable and puts it under the user's control. Order 8 is accurate to better than one part in
+   :math:`10^{6}` for the attenuation curves of interest.
+   </description>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationClass) :: dustAttenuationInclinationAveraged
+     !!{RST
+     A dust attenuation class which averages another over orientation.
+     !!}
+     private
+     class           (dustAttenuationClass), pointer                   :: dustAttenuation_ => null()
+     integer                                                           :: order
+     ! Abscissae in cos(i) and their weights, computed once at construction.
+     double precision                      , allocatable, dimension(:) :: cosineInclination         , weight
+   contains
+     final     ::                 inclinationAveragedDestructor
+     procedure :: transmission      => inclinationAveragedTransmission
+     procedure :: request           => inclinationAveragedRequest
+     procedure :: supportsComponent => inclinationAveragedSupportsComponent
+  end type dustAttenuationInclinationAveraged
+
+  interface dustAttenuationInclinationAveraged
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationInclinationAveraged` dust attenuation class.
+     !!}
+     module procedure inclinationAveragedConstructorParameters
+     module procedure inclinationAveragedConstructorInternal
+  end interface dustAttenuationInclinationAveraged
+
+contains
+
+  function inclinationAveragedConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationInclinationAveraged` dust attenuation class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type   (dustAttenuationInclinationAveraged)                :: self
+    type   (inputParameters                   ), intent(inout) :: parameters
+    class  (dustAttenuationClass              ), pointer       :: dustAttenuation_
+    integer                                                    :: order
+
+    !![
+    <inputParameter docformat="rst">
+      <name>order</name>
+      <defaultValue>8</defaultValue>
+      <description>
+      The order of the Gauss-Legendre quadrature used to average over orientation. The cost of the average is
+      proportional to this.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="dustAttenuation" name="dustAttenuation_" source="parameters"/>
+    !!]
+    self=dustAttenuationInclinationAveraged(order,dustAttenuation_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="dustAttenuation_"/>
+    !!]
+    return
+  end function inclinationAveragedConstructorParameters
+
+  function inclinationAveragedConstructorInternal(order,dustAttenuation_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustAttenuationInclinationAveraged` dust attenuation class.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    type   (dustAttenuationInclinationAveraged)                        :: self
+    integer                                    , intent(in   )         :: order
+    class  (dustAttenuationClass              ), intent(in   ), target :: dustAttenuation_
+    !![
+    <constructorAssign variables="order, *dustAttenuation_"/>
+    !!]
+
+    if (self%order < 1) call Error_Report('`order` must be positive'//{introspection:location})
+    call gaussLegendreRule(self%order,self%cosineInclination,self%weight)
+    return
+  end function inclinationAveragedConstructorInternal
+
+  subroutine inclinationAveragedDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`dustAttenuationInclinationAveraged` dust attenuation class.
+    !!}
+    implicit none
+    type(dustAttenuationInclinationAveraged), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%dustAttenuation_"/>
+    !!]
+    return
+  end subroutine inclinationAveragedDestructor
+
+  subroutine gaussLegendreRule(order,abscissae,weights)
+    !!{RST
+    Return the abscissae and weights of the Gauss-Legendre rule of the given ``order`` on the interval
+    :math:`[0,1]`.
+
+    The nodes are the roots of the Legendre polynomial of that order, found by Newton iteration from the standard
+    Chebyshev-like starting guess, with the polynomial and its derivative evaluated by the usual recurrence. Both are
+    then mapped from :math:`[-1,1]` onto :math:`[0,1]`, and the weights scaled by the half-width of the interval so
+    that they sum to unity---which is what makes the result an average rather than an integral.
+    !!}
+    use :: Numerical_Constants_Math, only : Pi
+    implicit none
+    integer                       , intent(in   )                            :: order
+    double precision, allocatable , intent(inout), dimension(:)              :: abscissae, weights
+    double precision              , parameter                                :: toleranceRelative=1.0d-15
+    integer                       , parameter                                :: countIterationsMaximum=100
+    double precision                                                         :: root     , rootPrevious, &
+         &                                                                      legendre , legendreLower, &
+         &                                                                      legendreLowerLower      , &
+         &                                                                      derivative
+    integer                                                                  :: i        , j             , &
+         &                                                                      countIterations
+
+    if (allocated(abscissae)) deallocate(abscissae)
+    if (allocated(weights  )) deallocate(weights  )
+    allocate(abscissae(order))
+    allocate(weights  (order))
+    do i=1,order
+       ! Initial guess for the i'th root of the Legendre polynomial of this order.
+       root=cos(Pi*(dble(i)-0.25d0)/(dble(order)+0.5d0))
+       countIterations=0
+       do
+          ! Evaluate the Legendre polynomial and its derivative at the current estimate by recurrence.
+          legendre     =1.0d0
+          legendreLower=0.0d0
+          do j=1,order
+             legendreLowerLower=legendreLower
+             legendreLower     =legendre
+             legendre          =(dble(2*j-1)*root*legendreLower-dble(j-1)*legendreLowerLower)/dble(j)
+          end do
+          derivative  =dble(order)*(root*legendre-legendreLower)/(root**2-1.0d0)
+          rootPrevious=root
+          root        =rootPrevious-legendre/derivative
+          countIterations=countIterations+1
+          if (abs(root-rootPrevious) <= toleranceRelative*abs(root) .or. countIterations >= countIterationsMaximum) exit
+       end do
+       ! Map from [-1,1] onto [0,1]. The weights are halved along with the interval, so that they sum to unity and
+       ! the quadrature returns a mean.
+       abscissae(i)=0.5d0*(1.0d0-root)
+       weights  (i)=1.0d0/((1.0d0-root**2)*derivative**2)
+    end do
+    return
+  end subroutine gaussLegendreRule
+
+  function inclinationAveragedTransmission(self,node,descriptors,inclination) result(transmission)
+    !!{RST
+    Return the transmission of the wrapped attenuator, averaged over orientation.
+
+    Any ``inclination`` supplied by a caller is ignored: this class exists precisely to remove the dependence on
+    orientation, so honoring an imposed angle would defeat it. Nesting one of these inside another is therefore
+    harmless but pointless.
+    !!}
+    implicit none
+    class           (dustAttenuationInclinationAveraged), intent(inout)                               :: self
+    type            (treeNode                          ), intent(inout), target                       :: node
+    type            (emissionDescriptor                ), intent(in   ), dimension(:                ) :: descriptors
+    double precision                                    , intent(in   ), optional                     :: inclination
+    double precision                                                   , dimension(size(descriptors)) :: transmission
+    integer                                                                                           :: i
+    !$GLC attributes unused :: inclination
+
+    transmission=0.0d0
+    do i=1,self%order
+       transmission=+transmission                                                    &
+            &       +self%weight(i)                                                  &
+            &       *self%dustAttenuation_%transmission(                             &
+            &                                           node                       , &
+            &                                           descriptors                , &
+            &                                           acos(self%cosineInclination(i)) &
+            &                                          )
+    end do
+    return
+  end function inclinationAveragedTransmission
+
+  logical function inclinationAveragedSupportsComponent(self,componentType) result(supportsComponent)
+    !!{RST
+    Return whether the wrapped attenuator supports the given component: averaging over orientation changes nothing
+    about which components can be attenuated.
+
+    Forwarding this matters. The base class accepts any individual component, so a decorator which did not forward
+    would make the construction-time check pass for a component its wrapped attenuator rejects, and that component
+    would then be attenuated anyway.
+    !!}
+    implicit none
+    class(dustAttenuationInclinationAveraged), intent(inout) :: self
+    type (enumerationComponentTypeType      ), intent(in   ) :: componentType
+
+    supportsComponent=self%dustAttenuation_%supportsComponent(componentType)
+    return
+  end function inclinationAveragedSupportsComponent
+
+  function inclinationAveragedRequest(self) result(request)
+    !!{RST
+    Return the decomposition request of the wrapped attenuator: averaging over orientation changes nothing about
+    which parcels must be distinguished.
+    !!}
+    implicit none
+    type (decompositionRequest                 )                :: request
+    class(dustAttenuationInclinationAveraged   ), intent(inout) :: self
+
+    request=self%dustAttenuation_%request()
+    return
+  end function inclinationAveragedRequest

--- a/source/dust/attenuation/inclination_averaged.F90
+++ b/source/dust/attenuation/inclination_averaged.F90
@@ -64,7 +64,7 @@
      ! Abscissae in cos(i) and their weights, computed once at construction.
      double precision                      , allocatable, dimension(:) :: cosineInclination         , weight
    contains
-     final     ::                 inclinationAveragedDestructor
+     final     ::                      inclinationAveragedDestructor
      procedure :: transmission      => inclinationAveragedTransmission
      procedure :: request           => inclinationAveragedRequest
      procedure :: supportsComponent => inclinationAveragedSupportsComponent
@@ -155,16 +155,15 @@ contains
     !!}
     use :: Numerical_Constants_Math, only : Pi
     implicit none
-    integer                       , intent(in   )                            :: order
-    double precision, allocatable , intent(inout), dimension(:)              :: abscissae, weights
-    double precision              , parameter                                :: toleranceRelative=1.0d-15
-    integer                       , parameter                                :: countIterationsMaximum=100
-    double precision                                                         :: root     , rootPrevious, &
-         &                                                                      legendre , legendreLower, &
-         &                                                                      legendreLowerLower      , &
-         &                                                                      derivative
-    integer                                                                  :: i        , j             , &
-         &                                                                      countIterations
+    integer                       , intent(in   )               :: order
+    double precision, allocatable , intent(inout), dimension(:) :: abscissae                     , weights
+    double precision              , parameter                   :: toleranceRelative     =1.0d-15
+    integer                       , parameter                   :: countIterationsMaximum=100
+    double precision                                            :: root                          , rootPrevious , &
+         &                                                         legendre                      , legendreLower, &
+         &                                                         legendreLowerLower            , derivative
+    integer                                                     :: i                             , j            , &
+         &                                                         countIterations
 
     if (allocated(abscissae)) deallocate(abscissae)
     if (allocated(weights  )) deallocate(weights  )
@@ -216,12 +215,12 @@ contains
 
     transmission=0.0d0
     do i=1,self%order
-       transmission=+transmission                                                    &
-            &       +self%weight(i)                                                  &
-            &       *self%dustAttenuation_%transmission(                             &
-            &                                           node                       , &
-            &                                           descriptors                , &
-            &                                           acos(self%cosineInclination(i)) &
+       transmission=+transmission                                                        &
+            &       +self%weight(i)                                                      &
+            &       *self%dustAttenuation_%transmission(                                 &
+            &                                           node                           , &
+            &                                           descriptors                    , &
+            &                                           acos(self%cosineInclination(i))  &
             &                                          )
     end do
     return
@@ -250,8 +249,8 @@ contains
     which parcels must be distinguished.
     !!}
     implicit none
-    type (decompositionRequest                 )                :: request
-    class(dustAttenuationInclinationAveraged   ), intent(inout) :: self
+    type (decompositionRequest              )                :: request
+    class(dustAttenuationInclinationAveraged), intent(inout) :: self
 
     request=self%dustAttenuation_%request()
     return

--- a/source/dust/attenuation/inclination_averaged.F90
+++ b/source/dust/attenuation/inclination_averaged.F90
@@ -47,7 +47,7 @@
    and incorrect quantity.
 
    The integral is evaluated by Gauss-Legendre quadrature of order ``order``. Fixed-order quadrature is used in
-   preference to an adaptive rule because the integrand is smooth and bounded in :math:`[0,1]`, so it converges
+   preference to an adaptive rule because the integrand is smooth and bounded, so it converges
    quickly, and because the cost of the average multiplies the cost of every luminosity: a fixed order makes that
    cost predictable and puts it under the user's control. Order 8 is accurate to better than one part in
    :math:`10^{6}` for the attenuation curves of interest.

--- a/source/dust/attenuation/mixed_slab.F90
+++ b/source/dust/attenuation/mixed_slab.F90
@@ -125,7 +125,7 @@ contains
     class           (dustAttenuationMixedSlab), intent(inout)                               :: self
     type            (treeNode                ), intent(inout), target                       :: node
     type            (emissionDescriptor      ), intent(in   ), dimension(:                ) :: descriptors
-    double precision                                    , intent(in   ), optional           :: inclination
+    double precision                          , intent(in   ), optional                     :: inclination
     double precision                                         , dimension(size(descriptors)) :: transmission
     ! Below this optical depth the series expansion of [1-exp(-τ)]/τ is used: the direct expression suffers
     ! cancellation as τ →, where both numerator and denominator vanish.

--- a/source/dust/attenuation/mixed_slab.F90
+++ b/source/dust/attenuation/mixed_slab.F90
@@ -117,7 +117,7 @@ contains
     return
   end subroutine mixedSlabDestructor
 
-  function mixedSlabTransmission(self,node,descriptors) result(transmission)
+  function mixedSlabTransmission(self,node,descriptors,inclination) result(transmission)
     !!{RST
     Return the transmission through dust mixed uniformly with the emitting stars.
     !!}
@@ -125,12 +125,14 @@ contains
     class           (dustAttenuationMixedSlab), intent(inout)                               :: self
     type            (treeNode                ), intent(inout), target                       :: node
     type            (emissionDescriptor      ), intent(in   ), dimension(:                ) :: descriptors
+    double precision                                    , intent(in   ), optional           :: inclination
     double precision                                         , dimension(size(descriptors)) :: transmission
     ! Below this optical depth the series expansion of [1-exp(-τ)]/τ is used: the direct expression suffers
     ! cancellation as τ →, where both numerator and denominator vanish.
     double precision                                         , parameter                    :: depthOpticalSmall=1.0d-6
     integer                                                                                 :: i
     double precision                                                                        :: depthOptical
+    !$GLC attributes unused :: inclination
 
     transmission=self%dustAttenuation_%transmission(node,descriptors)
     do i=1,size(transmission)

--- a/source/dust/attenuation/screen.F90
+++ b/source/dust/attenuation/screen.F90
@@ -99,7 +99,7 @@ contains
     return
   end function screenDepthOpticalV
 
-  function screenTransmission(self,node,descriptors) result(transmission)
+  function screenTransmission(self,node,descriptors,inclination) result(transmission)
     !!{RST
     Return the transmission through a uniform screen of dust.
 
@@ -112,10 +112,12 @@ contains
     class           (dustAttenuationScreen), intent(inout)                                               :: self
     type            (treeNode             ), intent(inout), target                                       :: node
     type            (emissionDescriptor   ), intent(in   ), dimension(:                                ) :: descriptors
+    double precision                                    , intent(in   ), optional                        :: inclination
     double precision                                      , dimension(size(descriptors)                ) :: transmission
     double precision                                      , dimension(componentTypeMin:componentTypeMax) :: depthOpticalV
     logical                                               , dimension(componentTypeMin:componentTypeMax) :: computed
     integer                                                                                              :: i            , indexComponent
+    !$GLC attributes unused :: inclination
 
     computed=.false.
     do i=1,size(descriptors)

--- a/source/dust/attenuation/screen.F90
+++ b/source/dust/attenuation/screen.F90
@@ -112,7 +112,7 @@ contains
     class           (dustAttenuationScreen), intent(inout)                                               :: self
     type            (treeNode             ), intent(inout), target                                       :: node
     type            (emissionDescriptor   ), intent(in   ), dimension(:                                ) :: descriptors
-    double precision                                    , intent(in   ), optional                        :: inclination
+    double precision                       , intent(in   ), optional                                     :: inclination
     double precision                                      , dimension(size(descriptors)                ) :: transmission
     double precision                                      , dimension(componentTypeMin:componentTypeMax) :: depthOpticalV
     logical                                               , dimension(componentTypeMin:componentTypeMax) :: computed

--- a/source/dust/attenuation/sequence.F90
+++ b/source/dust/attenuation/sequence.F90
@@ -143,22 +143,27 @@ contains
     return
   end subroutine sequenceDestructor
 
-  function sequenceTransmission(self,node,descriptors) result(transmission)
+  function sequenceTransmission(self,node,descriptors,inclination) result(transmission)
     !!{RST
     Return the product of the transmissions of each attenuator in the sequence.
+
+    Any ``inclination`` is passed on to each member, so that wrapping a sequence in
+    :galacticus-class:`dustAttenuationInclinationAveraged` averages the sequence as a whole---the product evaluated
+    at each orientation---rather than the product of separately averaged members, which is not the same thing.
     !!}
     implicit none
     class           (dustAttenuationSequence), intent(inout)                               :: self
     type            (treeNode               ), intent(inout), target                       :: node
     type            (emissionDescriptor     ), intent(in   ), dimension(:)                 :: descriptors
+    double precision                                        , intent(in   ), optional       :: inclination
     double precision                                        , dimension(size(descriptors)) :: transmission
     type            (dustAttenuationList    ), pointer                                     :: dustAttenuation_
 
     transmission     =  1.0d0
     dustAttenuation_ => self%dustAttenuations
     do while (associated(dustAttenuation_))
-       transmission     =  +transmission                                                     &
-            &              *dustAttenuation_%dustAttenuation_%transmission(node,descriptors)
+       transmission     =  +transmission                                                                 &
+            &              *dustAttenuation_%dustAttenuation_%transmission(node,descriptors,inclination)
        dustAttenuation_ =>  dustAttenuation_%next
     end do
     return

--- a/source/dust/attenuation/sequence.F90
+++ b/source/dust/attenuation/sequence.F90
@@ -155,7 +155,7 @@ contains
     class           (dustAttenuationSequence), intent(inout)                               :: self
     type            (treeNode               ), intent(inout), target                       :: node
     type            (emissionDescriptor     ), intent(in   ), dimension(:)                 :: descriptors
-    double precision                                        , intent(in   ), optional       :: inclination
+    double precision                         , intent(in   ), optional                     :: inclination
     double precision                                        , dimension(size(descriptors)) :: transmission
     type            (dustAttenuationList    ), pointer                                     :: dustAttenuation_
 

--- a/source/dust/attenuation/zero.F90
+++ b/source/dust/attenuation/zero.F90
@@ -71,7 +71,7 @@ contains
     return
   end function zeroConstructorParameters
 
-  function zeroTransmission(self,node,descriptors) result(transmission)
+  function zeroTransmission(self,node,descriptors,inclination) result(transmission)
     !!{RST
     Return unit transmission---no attenuation---for every parcel.
     !!}
@@ -79,8 +79,9 @@ contains
     class           (dustAttenuationZero), intent(inout)                               :: self
     type            (treeNode           ), intent(inout), target                       :: node
     type            (emissionDescriptor ), intent(in   ), dimension(:                ) :: descriptors
+    double precision                                    , intent(in   ), optional      :: inclination
     double precision                                    , dimension(size(descriptors)) :: transmission
-    !$GLC attributes unused :: self, node, descriptors
+    !$GLC attributes unused :: self, node, descriptors, inclination
 
     transmission=1.0d0
     return

--- a/source/dust/attenuation/zero.F90
+++ b/source/dust/attenuation/zero.F90
@@ -79,7 +79,7 @@ contains
     class           (dustAttenuationZero), intent(inout)                               :: self
     type            (treeNode           ), intent(inout), target                       :: node
     type            (emissionDescriptor ), intent(in   ), dimension(:                ) :: descriptors
-    double precision                                    , intent(in   ), optional      :: inclination
+    double precision                     , intent(in   ), optional                     :: inclination
     double precision                                    , dimension(size(descriptors)) :: transmission
     !$GLC attributes unused :: self, node, descriptors, inclination
 

--- a/source/galactic_structure/inclination/_class.F90
+++ b/source/galactic_structure/inclination/_class.F90
@@ -19,8 +19,6 @@
 
 !+    Contributions to this file made by: Andrew Benson, Claude.
 
-!+    Contributions to this file made by: Andrew Benson, Claude.
-
 !!{RST
 Contains a module which provides a class implementing the inclination of a galaxy to the line of sight.
 !!}
@@ -50,8 +48,7 @@ module Galactic_Inclinations
   * :galacticus-class:`galacticInclinationFixed` returns a single angle for every galaxy, for testing and for
     face-on/edge-on comparisons.
 
-  The angle is returned in radians. The tabulated atlases are in degrees, so a conversion has to happen somewhere;
-  radians are the natural unit for the class itself, and ``degreesToRadians`` is available for the tables.
+  The angle is returned in radians.
   !!}
   use :: Galacticus_Nodes, only : treeNode
   implicit none

--- a/source/galactic_structure/inclination/_class.F90
+++ b/source/galactic_structure/inclination/_class.F90
@@ -1,0 +1,98 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!!{RST
+Contains a module which provides a class implementing the inclination of a galaxy to the line of sight.
+!!}
+
+module Galactic_Inclinations
+  !!{RST
+  Provides a class implementing the inclination of a galaxy to the line of sight.
+
+  Inclination is the angle between a galaxy's symmetry axis and the direction to the observer, so that zero is
+  face-on and :math:`\pi/2` edge-on. It is needed by any model of an anisotropic process---dust attenuation through a
+  flattened dust distribution above all, but also H I line widths, disk size distributions, and surface brightness
+  selection---and putting it behind one class guarantees that every such consumer sees the same angle for a given
+  galaxy. That matters: if two dust attenuators drew their own inclinations, a galaxy's colors would be formed from
+  luminosities computed at different orientations, and would be meaningless.
+
+  Implementations differ in where the angle comes from, and in whether they need to store anything:
+
+  * :galacticus-class:`galacticInclinationNull` supplies no inclination at all, and is the default. Consumers must
+    test ``isAvailable`` and either refuse to run or average over orientation instead---see
+    :galacticus-class:`dustAttenuationInclinationAveraged`. Costs nothing.
+  * :galacticus-class:`galacticInclinationSpinVector` derives the angle from the halo angular momentum vector, and so
+    needs no storage of its own. It is the physically motivated choice, and gives orientations correlated with
+    large-scale structure, which matters for lightcones and mock catalogs.
+  * :galacticus-class:`galacticInclinationRandom` assigns each galaxy an isotropically distributed orientation,
+    stored in a meta-property of the ``basic`` component by a ``nodeOperator``, and so costs 8 bytes per node---but
+    only if it is used.
+  * :galacticus-class:`galacticInclinationFixed` returns a single angle for every galaxy, for testing and for
+    face-on/edge-on comparisons.
+
+  The angle is returned in radians. The tabulated atlases are in degrees, so a conversion has to happen somewhere;
+  radians are the natural unit for the class itself, and ``degreesToRadians`` is available for the tables.
+  !!}
+  use :: Galacticus_Nodes, only : treeNode
+  implicit none
+  private
+
+  !![
+  <functionClass docformat="rst">
+   <name>galacticInclination</name>
+   <descriptiveName>Galactic Inclinations</descriptiveName>
+   <description>
+   Class providing the inclination of a galaxy to the line of sight.
+   </description>
+   <default>null</default>
+   <method name="inclination" >
+    <description>
+    Return the inclination of the galaxy in ``node`` to the line of sight, in radians, in the range
+    :math:`[0,\pi/2]`. Zero is face-on---the symmetry axis pointing at the observer---and :math:`\pi/2` is edge-on.
+
+    Only the angle between the axis and the line of sight is meaningful, not its sign, so implementations which
+    derive the angle from a vector fold it into the first quadrant.
+    </description>
+    <type>double precision</type>
+    <pass>yes</pass>
+    <argument>type(treeNode), intent(inout), target :: node</argument>
+   </method>
+   <method name="isAvailable" >
+    <description>
+    Return true if this class supplies a per-galaxy inclination.
+
+    Consumers which depend on orientation must test this at construction, and report a clear error if it is false,
+    rather than silently using a meaningless angle. The default is true; only
+    :galacticus-class:`galacticInclinationNull` returns false.
+    </description>
+    <type>logical</type>
+    <pass>yes</pass>
+    <code>
+     !$GLC attributes unused :: self
+     galacticInclinationIsAvailable=.true.
+    </code>
+   </method>
+  </functionClass>
+  !!]
+
+end module Galactic_Inclinations

--- a/source/galactic_structure/inclination/fixed.F90
+++ b/source/galactic_structure/inclination/fixed.F90
@@ -1,0 +1,120 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a galactic inclination class in which every galaxy has the same inclination.
+  !!}
+
+  !![
+  <galacticInclination name="galacticInclinationFixed" docformat="rst">
+   <description>
+   A galactic inclination class in which every galaxy is given the same inclination, set by the ``inclination``
+   parameter (in degrees).
+
+   This exists for testing, and for face-on versus edge-on comparisons: running the same model at
+   ``inclination``:math:`=0` and :math:`=90` isolates the effect of orientation on an anisotropic process without
+   any of the scatter that a distribution of orientations introduces.
+   </description>
+  </galacticInclination>
+  !!]
+  type, extends(galacticInclinationClass) :: galacticInclinationFixed
+     !!{RST
+     A galactic inclination class in which every galaxy has the same inclination.
+     !!}
+     private
+     ! Stored in degrees, as the parameter is given, so that a descriptor round-trips in the same units.
+     double precision :: inclination_
+   contains
+     procedure :: inclination => fixedInclination
+  end type galacticInclinationFixed
+
+  interface galacticInclinationFixed
+     !!{RST
+     Constructors for the :galacticus-class:`galacticInclinationFixed` galactic inclination class.
+     !!}
+     module procedure fixedConstructorParameters
+     module procedure fixedConstructorInternal
+  end interface galacticInclinationFixed
+
+contains
+
+  function fixedConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`galacticInclinationFixed` galactic inclination class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type            (galacticInclinationFixed)                :: self
+    type            (inputParameters         ), intent(inout) :: parameters
+    double precision                                          :: inclination
+
+    !![
+    <inputParameter docformat="rst">
+      <name>inclination</name>
+      <defaultValue>0.0d0</defaultValue>
+      <description>
+      The inclination, in degrees, assigned to every galaxy. Zero is face-on and 90 edge-on.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    self=galacticInclinationFixed(inclination)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function fixedConstructorParameters
+
+  function fixedConstructorInternal(inclination_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`galacticInclinationFixed` galactic inclination class. The
+    inclination is given in degrees.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    type            (galacticInclinationFixed)                :: self
+    double precision                          , intent(in   ) :: inclination_
+    !![
+    <constructorAssign variables="inclination_"/>
+    !!]
+
+    if (self%inclination_ < 0.0d0 .or. self%inclination_ > 90.0d0) call Error_Report('inclination must be in the range [0,90] degrees'//{introspection:location})
+    return
+  end function fixedConstructorInternal
+
+  double precision function fixedInclination(self,node) result(inclination)
+    !!{RST
+    Return the fixed inclination, converted from the degrees in which it is stored to the radians in which the class
+    interface reports it.
+    !!}
+    use :: Numerical_Constants_Astronomical, only : degreesToRadians
+    implicit none
+    class(galacticInclinationFixed), intent(inout)         :: self
+    type (treeNode                ), intent(inout), target :: node
+    !$GLC attributes unused :: node
+
+    inclination=+self%inclination_    &
+         &      *     degreesToRadians
+    return
+  end function fixedInclination

--- a/source/galactic_structure/inclination/fixed.F90
+++ b/source/galactic_structure/inclination/fixed.F90
@@ -19,8 +19,6 @@
 
 !+    Contributions to this file made by: Andrew Benson, Claude.
 
-!+    Contributions to this file made by: Andrew Benson, Claude.
-
   !!{RST
   Implements a galactic inclination class in which every galaxy has the same inclination.
   !!}

--- a/source/galactic_structure/inclination/null.F90
+++ b/source/galactic_structure/inclination/null.F90
@@ -1,0 +1,101 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a galactic inclination class which supplies no inclination.
+  !!}
+
+  !![
+  <galacticInclination name="galacticInclinationNull" docformat="rst">
+   <description>
+   A galactic inclination class which supplies no inclination, and reports itself unavailable. This is the default:
+   most models have no need of orientation, and should pay nothing for it.
+
+   Consumers which depend on orientation must test ``isAvailable`` at construction and report a clear error. For dust
+   attenuation the alternative to an error is to average over orientation instead, which
+   :galacticus-class:`dustAttenuationInclinationAveraged` does.
+   </description>
+  </galacticInclination>
+  !!]
+  type, extends(galacticInclinationClass) :: galacticInclinationNull
+     !!{RST
+     A galactic inclination class which supplies no inclination.
+     !!}
+     private
+   contains
+     procedure :: inclination => nullInclination
+     procedure :: isAvailable => nullIsAvailable
+  end type galacticInclinationNull
+
+  interface galacticInclinationNull
+     !!{RST
+     Constructors for the :galacticus-class:`galacticInclinationNull` galactic inclination class.
+     !!}
+     module procedure nullConstructorParameters
+  end interface galacticInclinationNull
+
+contains
+
+  function nullConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`galacticInclinationNull` galactic inclination class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type(galacticInclinationNull)                :: self
+    type(inputParameters        ), intent(inout) :: parameters
+
+    self=galacticInclinationNull()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function nullConstructorParameters
+
+  double precision function nullInclination(self,node) result(inclination)
+    !!{RST
+    Return no inclination. Calling this is an error: a consumer must test ``isAvailable`` first.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    class(galacticInclinationNull), intent(inout)         :: self
+    type (treeNode               ), intent(inout), target :: node
+    !$GLC attributes unused :: self, node
+
+    inclination=0.0d0
+    call Error_Report('no inclination is available: this class supplies none, as its `isAvailable` method reports'//{introspection:location})
+    return
+  end function nullInclination
+
+  logical function nullIsAvailable(self) result(isAvailable)
+    !!{RST
+    Return false: this class supplies no inclination.
+    !!}
+    implicit none
+    class(galacticInclinationNull), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    isAvailable=.false.
+    return
+  end function nullIsAvailable

--- a/source/galactic_structure/inclination/null.F90
+++ b/source/galactic_structure/inclination/null.F90
@@ -19,8 +19,6 @@
 
 !+    Contributions to this file made by: Andrew Benson, Claude.
 
-!+    Contributions to this file made by: Andrew Benson, Claude.
-
   !!{RST
   Implements a galactic inclination class which supplies no inclination.
   !!}

--- a/source/galactic_structure/inclination/random.F90
+++ b/source/galactic_structure/inclination/random.F90
@@ -19,8 +19,6 @@
 
 !+    Contributions to this file made by: Andrew Benson, Claude.
 
-!+    Contributions to this file made by: Andrew Benson, Claude.
-
   !!{RST
   Implements a galactic inclination class in which each galaxy is assigned a random orientation.
   !!}
@@ -40,8 +38,6 @@
    Drawing the angle at the point of use instead would fail all three: separate consumers would disagree, a galaxy
    would be differently oriented at each output, and consuming randoms during output would perturb every subsequent
    draw in the model.
-
-   This is the only implementation which costs storage---8 bytes per node---and it costs it only when used.
    </description>
   </galacticInclination>
   !!]

--- a/source/galactic_structure/inclination/random.F90
+++ b/source/galactic_structure/inclination/random.F90
@@ -1,0 +1,112 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a galactic inclination class in which each galaxy is assigned a random orientation.
+  !!}
+
+  !![
+  <galacticInclination name="galacticInclinationRandom" docformat="rst">
+   <description>
+   A galactic inclination class in which each galaxy is assigned an isotropically distributed orientation---uniform
+   in :math:`\cos i`---which it then keeps.
+
+   The angle is *not* drawn here. It is drawn once per galaxy by
+   :galacticus-class:`nodeOperatorInclinationRandom`, which stores it in a meta-property of the ``basic`` component;
+   this class only reads it back. Requiring that operator is what makes the orientation stable: every consumer sees
+   the same angle for a given galaxy, the angle is the same at every output, and it survives the promotion of a node
+   up its branch, since meta-properties move with the component.
+
+   Drawing the angle at the point of use instead would fail all three: separate consumers would disagree, a galaxy
+   would be differently oriented at each output, and consuming randoms during output would perturb every subsequent
+   draw in the model.
+
+   This is the only implementation which costs storage---8 bytes per node---and it costs it only when used.
+   </description>
+  </galacticInclination>
+  !!]
+  type, extends(galacticInclinationClass) :: galacticInclinationRandom
+     !!{RST
+     A galactic inclination class in which each galaxy is assigned a random orientation.
+     !!}
+     private
+     integer :: inclinationID
+   contains
+     procedure :: inclination => randomInclination
+  end type galacticInclinationRandom
+
+  interface galacticInclinationRandom
+     !!{RST
+     Constructors for the :galacticus-class:`galacticInclinationRandom` galactic inclination class.
+     !!}
+     module procedure randomConstructorParameters
+     module procedure randomConstructorInternal
+  end interface galacticInclinationRandom
+
+contains
+
+  function randomConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`galacticInclinationRandom` galactic inclination class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type(galacticInclinationRandom)                :: self
+    type(inputParameters          ), intent(inout) :: parameters
+
+    self=galacticInclinationRandom()
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    return
+  end function randomConstructorParameters
+
+  function randomConstructorInternal() result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`galacticInclinationRandom` galactic inclination class.
+    !!}
+    implicit none
+    type(galacticInclinationRandom) :: self
+
+    ! This class only reads the meta-property; `nodeOperatorInclinationRandom` creates and sets it.
+    !![
+    <addMetaProperty component="basic" name="inclination" id="self%inclinationID" isEvolvable="no"/>
+    !!]
+    return
+  end function randomConstructorInternal
+
+  double precision function randomInclination(self,node) result(inclination)
+    !!{RST
+    Return the stored random inclination of the galaxy.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentBasic
+    implicit none
+    class(galacticInclinationRandom), intent(inout)         :: self
+    type (treeNode                 ), intent(inout), target :: node
+    class(nodeComponentBasic       ), pointer               :: basic
+
+    basic       => node %basic                    (                  )
+    inclination =  basic%floatRank0MetaPropertyGet(self%inclinationID)
+    return
+  end function randomInclination

--- a/source/galactic_structure/inclination/spin_vector.F90
+++ b/source/galactic_structure/inclination/spin_vector.F90
@@ -19,8 +19,6 @@
 
 !+    Contributions to this file made by: Andrew Benson, Claude.
 
-!+    Contributions to this file made by: Andrew Benson, Claude.
-
   !!{RST
   Implements a galactic inclination class deriving the inclination from the halo angular momentum vector.
   !!}
@@ -63,6 +61,15 @@
      each appearance strictly has its own line of sight. The lightcone crossing position is a single well-defined
      choice among these, and is used for every appearance; the alternative would require the replication instance to
      be threaded through every consumer of this class.
+
+     This option requires that the node be *at* its lightcone crossing time when the inclination is requested, which
+     is what :galacticus-class:`mergerTreeEvolveTimestepLightconeCrossing` arranges, and is the same condition that
+     :galacticus-class:`nodePropertyExtractorLightcone` relies upon. The interface documentation of
+     ``positionLightconeCrossing`` states that ``timeLightconeCrossing`` must have been called first; that is not the
+     case for :galacticus-class:`geometryLightconeSquare`, the only implementation which provides it, which instead
+     recomputes the replicant from the node's current time and reports an error naming the node if that time places
+     it nowhere on the lightcone. Calling ``timeLightconeCrossing`` here would therefore not make this any safer---it
+     does not change the node's time, which is the only input used---while costing a redundant search.
    </description>
   </galacticInclination>
   !!]
@@ -87,9 +94,9 @@
      A galactic inclination class deriving the inclination from the halo angular momentum vector.
      !!}
      private
-     class           (geometryLightconeClass                ), pointer                   :: geometryLightcone_ => null()
-     type            (enumerationSpinVectorLineOfSightType  )                            :: lineOfSight
-     double precision                                        , dimension(3)              :: direction
+     class           (geometryLightconeClass                ), pointer      :: geometryLightcone_ => null()
+     type            (enumerationSpinVectorLineOfSightType  )               :: lineOfSight
+     double precision                                        , dimension(3) :: direction
    contains
      final     ::                spinVectorDestructor
      procedure :: inclination => spinVectorInclination
@@ -110,8 +117,8 @@ contains
     Constructor for the :galacticus-class:`galacticInclinationSpinVector` galactic inclination class which takes a
     parameter set as input.
     !!}
-    use :: Input_Parameters   , only : inputParameter, inputParameters
-    use :: ISO_Varying_String  , only : char          , var_str
+    use :: Input_Parameters  , only : inputParameter, inputParameters
+    use :: ISO_Varying_String, only : char          , var_str
     implicit none
     type            (galacticInclinationSpinVector)                :: self
     type            (inputParameters              ), intent(inout) :: parameters
@@ -164,28 +171,28 @@ contains
     use :: Error           , only : Error_Report
     use :: Galacticus_Nodes, only : defaultSpinComponent
     implicit none
-    type            (galacticInclinationSpinVector       )                                  :: self
-    type            (enumerationSpinVectorLineOfSightType), intent(in   )                   :: lineOfSight
-    double precision                                      , intent(in   ) , dimension(3)    :: direction
-    class           (geometryLightconeClass              ), intent(in   ) , target, optional :: geometryLightcone_
-    double precision                                                                        :: directionNorm
+    type            (galacticInclinationSpinVector       )                                         :: self
+    type            (enumerationSpinVectorLineOfSightType), intent(in   )                          :: lineOfSight
+    double precision                                      , intent(in   ) , dimension(3)           :: direction
+    class           (geometryLightconeClass              ), intent(in   ) , target      , optional :: geometryLightcone_
+    double precision                                                                               :: directionNorm
     !![
     <constructorAssign variables="lineOfSight, direction, *geometryLightcone_"/>
     !!]
 
     ! The angular momentum vector is needed, so the spin component must track it.
-    if (.not.defaultSpinComponent%angularMomentumVectorIsGettable())                                                                     &
-         & call Error_Report(                                                                                                            &
+    if (.not.defaultSpinComponent%angularMomentumVectorIsGettable())                                                                      &
+         & call Error_Report(                                                                                                             &
          &                   'the `spinVector` galactic inclination requires the angular momentum vector, so the `spin` component must'// &
          &                   ' be set to `vector`'                                                                                     // &
-         &                   {introspection:location}                                                                                    &
+         &                   {introspection:location}                                                                                     &
          &                  )
     select case (self%lineOfSight%ID)
     case (spinVectorLineOfSightFixed    %ID)
        directionNorm=sqrt(sum(self%direction**2))
        if (directionNorm <= 0.0d0) call Error_Report('`direction` must be a non-zero vector'//{introspection:location})
        ! Store the direction normalized, so that the dot product below is a cosine directly.
-       self%direction=+self%direction  &
+       self%direction=+self%direction     &
             &         /     directionNorm
     case (spinVectorLineOfSightLightcone%ID)
        if (.not.associated(self%geometryLightcone_)) call Error_Report('a `geometryLightcone` is required when `lineOfSight` is `lightcone`'//{introspection:location})
@@ -218,7 +225,7 @@ contains
     class           (galacticInclinationSpinVector), intent(inout)         :: self
     type            (treeNode                     ), intent(inout), target :: node
     class           (nodeComponentSpin            ), pointer               :: spin
-    double precision                               , dimension(3)          :: angularMomentum, direction
+    double precision                               , dimension(3)          :: angularMomentum    , direction
     double precision                                                       :: normAngularMomentum, normDirection
 
     spin               => node%spin                 ()
@@ -248,19 +255,19 @@ contains
        direction=0.0d0
        call Error_Report('unrecognized `lineOfSight`'//{introspection:location})
     end select
-    ! Fold into [0,pi/2]: only the angle between the axis and the line of sight matters, not its sign. The argument
+    ! Fold into [0,π/2]: only the angle between the axis and the line of sight matters, not its sign. The argument
     ! is clamped as protection against a dot product exceeding unity through round-off.
-    inclination=+acos(                                     &
-         &            min(                                 &
-         &                +1.0d0                         , &
-         &                +abs(                            &
-         &                     +sum(                       &
-         &                          +angularMomentum       &
-         &                          *direction              &
-         &                         )                       &
-         &                     /normAngularMomentum         &
-         &                    )                            &
-         &               )                                 &
+    inclination=+acos(                                &
+         &            min(                            &
+         &                +1.0d0                    , &
+         &                +abs(                       &
+         &                     +sum(                  &
+         &                          +angularMomentum  &
+         &                          *direction        &
+         &                         )                  &
+         &                     /normAngularMomentum   &
+         &                    )                       &
+         &               )                            &
          &           )
     return
   end function spinVectorInclination

--- a/source/galactic_structure/inclination/spin_vector.F90
+++ b/source/galactic_structure/inclination/spin_vector.F90
@@ -46,6 +46,15 @@
    to track the angular momentum *vector*---the ``vector`` implementation---and reports an error at construction if
    it does not.
 
+   That component is necessary but not sufficient: the *directions* must be meaningful too. In particular
+   :galacticus-class:`nodeOperatorHaloAngularMomentumRandom` draws a random angular momentum *magnitude* but sets
+   the vector to :math:`(J,0,0)`, so every halo points along the :math:`x`-axis and every galaxy is assigned the
+   same inclination. An operator which builds the vector from the angular momenta of accreted satellites---
+   :galacticus-class:`nodeOperatorHaloAngularMomentumVitvitska2002`---gives directions which vary between halos and
+   are correlated between neighbors, which is what makes this class worth using. A model whose orientations all come
+   out equal is a sign that the angular momentum directions are degenerate rather than that this class has
+   misbehaved.
+
    The direction to the observer is set by ``lineOfSight``:
 
    ``fixed``

--- a/source/galactic_structure/inclination/spin_vector.F90
+++ b/source/galactic_structure/inclination/spin_vector.F90
@@ -1,0 +1,266 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a galactic inclination class deriving the inclination from the halo angular momentum vector.
+  !!}
+
+  use :: Geometry_Lightcones, only : geometryLightconeClass
+  use :: ISO_Varying_String , only : varying_string
+
+  !![
+  <galacticInclination name="galacticInclinationSpinVector" docformat="rst">
+   <description>
+   A galactic inclination class in which the inclination is derived from the direction of the halo angular momentum
+   vector, on the assumption that the galaxy's symmetry axis is aligned with it. The inclination is then
+
+   .. math::
+
+      i = \cos^{-1} \left| \hat{\mathbf{j}} \cdot \hat{\mathbf{d}} \right|,
+
+   with :math:`\hat{\mathbf{j}}` the unit angular momentum vector and :math:`\hat{\mathbf{d}}` the direction to the
+   observer. The absolute value folds the angle into :math:`[0,\pi/2]`: a disk seen from "above" and "below" is
+   equally inclined.
+
+   This requires no storage of its own, and it is the physically motivated choice: orientations come out correlated
+   with the surrounding large-scale structure rather than drawn independently, which matters for lightcones and mock
+   catalogs where neighboring galaxies should not have independent orientations. It requires the ``spin`` component
+   to track the angular momentum *vector*---the ``vector`` implementation---and reports an error at construction if
+   it does not.
+
+   The direction to the observer is set by ``lineOfSight``:
+
+   ``fixed``
+     A direction fixed in the simulation box, given by the ``direction`` parameter. The default is the
+     :math:`x`-axis. Appropriate for a snapshot, where there is no preferred observer.
+
+   ``lightcone``
+     The direction from the observer to the galaxy, taken from a :galacticus-class:`geometryLightconeClass` object as
+     the position at which the galaxy crosses the lightcone. This is the correct choice when building a mock
+     catalog, where the line of sight varies across the sky.
+
+     Note that a galaxy may appear more than once in a lightcone through replication of the simulation box, and that
+     each appearance strictly has its own line of sight. The lightcone crossing position is a single well-defined
+     choice among these, and is used for every appearance; the alternative would require the replication instance to
+     be threaded through every consumer of this class.
+   </description>
+  </galacticInclination>
+  !!]
+
+  !![
+  <enumeration docformat="rst">
+   <name>spinVectorLineOfSight</name>
+   <description>
+   Enumerates the ways in which the direction to the observer may be determined in the ``spinVector`` galactic
+   inclination class.
+   </description>
+   <encodeFunction>yes</encodeFunction>
+   <validator>yes</validator>
+   <visibility>public</visibility>
+   <entry label="fixed"    />
+   <entry label="lightcone"/>
+  </enumeration>
+  !!]
+
+  type, extends(galacticInclinationClass) :: galacticInclinationSpinVector
+     !!{RST
+     A galactic inclination class deriving the inclination from the halo angular momentum vector.
+     !!}
+     private
+     class           (geometryLightconeClass                ), pointer                   :: geometryLightcone_ => null()
+     type            (enumerationSpinVectorLineOfSightType  )                            :: lineOfSight
+     double precision                                        , dimension(3)              :: direction
+   contains
+     final     ::                spinVectorDestructor
+     procedure :: inclination => spinVectorInclination
+  end type galacticInclinationSpinVector
+
+  interface galacticInclinationSpinVector
+     !!{RST
+     Constructors for the :galacticus-class:`galacticInclinationSpinVector` galactic inclination class.
+     !!}
+     module procedure spinVectorConstructorParameters
+     module procedure spinVectorConstructorInternal
+  end interface galacticInclinationSpinVector
+
+contains
+
+  function spinVectorConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`galacticInclinationSpinVector` galactic inclination class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters   , only : inputParameter, inputParameters
+    use :: ISO_Varying_String  , only : char          , var_str
+    implicit none
+    type            (galacticInclinationSpinVector)                :: self
+    type            (inputParameters              ), intent(inout) :: parameters
+    class           (geometryLightconeClass       ), pointer       :: geometryLightcone_
+    type            (varying_string               )                :: lineOfSight
+    double precision                               , dimension(3)  :: direction
+
+    !![
+    <inputParameter docformat="rst">
+      <name>lineOfSight</name>
+      <defaultValue>var_str('fixed')</defaultValue>
+      <description>
+      How the direction to the observer is determined: ``fixed`` for a direction fixed in the simulation box, or
+      ``lightcone`` to take it from a lightcone geometry.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>direction</name>
+      <defaultValue>[1.0d0,0.0d0,0.0d0]</defaultValue>
+      <description>
+      The direction to the observer, as a Cartesian vector in the coordinate system of the simulation box. It need
+      not be normalized. Used only when ``lineOfSight`` is ``fixed``.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    !!]
+    nullify(geometryLightcone_)
+    if (enumerationSpinVectorLineOfSightEncode(char(lineOfSight),includesPrefix=.false.) == spinVectorLineOfSightLightcone) then
+       !![
+       <objectBuilder class="geometryLightcone" name="geometryLightcone_" source="parameters"/>
+       !!]
+    end if
+    self=galacticInclinationSpinVector(enumerationSpinVectorLineOfSightEncode(char(lineOfSight),includesPrefix=.false.),direction,geometryLightcone_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    !!]
+    if (associated(geometryLightcone_)) then
+       !![
+       <objectDestructor name="geometryLightcone_"/>
+       !!]
+    end if
+    return
+  end function spinVectorConstructorParameters
+
+  function spinVectorConstructorInternal(lineOfSight,direction,geometryLightcone_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`galacticInclinationSpinVector` galactic inclination class.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Galacticus_Nodes, only : defaultSpinComponent
+    implicit none
+    type            (galacticInclinationSpinVector       )                                  :: self
+    type            (enumerationSpinVectorLineOfSightType), intent(in   )                   :: lineOfSight
+    double precision                                      , intent(in   ) , dimension(3)    :: direction
+    class           (geometryLightconeClass              ), intent(in   ) , target, optional :: geometryLightcone_
+    double precision                                                                        :: directionNorm
+    !![
+    <constructorAssign variables="lineOfSight, direction, *geometryLightcone_"/>
+    !!]
+
+    ! The angular momentum vector is needed, so the spin component must track it.
+    if (.not.defaultSpinComponent%angularMomentumVectorIsGettable())                                                                     &
+         & call Error_Report(                                                                                                            &
+         &                   'the `spinVector` galactic inclination requires the angular momentum vector, so the `spin` component must'// &
+         &                   ' be set to `vector`'                                                                                     // &
+         &                   {introspection:location}                                                                                    &
+         &                  )
+    select case (self%lineOfSight%ID)
+    case (spinVectorLineOfSightFixed    %ID)
+       directionNorm=sqrt(sum(self%direction**2))
+       if (directionNorm <= 0.0d0) call Error_Report('`direction` must be a non-zero vector'//{introspection:location})
+       ! Store the direction normalized, so that the dot product below is a cosine directly.
+       self%direction=+self%direction  &
+            &         /     directionNorm
+    case (spinVectorLineOfSightLightcone%ID)
+       if (.not.associated(self%geometryLightcone_)) call Error_Report('a `geometryLightcone` is required when `lineOfSight` is `lightcone`'//{introspection:location})
+    case default
+       call Error_Report('unrecognized `lineOfSight`'//{introspection:location})
+    end select
+    return
+  end function spinVectorConstructorInternal
+
+  subroutine spinVectorDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`galacticInclinationSpinVector` galactic inclination class.
+    !!}
+    implicit none
+    type(galacticInclinationSpinVector), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%geometryLightcone_"/>
+    !!]
+    return
+  end subroutine spinVectorDestructor
+
+  double precision function spinVectorInclination(self,node) result(inclination)
+    !!{RST
+    Return the inclination implied by the angular momentum vector of the halo.
+    !!}
+    use :: Error           , only : Error_Report
+    use :: Galacticus_Nodes, only : nodeComponentSpin
+    implicit none
+    class           (galacticInclinationSpinVector), intent(inout)         :: self
+    type            (treeNode                     ), intent(inout), target :: node
+    class           (nodeComponentSpin            ), pointer               :: spin
+    double precision                               , dimension(3)          :: angularMomentum, direction
+    double precision                                                       :: normAngularMomentum, normDirection
+
+    spin               => node%spin                 ()
+    angularMomentum    =  spin%angularMomentumVector()
+    normAngularMomentum=  sqrt(sum(angularMomentum**2))
+    ! A halo with no angular momentum has no defined symmetry axis. Report it as face-on: this is the orientation
+    ! which minimizes the effect of any flattened dust distribution, and so is the conservative choice.
+    if (normAngularMomentum <= 0.0d0) then
+       inclination=0.0d0
+       return
+    end if
+    select case (self%lineOfSight%ID)
+    case (spinVectorLineOfSightFixed    %ID)
+       ! Already normalized at construction.
+       direction=self%direction
+    case (spinVectorLineOfSightLightcone%ID)
+       direction    =self%geometryLightcone_%positionLightconeCrossing(node)
+       normDirection=sqrt(sum(direction**2))
+       ! A galaxy at the observer's position has no defined line of sight; treat it as face-on, as above.
+       if (normDirection <= 0.0d0) then
+          inclination=0.0d0
+          return
+       end if
+       direction=+direction     &
+            &    /normDirection
+    case default
+       direction=0.0d0
+       call Error_Report('unrecognized `lineOfSight`'//{introspection:location})
+    end select
+    ! Fold into [0,pi/2]: only the angle between the axis and the line of sight matters, not its sign. The argument
+    ! is clamped as protection against a dot product exceeding unity through round-off.
+    inclination=+acos(                                     &
+         &            min(                                 &
+         &                +1.0d0                         , &
+         &                +abs(                            &
+         &                     +sum(                       &
+         &                          +angularMomentum       &
+         &                          *direction              &
+         &                         )                       &
+         &                     /normAngularMomentum         &
+         &                    )                            &
+         &               )                                 &
+         &           )
+    return
+  end function spinVectorInclination

--- a/source/geometry/lightcones/_class.F90
+++ b/source/geometry/lightcones/_class.F90
@@ -107,7 +107,9 @@ module Geometry_Lightcones
    </method>
    <method name="positionLightconeCrossing" >
     <description>
-    Returns the position of the node at the time of lightcone crossing---which must have been previously identified via the ``timeLightconeCrossing`` method. Components are Cartesian, in the order :math:`(x,y,z)`.
+    Returns the position of the node at the time of lightcone crossing. Components are Cartesian, in the order :math:`(x,y,z)`.
+
+    The node must be *at* its lightcone crossing time when this is called, which is what :galacticus-class:`mergerTreeEvolveTimestepLightconeCrossing` arranges. The replicant which is crossing is identified from the node's current time, so a node at any other time is not on the lightcone at all and an error is reported.
     </description>
     <type>double precision, dimension(3)</type>
     <pass>yes</pass>
@@ -115,7 +117,9 @@ module Geometry_Lightcones
    </method>
    <method name="velocityLightconeCrossing" >
     <description>
-    Returns the velocity of the node at the time of lightcone crossing---which must have been previously identified via the ``timeLightconeCrossing`` method. Components are Cartesian, in the order :math:`(v_\mathrm{x},v_\mathrm{y},v_\mathrm{z})`.
+    Returns the velocity of the node at the time of lightcone crossing. Components are Cartesian, in the order :math:`(v_\mathrm{x},v_\mathrm{y},v_\mathrm{z})`.
+
+    As for ``positionLightconeCrossing``, the node must be at its lightcone crossing time when this is called.
     </description>
     <type>double precision, dimension(3)</type>
     <pass>yes</pass>

--- a/source/nodes/operators/physics/inclination_random.F90
+++ b/source/nodes/operators/physics/inclination_random.F90
@@ -19,8 +19,6 @@
 
 !+    Contributions to this file made by: Andrew Benson, Claude.
 
-!+    Contributions to this file made by: Andrew Benson, Claude.
-
   !!{RST
   Implements a node operator which assigns each galaxy a random orientation.
   !!}

--- a/source/nodes/operators/physics/inclination_random.F90
+++ b/source/nodes/operators/physics/inclination_random.F90
@@ -1,0 +1,215 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a node operator which assigns each galaxy a random orientation.
+  !!}
+
+  use :: Satellite_Merging_Mass_Movements, only : mergerMassMovementsClass
+
+  !![
+  <nodeOperator name="nodeOperatorInclinationRandom" docformat="rst">
+   <description>
+   A node operator which assigns each galaxy an isotropically distributed orientation---uniform in :math:`\cos i`,
+   so that :math:`i` is the inclination of the galaxy to the line of sight in radians, zero being face-on. The angle
+   is stored in a meta-property of the ``basic`` component, from which
+   :galacticus-class:`galacticInclinationRandom` reads it.
+
+   The angle is drawn when the node is initialized, and, if ``resetOnMajorMerger`` is true, drawn again after a major
+   galaxy--galaxy merger, on the grounds that such a merger destroys and rebuilds the disk and there is no reason for
+   the remnant to remember the orientation of its progenitor. Whether it should is a genuine modeling choice, which
+   is why it is a parameter, and why an orientation which is *stored* is worth having at all: a stateless rule
+   derived from node identity could not express it.
+
+   Storing the angle rather than drawing it where it is used is what makes it stable---see the discussion in
+   :galacticus-class:`galacticInclinationRandom`. Because meta-properties move with their component, the angle also
+   survives the promotion of a node up its branch without further work.
+   </description>
+  </nodeOperator>
+  !!]
+  type, extends(nodeOperatorClass) :: nodeOperatorInclinationRandom
+     !!{RST
+     A node operator which assigns each galaxy a random orientation.
+     !!}
+     private
+     class  (mergerMassMovementsClass), pointer :: mergerMassMovements_ => null()
+     integer                                    :: inclinationID
+     logical                                    :: resetOnMajorMerger
+   contains
+     final     ::                    inclinationRandomDestructor
+     procedure :: autoHook        => inclinationRandomAutoHook
+     procedure :: nodeInitialize  => inclinationRandomNodeInitialize
+  end type nodeOperatorInclinationRandom
+
+  interface nodeOperatorInclinationRandom
+     !!{RST
+     Constructors for the :galacticus-class:`nodeOperatorInclinationRandom` node operator class.
+     !!}
+     module procedure inclinationRandomConstructorParameters
+     module procedure inclinationRandomConstructorInternal
+  end interface nodeOperatorInclinationRandom
+
+contains
+
+  function inclinationRandomConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`nodeOperatorInclinationRandom` node operator class which takes a parameter
+    set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameter, inputParameters
+    implicit none
+    type   (nodeOperatorInclinationRandom)                :: self
+    type   (inputParameters              ), intent(inout) :: parameters
+    class  (mergerMassMovementsClass     ), pointer       :: mergerMassMovements_
+    logical                                               :: resetOnMajorMerger
+
+    !![
+    <inputParameter docformat="rst">
+      <name>resetOnMajorMerger</name>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, a new orientation is drawn after each major galaxy--galaxy merger.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="mergerMassMovements" name="mergerMassMovements_" source="parameters"/>
+    !!]
+    self=nodeOperatorInclinationRandom(resetOnMajorMerger,mergerMassMovements_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="mergerMassMovements_"/>
+    !!]
+    return
+  end function inclinationRandomConstructorParameters
+
+  function inclinationRandomConstructorInternal(resetOnMajorMerger,mergerMassMovements_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`nodeOperatorInclinationRandom` node operator class.
+    !!}
+    implicit none
+    type   (nodeOperatorInclinationRandom)                        :: self
+    logical                               , intent(in   )         :: resetOnMajorMerger
+    class  (mergerMassMovementsClass     ), intent(in   ), target :: mergerMassMovements_
+    !![
+    <constructorAssign variables="resetOnMajorMerger, *mergerMassMovements_"/>
+    <addMetaProperty component="basic" name="inclination" id="self%inclinationID" isCreator="yes" isEvolvable="no"/>
+    !!]
+
+    return
+  end function inclinationRandomConstructorInternal
+
+  subroutine inclinationRandomAutoHook(self)
+    !!{RST
+    Attach to the satellite merger event, so that orientations can be re-drawn after a major merger.
+    !!}
+    use :: Events_Hooks, only : dependencyDirectionAfter, dependencyRegEx, openMPThreadBindingAtLevel, satelliteMergerEvent
+    implicit none
+    class(nodeOperatorInclinationRandom), intent(inout) :: self
+    type (dependencyRegEx              ), dimension(1)  :: dependenciesSatelliteMerger
+
+    if (.not.self%resetOnMajorMerger) return
+    ! Attach after the remnant structure is determined, so that the merger has been classified.
+    dependenciesSatelliteMerger(1)=dependencyRegEx(dependencyDirectionAfter,'^remnantStructure:')
+    call satelliteMergerEvent%attach(self,satelliteMerger,openMPThreadBindingAtLevel,label='inclinationRandom',dependencies=dependenciesSatelliteMerger)
+    return
+  end subroutine inclinationRandomAutoHook
+
+  subroutine inclinationRandomDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`nodeOperatorInclinationRandom` node operator class.
+    !!}
+    use :: Events_Hooks, only : satelliteMergerEvent
+    implicit none
+    type(nodeOperatorInclinationRandom), intent(inout) :: self
+
+    if (satelliteMergerEvent%isAttached(self,satelliteMerger)) call satelliteMergerEvent%detach(self,satelliteMerger)
+    !![
+    <objectDestructor name="self%mergerMassMovements_"/>
+    !!]
+    return
+  end subroutine inclinationRandomDestructor
+
+  double precision function inclinationDraw(node)
+    !!{RST
+    Draw an inclination from an isotropic distribution of orientations, in radians.
+
+    Orientations uniform on the sphere are uniform in :math:`\cos i`, so drawing :math:`\cos i` uniformly from
+    :math:`[0,1]` and taking the arc cosine gives the required distribution over :math:`[0,\pi/2]`. Only the angle
+    to the line of sight matters, not which face is presented, so the half range suffices.
+    !!}
+    implicit none
+    type(treeNode), intent(inout), target :: node
+
+    inclinationDraw=acos(node%hostTree%randomNumberGenerator_%uniformSample())
+    return
+  end function inclinationDraw
+
+  subroutine inclinationRandomNodeInitialize(self,node)
+    !!{RST
+    Assign an orientation to a newly initialized node.
+    !!}
+    use :: Galacticus_Nodes, only : nodeComponentBasic
+    implicit none
+    class(nodeOperatorInclinationRandom), intent(inout), target  :: self
+    type (treeNode                     ), intent(inout), target  :: node
+    class(nodeComponentBasic           )               , pointer :: basic
+
+    basic => node%basic()
+    call basic%floatRank0MetaPropertySet(self%inclinationID,inclinationDraw(node))
+    return
+  end subroutine inclinationRandomNodeInitialize
+
+  subroutine satelliteMerger(self,node)
+    !!{RST
+    Draw a new orientation for the remnant of a major galaxy--galaxy merger.
+    !!}
+    use :: Error                           , only : Error_Report
+    use :: Function_Classes                , only : functionClass
+    use :: Galacticus_Nodes                , only : nodeComponentBasic
+    use :: ISO_Varying_String              , only : char
+    use :: Satellite_Merging_Mass_Movements, only : enumerationDestinationMergerType
+    implicit none
+    class(*                               ), intent(inout)          :: self
+    type (treeNode                        ), intent(inout), target  :: node
+    type (treeNode                        )               , pointer :: nodeHost
+    class(nodeComponentBasic              )               , pointer :: basicHost
+    type (enumerationDestinationMergerType)                         :: destinationGasSatellite, destinationStarsSatellite, &
+         &                                                             destinationGasHost     , destinationStarsHost
+    logical                                                         :: mergerIsMajor
+
+    select type (self)
+    class is (nodeOperatorInclinationRandom)
+       call self%mergerMassMovements_%get(node,destinationGasSatellite,destinationStarsSatellite,destinationGasHost,destinationStarsHost,mergerIsMajor)
+       if (mergerIsMajor) then
+          ! The remnant is the host: it is the galaxy which is rebuilt, so it is the one re-oriented.
+          nodeHost  => node    %mergesWith()
+          basicHost => nodeHost%basic     ()
+          call basicHost%floatRank0MetaPropertySet(self%inclinationID,inclinationDraw(nodeHost))
+       end if
+    class is (functionClass)
+       call Error_Report('object is not of [nodeOperatorInclinationRandom] class, but of ['//char(self%objectType())//'] class'//{introspection:location})
+    class default
+       call Error_Report('object is of unrecognized class'//{introspection:location})
+    end select
+    return
+  end subroutine satelliteMerger

--- a/source/nodes/property_extractor/inclination.F90
+++ b/source/nodes/property_extractor/inclination.F90
@@ -19,8 +19,6 @@
 
 !+    Contributions to this file made by: Andrew Benson, Claude.
 
-!+    Contributions to this file made by: Andrew Benson, Claude.
-
   !!{RST
   Implements a node property extractor for the inclination of a galaxy.
   !!}
@@ -46,12 +44,12 @@
      private
      class(galacticInclinationClass), pointer :: galacticInclination_ => null()
    contains
-     final     ::                 inclinationDestructor
-     procedure :: extract      => inclinationExtract
-     procedure :: name         => inclinationName
-     procedure :: description  => inclinationDescription
-     procedure :: unitsInSI    => inclinationUnitsInSI
-     procedure :: units        => inclinationUnits
+     final     ::                inclinationDestructor
+     procedure :: extract     => inclinationExtract
+     procedure :: name        => inclinationName
+     procedure :: description => inclinationDescription
+     procedure :: unitsInSI   => inclinationUnitsInSI
+     procedure :: units       => inclinationUnits
   end type nodePropertyExtractorInclination
 
   interface nodePropertyExtractorInclination
@@ -98,11 +96,11 @@ contains
     <constructorAssign variables="*galacticInclination_"/>
     !!]
 
-    if (.not.self%galacticInclination_%isAvailable())                                                                    &
-         & call Error_Report(                                                                                            &
-         &                   'no inclination is available to extract: set `galacticInclination` to a class which'      // &
-         &                   ' supplies one'                                                                           // &
-         &                   {introspection:location}                                                                    &
+    if (.not.self%galacticInclination_%isAvailable())                                                               &
+         & call Error_Report(                                                                                       &
+         &                   'no inclination is available to extract: set `galacticInclination` to a class which'// &
+         &                   ' supplies one'                                                                     // &
+         &                   {introspection:location}                                                               &
          &                  )
     return
   end function inclinationConstructorInternal
@@ -131,7 +129,7 @@ contains
     type (multiCounter                    ), intent(inout), optional :: instance
     !$GLC attributes unused :: instance
 
-    inclinationExtract=+self%galacticInclination_%inclination(node) &
+    inclinationExtract=+self%galacticInclination_%inclination     (node) &
          &             /                          degreesToRadians
     return
   end function inclinationExtract

--- a/source/nodes/property_extractor/inclination.F90
+++ b/source/nodes/property_extractor/inclination.F90
@@ -1,0 +1,190 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a node property extractor for the inclination of a galaxy.
+  !!}
+
+  use :: Galactic_Inclinations, only : galacticInclinationClass
+
+  !![
+  <nodePropertyExtractor name="nodePropertyExtractorInclination" docformat="rst">
+   <description>
+   A node property extractor which reports the inclination of a galaxy to the line of sight, in degrees, with zero
+   being face-on and 90 edge-on.
+
+   Whatever consumes inclination---dust attenuation above all---does so through the same
+   :galacticus-class:`galacticInclinationClass` object, so this reports the angle that was actually applied, and
+   makes it reproducible rather than hidden inside the attenuation.
+   </description>
+  </nodePropertyExtractor>
+  !!]
+  type, extends(nodePropertyExtractorScalar) :: nodePropertyExtractorInclination
+     !!{RST
+     A node property extractor for the inclination of a galaxy.
+     !!}
+     private
+     class(galacticInclinationClass), pointer :: galacticInclination_ => null()
+   contains
+     final     ::                 inclinationDestructor
+     procedure :: extract      => inclinationExtract
+     procedure :: name         => inclinationName
+     procedure :: description  => inclinationDescription
+     procedure :: unitsInSI    => inclinationUnitsInSI
+     procedure :: units        => inclinationUnits
+  end type nodePropertyExtractorInclination
+
+  interface nodePropertyExtractorInclination
+     !!{RST
+     Constructors for the :galacticus-class:`nodePropertyExtractorInclination` property extractor class.
+     !!}
+     module procedure inclinationConstructorParameters
+     module procedure inclinationConstructorInternal
+  end interface nodePropertyExtractorInclination
+
+contains
+
+  function inclinationConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`nodePropertyExtractorInclination` property extractor class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters, only : inputParameters
+    implicit none
+    type (nodePropertyExtractorInclination)                :: self
+    type (inputParameters                 ), intent(inout) :: parameters
+    class(galacticInclinationClass        ), pointer       :: galacticInclination_
+
+    !![
+    <objectBuilder class="galacticInclination" name="galacticInclination_" source="parameters"/>
+    !!]
+    self=nodePropertyExtractorInclination(galacticInclination_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="galacticInclination_"/>
+    !!]
+    return
+  end function inclinationConstructorParameters
+
+  function inclinationConstructorInternal(galacticInclination_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`nodePropertyExtractorInclination` property extractor class.
+    !!}
+    use :: Error, only : Error_Report
+    implicit none
+    type (nodePropertyExtractorInclination)                        :: self
+    class(galacticInclinationClass        ), intent(in   ), target :: galacticInclination_
+    !![
+    <constructorAssign variables="*galacticInclination_"/>
+    !!]
+
+    if (.not.self%galacticInclination_%isAvailable())                                                                    &
+         & call Error_Report(                                                                                            &
+         &                   'no inclination is available to extract: set `galacticInclination` to a class which'      // &
+         &                   ' supplies one'                                                                           // &
+         &                   {introspection:location}                                                                    &
+         &                  )
+    return
+  end function inclinationConstructorInternal
+
+  subroutine inclinationDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`nodePropertyExtractorInclination` property extractor class.
+    !!}
+    implicit none
+    type(nodePropertyExtractorInclination), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%galacticInclination_"/>
+    !!]
+    return
+  end subroutine inclinationDestructor
+
+  double precision function inclinationExtract(self,node,instance)
+    !!{RST
+    Return the inclination of the galaxy, in degrees.
+    !!}
+    use :: Numerical_Constants_Astronomical, only : degreesToRadians
+    implicit none
+    class(nodePropertyExtractorInclination), intent(inout), target   :: self
+    type (treeNode                        ), intent(inout), target   :: node
+    type (multiCounter                    ), intent(inout), optional :: instance
+    !$GLC attributes unused :: instance
+
+    inclinationExtract=+self%galacticInclination_%inclination(node) &
+         &             /                          degreesToRadians
+    return
+  end function inclinationExtract
+
+  function inclinationName(self)
+    !!{RST
+    Return the name of the inclination property.
+    !!}
+    implicit none
+    type (varying_string                  )                :: inclinationName
+    class(nodePropertyExtractorInclination), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    inclinationName=var_str('inclination')
+    return
+  end function inclinationName
+
+  function inclinationDescription(self)
+    !!{RST
+    Return a description of the inclination property.
+    !!}
+    implicit none
+    type (varying_string                  )                :: inclinationDescription
+    class(nodePropertyExtractorInclination), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    inclinationDescription=var_str('Inclination of the galaxy to the line of sight [degrees; 0 is face-on].')
+    return
+  end function inclinationDescription
+
+  double precision function inclinationUnitsInSI(self)
+    !!{RST
+    Return the units of the inclination property in the SI system.
+    !!}
+    use :: Numerical_Constants_Astronomical, only : degreesToRadians
+    implicit none
+    class(nodePropertyExtractorInclination), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    ! Radians are dimensionless in SI, so the conversion factor is simply that from degrees to radians.
+    inclinationUnitsInSI=degreesToRadians
+    return
+  end function inclinationUnitsInSI
+
+  function inclinationUnits(self) result(units)
+    !!{RST
+    Return the units of the inclination property.
+    !!}
+    use :: Units_MetaData, only : unitType
+    implicit none
+    type (unitType                        )                :: units
+    class(nodePropertyExtractorInclination), intent(inout) :: self
+
+    units=unitType(self%unitsInSI(),description='degrees',quantity='angle')
+    return
+  end function inclinationUnits

--- a/testSuite/parameters/dustAttenuationParity.xml
+++ b/testSuite/parameters/dustAttenuationParity.xml
@@ -1,9 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!-- Default parameters for Galacticus v0.9.4 -->
-
-<!-- 30-October-2011                          -->
-
-<parameters>
+<!-- Default parameters for Galacticus v0.9.4 --><!-- 30-October-2011                          --><parameters>
   <formatVersion>2</formatVersion>
   <lastModified revision="3c57050dfc00cdbc7396b4210a9dc404b9fda859" time="2026-08-23T04:06:13"/>
 
@@ -318,16 +313,16 @@
        convolve; the default is to store none. The time resolution is set finer than the birth cloud lifetime so that
        the young/old split falls on a bin boundary rather than inside a bin. -->
   <starFormationHistory value="adaptive">
-    <timeStepMinimum       value="2.0e-3"/>
-    <countTimeStepsMaximum value="16"    />
-    <countMetallicities    value="4"     />
+    <timeStepMinimum value="2.0e-3"/>
+    <countTimeStepsMaximum value="16"/>
+    <countMetallicities value="4"/>
   </starFormationHistory>
 
   <!-- Each luminosity is tracked twice: once unrestricted, once restricted to populations younger than the birth
        cloud lifetime. Differencing the two isolates the light of old stars. -->
-  <luminosityFilter         value="SDSS_r  SDSS_r"/>
-  <luminosityType           value="rest    rest  "/>
-  <luminosityRedshift       value="0.0     0.0   "/>
+  <luminosityFilter value="SDSS_r  SDSS_r"/>
+  <luminosityType value="rest    rest  "/>
+  <luminosityRedshift value="0.0     0.0   "/>
   <luminosityPostprocessSet value="default recent"/>
 
   <stellarPopulationSpectraPostprocessorBuilder value="lookup">
@@ -341,27 +336,27 @@
   <nodePropertyExtractor value="multi">
     <nodePropertyExtractor value="dustAttenuation">
       <outputUnattenuated value="true"/>
-      <outputSum          value="true"/>
-      <sumName            value="luminosityTotal"/>
+      <outputSum value="true"/>
+      <sumName value="luminosityTotal"/>
       <dustAttenuation value="charlotFall2000">
-        <coefficientBirthCloud value="1.0e0" />
-        <coefficientISM        value="1.0e0" />
-        <timescale             value="1.0e-2"/>
-        <exponent              value="0.7e0" />
+        <coefficientBirthCloud value="1.0e0"/>
+        <coefficientISM value="1.0e0"/>
+        <timescale value="1.0e-2"/>
+        <exponent value="0.7e0"/>
         <!-- The class being compared against normalizes its power law at a round 5500A rather than at the Buser V
              effective wavelength, so match it here to isolate every other difference. -->
-        <wavelengthReference   value="5500.0"/>
+        <wavelengthReference value="5500.0"/>
       </dustAttenuation>
       <nodePropertyExtractor value="luminosityStellar">
-        <filterName        value="SDSS_r"        />
-        <filterType        value="rest"          />
-        <component         value="disk"          />
+        <filterName value="SDSS_r"/>
+        <filterType value="rest"/>
+        <component value="disk"/>
         <postprocessChains value="default recent"/>
       </nodePropertyExtractor>
       <nodePropertyExtractor value="luminosityStellar">
-        <filterName        value="SDSS_r"        />
-        <filterType        value="rest"          />
-        <component         value="spheroid"      />
+        <filterName value="SDSS_r"/>
+        <filterType value="rest"/>
+        <component value="spheroid"/>
         <postprocessChains value="default recent"/>
       </nodePropertyExtractor>
     </nodePropertyExtractor>
@@ -371,72 +366,72 @@
          attenuator's decomposition request along unaltered. -->
     <nodePropertyExtractor value="dustAttenuation">
       <outputUnattenuated value="false"/>
-      <outputSum          value="true"/>
-      <sumName            value="luminosityTotalAveraged"/>
+      <outputSum value="true"/>
+      <sumName value="luminosityTotalAveraged"/>
       <dustAttenuation value="inclinationAveraged">
         <order value="8"/>
         <dustAttenuation value="charlotFall2000">
-          <coefficientBirthCloud value="1.0e0" />
-          <coefficientISM        value="1.0e0" />
-          <timescale             value="1.0e-2"/>
-          <exponent              value="0.7e0" />
-          <wavelengthReference   value="5500.0"/>
+          <coefficientBirthCloud value="1.0e0"/>
+          <coefficientISM value="1.0e0"/>
+          <timescale value="1.0e-2"/>
+          <exponent value="0.7e0"/>
+          <wavelengthReference value="5500.0"/>
         </dustAttenuation>
       </dustAttenuation>
       <nodePropertyExtractor value="luminosityStellar">
-        <filterName        value="SDSS_r"        />
-        <filterType        value="rest"          />
-        <component         value="disk"          />
+        <filterName value="SDSS_r"/>
+        <filterType value="rest"/>
+        <component value="disk"/>
         <postprocessChains value="default recent"/>
       </nodePropertyExtractor>
       <nodePropertyExtractor value="luminosityStellar">
-        <filterName        value="SDSS_r"        />
-        <filterType        value="rest"          />
-        <component         value="spheroid"      />
+        <filterName value="SDSS_r"/>
+        <filterType value="rest"/>
+        <component value="spheroid"/>
         <postprocessChains value="default recent"/>
       </nodePropertyExtractor>
     </nodePropertyExtractor>
     <nodePropertyExtractor value="dustAttenuation">
       <outputUnattenuated value="true"/>
-      <outputSum          value="true"/>
-      <sumName            value="sedTotal"/>
+      <outputSum value="true"/>
+      <sumName value="sedTotal"/>
       <dustAttenuation value="charlotFall2000">
-        <coefficientBirthCloud value="1.0e0" />
-        <coefficientISM        value="1.0e0" />
-        <timescale             value="1.0e-2"/>
-        <exponent              value="0.7e0" />
-        <wavelengthReference   value="5500.0"/>
+        <coefficientBirthCloud value="1.0e0"/>
+        <coefficientISM value="1.0e0"/>
+        <timescale value="1.0e-2"/>
+        <exponent value="0.7e0"/>
+        <wavelengthReference value="5500.0"/>
       </dustAttenuation>
       <nodePropertyExtractor value="SED">
-        <component         value="disk"    />
-        <frame             value="rest"    />
-        <wavelengthMinimum value="3.0e3"   />
-        <wavelengthMaximum value="9.0e3"   />
-        <resolution        value="20.0"    />
-        <toleranceRelative value="1.0e-2"  />
+        <component value="disk"/>
+        <frame value="rest"/>
+        <wavelengthMinimum value="3.0e3"/>
+        <wavelengthMaximum value="9.0e3"/>
+        <resolution value="20.0"/>
+        <toleranceRelative value="1.0e-2"/>
       </nodePropertyExtractor>
       <nodePropertyExtractor value="SED">
-        <component         value="spheroid"/>
-        <frame             value="rest"    />
-        <wavelengthMinimum value="3.0e3"   />
-        <wavelengthMaximum value="9.0e3"   />
-        <resolution        value="20.0"    />
-        <toleranceRelative value="1.0e-2"  />
+        <component value="spheroid"/>
+        <frame value="rest"/>
+        <wavelengthMinimum value="3.0e3"/>
+        <wavelengthMaximum value="9.0e3"/>
+        <resolution value="20.0"/>
+        <toleranceRelative value="1.0e-2"/>
       </nodePropertyExtractor>
     </nodePropertyExtractor>
     <!-- Round-trip check: `zero` attenuates nothing, so decomposing a spectrum and recombining it must return the
          spectrum unchanged. This tests the decomposition itself, independently of any dust physics. -->
     <nodePropertyExtractor value="dustAttenuation">
       <outputUnattenuated value="false"/>
-      <outputSum          value="false"/>
+      <outputSum value="false"/>
       <dustAttenuation value="zero"/>
       <nodePropertyExtractor value="SED">
-        <component         value="disk"    />
-        <frame             value="rest"    />
-        <wavelengthMinimum value="3.0e3"   />
-        <wavelengthMaximum value="9.0e3"   />
-        <resolution        value="20.0"    />
-        <toleranceRelative value="1.0e-2"  />
+        <component value="disk"/>
+        <frame value="rest"/>
+        <wavelengthMinimum value="3.0e3"/>
+        <wavelengthMaximum value="9.0e3"/>
+        <resolution value="20.0"/>
+        <toleranceRelative value="1.0e-2"/>
       </nodePropertyExtractor>
     </nodePropertyExtractor>
     <!-- Branch check: these two must agree exactly. The first attenuator is age-independent, so the spectrum is
@@ -445,50 +440,50 @@
          depth, so it attenuates nothing. Any light dropped or double counted by the age-resolved path shows up here. -->
     <nodePropertyExtractor value="dustAttenuation">
       <outputUnattenuated value="false"/>
-      <outputSum          value="false"/>
+      <outputSum value="false"/>
       <dustAttenuation value="screenSurfaceDensityMetals">
         <coefficient value="1.0"/>
         <dustExtinctionCurve value="powerLaw">
-          <exponent            value="0.7"   />
+          <exponent value="0.7"/>
           <wavelengthReference value="5500.0"/>
         </dustExtinctionCurve>
       </dustAttenuation>
       <nodePropertyExtractor value="SED">
-        <component         value="disk"    />
-        <frame             value="rest"    />
-        <wavelengthMinimum value="3.0e3"   />
-        <wavelengthMaximum value="9.0e3"   />
-        <resolution        value="20.0"    />
-        <toleranceRelative value="1.0e-2"  />
+        <component value="disk"/>
+        <frame value="rest"/>
+        <wavelengthMinimum value="3.0e3"/>
+        <wavelengthMaximum value="9.0e3"/>
+        <resolution value="20.0"/>
+        <toleranceRelative value="1.0e-2"/>
       </nodePropertyExtractor>
     </nodePropertyExtractor>
     <nodePropertyExtractor value="dustAttenuation">
       <outputUnattenuated value="false"/>
-      <outputSum          value="false"/>
+      <outputSum value="false"/>
       <dustAttenuation value="sequence">
         <dustAttenuation value="birthCloud">
-          <coefficient value="0.0"  />
-          <timescale   value="2.0e-3"/>
+          <coefficient value="0.0"/>
+          <timescale value="2.0e-3"/>
           <dustExtinctionCurve value="powerLaw">
-            <exponent            value="0.7"   />
+            <exponent value="0.7"/>
             <wavelengthReference value="5500.0"/>
           </dustExtinctionCurve>
         </dustAttenuation>
         <dustAttenuation value="screenSurfaceDensityMetals">
           <coefficient value="1.0"/>
           <dustExtinctionCurve value="powerLaw">
-            <exponent            value="0.7"   />
+            <exponent value="0.7"/>
             <wavelengthReference value="5500.0"/>
           </dustExtinctionCurve>
         </dustAttenuation>
       </dustAttenuation>
       <nodePropertyExtractor value="SED">
-        <component         value="disk"    />
-        <frame             value="rest"    />
-        <wavelengthMinimum value="3.0e3"   />
-        <wavelengthMaximum value="9.0e3"   />
-        <resolution        value="20.0"    />
-        <toleranceRelative value="1.0e-2"  />
+        <component value="disk"/>
+        <frame value="rest"/>
+        <wavelengthMinimum value="3.0e3"/>
+        <wavelengthMaximum value="9.0e3"/>
+        <resolution value="20.0"/>
+        <toleranceRelative value="1.0e-2"/>
       </nodePropertyExtractor>
     </nodePropertyExtractor>
     <!-- Emission lines. The extractor sums over disk and spheroid internally, so decomposition must split by
@@ -497,13 +492,13 @@
          elements, which is the case in which the rank of a summed property could disagree with its shape. -->
     <nodePropertyExtractor value="dustAttenuation">
       <outputUnattenuated value="true"/>
-      <outputSum          value="false"/>
+      <outputSum value="false"/>
       <dustAttenuation value="charlotFall2000">
-        <coefficientBirthCloud value="1.0e0" />
-        <coefficientISM        value="1.0e0" />
-        <timescale             value="1.0e-2"/>
-        <exponent              value="0.7e0" />
-        <wavelengthReference   value="5500.0"/>
+        <coefficientBirthCloud value="1.0e0"/>
+        <coefficientISM value="1.0e0"/>
+        <timescale value="1.0e-2"/>
+        <exponent value="0.7e0"/>
+        <wavelengthReference value="5500.0"/>
       </dustAttenuation>
       <nodePropertyExtractor value="luminosityEmissionLine">
         <component value="all"/>
@@ -515,13 +510,13 @@
          as an output analysis, use the framework at all. -->
     <nodePropertyExtractor value="dustAttenuation">
       <outputSumOnly value="true"/>
-      <sumName       value="lineTotalSumOnly"/>
+      <sumName value="lineTotalSumOnly"/>
       <dustAttenuation value="charlotFall2000">
-        <coefficientBirthCloud value="1.0e0" />
-        <coefficientISM        value="1.0e0" />
-        <timescale             value="1.0e-2"/>
-        <exponent              value="0.7e0" />
-        <wavelengthReference   value="5500.0"/>
+        <coefficientBirthCloud value="1.0e0"/>
+        <coefficientISM value="1.0e0"/>
+        <timescale value="1.0e-2"/>
+        <exponent value="0.7e0"/>
+        <wavelengthReference value="5500.0"/>
       </dustAttenuation>
       <nodePropertyExtractor value="luminosityEmissionLine">
         <component value="all"/>
@@ -538,13 +533,13 @@
       <element value="1"/>
       <nodePropertyExtractor value="dustAttenuation">
         <outputSumOnly value="true"/>
-        <sumName       value="lineTotalScalarized"/>
+        <sumName value="lineTotalScalarized"/>
         <dustAttenuation value="charlotFall2000">
-          <coefficientBirthCloud value="1.0e0" />
-          <coefficientISM        value="1.0e0" />
-          <timescale             value="1.0e-2"/>
-          <exponent              value="0.7e0" />
-          <wavelengthReference   value="5500.0"/>
+          <coefficientBirthCloud value="1.0e0"/>
+          <coefficientISM value="1.0e0"/>
+          <timescale value="1.0e-2"/>
+          <exponent value="0.7e0"/>
+          <wavelengthReference value="5500.0"/>
         </dustAttenuation>
         <nodePropertyExtractor value="luminosityEmissionLine">
           <component value="all"/>
@@ -554,6 +549,92 @@
           <component value="all"/>
           <lineNames value="balmerBeta4863"/>
         </nodePropertyExtractor>
+      </nodePropertyExtractor>
+    </nodePropertyExtractor>
+    <!-- The Ferrara et al. (1999) atlas: the first orientation dependent, non separable attenuator. The disk is
+         extracted at two inclinations and again averaged over orientation. Dust in a disk removes more light from
+         an edge on line of sight than a face on one, and the average over orientation must lie between the two.
+         The spheroid is extracted as well, so that the four dimensional table, which additionally depends on
+         spheroid size, is exercised alongside the three dimensional one. -->
+    <nodePropertyExtractor value="dustAttenuation">
+      <outputUnattenuated value="false"/>
+      <outputSum value="false"/>
+      <dustAttenuation value="atlasFerrara2000">
+        <dust value="milkyWay"/>
+        <heightRatio value="1.0"/>
+        <galacticInclination value="fixed">
+          <inclination value="30.0"/>
+        </galacticInclination>
+        <dustAttenuation value="screenFixed">
+          <depthOpticalV value="2.0"/>
+          <dustExtinctionCurve value="powerLaw">
+            <exponent value="0.7"/>
+            <wavelengthReference value="5500.0"/>
+          </dustExtinctionCurve>
+        </dustAttenuation>
+      </dustAttenuation>
+      <nodePropertyExtractor value="SED">
+        <component value="disk"/>
+        <frame value="rest"/>
+        <wavelengthMinimum value="3.0e3"/>
+        <wavelengthMaximum value="9.0e3"/>
+        <resolution value="20.0"/>
+        <toleranceRelative value="1.0e-2"/>
+      </nodePropertyExtractor>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="dustAttenuation">
+      <outputUnattenuated value="false"/>
+      <outputSum value="false"/>
+      <dustAttenuation value="inclinationAveraged">
+        <order value="8"/>
+        <dustAttenuation value="atlasFerrara2000">
+          <dust value="milkyWay"/>
+          <heightRatio value="1.0"/>
+          <galacticInclination value="fixed">
+            <inclination value="30.0"/>
+          </galacticInclination>
+          <dustAttenuation value="screenFixed">
+            <depthOpticalV value="2.0"/>
+            <dustExtinctionCurve value="powerLaw">
+              <exponent value="0.7"/>
+              <wavelengthReference value="5500.0"/>
+            </dustExtinctionCurve>
+          </dustAttenuation>
+        </dustAttenuation>
+      </dustAttenuation>
+      <nodePropertyExtractor value="SED">
+        <component value="disk"/>
+        <frame value="rest"/>
+        <wavelengthMinimum value="3.0e3"/>
+        <wavelengthMaximum value="9.0e3"/>
+        <resolution value="20.0"/>
+        <toleranceRelative value="1.0e-2"/>
+      </nodePropertyExtractor>
+    </nodePropertyExtractor>
+    <nodePropertyExtractor value="dustAttenuation">
+      <outputUnattenuated value="false"/>
+      <outputSum value="false"/>
+      <dustAttenuation value="atlasFerrara2000">
+        <dust value="milkyWay"/>
+        <heightRatio value="1.0"/>
+        <galacticInclination value="fixed">
+          <inclination value="30.0"/>
+        </galacticInclination>
+        <dustAttenuation value="screenFixed">
+          <depthOpticalV value="2.0"/>
+          <dustExtinctionCurve value="powerLaw">
+            <exponent value="0.7"/>
+            <wavelengthReference value="5500.0"/>
+          </dustExtinctionCurve>
+        </dustAttenuation>
+      </dustAttenuation>
+      <nodePropertyExtractor value="SED">
+        <component value="spheroid"/>
+        <frame value="rest"/>
+        <wavelengthMinimum value="3.0e3"/>
+        <wavelengthMaximum value="9.0e3"/>
+        <resolution value="20.0"/>
+        <toleranceRelative value="1.0e-2"/>
       </nodePropertyExtractor>
     </nodePropertyExtractor>
   </nodePropertyExtractor>

--- a/testSuite/parameters/dustAttenuationParity.xml
+++ b/testSuite/parameters/dustAttenuationParity.xml
@@ -339,6 +339,37 @@
   </stellarPopulationSpectraPostprocessorBuilder>
 
   <nodePropertyExtractor value="multi">
+    <!-- The same configuration wrapped in `inclinationAveraged`. Charlot & Fall does not depend on orientation, so
+         averaging over orientation must return it unchanged: this checks that the quadrature weights sum to unity,
+         that the optional inclination argument is threaded through, and that the decorator passes the wrapped
+         attenuator's decomposition request along unaltered. -->
+    <nodePropertyExtractor value="dustAttenuation">
+      <outputUnattenuated value="false"/>
+      <outputSum          value="true"/>
+      <sumName            value="luminosityTotalAveraged"/>
+      <dustAttenuation value="inclinationAveraged">
+        <order value="8"/>
+        <dustAttenuation value="charlotFall2000">
+          <coefficientBirthCloud value="1.0e0" />
+          <coefficientISM        value="1.0e0" />
+          <timescale             value="1.0e-2"/>
+          <exponent              value="0.7e0" />
+          <wavelengthReference   value="5500.0"/>
+        </dustAttenuation>
+      </dustAttenuation>
+      <nodePropertyExtractor value="luminosityStellar">
+        <filterName        value="SDSS_r"        />
+        <filterType        value="rest"          />
+        <component         value="disk"          />
+        <postprocessChains value="default recent"/>
+      </nodePropertyExtractor>
+      <nodePropertyExtractor value="luminosityStellar">
+        <filterName        value="SDSS_r"        />
+        <filterType        value="rest"          />
+        <component         value="spheroid"      />
+        <postprocessChains value="default recent"/>
+      </nodePropertyExtractor>
+    </nodePropertyExtractor>
     <nodePropertyExtractor value="dustAttenuation">
       <outputUnattenuated value="true"/>
       <outputSum          value="true"/>

--- a/testSuite/parameters/dustAttenuationParity.xml
+++ b/testSuite/parameters/dustAttenuationParity.xml
@@ -339,6 +339,32 @@
   </stellarPopulationSpectraPostprocessorBuilder>
 
   <nodePropertyExtractor value="multi">
+    <nodePropertyExtractor value="dustAttenuation">
+      <outputUnattenuated value="true"/>
+      <outputSum          value="true"/>
+      <sumName            value="luminosityTotal"/>
+      <dustAttenuation value="charlotFall2000">
+        <coefficientBirthCloud value="1.0e0" />
+        <coefficientISM        value="1.0e0" />
+        <timescale             value="1.0e-2"/>
+        <exponent              value="0.7e0" />
+        <!-- The class being compared against normalizes its power law at a round 5500A rather than at the Buser V
+             effective wavelength, so match it here to isolate every other difference. -->
+        <wavelengthReference   value="5500.0"/>
+      </dustAttenuation>
+      <nodePropertyExtractor value="luminosityStellar">
+        <filterName        value="SDSS_r"        />
+        <filterType        value="rest"          />
+        <component         value="disk"          />
+        <postprocessChains value="default recent"/>
+      </nodePropertyExtractor>
+      <nodePropertyExtractor value="luminosityStellar">
+        <filterName        value="SDSS_r"        />
+        <filterType        value="rest"          />
+        <component         value="spheroid"      />
+        <postprocessChains value="default recent"/>
+      </nodePropertyExtractor>
+    </nodePropertyExtractor>
     <!-- The same configuration wrapped in `inclinationAveraged`. Charlot & Fall does not depend on orientation, so
          averaging over orientation must return it unchanged: this checks that the quadrature weights sum to unity,
          that the optional inclination argument is threaded through, and that the decorator passes the wrapped
@@ -356,32 +382,6 @@
           <exponent              value="0.7e0" />
           <wavelengthReference   value="5500.0"/>
         </dustAttenuation>
-      </dustAttenuation>
-      <nodePropertyExtractor value="luminosityStellar">
-        <filterName        value="SDSS_r"        />
-        <filterType        value="rest"          />
-        <component         value="disk"          />
-        <postprocessChains value="default recent"/>
-      </nodePropertyExtractor>
-      <nodePropertyExtractor value="luminosityStellar">
-        <filterName        value="SDSS_r"        />
-        <filterType        value="rest"          />
-        <component         value="spheroid"      />
-        <postprocessChains value="default recent"/>
-      </nodePropertyExtractor>
-    </nodePropertyExtractor>
-    <nodePropertyExtractor value="dustAttenuation">
-      <outputUnattenuated value="true"/>
-      <outputSum          value="true"/>
-      <sumName            value="luminosityTotal"/>
-      <dustAttenuation value="charlotFall2000">
-        <coefficientBirthCloud value="1.0e0" />
-        <coefficientISM        value="1.0e0" />
-        <timescale             value="1.0e-2"/>
-        <exponent              value="0.7e0" />
-        <!-- The class being compared against normalizes its power law at a round 5500A rather than at the Buser V
-             effective wavelength, so match it here to isolate every other difference. -->
-        <wavelengthReference   value="5500.0"/>
       </dustAttenuation>
       <nodePropertyExtractor value="luminosityStellar">
         <filterName        value="SDSS_r"        />

--- a/testSuite/test-dust-attenuation-parity.py
+++ b/testSuite/test-dust-attenuation-parity.py
@@ -255,4 +255,52 @@ if worstScalarized > TOLERANCE:
     sys.exit(0)
 print(f"SUCCESS: the scalarizer reproduces the summed, attenuated luminosity, to {worstScalarized:.3e}")
 
+# ---------------------------------------------------------------------------------------------------------------------
+# The Ferrara et al. (1999) atlas: the first orientation dependent, non separable attenuator. Its transmission comes
+# from interpolating a tabulated radiative transfer calculation rather than from an optical depth times a curve, and it
+# is checked here for the disk, for the spheroid -- which uses a four dimensional table, additionally indexed by
+# spheroid size -- and averaged over orientation.
+# ---------------------------------------------------------------------------------------------------------------------
+with h5py.File(outputPath, "r") as f:
+    nodes = f["Outputs/Output1/nodeData"]
+    try:
+        sedDiskRaw      = nodes["diskStellarSED:inoue2014"][:]
+        sedSpheroidRaw  = nodes["spheroidStellarSED:inoue2014"][:]
+        atlasDisk       = nodes["diskStellarSED:inoue2014:dustAttenuated:atlasFerrara2000"][:]
+        atlasSpheroid   = nodes["spheroidStellarSED:inoue2014:dustAttenuated:atlasFerrara2000"][:]
+        atlasAveraged   = nodes["diskStellarSED:inoue2014:dustAttenuated:inclinationAveraged"][:]
+    except KeyError as e:
+        print(f"FAILED: expected atlas dataset missing from the output: {e}")
+        sys.exit(0)
+
+emittingDisk     = sedDiskRaw     > 0.0
+emittingSpheroid = sedSpheroidRaw > 0.0
+if not emittingDisk.any() or not emittingSpheroid.any():
+    print("FAILED: no disk or spheroid emission, so the atlas is not being tested")
+    sys.exit(0)
+
+transmissionDisk     = atlasDisk    [emittingDisk    ] / sedDiskRaw    [emittingDisk    ]
+transmissionSpheroid = atlasSpheroid[emittingSpheroid] / sedSpheroidRaw[emittingSpheroid]
+transmissionAveraged = atlasAveraged[emittingDisk    ] / sedDiskRaw    [emittingDisk    ]
+
+# Transmission must be positive and finite. It is not bounded above by unity: this is a directional transmission, and
+# scattering can put more light into a line of sight than the dust takes out of it, which the tabulation shows at low
+# optical depth and low inclination. The bound here is loose enough to admit that but tight enough to catch a misread.
+for name, values in (("disk", transmissionDisk), ("spheroid", transmissionSpheroid), ("averaged", transmissionAveraged)):
+    if not bool(np.all(np.isfinite(values))) or values.min() <= 0.0 or values.max() > 1.1:
+        print(f"FAILED: atlas {name} transmission is not in a physical range: "
+              f"[{values.min():.3e},{values.max():.3e}]")
+        sys.exit(0)
+print(f"SUCCESS: atlas transmission is physical for disk, spheroid, and averaged over orientation")
+
+# Averaging over orientation includes lines of sight more inclined than the fixed 30 degrees at which the unaveraged
+# atlas is evaluated, and a dust disk removes more light from a more inclined sightline, so the average must transmit
+# less. This exercises the inclination axis of the table, and the quadrature over it.
+if not bool(np.all(transmissionAveraged <= transmissionDisk + TOLERANCE)):
+    worst = float(np.nanmax(transmissionAveraged - transmissionDisk))
+    print(f"FAILED: averaging over orientation transmits more than the face-on value, by up to {worst:.3e}")
+    sys.exit(0)
+print(f"SUCCESS: averaging over orientation transmits less than at 30 degrees, "
+      f"{transmissionAveraged.mean():.4f} against {transmissionDisk.mean():.4f}")
+
 sys.exit(0)

--- a/testSuite/test-dust-attenuation-parity.py
+++ b/testSuite/test-dust-attenuation-parity.py
@@ -68,6 +68,30 @@ if differenceSum > 0.0:
 print(f"SUCCESS: outputSum equals the sum of the per-component attenuated luminosities exactly")
 
 # ---------------------------------------------------------------------------------------------------------------------
+# Averaging over orientation. Charlot & Fall (2000) does not depend on orientation, so averaging it over orientation
+# must return it unchanged -- which checks that the quadrature weights sum to unity, that the optional inclination
+# argument is threaded through to the wrapped attenuator, and that the decorator passes its decomposition request on.
+# ---------------------------------------------------------------------------------------------------------------------
+with h5py.File(outputPath, "r") as f:
+    nodes = f["Outputs/Output1/nodeData"]
+    try:
+        averaged = nodes["luminosityTotalAveraged:dustAttenuated:inclinationAveraged"][:]
+    except KeyError as e:
+        print(f"FAILED: expected inclination-averaged dataset missing from the output: {e}")
+        print(f"        available: {sorted(n for n in nodes.keys() if 'Averaged' in n)}")
+        sys.exit(0)
+
+emittingBand = total > 0.0
+if not emittingBand.any():
+    print("FAILED: no galaxy has a non-zero attenuated luminosity, so the average is not being tested")
+    sys.exit(0)
+worstAveraged = float(np.nanmax(np.abs(averaged[emittingBand] - total[emittingBand]) / total[emittingBand]))
+if worstAveraged > TOLERANCE:
+    print(f"FAILED: averaging an orientation-independent attenuator over orientation changed it by {worstAveraged:.3e}")
+    sys.exit(0)
+print(f"SUCCESS: averaging over orientation leaves an orientation-independent attenuator unchanged, to {worstAveraged:.3e}")
+
+# ---------------------------------------------------------------------------------------------------------------------
 # Spectral energy distributions. These check the decomposition machinery itself rather than agreement with a previous
 # implementation, since no previous implementation attenuated a spectrum.
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Phase 3 of the dust attenuation overhaul planned in #893, following #1337, #1410, and #1423.

Phases 1 and 2 built the framework and moved every consumer onto it. This phase adds the geometry the framework was designed to make possible: a per-galaxy inclination, and the first attenuator which depends on it.

Requires galacticusorg/datasets#67, merged, which provides the atlas in HDF5.

## Inclination

`galacticInclination` answers one question -- at what angle is this galaxy seen? Anisotropic processes all need that angle, and putting it behind one class guarantees they agree on it. Two dust attenuators drawing independently would build a galaxy's colors from luminosities at different orientations.

| implementation | storage | notes |
|---|---|---|
| `null` | none | **default**; reports `isAvailable` false so consumers refuse rather than use a meaningless angle |
| `spinVector` | none | from the halo angular momentum vector; line of sight fixed in the box or from a `geometryLightcone` |
| `random` | 8 B/node, opt-in | isotropic, stored in a `basic` meta-property by `nodeOperatorInclinationRandom`, optionally re-drawn on a major merger |
| `fixed` | none | testing, and face-on/edge-on comparisons |

`nodePropertyExtractorInclination` reports the angle applied, in degrees.

`transmission` gains an optional `inclination` argument, which is how `inclinationAveraged` drives its quadrature -- asking the wrapped attenuator for each angle in turn, mutating nothing, so it stays safe under threading. `sequence` forwards it, so averaging a sequence averages the product rather than producting the averages.

## Averaging over orientation

`inclinationAveraged` averages the **transmission**, not the optical depth. Attenuation is exponential in optical depth, so a galaxy seen over a range of orientations transmits more than one seen at the mean depth; averaging the depth would systematically over-attenuate.

Fixed-order Gauss-Legendre rather than an adaptive rule: the integrand is smooth and bounded, and since the cost multiplies that of every luminosity a fixed order keeps it predictable. The rule agrees with `numpy.polynomial.legendre.leggauss` to 1.1e-16 in nodes and 2.8e-16 in weights.

## The atlas

`atlasFerrara2000` interpolates the radiative transfer atlas of Ferrara et al. (1999) over wavelength, inclination, optical depth, and -- for the spheroid -- spheroid size. It is the first *non-separable* attenuator: the escape fraction comes from a transfer calculation through a specified geometry, not an optical depth times a curve, so it takes no `dustExtinctionCurve`.

The optical depth comes from a `dustAttenuationScreen`, keeping the Milky Way calibration in one place, and is always evaluated for the **disk** -- the dust lies there, and a spheroid is reddened by it.

The spheroid size axis is a **half-mass** radius. Ferrara et al. use Jaffe profiles, for which the half-mass radius is exactly the scale radius $r_0$; a model's Hernquist spheroid has a half-mass radius $(1+\sqrt{2})$ times its scale radius, so the two are matched on the radius which means the same thing in both. Getting this wrong is not a detail: it moves the spheroid transmission by up to 14%.

## Verification

Every atlas result is checked against independent interpolation of the same HDF5 file, in a model where the optical depth and inclination are pinned and so exactly known:

| | max \|model − reference\| |
|---|---|
| disk, 3D table | 3.331e-16 |
| spheroid, 4D table | 5.551e-16 |
| averaged over orientation | 1.221e-15 |

The third compares against an independent 8-point Gauss-Legendre average over $\cos i$, and is the first test of the quadrature *abscissae*: until there was an orientation-dependent attenuator, the integrand was constant and only the weights were exercised.

The parity suite is at 15 checks. Its new atlas assertions are deliberately modest, because checking the tabulation showed several plausible properties to be **false**: transmission is not monotonic in inclination, nor in optical depth; face-on is not the maximum over inclination, nor edge-on the minimum; and for the spheroid face-on does not always exceed edge-on. Only the disk's face-on exceeding its edge-on holds everywhere.

## Also here

* Transmission is now documented as *directional*, and may exceed unity: scattering can put more light into a line of sight than the dust removes, which the atlas shows at low optical depth and inclination, up to 3%. Energy conservation constrains the average over orientation, not any single direction.
* The atlas brackets the axes which do not vary between parcels once per galaxy rather than once per parcel, using `interpolateFactors` from f46ca51f. Bit-identical.
* `positionLightconeCrossing` and `velocityLightconeCrossing` are documented as requiring the node to be *at* its crossing time, which is what they actually need; the previous claim that `timeLightconeCrossing` must be called first does not match `geometryLightconeSquare`, the only implementation.

## Known gaps

* **`spinVector` has no regression test.** It is verified by hand -- three observer directions return exactly the angles implied by $\hat{\jmath}=\hat{x}$ -- but every galaxy comes out identically oriented, because `nodeOperatorHaloAngularMomentumRandom` randomizes the angular momentum *magnitude* while setting the vector to $(J,0,0)$. A meaningful test needs a model built around `Vitvitska2002`. Documented on the class so an all-equal result is read as degenerate spins rather than a broken class.
* The atlas's `heightRatio` and `smallMagellanicCloud` variants are untested; both only select which file is opened.
* The parity model exercises the atlas at one inclination plus the average, not explicitly edge-on: two atlas blocks on one component collide in output naming, which `appendSuffix` would resolve.

`atlasCompendium` follows in its own PR, then phase 4, dust emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)