### PR TITLE
Add `starFormationHistoryOutputStateAdvance` regression test

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1894,7 +1894,8 @@ jobs:
                 testSuite/regressions/lightconeCrossingAtCurrentTime.xml,
                 testSuite/regressions/constrainedTreeImpossible.py,
                 testSuite/regressions/ignoreWellOrdering.xml,
-                testSuite/regressions/johnson2021CorrelatedDeviatesWithRegrid.xml ]
+                testSuite/regressions/johnson2021CorrelatedDeviatesWithRegrid.xml,
+                testSuite/regressions/starFormationHistoryOutputStateAdvance.xml ]
     uses: ./.github/workflows/testModel.yml
     with:
       file: ${{ matrix.file }}


### PR DESCRIPTION
## Summary
- Adds a missing regression model to the CI harness.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs / tooling
- [ ] Other:

## How to test
- Let CI run and check that this model was run and was successful.

## Checklist
- [ ] I ran relevant tests (or explain why not):
- [ ] I updated documentation/comments if needed
- [ ] If this PR is from a fork: I enabled 'Allow edits from maintainers'
