### PR TITLE
Build and host documentation for each release on ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,14 +21,9 @@ build:
     - python -m sphinx -b html docs $READTHEDOCS_OUTPUT/html
     # Package the built site as a single downloadable archive, so that each
     # version -- in particular, each release -- has a self-contained copy of its
-    # documentation that can be kept offline (offered as the "HTML" download in
-    # the version flyout, and attachable to the GitHub release).
-    - >-
-      python -c "import os, shutil;
-      output = os.environ['READTHEDOCS_OUTPUT'];
-      os.makedirs(os.path.join(output, 'htmlzip'), exist_ok=True);
-      shutil.make_archive(os.path.join(output, 'htmlzip', 'galacticus'), 'zip',
-      os.path.join(output, 'html'))"
+    # documentation. (Note that commands here do not survive nested quoting, so
+    # this must be a script and not an inline `python -c "..."`.)
+    - python scripts/doc/archiveDocs.py $READTHEDOCS_OUTPUT
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,6 +19,16 @@ build:
     - PYTHONPATH=python python scripts/doc/extractDocsRST.py source docs
     # Build the HTML site.
     - python -m sphinx -b html docs $READTHEDOCS_OUTPUT/html
+    # Package the built site as a single downloadable archive, so that each
+    # version -- in particular, each release -- has a self-contained copy of its
+    # documentation that can be kept offline (offered as the "HTML" download in
+    # the version flyout, and attachable to the GitHub release).
+    - >-
+      python -c "import os, shutil;
+      output = os.environ['READTHEDOCS_OUTPUT'];
+      os.makedirs(os.path.join(output, 'htmlzip'), exist_ok=True);
+      shutil.make_archive(os.path.join(output, 'htmlzip', 'galacticus'), 'zip',
+      os.path.join(output, 'html'))"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,35 @@ project = 'Galacticus'
 author = 'Andrew Benson'
 copyright = f'2009–{datetime.date.today().year} Andrew Benson'
 
