### PR TITLE
refactor(massDistributions): collapse the rank-by-rank select case in sphericalTabulatedInterpolate

### DIFF
--- a/source/mass_distributions/spherical/tabulated.F90
+++ b/source/mass_distributions/spherical/tabulated.F90
@@ -902,7 +902,10 @@ contains
     double precision                                                   , dimension(2  ) :: hRadius
     integer         (c_size_t                          ), allocatable  , dimension(:  ) :: iParameters , jParameters
     double precision                                    , allocatable  , dimension(:,:) :: hParameters
-    integer         (c_size_t                          )                                :: iRadius     , jRadius
+    integer         (c_size_t                          )                                :: iRadius     , jRadius     , &
+         &                                                                                 i
+    integer         (c_size_t                          )               , dimension(3  ) :: indices
+    double precision                                                                    :: term
     type            (multiCounter                      )                                :: counter
 
     ! Compute interpolating factors. Along each axis the position of the value is found as its coordinate on the absolute
@@ -939,92 +942,30 @@ contains
     iParameters     =min(max(iParameters,1_c_size_t),tabulation%countParameters-1_c_size_t)
     hRadius    (1  )=1.0d0-hRadius    (2  )
     hParameters(1,:)=1.0d0-hParameters(2,:)
-    ! Perform the interpolation.
+    ! Perform the interpolation. The table is always of rank 4, with the trailing dimensions of extent 1 where the
+    ! corresponding parameter is unused, so padding the vector of parameter indices with 1 in those dimensions makes the sum
+    ! below correct at every rank without a rank-by-rank case. Three tabulated parameters is therefore the hard maximum.
+    if (size(parameters) > 3) call Error_Report('rank not supported'//{introspection:location})
+    ! The corners of the interpolating hypercube in the parameters form the outer loop - with `multiCounter` incrementing its
+    ! first dimension fastest - and the pair of radial nodes the inner one, and within each term the weights are multiplied in
+    ! one at a time in axis order. Both orders matter: floating point addition and multiplication are not associative, so
+    ! changing either would perturb the interpolated value in its last bits, which is precisely the sequence dependence that
+    ! this tabulation exists to remove.
     interpolated=0.0d0
+    indices     =1_c_size_t
     counter     =multiCounter(spread(2_c_size_t,1,size(parameters)))
-    select case(size(parameters))
-    case (0)
-          do jRadius=1,2
-             interpolated=+interpolated                                                 &
-                  &       +tabulation %table(                                           &
-                  &                          iRadius       +jRadius       -1_c_size_t,  &
-                  &                                                        1_c_size_t,  &
-                  &                                                        1_c_size_t,  &
-                  &                                                        1_c_size_t   &
-                  &                         )                                           &
-                  &       *hRadius          (                                           &
-                  &                                         jRadius                     &
-                  &                         )
+    do while (counter%increment())
+       jParameters                    =counter%states()
+       indices    (1:size(parameters))=iParameters+jParameters-1_c_size_t
+       do jRadius=1,2
+          term        =+tabulation%table(iRadius+jRadius-1_c_size_t,indices(1),indices(2),indices(3))*hRadius(jRadius)
+          do i=1,size(parameters)
+             term     =+term                          &
+                  &    *hParameters(jParameters(i),i)
           end do
-    case (1)
-       do while (counter%increment())
-          jParameters=counter%states()
-          do jRadius=1,2
-             interpolated=+interpolated                                                 &
-                  &       +tabulation %table(                                           &
-                  &                          iRadius       +jRadius       -1_c_size_t,  &
-                  &                          iParameters(1)+jParameters(1)-1_c_size_t,  &
-                  &                                                        1_c_size_t,  &
-                  &                                                        1_c_size_t   &
-                  &                         )                                           &
-                  &       *hRadius          (                                           &
-                  &                                         jRadius                     &
-                  &                         )                                           &
-                  &       *hParameters      (                                           &
-                  &                                         jParameters(1)           ,1 &
-                  &                         )
-          end do
+          interpolated=+interpolated+term
        end do
-    case (2)
-       do while (counter%increment())
-          jParameters=counter%states()
-          do jRadius=1,2
-             interpolated=+interpolated                                                 &
-                  &       +tabulation %table(                                           &
-                  &                          iRadius       +jRadius       -1_c_size_t,  &
-                  &                          iParameters(1)+jParameters(1)-1_c_size_t,  &
-                  &                          iParameters(2)+jParameters(2)-1_c_size_t,  &
-                  &                                                        1_c_size_t   &
-                  &                         )                                           &
-                  &       *hRadius          (                                           &
-                  &                                         jRadius                     &
-                  &                         )                                           &
-                  &       *hParameters      (                                           &
-                  &                                         jParameters(1)           ,1 &
-                  &                         )                                           &
-                  &       *hParameters      (                                           &
-                  &                                         jParameters(2)           ,2 &
-                  &                         )
-          end do
-       end do
-    case (3)
-       do while (counter%increment())
-          jParameters=counter%states()
-          do jRadius=1,2
-             interpolated=+interpolated                                                 &
-                  &       +tabulation %table(                                           &
-                  &                          iRadius       +jRadius       -1_c_size_t,  &
-                  &                          iParameters(1)+jParameters(1)-1_c_size_t,  &
-                  &                          iParameters(2)+jParameters(2)-1_c_size_t,  &
-                  &                          iParameters(3)+jParameters(3)-1_c_size_t   &
-                  &                         )                                           &
-                  &       *hRadius          (                                           &
-                  &                                         jRadius                     &
-                  &                         )                                           &
-                  &       *hParameters      (                                           &
-                  &                                         jParameters(1)           ,1 &
-                  &                         )                                           &
-                  &       *hParameters      (                                           &
-                  &                                         jParameters(2)           ,2 &
-                  &                         )                                           &
-                  &       *hParameters      (                                           &
-                  &                                         jParameters(3)           ,3 &
-                  &                         )
-          end do
-       end do
-    case default
-       call Error_Report('rank not supported'//{introspection:location})
-    end select
+    end do
     ! If logarithmic interpolation was used, inverse transform now.
     if (tabulation%logTransform) interpolated=+exp(interpolated)
     ! For quantities that are negative, invert the sign.


### PR DESCRIPTION
Closes #1419.

## What

`sphericalTabulatedInterpolate` summed over the corners of the interpolating hypercube inside a
`select case(size(parameters))` with four near-identical branches for ranks 0, 1, 2 and 3 — roughly
85 lines expressing one 15-line calculation four times. This replaces them with a single
rank-generic loop.

Two facts already established in this file make that straightforward:

* **The table is always rank 4**, with trailing dimensions of extent 1 where the corresponding
  parameter is unused. The carry-over assignment in `sphericalTabulatedTabulate` already relies on
  exactly this; the same argument applies to the interpolation, so padding the vector of parameter
  indices with `1` in the inactive dimensions makes one loop correct at every rank.
* **`multiCounter` already handles zero dimensions**, yielding exactly one iteration, so the
  `case (0)` branch — the only one that bypassed the counter — needs no special handling.

Per (b) of the issue, the `case default` guard survives as a bounds check ahead of the loop.

**23 insertions, 83 deletions.** The lattice-based computation of `iRadius`/`iParameters`/`hRadius`/
`hParameters` is untouched, and no `interpolatorMultiD` is introduced (assessed and declined in #1418).

## Preserving the value exactly

This routine exists to make interpolated values reproducible to the last bit, so the rewrite has to
be exactly value-preserving, not merely accurate. Two things are load-bearing and both are preserved:

* The original expression is unparenthesized and so evaluates strictly left to right. The weights are
  therefore accumulated one at a time in axis order, rather than gathered into a `product()`, which
  would reassociate them.
* The loop nesting — parameter corners outside, radial nodes inside, with `multiCounter` incrementing
  its first dimension fastest — is unchanged, since the accumulation order into the sum matters equally.

## Verification

Bit-for-bit equality, not agreement to a tolerance. Ranks 0 and 3 are not reachable from the same
place as 1 and 2, so coverage is assembled from what each profile actually tabulates
(`fourierTransform` appends `radiusOuterScaled`, so it sits one rank above its class):

| rank | evidence | result |
|---|---|---|
| 0 | standalone harness, 100 000 random tabulations | 0 differing trials |
| 1 | bit-dump of cored-NFW and cusp-NFW through the real code path | identical |
| 2 | bit-dump (`fourierTransform`) + `SIDM_parametric.xml`, 114 `/Outputs` datasets | identical |
| 3 | `radiusSpecifiersSoliton.xml`, 258 `/Outputs` datasets | identical |

The rank-0–3 harness drives the original branches and the replacement through the same
`multiCounter`, differing only in the loop body. The bit-dump compared **196** interpolated values —
every tabulated quantity of both profiles — as raw `int64` bit patterns from two separately linked
binaries. In each model comparison the tabulation caches were confirmed byte-identical to a pre-run
snapshot, so both builds demonstrably interpolated in the same tables.

Also passing: the 27 `tests.mass_distributions.tabulated` unit tests, including the
extension-invariance assertions at `absTol=0`; `test-SIDM-parametric.py`;
`test-radius-specifiers-soliton.py`; and `quickTest.xml`.

## Two notes for reviewers

**Bit-identity is a statement about the reference build configuration.** Neither the `Makefile` nor CI
sets `-march`, so no FMA is emitted and source order fully determines the result. Under
`-march=native`, gfortran's default `-ffp-contract=fast` makes contraction depend on inlining and
scheduling rather than on expression shape — measured over 100k inputs per rank, the form used here
differed from the original only at rank 0, while a variant that deliberately kept the final
multiply-add fused differed at ranks 1–3. No source ordering can guarantee bit-identity across an edit
on FMA hardware, so the code is not contorted in pursuit of it. Invariance of a tabulation under
extension is unaffected either way, since that compares a binary against itself.

**`testPromptCuspNFW.xml` is not reproducible run-to-run**, which is unrelated to this change but was
found while verifying it: the same binary run twice single-threaded disagrees with itself in 30 of 39
`/Outputs` datasets, including the integer `nodeIndex`, despite the file fixing
`<randomNumberGenerator><seed value="4637"/>`. It cannot be used for before/after comparison, and may
deserve a look on its own.

The pre-commit hook flags this file as deviating from `formatDeclarations.py` house style. That
deviation is pre-existing — the formatter rewrites 237 lines of the *pre-change* file — so it is left
for a separate reformatting commit rather than mixed in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgkePv5Nf8pqbgE8UXheZw
