### PR TITLE
Dust compendium atlas, and the Ferrara atlas spheroid radius convention

### DIFF
--- a/aux/words.dict
+++ b/aux/words.dict
@@ -140,6 +140,7 @@ IMFs
 ISCO
 Inoue
 Jacobian
+Jaffe
 Jerjen
 Jessop
 Jiang
@@ -301,6 +302,7 @@ arcminute
 arcminutes
 astrosylva
 asymptotes
+attenuations
 attenuator
 attenuators
 autocorrelation

--- a/docs/Galacticus.bib
+++ b/docs/Galacticus.bib
@@ -733,6 +733,22 @@
   howpublished	= {{http://adsabs.harvard.edu/abs/2010arXiv1004.1162B}}
 }
 
+@Article{	  benson_compendium_2018,
+  author	= {{Benson}, Andrew},
+  title		= "{A Compendium of Extinction Curves for Simple Galactic
+		  Geometries}",
+  journal	= {Research Notes of the American Astronomical Society},
+  keywords	= {Astrophysics - Astrophysics of Galaxies},
+  year		= 2018,
+  month		= oct,
+  volume	= {2},
+  number	= {4},
+  pages		= {188},
+  doi		= {10.3847/2515-5172/aae5f4},
+  adsurl	= {https://ui.adsabs.harvard.edu/abs/2018RNAAS...2..188B},
+  adsnote	= {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @Article{	  benson_comparison_2001,
   author	= {{Benson}, A.~J. and {Pearce}, F.~R. and {Frenk}, C.~S. and
 		  {Baugh}, C.~M. and {Jenkins}, A.},
@@ -9235,6 +9251,27 @@
   eprint	= {1807.06211},
   primaryclass	= {astro-ph.CO},
   adsurl	= {https://ui.adsabs.harvard.edu/abs/2020A&A...641A..10P},
+  adsnote	= {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Article{	  popping_dust_2017,
+  author	= {{Popping}, Gerg\"o and {Somerville}, Rachel S. and
+		  {Galametz}, Maud},
+  title		= "{The dust content of galaxies from z = 0 to z = 9}",
+  journal	= {\mnras},
+  keywords	= {ISM: abundances, dust, extinction, galaxies: evolution,
+		  galaxies: high-redshift, galaxies: ISM, Astrophysics -
+		  Astrophysics of Galaxies},
+  year		= 2017,
+  month		= nov,
+  volume	= {471},
+  number	= {3},
+  pages		= {3152-3185},
+  doi		= {10.1093/mnras/stx1545},
+  archiveprefix	= {arXiv},
+  eprint	= {1706.06587},
+  primaryclass	= {astro-ph.GA},
+  adsurl	= {https://ui.adsabs.harvard.edu/abs/2017MNRAS.471.3152P},
   adsnote	= {Provided by the SAO/NASA Astrophysics Data System}
 }
 

--- a/docs/Galacticus.bib
+++ b/docs/Galacticus.bib
@@ -1235,6 +1235,26 @@
   pages		= {122}
 }
 
+@Article{	  bianchi_monte_carlo_1996,
+  author	= {{Bianchi}, Simone and {Ferrara}, Andrea and {Giovanardi},
+		  Carlo},
+  title		= "{Monte Carlo Simulations of Dusty Spiral Galaxies: Extinction
+		  and Polarization Properties}",
+  journal	= {\apj},
+  keywords	= {DUST, EXTINCTION, GALAXIES: ISM, GALAXIES: SPIRAL, METHODS:
+		  NUMERICAL, POLARIZATION, Astrophysics},
+  year		= 1996,
+  month		= jul,
+  volume	= {465},
+  pages		= {127},
+  doi		= {10.1086/177407},
+  archiveprefix	= {arXiv},
+  eprint	= {astro-ph/9601099},
+  primaryclass	= {astro-ph},
+  adsurl	= {https://ui.adsabs.harvard.edu/abs/1996ApJ...465..127B},
+  adsnote	= {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @Article{	  bigiel_star_2008,
   author	= {{Bigiel}, F. and {Leroy}, A. and {Walter}, F. and
 		  {Brinks}, E. and {de Blok}, W.~J.~G. and {Madore}, B. and

--- a/docs/manuals/user-guide/data/dust-compendium-datasets.rst
+++ b/docs/manuals/user-guide/data/dust-compendium-datasets.rst
@@ -1,9 +1,28 @@
 Dust Compendium Datasets
 ========================
 
-Datasets containing dust extinctions for simple galactic geometries, computed using the methods described by `Benson (2018) <https://ui.adsabs.harvard.edu/abs/2018RNAAS...2..188B>`_ and in a format compatible with the `DustCompendium <https://github.com/galacticusorg/analysis-python/blob/master/galacticus/dust/dustCompendium.py>`_ class in the `analysis-python <https://github.com/galacticusorg/analysis-python>`_ tools are available for download. The individual datasets are linked to and described below.
+Datasets containing dust extinctions for simple galactic geometries, computed using the methods described by :cite:t:`benson_compendium_2018`, are available for download. The individual datasets are linked to and described below.
 
 Galacticus reads these files directly, through the :galacticus-class:`dustAttenuationAtlasCompendium` dust attenuation class: set its ``fileName`` to the name of the file to use, and its ``url`` to the download link given below for the record containing it. The file is fetched once and cached under the dynamic datasets path, so it need not be downloaded by hand.
+
+Spheroid radii
+--------------
+
+Spheroid sizes in these datasets are tabulated as the **scale radius**, *r*\ :sub:`s`\ , of the spheroid density profile, in units of the radial scale length of the stellar disk. This differs from the convention of :cite:t:`ferrara_atlas_1999`, whose atlas is tabulated instead against an **effective radius**, *R*\ :sub:`e`\ , and the two are related by
+
+.. math::
+
+   r_\mathrm{s} = 1.16 \, R_\mathrm{e}.
+
+That factor is not a property of any one profile, but a correspondence between two of them, and it is worth understanding where it comes from before using either dataset.
+
+:cite:t:`ferrara_atlas_1999` describe their spheroids as having an effective radius, but realize them in the radiative transfer calculation as Jaffe profiles, which stand in for the *R*\ :sup:`1/4` profiles that the effective radius properly belongs to. The appendix of :cite:t:`bianchi_monte_carlo_1996`, which describes the Monte Carlo code the atlas was computed with, sets the correspondence between the two, and their reasoning fixes the number. The *R*\ :sup:`1/4` and Jaffe distributions are similar in shape, but the relation between the Jaffe scale radius and the effective radius depends on which property of the galaxy one chooses to match best. Their Monte Carlo associates a random number directly with the fraction of the luminosity enclosed within a given radius, and draws photon emission positions from it, so the quantity that must correspond between the two profiles is that enclosed luminosity --- not any particular radius, and not the total light. Under that criterion the best correspondence is *r*\ :sub:`s`\ =1.16\ *R*\ :sub:`e`\ ; matching the half-light radii instead would have given roughly 1.35. The choice is therefore a real one, and not a matter of convention: the two differ by about the same 16 percent as the factor itself.
+
+Two consequences follow for anyone using these datasets.
+
+First, a spheroid described by a given effective radius in :cite:t:`ferrara_atlas_1999` corresponds to a **larger** scale radius here, by 16 percent. The two tabulations are not interchangeable on the same axis values.
+
+Second, matching a galaxy whose spheroid follows some third profile --- a Hernquist profile, say --- onto either tabulation is necessarily approximate, and by the same reasoning it should be done on an integral property rather than on a scale radius. Galacticus matches on the half-mass radius, which is the one measure that means the same thing whatever profile either side assumes, and then converts to whichever radius the tabulation is labeled with: this is what the ``spheroidProfile`` parameter of :galacticus-class:`dustAttenuationAtlasCompendium` selects. The residual uncertainty in doing so is of the same order as the 1.16 factor itself, so spheroid attenuations for a profile other than the tabulated one should not be relied upon at better than the ten percent level.
 
 Any questions about these datasets should be directed to `Andrew Benson <mailto:abenson@carnegiescience.edu>`_.
 
@@ -60,7 +79,7 @@ Dust grain properties are taken from `Draine (2003) <http://adsabs.harvard.edu/a
 Stellar Geometry
 ~~~~~~~~~~~~~~~~~
 
-Galactic disks follow exponential profiles in both radial and vertical directions, with the vertical scale height equal to 0.1 or 0.5 times the radial scale length as encoded in the file name with prefix ``hzStars``. Note that spheroid radii in this work are listed as the scale radius, *r*\ :sub:`s`\ , while Ferrara et al. (1999) listed the corresponding effective radius, *r*\ :sub:`e`\ =\ *r*\ :sub:`s`\ /1.16.
+Galactic disks follow exponential profiles in both radial and vertical directions, with the vertical scale height equal to 0.1 or 0.5 times the radial scale length as encoded in the file name with prefix ``hzStars``.
 
 Dust Geometry
 ~~~~~~~~~~~~~
@@ -75,10 +94,10 @@ Files
 Ferrara et al. (1999)-like models
 ---------------------------------
 
-These models are intended to closely match the models run by `Ferrara et al. (1999) <http://adsabs.harvard.edu/abs/1999ApJS..123..437F>`_ - they use the same dust grain properties and galactic geometry.
+These models are intended to closely match the models run by :cite:t:`ferrara_atlas_1999` - they use the same dust grain properties and galactic geometry.
 
 Files
 ~~~~~
 
-* `"Original" <https://doi.org/10.5281/zenodo.6336095>`_ - models tabulated at the same inclinations, optical depths, wavelengths, and morphologies as in `Ferrara et al. (1999) <http://adsabs.harvard.edu/abs/1999ApJS..123..437F>`_.
-* `"HiRes" <https://doi.org/10.5281/zenodo.6336097>`_ - models tabulated with a much higher resolution grid of inclinations, optical depths, wavelengths, and morphologies than in `Ferrara et al. (1999) <http://adsabs.harvard.edu/abs/1999ApJS..123..437F>`_, but with the same dust properties and galactic mass distributions.
+* `"Original" <https://doi.org/10.5281/zenodo.6336095>`_ - models tabulated at the same inclinations, optical depths, wavelengths, and morphologies as in :cite:t:`ferrara_atlas_1999`.
+* `"HiRes" <https://doi.org/10.5281/zenodo.6336097>`_ - models tabulated with a much higher resolution grid of inclinations, optical depths, wavelengths, and morphologies than in :cite:t:`ferrara_atlas_1999`, but with the same dust properties and galactic mass distributions.

--- a/docs/manuals/user-guide/data/dust-compendium-datasets.rst
+++ b/docs/manuals/user-guide/data/dust-compendium-datasets.rst
@@ -3,6 +3,8 @@ Dust Compendium Datasets
 
 Datasets containing dust extinctions for simple galactic geometries, computed using the methods described by `Benson (2018) <https://ui.adsabs.harvard.edu/abs/2018RNAAS...2..188B>`_ and in a format compatible with the `DustCompendium <https://github.com/galacticusorg/analysis-python/blob/master/galacticus/dust/dustCompendium.py>`_ class in the `analysis-python <https://github.com/galacticusorg/analysis-python>`_ tools are available for download. The individual datasets are linked to and described below.
 
+Galacticus reads these files directly, through the :galacticus-class:`dustAttenuationAtlasCompendium` dust attenuation class: set its ``fileName`` to the name of the file to use, and its ``url`` to the download link given below for the record containing it. The file is fetched once and cached under the dynamic datasets path, so it need not be downloaded by hand.
+
 Any questions about these datasets should be directed to `Andrew Benson <mailto:abenson@carnegiescience.edu>`_.
 
 Draine (2003) grains

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -986,6 +986,7 @@
        <xs:attribute name="value" use="optional">
         <xs:simpleType>
          <xs:restriction base="xs:string">
+          <xs:enumeration value="atlasCompendium"/>
           <xs:enumeration value="atlasFerrara2000"/>
           <xs:enumeration value="birthCloud"/>
           <xs:enumeration value="charlotFall2000"/>
@@ -5042,6 +5043,22 @@
          <xs:restriction base="xs:string">
           <xs:enumeration value="darkMatter"/>
           <xs:enumeration value="hotGas"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+    <xs:anyAttribute processContents="lax"/>
+   </xs:complexType>
+  </xs:element>
+  <xs:element name="spheroidProfile">
+   <xs:complexType mixed="true">
+    <xs:sequence>
+     <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+       <xs:attribute name="value" use="optional">
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="hernquist"/>
+          <xs:enumeration value="jaffe"/>
          </xs:restriction>
         </xs:simpleType>
        </xs:attribute>

--- a/source/dust/attenuation/_class.F90
+++ b/source/dust/attenuation/_class.F90
@@ -200,16 +200,21 @@ contains
 
   double precision function radiusSpheroidRelative(node) result(radiusSpheroid)
     !!{RST
-    Return the size of the spheroid in the units the radiative transfer atlases are tabulated against: its half-mass
-    radius, in units of the disk scale length.
+    Return the half-mass radius of the spheroid, in units of the disk scale length.
 
-    The atlases model spheroids with a specific profile---:cite:t:`ferrara_atlas_1999` use a Jaffe profile, for which
-    the enclosed mass is :math:`M(r)/M = (r/r_0)/(1+r/r_0)` so that the half-mass radius is exactly the scale radius
-    :math:`r_0`---and tabulate against the spheroid effective radius. A model galaxy's spheroid will in general follow
-    some other profile, for which the scale radius is *not* the half-mass radius---for a Hernquist profile the latter
-    is :math:`(1+\sqrt{2})` times the former---so the half-mass radius is taken from the stellar mass distribution of
-    the spheroid rather than from its scale radius. That is the radius which means the same thing whatever profile
-    either side assumes, and matching on it is what makes an atlas applicable to a spheroid it was not computed for.
+    Each radiative transfer atlas tabulates the spheroid along an axis of its own, and none of those axes is
+    directly a model galaxy's spheroid radius: the atlas simulated a particular density profile, and labelled the
+    axis with a particular radius of it. What is returned here is the one measure that means the same thing whatever
+    profile either side assumes---the half-mass radius, taken from the stellar mass distribution of the spheroid
+    rather than from its scale radius, since for a Hernquist profile the latter is smaller by
+    :math:`(1+\sqrt{2})`. Each atlas then converts this to its own axis by dividing by the half-mass radius that one
+    unit of that axis corresponds to.
+
+    Matching two differently shaped profiles on a single radius is itself an approximation, and not the best one
+    available: :cite:t:`bianchi_monte_carlo_1996` matched an :math:`R^{1/4}` profile to a Jaffe profile by fitting
+    their enclosed luminosity, and obtained a relation differing by :math:`\approx 14` per cent from what matching
+    half-light radii would have given. Attenuations for a spheroid whose profile is not the one an atlas simulated
+    should therefore not be relied upon at better than the ten per cent level, whatever the optical depth.
 
     The disk is measured by its scale radius, which is what the atlases normalize to, and which is what the disk
     component's radius already is for an exponential profile.

--- a/source/dust/attenuation/_class.F90
+++ b/source/dust/attenuation/_class.F90
@@ -58,7 +58,7 @@ module Dust_Attenuations
   ! Made public so that it survives into the object file: it is called only from the submodules into which the
   ! implementations of this class are generated, never from this module itself, and a private procedure with no
   ! caller in its own module can be discarded before those submodules are linked against it.
-  public :: componentGasProperties
+  public :: componentGasProperties, radiusSpheroidRelative
 
   ! Metallicity of the local interstellar medium, by mass. Dust-to-gas ratios are scaled relative to this value, on
   ! the assumption that the dust-to-metals ratio is universal. Declared here, rather than in an implementation file,
@@ -197,5 +197,59 @@ contains
     metallicity=abundancesGas%metallicity(metallicityTypeLinearByMass)
     return
   end subroutine componentGasProperties
+
+  double precision function radiusSpheroidRelative(node) result(radiusSpheroid)
+    !!{RST
+    Return the size of the spheroid in the units the radiative transfer atlases are tabulated against: its half-mass
+    radius, in units of the disk scale length.
+
+    The atlases model spheroids with a specific profile---:cite:t:`ferrara_atlas_1999` use a Jaffe profile, for which
+    the enclosed mass is :math:`M(r)/M = (r/r_0)/(1+r/r_0)` so that the half-mass radius is exactly the scale radius
+    :math:`r_0`---and tabulate against the spheroid effective radius. A model galaxy's spheroid will in general follow
+    some other profile, for which the scale radius is *not* the half-mass radius---for a Hernquist profile the latter
+    is :math:`(1+\sqrt{2})` times the former---so the half-mass radius is taken from the stellar mass distribution of
+    the spheroid rather than from its scale radius. That is the radius which means the same thing whatever profile
+    either side assumes, and matching on it is what makes an atlas applicable to a spheroid it was not computed for.
+
+    The disk is measured by its scale radius, which is what the atlases normalize to, and which is what the disk
+    component's radius already is for an exponential profile.
+
+    A galaxy with no disk has no scale to measure the spheroid against, and no dust either, so the value is
+    immaterial: zero is returned, which callers clamp into the tabulated range.
+
+    This lives here, alongside ``componentGasProperties``, rather than in either atlas: each implementation of
+    this class is generated into its own submodule, and while a submodule can see its parent module it can not see
+    its siblings.
+    !!}
+    use :: Error                     , only : Error_Report
+    use :: Galactic_Structure_Options, only : componentTypeSpheroid, massTypeStellar
+    use :: Galacticus_Nodes          , only : nodeComponentDisk
+    use :: Mass_Distributions        , only : massDistributionClass, massDistributionSpherical
+    implicit none
+    type            (treeNode             ), intent(inout), target  :: node
+    class           (nodeComponentDisk    )               , pointer :: disk
+    class           (massDistributionClass)               , pointer :: massDistributionSpheroid
+    double precision                                                :: radiusDisk
+
+    disk       => node%disk  ()
+    radiusDisk =  disk%radius()
+    if (radiusDisk <= 0.0d0) then
+       radiusSpheroid=0.0d0
+       return
+    end if
+    massDistributionSpheroid => node%massDistribution(componentTypeSpheroid,massTypeStellar)
+    select type (massDistributionSpheroid)
+    class is (massDistributionSpherical)
+       radiusSpheroid=+massDistributionSpheroid%radiusHalfMass() &
+            &         /                         radiusDisk
+    class default
+       radiusSpheroid=0.0d0
+       call Error_Report('a half-mass radius is needed for the spheroid, which requires a spherical mass distribution'//{introspection:location})
+    end select
+    !![
+    <objectDestructor name="massDistributionSpheroid"/>
+    !!]
+    return
+  end function radiusSpheroidRelative
 
 end module Dust_Attenuations

--- a/source/dust/attenuation/_class.F90
+++ b/source/dust/attenuation/_class.F90
@@ -203,7 +203,7 @@ contains
     Return the half-mass radius of the spheroid, in units of the disk scale length.
 
     Each radiative transfer atlas tabulates the spheroid along an axis of its own, and none of those axes is
-    directly a model galaxy's spheroid radius: the atlas simulated a particular density profile, and labelled the
+    directly a model galaxy's spheroid radius: the atlas simulated a particular density profile, and labeled the
     axis with a particular radius of it. What is returned here is the one measure that means the same thing whatever
     profile either side assumes---the half-mass radius, taken from the stellar mass distribution of the spheroid
     rather than from its scale radius, since for a Hernquist profile the latter is smaller by
@@ -212,9 +212,9 @@ contains
 
     Matching two differently shaped profiles on a single radius is itself an approximation, and not the best one
     available: :cite:t:`bianchi_monte_carlo_1996` matched an :math:`R^{1/4}` profile to a Jaffe profile by fitting
-    their enclosed luminosity, and obtained a relation differing by :math:`\approx 14` per cent from what matching
+    their enclosed luminosity, and obtained a relation differing by :math:`\approx 14` percent from what matching
     half-light radii would have given. Attenuations for a spheroid whose profile is not the one an atlas simulated
-    should therefore not be relied upon at better than the ten per cent level, whatever the optical depth.
+    should therefore not be relied upon at better than the ten percent level, whatever the optical depth.
 
     The disk is measured by its scale radius, which is what the atlases normalize to, and which is what the disk
     component's radius already is for an exponential profile.

--- a/source/dust/attenuation/atlas_Ferrara2000.F90
+++ b/source/dust/attenuation/atlas_Ferrara2000.F90
@@ -336,7 +336,7 @@ contains
              ! Clamp into the tabulated range before taking a logarithm. A galaxy may have no spheroid, or no disk
              ! to measure one against, giving a ratio of zero whose logarithm would trap; and the interpolator holds
              ! values at the boundary in any case, so nothing is lost by clamping here rather than there.
-             radiusSpheroid        =max(atlasFerrara2000RadiusSpheroid(node),minval(self%radiusSpheroid))
+             radiusSpheroid        =max(radiusSpheroidRelative(node),minval(self%radiusSpheroid))
              radiusSpheroidComputed=.true.
              call self%interpolatorRadiusSpheroid%linearFactors(log(radiusSpheroid),indicesSpheroid(1),weightsSpheroid(:,1))
           end if
@@ -348,57 +348,6 @@ contains
     end do
     return
   end function atlasFerrara2000Transmission
-
-  double precision function atlasFerrara2000RadiusSpheroid(node) result(radiusSpheroid)
-    !!{RST
-    Return the size of the spheroid in the units the atlas is tabulated against: its half-mass radius, in units of
-    the disk scale length.
-
-    :cite:t:`ferrara_atlas_1999` model spheroids as Jaffe profiles and tabulate against the spheroid effective
-    radius. For a Jaffe profile the enclosed mass is :math:`M(r)/M = (r/r_0)/(1+r/r_0)`, so the half-mass radius is
-    exactly the scale radius :math:`r_0`, and the tabulated axis is therefore a half-mass radius.
-
-    A model galaxy's spheroid will in general follow some other profile, for which the scale radius is *not* the
-    half-mass radius---for a Hernquist profile the latter is :math:`(1+\sqrt{2})` times the former---so the
-    half-mass radius is taken from the stellar mass distribution of the spheroid rather than from its scale radius.
-    That is the radius which means the same thing whatever profile either side assumes, and matching on it is what
-    makes the atlas applicable to a spheroid it was not computed for.
-
-    The disk is measured by its scale radius, which is what :cite:t:`ferrara_atlas_1999` normalize to, and which is
-    what the disk component's radius already is for an exponential profile.
-    !!}
-    use :: Error                     , only : Error_Report
-    use :: Galactic_Structure_Options, only : componentTypeSpheroid, massTypeStellar
-    use :: Galacticus_Nodes          , only : nodeComponentDisk
-    use :: Mass_Distributions        , only : massDistributionClass, massDistributionSpherical
-    implicit none
-    type            (treeNode             ), intent(inout), target  :: node
-    class           (nodeComponentDisk    )               , pointer :: disk
-    class           (massDistributionClass)               , pointer :: massDistributionSpheroid
-    double precision                                                :: radiusDisk
-
-    disk       => node%disk  ()
-    radiusDisk =  disk%radius()
-    ! With no disk there is no scale to measure the spheroid against, and no dust either, so the value is
-    ! immaterial: return zero, which the caller clamps into the tabulated range.
-    if (radiusDisk <= 0.0d0) then
-       radiusSpheroid=0.0d0
-       return
-    end if
-    massDistributionSpheroid => node%massDistribution(componentTypeSpheroid,massTypeStellar)
-    select type (massDistributionSpheroid)
-    class is (massDistributionSpherical)
-       radiusSpheroid=+massDistributionSpheroid%radiusHalfMass() &
-            &         /                         radiusDisk
-    class default
-       radiusSpheroid=0.0d0
-       call Error_Report('a half-mass radius is needed for the spheroid, which requires a spherical mass distribution'//{introspection:location})
-    end select
-    !![
-    <objectDestructor name="massDistributionSpheroid"/>
-    !!]
-    return
-  end function atlasFerrara2000RadiusSpheroid
 
   function atlasFerrara2000Request(self) result(request)
     !!{RST

--- a/source/dust/attenuation/atlas_Ferrara2000.F90
+++ b/source/dust/attenuation/atlas_Ferrara2000.F90
@@ -71,6 +71,20 @@
      :math:`V` band. For an exponential disk :math:`\Sigma_0 = M/2\pi r_\mathrm{d}^2`, which is what
      ``screenSurfaceDensityMetals`` computes, so the definitions agree.
 
+   * The size of the spheroid, on the axis the atlas tabulates. That axis is *not* a radius of the profile the
+     atlas actually simulated: :cite:t:`ferrara_atlas_1999` realize their spheroids as Jaffe profiles, but label
+     the axis with the effective radius :math:`R_\mathrm{e}` of the :math:`R^{1/4}` profile those Jaffe profiles
+     stand in for. :cite:t:`bianchi_monte_carlo_1996`, whose radiative transfer code the atlas was computed with,
+     give the correspondence in their appendix as :math:`r_\mathrm{b} = 1.16 R_\mathrm{e}`, with
+     :math:`r_\mathrm{b}` the Jaffe scale radius---chosen as the relation which best matches the luminosity
+     enclosed within a given radius, since that is what their Monte Carlo samples.
+
+     For a Jaffe profile the enclosed mass is :math:`M(r)/M = (r/r_0)/(1+r/r_0)`, so the half-mass radius is exactly
+     the scale radius. One unit of the tabulated axis therefore corresponds to :math:`1.16` half-mass radii, and a
+     model galaxy's half-mass radius is divided by that factor before being interpolated in. Omitting it would place
+     every spheroid 16 per cent too far out along the axis, worth up to about ten per cent in transmission at the
+     largest tabulated optical depths, and little at small ones.
+
    * The inclination, from a :galacticus-class:`galacticInclinationClass` object, or from the ``inclination``
      argument when one is imposed, as :galacticus-class:`dustAttenuationInclinationAveraged` does. One or the other
      must be available, and an error is reported if neither is.
@@ -285,6 +299,10 @@ contains
     type            (emissionDescriptor             ), intent(in   ), dimension(:                ) :: descriptors
     double precision                                 , intent(in   ), optional                     :: inclination
     double precision                                                , dimension(size(descriptors)) :: transmission
+    ! Half-mass radii per unit of the tabulated spheroid axis. The atlas labels that axis with the effective radius
+    ! of an R^1/4 profile, while realizing the spheroid as a Jaffe profile of scale radius r_b = 1.16 R_e (Bianchi
+    ! et al. 1996, appendix); the Jaffe half-mass radius is exactly its scale radius.
+    double precision                                 , parameter                                   :: radiusHalfMassToEffective=1.16d0
     double precision                                                                               :: depthOptical          , inclination_, &
          &                                                                                            radiusSpheroid        , logDepth    , &
          &                                                                                            inclinationDegrees
@@ -333,10 +351,15 @@ contains
           transmission(i)=self%interpolatorDisk    %interpolateFactors(self%transmissionDisk    ,indicesDisk    ,weightsDisk    )
        else if (descriptors(i)%componentType == componentTypeSpheroid) then
           if (.not.radiusSpheroidComputed) then
-             ! Clamp into the tabulated range before taking a logarithm. A galaxy may have no spheroid, or no disk
-             ! to measure one against, giving a ratio of zero whose logarithm would trap; and the interpolator holds
-             ! values at the boundary in any case, so nothing is lost by clamping here rather than there.
-             radiusSpheroid        =max(radiusSpheroidRelative(node),minval(self%radiusSpheroid))
+             ! Convert the half-mass radius to the effective radius the atlas is tabulated against, then clamp into
+             ! the tabulated range before taking a logarithm. A galaxy may have no spheroid, or no disk to measure
+             ! one against, giving a ratio of zero whose logarithm would trap; and the interpolator holds values at
+             ! the boundary in any case, so nothing is lost by clamping here rather than there.
+             radiusSpheroid        =max(                                       &
+                  &                     +radiusSpheroidRelative(node)          &
+                  &                     /radiusHalfMassToEffective           , &
+                  &                     +minval(self%radiusSpheroid)           &
+                  &                    )
              radiusSpheroidComputed=.true.
              call self%interpolatorRadiusSpheroid%linearFactors(log(radiusSpheroid),indicesSpheroid(1),weightsSpheroid(:,1))
           end if

--- a/source/dust/attenuation/atlas_Ferrara2000.F90
+++ b/source/dust/attenuation/atlas_Ferrara2000.F90
@@ -82,7 +82,7 @@
      For a Jaffe profile the enclosed mass is :math:`M(r)/M = (r/r_0)/(1+r/r_0)`, so the half-mass radius is exactly
      the scale radius. One unit of the tabulated axis therefore corresponds to :math:`1.16` half-mass radii, and a
      model galaxy's half-mass radius is divided by that factor before being interpolated in. Omitting it would place
-     every spheroid 16 per cent too far out along the axis, worth up to about ten per cent in transmission at the
+     every spheroid 16 percent too far out along the axis, worth up to about ten percent in transmission at the
      largest tabulated optical depths, and little at small ones.
 
    * The inclination, from a :galacticus-class:`galacticInclinationClass` object, or from the ``inclination``
@@ -300,11 +300,11 @@ contains
     double precision                                 , intent(in   ), optional                     :: inclination
     double precision                                                , dimension(size(descriptors)) :: transmission
     ! Half-mass radii per unit of the tabulated spheroid axis. The atlas labels that axis with the effective radius
-    ! of an R^1/4 profile, while realizing the spheroid as a Jaffe profile of scale radius r_b = 1.16 R_e (Bianchi
+    ! of an R^1/4 profile, while realizing the spheroid as a Jaffe profile of scale radius r_b = 1.16 Rₑ (Bianchi
     ! et al. 1996, appendix); the Jaffe half-mass radius is exactly its scale radius.
     double precision                                 , parameter                                   :: radiusHalfMassToEffective=1.16d0
-    double precision                                                                               :: depthOptical          , inclination_, &
-         &                                                                                            radiusSpheroid        , logDepth    , &
+    double precision                                                                               :: depthOptical                    , inclination_, &
+         &                                                                                            radiusSpheroid                  , logDepth    , &
          &                                                                                            inclinationDegrees
     logical                                                                                        :: radiusSpheroidComputed
     integer                                                                                        :: i
@@ -355,10 +355,10 @@ contains
              ! the tabulated range before taking a logarithm. A galaxy may have no spheroid, or no disk to measure
              ! one against, giving a ratio of zero whose logarithm would trap; and the interpolator holds values at
              ! the boundary in any case, so nothing is lost by clamping here rather than there.
-             radiusSpheroid        =max(                                       &
-                  &                     +radiusSpheroidRelative(node)          &
-                  &                     /radiusHalfMassToEffective           , &
-                  &                     +minval(self%radiusSpheroid)           &
+             radiusSpheroid        =max(                               &
+                  &                     +radiusSpheroidRelative(node)  &
+                  &                     /radiusHalfMassToEffective   , &
+                  &                     +minval(self%radiusSpheroid)   &
                   &                    )
              radiusSpheroidComputed=.true.
              call self%interpolatorRadiusSpheroid%linearFactors(log(radiusSpheroid),indicesSpheroid(1),weightsSpheroid(:,1))

--- a/source/dust/attenuation/atlas_compendium.F90
+++ b/source/dust/attenuation/atlas_compendium.F90
@@ -31,75 +31,78 @@
   ! The tabulations published on Zenodo, with the record each belongs to and the spheroid profile it was
   ! computed for, so that naming a file is enough to fetch it and to place spheroids on it correctly. A
   ! file which is not one of these can still be used, by giving `url` and `spheroidProfile` explicitly.
-  integer                                       , parameter                        :: compendiumFilesCount=21
-  character       (len=82                       ), parameter, dimension(compendiumFilesCount) :: compendiumFileName  =[ &
-       & 'Ferrara1999_GRASIL_dustD03Rv3.1_hzStars0.1_hzDust1.0_highRes_Attenuations.hdf5    ', &
-       & 'Ferrara1999_GRASIL_dustD03Rv3.1_hzStars0.5_hzDust1.0_highRes_Attenuations.hdf5    ', &
-       & 'Ferrara1999_GRASIL_dustD03Rv5.5_hzStars0.1_hzDust1.0_highRes_Attenuations.hdf5    ', &
-       & 'Ferrara1999_GRASIL_dustD03Rv5.5_hzStars0.5_hzDust1.0_highRes_Attenuations.hdf5    ', &
-       & 'Ferrara1999_MW_hz0.4_Attenuations.hdf5                                            ', &
-       & 'Ferrara1999_MW_hz0.4_highRes_Attenuations.hdf5                                    ', &
-       & 'Ferrara1999_MW_hz1.0_Attenuations.hdf5                                            ', &
-       & 'Ferrara1999_MW_hz1.0_highRes_Attenuations.hdf5                                    ', &
-       & 'Ferrara1999_MW_hz2.5_Attenuations.hdf5                                            ', &
-       & 'Ferrara1999_MW_hz2.5_highRes_Attenuations.hdf5                                    ', &
-       & 'Ferrara1999_SMC_hz0.4_Attenuations.hdf5                                           ', &
-       & 'Ferrara1999_SMC_hz0.4_highRes_Attenuations.hdf5                                   ', &
-       & 'Ferrara1999_SMC_hz1.0_Attenuations.hdf5                                           ', &
-       & 'Ferrara1999_SMC_hz1.0_highRes_Attenuations.hdf5                                   ', &
-       & 'Ferrara1999_SMC_hz2.5_Attenuations.hdf5                                           ', &
-       & 'Ferrara1999_SMC_hz2.5_highRes_Attenuations.hdf5                                   ', &
-       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustD03Rv3.1_Attenuations.hdf5      ', &
-       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustD03Rv4.0_Attenuations.hdf5      ', &
-       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustD03Rv5.5_Attenuations.hdf5      ', &
-       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustKMH94FullRv3.1_Attenuations.hdf5', &
-       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustKMH94HGRv3.1_Attenuations.hdf5  '  &
+  integer                                        , parameter                                  :: compendiumFilesCount=21
+  character       (len=82                       ), parameter, dimension(compendiumFilesCount) :: compendiumFileName  =   &
+       & [                                                                                                               &
+       &  'Ferrara1999_GRASIL_dustD03Rv3.1_hzStars0.1_hzDust1.0_highRes_Attenuations.hdf5    ',                          &
+       &  'Ferrara1999_GRASIL_dustD03Rv3.1_hzStars0.5_hzDust1.0_highRes_Attenuations.hdf5    ',                          &
+       &  'Ferrara1999_GRASIL_dustD03Rv5.5_hzStars0.1_hzDust1.0_highRes_Attenuations.hdf5    ',                          &
+       &  'Ferrara1999_GRASIL_dustD03Rv5.5_hzStars0.5_hzDust1.0_highRes_Attenuations.hdf5    ',                          &
+       &  'Ferrara1999_MW_hz0.4_Attenuations.hdf5                                            ',                          &
+       &  'Ferrara1999_MW_hz0.4_highRes_Attenuations.hdf5                                    ',                          &
+       &  'Ferrara1999_MW_hz1.0_Attenuations.hdf5                                            ',                          &
+       &  'Ferrara1999_MW_hz1.0_highRes_Attenuations.hdf5                                    ',                          &
+       &  'Ferrara1999_MW_hz2.5_Attenuations.hdf5                                            ',                          &
+       &  'Ferrara1999_MW_hz2.5_highRes_Attenuations.hdf5                                    ',                          &
+       &  'Ferrara1999_SMC_hz0.4_Attenuations.hdf5                                           ',                          &
+       &  'Ferrara1999_SMC_hz0.4_highRes_Attenuations.hdf5                                   ',                          &
+       &  'Ferrara1999_SMC_hz1.0_Attenuations.hdf5                                           ',                          &
+       &  'Ferrara1999_SMC_hz1.0_highRes_Attenuations.hdf5                                   ',                          &
+       &  'Ferrara1999_SMC_hz2.5_Attenuations.hdf5                                           ',                          &
+       &  'Ferrara1999_SMC_hz2.5_highRes_Attenuations.hdf5                                   ',                          &
+       &  'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustD03Rv3.1_Attenuations.hdf5      ',                          &
+       &  'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustD03Rv4.0_Attenuations.hdf5      ',                          &
+       &  'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustD03Rv5.5_Attenuations.hdf5      ',                          &
+       &  'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustKMH94FullRv3.1_Attenuations.hdf5',                          &
+       &  'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustKMH94HGRv3.1_Attenuations.hdf5  '                           &
        & ]
-  character       (len=7                        ), parameter, dimension(compendiumFilesCount) :: compendiumRecord    =[ &
-       & '6335951', &
-       & '6335951', &
-       & '6335951', &
-       & '6335951', &
-       & '6336095', &
-       & '6336097', &
-       & '6336095', &
-       & '6336097', &
-       & '6336095', &
-       & '6336097', &
-       & '6336095', &
-       & '6336097', &
-       & '6336095', &
-       & '6336097', &
-       & '6336095', &
-       & '6336097', &
-       & '6335021', &
-       & '6335545', &
-       & '6335642', &
-       & '6335668', &
-       & '6335670'  &
+  character       (len=7                        ), parameter, dimension(compendiumFilesCount) :: compendiumRecord    =   &
+       & [                                                                                                               &
+       &  '6335951',                                                                                                     &
+       &  '6335951',                                                                                                     &
+       &  '6335951',                                                                                                     &
+       &  '6335951',                                                                                                     &
+       &  '6336095',                                                                                                     &
+       &  '6336097',                                                                                                     &
+       &  '6336095',                                                                                                     &
+       &  '6336097',                                                                                                     &
+       &  '6336095',                                                                                                     &
+       &  '6336097',                                                                                                     &
+       &  '6336095',                                                                                                     &
+       &  '6336097',                                                                                                     &
+       &  '6336095',                                                                                                     &
+       &  '6336097',                                                                                                     &
+       &  '6336095',                                                                                                     &
+       &  '6336097',                                                                                                     &
+       &  '6335021',                                                                                                     &
+       &  '6335545',                                                                                                     &
+       &  '6335642',                                                                                                     &
+       &  '6335668',                                                                                                     &
+       &  '6335670'                                                                                                      &
        & ]
-  logical                                       , parameter, dimension(compendiumFilesCount) :: compendiumJaffe     =[ &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .true. , &
-       & .false., &
-       & .false., &
-       & .false., &
-       & .false., &
-       & .false.  &
+  logical                                       , parameter, dimension(compendiumFilesCount) :: compendiumJaffe     =    &
+       & [                                                                                                               &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .true. ,                                                                                                        &
+       & .false.,                                                                                                        &
+       & .false.,                                                                                                        &
+       & .false.,                                                                                                        &
+       & .false.,                                                                                                        &
+       & .false.                                                                                                         &
        & ]
 
   !![
@@ -322,16 +325,16 @@ contains
     Internal constructor for the :galacticus-class:`dustAttenuationAtlasCompendium` dust attenuation class. The
     tabulation is located---downloading it if necessary---read once, here, and interpolators built over it.
     !!}
-    use, intrinsic :: ISO_C_Binding      , only : c_size_t
-    use :: Error             , only : Error_Report
-    use :: File_Utilities    , only : Directory_Make      , File_Exists       , File_Lock     , File_Remove   , &
-          &                           File_Unlock         , lockDescriptor
-    use :: HDF5_Access       , only : hdf5Access
-    use :: Input_Paths       , only : inputPath           , pathTypeDataDynamic
-    use :: IO_HDF5           , only : hdf5File
-    use :: ISO_Varying_String, only : char                , operator(//)      , operator(==)  , varying_string
-    use :: System_Download   , only : download
-    use :: Table_Labels      , only : extrapolationTypeFix
+    use, intrinsic :: ISO_C_Binding     , only : c_size_t
+    use            :: Error             , only : Error_Report
+    use            :: File_Utilities    , only : Directory_Make      , File_Exists       , File_Lock     , File_Remove   , &
+          &                                      File_Unlock         , lockDescriptor
+    use            :: HDF5_Access       , only : hdf5Access
+    use            :: Input_Paths       , only : inputPath           , pathTypeDataDynamic
+    use            :: IO_HDF5           , only : hdf5File
+    use            :: ISO_Varying_String, only : char                , operator(//)      , operator(==)  , varying_string
+    use            :: System_Download   , only : download
+    use            :: Table_Labels      , only : extrapolationTypeFix
     implicit none
     type            (dustAttenuationAtlasCompendium          )                                  :: self
     type            (varying_string                          ), intent(in   )                   :: fileName                    , url
@@ -342,7 +345,7 @@ contains
     type            (hdf5File                                )                                  :: file
     type            (lockDescriptor                          )                                  :: lock
     type            (varying_string                          )                                  :: pathFile                    , pathDirectory
-    integer                                                                                     :: status                      , known               , &
+    integer                                                                                     :: status                      , known                           , &
          &                                                                                         i
     integer         (c_size_t                                )                                  :: sizeFile
     double precision                                          , allocatable, dimension(:      ) :: depthOptical
@@ -382,17 +385,17 @@ contains
             & call Error_Report('`'//self%fileName//'` was computed with Jaffe spheroids, so `spheroidProfile` must be `jaffe`'        //{introspection:location})
        if     (.not.  compendiumJaffe(known) .and. self%spheroidProfile /= compendiumSpheroidProfileHernquist) &
             & call Error_Report('`'//self%fileName//'` was computed with Hernquist spheroids, so `spheroidProfile` must be `hernquist`'//{introspection:location})
-       if (self%url == 'none')                                                                            &
-            & self%url=  'https://zenodo.org/api/records/'//trim(compendiumRecord(known))//'/files/' &
-            &          //self%fileName                                                              &
-            &          //'/content'
+       if (self%url == 'none')                                                                       &
+            & self%url='https://zenodo.org/api/records/'//trim(compendiumRecord(known))//'/files/'// &
+            &          self%fileName                                                              // &
+            &          '/content'
     end if
     pathDirectory=inputPath(pathTypeDataDynamic)//'dust/compendium'
     pathFile     =pathDirectory//'/'//self%fileName
     if (.not.File_Exists(pathFile)) then
        if (self%url == 'none') call Error_Report('the compendium tabulation `'//self%fileName//'` is not present, is not one of the published tabulations, and no `url` was given from which to download it'//{introspection:location})
-       call Directory_Make(pathDirectory)
-       call File_Lock     (char(pathFile),lock,lockIsShared=.false.)
+       call Directory_Make(pathDirectory                          )
+       call File_Lock     (pathFile     ,lock,lockIsShared=.false.)
        if (.not.File_Exists(pathFile)) then
           ! Zenodo returns an HTTP error intermittently, so allow a few attempts before giving up.
           call download(char(self%url),char(pathFile),retries=3,retryWait=10,status=status)
@@ -447,9 +450,9 @@ contains
             & call Error_Report('`attenuationSpheroid` is not unity at zero optical depth'//{introspection:location})
        if     (size(depthOptical) < 3)                                                                                            &
             & call Error_Report('the optical depth axis is too short to interpolate in once its zero entry is dropped'//{introspection:location})
-       self%depthOptical        =depthOptical        (  2:      )
-       self%transmissionDisk    =transmissionDisk    (2:,:  ,:  )
-       self%transmissionSpheroid=transmissionSpheroid(: ,2:,:,:)
+       self%depthOptical        =depthOptical        (2:       )
+       self%transmissionDisk    =transmissionDisk    (2:, :,:  )
+       self%transmissionSpheroid=transmissionSpheroid( :,2:,:,:)
     else
        call move_alloc(depthOptical        ,self%depthOptical        )
        call move_alloc(transmissionDisk    ,self%transmissionDisk    )
@@ -617,8 +620,8 @@ contains
     ! towards unit transmission, which is the value the dropped zero-optical-depth entry held. Clamping instead would
     ! leave a galaxy with almost no dust as attenuated as one at the tabulation's lower edge, which in the
     ! ultraviolet is not a small difference.
-    blending              =       self%depthOpticalZeroTabulated       &
-         &                  .and.      depthOptical < self%depthOpticalMinimum
+    blending              =       self%depthOpticalZeroTabulated                            &
+         &                  .and.      depthOptical              < self%depthOpticalMinimum
     if (blending) then
        blendZero          =+     depthOptical        &
             &              /self%depthOpticalMinimum
@@ -708,12 +711,12 @@ contains
        end if
        ! Guarded rather than applied unconditionally: for a strongly attenuated parcel, 1+(T-1) would lose precision
        ! to cancellation.
-       if (blending)                              &
-            & transmission(i)=+1.0d0              &
-            &                 +blendZero          &
-            &                 *(                  &
-            &                   +transmission(i)  &
-            &                   -1.0d0            &
+       if (blending)                             &
+            & transmission(i)=+1.0d0             &
+            &                 +blendZero         &
+            &                 *(                 &
+            &                   +transmission(i) &
+            &                   -1.0d0           &
             &                  )
     end do
     return

--- a/source/dust/attenuation/atlas_compendium.F90
+++ b/source/dust/attenuation/atlas_compendium.F90
@@ -31,6 +31,8 @@
   ! The tabulations published on Zenodo, with the record each belongs to and the spheroid profile it was
   ! computed for, so that naming a file is enough to fetch it and to place spheroids on it correctly. A
   ! file which is not one of these can still be used, by giving `url` and `spheroidProfile` explicitly.
+  ! The tabulations are in microns, while parcels, and the trimming parameters, are in Angstroms.
+  double precision                               , parameter                                  :: angstromsPerMicron  =1.0d+4
   integer                                        , parameter                                  :: compendiumFilesCount=21
   character       (len=82                       ), parameter, dimension(compendiumFilesCount) :: compendiumFileName  =   &
        & [                                                                                                               &
@@ -139,11 +141,20 @@
    known to this class, so naming one is enough; ``url`` is needed only for a tabulation which is not among them,
    such as one the user has produced themselves.
 
-   Be aware of the size of these files. All but the six original-resolution :cite:t:`ferrara_atlas_1999`
-   tabulations are 584 MB apiece, tabulated on a grid of 250 wavelengths, 46 inclinations, 60 optical depths, and
-   51 spheroid sizes. Half of each file is Monte Carlo uncertainties, which are not read; the attenuations and their
-   extrapolation coefficients come to 297 MB, and are held for the life of the run. Almost all of that is the
-   spheroid table, which alone is 282 MB.
+   Be aware of the size of these files, which is the reason for the trimming parameters below. All but the six
+   original-resolution :cite:t:`ferrara_atlas_1999` tabulations are 584 MB apiece, on a grid of 250 wavelengths, 46
+   inclinations, 60 optical depths, and 51 spheroid sizes. Half of each file is Monte Carlo uncertainties, which are
+   not read; the attenuations and their extrapolation coefficients come to 297 MB, almost all of it the spheroid
+   table.
+
+   That 297 MB is *per copy*, and there is one copy per OpenMP thread per instance of this class, since each thread
+   works on a deep copy of the attenuator. A parameter file with two of these attenuators, run on twenty threads,
+   therefore holds forty copies: 12 GB of tabulation, measured. Restricting each axis to the range actually needed
+   is what keeps that in hand---``wavelengthMinimum``, ``wavelengthMaximum``, ``opticalDepthMaximum``,
+   ``radiusSpheroidMinimum``, and ``radiusSpheroidMaximum`` below. Only the retained part of each axis is read from
+   the file, as an HDF5 hyperslab, so a trimmed tabulation is never held at full size even transiently. Trimming
+   changes no result which lies inside the retained range: the bracketing nodes on either side are kept, so values
+   within the range are interpolated exactly as they would have been from the full table.
 
    Two quantities are supplied per galaxy rather than tabulated:
 
@@ -203,7 +214,9 @@
      type            (varying_string                          )                                  :: fileName                                , url
      type            (enumerationCompendiumSpheroidProfileType)                                  :: spheroidProfile
      double precision                                                                            :: dustToMetalsRatio                       , opacity                         , &
-          &                                                                                         radiusSpheroidHalfMassToScale
+          &                                                                                         radiusSpheroidHalfMassToScale           , wavelengthMinimum               , &
+          &                                                                                         wavelengthMaximum                       , opticalDepthMaximum             , &
+          &                                                                                         radiusSpheroidMinimum                   , radiusSpheroidMaximum
      logical                                                                                     :: extrapolateOpticalDepth                 , inclinationAvailable            , &
           &                                                                                         depthOpticalZeroTabulated
      ! The smallest *positive* tabulated optical depth. Tabulations generally include a zero-optical-depth entry,
@@ -259,7 +272,9 @@ contains
     class           (galacticInclinationClass      ), pointer       :: galacticInclination_
     type            (varying_string                )                :: fileName               , url, &
          &                                                             spheroidProfile
-    double precision                                                :: dustToMetalsRatio
+    double precision                                                :: dustToMetalsRatio      , wavelengthMinimum    , &
+         &                                                             wavelengthMaximum      , opticalDepthMaximum  , &
+         &                                                             radiusSpheroidMinimum  , radiusSpheroidMaximum
     logical                                                         :: extrapolateOpticalDepth
 
     !![
@@ -294,6 +309,56 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
+      <name>wavelengthMinimum</name>
+      <defaultValue>0.0d0</defaultValue>
+      <description>
+      The shortest wavelength, in Angstroms, which need be represented. Tabulated wavelengths below this are not
+      read. Zero retains the whole axis.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>wavelengthMaximum</name>
+      <defaultValue>huge(0.0d0)</defaultValue>
+      <description>
+      The longest wavelength, in Angstroms, which need be represented. Tabulated wavelengths above this are not read.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>opticalDepthMaximum</name>
+      <defaultValue>huge(0.0d0)</defaultValue>
+      <description>
+      The largest :math:`V`-band optical depth which need be represented. Tabulated depths above this are not read,
+      and galaxies exceeding it have their transmission held at the retained boundary. There is no corresponding
+      minimum: the low-depth end of the axis costs little and is always needed.
+
+      Trimming this axis requires ``extrapolateOpticalDepth`` to be false, and is refused otherwise. The
+      extrapolation coefficients describe the behavior beyond the largest depth in the *file* and are anchored
+      there; applied just above a trimmed boundary they are far outside the range they were fitted over, and for the
+      published high-resolution tabulation would overestimate the transmission by a factor of seven at an optical
+      depth of five.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>radiusSpheroidMinimum</name>
+      <defaultValue>0.0d0</defaultValue>
+      <description>
+      The smallest spheroid size, as a scale radius in units of the disk scale length, which need be represented.
+      Zero retains the whole axis.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>radiusSpheroidMaximum</name>
+      <defaultValue>huge(0.0d0)</defaultValue>
+      <description>
+      The largest spheroid size, as a scale radius in units of the disk scale length, which need be represented.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
       <name>extrapolateOpticalDepth</name>
       <defaultValue>.true.</defaultValue>
       <description>
@@ -315,7 +380,7 @@ contains
     </inputParameter>
     <objectBuilder class="galacticInclination" name="galacticInclination_" source="parameters"/>
     !!]
-    self=dustAttenuationAtlasCompendium(fileName,url,dustToMetalsRatio,extrapolateOpticalDepth,enumerationCompendiumSpheroidProfileEncode(char(spheroidProfile),includesPrefix=.false.),galacticInclination_)
+    self=dustAttenuationAtlasCompendium(fileName,url,dustToMetalsRatio,wavelengthMinimum,wavelengthMaximum,opticalDepthMaximum,radiusSpheroidMinimum,radiusSpheroidMaximum,extrapolateOpticalDepth,enumerationCompendiumSpheroidProfileEncode(char(spheroidProfile),includesPrefix=.false.),galacticInclination_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="galacticInclination_"/>
@@ -323,7 +388,7 @@ contains
     return
   end function atlasCompendiumConstructorParameters
 
-  function atlasCompendiumConstructorInternal(fileName,url,dustToMetalsRatio,extrapolateOpticalDepth,spheroidProfile,galacticInclination_) result(self)
+  function atlasCompendiumConstructorInternal(fileName,url,dustToMetalsRatio,wavelengthMinimum,wavelengthMaximum,opticalDepthMaximum,radiusSpheroidMinimum,radiusSpheroidMaximum,extrapolateOpticalDepth,spheroidProfile,galacticInclination_) result(self)
     !!{RST
     Internal constructor for the :galacticus-class:`dustAttenuationAtlasCompendium` dust attenuation class. The
     tabulation is located---downloading it if necessary---read once, here, and interpolators built over it.
@@ -334,6 +399,7 @@ contains
           &                                      File_Unlock         , lockDescriptor
     use            :: HDF5_Access       , only : hdf5Access
     use            :: Input_Paths       , only : inputPath           , pathTypeDataDynamic
+    use            :: HDF5              , only : hsize_t
     use            :: IO_HDF5           , only : hdf5File
     use            :: ISO_Varying_String, only : char                , operator(//)      , operator(==)  , varying_string
     use            :: System_Download   , only : download
@@ -341,7 +407,9 @@ contains
     implicit none
     type            (dustAttenuationAtlasCompendium          )                                  :: self
     type            (varying_string                          ), intent(in   )                   :: fileName                    , url
-    double precision                                          , intent(in   )                   :: dustToMetalsRatio
+    double precision                                          , intent(in   )                   :: dustToMetalsRatio           , wavelengthMinimum   , &
+         &                                                                                         wavelengthMaximum           , opticalDepthMaximum , &
+         &                                                                                         radiusSpheroidMinimum       , radiusSpheroidMaximum
     logical                                                   , intent(in   )                   :: extrapolateOpticalDepth
     type            (enumerationCompendiumSpheroidProfileType), intent(in   )                   :: spheroidProfile
     class           (galacticInclinationClass                ), intent(in   ), target           :: galacticInclination_
@@ -351,6 +419,13 @@ contains
     integer                                                                                     :: status                      , known                           , &
          &                                                                                         i
     integer         (c_size_t                                )                                  :: sizeFile
+    integer         (hsize_t                                 )              , dimension(3     ) :: beginDisk                   , countDisk           , &
+         &                                                                                         beginExtrapolationDisk      , countExtrapolationDisk
+    integer         (hsize_t                                 )              , dimension(4     ) :: beginSpheroid               , countSpheroid       , &
+         &                                                                                         beginExtrapolationSpheroid  , countExtrapolationSpheroid
+    integer                                                                                     :: indexWavelengthBegin        , indexWavelengthEnd  , &
+         &                                                                                         indexDepthOpticalBegin      , indexDepthOpticalEnd, &
+         &                                                                                         indexRadiusSpheroidBegin    , indexRadiusSpheroidEnd
     double precision                                          , allocatable, dimension(:      ) :: depthOptical
     double precision                                          , allocatable, dimension(:,:,:  ) :: extrapolationDisk           , transmissionDisk
     double precision                                          , allocatable, dimension(:,:,:,:) :: extrapolationSpheroid       , transmissionSpheroid
@@ -358,7 +433,7 @@ contains
     type            (interpolator                            )             , dimension(4      ) :: interpolatorsSpheroid
     type            (interpolator                            )             , dimension(2      ) :: interpolatorsDiskExtrapolate
     !![
-    <constructorAssign variables="fileName, url, dustToMetalsRatio, extrapolateOpticalDepth, spheroidProfile, *galacticInclination_"/>
+    <constructorAssign variables="fileName, url, dustToMetalsRatio, wavelengthMinimum, wavelengthMaximum, opticalDepthMaximum, radiusSpheroidMinimum, radiusSpheroidMaximum, extrapolateOpticalDepth, spheroidProfile, *galacticInclination_"/>
     !!]
 
     ! An inclination must be available, either per galaxy or imposed by an attenuator averaging over orientation.
@@ -426,11 +501,50 @@ contains
     call file%readDataset  ('inclination'                      ,self%inclination          )
     call file%readDataset  ('opticalDepth'                     ,     depthOptical         )
     call file%readDataset  ('spheroidScaleRadial'              ,self%radiusSpheroid       )
-    call file%readDataset  ('attenuationDisk'                  ,     transmissionDisk     )
-    call file%readDataset  ('attenuationSpheroid'              ,     transmissionSpheroid )
-    call file%readDataset  ('extrapolationCoefficientsDisk'    ,     extrapolationDisk    )
-    call file%readDataset  ('extrapolationCoefficientsSpheroid',     extrapolationSpheroid)
+    ! Work out which part of each axis need be retained. The bracketing nodes on either side of the requested range
+    ! are kept, so that anything inside it is interpolated rather than held at a boundary. Inclination is never
+    ! trimmed: it is one of the shortest axes, and the whole of it is always needed.
+    call axisRange(self%wavelength    *angstromsPerMicron,self%wavelengthMinimum,self%wavelengthMaximum,indexWavelengthBegin   ,indexWavelengthEnd   )
+    call axisRange(     depthOptical                     ,-1.0d0                ,self%opticalDepthMaximum  ,indexDepthOpticalBegin ,indexDepthOpticalEnd )
+    call axisRange(self%radiusSpheroid                   ,self%radiusSpheroidMinimum,self%radiusSpheroidMaximum,indexRadiusSpheroidBegin,indexRadiusSpheroidEnd)
+    ! The low-depth end of the optical depth axis is always retained, so that the zero entry, and the approach to
+    ! unit transmission, survive trimming.
+    indexDepthOpticalBegin=1
+    ! Trimming the optical depth axis and extrapolating beyond it are incompatible, and silently so, which is why
+    ! this is an error rather than a quiet choice made on the user's behalf. The extrapolation coefficients describe
+    ! the asymptotic behavior beyond the depth at which the *file* stops, and are anchored there. Evaluated just
+    ! above a trimmed boundary they are far outside the range they were fitted over: for the published high
+    ! resolution tabulation they overestimate the transmission by a factor of seven at an optical depth of five, and
+    ! by a factor of thirty at unity. They would also not join continuously to the retained table.
+    if (self%extrapolateOpticalDepth .and. indexDepthOpticalEnd < size(depthOptical))                                    &
+         & call Error_Report(                                                                                            &
+         &                   '`opticalDepthMaximum` trims the tabulation, but `extrapolateOpticalDepth` is true: the'//  &
+         &                   ' extrapolation coefficients are only valid beyond the largest depth in the file, not'  //  &
+         &                   ' beyond a trimmed boundary. Set `extrapolateOpticalDepth` to false to hold the'        //  &
+         &                   ' transmission at the retained boundary instead, or raise `opticalDepthMaximum`.'       //  &
+         &                   {introspection:location}                                                                    &
+         &                  )
+    ! Read the attenuations as a hyperslab covering only the retained part of each axis, so that a trimmed
+    ! tabulation is never held at full size, even transiently. `readBegin` and `readCount` are given in the order of
+    ! the Fortran array, which for these datasets is the reverse of the order they were written in.
+    beginDisk    =int([indexDepthOpticalBegin  ,1                                    ,indexWavelengthBegin                    ],kind=hsize_t)
+    countDisk    =int([indexDepthOpticalEnd-indexDepthOpticalBegin+1,size(self%inclination),indexWavelengthEnd-indexWavelengthBegin+1],kind=hsize_t)
+    beginSpheroid=[int(indexRadiusSpheroidBegin,kind=hsize_t),beginDisk]
+    countSpheroid=[int(indexRadiusSpheroidEnd-indexRadiusSpheroidBegin+1,kind=hsize_t),countDisk]
+    call file%readDataset  ('attenuationDisk'                  ,     transmissionDisk     ,readBegin=beginDisk    ,readCount=countDisk    )
+    call file%readDataset  ('attenuationSpheroid'              ,     transmissionSpheroid ,readBegin=beginSpheroid,readCount=countSpheroid)
+    ! The extrapolation coefficients carry no optical depth axis, but are trimmed on the others.
+    beginExtrapolationDisk    =int([1                    ,indexWavelengthBegin                    ,1],kind=hsize_t)
+    countExtrapolationDisk    =int([size(self%inclination),indexWavelengthEnd-indexWavelengthBegin+1,2],kind=hsize_t)
+    beginExtrapolationSpheroid=[int(indexRadiusSpheroidBegin,kind=hsize_t),beginExtrapolationDisk]
+    countExtrapolationSpheroid=[int(indexRadiusSpheroidEnd-indexRadiusSpheroidBegin+1,kind=hsize_t),countExtrapolationDisk]
+    call file%readDataset  ('extrapolationCoefficientsDisk'    ,     extrapolationDisk    ,readBegin=beginExtrapolationDisk    ,readCount=countExtrapolationDisk    )
+    call file%readDataset  ('extrapolationCoefficientsSpheroid',     extrapolationSpheroid,readBegin=beginExtrapolationSpheroid,readCount=countExtrapolationSpheroid)
     !$ call hdf5Access%unset()
+    ! Trim the axes to match what was read.
+    self%wavelength    =self%wavelength    (indexWavelengthBegin    :indexWavelengthEnd    )
+    self%radiusSpheroid=self%radiusSpheroid(indexRadiusSpheroidBegin:indexRadiusSpheroidEnd)
+    depthOptical       =     depthOptical  (indexDepthOpticalBegin  :indexDepthOpticalEnd  )
     ! Check that the tables have the shape the axes imply, before anything is sliced. A transposed read would
     ! otherwise show up much later as quietly wrong attenuation.
     if (any(shape(     transmissionDisk    ) /= [size(     depthOptical   ),size(self%inclination ),size(self%wavelength)                       ])) &
@@ -496,6 +610,41 @@ contains
     self%interpolatorRadiusSpheroid        =interpolatorsSpheroid(1)
     return
   end function atlasCompendiumConstructorInternal
+
+  subroutine axisRange(axis,valueMinimum,valueMaximum,indexBegin,indexEnd)
+    !!{RST
+    Return the range of indices of ``axis`` which must be retained in order to represent every value between
+    ``valueMinimum`` and ``valueMaximum``.
+
+    The bracketing nodes on either side of the requested range are kept, so that a value anywhere inside it is
+    interpolated rather than held at a boundary. At least two nodes are always returned, since an axis of a single
+    node can not be interpolated in.
+    !!}
+    implicit none
+    double precision, intent(in   ), dimension(:) :: axis
+    double precision, intent(in   )               :: valueMinimum, valueMaximum
+    integer         , intent(  out)               :: indexBegin  , indexEnd
+    integer                                       :: i
+
+    indexBegin=1
+    indexEnd  =size(axis)
+    do i=1,size(axis)
+       if (axis(i) <= valueMinimum) indexBegin=i
+    end do
+    do i=size(axis),1,-1
+       if (axis(i) >= valueMaximum) indexEnd  =i
+    end do
+    ! Guarantee at least two nodes, whatever was asked for.
+    if (indexEnd <= indexBegin) then
+       if (indexBegin < size(axis)) then
+          indexEnd  =indexBegin+1
+       else
+          indexBegin=indexEnd  -1
+       end if
+    end if
+    return
+  end subroutine axisRange
+
 
   subroutine atlasCompendiumDestructor(self)
     !!{RST
@@ -574,8 +723,6 @@ contains
     type            (emissionDescriptor            ), intent(in   ), dimension(:                ) :: descriptors
     double precision                                , intent(in   ), optional                     :: inclination
     double precision                                               , dimension(size(descriptors)) :: transmission
-    ! The tabulation is in microns, while parcels report their wavelength in Angstroms.
-    double precision                                , parameter                                   :: micronsPerAngstrom        =1.0d-4
     double precision                                                                              :: depthOptical                     , inclination_       , &
          &                                                                                           radiusSpheroid                   , logDepth           , &
          &                                                                                           inclinationDegrees               , coefficientConstant, &
@@ -656,7 +803,7 @@ contains
        weightsSpheroid           (:,2:3)=weightsDisk       (:,1:2)
     end if
     do i=1,size(descriptors)
-       call self%interpolatorWavelength%linearFactors(log(descriptors(i)%wavelength*micronsPerAngstrom),indexWavelength,weightWavelength)
+       call self%interpolatorWavelength%linearFactors(log(descriptors(i)%wavelength/angstromsPerMicron),indexWavelength,weightWavelength)
        if (extrapolating) then
           indicesDiskExtrapolate    (  2)=indexWavelength
           weightsDiskExtrapolate    (:,2)=weightWavelength

--- a/source/dust/attenuation/atlas_compendium.F90
+++ b/source/dust/attenuation/atlas_compendium.F90
@@ -28,6 +28,80 @@
   use :: Numerical_Interpolation       , only : interpolator
   use :: Numerical_Interpolation_MultiD, only : interpolatorMultiD
 
+  ! The tabulations published on Zenodo, with the record each belongs to and the spheroid profile it was
+  ! computed for, so that naming a file is enough to fetch it and to place spheroids on it correctly. A
+  ! file which is not one of these can still be used, by giving `url` and `spheroidProfile` explicitly.
+  integer                                       , parameter                        :: compendiumFilesCount=21
+  character       (len=82                       ), parameter, dimension(compendiumFilesCount) :: compendiumFileName  =[ &
+       & 'Ferrara1999_GRASIL_dustD03Rv3.1_hzStars0.1_hzDust1.0_highRes_Attenuations.hdf5    ', &
+       & 'Ferrara1999_GRASIL_dustD03Rv3.1_hzStars0.5_hzDust1.0_highRes_Attenuations.hdf5    ', &
+       & 'Ferrara1999_GRASIL_dustD03Rv5.5_hzStars0.1_hzDust1.0_highRes_Attenuations.hdf5    ', &
+       & 'Ferrara1999_GRASIL_dustD03Rv5.5_hzStars0.5_hzDust1.0_highRes_Attenuations.hdf5    ', &
+       & 'Ferrara1999_MW_hz0.4_Attenuations.hdf5                                            ', &
+       & 'Ferrara1999_MW_hz0.4_highRes_Attenuations.hdf5                                    ', &
+       & 'Ferrara1999_MW_hz1.0_Attenuations.hdf5                                            ', &
+       & 'Ferrara1999_MW_hz1.0_highRes_Attenuations.hdf5                                    ', &
+       & 'Ferrara1999_MW_hz2.5_Attenuations.hdf5                                            ', &
+       & 'Ferrara1999_MW_hz2.5_highRes_Attenuations.hdf5                                    ', &
+       & 'Ferrara1999_SMC_hz0.4_Attenuations.hdf5                                           ', &
+       & 'Ferrara1999_SMC_hz0.4_highRes_Attenuations.hdf5                                   ', &
+       & 'Ferrara1999_SMC_hz1.0_Attenuations.hdf5                                           ', &
+       & 'Ferrara1999_SMC_hz1.0_highRes_Attenuations.hdf5                                   ', &
+       & 'Ferrara1999_SMC_hz2.5_Attenuations.hdf5                                           ', &
+       & 'Ferrara1999_SMC_hz2.5_highRes_Attenuations.hdf5                                   ', &
+       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustD03Rv3.1_Attenuations.hdf5      ', &
+       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustD03Rv4.0_Attenuations.hdf5      ', &
+       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustD03Rv5.5_Attenuations.hdf5      ', &
+       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustKMH94FullRv3.1_Attenuations.hdf5', &
+       & 'compendium_exp_sech_Hernquist_hd0.137_hz0.137_dustKMH94HGRv3.1_Attenuations.hdf5  '  &
+       & ]
+  character       (len=7                        ), parameter, dimension(compendiumFilesCount) :: compendiumRecord    =[ &
+       & '6335951', &
+       & '6335951', &
+       & '6335951', &
+       & '6335951', &
+       & '6336095', &
+       & '6336097', &
+       & '6336095', &
+       & '6336097', &
+       & '6336095', &
+       & '6336097', &
+       & '6336095', &
+       & '6336097', &
+       & '6336095', &
+       & '6336097', &
+       & '6336095', &
+       & '6336097', &
+       & '6335021', &
+       & '6335545', &
+       & '6335642', &
+       & '6335668', &
+       & '6335670'  &
+       & ]
+  logical                                       , parameter, dimension(compendiumFilesCount) :: compendiumJaffe     =[ &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .true. , &
+       & .false., &
+       & .false., &
+       & .false., &
+       & .false., &
+       & .false.  &
+       & ]
+
   !![
   <enumeration docformat="rst">
    <name>compendiumSpheroidProfile</name>
@@ -57,8 +131,13 @@
 
    The tabulations are published as a set of HDF5 files, one per combination of grain properties and geometry, and
    are described in the :doc:`dust compendium datasets &lt;/manuals/user-guide/data/dust-compendium-datasets&gt;` section
-   of the user guide. ``fileName`` selects one. If that file is not already present it is downloaded from ``url``
-   and cached under the dynamic datasets path, so a file is fetched once and reused thereafter.
+   of the user guide. ``fileName`` selects one. If that file is not already present it is downloaded and cached
+   under the dynamic datasets path, so a file is fetched once and reused thereafter. The published file names are
+   known to this class, so naming one is enough; ``url`` is needed only for a tabulation which is not among them,
+   such as one the user has produced themselves.
+
+   Be aware that all but the six original-resolution :cite:t:`ferrara_atlas_1999` tabulations are 584 MB apiece,
+   and that most of that is read into memory and held for the life of the run.
 
    Two quantities are supplied per galaxy rather than tabulated:
 
@@ -99,6 +178,13 @@
    Beyond the largest tabulated optical depth the transmission is extrapolated as
    :math:`T = \exp(c_0 + c_1 \ln \tau_\mathrm{V})`, using coefficients tabulated alongside the attenuations. Setting
    ``extrapolateOpticalDepth`` to false instead holds the transmission at its value at the tabulation boundary.
+
+   The optical depth axis is interpolated logarithmically, which is worth roughly a factor of two in accuracy over
+   interpolating linearly on the geometric grids these tabulations use, but which a tabulated zero can not take part
+   in. The tabulations generally do carry a zero-optical-depth entry, at which the transmission is unity; it is
+   dropped on reading, and below the smallest remaining depth the transmission is instead interpolated linearly
+   back towards unity. Clamping there would leave a galaxy with almost no dust as attenuated as one at the
+   tabulation's lower edge, which in the ultraviolet is not a small difference.
    </description>
   </dustAttenuation>
   !!]
@@ -112,7 +198,12 @@
      type            (enumerationCompendiumSpheroidProfileType)                                  :: spheroidProfile
      double precision                                                                            :: dustToMetalsRatio                       , opacity                         , &
           &                                                                                         radiusSpheroidHalfMassToScale
-     logical                                                                                     :: extrapolateOpticalDepth                 , inclinationAvailable
+     logical                                                                                     :: extrapolateOpticalDepth                 , inclinationAvailable            , &
+          &                                                                                         depthOpticalZeroTabulated
+     ! The smallest *positive* tabulated optical depth. Tabulations generally include a zero-optical-depth entry,
+     ! which is dropped because the axis is interpolated logarithmically; below this depth the transmission is
+     ! recovered by interpolating linearly back towards unity, which is what that entry holds.
+     double precision                                                                            :: depthOpticalMinimum
      ! Grid axes. Wavelengths are in microns and inclinations in degrees, as tabulated; the spheroid axis is the
      ! spheroid scale radius in units of the disk scale length.
      double precision                                          , allocatable, dimension(:      ) :: wavelength                              , inclination                     , &
@@ -169,8 +260,10 @@ contains
     <inputParameter docformat="rst">
       <name>fileName</name>
       <description>
-      The name of the dust compendium tabulation file to use. If no file of this name is present under the
-      ``dust/compendium`` directory of the dynamic datasets path it is downloaded from ``url``.
+      The name of the dust compendium tabulation file to use, for example
+      ``Ferrara1999_MW_hz1.0_Attenuations.hdf5``. If no file of this name is present under the ``dust/compendium``
+      directory of the dynamic datasets path it is downloaded---from the Zenodo record holding it if it is one of
+      the published tabulations, and otherwise from ``url``.
       </description>
       <source>parameters</source>
     </inputParameter>
@@ -178,8 +271,9 @@ contains
       <name>url</name>
       <defaultValue>var_str('none')</defaultValue>
       <description>
-      The URL from which to download ``fileName`` if it is not already present. If ``none``, the file must be
-      supplied by other means.
+      The URL from which to download ``fileName`` if it is not already present and is not one of the published
+      tabulations, whose locations this class already knows. If ``none``, such a file must be supplied by other
+      means.
       </description>
       <source>parameters</source>
     </inputParameter>
@@ -208,7 +302,8 @@ contains
       <description>
       The spheroid density profile for which the tabulation was computed: ``hernquist``, or ``jaffe`` for
       tabulations computed to match :cite:t:`ferrara_atlas_1999`. This sets how a model galaxy's spheroid is mapped
-      onto the ``spheroidScaleRadial`` axis.
+      onto the ``spheroidScaleRadial`` axis. For a published tabulation the value is checked against the profile
+      that file was actually computed with, since getting it wrong is a silent error of tens of percent.
       </description>
       <source>parameters</source>
     </inputParameter>
@@ -227,9 +322,10 @@ contains
     Internal constructor for the :galacticus-class:`dustAttenuationAtlasCompendium` dust attenuation class. The
     tabulation is located---downloading it if necessary---read once, here, and interpolators built over it.
     !!}
+    use, intrinsic :: ISO_C_Binding      , only : c_size_t
     use :: Error             , only : Error_Report
-    use :: File_Utilities    , only : Directory_Make      , File_Exists       , File_Lock     , File_Unlock   , &
-          &                           lockDescriptor
+    use :: File_Utilities    , only : Directory_Make      , File_Exists       , File_Lock     , File_Remove   , &
+          &                           File_Unlock         , lockDescriptor
     use :: HDF5_Access       , only : hdf5Access
     use :: Input_Paths       , only : inputPath           , pathTypeDataDynamic
     use :: IO_HDF5           , only : hdf5File
@@ -246,9 +342,12 @@ contains
     type            (hdf5File                                )                                  :: file
     type            (lockDescriptor                          )                                  :: lock
     type            (varying_string                          )                                  :: pathFile                    , pathDirectory
-    integer                                                                                     :: status
-    double precision                                          , allocatable, dimension(:,:,:  ) :: extrapolationDisk
-    double precision                                          , allocatable, dimension(:,:,:,:) :: extrapolationSpheroid
+    integer                                                                                     :: status                      , known               , &
+         &                                                                                         i
+    integer         (c_size_t                                )                                  :: sizeFile
+    double precision                                          , allocatable, dimension(:      ) :: depthOptical
+    double precision                                          , allocatable, dimension(:,:,:  ) :: extrapolationDisk           , transmissionDisk
+    double precision                                          , allocatable, dimension(:,:,:,:) :: extrapolationSpheroid       , transmissionSpheroid
     type            (interpolator                            )             , dimension(3      ) :: interpolatorsDisk           , interpolatorsSpheroidExtrapolate
     type            (interpolator                            )             , dimension(4      ) :: interpolatorsSpheroid
     type            (interpolator                            )             , dimension(2      ) :: interpolatorsDiskExtrapolate
@@ -272,15 +371,38 @@ contains
     end select
     ! Locate the tabulation, downloading it if we do not already have it. The lock makes concurrent processes wait
     ! for the first of them to finish the download rather than each starting one of their own.
+    ! Look the file up among the published tabulations, which supplies both where to fetch it from and which
+    ! spheroid profile it was computed for.
+    known=0
+    do i=1,compendiumFilesCount
+       if (trim(compendiumFileName(i)) == char(self%fileName)) known=i
+    end do
+    if (known > 0) then
+       if     (       compendiumJaffe(known) .and. self%spheroidProfile /= compendiumSpheroidProfileJaffe    ) &
+            & call Error_Report('`'//self%fileName//'` was computed with Jaffe spheroids, so `spheroidProfile` must be `jaffe`'        //{introspection:location})
+       if     (.not.  compendiumJaffe(known) .and. self%spheroidProfile /= compendiumSpheroidProfileHernquist) &
+            & call Error_Report('`'//self%fileName//'` was computed with Hernquist spheroids, so `spheroidProfile` must be `hernquist`'//{introspection:location})
+       if (self%url == 'none')                                                                            &
+            & self%url=  'https://zenodo.org/api/records/'//trim(compendiumRecord(known))//'/files/' &
+            &          //self%fileName                                                              &
+            &          //'/content'
+    end if
     pathDirectory=inputPath(pathTypeDataDynamic)//'dust/compendium'
     pathFile     =pathDirectory//'/'//self%fileName
     if (.not.File_Exists(pathFile)) then
-       if (self%url == 'none') call Error_Report('the compendium tabulation `'//self%fileName//'` is not present, and no `url` was given from which to download it'//{introspection:location})
+       if (self%url == 'none') call Error_Report('the compendium tabulation `'//self%fileName//'` is not present, is not one of the published tabulations, and no `url` was given from which to download it'//{introspection:location})
        call Directory_Make(pathDirectory)
        call File_Lock     (char(pathFile),lock,lockIsShared=.false.)
        if (.not.File_Exists(pathFile)) then
-          call download(char(self%url),char(pathFile),status=status)
-          if (status /= 0 .or. .not.File_Exists(pathFile)) then
+          ! Zenodo returns an HTTP error intermittently, so allow a few attempts before giving up.
+          call download(char(self%url),char(pathFile),retries=3,retryWait=10,status=status)
+          ! Judge the download by what actually landed on disk, not by the reported status alone: a downloader which
+          ! fails at the TLS layer can leave an empty file behind, and were that left in place it would be read as
+          ! though it were the tabulation on this and every subsequent run.
+          sizeFile=0_c_size_t
+          if (File_Exists(pathFile)) inquire(file=char(pathFile),size=sizeFile)
+          if (status /= 0 .or. sizeFile <= 0_c_size_t) then
+             if (File_Exists(pathFile)) call File_Remove(pathFile)
              call File_Unlock(lock)
              call Error_Report('unable to download the compendium tabulation from `'//self%url//'`'//{introspection:location})
           end if
@@ -296,23 +418,47 @@ contains
     call file%readAttribute('opacity'                          ,self%opacity              )
     call file%readDataset  ('wavelength'                       ,self%wavelength           )
     call file%readDataset  ('inclination'                      ,self%inclination          )
-    call file%readDataset  ('opticalDepth'                     ,self%depthOptical         )
+    call file%readDataset  ('opticalDepth'                     ,     depthOptical         )
     call file%readDataset  ('spheroidScaleRadial'              ,self%radiusSpheroid       )
-    call file%readDataset  ('attenuationDisk'                  ,self%transmissionDisk     )
-    call file%readDataset  ('attenuationSpheroid'              ,self%transmissionSpheroid )
+    call file%readDataset  ('attenuationDisk'                  ,     transmissionDisk     )
+    call file%readDataset  ('attenuationSpheroid'              ,     transmissionSpheroid )
     call file%readDataset  ('extrapolationCoefficientsDisk'    ,     extrapolationDisk    )
     call file%readDataset  ('extrapolationCoefficientsSpheroid',     extrapolationSpheroid)
     !$ call hdf5Access%unset()
-    ! Check that the tables have the shape the axes imply. A transposed read would otherwise show up much later as
-    ! quietly wrong attenuation.
-    if (any(shape(self%transmissionDisk    ) /= [size(self%depthOptical  ),size(self%inclination ),size(self%wavelength)                       ])) &
+    ! Check that the tables have the shape the axes imply, before anything is sliced. A transposed read would
+    ! otherwise show up much later as quietly wrong attenuation.
+    if (any(shape(     transmissionDisk    ) /= [size(     depthOptical   ),size(self%inclination ),size(self%wavelength)                       ])) &
          & call Error_Report('`attenuationDisk` does not have the shape implied by the axes'                  //{introspection:location})
-    if (any(shape(self%transmissionSpheroid) /= [size(self%radiusSpheroid),size(self%depthOptical),size(self%inclination),size(self%wavelength)])) &
+    if (any(shape(     transmissionSpheroid) /= [size(self%radiusSpheroid),size(     depthOptical ),size(self%inclination),size(self%wavelength)])) &
          & call Error_Report('`attenuationSpheroid` does not have the shape implied by the axes'              //{introspection:location})
-    if (any(shape(     extrapolationDisk   ) /= [size(self%inclination   ),size(self%wavelength  ),2                                           ])) &
+    if (any(shape(     extrapolationDisk   ) /= [size(self%inclination   ),size(self%wavelength  ),2                                            ])) &
          & call Error_Report('`extrapolationCoefficientsDisk` does not have the shape implied by the axes'    //{introspection:location})
-    if (any(shape(     extrapolationSpheroid) /= [size(self%radiusSpheroid),size(self%inclination ),size(self%wavelength),2                    ])) &
+    if (any(shape(     extrapolationSpheroid) /= [size(self%radiusSpheroid),size(self%inclination ),size(self%wavelength),2                     ])) &
          & call Error_Report('`extrapolationCoefficientsSpheroid` does not have the shape implied by the axes'//{introspection:location})
+    ! The optical depth axis is interpolated logarithmically, which a tabulated zero can not take part in. Such an
+    ! entry is dropped here and its role taken over by the linear interpolation towards unity applied below the
+    ! smallest remaining depth. Nothing is lost in doing so---no dust transmits everything---but check that, rather
+    ! than assume it, since a tabulation which disagreed would be telling us something about itself.
+    self%depthOpticalZeroTabulated=depthOptical(1) <= 0.0d0
+    if (self%depthOpticalZeroTabulated) then
+       if     (any(transmissionDisk    (1,:,:  ) /= 1.0d0))                                                                       &
+            & call Error_Report('`attenuationDisk` is not unity at zero optical depth'    //{introspection:location})
+       if     (any(transmissionSpheroid(:,1,:,:) /= 1.0d0))                                                                       &
+            & call Error_Report('`attenuationSpheroid` is not unity at zero optical depth'//{introspection:location})
+       if     (size(depthOptical) < 3)                                                                                            &
+            & call Error_Report('the optical depth axis is too short to interpolate in once its zero entry is dropped'//{introspection:location})
+       self%depthOptical        =depthOptical        (  2:      )
+       self%transmissionDisk    =transmissionDisk    (2:,:  ,:  )
+       self%transmissionSpheroid=transmissionSpheroid(: ,2:,:,:)
+    else
+       call move_alloc(depthOptical        ,self%depthOptical        )
+       call move_alloc(transmissionDisk    ,self%transmissionDisk    )
+       call move_alloc(transmissionSpheroid,self%transmissionSpheroid)
+    end if
+    if (allocated(depthOptical        )) deallocate(depthOptical        )
+    if (allocated(transmissionDisk    )) deallocate(transmissionDisk    )
+    if (allocated(transmissionSpheroid)) deallocate(transmissionSpheroid)
+    self%depthOpticalMinimum=self%depthOptical(1)
     ! Split the extrapolation coefficients into their constant and logarithmic terms, so that each is a contiguous
     ! array rather than a strided section of a larger one.
     self%extrapolationDiskConstant       =extrapolationDisk    (:,:  ,1)
@@ -427,8 +573,9 @@ contains
     double precision                                                                              :: depthOptical                     , inclination_       , &
          &                                                                                           radiusSpheroid                   , logDepth           , &
          &                                                                                           inclinationDegrees               , coefficientConstant, &
-         &                                                                                           coefficientLogarithmic
-    logical                                                                                       :: radiusSpheroidComputed           , extrapolating
+         &                                                                                           coefficientLogarithmic           , blendZero
+    logical                                                                                       :: radiusSpheroidComputed           , extrapolating      , &
+         &                                                                                           blending
     integer                                                                                       :: i
     ! Bracketing indices and linear weights, per dimension, in the order the tables are laid out: for the disk
     ! (optical depth, inclination, wavelength), and for the spheroid (spheroid size, optical depth, inclination,
@@ -466,7 +613,20 @@ contains
        transmission=1.0d0
        return
     end if
-    logDepth              =log(depthOptical)
+    ! Below the smallest tabulated depth, evaluate the table at that depth and interpolate the result linearly back
+    ! towards unit transmission, which is the value the dropped zero-optical-depth entry held. Clamping instead would
+    ! leave a galaxy with almost no dust as attenuated as one at the tabulation's lower edge, which in the
+    ! ultraviolet is not a small difference.
+    blending              =       self%depthOpticalZeroTabulated       &
+         &                  .and.      depthOptical < self%depthOpticalMinimum
+    if (blending) then
+       blendZero          =+     depthOptical        &
+            &              /self%depthOpticalMinimum
+       logDepth           =log(self%depthOpticalMinimum)
+    else
+       blendZero          =1.0d0
+       logDepth           =log(     depthOptical      )
+    end if
     extrapolating         =  self%extrapolateOpticalDepth                              &
          &                 .and.                                                       &
          &                   depthOptical > self%depthOptical(size(self%depthOptical))
@@ -546,6 +706,15 @@ contains
           transmission(i)=1.0d0
           call Error_Report('this tabulation covers only disk and spheroid components'//{introspection:location})
        end if
+       ! Guarded rather than applied unconditionally: for a strongly attenuated parcel, 1+(T-1) would lose precision
+       ! to cancellation.
+       if (blending)                              &
+            & transmission(i)=+1.0d0              &
+            &                 +blendZero          &
+            &                 *(                  &
+            &                   +transmission(i)  &
+            &                   -1.0d0            &
+            &                  )
     end do
     return
   end function atlasCompendiumTransmission

--- a/source/dust/attenuation/atlas_compendium.F90
+++ b/source/dust/attenuation/atlas_compendium.F90
@@ -160,7 +160,7 @@ contains
     type            (dustAttenuationAtlasCompendium)                :: self
     type            (inputParameters               ), intent(inout) :: parameters
     class           (galacticInclinationClass      ), pointer       :: galacticInclination_
-    type            (varying_string                )                :: fileName            , url, &
+    type            (varying_string                )                :: fileName               , url, &
          &                                                             spheroidProfile
     double precision                                                :: dustToMetalsRatio
     logical                                                         :: extrapolateOpticalDepth
@@ -293,23 +293,23 @@ contains
        !$ call hdf5Access%unset()
        call Error_Report('`'//self%fileName//'` has no `opacity` attribute, so is not a dust compendium tabulation'//{introspection:location})
     end if
-    call file%readAttribute('opacity'                          ,self%opacity             )
-    call file%readDataset  ('wavelength'                       ,self%wavelength          )
-    call file%readDataset  ('inclination'                      ,self%inclination         )
-    call file%readDataset  ('opticalDepth'                     ,self%depthOptical        )
-    call file%readDataset  ('spheroidScaleRadial'              ,self%radiusSpheroid      )
-    call file%readDataset  ('attenuationDisk'                  ,self%transmissionDisk    )
-    call file%readDataset  ('attenuationSpheroid'              ,self%transmissionSpheroid)
-    call file%readDataset  ('extrapolationCoefficientsDisk'    ,     extrapolationDisk   )
+    call file%readAttribute('opacity'                          ,self%opacity              )
+    call file%readDataset  ('wavelength'                       ,self%wavelength           )
+    call file%readDataset  ('inclination'                      ,self%inclination          )
+    call file%readDataset  ('opticalDepth'                     ,self%depthOptical         )
+    call file%readDataset  ('spheroidScaleRadial'              ,self%radiusSpheroid       )
+    call file%readDataset  ('attenuationDisk'                  ,self%transmissionDisk     )
+    call file%readDataset  ('attenuationSpheroid'              ,self%transmissionSpheroid )
+    call file%readDataset  ('extrapolationCoefficientsDisk'    ,     extrapolationDisk    )
     call file%readDataset  ('extrapolationCoefficientsSpheroid',     extrapolationSpheroid)
     !$ call hdf5Access%unset()
     ! Check that the tables have the shape the axes imply. A transposed read would otherwise show up much later as
     ! quietly wrong attenuation.
-    if (any(shape(self%transmissionDisk    ) /= [size(self%depthOptical  ),size(self%inclination ),size(self%wavelength)                      ])) &
+    if (any(shape(self%transmissionDisk    ) /= [size(self%depthOptical  ),size(self%inclination ),size(self%wavelength)                       ])) &
          & call Error_Report('`attenuationDisk` does not have the shape implied by the axes'                  //{introspection:location})
     if (any(shape(self%transmissionSpheroid) /= [size(self%radiusSpheroid),size(self%depthOptical),size(self%inclination),size(self%wavelength)])) &
          & call Error_Report('`attenuationSpheroid` does not have the shape implied by the axes'              //{introspection:location})
-    if (any(shape(     extrapolationDisk   ) /= [size(self%inclination   ),size(self%wavelength  ),2                                          ])) &
+    if (any(shape(     extrapolationDisk   ) /= [size(self%inclination   ),size(self%wavelength  ),2                                           ])) &
          & call Error_Report('`extrapolationCoefficientsDisk` does not have the shape implied by the axes'    //{introspection:location})
     if (any(shape(     extrapolationSpheroid) /= [size(self%radiusSpheroid),size(self%inclination ),size(self%wavelength),2                    ])) &
          & call Error_Report('`extrapolationCoefficientsSpheroid` does not have the shape implied by the axes'//{introspection:location})
@@ -423,29 +423,29 @@ contains
     double precision                                , intent(in   ), optional                     :: inclination
     double precision                                               , dimension(size(descriptors)) :: transmission
     ! The tabulation is in microns, while parcels report their wavelength in Angstroms.
-    double precision                                , parameter                                   :: micronsPerAngstrom  =1.0d-4
-    double precision                                                                              :: depthOptical              , inclination_      , &
-         &                                                                                           radiusSpheroid            , logDepth          , &
-         &                                                                                           inclinationDegrees        , coefficientConstant, &
+    double precision                                , parameter                                   :: micronsPerAngstrom        =1.0d-4
+    double precision                                                                              :: depthOptical                     , inclination_       , &
+         &                                                                                           radiusSpheroid                   , logDepth           , &
+         &                                                                                           inclinationDegrees               , coefficientConstant, &
          &                                                                                           coefficientLogarithmic
-    logical                                                                                       :: radiusSpheroidComputed    , extrapolating
+    logical                                                                                       :: radiusSpheroidComputed           , extrapolating
     integer                                                                                       :: i
     ! Bracketing indices and linear weights, per dimension, in the order the tables are laid out: for the disk
     ! (optical depth, inclination, wavelength), and for the spheroid (spheroid size, optical depth, inclination,
     ! wavelength). The extrapolation coefficients carry no optical depth axis, so drop it. Only the wavelength entry
     ! changes between parcels.
-    integer         (c_size_t                      )                , dimension(  3)              :: indicesDisk
+    integer         (c_size_t                      )                , dimension(    3)            :: indicesDisk
     double precision                                                , dimension(0:1,3)            :: weightsDisk
-    integer         (c_size_t                      )                , dimension(  4)              :: indicesSpheroid
+    integer         (c_size_t                      )                , dimension(    4)            :: indicesSpheroid
     double precision                                                , dimension(0:1,4)            :: weightsSpheroid
-    integer         (c_size_t                      )                , dimension(  2)              :: indicesDiskExtrapolate
+    integer         (c_size_t                      )                , dimension(    2)            :: indicesDiskExtrapolate
     double precision                                                , dimension(0:1,2)            :: weightsDiskExtrapolate
-    integer         (c_size_t                      )                , dimension(  3)              :: indicesSpheroidExtrapolate
+    integer         (c_size_t                      )                , dimension(    3)            :: indicesSpheroidExtrapolate
     double precision                                                , dimension(0:1,3)            :: weightsSpheroidExtrapolate
-    integer         (c_size_t                      )                                              :: indexInclination          , indexWavelength   , &
-         &                                                                                           indexRadiusSpheroid       , indexDepthOptical
-    double precision                                                , dimension(0:1)              :: weightInclination         , weightWavelength  , &
-         &                                                                                           weightRadiusSpheroid      , weightDepthOptical
+    integer         (c_size_t                      )                                              :: indexInclination                 , indexWavelength   , &
+         &                                                                                           indexRadiusSpheroid              , indexDepthOptical
+    double precision                                                , dimension(0:1  )            :: weightInclination                , weightWavelength  , &
+         &                                                                                           weightRadiusSpheroid             , weightDepthOptical
 
     ! The dust lies in the disk in this model, and a spheroid is reddened by the disk's dust, so the optical depth is
     ! always that of the disk.
@@ -467,8 +467,8 @@ contains
        return
     end if
     logDepth              =log(depthOptical)
-    extrapolating         =  self%extrapolateOpticalDepth                                   &
-         &                 .and.                                                            &
+    extrapolating         =  self%extrapolateOpticalDepth                              &
+         &                 .and.                                                       &
          &                   depthOptical > self%depthOptical(size(self%depthOptical))
     radiusSpheroidComputed=.false.
     radiusSpheroid        =0.0d0
@@ -476,16 +476,16 @@ contains
     ! belonging to the interpolator which will actually be used is maintained.
     call self%interpolatorInclination%linearFactors(inclinationDegrees,indexInclination,weightInclination)
     if (extrapolating) then
-       indicesDiskExtrapolate    (  1)=indexInclination
-       weightsDiskExtrapolate    (:,1)=weightInclination
-       indicesSpheroidExtrapolate(  2)=indexInclination
-       weightsSpheroidExtrapolate(:,2)=weightInclination
+       indicesDiskExtrapolate    (  1  )=indexInclination
+       weightsDiskExtrapolate    (:,1  )=weightInclination
+       indicesSpheroidExtrapolate(  2  )=indexInclination
+       weightsSpheroidExtrapolate(:,2  )=weightInclination
     else
        call self%interpolatorDepthOptical%linearFactors(logDepth,indexDepthOptical,weightDepthOptical)
-       indicesDisk               (  1)=indexDepthOptical
-       weightsDisk               (:,1)=weightDepthOptical
-       indicesDisk               (  2)=indexInclination
-       weightsDisk               (:,2)=weightInclination
+       indicesDisk               (  1  )=indexDepthOptical
+       weightsDisk               (:,1  )=weightDepthOptical
+       indicesDisk               (  2  )=indexInclination
+       weightsDisk               (:,2  )=weightInclination
        indicesSpheroid           (  2:3)=indicesDisk       (  1:2)
        weightsSpheroid           (:,2:3)=weightsDisk       (:,1:2)
     end if
@@ -519,10 +519,10 @@ contains
              ! Clamp into the tabulated range before taking a logarithm. A galaxy may have no spheroid, or no disk
              ! to measure one against, giving a ratio of zero whose logarithm would trap; and the interpolator holds
              ! values at the boundary in any case, so nothing is lost by clamping here rather than there.
-             radiusSpheroid        =max(                                       &
-                  &                     +radiusSpheroidRelative(node)          &
-                  &                     /self%radiusSpheroidHalfMassToScale  , &
-                  &                     +minval(self%radiusSpheroid)           &
+             radiusSpheroid        =max(                                     &
+                  &                     +radiusSpheroidRelative(node)        &
+                  &                     /self%radiusSpheroidHalfMassToScale, &
+                  &                     +minval(self%radiusSpheroid)         &
                   &                    )
              radiusSpheroidComputed=.true.
              call self%interpolatorRadiusSpheroid%linearFactors(log(radiusSpheroid),indexRadiusSpheroid,weightRadiusSpheroid)
@@ -556,7 +556,7 @@ contains
     else which varies within a component.
     !!}
     implicit none
-    type (decompositionRequest         )                :: request
+    type (decompositionRequest          )                :: request
     class(dustAttenuationAtlasCompendium), intent(inout) :: self
     !$GLC attributes unused :: self
 

--- a/source/dust/attenuation/atlas_compendium.F90
+++ b/source/dust/attenuation/atlas_compendium.F90
@@ -139,8 +139,11 @@
    known to this class, so naming one is enough; ``url`` is needed only for a tabulation which is not among them,
    such as one the user has produced themselves.
 
-   Be aware that all but the six original-resolution :cite:t:`ferrara_atlas_1999` tabulations are 584 MB apiece,
-   and that most of that is read into memory and held for the life of the run.
+   Be aware of the size of these files. All but the six original-resolution :cite:t:`ferrara_atlas_1999`
+   tabulations are 584 MB apiece, tabulated on a grid of 250 wavelengths, 46 inclinations, 60 optical depths, and
+   51 spheroid sizes. Half of each file is Monte Carlo uncertainties, which are not read; the attenuations and their
+   extrapolation coefficients come to 297 MB, and are held for the life of the run. Almost all of that is the
+   spheroid table, which alone is 282 MB.
 
    Two quantities are supplied per galaxy rather than tabulated:
 

--- a/source/dust/attenuation/atlas_compendium.F90
+++ b/source/dust/attenuation/atlas_compendium.F90
@@ -24,6 +24,7 @@
   !!}
 
   use :: Galactic_Inclinations         , only : galacticInclinationClass
+  use :: Locks                         , only : ompReadWriteLock
   use :: ISO_Varying_String            , only : varying_string
   use :: Numerical_Interpolation       , only : interpolator
   use :: Numerical_Interpolation_MultiD, only : interpolatorMultiD
@@ -31,6 +32,32 @@
   ! The tabulations published on Zenodo, with the record each belongs to and the spheroid profile it was
   ! computed for, so that naming a file is enough to fetch it and to place spheroids on it correctly. A
   ! file which is not one of these can still be used, by giving `url` and `spheroidProfile` explicitly.
+  ! A store of tabulations shared by every instance and every thread which wants them. The tables are read-only
+  ! once built and are the bulk of this class's memory---297 MB for a high resolution tabulation---so holding one
+  ! copy per OpenMP thread per instance, as deep copying the object otherwise does, costs gigabytes for no benefit.
+  ! Entries are keyed by the file they came from together with the trimming applied to it, so two instances reading
+  ! different files, or the same file trimmed differently, get separate tables and can not interfere.
+  !
+  ! The interpolators are deliberately *not* shared. Each caches a bracket index and a GSL accelerator which it
+  ! mutates as it interpolates, so a shared one would be a data race; they stay per-thread, where they are small.
+  !
+  ! Access follows the pattern of the filter store in `source/instruments/filters.F90`: a read/write lock, so that
+  ! any number of threads may read the tables at once while a thread adding one has them to itself. Entries are
+  ! never removed---a tabulation wanted once is wanted for the life of the run---so an index into the store stays
+  ! valid, which is what lets an object carry one across a deep copy and share the table rather than duplicate it.
+  type :: compendiumTable
+     type            (varying_string)                                          :: key
+     double precision                , allocatable, dimension(:,:,:        )   :: transmissionDisk
+     double precision                , allocatable, dimension(:,:,:,:      )   :: transmissionSpheroid
+     double precision                , allocatable, dimension(:,:          )   :: extrapolationDiskConstant       , extrapolationDiskLogarithmic
+     double precision                , allocatable, dimension(:,:,:        )   :: extrapolationSpheroidConstant   , extrapolationSpheroidLogarithmic
+  end type compendiumTable
+  type   (compendiumTable ), allocatable, dimension(:) :: compendiumTables
+  integer                                  , parameter :: compendiumTablesCapacity       =16
+  integer                                              :: compendiumTablesCount          =0
+  type   (ompReadWriteLock)                            :: compendiumTablesLock
+  logical                                              :: compendiumTablesLockInitialized =.false.
+
   ! The tabulations are in microns, while parcels, and the trimming parameters, are in Angstroms.
   double precision                               , parameter                                  :: angstromsPerMicron  =1.0d+4
   integer                                        , parameter                                  :: compendiumFilesCount=21
@@ -147,10 +174,13 @@
    not read; the attenuations and their extrapolation coefficients come to 297 MB, almost all of it the spheroid
    table.
 
-   That 297 MB is *per copy*, and there is one copy per OpenMP thread per instance of this class, since each thread
-   works on a deep copy of the attenuator. A parameter file with two of these attenuators, run on twenty threads,
-   therefore holds forty copies: 12 GB of tabulation, measured. Restricting each axis to the range actually needed
-   is what keeps that in hand---``wavelengthMinimum``, ``wavelengthMaximum``, ``opticalDepthMaximum``,
+   The tables themselves are held once and shared, rather than being duplicated by the deep copy which gives each
+   OpenMP thread its own attenuator, so that figure is paid once per distinct tabulation rather than once per thread
+   per instance. Two instances reading different files, or the same file trimmed differently, get separate tables.
+   The interpolators are *not* shared, each caching a bracket index and a GSL accelerator which it mutates as it
+   works; they stay per-thread, where they are small.
+
+   Restricting each axis to the range actually needed reduces what is held further---``wavelengthMinimum``, ``wavelengthMaximum``, ``opticalDepthMaximum``,
    ``radiusSpheroidMinimum``, and ``radiusSpheroidMaximum`` below. Only the retained part of each axis is read from
    the file, as an HDF5 hyperslab, so a trimmed tabulation is never held at full size even transiently. Trimming
    changes no result which lies inside the retained range: the bracketing nodes on either side are kept, so values
@@ -227,14 +257,10 @@
      ! spheroid scale radius in units of the disk scale length.
      double precision                                          , allocatable, dimension(:      ) :: wavelength                              , inclination                     , &
           &                                                                                         depthOptical                            , radiusSpheroid
-     ! Tabulated transmission. The datasets are written (wavelength, inclination, opticalDepth[, radius]) as a
-     ! row-major reader sees them, so the Fortran dimensions are the reverse of that.
-     double precision                                          , allocatable, dimension(:,:,:  ) :: transmissionDisk
-     double precision                                          , allocatable, dimension(:,:,:,:) :: transmissionSpheroid
-     ! Coefficients of the high-optical-depth extrapolation, split into their constant and logarithmic terms at read
-     ! time so that each is a contiguous array the interpolators can be handed directly.
-     double precision                                          , allocatable, dimension(:,:    ) :: extrapolationDiskConstant               , extrapolationDiskLogarithmic
-     double precision                                          , allocatable, dimension(:,:,:  ) :: extrapolationSpheroidConstant           , extrapolationSpheroidLogarithmic
+     ! The tabulated transmission and extrapolation coefficients live in the shared store above; this is which
+     ! entry of it belongs to this object. It is not stored as part of the object's state: it is resolved from the
+     ! file name and trimming, which are.
+     integer                                                                                     :: tableIndex
      type            (interpolatorMultiD                      )                                  :: interpolatorDisk                        , interpolatorSpheroid            , &
           &                                                                                         interpolatorDiskExtrapolate             , interpolatorSpheroidExtrapolate
      ! The axis interpolators are retained as well as being handed to the multilinear interpolators above. Only the
@@ -423,6 +449,8 @@ contains
          &                                                                                         beginExtrapolationDisk      , countExtrapolationDisk
     integer         (hsize_t                                 )              , dimension(4     ) :: beginSpheroid               , countSpheroid       , &
          &                                                                                         beginExtrapolationSpheroid  , countExtrapolationSpheroid
+    type            (varying_string                          )                                  :: tableKey
+    character       (len=128                                 )                                  :: labelTable
     integer                                                                                     :: indexWavelengthBegin        , indexWavelengthEnd  , &
          &                                                                                         indexDepthOpticalBegin      , indexDepthOpticalEnd, &
          &                                                                                         indexRadiusSpheroidBegin    , indexRadiusSpheroidEnd
@@ -524,6 +552,13 @@ contains
          &                   ' transmission at the retained boundary instead, or raise `opticalDepthMaximum`.'       //  &
          &                   {introspection:location}                                                                    &
          &                  )
+    ! The key identifies the tabulation together with the trimming applied to it, so that the same file trimmed two
+    ! different ways yields two entries and one trimmed identically yields one. The resolved index bounds are used
+    ! rather than the parameters themselves, so that two requests which land on the same nodes share a table.
+    write (labelTable,'(6(i0,a1))') indexWavelengthBegin    ,':',indexWavelengthEnd    ,':', &
+         &                          indexDepthOpticalBegin  ,':',indexDepthOpticalEnd  ,':', &
+         &                          indexRadiusSpheroidBegin,':',indexRadiusSpheroidEnd,':'
+    tableKey=self%fileName//'|'//trim(labelTable)
     ! Read the attenuations as a hyperslab covering only the retained part of each axis, so that a trimmed
     ! tabulation is never held at full size, even transiently. `readBegin` and `readCount` are given in the order of
     ! the Fortran array, which for these datasets is the reverse of the order they were written in.
@@ -545,8 +580,8 @@ contains
     self%wavelength    =self%wavelength    (indexWavelengthBegin    :indexWavelengthEnd    )
     self%radiusSpheroid=self%radiusSpheroid(indexRadiusSpheroidBegin:indexRadiusSpheroidEnd)
     depthOptical       =     depthOptical  (indexDepthOpticalBegin  :indexDepthOpticalEnd  )
-    ! Check that the tables have the shape the axes imply, before anything is sliced. A transposed read would
-    ! otherwise show up much later as quietly wrong attenuation.
+    ! Check that the tables have the shape the axes imply. A transposed read would otherwise show up much later as
+    ! quietly wrong attenuation.
     if (any(shape(     transmissionDisk    ) /= [size(     depthOptical   ),size(self%inclination ),size(self%wavelength)                       ])) &
          & call Error_Report('`attenuationDisk` does not have the shape implied by the axes'                  //{introspection:location})
     if (any(shape(     transmissionSpheroid) /= [size(self%radiusSpheroid),size(     depthOptical ),size(self%inclination),size(self%wavelength)])) &
@@ -561,30 +596,66 @@ contains
     ! than assume it, since a tabulation which disagreed would be telling us something about itself.
     self%depthOpticalZeroTabulated=depthOptical(1) <= 0.0d0
     if (self%depthOpticalZeroTabulated) then
-       if     (any(transmissionDisk    (1,:,:  ) /= 1.0d0))                                                                       &
-            & call Error_Report('`attenuationDisk` is not unity at zero optical depth'    //{introspection:location})
-       if     (any(transmissionSpheroid(:,1,:,:) /= 1.0d0))                                                                       &
-            & call Error_Report('`attenuationSpheroid` is not unity at zero optical depth'//{introspection:location})
-       if     (size(depthOptical) < 3)                                                                                            &
+       if     (any(transmissionDisk    (1,:,:  ) /= 1.0d0))                                                                            &
+            & call Error_Report('`attenuationDisk` is not unity at zero optical depth'                                //{introspection:location})
+       if     (any(transmissionSpheroid(:,1,:,:) /= 1.0d0))                                                                            &
+            & call Error_Report('`attenuationSpheroid` is not unity at zero optical depth'                            //{introspection:location})
+       if     (size(depthOptical) < 3)                                                                                                 &
             & call Error_Report('the optical depth axis is too short to interpolate in once its zero entry is dropped'//{introspection:location})
-       self%depthOptical        =depthOptical        (2:       )
-       self%transmissionDisk    =transmissionDisk    (2:, :,:  )
-       self%transmissionSpheroid=transmissionSpheroid( :,2:,:,:)
+       self%depthOptical=depthOptical(2:)
     else
-       call move_alloc(depthOptical        ,self%depthOptical        )
-       call move_alloc(transmissionDisk    ,self%transmissionDisk    )
-       call move_alloc(transmissionSpheroid,self%transmissionSpheroid)
+       self%depthOptical=depthOptical
     end if
-    if (allocated(depthOptical        )) deallocate(depthOptical        )
-    if (allocated(transmissionDisk    )) deallocate(transmissionDisk    )
-    if (allocated(transmissionSpheroid)) deallocate(transmissionSpheroid)
+    if (allocated(depthOptical)) deallocate(depthOptical)
     self%depthOpticalMinimum=self%depthOptical(1)
-    ! Split the extrapolation coefficients into their constant and logarithmic terms, so that each is a contiguous
-    ! array rather than a strided section of a larger one.
-    self%extrapolationDiskConstant       =extrapolationDisk    (:,:  ,1)
-    self%extrapolationDiskLogarithmic    =extrapolationDisk    (:,:  ,2)
-    self%extrapolationSpheroidConstant   =extrapolationSpheroid(:,:,:,1)
-    self%extrapolationSpheroidLogarithmic=extrapolationSpheroid(:,:,:,2)
+    ! Hand the tables to the shared store, or discard them if another instance got there first, and keep only the
+    ! index of the entry. That index survives the deep copy which gives each thread its own attenuator, so every
+    ! thread reads the one table rather than carrying its own.
+    if (.not.compendiumTablesLockInitialized) then
+       !$omp critical (dustAttenuationCompendiumTablesLock)
+       if (.not.compendiumTablesLockInitialized) then
+          compendiumTablesLock           =ompReadWriteLock()
+          compendiumTablesLockInitialized=.true.
+       end if
+       !$omp end critical (dustAttenuationCompendiumTablesLock)
+    end if
+    call compendiumTablesLock%setWrite(haveReadLock=.false.)
+    self%tableIndex=0
+    do i=1,compendiumTablesCount
+       if (compendiumTables(i)%key == tableKey) self%tableIndex=i
+    end do
+    if (self%tableIndex == 0) then
+       ! The store is allocated once at its full capacity rather than grown. Growing it would mean copying the
+       ! tables already in it, which for a high resolution tabulation is a transient 297 MB per entry for no
+       ! purpose. The capacity is far beyond any plausible model: it bounds the number of *distinct* tabulations,
+       ! counting a file trimmed two ways as two, and each one costs hundreds of megabytes to hold.
+       if (.not.allocated(compendiumTables)) allocate(compendiumTables(compendiumTablesCapacity))
+       if (compendiumTablesCount == compendiumTablesCapacity) then
+          call compendiumTablesLock%unsetWrite(haveReadLock=.false.)
+          call Error_Report('more distinct compendium tabulations are in use than can be held at once'//{introspection:location})
+       end if
+       compendiumTablesCount=compendiumTablesCount+1
+       self%tableIndex      =compendiumTablesCount
+       compendiumTables(self%tableIndex)%key=tableKey
+       if (self%depthOpticalZeroTabulated) then
+          compendiumTables(self%tableIndex)%transmissionDisk    =transmissionDisk    (2:, :,:  )
+          compendiumTables(self%tableIndex)%transmissionSpheroid=transmissionSpheroid( :,2:,:,:)
+       else
+          call move_alloc(transmissionDisk    ,compendiumTables(self%tableIndex)%transmissionDisk    )
+          call move_alloc(transmissionSpheroid,compendiumTables(self%tableIndex)%transmissionSpheroid)
+       end if
+       ! Split the extrapolation coefficients into their constant and logarithmic terms, so that each is a
+       ! contiguous array which the interpolators can be handed directly.
+       compendiumTables(self%tableIndex)%extrapolationDiskConstant       =extrapolationDisk    (:,:  ,1)
+       compendiumTables(self%tableIndex)%extrapolationDiskLogarithmic    =extrapolationDisk    (:,:  ,2)
+       compendiumTables(self%tableIndex)%extrapolationSpheroidConstant   =extrapolationSpheroid(:,:,:,1)
+       compendiumTables(self%tableIndex)%extrapolationSpheroidLogarithmic=extrapolationSpheroid(:,:,:,2)
+    end if
+    call compendiumTablesLock%unsetWrite(haveReadLock=.false.)
+    if (allocated(transmissionDisk     )) deallocate(transmissionDisk     )
+    if (allocated(transmissionSpheroid )) deallocate(transmissionSpheroid )
+    if (allocated(extrapolationDisk    )) deallocate(extrapolationDisk    )
+    if (allocated(extrapolationSpheroid)) deallocate(extrapolationSpheroid)
     ! Build interpolators, ordered from the most rapidly varying dimension of the table outward. Optical depth and
     ! spheroid size are interpolated logarithmically, being tabulated on geometric grids; wavelength likewise. Values
     ! outside the tabulated ranges are held at the boundary.
@@ -728,7 +799,7 @@ contains
          &                                                                                           inclinationDegrees               , coefficientConstant, &
          &                                                                                           coefficientLogarithmic           , blendZero
     logical                                                                                       :: radiusSpheroidComputed           , extrapolating      , &
-         &                                                                                           blending
+         &                                                                                           blending                         , isLocked
     integer                                                                                       :: i
     ! Bracketing indices and linear weights, per dimension, in the order the tables are laid out: for the disk
     ! (optical depth, inclination, wavelength), and for the spheroid (spheroid size, optical depth, inclination,
@@ -785,6 +856,10 @@ contains
          &                   depthOptical > self%depthOptical(size(self%depthOptical))
     radiusSpheroidComputed=.false.
     radiusSpheroid        =0.0d0
+    ! Hold the shared tables for reading while they are interpolated in. The lock is shared between readers, so
+    ! threads do not wait on one another; it excludes only a thread adding a table, which would move the store.
+    isLocked=compendiumTablesLock%owned()
+    if (.not.isLocked) call compendiumTablesLock%setRead()
     ! Bracket the axes which are properties of the galaxy rather than of a parcel, once. Only the set of factors
     ! belonging to the interpolator which will actually be used is maintained.
     call self%interpolatorInclination%linearFactors(inclinationDegrees,indexInclination,weightInclination)
@@ -817,15 +892,15 @@ contains
        end if
        if      (descriptors(i)%componentType == componentTypeDisk    ) then
           if (extrapolating) then
-             coefficientConstant   =self%interpolatorDiskExtrapolate%interpolateFactors(self%extrapolationDiskConstant   ,indicesDiskExtrapolate,weightsDiskExtrapolate)
-             coefficientLogarithmic=self%interpolatorDiskExtrapolate%interpolateFactors(self%extrapolationDiskLogarithmic,indicesDiskExtrapolate,weightsDiskExtrapolate)
+             coefficientConstant   =self%interpolatorDiskExtrapolate%interpolateFactors(compendiumTables(self%tableIndex)%extrapolationDiskConstant   ,indicesDiskExtrapolate,weightsDiskExtrapolate)
+             coefficientLogarithmic=self%interpolatorDiskExtrapolate%interpolateFactors(compendiumTables(self%tableIndex)%extrapolationDiskLogarithmic,indicesDiskExtrapolate,weightsDiskExtrapolate)
              transmission(i)       =exp(                        &
                   &                     +coefficientConstant    &
                   &                     +coefficientLogarithmic &
                   &                     *logDepth               &
                   &                    )
           else
-             transmission(i)       =self%interpolatorDisk%interpolateFactors(self%transmissionDisk,indicesDisk,weightsDisk)
+             transmission(i)       =self%interpolatorDisk%interpolateFactors(compendiumTables(self%tableIndex)%transmissionDisk,indicesDisk,weightsDisk)
           end if
        else if (descriptors(i)%componentType == componentTypeSpheroid) then
           if (.not.radiusSpheroidComputed) then
@@ -845,15 +920,15 @@ contains
              weightsSpheroidExtrapolate(:,1)=weightRadiusSpheroid
           end if
           if (extrapolating) then
-             coefficientConstant   =self%interpolatorSpheroidExtrapolate%interpolateFactors(self%extrapolationSpheroidConstant   ,indicesSpheroidExtrapolate,weightsSpheroidExtrapolate)
-             coefficientLogarithmic=self%interpolatorSpheroidExtrapolate%interpolateFactors(self%extrapolationSpheroidLogarithmic,indicesSpheroidExtrapolate,weightsSpheroidExtrapolate)
+             coefficientConstant   =self%interpolatorSpheroidExtrapolate%interpolateFactors(compendiumTables(self%tableIndex)%extrapolationSpheroidConstant   ,indicesSpheroidExtrapolate,weightsSpheroidExtrapolate)
+             coefficientLogarithmic=self%interpolatorSpheroidExtrapolate%interpolateFactors(compendiumTables(self%tableIndex)%extrapolationSpheroidLogarithmic,indicesSpheroidExtrapolate,weightsSpheroidExtrapolate)
              transmission(i)       =exp(                        &
                   &                     +coefficientConstant    &
                   &                     +coefficientLogarithmic &
                   &                     *logDepth               &
                   &                    )
           else
-             transmission(i)       =self%interpolatorSpheroid%interpolateFactors(self%transmissionSpheroid,indicesSpheroid,weightsSpheroid)
+             transmission(i)       =self%interpolatorSpheroid%interpolateFactors(compendiumTables(self%tableIndex)%transmissionSpheroid,indicesSpheroid,weightsSpheroid)
           end if
        else
           transmission(i)=1.0d0
@@ -869,6 +944,7 @@ contains
             &                   -1.0d0           &
             &                  )
     end do
+    if (.not.isLocked) call compendiumTablesLock%unsetRead()
     return
   end function atlasCompendiumTransmission
 

--- a/source/dust/attenuation/atlas_compendium.F90
+++ b/source/dust/attenuation/atlas_compendium.F90
@@ -1,0 +1,583 @@
+!! Copyright 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018,
+!!           2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026
+!!    Andrew Benson <abenson@carnegiescience.edu>
+!!
+!! This file is part of Galacticus.
+!!
+!!    Galacticus is free software: you can redistribute it and/or modify
+!!    it under the terms of the GNU General Public License as published by
+!!    the Free Software Foundation, either version 3 of the License, or
+!!    (at your option) any later version.
+!!
+!!    Galacticus is distributed in the hope that it will be useful,
+!!    but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!    GNU General Public License for more details.
+!!
+!!    You should have received a copy of the GNU General Public License
+!!    along with Galacticus.  If not, see <http://www.gnu.org/licenses/>.
+
+!+    Contributions to this file made by: Andrew Benson, Claude.
+
+  !!{RST
+  Implements a dust attenuation class using the dust compendium of :cite:t:`benson_compendium_2018`.
+  !!}
+
+  use :: Galactic_Inclinations         , only : galacticInclinationClass
+  use :: ISO_Varying_String            , only : varying_string
+  use :: Numerical_Interpolation       , only : interpolator
+  use :: Numerical_Interpolation_MultiD, only : interpolatorMultiD
+
+  !![
+  <enumeration docformat="rst">
+   <name>compendiumSpheroidProfile</name>
+   <description>
+   Enumerates the spheroid density profiles for which dust compendium tabulations have been computed.
+   </description>
+   <encodeFunction>yes</encodeFunction>
+   <validator>yes</validator>
+   <visibility>public</visibility>
+   <entry label="hernquist"/>
+   <entry label="jaffe"    />
+  </enumeration>
+  !!]
+
+  !![
+  <dustAttenuation name="dustAttenuationAtlasCompendium" docformat="rst">
+   <description>
+   Dust attenuation from the dust compendium of :cite:t:`benson_compendium_2018`: radiative transfer solutions for simple
+   galactic geometries, tabulating the fraction of light escaping a galaxy as a function of wavelength, inclination,
+   optical depth, and---for the spheroid---the size of the spheroid relative to the disk.
+
+   This is a *non-separable* attenuator, exactly as :galacticus-class:`dustAttenuationAtlasFerrara2000` is: the
+   tabulated escape fraction is the result of a radiative transfer calculation through a specified geometry, and is
+   not the exponential of a single optical depth times a wavelength-dependent curve, so it takes no
+   ``dustExtinctionCurve``. It also means the transmission can slightly exceed unity where scattering redirects more
+   light into the line of sight than the dust removes from it.
+
+   The tabulations are published as a set of HDF5 files, one per combination of grain properties and geometry, and
+   are described in the :doc:`dust compendium datasets &lt;/manuals/user-guide/data/dust-compendium-datasets&gt;` section
+   of the user guide. ``fileName`` selects one. If that file is not already present it is downloaded from ``url``
+   and cached under the dynamic datasets path, so a file is fetched once and reused thereafter.
+
+   Two quantities are supplied per galaxy rather than tabulated:
+
+   * The :math:`V`-band optical depth through the center of the galaxy, perpendicular to the plane. Unlike
+     :galacticus-class:`dustAttenuationAtlasFerrara2000`, which delegates this to a
+     :galacticus-class:`dustAttenuationScreen`, it is computed here from the tabulation's *own* opacity, read from
+     the ``opacity`` attribute of the file:
+
+     .. math::
+
+        \tau_\mathrm{V} = \kappa_\mathrm{V} \, f_\mathrm{dust:metals} \, \Sigma_\mathrm{Z},
+
+     with :math:`\kappa_\mathrm{V}` the :math:`V`-band opacity per unit mass of dust used in the radiative transfer
+     calculation, :math:`f_\mathrm{dust:metals}` the dust-to-metals ratio (``dustToMetalsRatio``), and
+     :math:`\Sigma_\mathrm{Z} = Z M_\mathrm{gas} / 2 \pi r_\mathrm{d}^2` the central surface density of gas-phase
+     metals of the disk. Using the opacity which produced the table is what makes the optical depth mean the same
+     thing to the model as it does to the tabulation; a screen calibrated to the Milky Way, as
+     :galacticus-class:`dustAttenuationScreenSurfaceDensityMetals` is, need not agree with it.
+
+     As in :galacticus-class:`dustAttenuationAtlasFerrara2000`, the optical depth is *always* that of the disk,
+     whichever component is being attenuated: the dust lies in the disk, and a spheroid is reddened by the disk's
+     dust.
+
+   * The inclination, from a :galacticus-class:`galacticInclinationClass` object, or from the ``inclination``
+     argument when one is imposed, as :galacticus-class:`dustAttenuationInclinationAveraged` does. One or the other
+     must be available, and an error is reported if neither is.
+
+   * The size of the spheroid, in the units the ``spheroidScaleRadial`` axis is tabulated against. Note that this
+     axis does *not* mean the same thing as the corresponding axis of
+     :galacticus-class:`dustAttenuationAtlasFerrara2000`: :cite:t:`ferrara_atlas_1999` tabulate against the spheroid
+     *effective* radius, whereas the compendium tabulates against the spheroid *scale* radius. ``spheroidProfile``
+     names the profile the tabulation was computed for---``hernquist`` for most of them, ``jaffe`` for those
+     computed to match :cite:t:`ferrara_atlas_1999`---and the model's spheroid is matched to it on half-mass radius,
+     which is the radius that means the same thing whatever profile either side assumes, then converted to that
+     profile's scale radius. For a Hernquist profile the half-mass radius is :math:`(1+\sqrt{2})` times the scale
+     radius, and for a Jaffe profile the two are equal.
+
+   Beyond the largest tabulated optical depth the transmission is extrapolated as
+   :math:`T = \exp(c_0 + c_1 \ln \tau_\mathrm{V})`, using coefficients tabulated alongside the attenuations. Setting
+   ``extrapolateOpticalDepth`` to false instead holds the transmission at its value at the tabulation boundary.
+   </description>
+  </dustAttenuation>
+  !!]
+  type, extends(dustAttenuationClass) :: dustAttenuationAtlasCompendium
+     !!{RST
+     A dust attenuation class using the dust compendium of :cite:t:`benson_compendium_2018`.
+     !!}
+     private
+     class           (galacticInclinationClass                ), pointer                         :: galacticInclination_          => null()
+     type            (varying_string                          )                                  :: fileName                                , url
+     type            (enumerationCompendiumSpheroidProfileType)                                  :: spheroidProfile
+     double precision                                                                            :: dustToMetalsRatio                       , opacity                         , &
+          &                                                                                         radiusSpheroidHalfMassToScale
+     logical                                                                                     :: extrapolateOpticalDepth                 , inclinationAvailable
+     ! Grid axes. Wavelengths are in microns and inclinations in degrees, as tabulated; the spheroid axis is the
+     ! spheroid scale radius in units of the disk scale length.
+     double precision                                          , allocatable, dimension(:      ) :: wavelength                              , inclination                     , &
+          &                                                                                         depthOptical                            , radiusSpheroid
+     ! Tabulated transmission. The datasets are written (wavelength, inclination, opticalDepth[, radius]) as a
+     ! row-major reader sees them, so the Fortran dimensions are the reverse of that.
+     double precision                                          , allocatable, dimension(:,:,:  ) :: transmissionDisk
+     double precision                                          , allocatable, dimension(:,:,:,:) :: transmissionSpheroid
+     ! Coefficients of the high-optical-depth extrapolation, split into their constant and logarithmic terms at read
+     ! time so that each is a contiguous array the interpolators can be handed directly.
+     double precision                                          , allocatable, dimension(:,:    ) :: extrapolationDiskConstant               , extrapolationDiskLogarithmic
+     double precision                                          , allocatable, dimension(:,:,:  ) :: extrapolationSpheroidConstant           , extrapolationSpheroidLogarithmic
+     type            (interpolatorMultiD                      )                                  :: interpolatorDisk                        , interpolatorSpheroid            , &
+          &                                                                                         interpolatorDiskExtrapolate             , interpolatorSpheroidExtrapolate
+     ! The axis interpolators are retained as well as being handed to the multilinear interpolators above. Only the
+     ! wavelength changes between the parcels of a galaxy, so bracketing the other axes once per galaxy and reusing
+     ! the result saves that work on every parcel.
+     type            (interpolator                            )                                  :: interpolatorWavelength                  , interpolatorInclination         , &
+          &                                                                                         interpolatorDepthOptical                , interpolatorRadiusSpheroid
+   contains
+     final     ::                      atlasCompendiumDestructor
+     procedure :: transmission      => atlasCompendiumTransmission
+     procedure :: request           => atlasCompendiumRequest
+     procedure :: supportsComponent => atlasCompendiumSupportsComponent
+  end type dustAttenuationAtlasCompendium
+
+  interface dustAttenuationAtlasCompendium
+     !!{RST
+     Constructors for the :galacticus-class:`dustAttenuationAtlasCompendium` dust attenuation class.
+     !!}
+     module procedure atlasCompendiumConstructorParameters
+     module procedure atlasCompendiumConstructorInternal
+  end interface dustAttenuationAtlasCompendium
+
+contains
+
+  function atlasCompendiumConstructorParameters(parameters) result(self)
+    !!{RST
+    Constructor for the :galacticus-class:`dustAttenuationAtlasCompendium` dust attenuation class which takes a
+    parameter set as input.
+    !!}
+    use :: Input_Parameters  , only : inputParameter, inputParameters
+    use :: ISO_Varying_String, only : char          , var_str        , varying_string
+    implicit none
+    type            (dustAttenuationAtlasCompendium)                :: self
+    type            (inputParameters               ), intent(inout) :: parameters
+    class           (galacticInclinationClass      ), pointer       :: galacticInclination_
+    type            (varying_string                )                :: fileName            , url, &
+         &                                                             spheroidProfile
+    double precision                                                :: dustToMetalsRatio
+    logical                                                         :: extrapolateOpticalDepth
+
+    !![
+    <inputParameter docformat="rst">
+      <name>fileName</name>
+      <description>
+      The name of the dust compendium tabulation file to use. If no file of this name is present under the
+      ``dust/compendium`` directory of the dynamic datasets path it is downloaded from ``url``.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>url</name>
+      <defaultValue>var_str('none')</defaultValue>
+      <description>
+      The URL from which to download ``fileName`` if it is not already present. If ``none``, the file must be
+      supplied by other means.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>dustToMetalsRatio</name>
+      <defaultValue>0.44d0</defaultValue>
+      <defaultSource>Approximately correct for the Milky Way (e.g. :cite:t:`popping_dust_2017`).</defaultSource>
+      <description>
+      The fraction of the mass of metals which is in dust, used with the opacity of the tabulation to convert a
+      surface density of metals into an optical depth.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>extrapolateOpticalDepth</name>
+      <defaultValue>.true.</defaultValue>
+      <description>
+      If true, transmissions for optical depths beyond the largest tabulated value are extrapolated using the
+      coefficients supplied with the tabulation. If false, they are held at the value at the tabulation boundary.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <inputParameter docformat="rst">
+      <name>spheroidProfile</name>
+      <defaultValue>var_str('hernquist')</defaultValue>
+      <description>
+      The spheroid density profile for which the tabulation was computed: ``hernquist``, or ``jaffe`` for
+      tabulations computed to match :cite:t:`ferrara_atlas_1999`. This sets how a model galaxy's spheroid is mapped
+      onto the ``spheroidScaleRadial`` axis.
+      </description>
+      <source>parameters</source>
+    </inputParameter>
+    <objectBuilder class="galacticInclination" name="galacticInclination_" source="parameters"/>
+    !!]
+    self=dustAttenuationAtlasCompendium(fileName,url,dustToMetalsRatio,extrapolateOpticalDepth,enumerationCompendiumSpheroidProfileEncode(char(spheroidProfile),includesPrefix=.false.),galacticInclination_)
+    !![
+    <inputParametersValidate source="parameters"/>
+    <objectDestructor name="galacticInclination_"/>
+    !!]
+    return
+  end function atlasCompendiumConstructorParameters
+
+  function atlasCompendiumConstructorInternal(fileName,url,dustToMetalsRatio,extrapolateOpticalDepth,spheroidProfile,galacticInclination_) result(self)
+    !!{RST
+    Internal constructor for the :galacticus-class:`dustAttenuationAtlasCompendium` dust attenuation class. The
+    tabulation is located---downloading it if necessary---read once, here, and interpolators built over it.
+    !!}
+    use :: Error             , only : Error_Report
+    use :: File_Utilities    , only : Directory_Make      , File_Exists       , File_Lock     , File_Unlock   , &
+          &                           lockDescriptor
+    use :: HDF5_Access       , only : hdf5Access
+    use :: Input_Paths       , only : inputPath           , pathTypeDataDynamic
+    use :: IO_HDF5           , only : hdf5File
+    use :: ISO_Varying_String, only : char                , operator(//)      , operator(==)  , varying_string
+    use :: System_Download   , only : download
+    use :: Table_Labels      , only : extrapolationTypeFix
+    implicit none
+    type            (dustAttenuationAtlasCompendium          )                                  :: self
+    type            (varying_string                          ), intent(in   )                   :: fileName                    , url
+    double precision                                          , intent(in   )                   :: dustToMetalsRatio
+    logical                                                   , intent(in   )                   :: extrapolateOpticalDepth
+    type            (enumerationCompendiumSpheroidProfileType), intent(in   )                   :: spheroidProfile
+    class           (galacticInclinationClass                ), intent(in   ), target           :: galacticInclination_
+    type            (hdf5File                                )                                  :: file
+    type            (lockDescriptor                          )                                  :: lock
+    type            (varying_string                          )                                  :: pathFile                    , pathDirectory
+    integer                                                                                     :: status
+    double precision                                          , allocatable, dimension(:,:,:  ) :: extrapolationDisk
+    double precision                                          , allocatable, dimension(:,:,:,:) :: extrapolationSpheroid
+    type            (interpolator                            )             , dimension(3      ) :: interpolatorsDisk           , interpolatorsSpheroidExtrapolate
+    type            (interpolator                            )             , dimension(4      ) :: interpolatorsSpheroid
+    type            (interpolator                            )             , dimension(2      ) :: interpolatorsDiskExtrapolate
+    !![
+    <constructorAssign variables="fileName, url, dustToMetalsRatio, extrapolateOpticalDepth, spheroidProfile, *galacticInclination_"/>
+    !!]
+
+    ! An inclination must be available, either per galaxy or imposed by an attenuator averaging over orientation.
+    self%inclinationAvailable=self%galacticInclination_%isAvailable()
+    ! The ratio of half-mass to scale radius for the profile the tabulation was computed with. A model galaxy's
+    ! spheroid is matched to the tabulation on half-mass radius, then divided by this to reach the scale radius that
+    ! the `spheroidScaleRadial` axis is measured in.
+    select case (self%spheroidProfile%ID)
+    case (compendiumSpheroidProfileHernquist%ID)
+       self%radiusSpheroidHalfMassToScale=1.0d0+sqrt(2.0d0)
+    case (compendiumSpheroidProfileJaffe    %ID)
+       self%radiusSpheroidHalfMassToScale=1.0d0
+    case default
+       self%radiusSpheroidHalfMassToScale=0.0d0
+       call Error_Report('unrecognized spheroid profile'//{introspection:location})
+    end select
+    ! Locate the tabulation, downloading it if we do not already have it. The lock makes concurrent processes wait
+    ! for the first of them to finish the download rather than each starting one of their own.
+    pathDirectory=inputPath(pathTypeDataDynamic)//'dust/compendium'
+    pathFile     =pathDirectory//'/'//self%fileName
+    if (.not.File_Exists(pathFile)) then
+       if (self%url == 'none') call Error_Report('the compendium tabulation `'//self%fileName//'` is not present, and no `url` was given from which to download it'//{introspection:location})
+       call Directory_Make(pathDirectory)
+       call File_Lock     (char(pathFile),lock,lockIsShared=.false.)
+       if (.not.File_Exists(pathFile)) then
+          call download(char(self%url),char(pathFile),status=status)
+          if (status /= 0 .or. .not.File_Exists(pathFile)) then
+             call File_Unlock(lock)
+             call Error_Report('unable to download the compendium tabulation from `'//self%url//'`'//{introspection:location})
+          end if
+       end if
+       call File_Unlock(lock)
+    end if
+    !$ call hdf5Access%set()
+    file=hdf5File(char(pathFile),readOnly=.true.)
+    if (.not.file%hasAttribute('opacity')) then
+       !$ call hdf5Access%unset()
+       call Error_Report('`'//self%fileName//'` has no `opacity` attribute, so is not a dust compendium tabulation'//{introspection:location})
+    end if
+    call file%readAttribute('opacity'                          ,self%opacity             )
+    call file%readDataset  ('wavelength'                       ,self%wavelength          )
+    call file%readDataset  ('inclination'                      ,self%inclination         )
+    call file%readDataset  ('opticalDepth'                     ,self%depthOptical        )
+    call file%readDataset  ('spheroidScaleRadial'              ,self%radiusSpheroid      )
+    call file%readDataset  ('attenuationDisk'                  ,self%transmissionDisk    )
+    call file%readDataset  ('attenuationSpheroid'              ,self%transmissionSpheroid)
+    call file%readDataset  ('extrapolationCoefficientsDisk'    ,     extrapolationDisk   )
+    call file%readDataset  ('extrapolationCoefficientsSpheroid',     extrapolationSpheroid)
+    !$ call hdf5Access%unset()
+    ! Check that the tables have the shape the axes imply. A transposed read would otherwise show up much later as
+    ! quietly wrong attenuation.
+    if (any(shape(self%transmissionDisk    ) /= [size(self%depthOptical  ),size(self%inclination ),size(self%wavelength)                      ])) &
+         & call Error_Report('`attenuationDisk` does not have the shape implied by the axes'                  //{introspection:location})
+    if (any(shape(self%transmissionSpheroid) /= [size(self%radiusSpheroid),size(self%depthOptical),size(self%inclination),size(self%wavelength)])) &
+         & call Error_Report('`attenuationSpheroid` does not have the shape implied by the axes'              //{introspection:location})
+    if (any(shape(     extrapolationDisk   ) /= [size(self%inclination   ),size(self%wavelength  ),2                                          ])) &
+         & call Error_Report('`extrapolationCoefficientsDisk` does not have the shape implied by the axes'    //{introspection:location})
+    if (any(shape(     extrapolationSpheroid) /= [size(self%radiusSpheroid),size(self%inclination ),size(self%wavelength),2                    ])) &
+         & call Error_Report('`extrapolationCoefficientsSpheroid` does not have the shape implied by the axes'//{introspection:location})
+    ! Split the extrapolation coefficients into their constant and logarithmic terms, so that each is a contiguous
+    ! array rather than a strided section of a larger one.
+    self%extrapolationDiskConstant       =extrapolationDisk    (:,:  ,1)
+    self%extrapolationDiskLogarithmic    =extrapolationDisk    (:,:  ,2)
+    self%extrapolationSpheroidConstant   =extrapolationSpheroid(:,:,:,1)
+    self%extrapolationSpheroidLogarithmic=extrapolationSpheroid(:,:,:,2)
+    ! Build interpolators, ordered from the most rapidly varying dimension of the table outward. Optical depth and
+    ! spheroid size are interpolated logarithmically, being tabulated on geometric grids; wavelength likewise. Values
+    ! outside the tabulated ranges are held at the boundary.
+    interpolatorsDisk                   (1)=interpolator(log(self%depthOptical  ),extrapolationType=extrapolationTypeFix)
+    interpolatorsDisk                   (2)=interpolator(    self%inclination    ,extrapolationType=extrapolationTypeFix)
+    interpolatorsDisk                   (3)=interpolator(log(self%wavelength    ),extrapolationType=extrapolationTypeFix)
+    interpolatorsSpheroid               (1)=interpolator(log(self%radiusSpheroid),extrapolationType=extrapolationTypeFix)
+    interpolatorsSpheroid               (2)=interpolatorsDisk    (1)
+    interpolatorsSpheroid               (3)=interpolatorsDisk    (2)
+    interpolatorsSpheroid               (4)=interpolatorsDisk    (3)
+    interpolatorsDiskExtrapolate        (1)=interpolatorsDisk    (2)
+    interpolatorsDiskExtrapolate        (2)=interpolatorsDisk    (3)
+    interpolatorsSpheroidExtrapolate    (1)=interpolatorsSpheroid(1)
+    interpolatorsSpheroidExtrapolate    (2)=interpolatorsDisk    (2)
+    interpolatorsSpheroidExtrapolate    (3)=interpolatorsDisk    (3)
+    self%interpolatorDisk                  =interpolatorMultiD(interpolatorsDisk               )
+    self%interpolatorSpheroid              =interpolatorMultiD(interpolatorsSpheroid           )
+    self%interpolatorDiskExtrapolate       =interpolatorMultiD(interpolatorsDiskExtrapolate    )
+    self%interpolatorSpheroidExtrapolate   =interpolatorMultiD(interpolatorsSpheroidExtrapolate)
+    self%interpolatorDepthOptical          =interpolatorsDisk    (1)
+    self%interpolatorInclination           =interpolatorsDisk    (2)
+    self%interpolatorWavelength            =interpolatorsDisk    (3)
+    self%interpolatorRadiusSpheroid        =interpolatorsSpheroid(1)
+    return
+  end function atlasCompendiumConstructorInternal
+
+  subroutine atlasCompendiumDestructor(self)
+    !!{RST
+    Destructor for the :galacticus-class:`dustAttenuationAtlasCompendium` dust attenuation class.
+    !!}
+    implicit none
+    type(dustAttenuationAtlasCompendium), intent(inout) :: self
+
+    !![
+    <objectDestructor name="self%galacticInclination_"/>
+    !!]
+    return
+  end subroutine atlasCompendiumDestructor
+
+  double precision function atlasCompendiumDepthOpticalV(self,node) result(depthOpticalV)
+    !!{RST
+    Return the :math:`V`-band optical depth through the center of the disk, perpendicular to its plane, computed
+    from the opacity of the tabulation itself.
+
+    The tabulation records the opacity per unit mass of dust which was used in the radiative transfer calculation
+    which produced it, so combining that with a dust-to-metals ratio and the surface density of gas-phase metals
+    places a model galaxy on the tabulation using the same definition of optical depth that the tabulation was built
+    with.
+    !!}
+    use :: Galactic_Structure_Options      , only : componentTypeDisk
+    use :: Numerical_Constants_Astronomical, only : massSolar        , megaParsec
+    use :: Numerical_Constants_Math        , only : Pi
+    use :: Numerical_Constants_Prefixes    , only : hecto            , kilo
+    implicit none
+    class           (dustAttenuationAtlasCompendium), intent(inout)         :: self
+    type            (treeNode                      ), intent(inout), target :: node
+    double precision                                                        :: massGas             , radius, &
+         &                                                                     metallicity         ,         &
+         &                                                                     densitySurfaceMetals
+
+    call componentGasProperties(node,componentTypeDisk,massGas,radius,metallicity)
+    ! A disk with no gas, or no size, has no dust.
+    if (massGas <= 0.0d0 .or. radius <= 0.0d0) then
+       depthOpticalV=0.0d0
+       return
+    end if
+    ! Central surface density of metals, in g/cm².
+    densitySurfaceMetals=+metallicity      &
+         &               *massGas          &
+         &               *massSolar        &
+         &               *kilo             &
+         &               /2.0d0            &
+         &               /Pi               &
+         &               /(                &
+         &                 +radius         &
+         &                 *megaParsec     &
+         &                 *hecto          &
+         &                )**2
+    depthOpticalV       =+self%opacity           &
+         &               *self%dustToMetalsRatio &
+         &               *densitySurfaceMetals
+    return
+  end function atlasCompendiumDepthOpticalV
+
+  function atlasCompendiumTransmission(self,node,descriptors,inclination) result(transmission)
+    !!{RST
+    Return the transmission of each parcel, interpolated in the compendium tabulation.
+
+    The optical depth and the inclination are properties of the galaxy rather than of a parcel, so both are obtained
+    once here and reused across every parcel, as is the spheroid size if any parcel needs it. Whether the optical
+    depth lies beyond the tabulation---and so whether the transmission is interpolated or extrapolated---is likewise
+    a property of the galaxy, and is decided once.
+    !!}
+    use, intrinsic :: ISO_C_Binding                   , only : c_size_t
+    use            :: Error                           , only : Error_Report
+    use            :: Galactic_Structure_Options      , only : componentTypeDisk, componentTypeSpheroid
+    use            :: Numerical_Constants_Astronomical, only : degreesToRadians
+    implicit none
+    class           (dustAttenuationAtlasCompendium), intent(inout)                               :: self
+    type            (treeNode                      ), intent(inout), target                       :: node
+    type            (emissionDescriptor            ), intent(in   ), dimension(:                ) :: descriptors
+    double precision                                , intent(in   ), optional                     :: inclination
+    double precision                                               , dimension(size(descriptors)) :: transmission
+    ! The tabulation is in microns, while parcels report their wavelength in Angstroms.
+    double precision                                , parameter                                   :: micronsPerAngstrom  =1.0d-4
+    double precision                                                                              :: depthOptical              , inclination_      , &
+         &                                                                                           radiusSpheroid            , logDepth          , &
+         &                                                                                           inclinationDegrees        , coefficientConstant, &
+         &                                                                                           coefficientLogarithmic
+    logical                                                                                       :: radiusSpheroidComputed    , extrapolating
+    integer                                                                                       :: i
+    ! Bracketing indices and linear weights, per dimension, in the order the tables are laid out: for the disk
+    ! (optical depth, inclination, wavelength), and for the spheroid (spheroid size, optical depth, inclination,
+    ! wavelength). The extrapolation coefficients carry no optical depth axis, so drop it. Only the wavelength entry
+    ! changes between parcels.
+    integer         (c_size_t                      )                , dimension(  3)              :: indicesDisk
+    double precision                                                , dimension(0:1,3)            :: weightsDisk
+    integer         (c_size_t                      )                , dimension(  4)              :: indicesSpheroid
+    double precision                                                , dimension(0:1,4)            :: weightsSpheroid
+    integer         (c_size_t                      )                , dimension(  2)              :: indicesDiskExtrapolate
+    double precision                                                , dimension(0:1,2)            :: weightsDiskExtrapolate
+    integer         (c_size_t                      )                , dimension(  3)              :: indicesSpheroidExtrapolate
+    double precision                                                , dimension(0:1,3)            :: weightsSpheroidExtrapolate
+    integer         (c_size_t                      )                                              :: indexInclination          , indexWavelength   , &
+         &                                                                                           indexRadiusSpheroid       , indexDepthOptical
+    double precision                                                , dimension(0:1)              :: weightInclination         , weightWavelength  , &
+         &                                                                                           weightRadiusSpheroid      , weightDepthOptical
+
+    ! The dust lies in the disk in this model, and a spheroid is reddened by the disk's dust, so the optical depth is
+    ! always that of the disk.
+    depthOptical=atlasCompendiumDepthOpticalV(self,node)
+    if (present(inclination)) then
+       inclination_=inclination
+    else if (self%inclinationAvailable) then
+       inclination_=self%galacticInclination_%inclination(node)
+    else
+       inclination_=0.0d0
+       call Error_Report('this attenuator depends on orientation, but no inclination is available: either set `galacticInclination` to a class which supplies one, or wrap this attenuator in `inclinationAveraged`'//{introspection:location})
+    end if
+    ! The tabulation is in degrees, and interpolated logarithmically in optical depth. A galaxy with no dust at all
+    ! transmits everything, so guard the logarithm rather than letting it overflow.
+    inclinationDegrees=+inclination_     &
+         &             /degreesToRadians
+    if (depthOptical <= 0.0d0) then
+       transmission=1.0d0
+       return
+    end if
+    logDepth              =log(depthOptical)
+    extrapolating         =  self%extrapolateOpticalDepth                                   &
+         &                 .and.                                                            &
+         &                   depthOptical > self%depthOptical(size(self%depthOptical))
+    radiusSpheroidComputed=.false.
+    radiusSpheroid        =0.0d0
+    ! Bracket the axes which are properties of the galaxy rather than of a parcel, once. Only the set of factors
+    ! belonging to the interpolator which will actually be used is maintained.
+    call self%interpolatorInclination%linearFactors(inclinationDegrees,indexInclination,weightInclination)
+    if (extrapolating) then
+       indicesDiskExtrapolate    (  1)=indexInclination
+       weightsDiskExtrapolate    (:,1)=weightInclination
+       indicesSpheroidExtrapolate(  2)=indexInclination
+       weightsSpheroidExtrapolate(:,2)=weightInclination
+    else
+       call self%interpolatorDepthOptical%linearFactors(logDepth,indexDepthOptical,weightDepthOptical)
+       indicesDisk               (  1)=indexDepthOptical
+       weightsDisk               (:,1)=weightDepthOptical
+       indicesDisk               (  2)=indexInclination
+       weightsDisk               (:,2)=weightInclination
+       indicesSpheroid           (  2:3)=indicesDisk       (  1:2)
+       weightsSpheroid           (:,2:3)=weightsDisk       (:,1:2)
+    end if
+    do i=1,size(descriptors)
+       call self%interpolatorWavelength%linearFactors(log(descriptors(i)%wavelength*micronsPerAngstrom),indexWavelength,weightWavelength)
+       if (extrapolating) then
+          indicesDiskExtrapolate    (  2)=indexWavelength
+          weightsDiskExtrapolate    (:,2)=weightWavelength
+          indicesSpheroidExtrapolate(  3)=indexWavelength
+          weightsSpheroidExtrapolate(:,3)=weightWavelength
+       else
+          indicesDisk               (  3)=indexWavelength
+          weightsDisk               (:,3)=weightWavelength
+          indicesSpheroid           (  4)=indexWavelength
+          weightsSpheroid           (:,4)=weightWavelength
+       end if
+       if      (descriptors(i)%componentType == componentTypeDisk    ) then
+          if (extrapolating) then
+             coefficientConstant   =self%interpolatorDiskExtrapolate%interpolateFactors(self%extrapolationDiskConstant   ,indicesDiskExtrapolate,weightsDiskExtrapolate)
+             coefficientLogarithmic=self%interpolatorDiskExtrapolate%interpolateFactors(self%extrapolationDiskLogarithmic,indicesDiskExtrapolate,weightsDiskExtrapolate)
+             transmission(i)       =exp(                        &
+                  &                     +coefficientConstant    &
+                  &                     +coefficientLogarithmic &
+                  &                     *logDepth               &
+                  &                    )
+          else
+             transmission(i)       =self%interpolatorDisk%interpolateFactors(self%transmissionDisk,indicesDisk,weightsDisk)
+          end if
+       else if (descriptors(i)%componentType == componentTypeSpheroid) then
+          if (.not.radiusSpheroidComputed) then
+             ! Clamp into the tabulated range before taking a logarithm. A galaxy may have no spheroid, or no disk
+             ! to measure one against, giving a ratio of zero whose logarithm would trap; and the interpolator holds
+             ! values at the boundary in any case, so nothing is lost by clamping here rather than there.
+             radiusSpheroid        =max(                                       &
+                  &                     +radiusSpheroidRelative(node)          &
+                  &                     /self%radiusSpheroidHalfMassToScale  , &
+                  &                     +minval(self%radiusSpheroid)           &
+                  &                    )
+             radiusSpheroidComputed=.true.
+             call self%interpolatorRadiusSpheroid%linearFactors(log(radiusSpheroid),indexRadiusSpheroid,weightRadiusSpheroid)
+             indicesSpheroid           (  1)=indexRadiusSpheroid
+             weightsSpheroid           (:,1)=weightRadiusSpheroid
+             indicesSpheroidExtrapolate(  1)=indexRadiusSpheroid
+             weightsSpheroidExtrapolate(:,1)=weightRadiusSpheroid
+          end if
+          if (extrapolating) then
+             coefficientConstant   =self%interpolatorSpheroidExtrapolate%interpolateFactors(self%extrapolationSpheroidConstant   ,indicesSpheroidExtrapolate,weightsSpheroidExtrapolate)
+             coefficientLogarithmic=self%interpolatorSpheroidExtrapolate%interpolateFactors(self%extrapolationSpheroidLogarithmic,indicesSpheroidExtrapolate,weightsSpheroidExtrapolate)
+             transmission(i)       =exp(                        &
+                  &                     +coefficientConstant    &
+                  &                     +coefficientLogarithmic &
+                  &                     *logDepth               &
+                  &                    )
+          else
+             transmission(i)       =self%interpolatorSpheroid%interpolateFactors(self%transmissionSpheroid,indicesSpheroid,weightsSpheroid)
+          end if
+       else
+          transmission(i)=1.0d0
+          call Error_Report('this tabulation covers only disk and spheroid components'//{introspection:location})
+       end if
+    end do
+    return
+  end function atlasCompendiumTransmission
+
+  function atlasCompendiumRequest(self) result(request)
+    !!{RST
+    Return the decomposition required: the attenuation differs between disk and spheroid, but depends on nothing
+    else which varies within a component.
+    !!}
+    implicit none
+    type (decompositionRequest         )                :: request
+    class(dustAttenuationAtlasCompendium), intent(inout) :: self
+    !$GLC attributes unused :: self
+
+    request%resolveComponents =.true.
+    request%resolveMetallicity=.false.
+    request%resolveRadius     =.false.
+    return
+  end function atlasCompendiumRequest
+
+  logical function atlasCompendiumSupportsComponent(self,componentType) result(supportsComponent)
+    !!{RST
+    Return true only for the disk and spheroid, which are the components this tabulation covers.
+    !!}
+    use :: Galactic_Structure_Options, only : componentTypeDisk, componentTypeSpheroid
+    implicit none
+    class(dustAttenuationAtlasCompendium), intent(inout) :: self
+    type (enumerationComponentTypeType  ), intent(in   ) :: componentType
+    !$GLC attributes unused :: self
+
+    supportsComponent=  componentType == componentTypeDisk     &
+         &            .or.                                     &
+         &              componentType == componentTypeSpheroid
+    return
+  end function atlasCompendiumSupportsComponent

--- a/source/dust/attenuation/atlas_compendium.F90
+++ b/source/dust/attenuation/atlas_compendium.F90
@@ -53,7 +53,8 @@
      double precision                , allocatable, dimension(:,:,:        )   :: extrapolationSpheroidConstant   , extrapolationSpheroidLogarithmic
   end type compendiumTable
   type   (compendiumTable ), allocatable, dimension(:) :: compendiumTables
-  integer                                  , parameter :: compendiumTablesCapacity       =16
+  ! The store starts at this many entries and doubles if that is exceeded.
+  integer                                  , parameter :: compendiumTablesCapacityInitial=16
   integer                                              :: compendiumTablesCount          =0
   type   (ompReadWriteLock)                            :: compendiumTablesLock
   logical                                              :: compendiumTablesLockInitialized =.false.
@@ -420,6 +421,7 @@ contains
     tabulation is located---downloading it if necessary---read once, here, and interpolators built over it.
     !!}
     use, intrinsic :: ISO_C_Binding     , only : c_size_t
+    use            :: Display           , only : displayMagenta    , displayMessage    , displayReset  , verbosityLevelSilent
     use            :: Error             , only : Error_Report
     use            :: File_Utilities    , only : Directory_Make      , File_Exists       , File_Lock     , File_Remove   , &
           &                                      File_Unlock         , lockDescriptor
@@ -449,8 +451,9 @@ contains
          &                                                                                         beginExtrapolationDisk      , countExtrapolationDisk
     integer         (hsize_t                                 )              , dimension(4     ) :: beginSpheroid               , countSpheroid       , &
          &                                                                                         beginExtrapolationSpheroid  , countExtrapolationSpheroid
+    type            (compendiumTable                         ), allocatable, dimension(:      ) :: compendiumTablesTemporary
     type            (varying_string                          )                                  :: tableKey
-    character       (len=128                                 )                                  :: labelTable
+    character       (len=256                                 )                                  :: labelTable
     integer                                                                                     :: indexWavelengthBegin        , indexWavelengthEnd  , &
          &                                                                                         indexDepthOpticalBegin      , indexDepthOpticalEnd, &
          &                                                                                         indexRadiusSpheroidBegin    , indexRadiusSpheroidEnd
@@ -625,14 +628,29 @@ contains
        if (compendiumTables(i)%key == tableKey) self%tableIndex=i
     end do
     if (self%tableIndex == 0) then
-       ! The store is allocated once at its full capacity rather than grown. Growing it would mean copying the
-       ! tables already in it, which for a high resolution tabulation is a transient 297 MB per entry for no
-       ! purpose. The capacity is far beyond any plausible model: it bounds the number of *distinct* tabulations,
-       ! counting a file trimmed two ways as two, and each one costs hundreds of megabytes to hold.
-       if (.not.allocated(compendiumTables)) allocate(compendiumTables(compendiumTablesCapacity))
-       if (compendiumTablesCount == compendiumTablesCapacity) then
-          call compendiumTablesLock%unsetWrite(haveReadLock=.false.)
-          call Error_Report('more distinct compendium tabulations are in use than can be held at once'//{introspection:location})
+       ! The store is allocated at a capacity which no plausible model reaches---it bounds the number of *distinct*
+       ! tabulations, counting a file trimmed two ways as two, and each costs hundreds of megabytes to hold---but
+       ! grows if one does. Growing does not copy the tables: their allocations are transferred to the new array,
+       ! so the cost is that of the descriptors alone, whatever the tables contain.
+       if (.not.allocated(compendiumTables)) allocate(compendiumTables(compendiumTablesCapacityInitial))
+       if (compendiumTablesCount == size(compendiumTables)) then
+          write (labelTable,'(a,i0,a,i0,a)')                                                                       &
+               & 'dust compendium tabulation store grown from ',size(compendiumTables),' entries to ',              &
+               & 2*size(compendiumTables),                                                                          &
+               & ' - raise `compendiumTablesCapacityInitial` if your models routinely need more, to avoid this'
+          call displayMessage(displayMagenta()//"WARNING: "//displayReset()//trim(labelTable),verbosityLevelSilent)
+          call move_alloc(compendiumTables,compendiumTablesTemporary)
+          allocate(compendiumTables(2*compendiumTablesCount))
+          do i=1,compendiumTablesCount
+             compendiumTables(i)%key=compendiumTablesTemporary(i)%key
+             call move_alloc(compendiumTablesTemporary(i)%transmissionDisk                ,compendiumTables(i)%transmissionDisk                )
+             call move_alloc(compendiumTablesTemporary(i)%transmissionSpheroid            ,compendiumTables(i)%transmissionSpheroid            )
+             call move_alloc(compendiumTablesTemporary(i)%extrapolationDiskConstant       ,compendiumTables(i)%extrapolationDiskConstant       )
+             call move_alloc(compendiumTablesTemporary(i)%extrapolationDiskLogarithmic    ,compendiumTables(i)%extrapolationDiskLogarithmic    )
+             call move_alloc(compendiumTablesTemporary(i)%extrapolationSpheroidConstant   ,compendiumTables(i)%extrapolationSpheroidConstant   )
+             call move_alloc(compendiumTablesTemporary(i)%extrapolationSpheroidLogarithmic,compendiumTables(i)%extrapolationSpheroidLogarithmic)
+          end do
+          deallocate(compendiumTablesTemporary)
        end if
        compendiumTablesCount=compendiumTablesCount+1
        self%tableIndex      =compendiumTablesCount


### PR DESCRIPTION
Adds `dustAttenuationAtlasCompendium`, reading the radiative transfer tabulations of Benson (2018) published on Zenodo, and fixes a spheroid radius error in the sibling `atlasFerrara2000` uncovered while doing so. This completes the `atlasCompendium` item of Phase 3 of #893.

## The class

The compendium files share the HDF5 layout `atlasFerrara2000` already reads, plus two things it does not carry: coefficients for extrapolating beyond the tabulated optical depth, and the opacity used in the radiative transfer itself. Three things differ from the Ferrara atlas, each deliberate:

- **The optical depth comes from the file's own `opacity` attribute** and a dust-to-metals ratio, rather than being delegated to a `dustAttenuationScreen`. Using the opacity that produced the table is what makes the optical depth mean the same thing to the model as it does to the tabulation. The two normalizations do agree to tens of percent: Savage & Mathis implies 1.05e4 cm²/g of metals, hence 2.4e4 cm²/g of dust, which is in the Draine (2003) V-band range; the file says 3.21e4.
- **`spheroidScaleRadial` is a *scale* radius**, where Ferrara et al. (1999) tabulate an *effective* radius. A model spheroid is matched on half-mass radius and converted to the scale radius of the profile the tabulation was computed for, which `spheroidProfile` names.
- **Beyond the tabulation the transmission is extrapolated** as `exp(c₀ + c₁ ln τ)`, which `extrapolateOpticalDepth` can disable.

The published file names are known to the class, with the Zenodo record each belongs to and the spheroid profile it was computed for, so naming a file is enough to fetch it; `url` is only needed for a tabulation that is not among them. The profile is checked against the file, since getting it wrong is a silent error of tens of percent.

## The Ferrara radius fix

The `spheroidScaleRadial` axis of the Ferrara atlas is not a radius of the profile that atlas simulated. Their spheroids are realized as Jaffe profiles, but the axis is labelled with the effective radius R_e of the R^1/4 profile those stand in for. Bianchi, Ferrara & Giovanardi (1996), whose radiative transfer code the atlas was computed with, give the correspondence in their appendix as `r_b = 1.16 R_e`, chosen as the relation best matching the luminosity enclosed within a given radius since that is what their Monte Carlo samples.

A Jaffe profile's half-mass radius is exactly its scale radius, so one unit of the tabulated axis is 1.16 half-mass radii. `atlasFerrara2000` was treating it as one, placing every spheroid 16% too far out. The error grows with optical depth: at `r_half/r_disk = 0.5` it is 0.4% at τ_V = 0.5, 3% at τ_V = 2, and 11% at τ_V = 50.

The compendium already handled this correctly, and the real Ferrara-like tabulation confirms it: its axis is `[0.116, 0.464, 1.856]`, exactly 1.16× Ferrara's values.

## Memory

The high-resolution tabulations are gridded on 250 wavelengths × 46 inclinations × 60 optical depths × 51 spheroid sizes. Half of each 584 MB file is Monte Carlo uncertainties, which are never read; the attenuations and their extrapolation coefficients come to 297 MB.

That was being held **once per OpenMP thread per instance**, since each thread works on a deep copy of the attenuator. Two attenuators on twenty threads meant forty copies. Two changes address it:

- **Range trimming.** Five parameters bound the wavelength, optical depth and spheroid size axes; only the retained part of each is read, as an HDF5 hyperslab, so a trimmed tabulation is never held at full size even transiently. Trimming is exact inside the retained range — the bracketing nodes are kept, so values within it interpolate from the same nodes as they would from the full table.
- **A shared store.** The tables are read-only once built, so they live in a module-level store and each object carries only an index into it; an integer survives the deep copy unchanged. Entries are keyed by file plus resolved trim bounds. The interpolators are deliberately *not* shared — each caches a bracket index and a GSL accelerator it mutates, so a shared one would be a data race. Access uses an `ompReadWriteLock` following `source/instruments/filters.F90`, so readers do not wait on one another. The store starts at sixteen entries and doubles as needed, transferring allocations with `move_alloc` so growth never copies a table.

Peak resident memory on the high-resolution tabulation:

| threads | before | trimming + sharing |
|---|---|---|
| 1 | 1257 MB | 659 MB |
| 2 | 1853 MB | 659 MB |
| 4 | 3043 MB | 659 MB |
| 20 | **12507 MB** | **1105 MB** |

Trimming a further axis range takes each copy from 297 MB to 13 MB.

## Verification

Against the real published `Ferrara1999_MW_hz1.0_Attenuations.hdf5`, with `dustToMetalsRatio` set so the file's own opacity gives the same optical depth as the Savage & Mathis normalization the Ferrara block uses, so the two differ only in the tabulation:

- **The two independent Monte Carlo calculations agree to better than 0.7%** for both disk and spheroid. That also confirms the spheroid radius conventions on both sides, since either being wrong would show up there at several percent.
- The extrapolation satisfies `T(τ)·T(100τ) == T(10τ)²` to 1.9e-15, using no external input, and joins the table continuously: with extrapolation disabled, the transmission at τ > 50 equals `atlasFerrara2000` evaluated exactly at τ = 50 to 2.1e-15.
- The low-depth branch is exactly linear: `(T−1)` doubles when τ doubles, to 2.000000000 across all values.
- Trimmed runs reproduce untrimmed ones **bit for bit**, with untrimmed Ferrara blocks in the same model as controls.
- **Separate files stay separate**: a model with the Milky Way tabulation on the disk and the Small Magellanic Cloud tabulation on the spheroid reproduces, bit for bit, the runs with each file alone. The two files differ by up to 1.4%, so that test has power. This holds across a store growth as well.

Existing tests: parity 15/15, extinction curves 94/94, attenuation descriptors 28/28, SDSS analyses 3/3, Hα 2/2, `quickTest` exits 0. Docstrings, contributor markers and the parameter schema are clean.

## Things a reviewer should know

**Two guards exist because the failure would otherwise be silent.**

Trimming the optical depth axis is refused unless `extrapolateOpticalDepth` is false. The extrapolation coefficients are anchored at the *file's* largest depth; applied just above a trimmed boundary they overestimate the transmission by a factor of seven at τ = 5 and thirty at τ = 1. Since `extrapolateOpticalDepth` defaults to true this would have been the default path.

The tabulated zero-optical-depth entry is dropped on reading, because the axis is interpolated logarithmically, and below the smallest remaining depth the transmission is interpolated linearly back towards unity rather than clamped. Clamping would leave a galaxy with almost no dust as attenuated as one at the tabulation's lower edge — in the ultraviolet, a factor of twenty in the excess above unit transmission. The entry is checked to be unity rather than assumed so.

**Known gap.** There is no committed regression test using a real compendium file. The six original-resolution Ferrara-like files are only 0.09 MB each and would make a good parity block, but two atlas attenuators on one component collide in output naming — the same gap noted in #1430. `appendSuffix` on `nodePropertyExtractorDustAttenuation` would unblock it.

**Not implemented.** Decimating the axes, deliberately: it is not free, costing 1.6% where the transmission exceeds 0.5 but 44% where it exceeds 0.001, and trimming plus sharing already took peak memory from 12.5 GB to 1.1 GB.

**Also.** Downloads gained retries and are judged by what landed on disk rather than the reported status — `wget` fails at the TLS layer against Zenodo and leaves a zero-byte file, which would otherwise be read as the tabulation on every subsequent run. Observed, not hypothetical.
