### PR TITLE
fix: Guard the `virialOrbitLossCone` environmental boost factor against 0/0

### DIFF
--- a/source/satellites/merging/virial_orbits/loss_cone.F90
+++ b/source/satellites/merging/virial_orbits/loss_cone.F90
@@ -700,7 +700,7 @@ contains
          &                                                                               massEnvironment                                , radiusEnvironment                         , &
          &                                                                               jacobianFactor                                 , jacobianSign                              , &
          &                                                                               radiusEvaluateLagrangian                       , overdensityEnvironmentMinimum             , &
-         &                                                                               energyOrbitDoubled
+         &                                                                               energyOrbitDoubled                             , normalizationEnvironment
     type            (interpolator                  )                    , allocatable :: interpolatorVelocityDispersionLinear
     type            (integrator                    )                    , allocatable :: integratorEnvironment                          , integratorEnvironmentNormalizer
     
@@ -821,7 +821,7 @@ contains
        countTotal=countTotal+count(.not.isComputed(iHost,1:iHost))
     end do
     countProgress=0
-    !$omp parallel private(iHost,iSatellite,massHost,massSatellite,tree,nodeHost,nodeSatellite,basicHost,basicSatellite,radiusVirialHost,velocityVirialHost,velocityDispersionLinear,indexVelocityRadial,indexVelocityTangential,velocityRadialVirial,velocityTangentialVirial,countVelocityRadialInfall,indexVelocityRadialInfall,velocityRadialInfall,radiusInfallTerm1,radiusInfallTerm2,radiiEvaluation,iEvaluate,radiusEvaluateVirial,timeEvaluate,radiusApocenterVirial,radiusPericenterVirial,timeOfFlightVirial,timeOfFlight,radiusEvaluate,radiusEvaluateComoving,velocityDispersionEvaluate,velocityRadialMeanEvaluate,velocityDispersionRadialEvaluateVirial,velocityDispersionTangentialEvaluateVirial,velocityMeanRadialEvaluateVirial,velocityTangentialInfall,jacobianFactor,jacobianDeterminant,distributionFunction,interpolatorVelocityDispersionLinear,integratorEnvironment,integratorEnvironmentNormalizer,factorEnvironmental,massEnvironment,radiusEnvironment,overdensityEnvironmentMinimum,energyOrbitDoubled)
+    !$omp parallel private(iHost,iSatellite,massHost,massSatellite,tree,nodeHost,nodeSatellite,basicHost,basicSatellite,radiusVirialHost,velocityVirialHost,velocityDispersionLinear,indexVelocityRadial,indexVelocityTangential,velocityRadialVirial,velocityTangentialVirial,countVelocityRadialInfall,indexVelocityRadialInfall,velocityRadialInfall,radiusInfallTerm1,radiusInfallTerm2,radiiEvaluation,iEvaluate,radiusEvaluateVirial,timeEvaluate,radiusApocenterVirial,radiusPericenterVirial,timeOfFlightVirial,timeOfFlight,radiusEvaluate,radiusEvaluateComoving,velocityDispersionEvaluate,velocityRadialMeanEvaluate,velocityDispersionRadialEvaluateVirial,velocityDispersionTangentialEvaluateVirial,velocityMeanRadialEvaluateVirial,velocityTangentialInfall,jacobianFactor,jacobianDeterminant,distributionFunction,interpolatorVelocityDispersionLinear,integratorEnvironment,integratorEnvironmentNormalizer,factorEnvironmental,normalizationEnvironment,massEnvironment,radiusEnvironment,overdensityEnvironmentMinimum,energyOrbitDoubled)
     allocate(tree                                                                          )
     allocate(     cosmologyFunctions_            ,mold=self%cosmologyFunctions_            )
     allocate(     cosmologyParameters_           ,mold=self%cosmologyParameters_           )
@@ -952,10 +952,23 @@ contains
        ! Compute host virial properties.
        radiusVirialHost  =darkMatterHaloScale_%radiusVirial  (nodeHost)
        velocityVirialHost=darkMatterHaloScale_%velocityVirial(nodeHost)