+
+# The version of Galacticus that this documentation describes.  ReadTheDocs
+# builds each release tag as its own, permanently hosted version (see "Versions
+# and Releases" in the developer guide) and names the tag it is building in the
+# environment; anything else (the ``master`` branch, or a local build) is
+# described with ``git`` instead.
+def _documentation_version() -> str:
+    import subprocess
+    for variable in ('READTHEDOCS_GIT_IDENTIFIER', 'READTHEDOCS_VERSION_NAME'):
+        identifier = os.environ.get(variable, '')
+        if re.fullmatch(r'v\d+\.\d+\.\d+', identifier):
+            return identifier[1:]
+    try:
+        described = subprocess.run(
+            # ``--match`` keeps the moving ``bleeding-edge`` tag and the
+            # ``publication/…`` tags out of the description.
+            ['git', 'describe', '--tags', '--always', '--match', 'v[0-9]*'],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            capture_output=True, text=True, check=True)
+    except (OSError, subprocess.CalledProcessError):
+        return ''                      # not a git checkout (or no tags fetched)
+    return described.stdout.strip().lstrip('v')
+
+
+release = _documentation_version()
+version = release
+# True when these are the docs for a tagged release, rather than for a branch.
+_release_build = bool(re.fullmatch(r'\d+\.\d+\.\d+', release))
+
 extensions = [
     'sphinx.ext.mathjax',
     'sphinxcontrib.bibtex',
@@ -110,7 +139,13 @@ mathjax3_config = {
 numfig = True
 
 html_theme = 'furo'
-html_title = 'Galacticus'
+# On a release build name the version in the sidebar, so it is obvious which
+# release's documentation is being read.
+html_title = f'Galacticus {release}' if _release_build else 'Galacticus'
+
+# ReadTheDocs serves each version at its own URL and provides it here, so that
+# the pages of this build carry the correct canonical link.
+html_baseurl = os.environ.get('READTHEDOCS_CANONICAL_URL', '')
 # The galaxy icon shown at the top of the sidebar on every page (transparent,
 # so it works in both light and dark modes).
 html_logo = '_static/galacticus-icon.png'
@@ -204,9 +239,26 @@ def _resolve_galacticus_ref(app, env, node, contnode):
     return contnode                               # dangling in source: plain text
 
 
+# --- version-aware self-links ----------------------------------------------
+# A number of pages (and the Mermaid diagrams embedded in them) link to other
+# Galacticus documentation pages by absolute URL, written against
+# ``…/en/latest/``.  In the documentation archived for a release those must
+# lead to that release's own pages rather than to the current development
+# documentation, so rewrite them to the URL of the version being built.
+_docs_url_latest       = 'https://galacticus.readthedocs.io/en/latest/'
+_docs_url_this_version = (html_baseurl.rstrip('/') + '/') if html_baseurl \
+                         else _docs_url_latest
+
+
+def _rewrite_self_links(app, docname, source):
+    source[0] = source[0].replace(_docs_url_latest, _docs_url_this_version)
+
+
 def setup(app):
     app.add_role('galacticus-class', _GalacticusClassRole())
     app.add_role('galacticus-ref', _GalacticusRefRole())
     app.connect('missing-reference', _resolve_galacticus_class)
     app.connect('missing-reference', _resolve_galacticus_ref)
+    if _docs_url_this_version != _docs_url_latest:
+        app.connect('source-read', _rewrite_self_links)
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/docs/manuals/developer-guide/versions-and-releases.rst
+++ b/docs/manuals/developer-guide/versions-and-releases.rst
@@ -127,11 +127,96 @@ source of truth.
 .. note::
 
    The LaTeX/PDF manuals have been retired; documentation is published
-   automatically on `ReadTheDocs <https://galacticus.readthedocs.io/>`_. The
+   automatically on `ReadTheDocs <https://galacticus.readthedocs.io/>`_, which
+   also builds and keeps a copy of the documentation for the tagged release (see
+   `Documentation for Each Release`_). The
    statically-linked Linux and macOS binaries, the run-time tool archives, the
    Docker image, and the archives of external build dependencies are all produced
    and uploaded automatically by CI (or maintained out of band), so none of them
    need to be assembled or relinked by hand as part of a release.
+
+Documentation for Each Release
+------------------------------
+
+The documentation is built and hosted by `ReadTheDocs
+<https://galacticus.readthedocs.io/>`_, which keeps a separate, permanently
+hosted copy of every version that it builds:
+
+``latest``
+   Rebuilt from ``master`` on every push - the documentation matching the rolling
+   ``bleeding-edge`` release, at https://galacticus.readthedocs.io/en/latest/.
+
+``stable``
+   The most recent tagged release. ReadTheDocs maintains this automatically,
+   moving it to point at the highest semantic-version tag as each new release
+   is built.
+
+``vX.Y.Z``
+   A frozen copy of the documentation as it stood at that release, at
+   ``https://galacticus.readthedocs.io/en/vX.Y.Z/``. Once built it is stored and
+   served as-is, so it remains available even after the sources, and the
+   toolchain that rendered them, have moved on.
+
+Every version additionally offers a single-file archive of the whole site, under
+:menuselection:`Downloads --> HTML` in the version menu at the bottom of each
+page. It is produced by the final command in ``.readthedocs.yaml``, so a copy of
+a release's documentation can be kept offline, or attached to that release on
+GitHub.
+
+Nothing has to be done at release time: pushing the ``vX.Y.Z`` tag notifies
+ReadTheDocs, an automation rule (see below) activates the new version, and the
+build runs. That build never compiles Galacticus - ``scripts/doc/extractDocsRST.py``
+reads the documentation out of the Fortran sources - so it takes only a few
+minutes.
+
+The build is version-aware: ``docs/conf.py`` takes the tag being built from
+ReadTheDocs' environment, so a release's pages carry its version in the sidebar
+title, declare themselves canonical at their own URL, and have their absolute
+links to other Galacticus documentation pages rewritten from ``.../en/latest/...``
+to that release's own URL. A release's documentation therefore stays internally
+consistent, instead of leading the reader back into the development
+documentation.
+
+One-Time Setup on ReadTheDocs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following are configured once, by a project maintainer, in the ReadTheDocs
+dashboard for the project (https://readthedocs.org/projects/galacticus/); they
+cannot be set from this repository.
+
+#. **Build and keep every new release.** Under
+   :menuselection:`Admin --> Automation Rules --> Add rule`, add a rule with:
+
+   * *Description*: ``Publish documentation for each release``;
+   * *Match*: ``SemVer versions`` - this matches the ``vX.Y.Z`` tags only, so the
+     moving ``bleeding-edge`` tag and the ``publication/...`` tags are ignored;
+   * *Version type*: ``Tag``; and
+   * *Action*: ``Activate version``.
+
+#. **Publish the releases tagged so far.** An automation rule acts on versions
+   created after it was added, so releases tagged earlier must be activated by
+   hand, under :menuselection:`Admin --> Versions`. Every tag from ``v0.9.7``
+   (the earliest still present) onwards contains a ``.readthedocs.yaml``, so all
+   of them can be built.
+
+#. **Check that** ``stable`` **is active**, under
+   :menuselection:`Admin --> Versions`. ReadTheDocs creates it automatically once
+   a semantic-version tag exists, and thereafter keeps it pointing at the newest
+   release.
+
+#. Optionally, choose which version https://galacticus.readthedocs.io/ serves to
+   a visitor who names none, under
+   :menuselection:`Admin --> Settings --> Default version`. This is ``latest``,
+   which suits a project whose users mostly track ``bleeding-edge``; switch it to
+   ``stable`` if the newest release should be what is seen first. The explicit
+   ``.../en/latest/...`` links in ``README.md`` and throughout the documentation
+   are unaffected by this setting either way.
+
+An active version is only ever rebuilt if its tag moves, so keeping every release
+online costs nothing beyond the single build made when it was tagged. A release
+that should no longer be listed can be hidden (it remains reachable at its own
+URL, but is dropped from the version menu) or, to take it offline entirely,
+deactivated.
 
 Publishing the Python Package to PyPI
 -------------------------------------

--- a/docs/manuals/developer-guide/versions-and-releases.rst
+++ b/docs/manuals/developer-guide/versions-and-releases.rst
@@ -159,9 +159,9 @@ hosted copy of every version that it builds:
 
 Every version additionally offers a single-file archive of the whole site, under
 :menuselection:`Downloads --> HTML` in the version menu at the bottom of each
-page. It is produced by the final command in ``.readthedocs.yaml``, so a copy of
-a release's documentation can be kept offline, or attached to that release on
-GitHub.
+page. It is built by ``scripts/doc/archiveDocs.py``, run as the final command of
+``.readthedocs.yaml``, so a copy of a release's documentation can be kept
+offline, or attached to that release on GitHub.
 
 Nothing has to be done at release time: pushing the ``vX.Y.Z`` tag notifies
 ReadTheDocs, an automation rule (see below) activates the new version, and the

--- a/scripts/doc/archiveDocs.py
+++ b/scripts/doc/archiveDocs.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Package the built documentation as a single downloadable archive.
+
+Run as ``archiveDocs.py <outputDir>``, where ``<outputDir>`` is the ReadTheDocs
+build output directory (``$READTHEDOCS_OUTPUT``).  The HTML site that Sphinx
+wrote to ``<outputDir>/html`` is zipped into ``<outputDir>/htmlzip``, from where
+ReadTheDocs offers it as the "HTML" download for the version being built — so
+every version, and in particular every release, has a self-contained copy of its
+documentation that can be kept offline.
+
+This lives in a script rather than inline in ``.readthedocs.yaml`` because the
+commands there do not survive nested quoting: the single quotes inside a
+``python -c "..."`` command are stripped before the command is run.
+"""
+import os
+import shutil
+import sys
+
+
+def archive(output_directory: str) -> str:
+    """Zip the built HTML site, returning the path of the archive written."""
+    html    = os.path.join(output_directory, 'html'   )
+    htmlzip = os.path.join(output_directory, 'htmlzip')
+    if not os.path.isdir(html):
+        raise SystemExit(f"archiveDocs.py: no HTML build found in '{html}'")
+    os.makedirs(htmlzip, exist_ok=True)
+    # ReadTheDocs requires exactly one file in the directory for each format.
+    return shutil.make_archive(os.path.join(htmlzip, 'galacticus'), 'zip', html)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        raise SystemExit('usage: archiveDocs.py <outputDir>')
+    print(f'Documentation archived as {archive(sys.argv[1])}')


### PR DESCRIPTION
## Summary

Implements automated building and hosting of documentation for each tagged release on ReadTheDocs, with version-aware links and offline-downloadable archives.

Changes include:
- Documentation for the setup and workflow in the developer guide
- Version detection in `docs/conf.py` to identify release builds and set appropriate titles and canonical URLs
- Self-link rewriting to keep release documentation internally consistent (pointing to that release's pages rather than development docs)
- HTML archive generation in `.readthedocs.yaml` for offline distribution

## Type of change

- [x] Docs / tooling
- [x] New feature

## How to test

The changes are configuration and documentation:

1. **Documentation changes** — verify the new "Documentation for Each Release" section in `docs/manuals/developer-guide/versions-and-releases.rst` renders correctly and is clear.

2. **Version detection** — local builds should continue to work as before (showing version from `git describe` or empty if not in a git checkout). ReadTheDocs builds will detect the tag from environment variables and display it in the sidebar.

3. **Self-link rewriting** — verify that absolute links to `…/en/latest/…` in documentation and embedded diagrams are rewritten to the release's own URL when building a release (this is automatic on ReadTheDocs; local release builds can be tested by setting `READTHEDOCS_CANONICAL_URL`).

4. **Archive generation** — the `.readthedocs.yaml` build now produces a `htmlzip/galacticus.zip` containing the full built documentation, available for download from the version menu on ReadTheDocs.

The ReadTheDocs dashboard setup (automation rules, version activation) is one-time manual configuration documented in the guide; it does not require testing in this PR.

## Checklist

- [x] I updated documentation/comments if needed
- [x] No testing needed — configuration and documentation changes; ReadTheDocs integration is verified by the platform itself

https://claude.ai/code/session_01RHQBnqEsgiW9KXQ5uoznMf