### PR TITLE
Allow compiler workarounds to be staged for removal via an issue reference

### DIFF
--- a/.github/workflows/workarounds.yml
+++ b/.github/workflows/workarounds.yml
@@ -5,6 +5,10 @@ on:
     - cron: '08 08 * * *'
 permissions:
   contents: read
+  # Required so that the checker can query the state of the issues referenced by
+  # the `issue` attribute of `<workaround>` directives (a workaround whose issue
+  # has been closed is no longer considered "staged for removal").
+  issues: read
 jobs:
   Check-Workarounds:
     runs-on: ubuntu-latest
@@ -26,6 +30,8 @@ jobs:
           sudo apt -y update
           sudo apt install -y curl
       - name: Check for workaround fixes
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           cd $GALACTICUS_EXEC_PATH
           git config --global --add safe.directory $GALACTICUS_EXEC_PATH

--- a/aux/words.dict
+++ b/aux/words.dict
@@ -69,6 +69,7 @@ Birnboim
 Blanc
 Boylan
 Bruzual
+Bugzilla
 Buser
 CAMB
 CCD

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -1302,6 +1302,14 @@ The ``workaround`` directive annotates code that exists only to work around a bu
 
 The ``type`` attribute (required) names the tool containing the bug (e.g. ``gfortran``), while the optional ``PR`` and ``url`` attributes identify the relevant bug report. A ``description`` element should explain the bug being worked around. Optional ``seeAlso`` elements (with the same ``type``/``PR``/``url`` attributes) can reference related bug reports.
 
+The ``Workarounds`` workflow (``.github/workflows/workarounds.yml``) runs ``scripts/aux/workaroundChecker.py`` daily, which looks up the ``PR`` of every ``workaround`` directive in GCC's Bugzilla and fails if any of them has been marked ``RESOLVED``---so that fixed bugs do not leave dead workarounds behind. A bug being fixed upstream does not always mean the workaround can be removed immediately though: typically we must wait until the fix appears in a released compiler that is available on all of the platforms we build for. For such cases, open an issue recording what must happen before the workaround can be removed, and reference it from the directive with the optional ``issue`` attribute:
+
+.. code-block:: none
+
+    <workaround type="gfortran" PR="105807" url="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105807" issue="1234">
+
+The attribute takes either a bare issue number in this repository (as above) or a full URL. The checker then reports the workaround as *staged for removal* and does not fail, for as long as the referenced issue remains open---if the issue is closed while the workaround is still present the checker begins to fail again. Only one occurrence of a given ``PR`` need carry the attribute; a single issue tracks removal of all workarounds for that bug.
+
 Module Scoping
 ~~~~~~~~~~~~~~
 

--- a/schema/workaround.xsd
+++ b/schema/workaround.xsd
@@ -18,6 +18,11 @@
       <xs:attribute name="type" use="required"/>
       <xs:attribute name="PR"                 />
       <xs:attribute name="url"                />
+      <!-- issue="<number>" (in this repository) or issue="<url>" records that
+           removal of the workaround has been staged as an issue.  The
+           workaroundChecker then reports the workaround as staged, rather than
+           failing, when its PR is marked as resolved upstream. -->
+      <xs:attribute name="issue"              />
       <!-- docformat="rst" marks the description as reStructuredText. -->
       <xs:attribute name="docformat"          />
     </xs:complexType>

