### PR TITLE
feat(launcher): run Galacticus on Windows through WSL 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Galacticus is a semi-analytic model of galaxy formation — a powerful, flexible toolkit for modeling the physics of how galaxies form and evolve. For the science behind it, see the [description paper](https://arxiv.org/abs/1008.1786); for everything else, the [documentation](https://galacticus.readthedocs.io/).
 
-**Install:** `pip install galacticus` gets you a ready-to-run model with no compilation — pre-built binaries, datasets, and tools are downloaded automatically for Linux and macOS. See the [Quickstart](#quickstart) and the [pip installation guide](https://galacticus.readthedocs.io/en/latest/manuals/user-guide/installation/pip.html).
+**Install:** `pip install galacticus` gets you a ready-to-run model with no compilation — pre-built binaries, datasets, and tools are downloaded automatically for Linux and macOS (and for Windows via WSL 2). See the [Quickstart](#quickstart) and the [pip installation guide](https://galacticus.readthedocs.io/en/latest/manuals/user-guide/installation/pip.html).
 
 Have questions? Ask in the [discussion forum](https://github.com/galacticusorg/galacticus/discussions), or browse the [wiki](https://github.com/galacticusorg/galacticus/wiki).
 
@@ -25,7 +25,7 @@ Have questions? Ask in the [discussion forum](https://github.com/galacticusorg/g
 > galacticus run parameters/quickTest.xml
 > ```
 >
-> The first run downloads the right binary, datasets, and tools for your platform (Linux x86-64, macOS Intel, or macOS Apple Silicon) and configures the environment for you. See the [pip installation guide](https://galacticus.readthedocs.io/en/latest/manuals/user-guide/installation/pip.html). The rest of this section covers building from source, which you need only if you want to modify or extend Galacticus.
+> The first run downloads the right binary, datasets, and tools for your platform (Linux x86-64, macOS Intel, or macOS Apple Silicon) and configures the environment for you. On Windows, run `galacticus install-wsl` first: it sets up WSL 2 and installs Galacticus inside it, after which `galacticus run` works from any Windows command prompt. See the [pip installation guide](https://galacticus.readthedocs.io/en/latest/manuals/user-guide/installation/pip.html). The rest of this section covers building from source, which you need only if you want to modify or extend Galacticus.
 
 This section walks you through building and running a minimal Galacticus model for the first time.
 

--- a/aux/words.dict
+++ b/aux/words.dict
@@ -1013,3 +1013,7 @@ AxionCAMB
 NGenHalofit
 Daemmerung
 initializers
+WSL
+UEFI
+PowerShell
+virtualization

--- a/docs/manuals/user-guide/installation/index.rst
+++ b/docs/manuals/user-guide/installation/index.rst
@@ -2,12 +2,13 @@ Installation
 ============
 
 Galacticus is designed to run on Linux, with experimental support for macOS.
-There are several ways to install it, listed here from easiest to most involved:
+On Windows it runs through WSL 2 (the Windows Subsystem for Linux). There are
+several ways to install it, listed here from easiest to most involved:
 
 * **pip** — the quickest way to get running for end users. ``pip install
   galacticus`` installs a launcher that downloads the right pre-built binary,
-  datasets, and tools on first use and sets the environment up for you; see
-  :doc:`pip`.
+  datasets, and tools on first use and sets the environment up for you; on
+  Windows it also sets up WSL 2 (``galacticus install-wsl``). See :doc:`pip`.
 * **Pre-compiled binary** — download and configure the binary yourself; no
   compilation required. Available for :doc:`Linux <binary>` and
   :doc:`macOS <binary-macos>`.

--- a/docs/manuals/user-guide/installation/pip.rst
+++ b/docs/manuals/user-guide/installation/pip.rst
@@ -12,9 +12,9 @@ run a model, the launcher downloads the pre-built executable, the run-time
 required environment variables for you — so there is nothing else to configure.
 
 Pre-built binaries are available for Linux (x86-64), macOS (Intel x86-64), and
-macOS (Apple Silicon). On other platforms — including native Windows — there is
-no pre-built binary; build :doc:`from source <source-linux>` instead (on Windows,
-use WSL 2 and the Linux build).
+macOS (Apple Silicon). On Windows the launcher runs the Linux binary through
+WSL 2 and can set that up for you — see :ref:`pip-windows`. On other platforms
+there is no pre-built binary; build :doc:`from source <source-linux>` instead.
 
 .. note::
 
@@ -98,6 +98,58 @@ Commands
 ``galacticus info``
    Show the resolved install, the environment variables it sets, and the current
    cache size.
+
+.. _pip-windows:
+
+Windows
+-------
+
+There is no native Windows build of Galacticus, but the Linux build runs under
+the Windows Subsystem for Linux (WSL 2), and on Windows the ``galacticus``
+command drives it for you: every command is forwarded to a copy of the launcher
+inside your WSL distribution, with file paths translated, and output is written
+to your current Windows directory as usual. ``pip install galacticus`` on
+Windows therefore works the same as on Linux, once WSL is set up. One command
+does that::
+
+   galacticus install-wsl
+
+It performs whichever of these steps are still missing, and asks before each
+one that changes your system (pass ``--yes`` to skip the questions):
+
+#. **Install WSL 2** if it is not present. This enables a Windows feature, so
+   Windows shows an administrator approval prompt, and a **reboot** is needed
+   afterwards. Reboot, then run ``galacticus install-wsl`` again.
+#. **Install a Linux distribution** (Ubuntu) if there is none. Ubuntu starts once
+   to create your Linux user — it asks for a user name and password and then
+   shows a Linux prompt; type ``exit`` at that prompt to continue.
+#. **Install Galacticus inside the distribution** and download the binary,
+   datasets, and tools (``--no-tools`` is honored, as for ``galacticus
+   install``).
+
+After that, ``galacticus run model.xml`` works from any Windows command prompt or
+PowerShell window. ``galacticus info`` reports which distribution is used: the
+default one, or the first ordinary one if the default belongs to a container
+runtime such as Docker Desktop. If you already have a WSL 2 distribution, only
+the last step runs, and it also runs on demand the first time you use
+``galacticus run``.
+
+Requirements and known failure modes:
+
+* Windows 10 (build 19041 or later) or Windows 11, on a machine with hardware
+  virtualization enabled. If Ubuntu fails to start with error ``0x80370102``,
+  virtualization is disabled in the firmware (BIOS/UEFI) settings; enable it
+  and try again. On a managed machine, group policy may block installing
+  Windows features — ask your administrator to install WSL 2.
+* A distribution running under WSL 1 cannot run Galacticus; ``galacticus
+  install-wsl`` offers to convert it to WSL 2.
+* Galacticus, its datasets, and its output cache are stored on the Linux
+  filesystem of the distribution (file access across the Windows/Linux
+  boundary is far too slow for them). Parameter files and output files can
+  live on the Windows side.
+* Running the launcher inside WSL directly (``pip install galacticus`` in a WSL
+  shell) also works, and is the choice for MPI runs — see ``galacticus
+  resolve`` above.
 
 .. _pip-no-tools:
 

--- a/python/galacticus_launcher/__init__.py
+++ b/python/galacticus_launcher/__init__.py
@@ -13,7 +13,9 @@ The ``galacticus`` console script (see :mod:`galacticus_launcher.cli`) is the
 entry point.  The launcher also works as a thin dispatch front-end on top of a
 non-pip install (a git clone built from source): when a usable build is already
 present in the environment, downloads are skipped entirely (see
-:mod:`galacticus_launcher.paths`).
+:mod:`galacticus_launcher.paths`).  On Windows, where no native binary exists,
+every command is forwarded to a copy of the launcher inside a WSL 2
+distribution (see :mod:`galacticus_launcher.wsl`).
 """
 
 from importlib import metadata as _metadata

--- a/python/galacticus_launcher/cli.py
+++ b/python/galacticus_launcher/cli.py
@@ -11,8 +11,13 @@ Sub-commands:
   MPI runs.
 * ``clean`` -- purge the regenerable cache (never the durable install).
 * ``info`` -- report the resolved install, paths, and environment.
+* ``install-wsl`` -- (Windows) set up WSL 2 and install Galacticus inside it.
 
 ``galacticus <params.xml>`` is accepted as shorthand for ``galacticus run``.
+
+On a Windows host every command except ``install-wsl`` is forwarded to the
+launcher inside the WSL distribution (see :mod:`galacticus_launcher.wsl`), as
+there is no native Windows binary.
 """
 
 import argparse
@@ -23,9 +28,10 @@ from pathlib import Path
 
 import platformdirs
 
-from . import __version__, download, macos, paths, platforms, validate as _validate
+from . import __version__, download, macos, paths, platforms, validate as _validate, wsl
 
-_COMMANDS = {"install", "update", "run", "validate", "resolve", "clean", "info"}
+_COMMANDS = {"install", "update", "run", "validate", "resolve", "clean", "info",
+             "install-wsl"}
 
 
 def _add_tools_option(parser):
@@ -112,13 +118,22 @@ def main(argv=None):
 
     sub.add_parser("info", help="show the resolved install and environment")
 
+    wsl_parser = sub.add_parser(
+        "install-wsl", help="(Windows only) set up WSL 2 and install Galacticus "
+                            "inside it; asks before changing the system")
+    wsl_parser.add_argument("--yes", "-y", action="store_true",
+                            help="proceed without asking for confirmation "
+                                 "(installing WSL needs administrator approval "
+                                 "and a reboot)")
+    _add_tools_option(wsl_parser)
+
     args = parser.parse_args(argv)
     if not args.command:
         parser.print_help()
         return 0
 
     try:
-        return _dispatch(args)
+        return _dispatch(args, argv)
     except platforms.UnsupportedPlatform as error:
         print(f"galacticus: {error}", file=sys.stderr)
         return 2
@@ -127,7 +142,12 @@ def main(argv=None):
         return 1
 
 
-def _dispatch(args):
+def _dispatch(args, argv=()):
+    if args.command == "install-wsl":
+        return wsl.install(yes=args.yes, tools=args.tools)
+    if wsl.is_windows():
+        # No native Windows binary exists: the whole command line runs inside WSL.
+        return wsl.dispatch(list(argv))
     if args.command == "clean":
         return _cmd_clean(args)
     if args.command == "info":

--- a/python/galacticus_launcher/platforms.py
+++ b/python/galacticus_launcher/platforms.py
@@ -77,7 +77,8 @@ def detect(system=None, machine=None):
         )
     raise UnsupportedPlatform(
         f"Galacticus provides no pre-built binary for system '{system}'. "
-        "On Windows, use WSL 2 and install the Linux build. Otherwise build "
-        "from source: https://galacticus.readthedocs.io/en/latest/manuals/"
-        "user-guide/installation/index.html"
+        "On Windows, run `galacticus install-wsl` to set up WSL 2 and install the "
+        "Linux build inside it. Otherwise build from source: "
+        "https://galacticus.readthedocs.io/en/latest/manuals/user-guide/"
+        "installation/index.html"
     )

--- a/python/galacticus_launcher/tests/test_wsl.py
+++ b/python/galacticus_launcher/tests/test_wsl.py
@@ -1,0 +1,321 @@
+"""Unit tests for the Windows/WSL delegation layer.
+
+Network-free and Windows-free: ``wsl.exe`` is never run. Every test replaces
+:func:`galacticus_launcher.wsl._run` (the single choke point through which
+``wsl.exe`` is invoked) with a fake keyed on the arguments, and forces the host
+detection as needed.
+"""
+
+import pytest
+
+pytest.importorskip("platformdirs")
+pytest.importorskip("requests")
+
+from galacticus_launcher import cli, wsl
+
+
+LIST_OUTPUT = """  NAME              STATE           VERSION
+* docker-desktop    Running         2
+  Ubuntu            Stopped         2
+  Debian            Stopped         1
+"""
+
+
+class FakeWSL:
+    """Stand-in for ``wsl._run``: records calls and answers from a script."""
+
+    def __init__(self, responses):
+        # responses: list of (predicate(args) -> bool, Result) checked in order.
+        self.responses = responses
+        self.calls = []
+
+    def __call__(self, args, *, capture=True):
+        self.calls.append((list(args), capture))
+        for predicate, result in self.responses:
+            if predicate(args):
+                # A callable response computes its Result from the arguments.
+                return result(args) if callable(result) else result
+        raise AssertionError(f"unexpected wsl.exe invocation: {args}")
+
+
+def _fake(monkeypatch, responses, *, windows=True, have_wsl=True):
+    fake = FakeWSL(responses)
+    monkeypatch.setattr(wsl, "_run", fake)
+    monkeypatch.setattr(wsl, "is_windows", lambda: windows)
+    monkeypatch.setattr(wsl.shutil, "which", lambda name: "C:\\Windows\\wsl.exe" if have_wsl else None)
+    return fake
+
+
+# --- decoding wsl.exe output -----------------------------------------------
+
+def test_decode_utf16_and_utf8():
+    utf16 = "\ufeffDefault Version: 2\r\n".encode("utf-16-le")
+    assert wsl.decode(utf16) == "Default Version: 2\n"
+    assert wsl.decode("/mnt/c/Users/x\n".encode("utf-8")) == "/mnt/c/Users/x\n"
+    assert wsl.decode(b"") == ""
+
+
+# --- distribution list & status --------------------------------------------
+
+def test_parse_distribution_list():
+    found = wsl.parse_distribution_list(LIST_OUTPUT)
+    assert [(d.name, d.version, d.default) for d in found] == [
+        ("docker-desktop", 2, True), ("Ubuntu", 2, False), ("Debian", 1, False)]
+
+
+def test_status_skips_container_runtime_distribution(monkeypatch):
+    _fake(monkeypatch, [(lambda a: a[:2] == ["--list", "--verbose"],
+                         wsl.Result(0, LIST_OUTPUT))])
+    current = wsl.status()
+    assert (current.state, current.distribution, current.version) == (wsl.STATE_READY, "Ubuntu", 2)
+
+
+def test_status_prefers_default_distribution(monkeypatch):
+    listing = "  NAME    STATE    VERSION\n  Ubuntu  Stopped  2\n* Debian  Running  2\n"
+    _fake(monkeypatch, [(lambda a: a[0] == "--list", wsl.Result(0, listing))])
+    assert wsl.status().distribution == "Debian"
+
+
+def test_status_no_distribution(monkeypatch):
+    _fake(monkeypatch, [(lambda a: a[0] == "--list", wsl.Result(1, "no distributions")),
+                        (lambda a: a[0] == "--status", wsl.Result(0, "Default Version: 2"))])
+    assert wsl.status().state == wsl.STATE_NO_DISTRIBUTION
+
+
+def test_status_not_installed(monkeypatch):
+    _fake(monkeypatch, [(lambda a: a[0] == "--list", wsl.Result(1, "")),
+                        (lambda a: a[0] == "--status", wsl.Result(1, "not installed"))])
+    assert wsl.status().state == wsl.STATE_NOT_INSTALLED
+
+
+def test_status_unsupported(monkeypatch):
+    _fake(monkeypatch, [], windows=False)
+    assert wsl.status().state == wsl.STATE_UNSUPPORTED
+    fake = _fake(monkeypatch, [], have_wsl=False)
+    assert wsl.status().state == wsl.STATE_UNSUPPORTED
+    assert fake.calls == []   # nothing is run when wsl.exe is absent
+
+
+def test_hint():
+    assert "virtualization" in wsl.hint("Error code: Wsl/Service/0x80370102")
+    assert wsl.hint("all fine") is None
+
+
+# --- command construction --------------------------------------------------
+
+def test_launcher_command_forwards_arguments_verbatim():
+    command = wsl.launcher_command(["run", "a b.xml", "--dry-run"])
+    assert command[:2] == ["/bin/sh", "-c"]
+    assert wsl.VENV in command[2] and '"$@"' in command[2]
+    assert command[3:] == ["galacticus", "run", "a b.xml", "--dry-run"]
+
+
+def test_run_builds_wsl_invocation(monkeypatch):
+    fake = _fake(monkeypatch, [(lambda a: True, wsl.Result(0, ""))])
+    wsl.run("Ubuntu", ["/bin/true"], user="root", capture=False)
+    assert fake.calls == [(["-d", "Ubuntu", "-u", "root", "--exec", "/bin/true"], False)]
+
+
+def test_environment_forwards_release_overrides(monkeypatch):
+    monkeypatch.setenv("GALACTICUS_RELEASE_TAG", "v1.2.3")
+    monkeypatch.delenv("GALACTICUS_DATASETS_REF", raising=False)
+    monkeypatch.setenv("WSLENV", "FOO/p")
+    assert wsl._environment()["WSLENV"] == "FOO/p:GALACTICUS_RELEASE_TAG"
+    monkeypatch.delenv("GALACTICUS_RELEASE_TAG")
+    monkeypatch.delenv("WSLENV")
+    assert "WSLENV" not in wsl._environment()
+
+
+# --- path translation ------------------------------------------------------
+
+def _wslpath_fake(args):
+    """Answer the batched `wslpath` call: prefix every path with /wsl."""
+    paths = args[args.index("sh") + 1:]
+    return wsl.Result(0, "".join(f"/wsl{p}\n" for p in paths))
+
+
+def test_translate_arguments(monkeypatch, tmp_path):
+    fake = _fake(monkeypatch, [(lambda a: "--exec" in a, _wslpath_fake)])
+    parameters = tmp_path / "model.xml"
+    parameters.write_text("<parameters/>")
+    output = tmp_path / "out.xml"            # does not exist yet
+    argv = ["run", str(parameters), "missing.xml", "--dry-run", "-o", str(output),
+            "--", "--tools"]
+    translated = wsl.translate_arguments("Ubuntu", argv)
+    assert translated == ["run", f"/wsl{parameters}", "missing.xml", "--dry-run",
+                          "-o", f"/wsl{tmp_path}/out.xml", "--", "--tools"]
+    # One wslpath invocation for both paths; the output file goes via its parent.
+    assert len(fake.calls) == 1
+    assert fake.calls[0][0][-2:] == [str(parameters), str(tmp_path)]
+
+
+def test_translate_arguments_without_paths_runs_nothing(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)   # so the bundled example path does not exist here
+    fake = _fake(monkeypatch, [])
+    assert wsl.translate_arguments("Ubuntu", ["info"]) == ["info"]
+    assert wsl.translate_arguments("Ubuntu", ["run", "parameters/quickTest.xml"]) == \
+        ["run", "parameters/quickTest.xml"]
+    assert fake.calls == []
+
+
+def test_translate_paths_reports_failure(monkeypatch):
+    _fake(monkeypatch, [(lambda a: True, wsl.Result(1, "wslpath: boom"))])
+    with pytest.raises(RuntimeError, match="boom"):
+        wsl.translate_paths("Ubuntu", ["C:\\x"])
+
+
+# --- provisioning ----------------------------------------------------------
+
+def test_is_release():
+    assert wsl.is_release("1.2.3")
+    assert not wsl.is_release("0.0.0")
+    assert not wsl.is_release("0.0.0.post1.dev395")
+    assert not wsl.is_release("1.2")
+
+
+def test_pip_target(monkeypatch, tmp_path):
+    assert wsl.pip_target("Ubuntu", version="1.2.3") == ["galacticus==1.2.3"]
+    monkeypatch.setattr(wsl, "source_tree", lambda: None)
+    assert wsl.pip_target("Ubuntu", version="0.0.0") == ["galacticus"]
+    monkeypatch.setattr(wsl, "translate_paths", lambda d, p: [f"/wsl{x}" for x in p])
+    assert wsl.pip_target("Ubuntu", version="0.0.0", tree=tmp_path) == ["-e", f"/wsl{tmp_path}"]
+
+
+def test_source_tree_detects_checkout():
+    # These tests run from the repository, so the launcher is a source tree.
+    tree = wsl.source_tree()
+    assert tree is not None and (tree / "pyproject.toml").is_file()
+
+
+def test_installed_checks_version(monkeypatch):
+    monkeypatch.setattr(wsl, "__version__", "1.2.3")
+    _fake(monkeypatch, [(lambda a: True, wsl.Result(0, "galacticus 1.2.3\n"))])
+    assert wsl.installed("Ubuntu")
+    _fake(monkeypatch, [(lambda a: True, wsl.Result(0, "galacticus 1.0.0\n"))])
+    assert not wsl.installed("Ubuntu")
+    _fake(monkeypatch, [(lambda a: True, wsl.Result(127, ""))])
+    assert not wsl.installed("Ubuntu")
+
+
+def test_provision_falls_back_to_apt(monkeypatch):
+    monkeypatch.setattr(wsl, "pip_target", lambda d: ["galacticus==1.2.3"])
+    attempts = []
+
+    def fake_run(distribution, command, *, user=None, capture=True):
+        attempts.append((user, command[-1]))
+        # First venv attempt fails (no python3-venv); apt and the retry succeed.
+        if user is None and len(attempts) == 1:
+            return wsl.Result(1, "")
+        return wsl.Result(0, "")
+
+    monkeypatch.setattr(wsl, "run", fake_run)
+    assert wsl.provision("Ubuntu", log=lambda *a, **k: None) == 0
+    assert [user for user, _ in attempts] == [None, "root", None]
+    assert "python3-venv" in attempts[1][1]
+
+
+# --- dispatch --------------------------------------------------------------
+
+def test_dispatch_not_ready(monkeypatch, capsys):
+    monkeypatch.setattr(wsl, "status",
+                        lambda: wsl.Status(wsl.STATE_NOT_INSTALLED, None, None, ""))
+    assert wsl.dispatch(["run", "x.xml"]) == 2
+    assert "install-wsl" in capsys.readouterr().err
+
+
+def test_dispatch_rejects_wsl1(monkeypatch, capsys):
+    monkeypatch.setattr(wsl, "status",
+                        lambda: wsl.Status(wsl.STATE_READY, "Ubuntu", 1, ""))
+    assert wsl.dispatch(["run", "x.xml"]) == 2
+    assert "WSL 2" in capsys.readouterr().err
+
+
+def test_dispatch_runs_inside_distribution(monkeypatch):
+    monkeypatch.setattr(wsl, "status",
+                        lambda: wsl.Status(wsl.STATE_READY, "Ubuntu", 2, ""))
+    monkeypatch.setattr(wsl, "installed", lambda d: True)
+    monkeypatch.setattr(wsl, "translate_arguments", lambda d, argv: ["run", "/mnt/c/m.xml"])
+    calls = []
+
+    def fake_run(distribution, command, *, user=None, capture=True):
+        calls.append((distribution, command, capture))
+        return wsl.Result(7, "")
+
+    monkeypatch.setattr(wsl, "run", fake_run)
+    assert wsl.dispatch(["run", "C:\\m.xml"]) == 7
+    (distribution, command, capture), = calls
+    assert distribution == "Ubuntu" and capture is False
+    assert command == wsl.launcher_command(["run", "/mnt/c/m.xml"])
+
+
+def test_dispatch_provisions_when_missing(monkeypatch):
+    monkeypatch.setattr(wsl, "status",
+                        lambda: wsl.Status(wsl.STATE_READY, "Ubuntu", 2, ""))
+    monkeypatch.setattr(wsl, "installed", lambda d: False)
+    monkeypatch.setattr(wsl, "provision", lambda d, log: 3)
+    assert wsl.dispatch(["info"]) == 3
+
+
+# --- CLI routing -----------------------------------------------------------
+
+def test_cli_forwards_everything_on_windows(monkeypatch):
+    seen = []
+    monkeypatch.setattr(wsl, "is_windows", lambda: True)
+    monkeypatch.setattr(wsl, "dispatch", lambda argv: seen.append(argv) or 7)
+    assert cli.main(["model.xml", "changes.xml", "--dry-run"]) == 7
+    assert seen == [["run", "model.xml", "changes.xml", "--dry-run"]]
+    assert cli.main(["clean", "--dry-run"]) == 7
+    assert seen[-1] == ["clean", "--dry-run"]
+
+
+def test_cli_install_wsl_routes_to_install(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(wsl, "install", lambda **kw: seen.update(kw) or 0)
+    assert cli.main(["install-wsl", "--yes", "--no-tools"]) == 0
+    assert seen == {"yes": True, "tools": False}
+
+
+def test_cli_install_wsl_is_noop_off_windows(capsys):
+    assert cli.main(["install-wsl"]) == 0
+    assert "only needed on Windows" in capsys.readouterr().out
+
+
+# --- `install-wsl` flow ----------------------------------------------------
+
+def _status(state, distribution=None, version=None):
+    return wsl.Status(state, distribution, version, "")
+
+
+def test_install_flow_installs_feature_then_asks_for_reboot(monkeypatch, capsys):
+    monkeypatch.setattr(wsl, "is_windows", lambda: True)
+    monkeypatch.setattr(wsl, "status", lambda: _status(wsl.STATE_NOT_INSTALLED))
+    monkeypatch.setattr(wsl, "enable_wsl", lambda: 0)
+    assert wsl.install(yes=True) == 0
+    assert "Reboot" in capsys.readouterr().out
+
+
+def test_install_flow_refuses_without_terminal(monkeypatch, capsys):
+    monkeypatch.setattr(wsl, "is_windows", lambda: True)
+    monkeypatch.setattr(wsl, "status", lambda: _status(wsl.STATE_NOT_INSTALLED))
+    monkeypatch.setattr(wsl.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(wsl, "enable_wsl", lambda: pytest.fail("must not install"))
+    assert wsl.install(yes=False) == 1
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_install_flow_installs_distribution_then_provisions(monkeypatch):
+    monkeypatch.setattr(wsl, "is_windows", lambda: True)
+    states = iter([_status(wsl.STATE_NO_DISTRIBUTION),
+                   _status(wsl.STATE_READY, "Ubuntu", 2)])
+    monkeypatch.setattr(wsl, "status", lambda: next(states))
+    monkeypatch.setattr(wsl, "install_distribution", lambda name=None: 0)
+    steps = []
+    monkeypatch.setattr(wsl, "provision", lambda d, log: steps.append("provision") or 0)
+
+    def fake_run(distribution, command, *, user=None, capture=True):
+        steps.append(command[-2:])
+        return wsl.Result(0, "")
+
+    monkeypatch.setattr(wsl, "run", fake_run)
+    assert wsl.install(yes=True, tools=False, log=lambda *a, **k: None) == 0
+    assert steps == ["provision", ["install", "--no-tools"]]

--- a/python/galacticus_launcher/wsl.py
+++ b/python/galacticus_launcher/wsl.py
@@ -1,0 +1,514 @@
+"""Windows support: drive Galacticus through WSL 2.
+
+There is no native Windows build of Galacticus (the model, its build system, and
+its run-time tools all assume a POSIX environment), but the Linux build runs
+under the Windows Subsystem for Linux (WSL 2).  On a Windows host the launcher
+therefore delegates every command to a copy of itself installed inside a WSL
+distribution, so that ``pip install galacticus`` on Windows gives the same
+one-command experience as on Linux and macOS:
+
+* ``galacticus install-wsl`` walks the user through installing WSL 2 (an
+  administrator prompt and a reboot are needed when WSL itself is missing),
+  installing the default Ubuntu distribution, and provisioning Galacticus inside
+  it.  It always asks before changing the system unless ``--yes`` is passed.
+* Every other command (``run``, ``install``, ``validate``, ...) is forwarded to
+  the launcher inside the distribution, with Windows paths on the command line
+  translated to their ``/mnt/<drive>/...`` equivalents.  The current directory
+  carries over automatically (``wsl.exe`` starts in the translated directory),
+  so output files land where they would on Linux.
+
+The copy inside the distribution lives in a dedicated virtual environment
+(``~/.local/share/galacticus/venv``), and the binary, datasets, and tools it
+downloads live on the Linux filesystem.  That placement matters: file access
+across the Windows/Linux boundary is far too slow for the datasets and the HDF5
+output.
+
+Only ``wsl.exe`` and ``powershell.exe`` are used, both of which ship with
+Windows.  ``wsl.exe`` writes its own messages as UTF-16, while the output of a
+Linux command run through it is passed through as UTF-8, so :func:`decode`
+handles both.
+"""
+
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+from . import __version__
+
+WSL_EXE = "wsl.exe"
+POWERSHELL_EXE = "powershell.exe"
+
+# The distribution `install-wsl` installs when none is present. Ubuntu is what
+# `wsl --install` itself defaults to, and is the distribution the Linux binary
+# is tested against in CI.
+DEFAULT_DISTRIBUTION = "Ubuntu"
+
+# Location of the launcher's virtual environment inside the distribution,
+# relative to the Linux user's home directory.
+VENV = ".local/share/galacticus/venv"
+
+# Distributions that are the backing store of a container runtime rather than a
+# usable Linux system. They are often the *default* distribution, so they are
+# skipped explicitly rather than trusting the default marker.
+_UTILITY_DISTRIBUTIONS = frozenset({
+    "docker-desktop", "docker-desktop-data",
+    "rancher-desktop", "rancher-desktop-data",
+    "podman-machine-default",
+})
+
+# Launcher environment variables forwarded into the distribution (via WSLENV),
+# so that e.g. `GALACTICUS_RELEASE_TAG=... galacticus run` behaves the same on
+# Windows. The path variables are deliberately NOT forwarded: Windows paths mean
+# nothing to the launcher inside the distribution.
+_FORWARDED = ("GALACTICUS_RELEASE_TAG", "GALACTICUS_DATASETS_REF")
+
+_DOCS = ("https://galacticus.readthedocs.io/en/latest/manuals/user-guide/"
+         "installation/pip.html#windows")
+
+# Well-known WSL failure codes and what to do about them.
+_HINTS = (
+    ("0x80370102", "virtualization is disabled: enable it (Intel VT-x / AMD-V) "
+                   "in the firmware (BIOS/UEFI) settings, or, in a virtual "
+                   "machine, enable nested virtualization"),
+    ("0x80370114", "the Virtual Machine Platform feature is not enabled; run "
+                   "`galacticus install-wsl` again (or `wsl --install`) as an "
+                   "administrator"),
+    ("0x800701bc", "the WSL 2 kernel is missing or outdated; run `wsl --update` "
+                   "and try again"),
+)
+
+STATE_UNSUPPORTED = "unsupported"          # not Windows, or a Windows without wsl.exe
+STATE_NOT_INSTALLED = "not-installed"      # wsl.exe present, WSL feature not installed
+STATE_NO_DISTRIBUTION = "no-distribution"  # WSL installed, no usable distribution
+STATE_READY = "ready"                      # a usable distribution exists
+
+Status = namedtuple("Status", ["state", "distribution", "version", "detail"])
+Distribution = namedtuple("Distribution", ["name", "state", "version", "default"])
+Result = namedtuple("Result", ["returncode", "output"])
+
+
+def is_windows():
+    return platform.system() == "Windows"
+
+
+# --- running wsl.exe -------------------------------------------------------
+
+def decode(data):
+    """Decode output from ``wsl.exe``.
+
+    Messages from ``wsl.exe`` itself (``--list``, ``--status``, errors) are
+    UTF-16LE; output of a Linux command run through it is UTF-8. UTF-16 text of
+    any length has NUL bytes, so that is the discriminator.
+    """
+    if not data:
+        return ""
+    if b"\x00" in data:
+        text = data.decode("utf-16-le", errors="replace")
+    else:
+        text = data.decode("utf-8", errors="replace")
+    return text.lstrip("\ufeff").replace("\x00", "").replace("\r\n", "\n")
+
+
+def _environment():
+    """The environment for a ``wsl.exe`` child: forward the launcher's release
+    overrides into the distribution through ``WSLENV``."""
+    env = dict(os.environ)
+    names = [name for name in _FORWARDED if env.get(name)]
+    if names:
+        current = [entry for entry in env.get("WSLENV", "").split(":") if entry]
+        env["WSLENV"] = ":".join(current + [n for n in names if n not in current])
+    return env
+
+
+def _run(args, *, capture=True):
+    """Run ``wsl.exe args...``. Returns :class:`Result`; output is empty when
+    not captured (the child then shares this process's console)."""
+    completed = subprocess.run([WSL_EXE, *args], capture_output=capture,
+                               env=_environment())
+    output = ""
+    if capture:
+        output = decode(completed.stdout) + decode(completed.stderr)
+    return Result(completed.returncode, output)
+
+
+def run(distribution, command, *, user=None, capture=True):
+    """Run `command` (an argv list, no shell) inside `distribution`."""
+    args = ["-d", distribution]
+    if user:
+        args += ["-u", user]
+    args += ["--exec", *command]
+    return _run(args, capture=capture)
+
+
+def launcher_command(argv):
+    """The argv that runs the launcher inside the distribution.
+
+    ``$HOME`` is only known to the Linux side, so a shell expands it; the
+    launcher's own arguments are passed as positional parameters and forwarded
+    with ``"$@"``, which keeps every argument intact (no re-quoting).
+    """
+    script = f'exec "$HOME/{VENV}/bin/galacticus" "$@"'
+    return ["/bin/sh", "-c", script, "galacticus", *argv]
+
+
+# --- status ----------------------------------------------------------------
+
+def parse_distribution_list(text):
+    """Parse ``wsl --list --verbose`` output.
+
+    The table looks like::
+
+          NAME              STATE           VERSION
+        * Ubuntu            Running         2
+          docker-desktop    Stopped         2
+
+    where ``*`` marks the default distribution.
+    """
+    distributions = []
+    for line in text.splitlines():
+        default = line.lstrip().startswith("*")
+        fields = line.lstrip(" *").split()
+        if len(fields) < 3 or fields[0].upper() == "NAME" or not fields[2].isdigit():
+            continue
+        distributions.append(Distribution(fields[0], fields[1], int(fields[2]), default))
+    return distributions
+
+
+def list_distributions():
+    result = _run(["--list", "--verbose"])
+    if result.returncode != 0:
+        return []
+    return parse_distribution_list(result.output)
+
+
+def status():
+    """Classify the host: see the ``STATE_*`` constants.
+
+    The distribution reported is the one the launcher will use: the default
+    one, unless that is a container runtime's utility distribution, in which
+    case the first ordinary one.
+    """
+    if not is_windows():
+        return Status(STATE_UNSUPPORTED, None, None, "not a Windows host")
+    if shutil.which(WSL_EXE) is None:
+        return Status(STATE_UNSUPPORTED, None, None,
+                      "wsl.exe was not found. WSL 2 needs Windows 10 (build 19041 "
+                      "or later) or Windows 11.")
+    usable = [d for d in list_distributions() if d.name not in _UTILITY_DISTRIBUTIONS]
+    if usable:
+        chosen = next((d for d in usable if d.default), usable[0])
+        return Status(STATE_READY, chosen.name, chosen.version, "")
+    # No usable distribution. `wsl --status` succeeds once the WSL feature is
+    # installed (it reports the default version), and fails on the stub that
+    # Windows ships before it is.
+    result = _run(["--status"])
+    state = STATE_NO_DISTRIBUTION if result.returncode == 0 else STATE_NOT_INSTALLED
+    return Status(state, None, None, result.output.strip())
+
+
+def hint(output):
+    """A remedy for a well-known WSL error code appearing in `output`, or None."""
+    for code, remedy in _HINTS:
+        if code in output.lower():
+            return remedy
+    return None
+
+
+# --- path translation ------------------------------------------------------
+
+def _path_and_suffix(argument):
+    """Split a command-line path into (existing path to translate, suffix).
+
+    ``wslpath`` resolves through the filesystem, so a not-yet-existing output
+    file is translated via its (existing) parent directory, with the file name
+    re-appended afterwards.
+    """
+    if os.path.exists(argument):
+        return os.path.abspath(argument), ""
+    parent, name = os.path.split(os.path.abspath(argument))
+    if name and os.path.isdir(parent):
+        return parent, "/" + name
+    return None, ""
+
+
+def translate_paths(distribution, windows_paths):
+    """Translate Windows paths to their paths inside `distribution`.
+
+    A single ``wslpath`` invocation handles the whole list (one process start),
+    honoring however the distribution mounts the Windows drives.
+    """
+    if not windows_paths:
+        return []
+    script = 'for p in "$@"; do wslpath -a "$p" || exit 1; done'
+    result = run(distribution, ["/bin/sh", "-c", script, "sh", *windows_paths])
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    if result.returncode != 0 or len(lines) != len(windows_paths):
+        raise RuntimeError(
+            f"could not translate paths for WSL distribution {distribution}: "
+            f"{result.output.strip() or 'no output from wslpath'}")
+    return lines
+
+
+def translate_arguments(distribution, argv):
+    """Return `argv` (sub-command first) with Windows paths rewritten.
+
+    Positional arguments naming an existing file or directory are translated,
+    as is the value of ``-o``/``--output`` (which need not exist yet). Options
+    and anything that does not resolve on the Windows side pass through
+    unchanged, so the launcher inside the distribution resolves bundled paths
+    such as ``parameters/quickTest.xml`` itself.
+    """
+    argv = list(argv)
+    targets = {}   # index -> (path, suffix)
+    expect_output = False
+    for index, argument in enumerate(argv[1:], start=1):
+        if expect_output:
+            expect_output = False
+            path, suffix = _path_and_suffix(argument)
+        elif argument in ("-o", "--output"):
+            expect_output = True
+            continue
+        elif argument.startswith("-") or not os.path.exists(argument):
+            continue
+        else:
+            path, suffix = os.path.abspath(argument), ""
+        if path is not None:
+            targets[index] = (path, suffix)
+    translated = translate_paths(distribution, [p for p, _ in targets.values()])
+    for (index, (_, suffix)), wsl_path in zip(targets.items(), translated):
+        argv[index] = wsl_path + suffix
+    return argv
+
+
+# --- provisioning inside the distribution ----------------------------------
+
+def is_release(version=None):
+    version = __version__ if version is None else version
+    return version != "0.0.0" and re.fullmatch(r"\d+\.\d+\.\d+", version) is not None
+
+
+def source_tree():
+    """The repository this launcher was installed from in development mode
+    (``pip install -e .``), or None for a normal (wheel) install."""
+    root = Path(__file__).resolve().parents[2]
+    return root if (root / "pyproject.toml").is_file() else None
+
+
+def pip_target(distribution, version=None, tree=None):
+    """Arguments telling ``pip install`` inside the distribution what to
+    install: the same released version as this launcher; for a development
+    install, the same source checkout (editable), else the newest release."""
+    version = __version__ if version is None else version
+    if is_release(version):
+        return [f"galacticus=={version}"]
+    tree = source_tree() if tree is None else tree
+    if tree is not None:
+        return ["-e", translate_paths(distribution, [str(tree)])[0]]
+    return ["galacticus"]
+
+
+# `pip` refuses to install into the system Python of recent Ubuntu releases, so
+# the launcher gets its own virtual environment. A venv left half-made by an
+# earlier failure (no pip) is rebuilt.
+_PROVISION_SCRIPT = f'''
+set -e
+venv="$HOME/{VENV}"
+if ! "$venv/bin/python" -m pip --version >/dev/null 2>&1; then
+    rm -rf "$venv"
+    mkdir -p "$(dirname "$venv")"
+    python3 -m venv "$venv"
+fi
+"$venv/bin/python" -m pip install --quiet --upgrade "$@"
+'''
+
+# Ubuntu's WSL image lacks the `venv` module (and, on some images, Python
+# itself). Installed as root, which WSL allows without a password.
+_PACKAGES_SCRIPT = "apt-get update -qq && apt-get install -y -qq python3 python3-venv"
+
+
+def installed(distribution):
+    """True if the launcher inside `distribution` exists and, for a released
+    version, matches this launcher's version."""
+    result = run(distribution, launcher_command(["--version"]))
+    if result.returncode != 0:
+        return False
+    if not is_release():
+        return True
+    return result.output.strip().endswith(__version__)
+
+
+def provision(distribution, *, log=print):
+    """Install (or update) the launcher inside `distribution`. Returns an exit code."""
+    target = pip_target(distribution)
+    log(f"Installing Galacticus ({' '.join(target)}) in WSL distribution {distribution} ...")
+    result = run(distribution, ["/bin/sh", "-c", _PROVISION_SCRIPT, "sh", *target],
+                 capture=False)
+    if result.returncode != 0:
+        log("Installing the Python packages the launcher needs (python3, "
+            "python3-venv) ...")
+        result = run(distribution, ["/bin/sh", "-c", _PACKAGES_SCRIPT], user="root",
+                     capture=False)
+        if result.returncode == 0:
+            result = run(distribution, ["/bin/sh", "-c", _PROVISION_SCRIPT, "sh", *target],
+                         capture=False)
+    if result.returncode != 0:
+        print(f"galacticus: installing the launcher in WSL distribution "
+              f"{distribution} failed (exit code {result.returncode}). See {_DOCS}",
+              file=sys.stderr)
+    return result.returncode
+
+
+# --- delegation ------------------------------------------------------------
+
+def _not_ready_message(current):
+    if current.state == STATE_UNSUPPORTED:
+        return f"galacticus: {current.detail} See {_DOCS}"
+    if current.state == STATE_NOT_INSTALLED:
+        what = "WSL 2 is not installed on this Windows machine"
+    else:
+        what = "WSL 2 is installed but has no Linux distribution"
+    return (f"galacticus: {what}. Galacticus runs on Windows through WSL 2; run "
+            f"`galacticus install-wsl` to set it up. See {_DOCS}")
+
+
+def dispatch(argv, *, log=print):
+    """Run the launcher command line `argv` inside WSL. Returns an exit code."""
+    current = status()
+    if current.state != STATE_READY:
+        print(_not_ready_message(current), file=sys.stderr)
+        return 2
+    if current.version != 2:
+        print(f"galacticus: WSL distribution {current.distribution} runs under WSL "
+              f"{current.version}, but Galacticus needs WSL 2. Run `galacticus "
+              f"install-wsl` to convert it. See {_DOCS}", file=sys.stderr)
+        return 2
+    if not installed(current.distribution):
+        code = provision(current.distribution, log=log)
+        if code != 0:
+            return code
+    if argv and argv[0] == "info":
+        log(f"Windows host: commands run inside WSL distribution "
+            f"{current.distribution} (WSL {current.version}).")
+    try:
+        argv = translate_arguments(current.distribution, argv)
+    except RuntimeError as error:
+        print(f"galacticus: {error}", file=sys.stderr)
+        return 1
+    sys.stdout.flush()
+    return run(current.distribution, launcher_command(argv), capture=False).returncode
+
+
+# --- `galacticus install-wsl` ----------------------------------------------
+
+def _confirm(question, yes):
+    if yes:
+        return True
+    if not sys.stdin.isatty():
+        print("galacticus: not running in a terminal; pass --yes to proceed without "
+              "confirmation.", file=sys.stderr)
+        return False
+    return input(f"{question} [y/N] ").strip().lower() in ("y", "yes")
+
+
+def enable_wsl():
+    """Install the WSL feature (no distribution). Needs administrator rights, so
+    it is started elevated through PowerShell, which shows the standard Windows
+    consent prompt; the elevated ``wsl.exe`` runs in its own console window.
+    Returns its exit code (non-zero also if the prompt was declined)."""
+    script = ("$process = Start-Process -FilePath 'wsl.exe' "
+              "-ArgumentList '--install','--no-distribution' "
+              "-Verb RunAs -Wait -PassThru; exit $process.ExitCode")
+    completed = subprocess.run([POWERSHELL_EXE, "-NoProfile", "-NonInteractive",
+                                "-Command", script])
+    return completed.returncode
+
+
+def install_distribution(name=DEFAULT_DISTRIBUTION):
+    """Install `name` and run its first-launch setup interactively in this
+    console (it asks for a Linux user name and password, then opens a shell).
+    Returns the exit code."""
+    return _run(["--install", "-d", name], capture=False).returncode
+
+
+def install(*, yes=False, tools=None, log=print):
+    """The ``galacticus install-wsl`` command. Returns an exit code.
+
+    Idempotent: each run does the next step that is missing (install WSL; reboot;
+    install a distribution; provision the launcher; download the Galacticus
+    assets), so after a reboot the user simply runs it again.
+    """
+    if not is_windows():
+        log("galacticus install-wsl is only needed on Windows; nothing to do.")
+        return 0
+    current = status()
+    if current.state == STATE_UNSUPPORTED:
+        print(f"galacticus: {current.detail} See {_DOCS}", file=sys.stderr)
+        return 2
+
+    if current.state == STATE_NOT_INSTALLED:
+        log("Galacticus runs on Windows through WSL 2 (the Windows Subsystem for "
+            "Linux), which is not installed on this machine.\n"
+            "Installing it enables the Virtual Machine Platform Windows feature "
+            "and the WSL 2 kernel. Windows will ask for administrator approval, "
+            "and a reboot is needed afterwards.")
+        if not _confirm("Install WSL 2 now?", yes):
+            return 1
+        code = enable_wsl()
+        if code != 0:
+            print(f"galacticus: installing WSL did not complete (exit code {code}). "
+                  f"If the administrator prompt was declined, run `galacticus "
+                  f"install-wsl` again; otherwise see {_DOCS}", file=sys.stderr)
+            return code
+        log("WSL 2 is installed. Reboot Windows, then run `galacticus install-wsl` "
+            "again to add the Linux distribution and Galacticus.")
+        return 0
+
+    if current.state == STATE_NO_DISTRIBUTION:
+        log(f"WSL 2 is installed but has no Linux distribution. The next step "
+            f"downloads {DEFAULT_DISTRIBUTION} (about 1 GB) and starts it once to "
+            f"create your Linux user: it will ask for a user name and password, "
+            f"then show a Linux prompt. Type `exit` at that prompt to continue.")
+        if not _confirm(f"Install {DEFAULT_DISTRIBUTION} now?", yes):
+            return 1
+        code = install_distribution()
+        current = status()
+        if code != 0 or current.state != STATE_READY:
+            remedy = hint(current.detail)
+            print(f"galacticus: installing {DEFAULT_DISTRIBUTION} did not complete "
+                  f"(exit code {code})." + (f" Likely cause: {remedy}." if remedy else "")
+                  + f" See {_DOCS}", file=sys.stderr)
+            return code or 1
+
+    if current.version != 2:
+        log(f"WSL distribution {current.distribution} runs under WSL "
+            f"{current.version}; Galacticus needs WSL 2. Converting it can take "
+            f"several minutes.")
+        if not _confirm(f"Convert {current.distribution} to WSL 2 now?", yes):
+            return 1
+        result = _run(["--set-version", current.distribution, "2"], capture=False)
+        if result.returncode != 0:
+            print(f"galacticus: `wsl --set-version {current.distribution} 2` failed "
+                  f"(exit code {result.returncode}). See {_DOCS}", file=sys.stderr)
+            return result.returncode
+
+    code = provision(current.distribution, log=log)
+    if code != 0:
+        return code
+    # Fetch the binary, datasets and tools now, so the first `galacticus run` is
+    # immediate; the tri-state --tools choice is passed straight through.
+    inner = ["install"]
+    if tools is True:
+        inner.append("--tools")
+    elif tools is False:
+        inner.append("--no-tools")
+    code = run(current.distribution, launcher_command(inner), capture=False).returncode
+    if code == 0:
+        log(f"Galacticus is ready in WSL distribution {current.distribution}. "
+            f"Run a model with `galacticus run <parameter file>` from any Windows "
+            f"command prompt.")
+    return code


### PR DESCRIPTION
There is no native Windows build of Galacticus, and `pip install galacticus`
on Windows previously stopped at the first command with a message telling
the user to use WSL 2 by hand. The launcher now drives WSL 2 itself:

* On a Windows host every command (`run`, `install`, `validate`, `clean`,
  `info`, ...) is forwarded to a copy of the launcher installed in a
  dedicated virtual environment inside the user's WSL distribution. Windows
  paths on the command line are translated with `wslpath` (one batched
  call), the current directory carries over, and `GALACTICUS_RELEASE_TAG` /
  `GALACTICUS_DATASETS_REF` are forwarded via `WSLENV`. Container-runtime
  utility distributions (docker-desktop, ...) are never chosen, and a WSL 1
  distribution is refused with instructions.
* A new `galacticus install-wsl` command performs whichever setup steps are
  missing, asking before each one that changes the system (`--yes` skips
  the questions): install the WSL feature (elevated through PowerShell,
  then a reboot is required), install Ubuntu and run its first-launch user
  setup interactively, convert a WSL 1 distribution, provision the launcher
  (installing python3-venv as root if the image lacks it), and download the
  Galacticus assets (`--tools`/`--no-tools` honored).
* Documentation: a Windows section in the pip installation guide, and
  mentions in the installation index and README.

The Windows-specific behavior cannot run in CI; the new unit tests cover
the pure logic (wsl.exe output decoding, distribution-list parsing, host
state classification, path translation, pip target selection, dispatch
routing, and the install-wsl step sequencing) with the single `wsl.exe`
entry point replaced by a fake. Verified with the full `python -m pytest`
suite (1076 passed) and pyflakes on the changed files.

Claude drafted the implementation, tests, and documentation; the WSL flow
itself still needs a hands-on check on a Windows machine before release.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ES6pwp9ywfXsQv4BykJjRz