-       ! Compute the environmental boost factor for velocity dispersion.
-       timeEvaluate_      =+self                           %time
-       factorEnvironmental=+integratorEnvironment          %integrate(overdensityEnvironmentMinimum,haloEnvironment_%overdensityLinearMaximum()) &
-            &              /integratorEnvironmentNormalizer%integrate(overdensityEnvironmentMinimum,haloEnvironment_%overdensityLinearMaximum())
+       ! Compute the environmental boost factor for velocity dispersion. This is the mean of (1+δ)^μ over environmental
+       ! overdensity, weighted by the product of the halo mass function, the branching rate, and the environmental
+       ! overdensity PDF. Since the mass lattice is deliberately epoch-independent (see "massTableMinimum" and
+       ! "massTableMaximum"), every tabulation---no matter how early the epoch at which it is built---includes hosts as
+       ! massive as 10¹⁵ M☉. At sufficiently early epochs such a host lies so far into the exponential tail of the halo
+       ! mass function that the mass function and branching rate underflow to exactly zero at every overdensity in the
+       ! range of integration. That product is a factor of both integrands, so both integrals then evaluate to exactly
+       ! zero and the ratio is an invalid operation (0/0), not a division by zero (issue #1426). With no weight anywhere
+       ! the appropriate limit is simply no environmental boost, i.e. unity.
+       timeEvaluate_           =+self                           %time
+       normalizationEnvironment=+integratorEnvironmentNormalizer%integrate(overdensityEnvironmentMinimum,haloEnvironment_%overdensityLinearMaximum())
+       if (normalizationEnvironment > 0.0d0) then
+          factorEnvironmental  =+integratorEnvironment          %integrate(overdensityEnvironmentMinimum,haloEnvironment_%overdensityLinearMaximum()) &
+               &                /normalizationEnvironment
+       else
+          factorEnvironmental  =+1.0d0
+       end if
        ! Iterate over satellite masses.
        do iSatellite=1,countMasses          
           ! Only consider satellites less (or equally) massive than their host.

--- a/testSuite/parameters/test-virial-orbit-loss-cone-early-epoch.xml
+++ b/testSuite/parameters/test-virial-orbit-loss-cone-early-epoch.xml
@@ -1,0 +1,346 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Regression test for the "lossCone" virial orbit class at early epochs (issue #1426).     -->
+<!--                                                                                          -->
+<!-- The mass lattice on which this class tabulates is deliberately epoch-independent, so     -->
+<!-- every tabulation includes hosts as massive as 1.0e15 M_Solar however early the epoch     -->
+<!-- at which it is built. At sufficiently early epochs the halo mass function and the        -->
+<!-- branching rate for such a host underflow to exactly zero across the whole range of       -->
+<!-- environmental overdensity, which made both the environmental boost factor integral       -->
+<!-- and its normalizing integral exactly zero, and so their ratio an invalid operation       -->
+<!-- (0/0). This model builds a single small tree based at z=10, which forces the first       -->
+<!-- tabulation to be built at that epoch.                                                    -->
+<!--                                                                                          -->
+<!-- Andrew Benson                                                                            -->
+<!--                                                                                          -->
+<!-- 03-September-2026                                                                        -->
+
+<parameters>
+  <formatVersion>2</formatVersion>
+  <lastModified revision="3c57050dfc00cdbc7396b4210a9dc404b9fda859" time="2026-08-23T04:06:13"/>
+
+
+  <!-- Component selection -->
+  <componentBasic value="standard"/>
+  <componentBlackHole value="standard"/>
+  <componentDarkMatterProfile value="scale"/>
+  <componentDisk value="standard">
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionDisk value="exponentialDisk">
+      <dimensionless value="true"/>
+    </massDistributionDisk>
+  </componentDisk>
+  <componentHotHalo value="standard">
+    <starveSatellites value="false"/>
+  </componentHotHalo>
+  <componentSatellite value="standard"/>
+  <componentSpheroid value="standard">
+    <ratioAngularMomentumScaleRadius value="0.5"/>
+    <efficiencyEnergeticOutflow value="1.0e-2"/>
+    <toleranceAbsoluteMass value="1.0e-6"/>
+    <massDistributionSpheroid value="hernquist">
+      <dimensionless value="true"/>
+    </massDistributionSpheroid>
+  </componentSpheroid>
+  <componentSpin value="scalar"/>
+
+  <!-- Cosmological parameters and options -->
+  <cosmologyFunctions value="matterLambda"/>
+  <cosmologyParameters value="simple">
+    <HubbleConstant value="70.2"/>
+    <OmegaMatter value="0.2725"/>
+    <OmegaDarkEnergy value="0.7275"/>
+    <OmegaBaryon value="0.0455"/>
+    <temperatureCMB value="2.72548"/>
+  </cosmologyParameters>
+
+  <!-- Power spectrum options -->
+  <transferFunction value="eisensteinHu1999">
+    <neutrinoNumberEffective value="3.046"/>
+    <neutrinoMassSummed value="0.000"/>
+  </transferFunction>
+  <powerSpectrumPrimordial value="powerLaw">
+    <index value="0.961"/>
+    <wavenumberReference value="1.000"/>
+    <running value="0.000"/>
+  </powerSpectrumPrimordial>
+  <powerSpectrumPrimordialTransferred value="simple"/>
+  <cosmologicalMassVariance value="filteredPower">
+    <sigma_8 value="0.807"/>
+  </cosmologicalMassVariance>
+
+  <!-- Structure formation options -->
+  <linearGrowth value="collisionlessMatter"/>
+  <haloMassFunction value="tinker2008"/>
+  <criticalOverdensity value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+  <virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
+
+  <!-- Merger tree building options -->
+  <mergerTreeSeeds value="random"/>
+  <mergerTreeConstructor value="build">
+    <!-- Base the tree at an early epoch, so that the tabulation is first built there. -->
+    <redshiftBase value="10.0"/>
+  </mergerTreeConstructor>
+  <mergerTreeBuilder value="cole2000">
+    <accretionLimit value="0.1"/>
+    <mergeProbability value="0.1"/>
+  </mergerTreeBuilder>
+  <mergerTreeBranchingProbability value="parkinsonColeHelly">
+    <G0 value="+0.57"/>
+    <gamma1 value="+0.38"/>
+    <gamma2 value="-0.01"/>
+    <accuracyFirstOrder value="+0.10"/>
+  </mergerTreeBranchingProbability>
+  <mergerTreeBuildMasses value="fixedMass">
+    <massTree value="1.0e12"/>
+    <treeCount value="1"/>
+  </mergerTreeBuildMasses>
+  <mergerTreeMassResolution value="fixed">
+    <massResolution value="1.0e10"/>
+  </mergerTreeMassResolution>
+  <!-- Substructure hierarchy options -->
+  <mergerTreeNodeMerger value="singleLevelHierarchy"/>
+
+  <!-- Dark matter halo structure options -->
+  <darkMatterProfileDMO value="NFW"/>
+  <darkMatterProfileScaleRadius value="concentrationLimiter">
+    <concentrationMinimum value="  4.0"/>
+    <concentrationMaximum value="100.0"/>
+    <darkMatterProfileScaleRadius value="concentration"/>
+  </darkMatterProfileScaleRadius>
+  <darkMatterProfileConcentration value="gao2008"/>
+  <haloSpinDistribution value="bett2007">
+    <alpha value="2.509"/>
+    <lambda0 value="0.04326"/>
+  </haloSpinDistribution>
+
+  <!-- Halo accretion options -->
+  <accretionHalo value="simple">
+    <redshiftReionization value="10.5"/>
+    <velocitySuppressionReionization value="35.0"/>
+  </accretionHalo>
+
+  <!-- Hot halo gas cooling model options -->
+  <hotHaloMassDistribution value="betaProfile"/>
+  <hotHaloTemperatureProfile value="virial"/>
+  <hotHaloMassDistributionCoreRadius value="virialFraction">
+    <coreRadiusOverVirialRadius value="0.3"/>
+  </hotHaloMassDistributionCoreRadius>
+  <coolingSpecificAngularMomentum value="constantRotation">
+    <sourceAngularMomentumSpecificMean value="hotGas"/>
+    <sourceNormalizationRotation value="hotGas"/>
+  </coolingSpecificAngularMomentum>
+  <hotHaloOutflowReincorporation value="haloDynamicalTime">
+    <multiplier value="5.0"/>
+  </hotHaloOutflowReincorporation>
+  <hotHaloOutflowStripping value="standard">
+     <efficiency value="0.1"/>
+  </hotHaloOutflowStripping>
+  <coolingInfallTorque value="fixed">
+     <fractionLossAngularMomentum value="0.3"/>
+  </coolingInfallTorque>
+  <coolingFunction value="atomicCIECloudy"/>
+  <coolingRadius value="simple"/>
+  <coolingRate value="whiteFrenk1991">
+    <velocityCutOff value="10000"/>
+  </coolingRate>
+  <coolingTime value="simple">
+    <degreesOfFreedom value="3.0"/>
+  </coolingTime>
+  <coolingTimeAvailable value="whiteFrenk1991">
+    <ageFactor value="0"/>
+  </coolingTimeAvailable>
+  <circumgalacticMediumHeating value="AGNFeedback"/>
+  <!-- Hot halo ram pressure stripping options -->
+  <hotHaloRamPressureStripping value="font2008"/>
+  <hotHaloRamPressureForce value="font2008"/>
+  <hotHaloRamPressureTimescale value="ramPressureAcceleration"/>
+  <!-- Galactic structure solver options -->
+  <galacticStructureSolver value="equilibrium"/>
+  <darkMatterProfile value="adiabaticGnedin2004">
+    <A value="0.73"/>
+    <omega value="0.7"/>
+  </darkMatterProfile>
+  <!-- Star formation rate options -->
+  <starFormationRateDisks value="intgrtdSurfaceDensity"/>
+  <starFormationRateSurfaceDensityDisks value="krumholz2009">
+    <frequencyStarFormation value="0.385"/>
+    <clumpingFactorMolecularComplex value="5.000"/>
+    <molecularFractionFast value="true"/>
+  </starFormationRateSurfaceDensityDisks>
+  <starFormationRateSpheroids value="timescale">
+    <starFormationTimescale value="dynamicalTime">
+      <efficiency value="0.04"/>
+      <exponentVelocity value="2.0"/>
+      <timescaleMinimum value="0.001"/>
+    </starFormationTimescale>
+  </starFormationRateSpheroids>
+
+  <!-- Stellar populations options -->
+  <stellarPopulationProperties value="instantaneous"/>
+  <stellarPopulationSpectra value="FSPS"/>
+  <stellarPopulationSelector value="fixed"/>
+
+  <initialMassFunction value="chabrier2001"/>
+  <stellarPopulation value="standard">
+    <recycledFraction value="0.46"/>
+    <metalYield value="0.035"/>
+  </stellarPopulation>
+
+  <!-- AGN feedback options -->
+  <blackHoleWind value="ciotti2009">
+    <efficiencyWind value="0.0024"/>
+    <efficiencyWindScalesWithEfficiencyRadiative value="true"/>
+  </blackHoleWind>
+  <blackHoleCGMHeating value="jetPower">
+    <efficiencyRadioMode value="1.0"/>
+  </blackHoleCGMHeating>
+
+  <!-- Accretion disk properties -->
+  <accretionDisks value="switched">
+    <accretionRateThinDiskMaximum value="0.30"/>
+    <accretionRateThinDiskMinimum value="0.01"/>
+    <scaleADAFRadiativeEfficiency value="true"/>
+    <accretionDisksShakuraSunyaev value="shakuraSunyaev"/>
+    <accretionDisksADAF value="ADAF">
+      <efficiencyRadiationType value="thinDisk"/>
+      <adiabaticIndex value="1.444"/>
+      <energyOption value="pureADAF"/>
+      <efficiencyRadiation value="0.01"/>
+      <viscosityOption value="fit"/>
+    </accretionDisksADAF>
+  </accretionDisks>
+
+  <!-- Black hole options -->
+  <blackHoleAccretionRate value="standard">
+    <bondiHoyleAccretionEnhancementSpheroid value="5.0"/>
+    <bondiHoyleAccretionEnhancementHotHalo value="6.0"/>
+    <bondiHoyleAccretionHotModeOnly value="true"/>
+    <bondiHoyleAccretionTemperatureSpheroid value="100.0"/>
+  </blackHoleAccretionRate>
+  <blackHoleBinaryMerger value="rezzolla2008"/>
+
+  <!-- Galaxy merger options -->
+  <virialOrbit value="lossCone">
+    <!-- A deliberately coarse tabulation: this test exercises the code paths of this class, it does not aim  -->
+    <!-- to produce a converged orbital distribution. The velocity grid (0, 0.5, 1, 1.5, 2) is chosen to      -->
+    <!-- include both degenerate cases which the class must special-case: purely radial orbits (v_theta=0),   -->
+    <!-- for which the pericentric radius vanishes, and marginally bound orbits (v_r^2+v_theta^2=2, i.e.      -->
+    <!-- v_r=v_theta=1), for which the turning-point quadratic degenerates. Both were division-by-zero        -->
+    <!-- floating point exceptions prior to the fixes for issue #1321.                                        -->
+    <velocityMinimum value="0.0"/>
+    <velocityMaximum value="2.0"/>
+    <countVelocitiesPerUnit value="2"/>
+    <countMassesPerDecade value="1"/>
+    <correlationFunctionTwoPoint value="powerSpectrumTransform">
+      <powerSpectrum value="standard"/>
+    </correlationFunctionTwoPoint>
+    <cosmologicalVelocityField value="filteredPower">
+      <correlationFunctionTwoPoint value="powerSpectrumTransform">
+        <powerSpectrum value="standard"/>
+      </correlationFunctionTwoPoint>
+    </cosmologicalVelocityField>
+  </virialOrbit>
+  <satelliteMergingTimescales value="jiang2008">
+    <timescaleMultiplier value="0.75"/>
+  </satelliteMergingTimescales>
+  <mergerMassMovements value="simple">
+    <destinationGasMinorMerger value="spheroid"/>
+    <massRatioMajorMerger value="0.25"/>
+  </mergerMassMovements>
+  <mergerRemnantSize value="cole2000">
+    <energyOrbital value="1"/>
+  </mergerRemnantSize>
+
+  <!-- Node evolution and physics -->
+  <nodeOperator value="multi">
+    <!-- Cosmological epoch -->
+    <nodeOperator value="cosmicTime"/>
+    <!-- DMO evolution -->
+    <nodeOperator value="DMOInterpolate"/>
+    <!-- Halo concentrations -->
+    <nodeOperator value="darkMatterProfileScaleSet"/>
+    <nodeOperator value="darkMatterProfileScaleInterpolate"/>
+    <!-- Halo spins -->
+    <nodeOperator value="haloAngularMomentumRandom">
+      <factorReset value="2.0"/>
+    </nodeOperator>
+    <nodeOperator value="haloAngularMomentumInterpolate"/>
+    <!-- Satellite evolution -->
+    <nodeOperator value="satelliteMergingTime"/>
+    <nodeOperator value="satelliteMassLoss"/>
+    <!-- Star formation -->
+    <nodeOperator value="starFormationDisks"/>
+    <nodeOperator value="starFormationSpheroids"/>
+    <!--Stellar feedback outflows-->
+    <nodeOperator value="stellarFeedbackDisks">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="250.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <nodeOperator value="stellarFeedbackSpheroids">
+      <stellarFeedbackOutflows value="rateLimit">
+        <timescaleOutflowFractionalMinimum value="0.001"/>
+        <stellarFeedbackOutflows value="powerLaw">
+          <velocityCharacteristic value="100.0"/>
+          <exponent value="3.5"/>
+        </stellarFeedbackOutflows>
+      </stellarFeedbackOutflows>
+    </nodeOperator>
+    <!-- Bar instability in galactic disks -->
+    <nodeOperator value="barInstability">
+      <galacticDynamicsBarInstability value="efstathiou1982">
+	<stabilityThresholdGaseous value="0.7"/>
+	<stabilityThresholdStellar value="1.1"/>
+      </galacticDynamicsBarInstability>
+    </nodeOperator>
+    <!-- Black hole physics -->
+    <nodeOperator value="blackHolesSeed">
+      <blackHoleSeeds value="fixed">
+        <mass value="100"/>
+        <spin value="0"/>
+      </blackHoleSeeds>
+    </nodeOperator>
+    <nodeOperator value="blackHolesAccretion"/>
+    <nodeOperator value="blackHolesWinds"/>
+    <!-- CGM physics -->
+    <nodeOperator value="CGMAccretion">
+      <allowNegativeCGMMass value="true"/>
+      <angularMomentumAlwaysGrows value="false"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOutflowReincorporation">
+      <includeSatellites value="true"/>
+    </nodeOperator>
+    <nodeOperator value="CGMCoolingHeating">
+      <component value="disk"/>
+      <coolingFrom value="currentNode"/>
+      <excessHeatDrivesOutflow value="true"/>
+      <rateMaximumExpulsion value="1.0"/>
+    </nodeOperator>
+    <nodeOperator value="CGMOuterRadiusRamPressureStripping"/>
+  </nodeOperator>
+
+  <!-- Numerical tolerances -->
+  <mergerTreeNodeEvolver value="standard">
+    <odeToleranceAbsolute value="0.01"/>
+    <odeToleranceRelative value="0.01"/>
+  </mergerTreeNodeEvolver>
+
+  <mergerTreeEvolver value="standard">
+    <timestepHostAbsolute value="1.0"/>
+    <timestepHostRelative value="0.1"/>
+  </mergerTreeEvolver>
+
+  <!-- Output options -->
+  <outputTimes value="list">
+    <redshifts value="10.0"/>
+  </outputTimes>
+  <outputFileName value="testSuite/outputs/test-virial-orbit-loss-cone-early-epoch.hdf5"/>
+  <mergerTreeOutputter value="standard">
+    <outputReferences value="false"/>
+  </mergerTreeOutputter>
+
+</parameters>

--- a/testSuite/test-virial-orbit-loss-cone.py
+++ b/testSuite/test-virial-orbit-loss-cone.py
@@ -1,20 +1,28 @@
 #!/usr/bin/env python3
-"""Regression test for the ``lossCone`` virial orbit class (issue #1321).
+"""Regression test for the ``lossCone`` virial orbit class (issues #1321 and #1426).
 
 The class deadlocked and could not be run at all. The defects it carried were
 reachable only once a model actually drove a tabulation, and they failed in
 three distinct ways---an unbreakable hang, a segmentation fault, and floating
-point exceptions---so this test runs a small model which uses the class and
+point exceptions---so this test runs small models which use the class and
 checks for all three:
 
-* the run is given a wall-clock timeout, so a re-introduced deadlock fails the
+* each run is given a wall-clock timeout, so a re-introduced deadlock fails the
   test promptly rather than hanging the CI job until its own (multi-hour)
   timeout;
-* the run must exit cleanly, with no error markers in its log;
+* each run must exit cleanly, with no error markers in its log;
 * the resulting galaxy properties must all be finite, so that a re-introduced
   divide-by-zero which is *not* trapped cannot pass silently as a NaN.
 
-The model is run multi-threaded because the class tabulates inside a nested
+Two models are run. The first (issue #1321) tabulates at the epochs reached by
+trees based at z=0, with a velocity grid chosen to sample the degenerate orbits
+which must be special-cased. The second (issue #1426) is based at z=10, which
+forces the tabulation to be built at an epoch so early that the halo mass
+function and branching rate underflow to zero for the most massive hosts on the
+(epoch-independent) mass lattice, making the environmental boost factor a 0/0
+invalid operation.
+
+Each model is run multi-threaded because the class tabulates inside a nested
 OpenMP parallel region, and that nesting is what surfaced both the original
 deadlock and a cache-file collision between threads.
 
@@ -28,85 +36,111 @@ import sys
 import h5py
 import numpy as np
 
-# The tabulation is coarse (see the parameter file), but it is still by far the dominant cost of this model, which takes
-# around 15s locally. Allow ample headroom over that so that a slow runner does not produce a spurious failure, while still
-# failing far sooner than the CI job timeout if the class deadlocks.
+# The tabulations are coarse (see the parameter files), but they are still by far the dominant cost of these models, which
+# take around 15s and 105s respectively locally. Allow ample headroom over that so that a slow runner does not produce a
+# spurious failure, while still failing far sooner than the CI job timeout if the class deadlocks.
 timeoutSeconds = 900
 
-pathParameters      = os.path.abspath("parameters/test-virial-orbit-loss-cone.xml" )
-pathOutputDirectory = os.path.abspath("outputs"                                    )
-pathOutputLog       = os.path.abspath("outputs/test-virial-orbit-loss-cone.log"     )
-pathOutputModel     = os.path.abspath("outputs/test-virial-orbit-loss-cone.hdf5"    )
+models = [
+    {
+        "label"     : "default epoch",
+        "parameters": "parameters/test-virial-orbit-loss-cone.xml",
+        "model"     : "outputs/test-virial-orbit-loss-cone.hdf5",
+        "log"       : "outputs/test-virial-orbit-loss-cone.log",
+    },
+    {
+        "label"     : "early epoch",
+        "parameters": "parameters/test-virial-orbit-loss-cone-early-epoch.xml",
+        "model"     : "outputs/test-virial-orbit-loss-cone-early-epoch.hdf5",
+        "log"       : "outputs/test-virial-orbit-loss-cone-early-epoch.log",
+    },
+]
 
+pathOutputDirectory = os.path.abspath("outputs")
 os.makedirs(pathOutputDirectory,exist_ok=True)
-if os.path.exists(pathOutputModel):
-    os.remove(pathOutputModel)
 
-# Run the model, under a timeout so that a deadlock is reported as a failure.
-print("Running model...")
-environment                    = os.environ.copy()
-environment["OMP_NUM_THREADS"] = environment.get("OMP_NUM_THREADS","4")
-with open(pathOutputLog,"w") as log:
-    try:
-        status = subprocess.run(
-            f"cd ..; ./Galacticus.exe {pathParameters}",
-            stdout  = log,
-            stderr  = log,
-            shell   = True,
-            env     = environment,
-            timeout = timeoutSeconds,
-        )
-    except subprocess.TimeoutExpired:
-        print(f"FAILED: model run did not complete within {timeoutSeconds}s - the lossCone class may be deadlocked")
-        sys.exit(0)
-print("...done ("+str(status)+")")
-if status.returncode != 0:
-    print("FAILED: model run:")
-    subprocess.run(f"cat {pathOutputLog}",shell=True)
-    sys.exit(0)
 
-# Check the log for errors. A floating point exception (which is how several of the defects in this class manifested) is
-# reported through this path.
-print("Checking for errors...")
-status = subprocess.run(
-    "grep -q -i"
-    " -e fatal"
-    " -e aborted"
-    " -e \"floating point exception\""
-    " -e \"Galacticus experienced an error in the GSL library\""
-    f" {pathOutputLog}",
-    shell=True,
-)
-if status.returncode == 0:
-    print("FAILED: model run (errors):")
-    subprocess.run(f"cat {pathOutputLog}",shell=True)
-    sys.exit(0)
-print("SUCCESS: model run")
+def modelRun(model):
+    """Run one model, returning True if it completed cleanly."""
+    pathParameters = os.path.abspath(model["parameters"])
+    pathOutputLog  = os.path.abspath(model["log"       ])
+    print("Running model ("+model["label"]+")...")
+    environment                    = os.environ.copy()
+    environment["OMP_NUM_THREADS"] = environment.get("OMP_NUM_THREADS","4")
+    with open(pathOutputLog,"w") as log:
+        try:
+            status = subprocess.run(
+                f"cd ..; ./Galacticus.exe {pathParameters}",
+                stdout  = log,
+                stderr  = log,
+                shell   = True,
+                env     = environment,
+                timeout = timeoutSeconds,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"FAILED: model run ({model['label']}) did not complete within {timeoutSeconds}s - the lossCone class may be deadlocked")
+            return False
+    print("...done ("+str(status)+")")
+    if status.returncode != 0:
+        print("FAILED: model run ("+model["label"]+"):")
+        subprocess.run(f"cat {pathOutputLog}",shell=True)
+        return False
+    # Check the log for errors. A floating point exception (which is how several of the defects in this class manifested) is
+    # reported through this path.
+    print("Checking for errors...")
+    status = subprocess.run(
+        "grep -q -i"
+        " -e fatal"
+        " -e aborted"
+        " -e \"floating point exception\""
+        " -e \"Galacticus experienced an error in the GSL library\""
+        f" {pathOutputLog}",
+        shell=True,
+    )
+    if status.returncode == 0:
+        print("FAILED: model run ("+model["label"]+") (errors):")
+        subprocess.run(f"cat {pathOutputLog}",shell=True)
+        return False
+    print("SUCCESS: model run ("+model["label"]+")")
+    return True
 
-# Validate the output. The orbital parameters drawn from this class feed the merging satellite calculations, so a
-# non-finite orbit propagates into the galaxy properties. Checking for finiteness catches a re-introduced division by
-# zero which happens not to be trapped.
-countNodes = 0
-countBad   = 0
-with h5py.File(pathOutputModel,"r") as model:
-    for outputName, output in model["Outputs"].items():
-        if "nodeData" not in output:
-            continue
-        for propertyName, property_ in output["nodeData"].items():
-            values = property_[:]
-            if not np.issubdtype(values.dtype,np.floating):
+
+def modelValidate(model):
+    """Validate the output of one model, returning True if all properties are finite."""
+    # The orbital parameters drawn from this class feed the merging satellite calculations, so a non-finite orbit propagates
+    # into the galaxy properties. Checking for finiteness catches a re-introduced division by zero which happens not to be
+    # trapped.
+    pathOutputModel = os.path.abspath(model["model"])
+    countNodes = 0
+    countBad   = 0
+    with h5py.File(pathOutputModel,"r") as modelFile:
+        for outputName, output in modelFile["Outputs"].items():
+            if "nodeData" not in output:
                 continue
-            if propertyName == "nodeIndex":
-                continue
-            countNodes = max(countNodes,values.size)
-            if not np.all(np.isfinite(values)):
-                countBad += 1
-                print(f"FAILED: non-finite values in {outputName}/nodeData/{propertyName}")
+            for propertyName, property_ in output["nodeData"].items():
+                values = property_[:]
+                if not np.issubdtype(values.dtype,np.floating):
+                    continue
+                if propertyName == "nodeIndex":
+                    continue
+                countNodes = max(countNodes,values.size)
+                if not np.all(np.isfinite(values)):
+                    countBad += 1
+                    print(f"FAILED: non-finite values in {outputName}/nodeData/{propertyName} ({model['label']})")
+    if countNodes == 0:
+        print("FAILED: model ("+model["label"]+") produced no galaxies - the test is not exercising the lossCone class")
+        return False
+    if countBad > 0:
+        return False
+    print(f"SUCCESS: virial orbit lossCone ({model['label']}; {countNodes} galaxies, all properties finite)")
+    return True
 
-if countNodes == 0:
-    print("FAILED: model produced no galaxies - the test is not exercising the lossCone class")
-    sys.exit(0)
-if countBad > 0:
-    sys.exit(0)
 
-print(f"SUCCESS: virial orbit lossCone ({countNodes} galaxies, all properties finite)")
+for model in models:
+    pathOutputModel = os.path.abspath(model["model"])
+    if os.path.exists(pathOutputModel):
+        os.remove(pathOutputModel)
+    if modelRun(model):
+        modelValidate(model)
+
+sys.exit(0)


### PR DESCRIPTION
Fixes #1426.

## The defect

`virialOrbitLossCone` aborts with a floating point exception when its tabulation is built at a sufficiently early epoch. The exception is an **invalid operation** (a literal `0/0`), not a divide-by-zero, and it occurs at the environmental boost factor in `lossConeTabulate`.

The two integrands differ only by a factor of `(1+δ_nl)**μ`; the halo mass function, the branching rate, and the environmental overdensity PDF are common to both. Because `massTableMinimum`/`massTableMaximum` are epoch-independent module parameters — deliberately, so that any two tabulations overlap and one can always be extended to cover the other — every tabulation evaluates hosts as massive as 10¹⁵ M☉ whatever epoch it is built at. At an early epoch such a host lies so far into the exponential tail of the Sheth-Tormen mass function that `massFunction * mergerRate` underflows to exactly zero at every overdensity in the range of integration. Both integrals are then exactly zero, and their ratio is `0/0`.

## The fix

Evaluate the normalizing integral first and, when it is zero, set `factorEnvironmental` to unity. That is the correct limit: the ratio is a `massFunction * mergerRate * pdf`-weighted mean of `(1+δ_nl)**μ`, so with no weight anywhere the natural value is "no environmental boost". A comment at the guard records why both integrals vanish together.

This is the guard proposed in the issue, in preference to bounding the tabulated mass range by epoch — the latter would also remove the wasted computation on 10¹⁵ M☉ hosts at z ~ 9, but it conflicts with the epoch-independence the pinned lattice relies on.

## Regression test

`testSuite/parameters/test-virial-orbit-loss-cone-early-epoch.xml` is a new model — a single small tree (fixed mass 10¹² M☉, resolution 10¹⁰ M☉) based at z=10 — which forces the first tabulation to be built at an epoch early enough to trigger the underflow. It reaches the same failure as the reproducer in the issue but in 28s rather than ~11 minutes.

`testSuite/test-virial-orbit-loss-cone.py` now loops over both this model and the existing z=0 model (issue #1321), applying the same run/error-grep/finiteness checks to each. It still exits `0` unconditionally and signals failure through a `FAILED:` line, as the harness requires. No CI change is needed — `cicd.yml` already runs this script by name.

## Verification

- **Against a build of the unmodified source**, the new model aborts after 28s with a floating point exception whose backtrace lands on the `factorEnvironmental` ratio at `loss_cone.p.F90:1890`, matching the backtrace reported in the issue. Run through the test script, the z=0 model passes and the new model reports `FAILED: model run (early epoch)` — so the test does catch the defect.
- **Against a build carrying the fix**, both models complete cleanly: `SUCCESS: virial orbit lossCone (default epoch; 7 galaxies, all properties finite)` and `SUCCESS: virial orbit lossCone (early epoch; 10 galaxies, all properties finite)`. The whole script takes 2m18s.
- `parameters/quickTest.xml` runs clean on the fixed build (exit `0`, no error markers).

The pre-commit hook's "source formatting" warning on `loss_cone.F90` is pre-existing — the file at `f4a24f6bcc`, before any change here, also differs from `formatDeclarations.py`/`formatModuleUses.py` house style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dnn7Deq2AAseFKs8Ki51p
