### PR TITLE
Compute the Halpha luminosity functions from the star formation history

### DIFF
--- a/parameters/baryonicPhysicsConstrained.xml
+++ b/parameters/baryonicPhysicsConstrained.xml
@@ -503,16 +503,49 @@
   <emissionLineLuminositySystematics1 value="-0.00098878419875252"/>
   <ratioEarlyType value="0.719247501103713"/>
 
+  <!-- Emission line calculations. The Halpha luminosity function analyses compute line luminosities by convolving
+       the star formation history with tabulated Cloudy models of HII regions, so a star formation history must be
+       stored, and must resolve the young, ionizing populations in time and in metallicity. These are the calibrated
+       choices of `parameters/reference/emissionLines.xml`; the metallicity boundaries match those of the tabulation
+       used. -->
+  <starFormationHistory value="adaptive">
+    <timeStepMinimum       value="1.25893e-4"/>
+    <countTimeStepsMaximum value="200"       />
+    <metallicityBoundaries value="
+				  0.00531914893617 0.010638297872340 0.021276595744680 0.067282503407837
+				  0.21276595744680 0.300896502632573 0.425531914893617 0.490000000000000
+				  0.58000000000000 0.672825034078379 0.750000000000000 0.900000000000000
+				  1.06382978723404 1.200000000000000 1.350000000000000 1.500000000000000
+				  1.68206258519595 1.950000000000000 2.200000000000000 2.450000000000000
+				  2.65957446808511
+				  "/>
+  </starFormationHistory>
+  <hiiRegionEscapeFraction value="fixed">
+    <escapeFraction value="0.10"/>
+    <ageLimit       value="0.01"/>
+  </hiiRegionEscapeFraction>
+  <hiiRegionMassFunction value="rosolowsky2021">
+    <exponent    value="-1.8e0"/>
+    <massMinimum value="+1.0e4"/>
+    <massMaximum value="+1.0e8"/>
+  </hiiRegionMassFunction>
+  <hiiRegionDensityDistribution value="logNormal">
+    <densityHydrogenReference value="3.0e2"/>
+    <densityHydrogenMinimum   value="1.0e1"/>
+    <densityHydrogenMaximum   value="4.0e2"/>
+    <sigma                    value="1.8e0"/>
+  </hiiRegionDensityDistribution>
+
   <!-- Luminosity calculations -->
-  <luminosityFilter value="         SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g         SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r         SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g         SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r         Lyc             Lyc             Lyc             Lyc             Lyc              Lyc             Lyc             Lyc         HeliumContinuum HeliumContinuum HeliumContinuum HeliumContinuum HeliumContinuum  HeliumContinuum HeliumContinuum HeliumContinuum         OxygenContinuum OxygenContinuum OxygenContinuum OxygenContinuum OxygenContinuum  OxygenContinuum OxygenContinuum OxygenContinuum        Buser_V         "/>
+  <luminosityFilter value="SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_g   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   SDSS_r   Buser_V"/>
   
-  <luminosityType value="         observed observed observed observed observed observed observed observed observed observed observed         observed observed observed observed observed observed observed observed observed observed observed         observed observed observed observed observed observed observed observed observed observed observed         observed observed observed observed observed observed observed observed observed observed observed         rest     rest     rest     rest     rest     rest     rest     rest         rest     rest     rest     rest     rest     rest     rest     rest         rest     rest     rest     rest     rest     rest     rest     rest        rest         "/>
+  <luminosityType value="observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed observed rest   "/>
   
-  <luminosityRedshift value="         0.02     0.04     0.06     0.08     0.10     0.12     0.14     0.16     0.18     0.20     0.24         0.02     0.04     0.06     0.08     0.10     0.12     0.14     0.16     0.18     0.20     0.24         0.02     0.04     0.06     0.08     0.10     0.12     0.14     0.16     0.18     0.20     0.24         0.02     0.04     0.06     0.08     0.10     0.12     0.14     0.16     0.18     0.20     0.24         0.02     0.04     0.06     0.08     0.10     0.40     0.86     2.20         0.02     0.04     0.06     0.08     0.10     0.40     0.86     2.20         0.02     0.04     0.06     0.08     0.10     0.40     0.86     2.20        0.00         "/>
+  <luminosityRedshift value="0.02     0.04     0.06     0.08     0.10     0.12     0.14     0.16     0.18     0.20     0.24     0.02     0.04     0.06     0.08     0.10     0.12     0.14     0.16     0.18     0.20     0.24     0.02     0.04     0.06     0.08     0.10     0.12     0.14     0.16     0.18     0.20     0.24     0.02     0.04     0.06     0.08     0.10     0.12     0.14     0.16     0.18     0.20     0.24     0.00   "/>
 
   
-  <luminosityBandRedshift value="         0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10         0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10         0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10         0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10         0.02     0.04     0.06     0.08     0.10     0.40     0.86     2.20         0.02     0.04     0.06     0.08     0.10     0.40     0.86     2.20         0.02     0.04     0.06     0.08     0.10     0.40     0.86     2.20        0.00         "/>
-  <luminosityPostprocessSet value="         default  default  default  default  default  default  default  default  default  default  default         default  default  default  default  default  default  default  default  default  default  default         recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent         recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent         default  default  default  default  default  default  default  default         default  default  default  default  default  default  default  default         default  default  default  default  default  default  default  default        default         "/>
+  <luminosityBandRedshift value="0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.10     0.00   "/>
+  <luminosityPostprocessSet value="default  default  default  default  default  default  default  default  default  default  default  default  default  default  default  default  default  default  default  default  default  default  recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   recent   default"/>
   <stellarPopulationSpectraPostprocessorBuilder value="lookup">
     <names value="default recent"/>
     <stellarPopulationSpectraPostprocessor value="inoue2014"/>

--- a/source/nodes/property_extractor/append_suffix.F90
+++ b/source/nodes/property_extractor/append_suffix.F90
@@ -17,6 +17,8 @@
 !!    You should have received a copy of the GNU General Public License
 !!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
 
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
   !!{RST
   Implements a node property extractor that appends a suffix to property names.
   !!}
@@ -77,9 +79,9 @@ contains
     Internal constructor for the :galacticus-class:`nodePropertyExtractorAppendSuffix` property extractor class.
     !!}
     implicit none
-    type(nodePropertyExtractorAppendSuffix)                :: self
-    type(multiExtractorList               ), intent(in   ) :: extractors
-    type(varying_string                   ), intent(in   ) :: suffix
+    type(nodePropertyExtractorAppendSuffix)                        :: self
+    type(multiExtractorList               ), intent(in   ), target :: extractors
+    type(varying_string                   ), intent(in   )         :: suffix
     !![
     <constructorAssign variables="suffix"/>
     !!]

--- a/source/nodes/property_extractor/dust_attenuation.F90
+++ b/source/nodes/property_extractor/dust_attenuation.F90
@@ -177,7 +177,7 @@ contains
     logical                                      , intent(in   )         :: outputUnattenuated, outputSum, &
          &                                                                  outputSumOnly
     type   (varying_string                      ), intent(in   )         :: sumName
-    type   (multiExtractorList                  ), intent(in   )         :: extractors
+    type   (multiExtractorList                  ), intent(in   ), target :: extractors
     !![
     <constructorAssign variables="outputUnattenuated, outputSum, outputSumOnly, sumName, *dustAttenuation_"/>
     !!]

--- a/source/nodes/property_extractor/luminosity_emission_line/_class.F90
+++ b/source/nodes/property_extractor/luminosity_emission_line/_class.F90
@@ -100,6 +100,7 @@
      procedure :: indexTemplateTime       => emissionLineLuminosityIndexTemplateTime
      procedure :: indexTemplateNode       => emissionLineLuminosityIndexTemplateNode 
      procedure :: units                   => emissionLineLuminosityUnits
+     procedure :: quantity                => emissionLineLuminosityQuantity
      procedure :: supportsAttenuation     => emissionLineLuminositySupportsAttenuation
      procedure :: decompose               => emissionLineLuminosityDecompose
   end type nodePropertyExtractorLuminosityEmissionLine
@@ -1046,6 +1047,20 @@ contains
     end do
     return
   end function emissionLineLuminosityUnits
