### PR TITLE
Link checker: scan the whole source tree, and extract URLs correctly

### DIFF
--- a/scripts/aux/linkChecker.py
+++ b/scripts/aux/linkChecker.py
@@ -93,6 +93,15 @@ _EXCLUDED_URL_RES = [
     re.compile(r'^https://drive\.google\.com/open\?id=0B7vqPPPgOdtIfjUtb3RsV2JUOTFFX29WV1FZNURPMHAxTEtZQjhJOGtyNXZUTTNVSzFZazQ$'),
     # Defunct Maraston stellar population model link, retained only for the historical record.
     re.compile(r"^http://www\.icg\.port\.ac\.uk/~maraston/Claudia's_Stellar_Population_Model\.html$"),
+    # A documentation URL written with a placeholder version, naming the form of
+    # a per-release documentation URL rather than any one release's -- see the
+    # "Versions and Releases" page of the developer guide.
+    re.compile(r'^https://galacticus\.readthedocs\.io/en/vX\.Y\.Z(?:[/?#]|$)'),
+    # Defunct link to Inoue's own IGM attenuation code, from which the file that
+    # `source/tests/spectra/postprocess/Inoue2014.F90` compares against was
+    # extracted.  No archived copy of the tarball could be found, so the URL is
+    # retained only to record where that file came from.
+    re.compile(r'^http://www\.las\.osaka-sandai\.ac\.jp/~inoue/ANAIGM/ANAIGM\.tar\.gz$'),
     # RFC 2606 reserves the `.invalid` TLD, and the `example.com`/`.net`/`.org`
     # domains, for use in documentation and testing.  The source uses both for
     # URLs which are deliberately not real -- the download system test's

--- a/scripts/aux/linkChecker.py
+++ b/scripts/aux/linkChecker.py
@@ -70,6 +70,21 @@ def record_success(url, failures):
 # literals (`` ``url`` ``) and are never valid inside a URL.
 _URL_RE = re.compile(r'https?://[^\s<>"}\]`]+')
 
+# A delimiter that terminates a URL, but which may be hidden behind an entity
+# reference in the source -- an RST link target ``<url>`` embedded in an XML
+# directive writes its closing ``>`` as ``&gt;``, which the regex above cannot
+# see and which unescaping then leaves stuck to the end of the URL.
+_URL_TERMINATOR_RE = re.compile(r'[\s<>"`]')
+
+# Fortran string concatenation immediately inside, or immediately following, a
+# matched URL: ``'https://…/archive/v'//version//'.tar.gz'``.  The literal is
+# only a *fragment* of a URL which is assembled at run time, so there is no
+# complete URL here to check -- and the fragment, checked as though it were
+# one, is reported as broken.  Such URLs are skipped: missing a link is much
+# cheaper than a standing false alarm.
+_CONCATENATION_RE       = re.compile(r'[\'"]\s*//')
+_CONCATENATION_AFTER_RE = re.compile(r'^[\'"]?\s*//')
+
 # URLs matching any of these patterns are placeholders / illustrative
 # examples (not real links) and are skipped during checking.
 _EXCLUDED_URL_RES = [
@@ -78,7 +93,32 @@ _EXCLUDED_URL_RES = [
     re.compile(r'^https://drive\.google\.com/open\?id=0B7vqPPPgOdtIfjUtb3RsV2JUOTFFX29WV1FZNURPMHAxTEtZQjhJOGtyNXZUTTNVSzFZazQ$'),
     # Defunct Maraston stellar population model link, retained only for the historical record.
     re.compile(r"^http://www\.icg\.port\.ac\.uk/~maraston/Claudia's_Stellar_Population_Model\.html$"),
+    # RFC 2606 reserves the `.invalid` TLD, and the `example.com`/`.net`/`.org`
+    # domains, for use in documentation and testing.  The source uses both for
+    # URLs which are deliberately not real -- the download system test's
+    # shell-injection payloads and its dummy download target, for example -- so
+    # such a URL failing is the expected result, not a broken link.
+    re.compile(r'^https?://[^/?#]*\.invalid(?:[:/?#]|$)'),
+    re.compile(r'^https?://(?:[^/?#]*\.)?example\.(?:com|net|org)(?:[:/?#]|$)'),
 ]
+
+
+# Hosts which serve HTTP 403 to the checker -- bot or datacenter-IP blocking by
+# a CDN -- while the page is up for ordinary clients.  A browser-like
+# user-agent does not help for these (unlike w3schools.com, handled with one
+# below), and a genuinely-missing page would answer 404/410, so a 403 from one
+# of these hosts is tolerated rather than reported.
+_FORBIDDEN_TOLERATED_RES = [
+    re.compile(r'^https://www\.openmp\.org/'),
+    re.compile(r'^https?://(?:www\.)?math\.stackexchange\.com/'),
+    re.compile(r'^https://goldbook\.iupac\.org/'),
+    re.compile(r'^https://journals\.aps\.org/'),
+]
+
+
+def tolerates_forbidden(url):
+    """Return True if an HTTP 403 from this URL's host is expected, not a fault."""
+    return any(pattern.search(url) for pattern in _FORBIDDEN_TOLERATED_RES)
 
 
 def is_excluded(url):
@@ -94,23 +134,52 @@ def scan_file(file_name, path, urls):
             for line in f:
                 line_number += 1
                 for m in _URL_RE.finditer(line):
-                    # Unescape XML/LaTeX (``&amp;``, ``&#x2F;``, ``\_`` …) and
-                    # drop trailing sentence punctuation and any closing-quote
-                    # delimiter (a ``'`` that wraps the URL, vs. an apostrophe
-                    # inside it which is followed by further URL characters).
-                    url = html.unescape(m.group(0)).rstrip('.,;:\'')
+                    # Skip a URL which is only one operand of a Fortran string
+                    # concatenation — it is a fragment, not a URL.
+                    if (_CONCATENATION_RE.search(m.group(0)) or
+                            _CONCATENATION_AFTER_RE.match(line[m.end():])):
+                        continue
+                    # Unescape XML/LaTeX (``&amp;``, ``&#x2F;``, ``\_`` …).
+                    url = html.unescape(m.group(0))
                     url = re.sub(r'\\(.)', r'\1', url)
-                    # Drop a trailing ``)`` that closes an enclosing construct
+                    # Unescaping can expose a delimiter that terminated the URL
+                    # in the source but was entity-encoded there, so truncate
+                    # again before trimming punctuation.
+                    url = _URL_TERMINATOR_RE.split(url, 1)[0]
+                    # Drop trailing sentence punctuation, any closing-quote
+                    # delimiter (a ``'`` that wraps the URL, vs. an apostrophe
+                    # inside it which is followed by further URL characters),
+                    # and a trailing ``)`` that closes an enclosing construct
                     # (shell ``$(curl ...)``, prose parenthetical) rather than
                     # belonging to the URL.  Balanced parens — e.g. Wikipedia's
                     # ``..._(computer_programming)`` — are kept; only an excess
-                    # of closing over opening parens is stripped.
-                    while url.endswith(')') and url.count(')') > url.count('('):
-                        url = url[:-1]
+                    # of closing over opening parens is stripped.  Repeat until
+                    # stable, since the two forms interleave (``…/meta.)``).
+                    previous = None
+                    while url != previous:
+                        previous = url
+                        url = url.rstrip('.,;:\'')
+                        while url.endswith(')') and url.count(')') > url.count('('):
+                            url = url[:-1]
+                    if not re.match(r'^https?://\S', url):
+                        continue
                     urls.setdefault(url, []).append(
                         {'file': file_name, 'path': path, 'lineNumber': line_number})
     except OSError as e:
         print(f"Warning: could not read {path}/{file_name}: {e}")
+
+
+def scan_sources(source_path, urls):
+    """Collect URLs from every Fortran source file under `source_path`.
+
+    The tree must be *walked*: `source/` is a directory hierarchy, so all but a
+    handful of its files live in subdirectories, and a non-recursive listing
+    would see almost none of the URLs embedded in the source.
+    """
+    for root, _dirs, files in os.walk(source_path):
+        for file_name in files:
+            if re.search(r'\.(F90|Inc)$', file_name):
+                scan_file(file_name, root, urls)
 
 
 def _find_closing_paren(s, open_pos):
@@ -237,12 +306,7 @@ def check_urls(urls, api_token, failures):
                                 line):
                             error = False
                             break
-                    if re.search(r'www\.openmp\.org', url):
-                        # openmp.org sits behind Cloudflare, which serves HTTP
-                        # 403 to the checker's datacenter IP even with a
-                        # browser-like user-agent, while the page is up for
-                        # ordinary clients. A genuinely-missing page would
-                        # return 404/410, so treat only this 403 as tolerated.
+                    if tolerates_forbidden(url):
                         if re.search(
                                 r'curl: \(22\) The requested URL returned error: 403',
                                 line):
@@ -338,11 +402,7 @@ def main():
     urls = {}
 
     # Embedded docstrings (RST) and constant/workaround directive attributes.
-    source_path = './source'
-    if os.path.isdir(source_path):
-        for file_name in os.listdir(source_path):
-            if re.search(r'\.(F90|Inc)$', file_name):
-                scan_file(file_name, source_path, urls)
+    scan_sources('./source', urls)
 
     # Committed RST documentation (manuals + landing page) and the glossary.
     for base in ('./docs', './doc'):

--- a/scripts/aux/tests/test_link_checker.py
+++ b/scripts/aux/tests/test_link_checker.py
@@ -1,0 +1,170 @@
+"""Tests for the source scanning of scripts/aux/linkChecker.py.
+
+`source/` is a directory hierarchy, and essentially every URL embedded in the
+source lives in a file below its top level. The sweep must therefore walk the
+tree: an earlier non-recursive listing saw only the three files at the top of
+`source/`, so the ~200 URLs in the rest of the tree went unchecked entirely.
+The cases below pin that behavior, along with the file selection and the source
+locations recorded for each URL (which the checker prints when reporting a
+broken link, and which are useless if they do not name the real file).
+
+Walking the tree also exposed how a URL is extracted from a line, which had
+never been exercised against the bulk of the source. Three forms there produce
+a "URL" that is not one, and each was reported as a broken link:
+
+  * an RST link target ``<url>`` inside an XML directive writes its delimiters
+    as ``&lt;``/``&gt;``, which the URL pattern cannot see, so unescaping left
+    a ``>`` stuck to the end of the URL;
+  * trailing punctuation and an enclosing ``)`` interleave (``…/meta.)``), and
+    a single pass of each left one of them behind; and
+  * a URL assembled by Fortran string concatenation is only a fragment, and no
+    complete URL exists in the source to check.
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_CHECKER = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir, 'linkChecker.py')
+
+
+@pytest.fixture(scope='module')
+def linkChecker():
+    spec = importlib.util.spec_from_file_location('linkChecker', _CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def sourceTree(tmp_path):
+    """A miniature `source/` tree, with URLs at several depths."""
+    def write(relativePath, url):
+        path = tmp_path / relativePath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('  !![\n'
+                        f'  <workaround type="gfortran" PR="1" url="{url}"/>\n'
+                        '  !!]\n')
+    write('top.F90',                              'https://example.com/top')
+    write('utility/nested.F90',                   'https://example.com/nested')
+    write('utility/IO/HDF5/deeplyNested.F90',     'https://example.com/deep')
+    write('numerical/included.Inc',               'https://example.com/included')
+    write('notSource.txt',                        'https://example.com/ignored')
+    write('utility/notSource.md',                 'https://example.com/alsoIgnored')
+    return tmp_path
+
+
+def test_urls_are_found_at_every_depth(linkChecker, sourceTree):
+    urls = {}
+    linkChecker.scan_sources(str(sourceTree), urls)
+    assert set(urls) == {
+        'https://example.com/top',
+        'https://example.com/nested',
+        'https://example.com/deep',
+        'https://example.com/included',
+    }
+
+
+def test_non_source_files_are_ignored(linkChecker, sourceTree):
+    urls = {}
+    linkChecker.scan_sources(str(sourceTree), urls)
+    assert 'https://example.com/ignored'     not in urls
+    assert 'https://example.com/alsoIgnored' not in urls
+
+
+def test_the_recorded_location_names_the_real_file(linkChecker, sourceTree):
+    urls = {}
+    linkChecker.scan_sources(str(sourceTree), urls)
+    source, = urls['https://example.com/deep']
+    assert source['file']       == 'deeplyNested.F90'
+    assert source['lineNumber'] == 2
+    assert os.path.join(source['path'], source['file']) == \
+        str(sourceTree / 'utility' / 'IO' / 'HDF5' / 'deeplyNested.F90')
+
+
+def test_a_missing_source_directory_is_not_an_error(linkChecker, tmp_path):
+    urls = {}
+    linkChecker.scan_sources(str(tmp_path / 'doesNotExist'), urls)
+    assert urls == {}
+
+
+@pytest.mark.parametrize('line,expected', [
+    # An RST link target inside an XML directive: delimiters entity-encoded.
+    ('`web page &lt;https://example.net/a&gt;`_',        'https://example.net/a'),
+    # Trailing sentence punctuation, and an enclosing parenthesis, interleaved.
+    ('see https://example.net/a/meta.)',                 'https://example.net/a/meta'),
+    ('see https://example.net/a.',                       'https://example.net/a'),
+    ('(see https://example.net/a)',                      'https://example.net/a'),
+    # A balanced parenthesis belongs to the URL and is kept.
+    ('https://example.net/Foo_(bar)',                    'https://example.net/Foo_(bar)'),
+    # An apostrophe inside a URL is kept; one wrapping it is not.
+    ("url='https://example.net/a'",                      'https://example.net/a'),
+    ("https://example.net/Claudia's_Model.html",         "https://example.net/Claudia's_Model.html"),
+])
+def test_url_extraction(linkChecker, tmp_path, line, expected):
+    (tmp_path / 'test.F90').write_text(line + '\n')
+    urls = {}
+    linkChecker.scan_sources(str(tmp_path), urls)
+    assert list(urls) == [expected]
+
+
+@pytest.mark.parametrize('line', [
+    # Fortran concatenation, the URL fragment ending at a double quote ...
+    'url="https://example.net/archive/v"//version//".tar.gz"',
+    # ... at a single quote, with the concatenation inside the matched text ...
+    "call download('https://example.net/releases/c'//char(version)//'.tar.gz')",
+    # ... and with the operator separated from the literal.
+    'url="https://example.net/archive/v" // version',
+])
+def test_concatenated_url_fragments_are_skipped(linkChecker, tmp_path, line):
+    (tmp_path / 'test.F90').write_text(line + '\n')
+    urls = {}
+    linkChecker.scan_sources(str(tmp_path), urls)
+    assert urls == {}
+
+
+@pytest.mark.parametrize('url,excluded', [
+    # RFC 2606 reserved names, used in the source for URLs that are
+    # deliberately not real (the download test's injection payloads).
+    ('https://invalid.invalid/x',      True),
+    ('http://foo.invalid',             True),
+    ('https://example.org/data.txt',   True),
+    ('https://www.example.com/a',      True),
+    # A real host that merely contains the reserved name is not excluded.
+    ('https://not-invalid.example.io/a', False),
+    ('https://example.org.uk/a',        False),
+    ('https://gcc.gnu.org/bugzilla/',   False),
+])
+def test_reserved_domains_are_excluded(linkChecker, url, excluded):
+    assert linkChecker.is_excluded(url) is excluded
+
+
+@pytest.mark.parametrize('url,tolerated', [
+    ('https://www.openmp.org/specifications/',                     True),
+    ('http://math.stackexchange.com/questions/40713/x',            True),
+    ('https://goldbook.iupac.org/terms/view/B00598',               True),
+    ('https://journals.aps.org/prl/abstract/10.1103/PhysRevLett',  True),
+    ('https://gcc.gnu.org/bugzilla/',                              False),
+])
+def test_hosts_that_block_the_checker_tolerate_a_forbidden(linkChecker, url,
+                                                           tolerated):
+    """These hosts answer 403 to the checker (bot/datacenter-IP blocking by a
+    CDN) while serving the page to ordinary clients, so a 403 from them is the
+    expected result rather than a broken link."""
+    assert linkChecker.tolerates_forbidden(url) is tolerated
+
+
+def test_urls_are_collected_across_calls(linkChecker, sourceTree, tmp_path):
+    """`main` passes one dictionary through the source, docs and wiki sweeps."""
+    urls = {'https://example.com/preexisting': [{'file': 'a', 'path': 'b',
+                                                 'lineNumber': 1}]}
+    linkChecker.scan_sources(str(sourceTree), urls)
+    assert 'https://example.com/preexisting' in urls
+    assert 'https://example.com/deep'        in urls
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__]))

--- a/scripts/aux/tests/test_link_checker.py
+++ b/scripts/aux/tests/test_link_checker.py
@@ -142,6 +142,21 @@ def test_reserved_domains_are_excluded(linkChecker, url, excluded):
     assert linkChecker.is_excluded(url) is excluded
 
 
+@pytest.mark.parametrize('url,excluded', [
+    # A dead link kept only to record where a file came from, and a
+    # documentation URL written with a placeholder version rather than a real
+    # one: both are working as intended and must not be reported.
+    ('http://www.las.osaka-sandai.ac.jp/~inoue/ANAIGM/ANAIGM.tar.gz', True),
+    ('https://galacticus.readthedocs.io/en/vX.Y.Z/',                  True),
+    ('https://galacticus.readthedocs.io/en/vX.Y.Z',                   True),
+    # A real per-version documentation URL is still checked.
+    ('https://galacticus.readthedocs.io/en/v1.2.3/',                  False),
+    ('https://galacticus.readthedocs.io/en/latest/',                  False),
+])
+def test_placeholder_and_lost_urls_are_excluded(linkChecker, url, excluded):
+    assert linkChecker.is_excluded(url) is excluded
+
+
 @pytest.mark.parametrize('url,tolerated', [
     ('https://www.openmp.org/specifications/',                     True),
     ('http://math.stackexchange.com/questions/40713/x',            True),

--- a/source/tests/halo_mass_function/Reed2007.F90
+++ b/source/tests/halo_mass_function/Reed2007.F90
@@ -18,12 +18,12 @@
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
 !!{RST
-Contains a program which tests the :cite:t:`reed_halo_2007` mass function by comparing to Darren Reed's `genmf <http://icc.dur.ac.uk/Research/PublicDownloads/genmf_readme.html>`_ code.
+Contains a program which tests the :cite:t:`reed_halo_2007` mass function by comparing to Darren Reed's `genmf <https://web.archive.org/web/20250711045335/http://icc.dur.ac.uk/Research/PublicDownloads/genmf_readme.html>`_ code.
 !!}
 
 program Tests_Halo_Mass_Function_Reed2007
   !!{RST
-  Tests the :cite:t:`reed_halo_2007` mass function by comparing to Darren Reed's `genmf <http://icc.dur.ac.uk/Research/PublicDownloads/genmf_readme.html>`_ code.
+  Tests the :cite:t:`reed_halo_2007` mass function by comparing to Darren Reed's `genmf <https://web.archive.org/web/20250711045335/http://icc.dur.ac.uk/Research/PublicDownloads/genmf_readme.html>`_ code.
   !!}
   use :: Cosmological_Density_Field          , only : criticalOverdensityFixed                , cosmologicalMassVarianceFilteredPower
   use :: Cosmology_Functions                 , only : cosmologyFunctionsMatterLambda

--- a/source/tests/spectra/postprocess/Inoue2014.F90
+++ b/source/tests/spectra/postprocess/Inoue2014.F90
@@ -44,6 +44,8 @@ program Test_Inoue2014
   ! Compare our calculation of attenuation with that from Inoue's own code and record the maximum error. The file read below was
   ! extracted from the tarball containing Inoue's code (where it was originally called "test") downloaded from:
   !   http://www.las.osaka-sandai.ac.jp/~inoue/ANAIGM/ANAIGM.tar.gz
+  ! That URL is now dead and no archived copy of the tarball could be found - it is retained here only to record the provenance of
+  ! the file, and is excluded from the link checker (see `scripts/aux/linkChecker.py`) for that reason.
   postprocessor=stellarPopulationSpectraPostprocessorInoue2014()
   relativeErrorMaximum=0.0d0
   open(newunit=inoueUnit,file="testSuite/data/inoue2014igmAttenuationModel.txt",status='old',form='formatted',iostat=ioStatus)

--- a/source/tests/stellar_populations/luminosities.F90
+++ b/source/tests/stellar_populations/luminosities.F90
@@ -30,7 +30,7 @@ program Test_Stellar_Populations_Luminosities
   use :: Cosmology_Parameters                      , only : cosmologyParametersSimple
   use :: Display                                   , only : displayVerbositySet                           , verbosityLevelWorking
   use :: Events_Hooks                              , only : eventsHooksInitialize
-  use :: File_Utilities                            , only : File_Exists                                   , Directory_Make
+  use :: File_Utilities                            , only : Directory_Make
   use :: Input_Paths                               , only : inputPath                                     , pathTypeDataDynamic                      , pathTypeDataStatic
   use :: ISO_Varying_String                        , only : char                                          , operator(//)                             , var_str             , varying_string   , &
        &                                                    assignment(=)
@@ -47,7 +47,6 @@ program Test_Stellar_Populations_Luminosities
   use :: Stellar_Populations_Initial_Mass_Functions, only : initialMassFunctionChabrier2001
   use :: Supernovae_Population_III                 , only : supernovaePopulationIIIHegerWoosley2002
   use :: Supernovae_Type_Ia                        , only : supernovaeTypeIaNagashima2005
-  use :: System_Download                           , only : download
   use :: Unit_Tests                                , only : Assert                                        , Unit_Tests_Begin_Group                   , Unit_Tests_End_Group, Unit_Tests_Finish
   implicit none
   type            (inputParameters                               ), target        :: parameters
@@ -70,10 +69,9 @@ program Test_Stellar_Populations_Luminosities
   type            (cosmologyParametersSimple                     )                :: cosmologyParameters_
   type            (cosmologyFunctionsMatterLambda                )                :: cosmologyFunctions_
   type            (stellarPopulationBroadBandLuminositiesStandard)                :: stellarPopulationBroadBandLuminosities_
-  type            (varying_string                                )                :: fileName                                       , fileNameBruzualCharlot                     , &
-       &                                                                             fileNameCompilation                            , fileNameTracks                             , &
-       &                                                                             fileNameSpectra                                , pathStore                                  , &
-       &                                                                             filterName
+  type            (varying_string                                )                :: fileNameBruzualCharlot                         , fileNameCompilation                        , &
+       &                                                                             fileNameTracks                                 , fileNameSpectra                            , &
+       &                                                                             pathStore                                      , filterName
   character       (len=1024                                      )                :: line
   integer                                                                         :: bc2003                                         , i                                          , &
        &                                                                             status
@@ -85,15 +83,7 @@ program Test_Stellar_Populations_Luminosities
   parameters=inputParameters()
   call eventsHooksInitialize()
   call displayVerbositySet  (verbosityLevelWorking)
-  ! Ensure that we have the required stellar population spectra file.
-  fileName              =inputPath(pathTypeDataDynamic)//'stellarPopulations/SSP_Spectra_BC2003_lowResolution_imfSalpeter.hdf5'
   fileNameBruzualCharlot=inputPath(pathTypeDataStatic )//"stellarPopulations/bc2003_lr_m72_salp_ssp.magnitude_F121.txt"
-  call Directory_Make(fileName)
-  if (.not.File_Exists(fileName))                                                                          &
-       & call download(                                                                                    &
-       &               "https://drive.google.com/uc?export=download&id=1DI52tMO4PEN-eGk79-0w2BHu9yaEcFMp", &
-       &               char(fileName)                                                                      &
-       &              )
   ! Begin parsing the Bruzual & Charlot model file.
   open(newunit=bc2003,file=char(fileNameBruzualCharlot),status='old',form='formatted',iostat=status)
   do i=1,6
@@ -117,6 +107,7 @@ program Test_Stellar_Populations_Luminosities
   fileNameTracks     =inputPath(pathTypeDataStatic )//'stellarAstrophysics/Stellar_Tracks_Padova.hdf5'
   fileNameSpectra    =inputPath(pathTypeDataStatic )//'stellarPopulations/SSP_Spectra_BC2003_lowResolution_imfSalpeter.hdf5'
   pathStore          =inputPath(pathTypeDataDynamic)//'stellarPopulations'
+  call Directory_Make(pathStore)
   ! Construct cosmology and stellar populations.
   cosmologyParameters_                   =cosmologyParametersSimple                     (                                                                 &
        &                                                                                 OmegaMatter                          =OmegaMatter              , &


### PR DESCRIPTION
Found while working on #1455: `scripts/aux/linkChecker.py` lists `./source` with `os.listdir`, so it only ever sees files at the *top* of that directory. Since `source/` was reorganized into a directory hierarchy that is **3 files out of 2001**, and essentially every URL embedded in the source has gone unchecked — which is why the 74 dead Bugzilla links fixed in #1455 sat there unreported.

The sweep collects **1** URL today. It should collect **192**.

## The fix

Walk the tree, in a `scan_sources` function so the behavior is testable.

## What walking the tree exposed

Doing that exercised the URL *extraction* against the bulk of the source for the first time, and it turns out three forms produce a "URL" that is not one. Each would have been reported as a broken link. Of 164 URLs probed, 53 failed — all but 6 of them artifacts:

| Form | Problem | Example |
| --- | --- | --- |
| RST link target inside an XML directive | delimiters are written `&lt;`/`&gt;`, which the URL pattern cannot see, so unescaping leaves a `>` stuck on the end | `https://www.roe.ac.uk/~jap/haloes/>` |
| trailing punctuation + enclosing paren | the two interleave, and one pass of each leaves the other behind | `.../450/meta.` |
| Fortran string concatenation | the literal is only a *fragment*; no complete URL exists to check | `https://github.com/cmbant/CAMB/archive/refs/tags/` |

Concatenated fragments are skipped rather than guessed at — missing a link is much cheaper than a standing false alarm.

Two further groups were failing while working exactly as intended, so they are now excluded or tolerated:

- **RFC 2606 reserved names** (`.invalid`, `example.com`/`.net`/`.org`) — used in the source for URLs that are deliberately not real, e.g. the download system test's shell-injection payloads and its dummy download target.
- **HTTP 403 from `math.stackexchange.com`, `goldbook.iupac.org`, `journals.aps.org`** — these block the checker at the CDN (verified: still 403 with a browser-like user-agent) while serving the page to ordinary clients. This is precisely the case already handled for `openmp.org`, so that host's inline special case is folded into the same list.

With the extraction fixes and the reserved-domain exclusions in place, **6 of 139 probed URLs fail — and all 6 are real, not artifacts**:

| URL | Status |
| --- | --- |
| `icc.dur.ac.uk/.../genmf_readme.html` | 404 — dead page |
| `las.osaka-sandai.ac.jp/~inoue/ANAIGM/ANAIGM.tar.gz` | 404 — dead page |
| `drive.google.com/uc?...1DI52tMO4PEN...` | 404 — dead page |
| `math.stackexchange.com/questions/40713/...` | 403 — CDN block |
| `goldbook.iupac.org/terms/view/B00598` | 403 — CDN block |
| `journals.aps.org/prl/abstract/10.1103/PhysRevLett.121.211302` | 403 — CDN block |

The probe was run *before* the tolerated-403 list was added, which is why all 6 appear here. The three 403s are the CDN blocks described above and are now tolerated, so **3 failures remain with the final code** — the three dead pages below.

## The three dead links, now resolved

All three are fixed in the second commit, so this PR leaves no known broken link behind:

| Link | Resolution |
| --- | --- |
| `icc.dur.ac.uk/.../genmf_readme.html` | Page is gone; repointed at the [Wayback Machine capture](https://web.archive.org/web/20250711045335/http://icc.dur.ac.uk/Research/PublicDownloads/genmf_readme.html) (verified HTTP 200). |
| `las.osaka-sandai.ac.jp/~inoue/ANAIGM/ANAIGM.tar.gz` | Tarball is gone and no archived copy exists. It records the provenance of the data the test compares against, so it is kept, annotated as dead in the source, and excluded from the checker. |
| `drive.google.com/uc?...` | Removed. See below — it was dead code fetching a dead URL. |

### The Google Drive download was dead code

The test downloaded `stellarPopulations/SSP_Spectra_BC2003_lowResolution_imfSalpeter.hdf5` into the **dynamic** datasets path — but that file is present in the **static** datasets, and the test already reads it from there (`fileNameSpectra`). Nothing ever read the downloaded copy. So the download is removed, along with the now-unused `fileName` variable and the `File_Exists`/`download` imports.

One subtlety worth a reviewer's eye: `Directory_Make(fileName)` had a second effect. Given a *file* path it creates each intermediate directory — including `<dynamic>/stellarPopulations`, which is `pathStore`, where the test stores its results — and then goes on to `mkdir` the full path, creating a *directory* named `SSP_Spectra_...hdf5` (which is also why `File_Exists` then returned true and the dead download never actually fired). Removing the call therefore required creating `pathStore` explicitly, which is what was meant in the first place.

> [!IMPORTANT]
> The Fortran changes are **not compile-tested**. The development box used has gfortran 13.3.0 (Galacticus requires ≥ 16) and no HDF5 headers, so the build fails long before reaching these files. Please confirm `tests.stellar_populations.luminosities.exe` builds and passes on a suitable toolchain.

## Also: the `vX.Y.Z` placeholder

The most recent Link-Check run failed on `https://galacticus.readthedocs.io/en/vX.Y.Z/`. That appears in the "Versions and Releases" page of the developer guide, where it names the *form* of a per-release documentation URL rather than any actual release — a placeholder, not a link — so it is now excluded. A real per-version URL (`.../en/v1.2.3/`) is still checked.

## Impact on the job

In a CI checkout (where the generated documentation pages do not exist) the curl-checked URL count goes from ~294 to ~451, roughly 3 minutes more runtime. The job already uses `continue-on-error` and requires 3 *consecutive* failures before flagging a URL, so a transient failure in the newly-covered set will not turn it red.

## Verification

New unit tests (`scripts/aux/tests/test_link_checker.py`, 22 cases) cover the tree walk, file selection, the source locations recorded for each URL, all three extraction fixes, the reserved-domain exclusions and the tolerated 403s. 36 aux tests pass. Every URL the fixed sweep collects was probed with the checker's own curl options to produce the numbers above.

---

Depends on nothing, but pairs naturally with #1455 — that PR repairs the 74 dead Bugzilla URLs which this PR would otherwise start reporting.

Drafted with assistance from Claude; to be reviewed and verified by a human before merge, per [CONTRIBUTING.md](https://github.com/galacticusorg/galacticus/blob/master/CONTRIBUTING.md#ai-assisted-contributions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1YXEsVCw2mGzmvucFceFm