--- a/scripts/aux/tests/test_workaroundChecker.py
+++ b/scripts/aux/tests/test_workaroundChecker.py
@@ -1,0 +1,140 @@
+"""Tests for scripts/aux/workaroundChecker.py.
+
+The checker looks up the GCC Bugzilla status of every `<workaround>` directive
+in the source and fails the `Workarounds` workflow when a bug has been fixed but
+its workaround is still present. A fix landing upstream does not always mean the
+workaround can be removed at once (we must usually wait for a released compiler
+carrying the fix to be available on every platform we build for), so a directive
+may carry an `issue` attribute pointing at the issue which tracks its removal.
+The cases below pin the behavior that makes that useful:
+
+  * a resolved PR whose workaround is staged behind an *open* issue is reported
+    but does not fail the check, while an unstaged one still does, and
+  * closing the issue while the workaround remains re-arms the failure --- the
+    staging must not silently hide the workaround forever.
+
+Both Bugzilla and the GitHub API are reached through `curl` in a subprocess, so
+they are stubbed out here rather than being contacted for real.
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_CHECKER = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir, 'workaroundChecker.py')
+
+
+def _load():
+    """Import `workaroundChecker.py` as a module (it has no `.py`-importable name
+    on the path, and executes nothing at import time beyond its definitions)."""
+    spec = importlib.util.spec_from_file_location('workaroundChecker', _CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _directive(pr, issue=None):
+    attributes = f'type="gfortran" PR="{pr}"'
+    if issue is not None:
+        attributes += f' issue="{issue}"'
+    return ('  !![\n'
+            f'  <workaround {attributes} docformat="rst">\n'
+            '   <description>\n'
+            '   A bug.\n'
+            '   </description>\n'
+            '  </workaround>\n'
+            '  !!]\n')
+
+
+def _run(monkeypatch, tmp_path, source, statuses, issueStates):
+    """Run the checker over `source`, with Bugzilla and GitHub stubbed.
+
+    `statuses` maps PR number to the Bugzilla status to report, `issueStates`
+    maps issue URL to the state ("open"/"closed") to report.
+    """
+    module = _load()
+    (tmp_path / 'test.F90').write_text(source)
+    monkeypatch.setattr(module, 'DIRECTORIES', (str(tmp_path),))
+    monkeypatch.setattr(module.time, 'sleep', lambda _seconds: None)
+    monkeypatch.setattr(module, 'issue_state',
+                        lambda url: issueStates.get(url, 'UNKNOWN'))
+
+    def _curl(command, **_kwargs):
+        pr = command[-1].rsplit('=', 1)[1]
+        status = statuses.get(pr, 'NEW')
+        return type('Result', (), {
+            'returncode': 0,
+            'stdout': f'<span id="static_bug_status">{status}\n',
+        })()
+
+    monkeypatch.setattr(module.subprocess, 'run', _curl)
+    return module.main(), module
+
+
+def test_resolved_unstaged_workaround_fails(monkeypatch, tmp_path, capsys):
+    status, _module = _run(monkeypatch, tmp_path, _directive(88632),
+                           {'88632': 'RESOLVED'}, {})
+    assert status == 1
+    assert '!!! Resolved PRs with workarounds exist !!!' in capsys.readouterr().out
+
+
+def test_resolved_staged_workaround_does_not_fail(monkeypatch, tmp_path, capsys):
+    url = 'https://github.com/galacticusorg/galacticus/issues/1234'
+    status, _module = _run(monkeypatch, tmp_path, _directive(88632, 1234),
+                           {'88632': 'RESOLVED'}, {url: 'open'})
+    output = capsys.readouterr().out
+    assert status == 0
+    assert 'staged for removal' in output
+    assert url in output
+    assert '!!!' not in output
+
+
+def test_staged_workaround_fails_once_its_issue_is_closed(monkeypatch, tmp_path,
+                                                          capsys):
+    url = 'https://github.com/galacticusorg/galacticus/issues/1234'
+    status, _module = _run(monkeypatch, tmp_path, _directive(88632, 1234),
+                           {'88632': 'RESOLVED'}, {url: 'closed'})
+    output = capsys.readouterr().out
+    assert status == 1
+    assert 'issue is CLOSED but workaround remains' in output
+
+
+def test_unresolved_workaround_never_fails(monkeypatch, tmp_path):
+    status, _module = _run(monkeypatch, tmp_path, _directive(88632),
+                           {'88632': 'ASSIGNED'}, {})
+    assert status == 0
+
+
+@pytest.mark.parametrize('issue,expected', [
+    ('1234',  'https://github.com/galacticusorg/galacticus/issues/1234'),
+    ('#1234', 'https://github.com/galacticusorg/galacticus/issues/1234'),
+    ('https://github.com/other/repo/issues/7',
+     'https://github.com/other/repo/issues/7'),
+    # Attribute values in directives are XML-escaped, as they are read back out
+    # of the XML directive blocks - the checker must unescape them.
+    ('https:&#x2F;&#x2F;github.com&#x2F;other&#x2F;repo&#x2F;issues&#x2F;7',
+     'https://github.com/other/repo/issues/7'),
+])
+def test_issue_attribute_forms(issue, expected):
+    module = _load()
+    assert module.issue_url(module.attribute(f'issue="{issue}"', 'issue')) == expected
+
+
+def test_directive_without_pr_is_ignored(monkeypatch, tmp_path):
+    source = ('  !![\n'
+              '  <workaround type="gfortran" url="https://example.com/" docformat="rst">\n'
+              '   <description>\n'
+              '   A bug with no PR.\n'
+              '   </description>\n'
+              '  </workaround>\n'
+              '  !!]\n')
+    status, module = _run(monkeypatch, tmp_path, source, {}, {})
+    assert status == 0
+    assert module.WORKAROUNDS == {}
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__]))

--- a/scripts/aux/workaroundChecker.py
+++ b/scripts/aux/workaroundChecker.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import html
+import json
 import os
 import re
 import subprocess
@@ -9,7 +11,31 @@ import time
 
 WORKAROUNDS = {}
 DIRECTORIES = ("./source",)
-PATTERN = re.compile(r'^\s*#?\s*<workaround\s.*PR="(\d+)"')
+# Match the opening tag of a `<workaround …>` directive, capturing its
+# attributes.  The tag may be preceded by a `#` (workarounds inside
+# preprocessor-conditional code).
+PATTERN = re.compile(r'^\s*#?\s*<workaround\s([^>]*)')
+# Attribute extraction from the captured attribute string.
+ATTRIBUTE = r'\b{name}="([^"]*)"'
+# Repository against which bare `issue="<number>"` attributes are resolved.
+REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "galacticusorg/galacticus")
+
+
+def attribute(attributes: str, name: str) -> str | None:
+    """Return the value of the named attribute, or `None` if it is absent.
+
+    Attribute values in directives are XML-escaped (URLs, for example, have
+    their `/` written as `&#x2F;`), so unescape before returning.
+    """
+    match = re.search(ATTRIBUTE.format(name=name), attributes)
+    return html.unescape(match.group(1)) if match else None
+
+
+def issue_url(issue: str) -> str:
+    """Normalize an `issue` attribute (a bare number, or a full URL) to a URL."""
+    if re.fullmatch(r'#?\d+', issue):
+        return f"https://github.com/{REPOSITORY}/issues/{issue.lstrip('#')}"
+    return issue
 
 
 def file_matcher() -> None:
@@ -26,10 +52,19 @@ def file_matcher() -> None:
                             match = PATTERN.search(line)
                             if not match:
                                 continue
-                            pr = match.group(1)
+                            attributes = match.group(1)
+                            pr = attribute(attributes, "PR")
+                            if pr is None:
+                                continue
                             if pr not in WORKAROUNDS:
-                                WORKAROUNDS[pr] = {"files": set(), "status": "UNKNOWN"}
+                                WORKAROUNDS[pr] = {"files": set(), "issues": set(), "status": "UNKNOWN"}
                             WORKAROUNDS[pr]["files"].add(full_name)
+                            # An `issue` attribute records that removal of this
+                            # workaround has already been staged as an issue in
+                            # our own repository — see `check_issues()`.
+                            issue = attribute(attributes, "issue")
+                            if issue:
+                                WORKAROUNDS[pr]["issues"].add(issue_url(issue))
                 except OSError:
                     continue
 
@@ -54,24 +89,73 @@ def check_links() -> None:
                 break
 
 
+def issue_state(url: str) -> str:
+    """Return the state ("open"/"closed") of one of our issues, or "UNKNOWN".
+
+    A workaround is only "staged" while its issue is *open*: if the issue has
+    been closed but the workaround is still present, the workaround has been
+    forgotten and should be reported again.  If the state can not be
+    determined (no network, API rate limit, a non-GitHub URL, …) we return
+    "UNKNOWN" and give the workaround the benefit of the doubt.
+    """
+    match = re.match(r'https://github\.com/([^/]+/[^/]+)/issues/(\d+)', url)
+    if not match:
+        return "UNKNOWN"
+    api = f"https://api.github.com/repos/{match.group(1)}/issues/{match.group(2)}"
+    command = ["curl", "--silent", "--location", "--fail",
+               "--header", "Accept: application/vnd.github+json"]
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        command += ["--header", f"Authorization: Bearer {token}"]
+    result = subprocess.run(command + [api], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        return "UNKNOWN"
+    try:
+        return json.loads(result.stdout).get("state", "UNKNOWN")
+    except json.JSONDecodeError:
+        return "UNKNOWN"
+
+
+def check_issues() -> None:
+    """Determine which resolved PRs have their removal staged as an open issue."""
+    for pr in WORKAROUNDS:
+        states = {url: issue_state(url) for url in sorted(WORKAROUNDS[pr]["issues"])}
+        WORKAROUNDS[pr]["issueStates"] = states
+        # "Staged" means at least one referenced issue is not known to be
+        # closed.  The same PR is often worked around in many files, but a
+        # single issue tracks removal of all of them, so we do not require
+        # every occurrence to carry the attribute.
+        WORKAROUNDS[pr]["staged"] = any(state != "closed" for state in states.values())
+
+
 def main() -> int:
     file_matcher()
     check_links()
+    check_issues()
 
-    resolved = sum(1 for pr in WORKAROUNDS if WORKAROUNDS[pr]["status"] == "RESOLVED")
+    resolved = [pr for pr in WORKAROUNDS
+                if WORKAROUNDS[pr]["status"] == "RESOLVED" and not WORKAROUNDS[pr]["staged"]]
+    staged = [pr for pr in WORKAROUNDS
+              if WORKAROUNDS[pr]["status"] == "RESOLVED" and WORKAROUNDS[pr]["staged"]]
     if resolved:
         status = 1
         print("!!! Resolved PRs with workarounds exist !!!\n")
     else:
         status = 0
-        print("No resolved PRs with workarounds exist\n")
+        print("No resolved PRs with unstaged workarounds exist\n")
+    if staged:
+        print(f"({len(staged)} resolved PR(s) have their workaround removal staged as an open issue)\n")
 
     for pr in sorted(WORKAROUNDS, key=int):
-        if WORKAROUNDS[pr]["status"] == "RESOLVED":
-            print("!!! ", end="")
+        workaround = WORKAROUNDS[pr]
+        if workaround["status"] == "RESOLVED":
+            print("!!! " if not workaround["staged"] else "--- ", end="")
         print(f"PR{pr} (https://gcc.gnu.org/bugzilla/show_bug.cgi?id={pr}):")
-        for file_name in sorted(WORKAROUNDS[pr]["files"]):
+        for file_name in sorted(workaround["files"]):
             print(f" -> {file_name}")
+        for url, state in workaround["issueStates"].items():
+            label = "staged for removal" if state != "closed" else "issue is CLOSED but workaround remains"
+            print(f" => {label}: {url}")
         print("\n")
 
     return status

--- a/scripts/doc/extractDocsRST.py
+++ b/scripts/doc/extractDocsRST.py
@@ -392,7 +392,8 @@ def scan_source(source_dir: str):
       type-bound methods declared in that file's ``<methods>`` block(s).
     * ``modules``: ``[{name, file, description, classRef}, …]`` — one per
       documented module (``classRef`` links class modules to their page).
-    * ``workarounds``: ``[{type, pr, url, description, seeAlso, file}, …]``.
+    * ``workarounds``: ``[{type, pr, url, issue, description, seeAlso, file},
+      …]``.
     * ``components``: ``{class: [{name, description, isDefault, extends,
       properties, file}, …]}`` — the node component implementations.
     """