+
+  function emissionLineLuminosityQuantity(self) result(quantity)
+    !!{RST
+    Return the class of the emission line luminosity property.
+    !!}
+    use :: Output_Analyses_Options, only : outputAnalysisPropertyQuantityLuminosity
+    implicit none
+    type (enumerationOutputAnalysisPropertyQuantityType)                :: quantity
+    class(nodePropertyExtractorLuminosityEmissionLine  ), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    quantity=outputAnalysisPropertyQuantityLuminosity
+    return
+  end function emissionLineLuminosityQuantity
 
   logical function emissionLineLuminositySupportsAttenuation(self) result(supportsAttenuation)
     !!{RST

--- a/source/output/analyses/luminosity_function/Halpha/Gunawardhana2013/SDSS.F90
+++ b/source/output/analyses/luminosity_function/Halpha/Gunawardhana2013/SDSS.F90
@@ -58,23 +58,25 @@ contains
     !!{RST
     Constructor for the :galacticus-class:`outputAnalysisLuminosityFunctionGunawardhana2013SDSS` output analysis class which takes a parameter set as input.
     !!}
-    use :: Input_Parameters              , only : inputParameter                 , inputParameters
-    use :: Star_Formation_Rates_Disks    , only : starFormationRateDisksClass
-    use :: Star_Formation_Rates_Spheroids, only : starFormationRateSpheroidsClass
+    use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
     type            (outputAnalysisLuminosityFunctionGunawardhana2013SDSS)                              :: self
     type            (inputParameters                                     ), intent(inout)               :: parameters
     class           (cosmologyFunctionsClass                             ), pointer                     :: cosmologyFunctions_
     class           (outputTimesClass                                    ), pointer                     :: outputTimes_
     class           (gravitationalLensingClass                           ), pointer                     :: gravitationalLensing_
-    class           (starFormationRateDisksClass                         ), pointer                     :: starFormationRateDisks_
-    class           (starFormationRateSpheroidsClass                     ), pointer                     :: starFormationRateSpheroids_
+    class           (starFormationHistoryClass                           ), pointer                     :: starFormationHistory_
+    class           (hiiRegionLuminosityFunctionClass                    ), pointer                     :: hiiRegionLuminosityFunction_
+    class           (hiiRegionMassFunctionClass                          ), pointer                     :: hiiRegionMassFunction_
+    class           (hiiRegionDensityDistributionClass                   ), pointer                     :: hiiRegionDensityDistribution_
+    class           (hiiRegionEscapeFractionClass                        ), pointer                     :: hiiRegionEscapeFraction_
     class           (dustAttenuationClass                                ), pointer                     :: dustAttenuation_
     double precision                                                      , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                                             :: covarianceBinomialBinsPerDecade
     double precision                                                                                    :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
          &                                                                                                 randomErrorMinimum               , randomErrorMaximum                  , &
-         &                                                                                                 sizeSourceLensing
+         &                                                                                                 sizeSourceLensing                , toleranceRelative
+    type            (varying_string                                      )                              :: cloudyTableFileName
 
     ! Check and read parameters.
     if (parameters%isPresent(    'randomErrorPolynomialCoefficient')) then
@@ -134,6 +136,24 @@ contains
       </description>
     </inputParameter>
     <inputParameter docformat="rst">
+      <name>cloudyTableFileName</name>
+      <source>parameters</source>
+      <variable>cloudyTableFileName</variable>
+      <defaultValue>var_str('%DATASTATICPATH%/hiiRegions/emissionLineLuminosities_BC2003_highResolution_imfChabrier.hdf5')</defaultValue>
+      <description>
+      The file of tabulated emission line luminosities to use.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>toleranceRelative</name>
+      <source>parameters</source>
+      <variable>toleranceRelative</variable>
+      <defaultValue>1.0d-3</defaultValue>
+      <description>
+      The relative tolerance used in integration over stellar population spectra when computing line luminosities.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
       <name>covarianceBinomialBinsPerDecade</name>
       <source>parameters</source>
       <variable>covarianceBinomialBinsPerDecade</variable>
@@ -160,28 +180,34 @@ contains
       The maximum halo mass to consider when constructing SDSS H\ :math:`\alpha` luminosity function covariance matrices for main branch galaxies.
       </description>
     </inputParameter>
-    <objectBuilder class="cosmologyFunctions"          name="cosmologyFunctions_"          source="parameters"/>
-    <objectBuilder class="outputTimes"                 name="outputTimes_"                 source="parameters"/>
-    <objectBuilder class="gravitationalLensing"        name="gravitationalLensing_"        source="parameters"/>
-    <objectBuilder class="starFormationRateDisks"      name="starFormationRateDisks_"      source="parameters"/>
-    <objectBuilder class="starFormationRateSpheroids"  name="starFormationRateSpheroids_"  source="parameters"/>
-    <objectBuilder class="dustAttenuation"             name="dustAttenuation_"             source="parameters"/>
+    <objectBuilder class="cosmologyFunctions"           name="cosmologyFunctions_"           source="parameters"/>
+    <objectBuilder class="outputTimes"                  name="outputTimes_"                  source="parameters"/>
+    <objectBuilder class="gravitationalLensing"         name="gravitationalLensing_"         source="parameters"/>
+    <objectBuilder class="starFormationHistory"         name="starFormationHistory_"         source="parameters"/>
+    <objectBuilder class="hiiRegionLuminosityFunction"  name="hiiRegionLuminosityFunction_"  source="parameters"/>
+    <objectBuilder class="hiiRegionMassFunction"        name="hiiRegionMassFunction_"        source="parameters"/>
+    <objectBuilder class="hiiRegionDensityDistribution" name="hiiRegionDensityDistribution_" source="parameters"/>
+    <objectBuilder class="hiiRegionEscapeFraction"      name="hiiRegionEscapeFraction_"      source="parameters"/>
+    <objectBuilder class="dustAttenuation"              name="dustAttenuation_"              source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisLuminosityFunctionGunawardhana2013SDSS(cosmologyFunctions_,gravitationalLensing_,dustAttenuation_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisLuminosityFunctionGunawardhana2013SDSS(cosmologyFunctions_,gravitationalLensing_,dustAttenuation_,outputTimes_,cloudyTableFileName,toleranceRelative,starFormationHistory_,hiiRegionLuminosityFunction_,hiiRegionMassFunction_,hiiRegionDensityDistribution_,hiiRegionEscapeFraction_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
-    <objectDestructor name="cosmologyFunctions_"        />
-    <objectDestructor name="outputTimes_"               />
-    <objectDestructor name="gravitationalLensing_"      />
-    <objectDestructor name="starFormationRateDisks_"    />
-    <objectDestructor name="starFormationRateSpheroids_"/>
-    <objectDestructor name="dustAttenuation_"           />
+    <objectDestructor name="cosmologyFunctions_"          />
+    <objectDestructor name="outputTimes_"                 />
+    <objectDestructor name="gravitationalLensing_"        />
+    <objectDestructor name="starFormationHistory_"        />
+    <objectDestructor name="hiiRegionLuminosityFunction_" />
+    <objectDestructor name="hiiRegionMassFunction_"       />
+    <objectDestructor name="hiiRegionDensityDistribution_"/>
+    <objectDestructor name="hiiRegionEscapeFraction_"     />
+    <objectDestructor name="dustAttenuation_"             />
     !!]
     return
   end function luminosityFunctionGunawardhana2013SDSSConstructorParameters
 
-  function luminosityFunctionGunawardhana2013SDSSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,dustAttenuation_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function luminosityFunctionGunawardhana2013SDSSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,dustAttenuation_,outputTimes_,cloudyTableFileName,toleranceRelative,starFormationHistory_,hiiRegionLuminosityFunction_,hiiRegionMassFunction_,hiiRegionDensityDistribution_,hiiRegionEscapeFraction_,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{RST
     Constructor for the :galacticus-class:`outputAnalysisLuminosityFunctionGunawardhana2013SDSS` output analysis class for internal use.
     !!}
@@ -193,16 +219,19 @@ contains
     use :: Gravitational_Lensing                 , only : gravitationalLensingClass
     use :: Output_Analysis_Distribution_Operators, only : distributionOperatorList                       , outputAnalysisDistributionOperatorGrvtnlLnsng, outputAnalysisDistributionOperatorRandomErrorPlynml, outputAnalysisDistributionOperatorSequence
     use :: Output_Analysis_Property_Operators    , only : outputAnalysisPropertyOperatorSystmtcPolynomial
-    use :: Star_Formation_Rates_Disks            , only : starFormationRateDisksClass
-    use :: Star_Formation_Rates_Spheroids        , only : starFormationRateSpheroidsClass
     implicit none
     type            (outputAnalysisLuminosityFunctionGunawardhana2013SDSS)                              :: self
     class           (cosmologyFunctionsClass                             ), intent(in   ), target       :: cosmologyFunctions_
     class           (outputTimesClass                                    ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                           ), intent(in   ), target       :: gravitationalLensing_
     class           (dustAttenuationClass                                ), intent(in   ), target       :: dustAttenuation_
-    class           (starFormationRateDisksClass                         ), intent(in   ), target       :: starFormationRateDisks_
-    class           (starFormationRateSpheroidsClass                     ), intent(in   ), target       :: starFormationRateSpheroids_
+    type            (varying_string                                      ), intent(in   )               :: cloudyTableFileName
+    double precision                                                      , intent(in   )               :: toleranceRelative
+    class           (starFormationHistoryClass                           ), intent(in   ), target       :: starFormationHistory_
+    class           (hiiRegionLuminosityFunctionClass                    ), intent(in   ), target       :: hiiRegionLuminosityFunction_
+    class           (hiiRegionMassFunctionClass                          ), intent(in   ), target       :: hiiRegionMassFunction_
+    class           (hiiRegionDensityDistributionClass                   ), intent(in   ), target       :: hiiRegionDensityDistribution_
+    class           (hiiRegionEscapeFractionClass                        ), intent(in   ), target       :: hiiRegionEscapeFraction_
     double precision                                                      , intent(in   )               :: randomErrorMinimum                                        , randomErrorMaximum                  , &
          &                                                                                                 sizeSourceLensing
     double precision                                                      , intent(in   ), dimension(:) :: randomErrorPolynomialCoefficient                          , systematicErrorPolynomialCoefficient
@@ -310,6 +339,8 @@ contains
          &                                  var_str('H$\alpha$ luminosity function for the Gunawardhana et al. (2013) SDSS analysis')                               , &
          &                                  char(inputPath(pathTypeDataStatic)//'/observations/luminosityFunctions/hAlphaLuminosityFunctionGunawardhana13SDSS.hdf5'), &
          &                                  .false.                                                                                                                 , &
+         &                                  cloudyTableFileName                                                                                                     , &
+         &                                  toleranceRelative                                                                                                       , &
          &                                  galacticFilter_                                                                                                         , &
          &                                  surveyGeometry_                                                                                                         , &
          &                                  dustAttenuation_                                                                                                        , &
@@ -318,8 +349,11 @@ contains
          &                                  outputAnalysisPropertyOperator_                                                                                         , &
          &                                  outputAnalysisDistributionOperator_                                                                                     , &
          &                                  outputTimes_                                                                                                            , &
-         &                                  starFormationRateDisks_                                                                                                 , &
-         &                                  starFormationRateSpheroids_                                                                                             , &
+         &                                  starFormationHistory_                                                                                                   , &
+         &                                  hiiRegionLuminosityFunction_                                                                                            , &
+         &                                  hiiRegionMassFunction_                                                                                                  , &
+         &                                  hiiRegionDensityDistribution_                                                                                           , &
+         &                                  hiiRegionEscapeFraction_                                                                                                , &
          &                                  covarianceBinomialBinsPerDecade                                                                                         , &
          &                                  covarianceBinomialMassHaloMinimum                                                                                       , &
          &                                  covarianceBinomialMassHaloMaximum                                                                                         &

--- a/source/output/analyses/luminosity_function/Halpha/Sobral2013/HiZELS.F90
+++ b/source/output/analyses/luminosity_function/Halpha/Sobral2013/HiZELS.F90
@@ -59,24 +59,26 @@ contains
     !!{RST
     Constructor for the :galacticus-class:`outputAnalysisLuminosityFunctionSobral2013HiZELS` output analysis class which takes a parameter set as input.
     !!}
-    use :: Gravitational_Lensing         , only : gravitationalLensing           , gravitationalLensingClass
-    use :: Input_Parameters              , only : inputParameter                 , inputParameters
-    use :: Star_Formation_Rates_Disks    , only : starFormationRateDisksClass
-    use :: Star_Formation_Rates_Spheroids, only : starFormationRateSpheroidsClass
+    use :: Gravitational_Lensing, only : gravitationalLensing, gravitationalLensingClass
+    use :: Input_Parameters     , only : inputParameter      , inputParameters
     implicit none
     type            (outputAnalysisLuminosityFunctionSobral2013HiZELS)                              :: self
     type            (inputParameters                                 ), intent(inout)               :: parameters
     class           (cosmologyFunctionsClass                         ), pointer                     :: cosmologyFunctions_
     class           (outputTimesClass                                ), pointer                     :: outputTimes_
     class           (gravitationalLensingClass                       ), pointer                     :: gravitationalLensing_
-    class           (starFormationRateDisksClass                     ), pointer                     :: starFormationRateDisks_
-    class           (starFormationRateSpheroidsClass                 ), pointer                     :: starFormationRateSpheroids_
+    class           (starFormationHistoryClass                       ), pointer                     :: starFormationHistory_
+    class           (hiiRegionLuminosityFunctionClass                ), pointer                     :: hiiRegionLuminosityFunction_
+    class           (hiiRegionMassFunctionClass                      ), pointer                     :: hiiRegionMassFunction_
+    class           (hiiRegionDensityDistributionClass               ), pointer                     :: hiiRegionDensityDistribution_
+    class           (hiiRegionEscapeFractionClass                    ), pointer                     :: hiiRegionEscapeFraction_
     class           (dustAttenuationClass                            ), pointer                     :: dustAttenuation_
     double precision                                                  , allocatable  , dimension(:) :: randomErrorPolynomialCoefficient , systematicErrorPolynomialCoefficient
     integer                                                                                         :: covarianceBinomialBinsPerDecade  , redshiftInterval
     double precision                                                                                :: covarianceBinomialMassHaloMinimum, covarianceBinomialMassHaloMaximum   , &
          &                                                                                             randomErrorMinimum               , randomErrorMaximum                  , &
-         &                                                                                             sizeSourceLensing
+         &                                                                                             sizeSourceLensing                , toleranceRelative
+    type            (varying_string                                  )                              :: cloudyTableFileName
 
     ! Check and read parameters.
     if (parameters%isPresent(    'randomErrorPolynomialCoefficient')) then
@@ -144,6 +146,24 @@ contains
       </description>
     </inputParameter>
     <inputParameter docformat="rst">
+      <name>cloudyTableFileName</name>
+      <source>parameters</source>
+      <variable>cloudyTableFileName</variable>
+      <defaultValue>var_str('%DATASTATICPATH%/hiiRegions/emissionLineLuminosities_BC2003_highResolution_imfChabrier.hdf5')</defaultValue>
+      <description>
+      The file of tabulated emission line luminosities to use.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>toleranceRelative</name>
+      <source>parameters</source>
+      <variable>toleranceRelative</variable>
+      <defaultValue>1.0d-3</defaultValue>
+      <description>
+      The relative tolerance used in integration over stellar population spectra when computing line luminosities.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
       <name>covarianceBinomialBinsPerDecade</name>
       <source>parameters</source>
       <variable>covarianceBinomialBinsPerDecade</variable>
@@ -170,28 +190,34 @@ contains
       The maximum halo mass to consider when constructing SDSS H\ :math:`\alpha` luminosity function covariance matrices for main branch galaxies.
       </description>
     </inputParameter>
-    <objectBuilder class="cosmologyFunctions"         name="cosmologyFunctions_"         source="parameters"/>
-    <objectBuilder class="outputTimes"                name="outputTimes_"                source="parameters"/>
-    <objectBuilder class="gravitationalLensing"       name="gravitationalLensing_"       source="parameters"/>
-    <objectBuilder class="starFormationRateDisks"     name="starFormationRateDisks_"     source="parameters"/>
-    <objectBuilder class="starFormationRateSpheroids" name="starFormationRateSpheroids_" source="parameters"/>
-    <objectBuilder class="dustAttenuation"            name="dustAttenuation_"            source="parameters"/>
+    <objectBuilder class="cosmologyFunctions"           name="cosmologyFunctions_"           source="parameters"/>
+    <objectBuilder class="outputTimes"                  name="outputTimes_"                  source="parameters"/>
+    <objectBuilder class="gravitationalLensing"         name="gravitationalLensing_"         source="parameters"/>
+    <objectBuilder class="starFormationHistory"         name="starFormationHistory_"         source="parameters"/>
+    <objectBuilder class="hiiRegionLuminosityFunction"  name="hiiRegionLuminosityFunction_"  source="parameters"/>
+    <objectBuilder class="hiiRegionMassFunction"        name="hiiRegionMassFunction_"        source="parameters"/>
+    <objectBuilder class="hiiRegionDensityDistribution" name="hiiRegionDensityDistribution_" source="parameters"/>
+    <objectBuilder class="hiiRegionEscapeFraction"      name="hiiRegionEscapeFraction_"      source="parameters"/>
+    <objectBuilder class="dustAttenuation"              name="dustAttenuation_"              source="parameters"/>
     !!]
     ! Build the object.
-    self=outputAnalysisLuminosityFunctionSobral2013HiZELS(cosmologyFunctions_,gravitationalLensing_,dustAttenuation_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
+    self=outputAnalysisLuminosityFunctionSobral2013HiZELS(cosmologyFunctions_,gravitationalLensing_,dustAttenuation_,outputTimes_,cloudyTableFileName,toleranceRelative,starFormationHistory_,hiiRegionLuminosityFunction_,hiiRegionMassFunction_,hiiRegionDensityDistribution_,hiiRegionEscapeFraction_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing)
     !![
     <inputParametersValidate source="parameters"/>
-    <objectDestructor name="cosmologyFunctions_"        />
-    <objectDestructor name="outputTimes_"               />
-    <objectDestructor name="gravitationalLensing_"      />
-    <objectDestructor name="starFormationRateDisks_"    />
-    <objectDestructor name="starFormationRateSpheroids_"/>
-    <objectDestructor name="dustAttenuation_"           />
+    <objectDestructor name="cosmologyFunctions_"          />
+    <objectDestructor name="outputTimes_"                 />
+    <objectDestructor name="gravitationalLensing_"        />
+    <objectDestructor name="starFormationHistory_"        />
+    <objectDestructor name="hiiRegionLuminosityFunction_" />
+    <objectDestructor name="hiiRegionMassFunction_"       />
+    <objectDestructor name="hiiRegionDensityDistribution_"/>
+    <objectDestructor name="hiiRegionEscapeFraction_"     />
+    <objectDestructor name="dustAttenuation_"             />
     !!]
     return
   end function luminosityFunctionSobral2013HiZELSConstructorParameters
 
-  function luminosityFunctionSobral2013HiZELSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,dustAttenuation_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
+  function luminosityFunctionSobral2013HiZELSConstructorInternal(cosmologyFunctions_,gravitationalLensing_,dustAttenuation_,outputTimes_,cloudyTableFileName,toleranceRelative,starFormationHistory_,hiiRegionLuminosityFunction_,hiiRegionMassFunction_,hiiRegionDensityDistribution_,hiiRegionEscapeFraction_,redshiftInterval,randomErrorMinimum,randomErrorMaximum,randomErrorPolynomialCoefficient,systematicErrorPolynomialCoefficient,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,sizeSourceLensing) result (self)
     !!{RST
     Constructor for the :galacticus-class:`outputAnalysisLuminosityFunctionSobral2013HiZELS` output analysis class for internal use.
     !!}
@@ -204,8 +230,6 @@ contains
     use :: Gravitational_Lensing                 , only : gravitationalLensingClass
     use :: Output_Analysis_Distribution_Operators, only : distributionOperatorList                       , outputAnalysisDistributionOperatorGrvtnlLnsng, outputAnalysisDistributionOperatorRandomErrorPlynml, outputAnalysisDistributionOperatorSequence
     use :: Output_Analysis_Property_Operators    , only : outputAnalysisPropertyOperatorSystmtcPolynomial
-    use :: Star_Formation_Rates_Disks            , only : starFormationRateDisksClass
-    use :: Star_Formation_Rates_Spheroids        , only : starFormationRateSpheroidsClass
     use :: String_Handling                       , only : operator(//)
     implicit none
     type            (outputAnalysisLuminosityFunctionSobral2013HiZELS   )                              :: self
@@ -213,8 +237,13 @@ contains
     class           (outputTimesClass                                   ), intent(inout), target       :: outputTimes_
     class           (gravitationalLensingClass                          ), intent(in   ), target       :: gravitationalLensing_
     class           (dustAttenuationClass                               ), intent(in   ), target       :: dustAttenuation_
-    class           (starFormationRateDisksClass                        ), intent(in   ), target       :: starFormationRateDisks_
-    class           (starFormationRateSpheroidsClass                    ), intent(in   ), target       :: starFormationRateSpheroids_
+    type            (varying_string                                     ), intent(in   )               :: cloudyTableFileName
+    double precision                                                     , intent(in   )               :: toleranceRelative
+    class           (starFormationHistoryClass                          ), intent(in   ), target       :: starFormationHistory_
+    class           (hiiRegionLuminosityFunctionClass                   ), intent(in   ), target       :: hiiRegionLuminosityFunction_
+    class           (hiiRegionMassFunctionClass                         ), intent(in   ), target       :: hiiRegionMassFunction_
+    class           (hiiRegionDensityDistributionClass                  ), intent(in   ), target       :: hiiRegionDensityDistribution_
+    class           (hiiRegionEscapeFractionClass                       ), intent(in   ), target       :: hiiRegionEscapeFraction_
     integer                                                              , intent(in   )               :: redshiftInterval
     double precision                                                     , intent(in   )               :: randomErrorMinimum                                        , randomErrorMaximum                  , &
          &                                                                                                sizeSourceLensing
@@ -345,6 +374,8 @@ contains
          &                                        var_str('H$\alpha$ luminosity function for the Sobral et al. (2013) HiZELS analysis; redshift interval ')//redshiftInterval , &
          &                                        char   (inputPath(pathTypeDataStatic)//'/observations/luminosityFunctions/'                              //fileName        ), &
          &                                        .false.                                                                                                                     , &
+         &                                        cloudyTableFileName                                                                                                         , &
+         &                                        toleranceRelative                                                                                                           , &
          &                                        galacticFilter_                                                                                                             , &
          &                                        surveyGeometry_                                                                                                             , &
          &                                        dustAttenuation_                                                                                                            , &
@@ -353,8 +384,11 @@ contains
          &                                        outputAnalysisPropertyOperator_                                                                                             , &
          &                                        outputAnalysisDistributionOperator_                                                                                         , &
          &                                        outputTimes_                                                                                                                , &
-         &                                        starFormationRateDisks_                                                                                                     , &
-         &                                        starFormationRateSpheroids_                                                                                                 , &
+         &                                        starFormationHistory_                                                                                                       , &
+         &                                        hiiRegionLuminosityFunction_                                                                                                , &
+         &                                        hiiRegionMassFunction_                                                                                                      , &
+         &                                        hiiRegionDensityDistribution_                                                                                               , &
+         &                                        hiiRegionEscapeFraction_                                                                                                    , &
          &                                        covarianceBinomialBinsPerDecade                                                                                             , &
          &                                        covarianceBinomialMassHaloMinimum                                                                                           , &
          &                                        covarianceBinomialMassHaloMaximum                                                                                             &

--- a/source/output/analyses/luminosity_function/Halpha/_class.F90
+++ b/source/output/analyses/luminosity_function/Halpha/_class.F90
@@ -23,14 +23,30 @@
 Implements a luminosity function output analysis class.
 !!}
 
-  use :: Cosmology_Functions, only : cosmologyFunctionsClass
-  use :: Geometry_Surveys   , only : surveyGeometryClass
-  use :: Dust_Attenuations  , only : dustAttenuationClass
+  use :: Cosmology_Functions             , only : cosmologyFunctionsClass
+  use :: Geometry_Surveys                , only : surveyGeometryClass
+  use :: Dust_Attenuations               , only : dustAttenuationClass
+  use :: Star_Formation_Histories        , only : starFormationHistoryClass        , starFormationHistoryNull
+  use :: HII_Region_Luminosity_Functions , only : hiiRegionLuminosityFunctionClass
+  use :: HII_Region_Mass_Functions       , only : hiiRegionMassFunctionClass
+  use :: HII_Region_Density_Distributions, only : hiiRegionDensityDistributionClass
+  use :: HII_Region_Escape_Fraction      , only : hiiRegionEscapeFractionClass
 
   !![
   <outputAnalysis name="outputAnalysisLuminosityFunctionHalpha" docformat="rst">
    <description>
    Computes the H\ :math:`\alpha` emission line galaxy luminosity function in bins of line luminosity, optionally including [NII] doublet contamination (``includeNitrogenII``), applying ISM dust attenuation, and with configurable binomial covariance matrix parameters for halo mass range and optional target dataset.
+
+   Line luminosities are computed by :galacticus-class:`nodePropertyExtractorLuminosityEmissionLine`, which convolves
+   the star formation history of each galaxy with tabulated Cloudy models of the H**ii** regions described by the
+   ``[hiiRegionLuminosityFunction]``, ``[hiiRegionMassFunction]``, ``[hiiRegionDensityDistribution]``, and
+   ``[hiiRegionEscapeFraction]`` objects. A star formation history must therefore be stored (see
+   ``[starFormationHistory]``); the ``null`` default stores none and no line emission results.
+
+   Note that the tabulation selected by ``[cloudyTableFileName]`` may already include the effect of dust *within* the
+   H**ii** region, depending on its dust-to-metals ratio---all of the currently distributed tabulations do. The
+   ``[dustAttenuation]`` model given here is applied on top, and so should describe only the dust *outside* the
+   region: configuring a birth cloud component in addition would count the same dust twice.
    </description>
   </outputAnalysis>
   !!]
@@ -39,13 +55,18 @@ Implements a luminosity function output analysis class.
      A luminosity function output analysis class.
      !!}
      private
-     class           (surveyGeometryClass               ), pointer                   :: surveyGeometry_             => null()
-     class           (cosmologyFunctionsClass           ), pointer                   :: cosmologyFunctions_         => null(), cosmologyFunctionsData => null()
-     class           (dustAttenuationClass              ), pointer                   :: dustAttenuation_            => null()
-     class           (starFormationRateDisksClass       ), pointer                   :: starFormationRateDisks_     => null()
-     class           (starFormationRateSpheroidsClass   ), pointer                   :: starFormationRateSpheroids_ => null()
-     double precision                                    , allocatable, dimension(:) :: luminosities
-     logical                                                                         :: includeNitrogenII
+     class           (surveyGeometryClass              ), pointer                   :: surveyGeometry_               => null()
+     class           (cosmologyFunctionsClass          ), pointer                   :: cosmologyFunctions_           => null(), cosmologyFunctionsData => null()
+     class           (dustAttenuationClass             ), pointer                   :: dustAttenuation_              => null()
+     class           (starFormationHistoryClass        ), pointer                   :: starFormationHistory_         => null()
+     class           (hiiRegionLuminosityFunctionClass ), pointer                   :: hiiRegionLuminosityFunction_  => null()
+     class           (hiiRegionMassFunctionClass       ), pointer                   :: hiiRegionMassFunction_        => null()
+     class           (hiiRegionDensityDistributionClass), pointer                   :: hiiRegionDensityDistribution_ => null()
+     class           (hiiRegionEscapeFractionClass     ), pointer                   :: hiiRegionEscapeFraction_      => null()
+     double precision                                   , allocatable, dimension(:) :: luminosities
+     type            (varying_string                   )                            :: cloudyTableFileName
+     double precision                                                               :: toleranceRelative
+     logical                                                                        :: includeNitrogenII
    contains
      final :: luminosityFunctionHalphaDestructor
   end type outputAnalysisLuminosityFunctionHalpha
@@ -65,10 +86,8 @@ contains
     !!{RST
     Constructor for the :galacticus-class:`outputAnalysisLuminosityFunctionHalpha` output analysis class which takes a parameter set as input.
     !!}
-    use :: Error                         , only : Error_Report
-    use :: Input_Parameters              , only : inputParameter                 , inputParameters
-    use :: Star_Formation_Rates_Disks    , only : starFormationRateDisksClass
-    use :: Star_Formation_Rates_Spheroids, only : starFormationRateSpheroidsClass
+    use :: Error           , only : Error_Report
+    use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
     type            (outputAnalysisLuminosityFunctionHalpha )                              :: self
     type            (inputParameters                        ), intent(inout)               :: parameters
@@ -78,17 +97,21 @@ contains
     class           (outputTimesClass                       ), pointer                     :: outputTimes_
     class           (outputAnalysisDistributionOperatorClass), pointer                     :: outputAnalysisDistributionOperator_
     class           (outputAnalysisPropertyOperatorClass    ), pointer                     :: outputAnalysisPropertyOperator_
-    class           (starFormationRateDisksClass            ), pointer                     :: starFormationRateDisks_
-    class           (starFormationRateSpheroidsClass        ), pointer                     :: starFormationRateSpheroids_
+    class           (starFormationHistoryClass              ), pointer                     :: starFormationHistory_
+    class           (hiiRegionLuminosityFunctionClass       ), pointer                     :: hiiRegionLuminosityFunction_
+    class           (hiiRegionMassFunctionClass             ), pointer                     :: hiiRegionMassFunction_
+    class           (hiiRegionDensityDistributionClass      ), pointer                     :: hiiRegionDensityDistribution_
+    class           (hiiRegionEscapeFractionClass           ), pointer                     :: hiiRegionEscapeFraction_
     class           (dustAttenuationClass                   ), pointer                     :: dustAttenuation_
     double precision                                         , dimension(:  ), allocatable :: luminosities                       , functionValueTarget              , &
          &                                                                                    functionCovarianceTarget1D
     double precision                                         , dimension(:,:), allocatable :: functionCovarianceTarget
     integer                                                                                :: covarianceBinomialBinsPerDecade
-    double precision                                                                       :: covarianceBinomialMassHaloMinimum  , covarianceBinomialMassHaloMaximum
+    double precision                                                                       :: covarianceBinomialMassHaloMinimum  , covarianceBinomialMassHaloMaximum, &
+         &                                                                                    toleranceRelative
     type            (inputParameters                        )                              :: dataAnalysisParameters
     type            (varying_string                         )                              :: label                              , comment                          , &
-         &                                                                                    targetLabel
+         &                                                                                    targetLabel                        , cloudyTableFileName
     logical                                                                                :: includeNitrogenII
 
     ! Check and read parameters.
@@ -148,6 +171,22 @@ contains
       If true, include contamination by the [NII] (6548Å :math:`+` 6584Å) doublet.
       </description>
     </inputParameter>
+    <inputParameter docformat="rst">
+      <name>cloudyTableFileName</name>
+      <source>parameters</source>
+      <defaultValue>var_str('%DATASTATICPATH%/hiiRegions/emissionLineLuminosities_BC2003_highResolution_imfChabrier.hdf5')</defaultValue>
+      <description>
+      The file of tabulated emission line luminosities to use.
+      </description>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>toleranceRelative</name>
+      <source>parameters</source>
+      <defaultValue>1.0d-3</defaultValue>
+      <description>
+      The relative tolerance used in integration over stellar population spectra when computing line luminosities.
+      </description>
+    </inputParameter>
     !!]
     if (parameters%isPresent('targetLabel')) then
        !![
@@ -199,11 +238,14 @@ contains
     <objectBuilder class="outputAnalysisPropertyOperator"     name="outputAnalysisPropertyOperator_"     source="parameters"            />
     <objectBuilder class="outputAnalysisDistributionOperator" name="outputAnalysisDistributionOperator_" source="parameters"            />
     <objectBuilder class="surveyGeometry"                     name="surveyGeometry_"                     source="parameters"            />
-    <objectBuilder class="starFormationRateDisks"             name="starFormationRateDisks_"             source="parameters"            />
-    <objectBuilder class="starFormationRateSpheroids"         name="starFormationRateSpheroids_"         source="parameters"            />
+    <objectBuilder class="starFormationHistory"               name="starFormationHistory_"               source="parameters"            />
+    <objectBuilder class="hiiRegionLuminosityFunction"        name="hiiRegionLuminosityFunction_"        source="parameters"            />
+    <objectBuilder class="hiiRegionMassFunction"              name="hiiRegionMassFunction_"              source="parameters"            />
+    <objectBuilder class="hiiRegionDensityDistribution"       name="hiiRegionDensityDistribution_"       source="parameters"            />
+    <objectBuilder class="hiiRegionEscapeFraction"            name="hiiRegionEscapeFraction_"            source="parameters"            />
     <objectBuilder class="dustAttenuation"                    name="dustAttenuation_"                    source="parameters"            />
     <conditionalCall>
-     <call>self=outputAnalysisLuminosityFunctionHalpha(label,comment,luminosities,includeNitrogenII,galacticFilter_,surveyGeometry_,dustAttenuation_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
+     <call>self=outputAnalysisLuminosityFunctionHalpha(label,comment,luminosities,includeNitrogenII,cloudyTableFileName,toleranceRelative,galacticFilter_,surveyGeometry_,dustAttenuation_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,starFormationHistory_,hiiRegionLuminosityFunction_,hiiRegionMassFunction_,hiiRegionDensityDistribution_,hiiRegionEscapeFraction_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
      <argument name="targetLabel"              value="targetLabel"              parameterPresent="parameters"/>
      <argument name="functionValueTarget"      value="functionValueTarget"      parameterPresent="parameters"/>
      <argument name="functionCovarianceTarget" value="functionCovarianceTarget" parameterPresent="parameters"/>
@@ -216,34 +258,40 @@ contains
     <objectDestructor name="outputAnalysisPropertyOperator_"    />
     <objectDestructor name="outputAnalysisDistributionOperator_"/>
     <objectDestructor name="surveyGeometry_"                    />
-    <objectDestructor name="starFormationRateDisks_"            />
-    <objectDestructor name="starFormationRateSpheroids_"        />
+    <objectDestructor name="starFormationHistory_"              />
+    <objectDestructor name="hiiRegionLuminosityFunction_"       />
+    <objectDestructor name="hiiRegionMassFunction_"             />
+    <objectDestructor name="hiiRegionDensityDistribution_"      />
+    <objectDestructor name="hiiRegionEscapeFraction_"           />
     <objectDestructor name="dustAttenuation_"                   />
     !!]
     return
   end function luminosityFunctionHalphaConstructorParameters
 
-  function luminosityFunctionHalphaConstructorFile(label,comment,fileName,includeNitrogenII,galacticFilter_,surveyGeometry_,dustAttenuation_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum) result (self)
+  function luminosityFunctionHalphaConstructorFile(label,comment,fileName,includeNitrogenII,cloudyTableFileName,toleranceRelative,galacticFilter_,surveyGeometry_,dustAttenuation_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,starFormationHistory_,hiiRegionLuminosityFunction_,hiiRegionMassFunction_,hiiRegionDensityDistribution_,hiiRegionEscapeFraction_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum) result (self)
     !!{RST
     Constructor for the :galacticus-class:`outputAnalysisLuminosityFunctionHalpha` output analysis class which reads bin information from a standard format file.
     !!}
-    use :: HDF5_Access                   , only : hdf5Access
-    use :: IO_HDF5                       , only : hdf5File
-    use :: Star_Formation_Rates_Disks    , only : starFormationRateDisksClass
-    use :: Star_Formation_Rates_Spheroids, only : starFormationRateSpheroidsClass
+    use :: HDF5_Access, only : hdf5Access
+    use :: IO_HDF5    , only : hdf5File
     implicit none
     type            (outputAnalysisLuminosityFunctionHalpha )                              :: self
     type            (varying_string                         ), intent(in   )               :: label                              , comment
     character       (len=*                                  ), intent(in   )               :: fileName
     logical                                                  , intent(in   )               :: includeNitrogenII
+    type            (varying_string                         ), intent(in   )               :: cloudyTableFileName
+    double precision                                         , intent(in   )               :: toleranceRelative
     class           (galacticFilterClass                    ), intent(in   ) , target      :: galacticFilter_
     class           (surveyGeometryClass                    ), intent(in   ) , target      :: surveyGeometry_
     class           (cosmologyFunctionsClass                ), intent(in   ) , target      :: cosmologyFunctions_                , cosmologyFunctionsData
     class           (outputTimesClass                       ), intent(inout) , target      :: outputTimes_
     class           (outputAnalysisPropertyOperatorClass    ), intent(inout) , target      :: outputAnalysisPropertyOperator_
     class           (outputAnalysisDistributionOperatorClass), intent(in   ) , target      :: outputAnalysisDistributionOperator_
-    class           (starFormationRateDisksClass            ), intent(in   ) , target      :: starFormationRateDisks_
-    class           (starFormationRateSpheroidsClass        ), intent(in   ) , target      :: starFormationRateSpheroids_
+    class           (starFormationHistoryClass              ), intent(in   ) , target      :: starFormationHistory_
+    class           (hiiRegionLuminosityFunctionClass       ), intent(in   ) , target      :: hiiRegionLuminosityFunction_
+    class           (hiiRegionMassFunctionClass             ), intent(in   ) , target      :: hiiRegionMassFunction_
+    class           (hiiRegionDensityDistributionClass      ), intent(in   ) , target      :: hiiRegionDensityDistribution_
+    class           (hiiRegionEscapeFractionClass           ), intent(in   ) , target      :: hiiRegionEscapeFraction_
     class           (dustAttenuationClass                   ), intent(in   ) , target      :: dustAttenuation_
     double precision                                         , dimension(:  ), allocatable :: luminosities                       , functionValueTarget              , &
          &                                                                                    functionErrorTarget
@@ -275,7 +323,7 @@ contains
     ! Construct the object.
     !![
     <conditionalCall>
-     <call>self=outputAnalysisLuminosityFunctionHalpha(label,comment,luminosities,includeNitrogenII,galacticFilter_,surveyGeometry_,dustAttenuation_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
+     <call>self=outputAnalysisLuminosityFunctionHalpha(label,comment,luminosities,includeNitrogenII,cloudyTableFileName,toleranceRelative,galacticFilter_,surveyGeometry_,dustAttenuation_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,starFormationHistory_,hiiRegionLuminosityFunction_,hiiRegionMassFunction_,hiiRegionDensityDistribution_,hiiRegionEscapeFraction_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum{conditions})</call>
      <argument name="targetLabel"              value="targetLabel"              condition="haveTarget"/>
      <argument name="functionValueTarget"      value="functionValueTarget"      condition="haveTarget"/>
      <argument name="functionCovarianceTarget" value="functionCovarianceTarget" condition="haveTarget"/>
@@ -284,18 +332,18 @@ contains
     return
   end function luminosityFunctionHalphaConstructorFile
 
-  function luminosityFunctionHalphaConstructorInternal(label,comment,luminosities,includeNitrogenII,galacticFilter_,surveyGeometry_,dustAttenuation_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,starFormationRateDisks_,starFormationRateSpheroids_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,targetLabel,functionValueTarget,functionCovarianceTarget) result(self)
+  function luminosityFunctionHalphaConstructorInternal(label,comment,luminosities,includeNitrogenII,cloudyTableFileName,toleranceRelative,galacticFilter_,surveyGeometry_,dustAttenuation_,cosmologyFunctions_,cosmologyFunctionsData,outputAnalysisPropertyOperator_,outputAnalysisDistributionOperator_,outputTimes_,starFormationHistory_,hiiRegionLuminosityFunction_,hiiRegionMassFunction_,hiiRegionDensityDistribution_,hiiRegionEscapeFraction_,covarianceBinomialBinsPerDecade,covarianceBinomialMassHaloMinimum,covarianceBinomialMassHaloMaximum,targetLabel,functionValueTarget,functionCovarianceTarget) result(self)
     !!{RST
     Constructor for the :galacticus-class:`outputAnalysisLuminosityFunctionHalpha` output analysis class which takes a parameter set as input.
     !!}
     use :: Cosmology_Functions                     , only : cosmologyFunctionsClass
     use :: Galactic_Filters                        , only : galacticFilterClass
+    use :: Galactic_Structure_Options              , only : componentTypeAll
     use :: Error                                   , only : Error_Report
     use :: Geometry_Surveys                        , only : surveyGeometryClass
     use :: ISO_Varying_String                      , only : var_str                                        , varying_string
     use :: Dust_Attenuations                       , only : dustAttenuationClass
-    use :: Node_Property_Extractors                , only : multiExtractorList                             , nodePropertyExtractorDustAttenuation        , nodePropertyExtractorLmnstyEmssnLinePanuzzo2003, &
-         &                                                  nodePropertyExtractorScalarizer
+    use :: Node_Property_Extractors                , only : multiExtractorList                             , nodePropertyExtractorDustAttenuation        , nodePropertyExtractorLuminosityEmissionLine    , nodePropertyExtractorScalarizer
     use :: Numerical_Constants_Astronomical        , only : megaParsec
     use :: Numerical_Constants_Units               , only : ergs
     use :: Output_Analyses_Options                 , only : outputAnalysisCovarianceModelBinomial
@@ -307,12 +355,12 @@ contains
     use :: Output_Analysis_Utilities               , only : Output_Analysis_Output_Weight_Survey_Volume
     use :: Output_Analysis_Weight_Operators        , only : outputAnalysisWeightOperatorCsmlgyVolume
     use :: Output_Times                            , only : outputTimesClass
-    use :: Star_Formation_Rates_Disks              , only : starFormationRateDisksClass
-    use :: Star_Formation_Rates_Spheroids          , only : starFormationRateSpheroidsClass
     implicit none
     type            (outputAnalysisLuminosityFunctionHalpha         )                                          :: self
     type            (varying_string                                 ), intent(in   )                           :: label                                                 , comment
     logical                                                          , intent(in   )                           :: includeNitrogenII
+    type            (varying_string                                 ), intent(in   )                           :: cloudyTableFileName
+    double precision                                                 , intent(in   )                           :: toleranceRelative
     double precision                                                 , intent(in   )          , dimension(:  ) :: luminosities
     class           (galacticFilterClass                            ), intent(in   ), target                   :: galacticFilter_
     class           (surveyGeometryClass                            ), intent(in   ), target                   :: surveyGeometry_
@@ -321,17 +369,21 @@ contains
     class           (outputAnalysisPropertyOperatorClass            ), intent(inout), target                   :: outputAnalysisPropertyOperator_
     class           (outputAnalysisDistributionOperatorClass        ), intent(in   ), target                   :: outputAnalysisDistributionOperator_
     class           (dustAttenuationClass                           ), intent(in   ), target                   :: dustAttenuation_
-    class           (starFormationRateDisksClass                    ), intent(in   ), target                   :: starFormationRateDisks_
-    class           (starFormationRateSpheroidsClass                ), intent(in   ), target                   :: starFormationRateSpheroids_
+    class           (starFormationHistoryClass                      ), intent(in   ), target                   :: starFormationHistory_
+    class           (hiiRegionLuminosityFunctionClass               ), intent(in   ), target                   :: hiiRegionLuminosityFunction_
+    class           (hiiRegionMassFunctionClass                     ), intent(in   ), target                   :: hiiRegionMassFunction_
+    class           (hiiRegionDensityDistributionClass              ), intent(in   ), target                   :: hiiRegionDensityDistribution_
+    class           (hiiRegionEscapeFractionClass                   ), intent(in   ), target                   :: hiiRegionEscapeFraction_
     integer                                                          , intent(in   )                           :: covarianceBinomialBinsPerDecade
     double precision                                                 , intent(in   )                           :: covarianceBinomialMassHaloMinimum                     , covarianceBinomialMassHaloMaximum
     type            (varying_string                                 ), intent(in   ), optional                 :: targetLabel
     double precision                                                 , intent(in   ), optional, dimension(:  ) :: functionValueTarget
     double precision                                                 , intent(in   ), optional, dimension(:,:) :: functionCovarianceTarget
-    type            (nodePropertyExtractorLmnstyEmssnLinePanuzzo2003)               , pointer                  :: nodePropertyExtractorLines_
+    type            (nodePropertyExtractorLuminosityEmissionLine    )               , pointer                  :: nodePropertyExtractorLines_
     type            (nodePropertyExtractorDustAttenuation           )               , pointer                  :: nodePropertyExtractorAttenuated_
     type            (nodePropertyExtractorScalarizer                )               , pointer                  :: nodePropertyExtractor_
-    type            (multiExtractorList                             )               , pointer                  :: extractors
+    type            (multiExtractorList                             )               , pointer                  :: extractors                                            , extractor_
+    type            (multiExtractorList                             ), allocatable            , dimension(:  ) :: extractorsLines
     type            (outputAnalysisPropertyOperatorLog10            )               , pointer                  :: outputAnalysisPropertyOperatorLog10_
     type            (outputAnalysisPropertyOperatorAntiLog10        )               , pointer                  :: outputAnalysisPropertyOperatorAntiLog10_
     type            (outputAnalysisPropertyOperatorCsmlgyLmnstyDstnc)               , pointer                  :: outputAnalysisPropertyOperatorCsmlgyLmnstyDstnc_
@@ -347,9 +399,10 @@ contains
     double precision                                                 , parameter                               :: bufferWidth                                     =1.0d0
     integer         (c_size_t                                       ), parameter                               :: bufferCountMinimum                              =5
     integer         (c_size_t                                       )                                          :: iBin                                                  , bufferCount
+    integer                                                                                                   :: iLine
     type            (outputAnalysisTargetDataStandard)                              :: outputAnalysisTargetData_
     !![
-    <constructorAssign variables="luminosities, includeNitrogenII, *surveyGeometry_, *cosmologyFunctions_, *cosmologyFunctionsData, *starFormationRateDisks_, *starFormationRateSpheroids_"/>
+    <constructorAssign variables="luminosities, includeNitrogenII, cloudyTableFileName, toleranceRelative, *surveyGeometry_, *cosmologyFunctions_, *cosmologyFunctionsData, *dustAttenuation_, *starFormationHistory_, *hiiRegionLuminosityFunction_, *hiiRegionMassFunction_, *hiiRegionDensityDistribution_, *hiiRegionEscapeFraction_"/>
     !!]
 
     ! Compute weights that apply to each output redshift.
@@ -360,8 +413,9 @@ contains
     end do
     ! Create a luminosity property extractor. The line luminosities themselves are unattenuated; dust is applied by
     ! wrapping them, which lets any `dustAttenuation` model be used and keeps a single implementation of the physics.
-    ! The wrapper emits only the summed, attenuated luminosity, which a scalarizer then presents as the single value
-    ! this analysis requires.
+    ! The wrapper emits only the sum, formed elementwise over its children, so one child is built per line, each
+    ! emitting a single element. The sum is then a single value --- the summed, attenuated luminosity of the lines ---
+    ! which a scalarizer presents as the scalar this analysis requires.
     if (includeNitrogenII) then
        allocate(lineNames(3))
        lineNames(1)=var_str('balmerAlpha6565')
@@ -371,19 +425,52 @@ contains
        allocate(lineNames(1))
        lineNames(1)=var_str('balmerAlpha6565')
     end if
-    allocate(nodePropertyExtractorLines_     )
+    ! Line luminosities are computed from the star formation history, so without one this analysis would run happily
+    ! and report a luminosity function of zero in every bin. Since `starFormationHistory` defaults to `null`, that is
+    ! what an otherwise unchanged parameter file would get, so refuse it here rather than return an empty analysis.
+    select type (starFormationHistory_)
+    type is (starFormationHistoryNull)
+       call Error_Report(                                                                                        &
+            &            'this analysis computes emission line luminosities from the star formation history,'//  &
+            &            ' so a [starFormationHistory] which stores one must be specified - the default of'  //  &
+            &            ' `null` stores none, which would give a luminosity function of zero in every bin'  //  &
+            &            {introspection:location}                                                                &
+            &           )
+    class default
+       ! A star formation history is stored, so line luminosities can be computed.
+    end select
+    ! `extractorsLines` keeps a handle on each line extractor which does not depend on the linked list, since that
+    ! list belongs to the wrapper once it has been passed to it.
+    allocate(extractorsLines(size(lineNames)))
+    extractors => null()
+    extractor_ => null()
+    do iLine=1,size(lineNames)
+       if (associated(extractor_)) then
+          allocate(extractor_%next)
+          extractor_ => extractor_%next
+       else
+          allocate(extractors      )
+          extractor_ => extractors
+       end if
+       allocate(nodePropertyExtractorLines_)
+       !![
+       <referenceConstruct object="nodePropertyExtractorLines_" constructor="nodePropertyExtractorLuminosityEmissionLine(cloudyTableFileName,componentTypeAll,lineNames(iLine:iLine),toleranceRelative,starFormationHistory_,outputTimes_,hiiRegionLuminosityFunction_,hiiRegionMassFunction_,hiiRegionDensityDistribution_,hiiRegionEscapeFraction_)"/>
+       !!]
+       extractor_            %extractor_ => nodePropertyExtractorLines_
+       extractorsLines(iLine)%extractor_ => nodePropertyExtractorLines_
+    end do
     allocate(nodePropertyExtractorAttenuated_)
     allocate(nodePropertyExtractor_          )
-    !![
-    <referenceConstruct object="nodePropertyExtractorLines_"      constructor="nodePropertyExtractorLmnstyEmssnLinePanuzzo2003(starFormationRateDisks_,starFormationRateSpheroids_,outputTimes_,lineNames,outputMask=sum(outputWeight,dim=1) > 0.0d0)"/>
-    !!]
-    allocate(extractors)
-    extractors%extractor_ => nodePropertyExtractorLines_
-    extractors%next       => null()
     !![
     <referenceConstruct object="nodePropertyExtractorAttenuated_" constructor="nodePropertyExtractorDustAttenuation(dustAttenuation_,.false.,.true.,.true.,var_str('luminosityEmissionLine'),extractors)"/>
     <referenceConstruct object="nodePropertyExtractor_"           constructor="nodePropertyExtractorScalarizer     (1,1,nodePropertyExtractorAttenuated_)"/>
     !!]
+    ! Release our own references to the line extractors --- the wrapper holds its own.
+    do iLine=1,size(lineNames)
+       !![
+       <objectDestructor name="extractorsLines(iLine)%extractor_"/>
+       !!]
+    end do
     ! Prepend log10 and cosmological luminosity distance property operators.
     allocate(outputAnalysisPropertyOperatorLog10_            )
     !![
@@ -489,7 +576,6 @@ contains
          &                               )
     ! Clean up.
     !![
-    <objectDestructor name="nodePropertyExtractorLines_"                     />
     <objectDestructor name="nodePropertyExtractorAttenuated_"                />
     <objectDestructor name="nodePropertyExtractor_"                          />
     <objectDestructor name="outputAnalysisPropertyOperatorLog10_"            />
@@ -503,6 +589,8 @@ contains
     !!]
     nullify(propertyOperatorSequence)
     nullify(normalizerSequence      )
+    nullify(extractors              )
+    nullify(extractor_              )
     return
   end function luminosityFunctionHalphaConstructorInternal
 
@@ -513,12 +601,15 @@ contains
     type(outputAnalysisLuminosityFunctionHalpha), intent(inout) :: self
 
     !![
-    <objectDestructor name="self%surveyGeometry_"            />
-    <objectDestructor name="self%dustAttenuation_"           />
-    <objectDestructor name="self%cosmologyFunctions_"        />
-    <objectDestructor name="self%cosmologyFunctionsData"     />
-    <objectDestructor name="self%starFormationRateDisks_"    />
-    <objectDestructor name="self%starFormationRateSpheroids_"/>
+    <objectDestructor name="self%surveyGeometry_"              />
+    <objectDestructor name="self%dustAttenuation_"             />
+    <objectDestructor name="self%cosmologyFunctions_"          />
+    <objectDestructor name="self%cosmologyFunctionsData"       />
+    <objectDestructor name="self%starFormationHistory_"        />
+    <objectDestructor name="self%hiiRegionLuminosityFunction_" />
+    <objectDestructor name="self%hiiRegionMassFunction_"       />
+    <objectDestructor name="self%hiiRegionDensityDistribution_"/>
+    <objectDestructor name="self%hiiRegionEscapeFraction_"     />
     !!]
     return
   end subroutine luminosityFunctionHalphaDestructor

--- a/testSuite/parameters/luminosityFunctionHalpha.xml
+++ b/testSuite/parameters/luminosityFunctionHalpha.xml
@@ -1,7 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Runs the Halpha luminosity function analyses, which reach the dust attenuation framework through the chain
-     scalarizer -> dustAttenuation(outputSumOnly) -> Panuzzo2003. The dust model is given explicitly and is the one
-     equivalent to the retired `depthOpticalISMCoefficient` these analyses used to carry themselves. -->
+     scalarizer -> dustAttenuation(outputSumOnly) -> luminosityEmissionLine (one child per line). The dust model is
+     given explicitly and is the one equivalent to the retired `depthOpticalISMCoefficient` these analyses used to
+     carry themselves. -->
 
 <parameters>
   <formatVersion>2</formatVersion>
@@ -311,31 +312,49 @@
     <redshifts value="0.00 0.02 0.04 0.06 0.08 0.10"/>
   </outputTimes>
 
-  <!-- A star formation history is stored so that the young stellar populations which ionize the gas are resolved in
-       time; the default is to store none. -->
+  <!-- Limit timesteps to the times at which the star formation history is tabulated, so that it is recorded
+       accurately. The `standard` default does not include this criterion. -->
+  <mergerTreeEvolveTimestep value="multi">
+    <mergerTreeEvolveTimestep value="standard"            />
+    <mergerTreeEvolveTimestep value="starFormationHistory"/>
+  </mergerTreeEvolveTimestep>
+
+  <!-- The emission line luminosities are computed by convolving the star formation history with tabulated Cloudy
+       models of HII regions, so a star formation history must be stored (the default is to store none) and must
+       resolve the young, ionizing populations in time and in metallicity. The metallicity boundaries match those of
+       the tabulation used below. -->
   <starFormationHistory value="adaptive">
-    <timeStepMinimum       value="2.0e-3"/>
-    <countTimeStepsMaximum value="16"    />
-    <countMetallicities    value="4"     />
+    <timeStepMinimum       value="1.0e-3"/>
+    <countTimeStepsMaximum value="32"    />
+    <metallicityBoundaries value="
+				  0.00531915 0.01063830 0.02127660 0.06728250 0.21276596 0.30089650
+				  0.42553191 0.67282503 1.06382979 1.68206259 2.65957447
+				  "/>
   </starFormationHistory>
 
-  <!-- Each luminosity is tracked twice: once unrestricted, once restricted to populations younger than the birth
-       cloud lifetime. Differencing the two isolates the light of old stars. -->
-  <!-- The Panuzzo (2003) emission line calculation needs the hydrogen, helium, and oxygen ionizing continuum
-       luminosities at every output for which the analysis has non-zero weight. -->
-  <luminosityFilter         value="Lyc     Lyc     Lyc     Lyc     Lyc     HeliumContinuum HeliumContinuum HeliumContinuum HeliumContinuum HeliumContinuum OxygenContinuum OxygenContinuum OxygenContinuum OxygenContinuum OxygenContinuum"/>
-  <luminosityType           value="rest    rest    rest    rest    rest    rest            rest            rest            rest            rest            rest            rest            rest            rest            rest           "/>
-  <luminosityRedshift       value="0.02    0.04    0.06    0.08    0.10    0.02            0.04            0.06            0.08            0.10            0.02            0.04            0.06            0.08            0.10           "/>
-  <luminosityPostprocessSet value="default default default default default default         default         default         default         default         default         default         default         default         default        "/>
-
-  <stellarPopulationSpectraPostprocessorBuilder value="lookup">
-    <names value="default"/>
-    <stellarPopulationSpectraPostprocessor value="identity"/>
-  </stellarPopulationSpectraPostprocessorBuilder>
+  <!-- The population of HII regions which the emission line calculation integrates over. These are the calibrated
+       choices of `parameters/reference/emissionLines.xml`. -->
+  <hiiRegionEscapeFraction value="fixed">
+    <escapeFraction value="0.10"/>
+    <ageLimit       value="0.01"/>
+  </hiiRegionEscapeFraction>
+  <hiiRegionMassFunction value="rosolowsky2021">
+    <exponent    value="-1.8e0"/>
+    <massMinimum value="+1.0e4"/>
+    <massMaximum value="+1.0e8"/>
+  </hiiRegionMassFunction>
+  <hiiRegionDensityDistribution value="logNormal">
+    <densityHydrogenReference value="3.0e2"/>
+    <densityHydrogenMinimum   value="1.0e1"/>
+    <densityHydrogenMaximum   value="4.0e2"/>
+    <sigma                    value="1.8e0"/>
+  </hiiRegionDensityDistribution>
 
   <!-- Halpha luminosity function analyses. The `dustAttenuation` object supplied here is what the analyses now use
        in place of the `depthOpticalISMCoefficient` they previously carried: `screenSurfaceDensityMetals` computes the
-       same optical depth from the same surface density of metals. -->
+       same optical depth from the same surface density of metals. It is a diffuse ISM screen: the tabulation of line
+       luminosities already includes the dust within the HII region, so a birth cloud component here would count that
+       dust twice. -->
   <!-- These tests are about dust, not lensing. The default lensing model needs to construct magnification
        distributions, which is slow and requires resources not present in every environment, so disable it as
        the bundled constrained model does. -->

--- a/testSuite/test-luminosity-function-Halpha.py
+++ b/testSuite/test-luminosity-function-Halpha.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Check that the Halpha luminosity function analysis reaches the dust attenuation framework.
 
-The analysis no longer carries a dust normalization of its own. Instead it wraps its emission line extractor in
+The analysis no longer carries a dust normalization of its own. Instead it wraps its emission line extractors in
 `nodePropertyExtractorDustAttenuation` and scalarizes the summed, attenuated luminosity:
 
-    scalarizer -> dustAttenuation(outputSumOnly) -> Panuzzo2003
+    scalarizer -> dustAttenuation(outputSumOnly) -> luminosityEmissionLine (one child per line)
 
 so the dust model given to the analysis is what determines the attenuation. This runs the analysis twice, once with
 no dust and once with a screen whose optical depth follows the surface density of metals, and checks that the dust


### PR DESCRIPTION
Moves `outputAnalysisLuminosityFunctionHalpha` onto
`nodePropertyExtractorLuminosityEmissionLine`, per the plan in #1420.

`Panuzzo2003` is rate-based: it applies an HII region model to the instantaneous
star formation rate. `LuminosityEmissionLine` is history-based: it convolves the
star formation history with tabulated Cloudy models of a population of HII
regions described by `hiiRegionLuminosityFunction`, `hiiRegionMassFunction`,
`hiiRegionDensityDistribution` and `hiiRegionEscapeFraction`. The two are not
interchangeable, so this is a physics change rather than a refactor.

## The extractor chain

`LuminosityEmissionLine` is a tuple, one element per line, while the analysis
narrows its extractor to a scalar. The dust wrapper forms its sum elementwise
over its children, so one child is built per line -- Halpha, plus the two [NII]
lines when `includeNitrogenII` is set -- each emitting a single element:

    scalarizer -> dustAttenuation(outputSumOnly) -> luminosityEmissionLine (one per line)

Each child uses `component=all`, whose `decompose` splits into disk and spheroid
parcels, so dust still reaches each component separately.

## Dust double counting

Every distributed Cloudy tabulation has a dust-to-metals ratio of ~0.4, so it
already includes the dust *within* the HII region. The `dustAttenuation` model
given to the analysis is applied on top and so should describe only the dust
*outside* it; a birth cloud component would count the same dust twice. This is
documented on the class, and the bundled parameter files use a diffuse ISM
screen.

## `Panuzzo2003` retained

Kept unchanged and still available as a property extractor, for backward
compatibility, as requested on #1420. Its `luminosities` method and `wavelength`
array are therefore also kept.

## Prerequisite fixes (first commit)

Three defects had to be fixed before an analysis could consume the chain at all:

* `nodePropertyExtractorDustAttenuation` and `nodePropertyExtractorAppendSuffix`
  declared their `extractors` dummy without `target`, then passed it to
  `nodePropertyExtractorMulti`, whose dummy *is* `target` and which stores
  `self%extractors => extractors`. That permits the compiler to work on a copy,
  leaving the multi extractor's list pointer associated with a temporary. Under
  gdb the attenuator's `extractors` sat at a different address from the list its
  caller built, and the caller's list node had been overwritten. It went
  unnoticed because no caller dereferenced the list after handing it over.
* `nodePropertyExtractorLuminosityEmissionLine` did not override `quantity`, so
  it reported `Unknown` and any wrapping analysis aborted in
  `outputAnalysisWeightOperatorCsmlgyVolume` with `unsupported property class`.

## Failing loudly on a missing history

Line luminosities now come from the star formation history, and
`starFormationHistory` defaults to `null`. An otherwise unchanged parameter file
would therefore run happily and report a luminosity function of zero in every
bin -- verified. The analysis now refuses a `null` history instead.

## Validation

Per galaxy the two methods agree closely: median `log10(new/old)` = -0.078 dex,
flat across three decades of star formation rate.

| | median L(Halpha)/SFR [erg/s per Msun/yr] |
| --- | --- |
| `luminosityEmissionLine` | 2.34e41 |
| `Panuzzo2003` | 3.02e41 |
| Kennicutt (1998) rescaled to Chabrier | ~2.2e41 |

**The comparison against Gunawardhana et al. (2013) and Sobral et al. (2013)
themselves is not yet a revalidation.** It was made only with a small
uncalibrated model (80 trees, 1e10-1e14 Msun), which lacks the volume to
populate the HiZELS luminosity range at z >= 1.5 -- the z=1.47 panel is empty
above the survey's faint limit of 1e41.7 erg/s. Only the SDSS interval spans the
data's full range, and there the model is low by ~0.7 dex at the faint end.
Doing this properly wants a run of `parameters/baryonicPhysicsConstrained.xml`,
which could not be run in my environment (`failed to run mangle harmonize`,
unrelated to this work).

## Depends on

The star formation history defects found while doing this (#1441) are fixed and
merged; this branch is rebased on that work. In particular the fix to advance
star formation histories for every outputter is what makes the `analyzer`
outputter usable with widely separated outputs, and hence what allows
`parameters/baryonicPhysicsConstrained.xml` to be configured here at all.

## Tests

`test-luminosity-function-Halpha.py`, `test-dust-attenuation-parity.py` (all 15
checks, including the `outputSumOnly` and scalarizer parity checks which
exercise the corrected pointer association, both exact to 0.000e+00) and
`test-dust-analyses-SDSS.py` all pass.

Closes #1420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gbz2W8snR2eshhqxY9DK5
