### PR TITLE
docs(troubleshooting): add entries for problems reported in recent issues and pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ The output is written to `galacticus.hdf5` in the directory you ran from. To cha
 | `./Galacticus.exe: No such file or directory` | The build did not complete successfully. Re-run `make` and check for errors. |
 | Parameter file not found | Ensure you are running the command from the repository root directory so that `parameters/quickTest.xml` resolves correctly. |
 | Missing library errors at link time | Verify that HDF5, FFTW3, and GSL development packages are installed and that their locations are on the relevant library paths. |
+| Build stops with `Error 137` or `Killed` | The compiler ran out of memory. Use fewer parallel jobs (`make -j2 Galacticus.exe`) or `make -j2 LTO=disabled Galacticus.exe`. |
+| `failed to download from "..."` at run time | An external tool or data file could not be fetched. Check network access and that `wget` or `curl` is installed; on a cluster, run once on a login node first. See the [troubleshooting guide](https://galacticus.readthedocs.io/en/latest/manuals/user-guide/troubleshooting/run-time-errors.html). |
+| Every run fails with `unable to close file object '/dev/shm/glcTmpPar...'` | `/dev/shm` is full of temporary files left by older versions. Remove `/dev/shm/glcTmpPar.*` files whose process has exited. |
 
 For further help, visit the [wiki](https://github.com/galacticusorg/galacticus/wiki) or ask in the [discussion forum](https://github.com/galacticusorg/galacticus/discussions).
 

--- a/docs/manuals/user-guide/troubleshooting/compile-time-errors.rst
+++ b/docs/manuals/user-guide/troubleshooting/compile-time-errors.rst
@@ -208,3 +208,36 @@ This error occurs because the object ``self`` is a member of a class that does n
 which says to take the argument ``foo`` to this constructor and assign it to a variable named ``foo`` in the object (``self``) being constructed. We typically do this as the value of ``foo`` is something that we later want to use in one of the class' methods.
 
 The solution to this is to add a variable named ``foo`` to the type definition for this class (with the same type and rank as the argument ``foo`` in the constructor).
+
+Internal compiler error
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   internal compiler error: in aarch64_function_arg_alignment, at config/aarch64/aarch64.cc
+
+An "internal compiler error" (ICE) is a bug in the compiler, not in Galacticus, and the message usually names the compiler source file where it happened. Galacticus requires ``gfortran`` 16 or later, and known ICEs in supported versions are worked around in the ``Makefile``: the AArch64 (Apple Silicon) alignment ICE above is avoided by compiling the affected object files at ``-O0`` (see the ``FCFLAGS_AARCH64_ICE_OBJECTS`` variable), and a submodule visibility bug is worked around in ``source/merger_trees/construct/read/importer/_class.F90``. These workarounds are retired as fixed compilers become available (`issue #1239 <https://github.com/galacticusorg/galacticus/issues/1239>`_, `issue #1421 <https://github.com/galacticusorg/galacticus/issues/1421>`_).
+
+If you hit an ICE, first check ``gfortran --version``. If the compiler is supported and the message matches the AArch64 case above but names an object file not yet in ``FCFLAGS_AARCH64_ICE_OBJECTS``, add it to that list and rebuild. Otherwise please report it, including the full ICE text, the compiler version, and the object file being compiled, so that a workaround can be added.
+
+Compiler killed during the build
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   f951: internal compiler error: Killed (program f951)
+   make: *** [work/build/foo.o] Error 137
+
+or a build that stops with ``Error 137`` and no other diagnostic, means the operating system killed the compiler for using too much memory. Compiling the large generated ``*_class`` units at ``-O3`` in parallel is the peak: on a machine with about 16 GB of memory, ``make -j4`` can exceed it. Reduce the number of parallel jobs (``make -j2 Galacticus.exe`` is what the continuous integration uses), or build with link-time optimization disabled (``make -j2 LTO=disabled Galacticus.exe``), which lowers the memory needed at link time. Re-running ``make`` after such a failure continues from where it stopped.
+
+Changes to the pre-processor have no effect
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you edit one of the Python code generators under ``python/Galacticus/Build/`` (or ``scripts/build/preprocess.py`` itself), rebuild, and find that the generated ``work/build/*.p.F90`` files are unchanged, you are using a checkout from before August 2026. Those ``Makefile`` rules did not list the generator sources as prerequisites, so an incremental build reported success while compiling stale generated code (`issue #1395 <https://github.com/galacticusorg/galacticus/issues/1395>`_). Current versions re-run the pre-processor whenever its own sources change. On an older checkout, remove the generated files and rebuild:
+
+.. code-block:: console
+
+   rm -f work/build/*.p.F90 work/build/*.p.Inc
+   make -j2 Galacticus.exe
+
+Only files whose pre-processed output actually differs are recompiled, so this is cheaper than a full ``make clean``.

--- a/docs/manuals/user-guide/troubleshooting/index.rst
+++ b/docs/manuals/user-guide/troubleshooting/index.rst
@@ -105,6 +105,26 @@ If a model is failing to make use of the majority of the available CPU cycles, a
 
 Additionally, you can ensure that compression is switched off in the HDF5 output by setting ``[hdf5CompressionLevel]``\ =-1. Finally, adjusting the HDF5 chunk size via the ``[hdf5ChunkSize]`` parameter may make for more efficient I/O. HDF5 datasets are read/written in chunks of this size. Increasing the size may improve I/O performance.
 
+Small differences in results between runs or versions
+-----------------------------------------------------
+
+Many expensive functions in Galacticus (spherical collapse solutions, linear growth factors, the mass variance, first-crossing distributions, and many more) are tabulated once and then interpolated. In versions before August 2026 the range of such a table was chosen from the *first* value requested, so the grid, and therefore the interpolation error, depended on the order in which the model happened to evaluate things: on the tree structure, on thread scheduling, and on other parameter choices. Two runs of physically identical models could then differ at the level of the interpolation error, and tables stored under ``datasets/dynamic/`` were discarded and rebuilt whenever a run requested a value outside the stored range.
+
+Since `issue #1317 <https://github.com/galacticusorg/galacticus/issues/1317>`_ most such tables are pinned to an absolute lattice, so their grids no longer depend on the request that triggered them, stored tables grow rather than being rebuilt, and the tabulated values are reproducible across runs. Two practical consequences:
+
+* Upgrading across that change shifts results once, by the interpolation error, so regression baselines and calibrated likelihood values may need to be re-anchored.
+* If you suspect a stale table (for example after an interrupted run, or after upgrading), deleting the relevant files under ``datasets/dynamic/`` is always safe; they will be rebuilt.
+
+Merger trees appear in a different order in the output
+-------------------------------------------------------
+
+The order in which trees appear in an output file is not deterministic when Galacticus runs with more than one OpenMP thread: each thread writes a tree when it finishes it, and threads finish in an order that depends on scheduling. The content of each tree is unaffected. When comparing two output files, match trees by the ``mergerTreeIndex`` dataset (with ``mergerTreeStartIndex`` and ``mergerTreeCount`` locating each tree's nodes) rather than comparing datasets position by position. Setting ``OMP_NUM_THREADS=1`` gives a fixed order for a single run, but note that when a model writes both a state file and an HDF5 file (for example for the ``postprocessForests`` task) the two can still list trees in different orders, because they are written under different locks; the tree-by-tree comparison is the robust approach in every case. See `pull request #1373 <https://github.com/galacticusorg/galacticus/pull/1373>`_ for the details.
+
+Parameters missing from the output file
+---------------------------------------
+
+The ``Parameters`` group of an output file records every parameter the model read, including defaults. In versions before August 2026, parameters read while initializing node components on each thread (for example those of the ``hotHalo`` and ``disk`` components) were omitted from this record, and ``scripts/aux/parametersExtract.py`` silently dropped them as well, so a parameter file reconstructed from an old output could be incomplete (`issue #1377 <https://github.com/galacticusorg/galacticus/issues/1377>`_). If you rely on an output file as the record of a run, check that the component parameters you expect are present, and regenerate from the original parameter file where they are not.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/manuals/user-guide/troubleshooting/run-time-errors.rst
+++ b/docs/manuals/user-guide/troubleshooting/run-time-errors.rst
@@ -5,6 +5,25 @@ As you are running Galacticus it's quite likely that you'll eventually run into 
 
 For *compile-time* errors (i.e. things that go wrong when you are building the ``Galacticus.exe`` executable) you should refer to :doc:`compile-time-errors`. For other problems (Galacticus is not performing as you expect, or doing what you want) see the general :doc:`index`.
 
+Reading a fatal error message
+-----------------------------
+
+A deliberate fatal error raised by Galacticus has a fixed layout:
+
+.. code-block:: text
+
+   Fatal error:
+   unable to allocate `particleID` (1000000000000 elements)
+   HELP: the run needs more memory than is available to it. Reduce the size of the problem (for
+   example, the number of trees or particles being processed), reduce the number of OpenMP threads,
+   since each holds its own copy of much of the state, or run where more memory is available
+    Occurred at:
+      subroutine:randomImport
+            file:nBody/import/random.F90   [line 159]
+     => Error occurred in master thread
+
+The first line after ``Fatal error:`` is the message itself. Many messages are followed by a ``HELP:`` line (shown in green on a terminal) which states the most likely fix; try that first. The ``Occurred at:`` block names the procedure, module, and source file that raised the error, and the final line identifies the OpenMP thread (and, under MPI, the process and host). A stack trace follows the message; see :doc:`debugging` for how to read it. When reporting a problem, include the whole block.
+
 Error Message Diagnosis and Reporting
 -------------------------------------
 
@@ -33,9 +52,65 @@ If a Galacticus run fails, this flowchart can help to diagnose a failed Galactic
      RamPressureComponentQ{{"Error message includes the phrase
                        'only ＂xyz＂ components are supported by the ＂abc＂ ramPressureStripping class'?"}}
      RamPressureComponentQ --yes--> RamPressureComponent
+     RamPressureComponentQ --no--> DataFileQ
      RamPressureComponent(See here)
      style RamPressureComponent fill:#74c7db
      click RamPressureComponent href "#inconsistent-assumptions-for-ram-pressure-models" "dummy"
+     DataFileQ{{"Error message includes the phrase
+                       'Unable to find data file'?"}}
+     DataFileQ --yes--> DataFile
+     DataFileQ --no--> CloseFileQ
+     DataFile(See here)
+     style DataFile fill:#74c7db
+     click DataFile href "#unable-to-find-data-file" "dummy"
+     CloseFileQ{{"Error message includes the phrase
+                       'unable to close file object '/dev/shm/glcTmpPar...'?"}}
+     CloseFileQ --yes--> CloseFile
+     CloseFileQ --no--> AllocateQ
+     CloseFile(See here)
+     style CloseFile fill:#74c7db
+     click CloseFile href "#temporary-parameter-files-fill-dev-shm" "dummy"
+     AllocateQ{{"Error message includes the phrase
+                       'unable to allocate'?"}}
+     AllocateQ --yes--> Allocate
+     AllocateQ --no--> RecursiveQ
+     Allocate(See here)
+     style Allocate fill:#74c7db
+     click Allocate href "#unable-to-allocate-memory" "dummy"
+     RecursiveQ{{"Error message includes the phrase
+                       'composites a member of its own class'?"}}
+     RecursiveQ --yes--> Recursive
+     RecursiveQ --no--> DeadlockQ
+     Recursive(See here)
+     style Recursive fill:#74c7db
+     click Recursive href "#recursive-object-construction" "dummy"
+     DeadlockQ{{"Error message includes the phrase
+                       'merger tree appears to be deadlocked'?"}}
+     DeadlockQ --yes--> Deadlock
+     DeadlockQ --no--> HistoryGridQ
+     Deadlock(See here)
+     style Deadlock fill:#74c7db
+     click Deadlock href "#merger-tree-appears-to-be-deadlocked" "dummy"
+     HistoryGridQ{{"Error message includes the phrase
+                       'serialized history increment cannot extend the time grid'?"}}
+     HistoryGridQ --yes--> HistoryGrid
+     HistoryGridQ --no--> DownloadQ
+     HistoryGrid(See here)
+     style HistoryGrid fill:#74c7db
+     click HistoryGrid href "#star-formation-history-cannot-extend-its-time-grid" "dummy"
+     DownloadQ{{"Error message includes the phrase
+                       'failed to download from'?"}}
+     DownloadQ --yes--> Download
+     DownloadQ --no--> RadiusZeroQ
+     Download(See here)
+     style Download fill:#74c7db
+     click Download href "#failed-to-download-a-file" "dummy"
+     RadiusZeroQ{{"Error message includes the phrase
+                       'Radius specifier evaluates to a radius of zero'?"}}
+     RadiusZeroQ --yes--> RadiusZero
+     RadiusZero(See here)
+     style RadiusZero fill:#74c7db
+     click RadiusZero href "#radius-specifier-evaluates-to-a-radius-of-zero" "dummy"
      System{{Error message includes the phrase:}}
      System --Floating point exception--> FPE
      System --Segmentation fault--> SegFault
@@ -62,6 +137,10 @@ Floating point errors and Segfaults
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A floating point exception or segmentation fault ("segfault") indicate a bug in Galacticus. These should never happen! If they do, please file a bug report using this `form <https://github.com/galacticusorg/galacticus/issues/new?assignees=abensonca&labels=bug&projects=&template=Bug-Report.yml&title=%5BBug%5D%3A+>`_, providing as much information as you can so that we can diagnose and fix the problem.
+
+Before reporting, check whether the stack trace names a known case:
+
+* ``lossConeTabulate`` (``satellites/merging/virial_orbits/loss_cone.F90``): the ``lossCone`` virial orbit class can raise an invalid floating point operation when its orbital tabulation is first built at a very early epoch (redshift above about 8), because the environmental boost factor becomes 0/0 for the most massive tabulated hosts. This is tracked as `issue #1426 <https://github.com/galacticusorg/galacticus/issues/1426>`_; until it is fixed, the workaround is to avoid trees whose progenitors request an orbit at such early times (for example by raising the mass resolution), or to use a different ``virialOrbit`` class.
 
 Bus errors, Illegal instructions, and Signal 9
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -213,3 +292,117 @@ means that Galacticus is looking for a data file (that it needs to read at run t
    export GALACTICUS_DATA_PATH=/path/to/where/you/installed/datasets
 
 (putting in the correct path of course).
+
+Temporary parameter files fill ``/dev/shm``
+-------------------------------------------
+
+If every run fails immediately after reading the parameter file with:
+
+.. code-block:: text
+
+   Fatal error:
+   unable to close file object '/dev/shm/glcTmpPar.145209.1'
+    Occurred at:
+      subroutine:IO_HDF5_Finalize_Shared
+          module:IO_HDF5
+            file:utility/IO/HDF5/_module.F90   [line 748]
+   HDF5: infinite loop closing library
+
+the shared-memory file system ``/dev/shm`` is full. Each run writes a small temporary HDF5 file, ``/dev/shm/glcTmpPar.<pid>.<n>``, holding the parameters to be recorded in the output. Versions of Galacticus before August 2026 never removed this file (`issue #1391 <https://github.com/galacticusorg/galacticus/issues/1391>`_), so after several hundred runs on one machine, or far fewer inside a Docker container (where ``/dev/shm`` defaults to 64 MB), the file system fills and every later run fails at startup. The failure is caused by *previous* runs, so it can look like a regression introduced by whatever you changed last.
+
+Remove the orphaned files, keeping any that belong to a model still running:
+
+.. code-block:: bash
+
+   for f in /dev/shm/glcTmpPar.*; do
+       p=$(basename "$f" | cut -d. -f2)
+       [ -d "/proc/$p" ] || rm -f "$f"
+   done
+
+Inside Docker, also start the container with a larger ``--shm-size``. Current versions of Galacticus remove the file as soon as it is opened, so the problem does not recur once you update. (On macOS the file is placed in ``/tmp`` instead, where the same leak was less likely to be noticed.)
+
+Unable to allocate memory
+-------------------------
+
+If you see:
+
+.. code-block:: text
+
+   unable to allocate `position` (3000000000 elements)
+   HELP: the run needs more memory than is available to it. Reduce the size of the problem (for
+   example, the number of trees or particles being processed), reduce the number of OpenMP threads,
+   since each holds its own copy of much of the state, or run where more memory is available
+
+Galacticus asked for more memory than the system (or your batch job) would give it. The message names the array and its size, which tells you what is driving the requirement: particle arrays when reading N-body data, node arrays when reading large merger tree files, and so on. The remedies are those in the ``HELP`` line, and the discussion of memory limits under `Bus errors, Illegal instructions, and Signal 9`_ applies here too. Not every allocation is guarded in this way, so an out-of-memory condition can also appear as one of those signals rather than as this message.
+
+Recursive object construction
+-----------------------------
+
+If you see:
+
+.. code-block:: text
+
+   a [darkMatterProfileDMO] composites a member of its own class but no such [darkMatterProfileDMO]
+   was provided explicitly - this would lead to an infinite recursive build; provide a
+   [darkMatterProfileDMO] explicitly (see issue 397)
+
+you have selected a *decorator* implementation: a class that wraps another implementation of the same class and modifies its results. Examples are ``darkMatterProfileDMO value="heated"`` (which heats another dark matter profile), ``criticalOverdensity value="renormalize"``, ``cosmologicalMassVariance value="scaled"``, and ``mergerTreeConstructor value="filter"``. A decorator needs to be told which implementation it wraps. If you do not nest one inside it, Galacticus looks for the nearest ``darkMatterProfileDMO`` in the parameter file, finds the decorator itself, and stops rather than build it forever.
+
+Nest the inner implementation inside the decorator:
+
+.. code-block:: xml
+
+   <darkMatterProfileDMO value="heated">
+     <darkMatterProfileDMO value="NFW"/>
+   </darkMatterProfileDMO>
+
+Some recursive references are legitimate and are handled automatically since `pull request #1264 <https://github.com/galacticusorg/galacticus/pull/1264>`_ (for example a class that needs a pointer back to the object which contains it); this message is raised only where the recursion would be infinite.
+
+Merger tree appears to be deadlocked
+------------------------------------
+
+If you see:
+
+.. code-block:: text
+
+   merger tree appears to be deadlocked (see preceding report) - check timestep criteria
+
+no node in a tree can take a step forward, usually because a timestep criterion or a satellite merging time has been set inconsistently. The report printed before the error lists the state of every node. See :doc:`tree-deadlocks` for how to read that report and find the offending node.
+
+Star formation history cannot extend its time grid
+--------------------------------------------------
+
+If you see:
+
+.. code-block:: text
+
+   serialized history increment cannot extend the time grid
+      subroutine:History_Increment_Serialized
+          module:Histories
+            file:objects/history.F90
+
+you are recording star formation histories with ``<starFormationHistory value="adaptive"/>`` in a model whose output times are widely separated (for example a set of outputs near redshift 0 together with a set near redshift 2). The adaptive class builds its time grid from the first output and cannot extend it far enough to reach the later ones. This is tracked as `issue #1441 <https://github.com/galacticusorg/galacticus/issues/1441>`_. Until it is resolved, run the widely separated groups of outputs as separate models, each with only the outputs it needs.
+
+Failed to download a file
+-------------------------
+
+If you see:
+
+.. code-block:: text
+
+   failed to download from "https://example.org/some/file.tar.gz"
+
+Galacticus needed a file it does not ship (an external tool such as CAMB, FSPS, or RecFast, or a data file) and could not fetch it. The downloader tries ``wget`` and then falls back to ``curl``, retrying each a few times, so first check that at least one of them is installed and that the machine you are running on has outbound network access. Compute nodes on clusters often do not; in that case run the model once on a login node so that the downloaded tools and the files under ``datasets/dynamic/`` are in place, then submit the job. If your site requires a proxy, set the usual ``https_proxy`` environment variable, which both downloaders honor.
+
+Two failure modes are worth knowing about. Some hosts refuse ``wget`` outright, answering every request with a ``404`` because of the way it negotiates TLS, even though the file exists; the fallback to ``curl`` handles this, but only if ``curl`` is installed (`pull request #1376 <https://github.com/galacticusorg/galacticus/pull/1376>`_). And the original RecFast download site is unreliable, so a mirror is tried as well (`pull request #1390 <https://github.com/galacticusorg/galacticus/pull/1390>`_). If a download fails persistently for a reason outside your control, you can fetch the file by other means and place it at the path Galacticus expects, which is given in the log immediately before the error.
+
+Radius specifier evaluates to a radius of zero
+----------------------------------------------
+
+If you see:
+
+.. code-block:: text
+
+   Radius specifier evaluates to a radius of zero:
+
+followed by the specifier with the offending part highlighted, a radius given in your parameter file (for example one used to define where a property is measured) has evaluated to zero. Most often the specifier refers to a component, such as a spheroid or a nuclear star cluster, that is absent or empty in the galaxy in question, so its scale radius is zero. Either choose a specifier based on a component that is always present, or use one of the extractors which define a value at zero radius (the ``projectedMass`` extractor, for example, does). The ``HELP:`` line links to the documentation of the radius specifier syntax.


### PR DESCRIPTION
## Summary
- Compared the troubleshooting guide (`docs/manuals/user-guide/troubleshooting/`) and the README troubleshooting table against the issues and pull requests from the last several months, and added entries for the user-facing problems that had none.
- **Run-time errors page:** a short guide to reading a fatal error message (the `HELP:` line and the `Occurred at` block); new sections for temporary parameter files filling `/dev/shm` (#1391), allocation failures (#1412), recursive construction of decorator classes with a worked XML fix (#397, #1264), the tree-deadlock message (pointing to the existing page), the adaptive star-formation-history time-grid error (#1441), download failures including the `wget` TLS refusal and the RecFast mirror (#1376, #1390), and zero-valued radius specifiers (#1325). The known `lossCone` floating point exception at early epochs (#1426) is noted under the FPE section. The diagnosis flowchart gains a branch for each of these and for the existing "Unable to find data file" entry.
- **Not-performing-as-expected page (`index.rst`):** small differences between runs or versions from dynamic tabulations and their pinning (#1317), non-deterministic tree order in output files (#1373), and parameters missing from output files written before the thread-initialization fix (#1377).
- **Compile-time errors page:** internal compiler errors and the Makefile workarounds (#1239, #1421), the compiler being killed for lack of memory (exit 137), and stale generated code when editing the pre-processor on older checkouts (#1395).
- **README table:** rows for the out-of-memory build, download failures, and the `/dev/shm` case.

Two entries describe problems whose fixes are already merged (the `/dev/shm` leak and the missing output parameters). They are kept because both fail confusingly on older binaries and output files that users still have, and each entry says which versions are affected.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Docs / tooling
- [ ] Other:

## How to test
- Build the documentation (`python scripts/doc/extractDocsRST.py source docs` then `sphinx-build docs docs/_build`) and open the three troubleshooting pages; check that each flowchart node's "See here" link lands on its section.
- Run the advisory spell check (`SPHINX_SPELLING=1 python -m sphinx -b spelling docs docs/_spelling`); the added text uses US spelling throughout.

## Checklist
- [x] I ran relevant tests (or explain why not): the three edited pages parse cleanly with docutils (the only warnings are the environmental "Pygments package not found"), and all eight new flowchart anchors were checked to resolve to real section ids. Sphinx was not available in the environment, so the full documentation build and spell check are left to CI.
- [x] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B6isbowmxB53StXdL3wQd

---
_Generated by [Claude Code](https://claude.ai/code/session_014B6isbowmxB53StXdL3wQd)_