@@ -477,6 +478,9 @@ def scan_source(source_dir: str):
                         'type':        _attr(wattrs, 'type'),
                         'pr':          _attr(wattrs, 'PR'),
                         'url':         _attr(wattrs, 'url'),
+                        # Our own issue tracking removal of the workaround, if
+                        # one has been opened (see the workaroundChecker).
+                        'issue':       _attr(wattrs, 'issue'),
                         'description': wdesc.group(1),
                         'seeAlso':     [{'type': _attr(s, 'type'),
                                          'pr':   _attr(s, 'PR'),
@@ -560,6 +564,10 @@ def scan_source(source_dir: str):
         key = (w.get('type'), w.get('pr'),
                ' '.join((w.get('description') or '').split()))
         entry = deduped.setdefault(key, {**w, 'seeAlso': []})
+        # Only one of a set of identical occurrences need carry the ``issue``
+        # attribute, so keep the first one found rather than the first entry's.
+        if not entry.get('issue') and w.get('issue'):
+            entry['issue'] = w['issue']
         have = {(s.get('type'), s.get('pr'), s.get('url'))
                 for s in entry['seeAlso']}
         for s in w.get('seeAlso') or []:
@@ -902,6 +910,16 @@ def render_modules(modules: list[dict]) -> str:
     return '\n'.join(out) + '\n'
 
 
+def _issue_link(issue: str) -> str:
+    """Render an ``issue`` attribute (a bare number, or a full URL) as a link."""
+    issue = html.unescape(issue)
+    if re.fullmatch(r'#?\d+', issue):
+        number = issue.lstrip('#')
+        return (f'`issue #{number} '
+                f'<https://github.com/galacticusorg/galacticus/issues/{number}>`_')
+    return f'`issue <{issue}>`_'
+
+
 def render_workarounds(workarounds: list[dict], glsmap: dict) -> str:
     """A developer reference of the compiler workarounds documented in source."""
     def link(typ, pr, url):
@@ -919,6 +937,10 @@ def render_workarounds(workarounds: list[dict], glsmap: dict) -> str:
         for s in w.get('seeAlso') or []:
             body += ('\n\nSee also: '
                      + link(s.get('type'), s.get('pr'), s.get('url')) + '.')
+        issue = w.get('issue')
+        if issue:
+            body += ('\n\nRemoval of this workaround is tracked by '
+                     + _issue_link(issue) + '.')
         out.append(link(w.get('type'), w.get('pr'), w.get('url')))
         out.append(textwrap.indent(body, '   '))
         out.append('')

--- a/source/dark_matter_halos/mass_accretion_history/Hearin2021_stochastic.F90
+++ b/source/dark_matter_halos/mass_accretion_history/Hearin2021_stochastic.F90
@@ -772,7 +772,7 @@ contains
             &         )
        ! Compute the parameters.
        !![
-       <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336" docformat="rst">
+       <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=37336" docformat="rst">
 	 <description>
 	 Function results are not finalized after use. So, we must store the result of "cholesky*randoms" in a variable here (instead of just using this directly in the expression for "sample") to avoid a memory leak. The variable "offsets" will be finalized when leaving this function scope.
 	 </description>

--- a/source/interface/Cloudy/_module.F90
+++ b/source/interface/Cloudy/_module.F90
@@ -27,7 +27,7 @@ module Interfaces_Cloudy
   !!}
 
   !![
-  <workaround type="gfortran" PR="94463" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=94463" docformat="rst">
+  <workaround type="gfortran" PR="94463" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=94463" docformat="rst">
   <description>
   Failure of name mangling on module read.
   </description>

--- a/source/interface/Local_Group_database.F90
+++ b/source/interface/Local_Group_database.F90
@@ -161,7 +161,7 @@ contains
     call XML_Get_Elements_By_Tag_Name(XML_Get_First_Element_By_Tag_Name(self%database%document,'galaxies'),'galaxy',self%galaxies)
     !$omp end critical (FoX_DOM_Access)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/math/linear_algebra.F90
+++ b/source/math/linear_algebra.F90
@@ -529,7 +529,7 @@ contains
     self%size_      =size(array,kind=c_size_t)
     self%vector_%gsl=gsl_vector_alloc(self%size_)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -558,7 +558,7 @@ contains
     self%size_      =n
     self%vector_%gsl=gsl_vector_alloc(self%size_)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -590,7 +590,7 @@ contains
     status          =gsl_vector_memcpy(self%vector_%gsl,source%vector_%gsl)
     if (status /= GSL_Success) call Error_Report('vector copy failed'//{introspection:location})
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -759,7 +759,7 @@ contains
     self%nonZeroRowColumnsChecked    =.false.
     self%hasZeroRowColumns           =.false.
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -793,7 +793,7 @@ contains
     self%hasZeroRowColumns          =.false.
     self%matrix_                 %gsl=gsl_matrix_alloc(self%size_(1),self%size_(2))
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -828,7 +828,7 @@ contains
     status                           =gsl_matrix_memcpy(self%matrix_%gsl   ,source%matrix_%gsl   )
     if (status /= GSL_Success) call Error_Report('matrix copy failed'//{introspection:location})
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -1123,7 +1123,7 @@ contains
        allocate(self%LUdecomposition)
        allocate(self%LUpermutation  )
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -1266,7 +1266,7 @@ contains
     status               =GSL_LinAlg_LU_Decomp (self%matrix_%gsl   ,self%permutation_%gsl,self%decompositionSign)
     if (status /= GSL_Success) call Error_Report('LU decomposition failed'//{introspection:location})
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/merger_trees/construct/builder/Cole2000/_class.F90
+++ b/source/merger_trees/construct/builder/Cole2000/_class.F90
@@ -144,12 +144,12 @@
 
   ! Sub-module scope variables used in tree building.
   !![
-  <workaround type="gfortran" PR="110547" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=110547" docformat="rst">
+  <workaround type="gfortran" PR="110547" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=110547" docformat="rst">
     <description>
     We use a pointer to self here rather than have self be passed to various methods (which are defined as "nopass" above) because otherwise gfortran calls the destructor of self on exit from these functions when using OpenMP task-based parallelism. This may be a compiler bug.
     </description>
   </workaround>
-  <workaround type="gfortran" PR="110548" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=110548" docformat="rst">
+  <workaround type="gfortran" PR="110548" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=110548" docformat="rst">
     <description>
     We use an allocatable treeWalker here. Some subclasses will not need a treeWalker. Ideally this would therefore be passed to functions as an optional argument, but current optional arguments used in OpenMP tasks cause segfaults. Therefore, we instead use the allocation status of this variable as an indication of whether or not a treeWalker is needed.
     </description>

--- a/source/merger_trees/construct/builder/Cole2000/parallel.F90
+++ b/source/merger_trees/construct/builder/Cole2000/parallel.F90
@@ -48,7 +48,7 @@
 
   ! Sub-module scope variables used in tree building.
   !![
-  <workaround type="gfortran" PR="110547" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=110547" docformat="rst">
+  <workaround type="gfortran" PR="110547" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=110547" docformat="rst">
     <description>
     We use a pointer to self here rather than have self be passed to various methods (which are defined as "nopass" in the parent class) because otherwise gfortran calls the destructor of self on exit from these functions when using OpenMP task-based parallelism. This may be a compiler bug. Note that we use a separate pointer here that is not threadprivate as threadprivate variables can not be passed as arguments in untied OpenMP tasks.
     </description>

--- a/source/merger_trees/construct/fully_specified.F90
+++ b/source/merger_trees/construct/fully_specified.F90
@@ -232,7 +232,7 @@ contains
        call Error_Report(message//{introspection:location})
     end if
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/merger_trees/construct/read/importer/_class.F90
+++ b/source/merger_trees/construct/read/importer/_class.F90
@@ -32,7 +32,7 @@ module Merger_Tree_Read_Importers
   private
   public :: nodeData, nodeDataMinimal
   !![
-  <workaround type="gfortran" PR="88632" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=88632" docformat="rst">
+  <workaround type="gfortran" PR="88632" issue="1454" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=88632" docformat="rst">
    <description>
    importerUnitConvert is used by submodules, so must be exported to the object file. gfortran currently does not do this if the symbol is private, so we mark it as public.
    </description>

--- a/source/merger_trees/construct/read/importer/_class.F90
+++ b/source/merger_trees/construct/read/importer/_class.F90
@@ -32,7 +32,7 @@ module Merger_Tree_Read_Importers
   private
   public :: nodeData, nodeDataMinimal
   !![
-  <workaround type="gfortran" PR="88632" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=88632" docformat="rst">
+  <workaround type="gfortran" PR="88632" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=88632" docformat="rst">
    <description>
    importerUnitConvert is used by submodules, so must be exported to the object file. gfortran currently does not do this if the symbol is private, so we mark it as public.
    </description>

--- a/source/merger_trees/outputter/standard.F90
+++ b/source/merger_trees/outputter/standard.F90
@@ -1262,8 +1262,8 @@ contains
           self%outputGroupsCount=max(self%outputGroupsCount+standardOutputGroupsIncrement,(indexOutput/standardOutputGroupsIncrement+1)*standardOutputGroupsIncrement)
           allocate(self%outputGroups(self%outputGroupsCount))
           !![
-	  <workaround type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=57696" docformat="rst">
-	    <seeAlso type="gfortran" PR="124012" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=124012"/>
+	  <workaround type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=57696" docformat="rst">
+	    <seeAlso type="gfortran" PR="124012" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=124012"/>
 	    <description>
 	    Type-bound defined assignment not done because multiple part array references would occur in intermediate expressions.
 

--- a/source/models/likelihoods/galaxy_population.F90
+++ b/source/models/likelihoods/galaxy_population.F90
@@ -232,7 +232,7 @@ contains
     allocate(self%parametersModel)
     self%parametersModel%parametersModel => parametersModel
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/models/likelihoods/halo_mass_function.F90
+++ b/source/models/likelihoods/halo_mass_function.F90
@@ -312,7 +312,7 @@ contains
     allocate(self%parametersModel)
     self%parametersModel%parametersModel => parametersModel
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/nodes/property_extractor/SED.F90
+++ b/source/nodes/property_extractor/SED.F90
@@ -1084,7 +1084,7 @@ contains
     type            (varying_string          )                              :: descriptorString          , values
     integer                                                                 :: i
     !![
-    <workaround type="gfortran" PR="102845" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=102845" docformat="rst">
+    <workaround type="gfortran" PR="102845" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=102845" docformat="rst">
       <description>
       Memory leak possibly due to OpenMP parallelism, or some failing of gfortran.
       </description>
@@ -1150,7 +1150,7 @@ contains
     call descriptor%destroy()
     descriptorString=descriptorString//":sourceDigest{"//String_C_To_Fortran(nodePropertyExtractorSED5)//"}"
     !![
-    <workaround type="gfortran" PR="102845" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=102845" docformat="rst">
+    <workaround type="gfortran" PR="102845" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=102845" docformat="rst">
      <description>
      Memory leak possibly due to OpenMP parallelism, or some failing of gfortran.
      </description>

--- a/source/nodes/property_extractor/luminosity_emission_line/_class.F90
+++ b/source/nodes/property_extractor/luminosity_emission_line/_class.F90
@@ -951,7 +951,7 @@ contains
     type            (varying_string                             )                              :: descriptorString    , values
     integer                                                                                    :: i                   , status
     !![
-    <workaround type="gfortran" PR="102845" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=102845" docformat="rst">
+    <workaround type="gfortran" PR="102845" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=102845" docformat="rst">
       <description>
       Memory leak possibly due to OpenMP parallelism, or some failing of gfortran.
       </description>
@@ -1017,7 +1017,7 @@ contains
     call descriptor%destroy()
     descriptorString=descriptorString//":sourceDigest{"//String_C_To_Fortran(nodePropertyExtractorLuminosityEmissionLine5)//"}"
     !![
-    <workaround type="gfortran" PR="102845" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=102845" docformat="rst">
+    <workaround type="gfortran" PR="102845" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=102845" docformat="rst">
      <description>
      Memory leak possibly due to OpenMP parallelism, or some failing of gfortran.
      </description>

--- a/source/numerical/ODE_solver/solver.F90
+++ b/source/numerical/ODE_solver/solver.F90
@@ -384,7 +384,7 @@ contains
        self%system%gsl=gsl_odeiv2_system_init(self%dim,c_funloc(derivativesWrapper),c_null_funptr                 )
     end if
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -410,7 +410,7 @@ contains
        self%driver%gsl=gsl_odeiv2_driver_alloc_y_new      (self%system%gsl,self%gsl_odeiv2_step_type,hStart_,toleranceAbsolute_,toleranceRelative_                                         )
     end if
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/numerical/differentiation.F90
+++ b/source/numerical/differentiation.F90
@@ -82,7 +82,7 @@ contains
     allocate(self%wrapper)
     self%wrapper%f=gslFunction(f)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/numerical/integration.F90
+++ b/source/numerical/integration.F90
@@ -243,7 +243,7 @@ contains
        allocate(self%integrationWorkspace)
        self%integrationWorkspace%workspace=gsl_integration_workspace_alloc(self%intervalsMaximum)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -258,7 +258,7 @@ contains
        allocate(self%integrandFunction)
        self%integrandFunction   %f        =gslFunction                    (     integrandWrapper)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>

--- a/source/numerical/interpolation/1D.F90
+++ b/source/numerical/interpolation/1D.F90
@@ -373,7 +373,7 @@ contains
        allocate(self%interp_     )
        self%interp_     %gsl=gsl_interp_alloc      (self%gsl_interp_type,self%countArray)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -388,7 +388,7 @@ contains
        allocate(self%interpAccel_)
        self%interpAccel_%gsl=gsl_interp_accel_alloc(                                    )
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -1005,7 +1005,7 @@ contains
        allocate(self%interpX     )
        self%interpX     %gsl=gsl_interp_alloc           (self%gsl_interp_type,self%countArrayX)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -1020,7 +1020,7 @@ contains
        allocate(self%interpY     )
        self%interpY     %gsl=gsl_interp_alloc           (self%gsl_interp_type,self%countArrayY)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -1035,7 +1035,7 @@ contains
        allocate(self%interpAccelX)
        self%interpAccelX%gsl=gsl_interp_accel_alloc(                                     )
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -1050,7 +1050,7 @@ contains
        allocate(self%interpAccelY)
        self%interpAccelY%gsl=gsl_interp_accel_alloc(                                     )
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>

--- a/source/numerical/multi_dimensional_minimizer.F90
+++ b/source/numerical/multi_dimensional_minimizer.F90
@@ -401,7 +401,7 @@ contains
        ! Allocate the minimizer object.
        self%minimizer_          %gsl=gsl_multimin_fdfminimizer_alloc   (self%gslMinimizerType ,countDimensions)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -415,7 +415,7 @@ contains
        allocate(self%minimizerFDFFunction)
        self%minimizerFDFFunction%gsl=gslMultiminFunctionFdFConstructor(countDimensions,c_funloc(gslMultiminFunctionFWrapper),c_funloc(gslMultiminFunctionDFWrapper),c_funloc(gslMultiminFunctionFDFWrapper))
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -436,7 +436,7 @@ contains
        ! Allocate the minimizer object.
        self%minimizer_        %gsl=gsl_multimin_fminimizer_alloc   (self%gslMinimizerType ,countDimensions)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -450,7 +450,7 @@ contains
        allocate(self%minimizerFFunction)
        self%minimizerFFunction%gsl=gslMultiminFunctionFConstructor(countDimensions,c_funloc(gslMultiminFunctionFWrapper))
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>

--- a/source/numerical/points/convex_hull.F90
+++ b/source/numerical/points/convex_hull.F90
@@ -143,7 +143,7 @@ contains
     if (size(points,dim=1) /= 3) call Error_Report('3D points are required'//{introspection:location})
     allocate(self%qhull_)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/numerical/random/quasi.F90
+++ b/source/numerical/random/quasi.F90
@@ -136,7 +136,7 @@ contains
     allocate(self%gsl_qrng)
     self%gsl_qrng%gsl=gsl_qrng_alloc (self%gsl_qrng_type,1)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/numerical/random_numbers/GSL.F90
+++ b/source/numerical/random_numbers/GSL.F90
@@ -302,7 +302,7 @@ contains
     allocate(self%randomNumberGenerator)
     self%randomNumberGenerator%rng=GSL_RNG_Alloc(GSL_Get_Rng_Default())
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -490,7 +490,7 @@ contains
        allocate(destination%randomNumberGenerator)
        destination%randomNumberGenerator%rng=GSL_Rng_Clone(self%randomNumberGenerator%rng)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>

--- a/source/numerical/root_finder.F90
+++ b/source/numerical/root_finder.F90
@@ -661,7 +661,7 @@ contains
           self%functionInitialized              =.true.
           ! Initialize resource managers.
           !![
-	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	    <description>
 	    ICE when passing a derived type component to a class(*) function argument.
 	    </description>
@@ -672,7 +672,7 @@ contains
 	  </workaround>
           !!]
           !![
-	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	    <description>
 	    ICE when passing a derived type component to a class(*) function argument.
 	    </description>
@@ -699,7 +699,7 @@ contains
           self%functionInitialized              =.true.
           ! Initialize resource managers.
           !![
-	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	    <description>
 	    ICE when passing a derived type component to a class(*) function argument.
 	    </description>
@@ -710,7 +710,7 @@ contains
 	  </workaround>
           !!]
           !![
-	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	    <description>
 	    ICE when passing a derived type component to a class(*) function argument.
 	    </description>

--- a/source/objects/nodes/_class.F90
+++ b/source/objects/nodes/_class.F90
@@ -1671,7 +1671,7 @@ module Galacticus_Nodes
     type (treeEvent ), pointer       :: event
     
     !![
-    <workaround type="gfortran" PR="94446" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=94446" docformat="rst">
+    <workaround type="gfortran" PR="94446" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=94446" docformat="rst">
      <description>
      Using the sizeof() intrinsic on a treeNode object causes a bogus "type mismatch" error when this module is used.
      </description>
@@ -1682,7 +1682,7 @@ module Galacticus_Nodes
     event => self%event
     do while (associated(event))
        !![
-       <workaround type="gfortran" PR="94446" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=94446" docformat="rst">
+       <workaround type="gfortran" PR="94446" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=94446" docformat="rst">
         <description>
         Using the sizeof() intrinsic on a treeNode object causes a bogus "type mismatch" error when this module is used.
         </description>

--- a/source/objects/tables/_module.F90
+++ b/source/objects/tables/_module.F90
@@ -177,7 +177,7 @@ module Tables
      Table type supporting generic one dimensional tables.
      !!}
      !![
-     <workaround type="gfortran" PR="123938" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=123938" docformat="rst">
+     <workaround type="gfortran" PR="123938" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=123938" docformat="rst">
        <description>
        gfortran causes a memory leak with allocatable components in nested derived-types.
        </description>
@@ -742,7 +742,7 @@ contains
   end function Table1D_Integration_Weights
   
   !![
-  <workaround type="gfortran" PR="121537" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=121537" docformat="rst">
+  <workaround type="gfortran" PR="121537" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=121537" docformat="rst">
     <description>
     gfortran misses a defined-assignment of a component.
     </description>
@@ -777,7 +777,7 @@ contains
           if (associated(from%interpolators)) then
              allocate(to%interpolators(size(from%interpolators)))
              !![
-	     <workaround type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=57696" docformat="rst">
+	     <workaround type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=57696" docformat="rst">
 	       <description>
 	       Defined assignment for components not used when those are ALLOCATABLE
 	       </description>

--- a/source/stellar_populations/broad_band_luminosities/standard.F90
+++ b/source/stellar_populations/broad_band_luminosities/standard.F90
@@ -358,7 +358,7 @@ contains
              call Move_Alloc(self%luminosityTables,luminosityTablesTemporary)
              allocate(self%luminosityTables(populationID))
              !![
-	     <workaround type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=57696" docformat="rst">
+	     <workaround type="gfortran" PR="57696" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=57696" docformat="rst">
 	       <description>
 	       Defined assignment for components not used when those are ALLOCATABLE.
 	       </description>

--- a/source/stellar_populations/spectra/postprocess/builder/lookup.F90
+++ b/source/stellar_populations/spectra/postprocess/builder/lookup.F90
@@ -86,7 +86,7 @@ contains
     allocate(names         (countPostprocessors))
     allocate(postprocessors(countPostprocessors))
     !![
-    <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=37336" docformat="rst">
+    <workaround type="gfortran" PR="37336" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=37336" docformat="rst">
       <description>
       Missing finalization of array constructors after their use in gfortran (PR#37336); workaround initializes the default names array using ``var_str`` before passing to ``inputParameter``.
       </description>

--- a/source/tasks/evolve_forests/_class.F90
+++ b/source/tasks/evolve_forests/_class.F90
@@ -282,7 +282,7 @@ contains
     allocate(self%nodeComponents_)
     allocate(self%nodeHierarchy_ )
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/tasks/postprocess_forests.F90
+++ b/source/tasks/postprocess_forests.F90
@@ -146,7 +146,7 @@ contains
     allocate(self%nodeComponents_)
     allocate(self%nodeHierarchy_ )
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/tests/resource_manager/wrapper.F90
+++ b/source/tests/resource_manager/wrapper.F90
@@ -89,7 +89,7 @@ contains
     allocate(self%sharedObject)
     self%sharedObject=sharedResource(1)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
     <description>
     ICE when passing a derived type component to a class(*) function argument.
     </description>

--- a/source/utility/IO/HDF5/_module.F90
+++ b/source/utility/IO/HDF5/_module.F90
@@ -1325,7 +1325,7 @@ contains
     allocate(self%objectID)
     allocate(self%fileID  )
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -1480,7 +1480,7 @@ contains
     ! Create an ID for this group.
     allocate(self%objectID)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -1685,7 +1685,7 @@ contains
     ! Create an ID for this attribute.
     allocate(self%objectID)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -3695,7 +3695,7 @@ attributeValue=trim(attributeValue)
     ! Create an ID for this dataset.
     allocate(self%objectID)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/utility/MPI.F90
+++ b/source/utility/MPI.F90
@@ -2207,7 +2207,7 @@ contains
        countInitialPointer => null()
        call C_F_Pointer(self%counter%memory,countInitialPointer)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -2227,7 +2227,7 @@ contains
        call mpiBarrier()
     end if
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/utility/files.F90
+++ b/source/utility/files.F90
@@ -283,7 +283,7 @@ contains
 
     allocate(self%unit)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/utility/input_parameters.F90
+++ b/source/utility/input_parameters.F90
@@ -450,7 +450,7 @@ contains
     call setLiveNodeLists(self%document%document,.false.)
     !$omp end critical (FoX_DOM_Access)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -861,7 +861,7 @@ contains
        call setLiveNodeLists(self%document%document,.false.)
        !$omp end critical (FoX_DOM_Access)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -895,7 +895,7 @@ contains
        self%outputParametersTemporary=.false.
        !$ call hdf5Access%unset()
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -927,7 +927,7 @@ contains
        self%outputParametersTemporary=.true.
        !$ call hdf5Access%unset()
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -1860,7 +1860,7 @@ contains
        !$ call hdf5Access%set()
        self%outputParameters=outputGroup%openGroup('Parameters',attributesCompactMaxiumum=0)
        !![
-       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+       <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	 <description>
 	 ICE when passing a derived type component to a class(*) function argument.
 	 </description>
@@ -2252,7 +2252,7 @@ contains
           allocate(inputParametersSubParameters%outputParameters)
           inputParametersSubParameters%outputParameters=self%outputParameters%openGroup(char(groupName))
           !![
-	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+	  <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
 	    <description>
 	    ICE when passing a derived type component to a class(*) function argument.
 	    </description>

--- a/source/utility/locks.F90
+++ b/source/utility/locks.F90
@@ -296,7 +296,7 @@ contains
 
     !$ allocate(self%lock)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -431,7 +431,7 @@ contains
     !$ allocate(self%locks(0:omp_get_max_threads()-1))
     !$ allocate(self%owns (0:omp_get_max_threads()-1))
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>
@@ -599,7 +599,7 @@ contains
 
     !$ allocate(self%lock)
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>

--- a/source/utility/regular_expressions.F90
+++ b/source/utility/regular_expressions.F90
@@ -112,7 +112,7 @@ contains
     allocate(self%r)
     self%r%r=Regular_Expression_Construct_C(trim(regularExpression)//char(0))
     !![
-    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi=105807" docformat="rst">
+    <workaround type="gfortran" PR="105807" url="https:&#x2F;&#x2F;gcc.gnu.org&#x2F;bugzilla&#x2F;show_bug.cgi?id=105807" docformat="rst">
       <description>
       ICE when passing a derived type component to a class(*) function argument.
       </description>


### PR DESCRIPTION
Our daily `Workarounds` workflow is correctly reporting that [GCC PR 88632](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88632) is fixed, but we cannot yet act on it — so the workflow will fail every day with nothing actionable behind it. This adds a way to stage a workaround for removal, and fixes a batch of dead links found along the way.

## 1. `issue` attribute on `workaround` directives

A `workaround` directive may now carry an optional `issue` attribute — a bare issue number in this repository, or a full URL — naming the issue that tracks its removal:

```fortran
<workaround type="gfortran" PR="88632" issue="1454" url="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88632" docformat="rst">
```

`scripts/aux/workaroundChecker.py` then reports such a workaround as *staged for removal* and leaves the exit status clean, while unstaged resolved PRs still fail exactly as before:

```
No resolved PRs with unstaged workarounds exist

(1 resolved PR(s) have their workaround removal staged as an open issue)

--- PR88632 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88632):
 -> ./source/merger_trees/construct/read/importer/_class.F90
 => staged for removal: https://github.com/galacticusorg/galacticus/issues/1454
```

Staging **lapses if the issue is closed while the workaround is still present** — the checker queries the issue state and resumes failing, so a closed issue cannot silence the check indefinitely. A failure to determine the state (offline, API rate limit, non-GitHub URL) is treated as still staged, so the check never fails spuriously. Only one occurrence of a given PR need carry the attribute, since a single issue tracks removal of all of them.

Supporting changes: `schema/workaround.xsd` admits the attribute (without it, both the build's directive parser and `embeddedAnalyzer.py` reject the directive); `extractDocsRST.py` carries it into the generated `docs/workarounds.rst`; the workflow gains `issues: read` and passes `GH_TOKEN`; and the developer guide documents the attribute and its semantics.

## 2. Staging the PR 88632 workaround — closes nothing yet

`importerUnitConvert` is `public` only so gfortran emits it for the importer submodules. PR 88632 is `RESOLVED FIXED`, but **the fix is in no released compiler**:

| Branch | Commit | Date |
| --- | --- | --- |
| `master` (GCC 17) | [`r17-1158-g9fc5a7a25e9e`](https://gcc.gnu.org/g:9fc5a7a25e9e29f58359c6363c9b10a99c6f99f0) | 2026-06-02 |
| `releases/gcc-16` | [`r16-9583-gc2d5855c8746`](https://gcc.gnu.org/g:c2d5855c8746bcee5ed9f8c5768ea3a3944368f1) | 2026-08-24 |

The gcc-16 backport landed *after* GCC 16.2 was released (2026-08-07), so the earliest releases carrying it are **GCC 16.3** and **17.1**. Ubuntu's `gcc-16` is currently `16-20260322` (26.04) / `16.2.0` (26.10) and Homebrew's `gcc` is `16.2.0` — removing the workaround today would fail to link on both CI platforms. Tracked by #1454.

## 3. Repaired 74 dead Bugzilla URLs

Every `workaround` `url` attribute in `source/` (73, plus one `seeAlso`) pointed at `show_bug.cgi=<PR>` rather than `show_bug.cgi?id=<PR>`, so all of them were dead — including as rendered into `docs/workarounds.rst`. The correct form was already used everywhere outside `source/`, so this was a systematic mangling of the in-source copies. Purely mechanical; it is the first commit, separated for reviewability.

> [!NOTE]
> These links had never been exercised: `scripts/aux/linkChecker.py` scans `./source` with `os.listdir`, so since the reorganization of `source/` into a directory hierarchy it has seen no file in a subdirectory. That is a separate pre-existing issue and is **not** addressed here.

## Verification

- New unit tests (`scripts/aux/tests/test_workaroundChecker.py`) cover the staged, unstaged and closed-issue paths, both attribute forms including XML-escaped URLs, and directives carrying no PR. 71 aux + doc tests pass.
- All 35 modified F90 files re-validated against their directive schemas with `embeddedAnalyzer.py`.
- `docs/workarounds.rst` regenerates cleanly; repaired URLs confirmed to resolve (HTTP 200).
- Checker run against the real source tree: exits 0, PR 88632 staged, every other workaround reported unchanged.

No Fortran *code* is changed — the source diff is confined to comment-embedded directive attributes — so no model run is affected.

---

Drafted with assistance from Claude; to be reviewed and verified by a human before merge, per [CONTRIBUTING.md](https://github.com/galacticusorg/galacticus/blob/master/CONTRIBUTING.md#ai-assisted-contributions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1YXEsVCw2mGzmvucFceFm
