### PR TITLE
style!: settle parameter names on noun-first order, and rename the labeled filter

### DIFF
--- a/constraints/dataAnalysis/hiMassFunction_ALFALFA_z0.00/mcmcConfig.xml
+++ b/constraints/dataAnalysis/hiMassFunction_ALFALFA_z0.00/mcmcConfig.xml
@@ -12,8 +12,8 @@
     <emulateOutliers>true</emulateOutliers>
     <simulatorLikelihood>
       <type>massFunction</type>
-      <haloMassMinimum>1.0e8</haloMassMinimum>
-      <haloMassMaximum>1.0e15</haloMassMaximum>
+      <massHaloMinimum>1.0e8</massHaloMinimum>
+      <massHaloMaximum>1.0e15</massHaloMaximum>
       <redshiftMinimum>0.00</redshiftMinimum>
       <redshiftMaximum>0.12</redshiftMaximum>
       <useSurveyLimits>true</useSurveyLimits>

--- a/constraints/dataAnalysis/projectedCorrelationFunction_SDSS_z0.07_Hearin/mcmcConfig.xml
+++ b/constraints/dataAnalysis/projectedCorrelationFunction_SDSS_z0.07_Hearin/mcmcConfig.xml
@@ -18,8 +18,8 @@
       <emulateOutliers>true</emulateOutliers>
       <simulatorLikelihood>
 	<type>projectedCorrelationFunction</type>
-	<haloMassMinimum>1.0e6</haloMassMinimum>
-	<haloMassMaximum>1.0e15</haloMassMaximum>
+	<massHaloMinimum>1.0e6</massHaloMinimum>
+	<massHaloMaximum>1.0e15</massHaloMaximum>
 	<lineOfSightDepth>57.142857</lineOfSightDepth>
 	<halfIntegral>false</halfIntegral>
 	<massFunctionFileName>covarianceMatrix.hdf5</massFunctionFileName>

--- a/constraints/dataAnalysis/stellarMassFunction_GAMA_z0.03/mcmcConfig.xml
+++ b/constraints/dataAnalysis/stellarMassFunction_GAMA_z0.03/mcmcConfig.xml
@@ -12,8 +12,8 @@
     <emulateOutliers>true</emulateOutliers>
     <simulatorLikelihood>
       <type>massFunction</type>
-      <haloMassMinimum>1.0e6</haloMassMinimum>
-      <haloMassMaximum>1.0e15</haloMassMaximum>
+      <massHaloMinimum>1.0e6</massHaloMinimum>
+      <massHaloMaximum>1.0e15</massHaloMaximum>
       <redshiftMinimum>0.00</redshiftMinimum>
       <redshiftMaximum>0.06</redshiftMaximum>
       <useSurveyLimits>true</useSurveyLimits>

--- a/constraints/dataAnalysis/stellarMassFunction_SDSS_z0.07/mcmcConfig.xml
+++ b/constraints/dataAnalysis/stellarMassFunction_SDSS_z0.07/mcmcConfig.xml
@@ -12,8 +12,8 @@
     <emulateOutliers>true</emulateOutliers>
     <simulatorLikelihood>
       <type>massFunction</type>
-      <haloMassMinimum>1.0e9</haloMassMinimum>
-      <haloMassMaximum>1.0e15</haloMassMaximum>
+      <massHaloMinimum>1.0e9</massHaloMinimum>
+      <massHaloMaximum>1.0e15</massHaloMaximum>
       <redshiftMinimum>0.0</redshiftMinimum>
       <redshiftMaximum>0.5</redshiftMaximum>
       <useSurveyLimits>true</useSurveyLimits>

--- a/constraints/dataAnalysis/stellarMassFunction_SDSS_z0.07_Bernardi/mcmcConfig.xml
+++ b/constraints/dataAnalysis/stellarMassFunction_SDSS_z0.07_Bernardi/mcmcConfig.xml
@@ -12,8 +12,8 @@
     <emulateOutliers>true</emulateOutliers>
     <simulatorLikelihood>
       <type>massFunction</type>
-      <haloMassMinimum>1.0e9</haloMassMinimum>
-      <haloMassMaximum>1.0e15</haloMassMaximum>
+      <massHaloMinimum>1.0e9</massHaloMinimum>
+      <massHaloMaximum>1.0e15</massHaloMaximum>
       <redshiftMinimum>0.0</redshiftMinimum>
       <redshiftMaximum>0.5</redshiftMaximum>
       <useSurveyLimits>true</useSurveyLimits>

--- a/constraints/dataAnalysis/stellarMassFunctions_PRIMUS_z0_1/mcmcConfig.xml
+++ b/constraints/dataAnalysis/stellarMassFunctions_PRIMUS_z0_1/mcmcConfig.xml
@@ -12,8 +12,8 @@
     <emulateOutliers>true</emulateOutliers>
     <simulatorLikelihood>
       <type>massFunction</type>
-      <haloMassMinimum>1.0e10</haloMassMinimum>
-      <haloMassMaximum>1.0e15</haloMassMaximum>
+      <massHaloMinimum>1.0e10</massHaloMinimum>
+      <massHaloMaximum>1.0e15</massHaloMaximum>
       <redshiftMinimum>3.0</redshiftMinimum>
       <redshiftMaximum>3.5</redshiftMaximum>
       <useSurveyLimits>true</useSurveyLimits>

--- a/constraints/dataAnalysis/stellarMassFunctions_UKIDSS_UDS_z3_5/mcmcConfig.xml
+++ b/constraints/dataAnalysis/stellarMassFunctions_UKIDSS_UDS_z3_5/mcmcConfig.xml
@@ -12,8 +12,8 @@
     <emulateOutliers>true</emulateOutliers>
     <simulatorLikelihood>
       <type>massFunction</type>
-      <haloMassMinimum>1.0e10</haloMassMinimum>
-      <haloMassMaximum>1.0e15</haloMassMaximum>
+      <massHaloMinimum>1.0e10</massHaloMinimum>
+      <massHaloMaximum>1.0e15</massHaloMaximum>
       <redshiftMinimum>3.0</redshiftMinimum>
       <redshiftMaximum>3.5</redshiftMaximum>
       <useSurveyLimits>true</useSurveyLimits>

--- a/constraints/dataAnalysis/stellarMassFunctions_ULTRAVISTA_z0.2_4.0/mcmcConfig.xml
+++ b/constraints/dataAnalysis/stellarMassFunctions_ULTRAVISTA_z0.2_4.0/mcmcConfig.xml
@@ -12,8 +12,8 @@
     <emulateOutliers>true</emulateOutliers>
     <simulatorLikelihood>
       <type>massFunction</type>
-      <haloMassMinimum>1.0e6</haloMassMinimum>
-      <haloMassMaximum>1.0e15</haloMassMaximum>
+      <massHaloMinimum>1.0e6</massHaloMinimum>
+      <massHaloMaximum>1.0e15</massHaloMaximum>
       <redshiftMinimum>0.2</redshiftMinimum>
       <redshiftMaximum>0.5</redshiftMaximum>
       <useSurveyLimits>true</useSurveyLimits>

--- a/constraints/dataAnalysis/stellarMassFunctions_VIPERS_z0_1/mcmcConfig.xml
+++ b/constraints/dataAnalysis/stellarMassFunctions_VIPERS_z0_1/mcmcConfig.xml
@@ -12,8 +12,8 @@
     <emulateOutliers>true</emulateOutliers>
     <simulatorLikelihood>
       <type>massFunction</type>
-      <haloMassMinimum>1.0e10</haloMassMinimum>
-      <haloMassMaximum>1.0e15</haloMassMaximum>
+      <massHaloMinimum>1.0e10</massHaloMinimum>
+      <massHaloMaximum>1.0e15</massHaloMaximum>
       <redshiftMinimum>3.0</redshiftMinimum>
       <redshiftMaximum>3.5</redshiftMaximum>
       <useSurveyLimits>true</useSurveyLimits>

--- a/constraints/dataAnalysis/stellarMassFunctions_ZFOURGE_z0.2_2.5/mcmcConfig.xml
+++ b/constraints/dataAnalysis/stellarMassFunctions_ZFOURGE_z0.2_2.5/mcmcConfig.xml
@@ -12,8 +12,8 @@
     <emulateOutliers>true</emulateOutliers>
     <simulatorLikelihood>
       <type>massFunction</type>
-      <haloMassMinimum>1.0e6</haloMassMinimum>
-      <haloMassMaximum>1.0e15</haloMassMaximum>
+      <massHaloMinimum>1.0e6</massHaloMinimum>
+      <massHaloMaximum>1.0e15</massHaloMaximum>
       <redshiftMinimum>0.2</redshiftMinimum>
       <redshiftMaximum>0.5</redshiftMaximum>
       <useSurveyLimits>true</useSurveyLimits>

--- a/constraints/pipelines/darkMatter/haloMassFunction_COZMIC.xml
+++ b/constraints/pipelines/darkMatter/haloMassFunction_COZMIC.xml
@@ -5,8 +5,8 @@
   
   <!-- Task and output -->
   <task value="haloMassFunction">
-   <haloMassMinimum                     value=" 1.122018454e06"/>
-   <haloMassMaximum                     value=" 1.122018454e16"/>
+   <massHaloMinimum                     value=" 1.122018454e06"/>
+   <massHaloMaximum                     value=" 1.122018454e16"/>
    <pointsPerDecade                     value="10.0"           />
    <includeMassAccretionRate            value="false"          />
    <includeUnevolvedSubhaloMassFunction value="false"          />

--- a/constraints/pipelines/darkMatter/haloMassFunction_MDPL.xml
+++ b/constraints/pipelines/darkMatter/haloMassFunction_MDPL.xml
@@ -6,8 +6,8 @@
   
   <!-- Task and output -->
   <task value="haloMassFunction">
-   <haloMassMinimum                     value=" 1.122018454e06"/>
-   <haloMassMaximum                     value=" 1.122018454e16"/>
+   <massHaloMinimum                     value=" 1.122018454e06"/>
+   <massHaloMaximum                     value=" 1.122018454e16"/>
    <pointsPerDecade                     value="10.0"           />
    <includeMassAccretionRate            value="false"          />
    <includeUnevolvedSubhaloMassFunction value="false"          />

--- a/constraints/pipelines/darkMatter/haloMassFunction_Symphony.xml
+++ b/constraints/pipelines/darkMatter/haloMassFunction_Symphony.xml
@@ -6,8 +6,8 @@
   
   <!-- Task and output -->
   <task value="haloMassFunction">
-   <haloMassMinimum                     value=" 1.122018454e06"/>
-   <haloMassMaximum                     value=" 1.122018454e16"/>
+   <massHaloMinimum                     value=" 1.122018454e06"/>
+   <massHaloMaximum                     value=" 1.122018454e16"/>
    <pointsPerDecade                     value="10.0"           />
    <includeMassAccretionRate            value="false"          />
    <includeUnevolvedSubhaloMassFunction value="false"          />

--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -688,8 +688,8 @@ In some instances it is useful to be able to call a function with different comb
       <call>self=massDistributionBetaProfile(beta{conditions})</call>
       <argument name="densityNormalization" value="densityNormalization" parameterPresent="parameters"/>
       <argument name="mass"                 value="mass"                 parameterPresent="parameters"/>
-      <argument name="outerRadius"          value="outerRadius"          parameterPresent="parameters"/>
-      <argument name="coreRadius"           value="coreRadius"           parameterPresent="parameters"/>
+      <argument name="radiusOuter"          value="radiusOuter"          parameterPresent="parameters"/>
+      <argument name="radiusCore"           value="radiusCore"           parameterPresent="parameters"/>
       <argument name="dimensionless"        value="dimensionless"        parameterPresent="parameters"/>
      </conditionalCall>
      <inputParametersValidate source="parameters"/>

--- a/docs/manuals/user-guide/tutorials/dark-matter-halo-mass-function.rst
+++ b/docs/manuals/user-guide/tutorials/dark-matter-halo-mass-function.rst
@@ -119,15 +119,15 @@ The range and resolution of the mass tabulation can be controlled by three optio
 .. code-block:: xml
 
    <task value="haloMassFunction">
-    <haloMassMinimum value="1.0e06"/>
-    <haloMassMaximum value="1.0e15"/>
+    <massHaloMinimum value="1.0e06"/>
+    <massHaloMaximum value="1.0e15"/>
     <pointsPerDecade value="30"    />
    </task>
 
 The parameters have the following meanings:
 
-* ``haloMassMinimum``: The lowest mass halo (in units of :math:`M_\odot`) at which to tabulate;
-* ``haloMassMaximum``: The highest mass halo (in units of :math:`M_\odot`) at which to tabulate;
+* ``massHaloMinimum``: The lowest mass halo (in units of :math:`M_\odot`) at which to tabulate;
+* ``massHaloMaximum``: The highest mass halo (in units of :math:`M_\odot`) at which to tabulate;
 * ``pointsPerDecade``: The number of points per decade of halo mass at which to tabulate.
 
 Understanding the output

--- a/docs/manuals/user-guide/tutorials/dark-matter-subhalo-evolution.rst
+++ b/docs/manuals/user-guide/tutorials/dark-matter-subhalo-evolution.rst
@@ -55,8 +55,8 @@ You can look at the entire parameter file for this tutorial `here <https://raw.g
          <pointsPerDecade   value="10"    />
        </task>
        <task value="haloMassFunction"  >
-         <haloMassMinimum value="1.0e06"/>
-         <haloMassMaximum value="1.0e15"/>
+         <massHaloMinimum value="1.0e06"/>
+         <massHaloMaximum value="1.0e15"/>
          <pointsPerDecade value="10"    />
        </task>
        <task value="evolveForests"    />

--- a/docs/manuals/user-guide/tutorials/warm-dark-matter-halo-mass-function.rst
+++ b/docs/manuals/user-guide/tutorials/warm-dark-matter-halo-mass-function.rst
@@ -23,7 +23,7 @@ You can look at the entire parameter file for this tutorial `here <https://raw.g
 
    <!-- Specify tasks to perform -->
    <task value="haloMassFunction">
-     <haloMassMinimum value="1.0e7"/>
+     <massHaloMinimum value="1.0e7"/>
    </task>
 
 The only difference with respect to the CDM case here is that we specify the minimum halo mass at which to compute the halo mass function. By default a minimum mass of :math:`10^{10}\mathrm{M}_\odot` is used, but here we want to go to lower masses to see the effects of warm dark matter.

--- a/parameters/reference/warmDarkMatter.xml
+++ b/parameters/reference/warmDarkMatter.xml
@@ -77,7 +77,7 @@
     <mergerTreeOperator value="pruneByFilter">
       <preservePrimaryProgenitor value="false"/>
       <pruneAllProgenitors       value="true" />
-      <galacticFilter value="labelled">
+      <galacticFilter value="labeled">
 	<label value="promptCuspUnformed"/>
       </galacticFilter>
     </mergerTreeOperator>

--- a/parameters/tutorials/darkMatterOnlySubHalos.xml
+++ b/parameters/tutorials/darkMatterOnlySubHalos.xml
@@ -21,8 +21,8 @@
       <pointsPerDecade   value="10"    />
     </task>
     <task value="haloMassFunction"  >
-      <haloMassMinimum value="1.0e06"/>
-      <haloMassMaximum value="1.0e15"/>
+      <massHaloMinimum value="1.0e06"/>
+      <massHaloMaximum value="1.0e15"/>
       <pointsPerDecade value="10"    />
     </task>
     <task value="evolveForests"    />

--- a/parameters/tutorials/haloMassFunctionWarmDarkMatter.xml
+++ b/parameters/tutorials/haloMassFunctionWarmDarkMatter.xml
@@ -8,7 +8,7 @@
 
   <!-- Specify tasks to perform -->
   <task value="haloMassFunction">
-    <haloMassMinimum value="1.0e7"/>    
+    <massHaloMinimum value="1.0e7"/>    
   </task>
 
   <!-- Component selection -->

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -1161,7 +1161,7 @@
           <xs:enumeration value="hostMassRange"/>
           <xs:enumeration value="intervalPass"/>
           <xs:enumeration value="isolatedHostNode"/>
-          <xs:enumeration value="labelled"/>
+          <xs:enumeration value="labeled"/>
           <xs:enumeration value="lightcone"/>
           <xs:enumeration value="lowPass"/>
           <xs:enumeration value="mainBranch"/>

--- a/scripts/aux/migrations.xml
+++ b/scripts/aux/migrations.xml
@@ -356,6 +356,41 @@
     <translation function="dust_attenuation_framework"/>
   </migration>
 
+  <migration commit="48c5e9fe8c7ed983d45d1b0018a81c2bc09f709e">
+    <!-- Adjective-first parameter names settled on the noun-first form, and the -->
+    <!-- `labelled` galactic filter renamed to `labeled`. Each rename is scoped  -->
+    <!-- to the implementation which reads it, so that identically-named         -->
+    <!-- parameters of other classes, and the `outerRadius` *property* of the    -->
+    <!-- hot halo components, are left alone.                                    -->
+    <translation xpath="//*[@value='exponentialDisk']/scaleRadius[@value]">
+      <name new="radiusScale"/>
+    </translation>
+    <translation xpath="//*[@value='NFW' or @value='einasto']/virialRadius[@value]">
+      <name new="radiusVirial"/>
+    </translation>
+    <translation xpath="//*[@value='betaProfile']/outerRadius[@value]">
+      <name new="radiusOuter"/>
+    </translation>
+    <translation xpath="//*[@value='betaProfile']/coreRadius[@value]">
+      <name new="radiusCore"/>
+    </translation>
+    <translation xpath="//task[@value='haloMassFunction' or @value='haloSpinDistribution']/haloMassMinimum[@value]">
+      <name new="massHaloMinimum"/>
+    </translation>
+    <translation xpath="//task[@value='haloMassFunction']/haloMassMaximum[@value]">
+      <name new="massHaloMaximum"/>
+    </translation>
+    <translation xpath="//posteriorSampleLikelihood[@value='massFunction' or @value='prjctdCorrelationFunction']/haloMassMinimum[@value]">
+      <name new="massHaloMinimum"/>
+    </translation>
+    <translation xpath="//posteriorSampleLikelihood[@value='massFunction' or @value='prjctdCorrelationFunction']/haloMassMaximum[@value]">
+      <name new="massHaloMaximum"/>
+    </translation>
+    <translation xpath="//galacticFilter[@value]">
+      <value old="labelled" new="labeled"/>
+    </translation>
+  </migration>
+
   <!-- Known default values for parameters -->
   <default parameter="componentBlackHole"             value="standard"        />
   <default parameter="componentDisk"                  value="standard"        />

--- a/source/dark_matter_profiles_DMO/Einasto.F90
+++ b/source/dark_matter_profiles_DMO/Einasto.F90
@@ -138,7 +138,7 @@ contains
 	 <constructor>
            massDistributionEinasto(                                                                                  &amp;
            &amp;                   mass          =basic            %mass                                     (    ), &amp;
-           &amp;                   virialRadius  =self             %darkMatterHaloScale_%radiusVirial        (node), &amp;
+           &amp;                   radiusVirial  =self             %darkMatterHaloScale_%radiusVirial        (node), &amp;
            &amp;                   scaleLength   =darkMatterProfile%scale                                    (    ), &amp;
            &amp;                   shapeParameter=darkMatterProfile%shape                                    (    ), &amp;
            &amp;                   componentType=                                       componentTypeDarkHalo      , &amp;

--- a/source/dark_matter_profiles_DMO/NFW.F90
+++ b/source/dark_matter_profiles_DMO/NFW.F90
@@ -164,7 +164,7 @@ contains
           ! properties for this node.
           call massDistribution__%initialize(                                                                          &
                &                              mass         =basic            %mass                             (    ), &
-               &                              virialRadius =self             %darkMatterHaloScale_%radiusVirial(node), &
+               &                              radiusVirial =self             %darkMatterHaloScale_%radiusVirial(node), &
                &                              scaleLength  =darkMatterProfile%scale                            (    )  &
                &                             )
        else
@@ -175,7 +175,7 @@ contains
 	    <constructor>
               massDistributionNFW(                                                                                  &amp;
               &amp;               mass         =basic            %mass                                      (    ), &amp;
-              &amp;               virialRadius =self             %darkMatterHaloScale_%radiusVirial         (node), &amp;
+              &amp;               radiusVirial =self             %darkMatterHaloScale_%radiusVirial         (node), &amp;
               &amp;               scaleLength  =darkMatterProfile%scale                                     (    ), &amp;
               &amp;               componentType=                                       componentTypeDarkHalo      , &amp;
               &amp;               massType     =                                       massTypeDark                 &amp;

--- a/source/dark_matter_profiles_DMO/cusp-NFW.F90
+++ b/source/dark_matter_profiles_DMO/cusp-NFW.F90
@@ -216,7 +216,7 @@ contains
 	 <constructor>
            massDistributionNFW(                                                                                  &amp;
             &amp;              mass         =basic            %mass                                      (    ), &amp;
-            &amp;              virialRadius =self             %darkMatterHaloScale_%radiusVirial         (node), &amp;
+            &amp;              radiusVirial =self             %darkMatterHaloScale_%radiusVirial         (node), &amp;
             &amp;              scaleLength  =darkMatterProfile%scale                                     (    ), &amp;
             &amp;              componentType=                                       componentTypeDarkHalo      , &amp;
             &amp;              massType     =                                       massTypeDark                 &amp;

--- a/source/dark_matter_profiles_DMO/soliton_NFW.F90
+++ b/source/dark_matter_profiles_DMO/soliton_NFW.F90
@@ -326,7 +326,7 @@ contains
 	    <constructor>
               massDistributionNFW(                                             &amp;
                &amp;              mass         =basic%mass                 (), &amp;
-               &amp;              virialRadius =      radiusVirial           , &amp;
+               &amp;              radiusVirial =      radiusVirial           , &amp;
                &amp;              scaleLength  =      radiusScale            , &amp;
                &amp;              componentType=      componentTypeDarkHalo  , &amp;
                &amp;              massType     =      massTypeDark             &amp;

--- a/source/dark_matter_profiles_DMO/soliton_NFW_heated.F90
+++ b/source/dark_matter_profiles_DMO/soliton_NFW_heated.F90
@@ -484,7 +484,7 @@ contains
 	    <constructor>
               massDistributionNFW(                                             &amp;
                &amp;              mass         =basic%mass                 (), &amp;
-               &amp;              virialRadius =      radiusVirial           , &amp;
+               &amp;              radiusVirial =      radiusVirial           , &amp;
                &amp;              scaleLength  =      radiusScale            , &amp;
                &amp;              componentType=      componentTypeDarkHalo  , &amp;
                &amp;              massType     =      massTypeDark             &amp;

--- a/source/galactic/filters/labeled.F90
+++ b/source/galactic/filters/labeled.F90
@@ -22,13 +22,13 @@ Implements a galactic filter which tests whether the given node has a specified 
 !!}
   
   !![
-  <galacticFilter name="galacticFilterLabelled" docformat="rst">
+  <galacticFilter name="galacticFilterLabeled" docformat="rst">
    <description>
    Tests whether the given node has been assigned the label specified by ``[label]``. This filter passes only nodes that carry the designated label, enabling targeted selection of nodes based on categorical metadata attached during tree construction or post-processing.
    </description>
   </galacticFilter>
   !!]
-  type, extends(galacticFilterClass) :: galacticFilterLabelled
+  type, extends(galacticFilterClass) :: galacticFilterLabeled
      !!{RST
      Tests whether the given node has a specified label.
      !!}
@@ -36,28 +36,28 @@ Implements a galactic filter which tests whether the given node has a specified 
      type   (varying_string) :: label
      integer                 :: labelID
    contains
-     procedure :: passes => labelledPasses
-  end type galacticFilterLabelled
+     procedure :: passes => labeledPasses
+  end type galacticFilterLabeled
 
-  interface galacticFilterLabelled
+  interface galacticFilterLabeled
      !!{RST
-     Constructors for the :galacticus-class:`galacticFilterLabelled` galactic filter class.
+     Constructors for the :galacticus-class:`galacticFilterLabeled` galactic filter class.
      !!}
-     module procedure labelledConstructorParameters
-     module procedure labelledConstructorInternal
-  end interface galacticFilterLabelled
+     module procedure labeledConstructorParameters
+     module procedure labeledConstructorInternal
+  end interface galacticFilterLabeled
 
 contains
 
-  function labelledConstructorParameters(parameters) result(self)
+  function labeledConstructorParameters(parameters) result(self)
     !!{RST
-    Constructor for the :galacticus-class:`galacticFilterLabelled` galactic filter class which takes a parameter set as input.
+    Constructor for the :galacticus-class:`galacticFilterLabeled` galactic filter class which takes a parameter set as input.
     !!}
     use :: Input_Parameters, only : inputParameter, inputParameters
     implicit none
-    type(galacticFilterLabelled)                :: self
-    type(inputParameters       ), intent(inout) :: parameters
-    type(varying_string        )                :: label
+    type(galacticFilterLabeled)                :: self
+    type(inputParameters      ), intent(inout) :: parameters
+    type(varying_string       )                :: label
 
     !![
     <inputParameter docformat="rst">
@@ -68,38 +68,38 @@ contains
       </description>
     </inputParameter>
     !!]
-    self=galacticFilterLabelled(label)
+    self=galacticFilterLabeled(label)
     !![
     <inputParametersValidate source="parameters"/>
     !!]
     return
-  end function labelledConstructorParameters
+  end function labeledConstructorParameters
   
-  function labelledConstructorInternal(label) result(self)
+  function labeledConstructorInternal(label) result(self)
     !!{RST
-    Internal constructor for the :galacticus-class:`galacticFilterLabelled` galactic filter class.
+    Internal constructor for the :galacticus-class:`galacticFilterLabeled` galactic filter class.
     !!}
     use :: Nodes_Labels, only : nodeLabelRegister
     implicit none
-    type(galacticFilterLabelled)                :: self
-    type(varying_string        ), intent(in   ) :: label
+    type(galacticFilterLabeled)                :: self
+    type(varying_string       ), intent(in   ) :: label
     !![
     <constructorAssign variables="label"/>
     !!]
 
     self%labelID=nodeLabelRegister(char(label))
     return
-  end function labelledConstructorInternal
+  end function labeledConstructorInternal
 
-  logical function labelledPasses(self,node)
+  logical function labeledPasses(self,node)
     !!{RST
     Implement a filter on node labels.
     !!}
     use :: Nodes_Labels, only : nodeLabelIsPresent
     implicit none
-    class(galacticFilterLabelled), intent(inout)         :: self
-    type (treeNode              ), intent(inout), target :: node
+    class(galacticFilterLabeled), intent(inout)         :: self
+    type (treeNode             ), intent(inout), target :: node
 
-    labelledPasses=nodeLabelIsPresent(self%labelID,node)
+    labeledPasses=nodeLabelIsPresent(self%labelID,node)
     return
-  end function labelledPasses
+  end function labeledPasses

--- a/source/hot_halo/cold_mode/mass_distribution/beta_profile.F90
+++ b/source/hot_halo/cold_mode/mass_distribution/beta_profile.F90
@@ -169,9 +169,9 @@ contains
 	 <constructor>
            massDistributionBetaProfile(                                                  &amp;
              &amp;                     beta                 =self%beta                 , &amp;
-             &amp;                     coreRadius           =     radiusScale          , &amp;
+             &amp;                     radiusCore           =     radiusScale          , &amp;
              &amp;                     mass                 =     mass                 , &amp;
-             &amp;                     outerRadius          =     radiusOuter          , &amp;
+             &amp;                     radiusOuter          =     radiusOuter          , &amp;
              &amp;                     truncateAtOuterRadius=     .true.               , &amp;
              &amp;                     componentType        =     componentTypeColdHalo, &amp;
              &amp;                     massType             =     massTypeGaseous        &amp;

--- a/source/hot_halo/mass_distribution/Ricotti2000.F90
+++ b/source/hot_halo/mass_distribution/Ricotti2000.F90
@@ -199,9 +199,9 @@ contains
 	 <constructor>
            massDistributionBetaProfile(                                            &amp;
              &amp;                     beta                 =beta                , &amp;
-             &amp;                     coreRadius           =radiusCore          , &amp;
+             &amp;                     radiusCore           =radiusCore          , &amp;
              &amp;                     mass                 =mass                , &amp;
-             &amp;                     outerRadius          =radiusOuter         , &amp;
+             &amp;                     radiusOuter          =radiusOuter         , &amp;
              &amp;                     truncateAtOuterRadius=.true.              , &amp;
              &amp;                     componentType        =componentTypeHotHalo, &amp;
              &amp;                     massType             =massTypeGaseous       &amp;

--- a/source/hot_halo/mass_distribution/beta_profile.F90
+++ b/source/hot_halo/mass_distribution/beta_profile.F90
@@ -181,9 +181,9 @@ contains
           ! this node.
           call massDistribution__%initialize(                                   &
                &                             beta                 =self%beta  , &
-               &                             coreRadius           =radiusScale, &
+               &                             radiusCore           =radiusScale, &
                &                             mass                 =mass       , &
-               &                             outerRadius          =radiusOuter, &
+               &                             radiusOuter          =radiusOuter, &
                &                             truncateAtOuterRadius=.true.       &
                &                            )
        else
@@ -193,9 +193,9 @@ contains
 	    <constructor>
               massDistributionBetaProfile(                                                 &amp;
                 &amp;                     beta                 =self%beta                , &amp;
-                &amp;                     coreRadius           =     radiusScale         , &amp;
+                &amp;                     radiusCore           =     radiusScale         , &amp;
                 &amp;                     mass                 =     mass                , &amp;
-                &amp;                     outerRadius          =     radiusOuter         , &amp;
+                &amp;                     radiusOuter          =     radiusOuter         , &amp;
                 &amp;                     truncateAtOuterRadius=     .true.              , &amp;
                 &amp;                     componentType        =     componentTypeHotHalo, &amp;
                 &amp;                     massType             =     massTypeGaseous       &amp;

--- a/source/mass_distributions/cylindrical/exponential_disk.F90
+++ b/source/mass_distributions/cylindrical/exponential_disk.F90
@@ -37,7 +37,7 @@
      The exponential disk mass distribution: :math:`\rho(r,z)=\rho_0 \exp(-r/r_\mathrm{s}) \hbox{sech}^2(z/z_\mathrm{s})`.
      !!}
      private
-     double precision                                                        :: scaleRadius                              , scaleHeight                              , &
+     double precision                                                        :: radiusScale                              , scaleHeight                              , &
           &                                                                     densityNormalization                     , surfaceDensityNormalization              , &
           &                                                                     mass
      ! Tables used for rotation curves and potential.
@@ -125,7 +125,7 @@ contains
     implicit none
     type            (massDistributionExponentialDisk)                :: self
     type            (inputParameters                ), intent(inout) :: parameters
-    double precision                                                 :: mass         , scaleRadius, &
+    double precision                                                 :: mass         , radiusScale, &
          &                                                              scaleHeight
     logical                                                          :: dimensionless
     type            (varying_string                 )                :: componentType
@@ -145,7 +145,7 @@ contains
       <minimum inclusive="false">0.0</minimum>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>scaleRadius</name>
+      <name>radiusScale</name>
       <defaultValue>1.0d0</defaultValue>
       <description>
       The scale radius of the exponential disk profile.
@@ -187,7 +187,7 @@ contains
     <conditionalCall>
      <call>self=massDistributionExponentialDisk(scaleHeight=scaleHeight,componentType=enumerationComponentTypeEncode(componentType,includesPrefix=.false.),massType=enumerationMassTypeEncode(massType,includesPrefix=.false.){conditions})</call>
      <argument name="mass"          value="mass"          parameterPresent="parameters"/>
-     <argument name="scaleRadius"   value="scaleRadius"   parameterPresent="parameters"/>
+     <argument name="radiusScale"   value="radiusScale"   parameterPresent="parameters"/>
      <argument name="dimensionless" value="dimensionless" parameterPresent="parameters"/>
     </conditionalCall>
     <inputParametersValidate source="parameters"/>
@@ -195,7 +195,7 @@ contains
     return
   end function exponentialDiskConstructorParameters
 
-  function exponentialDiskConstructorInternal(scaleRadius,scaleHeight,mass,dimensionless,componentType,massType) result(self)
+  function exponentialDiskConstructorInternal(radiusScale,scaleHeight,mass,dimensionless,componentType,massType) result(self)
     !!{RST
     Internal constructor for "exponentialDisk" mass distribution class.
     !!}
@@ -204,7 +204,7 @@ contains
     use :: Numerical_Constants_Math, only : Pi
     implicit none
     type            (massDistributionExponentialDisk)                          :: self
-    double precision                                 , intent(in   ), optional :: scaleRadius  , scaleHeight, &
+    double precision                                 , intent(in   ), optional :: radiusScale  , scaleHeight, &
          &                                                                        mass
     logical                                          , intent(in   ), optional :: dimensionless
     type            (enumerationComponentTypeType   ), intent(in   ), optional :: componentType
@@ -221,22 +221,22 @@ contains
     end if
     ! If dimensionless, then set scale length and mass to unity.
     if (self%dimensionless) then
-       if (present(scaleRadius)) then
-          if (Values_Differ(scaleRadius,1.0d0,absTol=1.0d-6)) call Error_Report('scaleRadius should be unity for a dimensionless profile (or simply do not specify a scale length)'//{introspection:location})
+       if (present(radiusScale)) then
+          if (Values_Differ(radiusScale,1.0d0,absTol=1.0d-6)) call Error_Report('radiusScale should be unity for a dimensionless profile (or simply do not specify a scale length)'//{introspection:location})
        end if
        if (present(mass       )) then
           if (Values_Differ(mass       ,1.0d0,absTol=1.0d-6)) call Error_Report('mass should be unity for a dimensionless profile (or simply do not specify a mass)'               //{introspection:location})
        end if
-       self%scaleRadius                =1.0d0
+       self%radiusScale                =1.0d0
        self%mass                       =1.0d0
        self%surfaceDensityNormalization=1.0d0/2.0d0/Pi
     else
        ! Set scale radius.
-       if (.not.present(scaleRadius)) call Error_Report('scale radius must be specified for dimensionful profiles'//{introspection:location})
+       if (.not.present(radiusScale)) call Error_Report('scale radius must be specified for dimensionful profiles'//{introspection:location})
        if (.not.present(mass       )) call Error_Report('mass must be specified for dimensionful profiles'        //{introspection:location})
-       self%scaleRadius                =scaleRadius
+       self%radiusScale                =radiusScale
        self%mass                       =mass
-       self%surfaceDensityNormalization=self%mass/2.0d0/Pi/self%scaleRadius**2
+       self%surfaceDensityNormalization=self%mass/2.0d0/Pi/self%radiusScale**2
     end if
     ! Set the scale height.
     if (present(scaleHeight)) then
@@ -339,7 +339,7 @@ contains
     double precision                                 , parameter     :: radiusHalfMassToScaleRadius=1.678346990d0
 
     exponentialDiskRadiusHalfMass=+radiusHalfMassToScaleRadius &
-         &                        *self%scaleRadius
+         &                        *self%radiusScale
     return
   end function exponentialDiskRadiusHalfMass
 
@@ -362,7 +362,7 @@ contains
     ! Get position in cylindrical coordinate system.
     position=coordinates
     ! Compute density.
-    r=    position%r() /self%scaleRadius
+    r=    position%r() /self%radiusScale
     z=abs(position%z())/self%scaleHeight
     if (z > coshArgumentMaximum) then
        coshTerm=(2.0d0*exp(-z)/(1.0d0+exp(-2.0d0*z)))**2
@@ -396,7 +396,7 @@ contains
     ! Get position in cylindrical coordinate system.
     position=coordinates
     ! Compute density.
-    r=    position%r() /self%scaleRadius
+    r=    position%r() /self%radiusScale
     z=abs(position%z())/self%scaleHeight
     if (z > coshArgumentMaximum) then
        coshTerm=(2.0d0*exp(-z)/(1.0d0+exp(-2.0d0*z)))**2
@@ -437,7 +437,7 @@ contains
          &                                 /                               radius &
          &                                 *exp(                                  &
          &                                      -                          radius &
-         &                                      /self                %scaleRadius &
+         &                                      /self                %radiusScale &
          &                                     )
     return
   end function exponentialDiskDensitySphericalAverage
@@ -465,10 +465,10 @@ contains
     double precision                                                         :: fractionalRadius
 
     fractionalRadius=+radius                              &
-         &           /self%scaleRadius
+         &           /self%radiusScale
     mass            =+2.0d0                               &
          &           *Pi                                  &
-         &           *self%scaleRadius                **2 &
+         &           *self%radiusScale                **2 &
          &           *self%surfaceDensityNormalization    &
          &           *(                                   &
          &             +1.0d0                             &
@@ -492,7 +492,7 @@ contains
     double precision                                                 :: r
 
     ! Get the radial coordinate.
-    r=coordinates%rCylindrical()/self%scaleRadius
+    r=coordinates%rCylindrical()/self%radiusScale
     ! Compute the density.
     exponentialDiskSurfaceDensity=self%surfaceDensityNormalization*exp(-r)
     return
@@ -507,7 +507,7 @@ contains
     double precision                                 , intent(in   )           :: densitySurface
     double precision                                 , intent(in   ), optional :: radiusGuess
     
-    radius=-     self%scaleRadius                 &
+    radius=-     self%radiusScale                 &
     &      *log(                                  &
     &           +     densitySurface              &
     &           /self%surfaceDensityNormalization &
@@ -527,7 +527,7 @@ contains
          &                                                              radiusFactor
 
     ! Get scale-free radius.
-    r=radius/self%scaleRadius
+    r=radius/self%radiusScale
     ! Compute rotation curve.
     if (r > radiusMaximum) then
        ! Beyond some maximum radius, approximate the disk as a spherical distribution to avoid evaluating Bessel functions for
@@ -546,7 +546,7 @@ contains
           halfRadius       =0.5d0*r
           radiusFactor=self%besselFactorRotationCurve(halfRadius)
        end if
-       exponentialDiskRotationCurve=sqrt(2.0d0*(self%mass/self%scaleRadius)*radiusFactor)
+       exponentialDiskRotationCurve=sqrt(2.0d0*(self%mass/self%radiusScale)*radiusFactor)
     end if
     ! Make dimensionful if necessary.
     if (.not.self%dimensionless) exponentialDiskRotationCurve= &
@@ -569,7 +569,7 @@ contains
     ! Compute Bessel functions argument.
     besselArgument=+radius           &
          &         /2.0d0            &
-         &         /self%scaleRadius
+         &         /self%radiusScale
     if (2.0d0*besselArgument > fractionalRadiusMaximum) then
        ! Beyond some maximum radius, approximate the disk as a point mass to avoid evaluating Bessel functions for
        ! very large arguments.
@@ -579,7 +579,7 @@ contains
        besselFactor=self%besselFactorRotationCurveGradient(besselArgument)
        exponentialDiskRotationCurveGradient=+self%mass           &
             &                               *besselFactor        &
-            &                               /self%scaleRadius**2
+            &                               /self%radiusScale**2
     end if
     ! Make dimensionful if necessary.
     if (.not.self%dimensionless) exponentialDiskRotationCurveGradient= &
@@ -620,17 +620,17 @@ contains
     ! Compute density.
     radius=position%r()
     ! If the radius is sufficiently large, treat the disk as a point mass.
-    if (radius > potentialRadiusMaximum*self%scaleRadius) then
+    if (radius > potentialRadiusMaximum*self%radiusScale) then
        exponentialDiskPotential=-self%mass/radius
     else
        ! Radius is sufficiently small to use the full calculation.
        ! Compute the potential. If the radius is lower than the height then approximate the disk
        ! mass as being spherically distributed.
        if (radius > self%scaleHeight) then
-          halfRadius           =radius/2.0d0/self%scaleRadius
+          halfRadius           =radius/2.0d0/self%radiusScale
           correctionSmallRadius=0.0d0
        else
-          halfRadius           =+self%scaleHeight/self%scaleRadius/2.0d0
+          halfRadius           =+self%scaleHeight/self%radiusScale/2.0d0
           correctionSmallRadius=+self%massEnclosedBySphere(self%scaleHeight) &
                &                /self%scaleHeight
           if (radius > 0.0d0) correctionSmallRadius=+correctionSmallRadius             &
@@ -640,7 +640,7 @@ contains
        ! Compute the potential including the correction to small radii.
        exponentialDiskPotential=                                  &
             &             -self%mass                              &
-            &             /self%scaleRadius                       &
+            &             /self%radiusScale                       &
             &             *self%besselFactorPotential(halfRadius) &
             &             +correctionSmallRadius
     end if
@@ -835,7 +835,7 @@ contains
     else
        integralHigh=+0.0d0
     end if
-    exponentialDiskSurfaceDensityRadialMoment=(integralHigh-integralLow)*Gamma_Function(moment+1.0d0)*self%scaleRadius**(moment+1.0d0)
+    exponentialDiskSurfaceDensityRadialMoment=(integralHigh-integralLow)*Gamma_Function(moment+1.0d0)*self%radiusScale**(moment+1.0d0)
     return
   end function exponentialDiskSurfaceDensityRadialMoment
 
@@ -881,7 +881,7 @@ contains
          &                    /megaParsec                     &
          &                    *gravitationalConstant_internal &
          &                    *self%mass                      &
-         &                    /self%scaleRadius**2
+         &                    /self%radiusScale**2
     exponentialDiskAcceleration=accelerationVector
     return
   end function exponentialDiskAcceleration
@@ -908,8 +908,8 @@ contains
     coordinatesCylindrical=coordinates
     coordinatesCartesian  =coordinatesCylindrical
     positionCartesian     =coordinatesCartesian
-    radiusCylindrical     =coordinatesCylindrical%r()/self%scaleRadius
-    positionCartesian     =positionCartesian         /self%scaleRadius
+    radiusCylindrical     =coordinatesCylindrical%r()/self%radiusScale
+    positionCartesian     =positionCartesian         /self%radiusScale
     ! Ensure that acceleration is tabulated.
     call self%accelerationTabulate()
     ! Interpolate in the tables.
@@ -943,7 +943,7 @@ contains
          & exponentialDiskTidalTensor=+exponentialDiskTidalTensor      &
          &                             *gravitationalConstant_internal &
          &                             *self%mass                      &
-         &                             /self%scaleRadius**3
+         &                             /self%radiusScale**3
     return
   end function exponentialDiskTidalTensor
   
@@ -968,8 +968,8 @@ contains
          &                                                                         jRadius                , jHeight
 
     ! Find interpolating factors.
-    radiusCylindrical=    coordinatesCylindrical%r()/self%scaleRadius
-    heightCylindrical=abs(coordinatesCylindrical%z()/self%scaleRadius)
+    radiusCylindrical=    coordinatesCylindrical%r()/self%radiusScale
+    heightCylindrical=abs(coordinatesCylindrical%z()/self%radiusScale)
     if     (                                                                              &
          &   radiusCylindrical > self%accelerationRadii  (size(self%accelerationRadii  )) &
          &  .or.                                                                          &
@@ -982,28 +982,28 @@ contains
        if (present(accelerationVertical))                                                                             &
             & accelerationVertical       =-                                                      heightCylindrical    &
             &                             /             radiusSpherical**3                                            &
-            &                             *        self%scaleRadius    **2
+            &                             *        self%radiusScale    **2
        if (present(accelerationRadial  ))                                                                             &
             & accelerationRadial         =-                                 radiusCylindrical                         &
             &                             /             radiusSpherical**3                                            &
-            &                             *        self%scaleRadius    **2
+            &                             *        self%radiusScale    **2
        if (present(tidalTensorVerticalVertical))                                                                      &
             & tidalTensorVerticalVertical=+(                                                                          &
             &                               -(1.0d0/    radiusSpherical**3)                                           &
             &                               +(3.0d0/    radiusSpherical**5)*                     heightCylindrical**2 &
             &                              )                                                                          &
-            &                             *        self%scaleRadius    **3
+            &                             *        self%radiusScale    **3
        if (present(tidalTensorRadialRadial    ))                                                                      &
             & tidalTensorRadialRadial    =+(                                                                          &
             &                               -(1.0d0/    radiusSpherical**3)                                           &
             &                               +(3.0d0/    radiusSpherical**5)*radiusCylindrical**2                      &
             &                              )                                                                          &
-            &                             *        self%scaleRadius    **3
+            &                             *        self%radiusScale    **3
        if (present(tidalTensorCross           ))                                                                      &
             & tidalTensorCross           =+(                                                                          &
             &                               +(3.0d0/    radiusSpherical**5)*radiusCylindrical   *heightCylindrical    &
             &                              )                                                                          &
-            &                             *        self%scaleRadius    **3
+            &                             *        self%radiusScale    **3
     else
        ! Interpolate in tabulated solution.
        if (radiusCylindrical < self%accelerationRadii  (1)) then
@@ -1100,7 +1100,7 @@ contains
       type     (lockDescriptor) :: fileLock
       
       ! Construct a file name for the table.
-      write (label,'(f8.6)') self%scaleHeight/self%scaleRadius
+      write (label,'(f8.6)') self%scaleHeight/self%radiusScale
       fileName=inputPath(pathTypeDataDynamic)// &
            &   'galacticStructure/'          // &
            &   self%objectType()             // &
@@ -1151,7 +1151,7 @@ contains
          !
          ! and we then make it dimensionless by multiplying by the radial scale length.
          beta   =+dble(xi)         &
-              &  *self%scaleRadius &
+              &  *self%radiusScale &
               &  /self%scaleHeight
          ! Iterate over radii and heights.
          call displayIndent("tabulating gravitational accelerations for exponential disk",verbosityLevelWorking)
@@ -1650,7 +1650,7 @@ contains
          &                                                              phi
 
     ! Select a radial coordinate.
-    radius=(-1.0d0-Lambert_Wm1((-1.0d0+      randomNumberGenerator_%uniformSample())/exp(1.0d0)))*self%scaleRadius
+    radius=(-1.0d0-Lambert_Wm1((-1.0d0+      randomNumberGenerator_%uniformSample())/exp(1.0d0)))*self%radiusScale
     ! Select a vertical coordinate.
     height=(      -atanh      ( +1.0d0-2.0d0*randomNumberGenerator_%uniformSample()            ))*self%scaleHeight
     ! Angular coordinate is uniformly distributed between 0 and 2π.

--- a/source/mass_distributions/spherical/Einasto.F90
+++ b/source/mass_distributions/spherical/Einasto.F90
@@ -100,7 +100,7 @@ contains
     type            (inputParameters        ), intent(inout) :: parameters
     double precision                                         :: mass                , scaleLength  , &
          &                                                      densityNormalization, concentration, &
-         &                                                      virialRadius        , shapeParameter
+         &                                                      radiusVirial        , shapeParameter
     logical                                                  :: dimensionless
     type            (varying_string         )                :: componentType
     type            (varying_string         )                :: massType
@@ -146,7 +146,7 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>virialRadius</name>
+      <name>radiusVirial</name>
       <defaultValue>1.0d0</defaultValue>
       <description>
       The virial radius of the Einasto profile.
@@ -182,7 +182,7 @@ contains
      <argument name="densityNormalization" value="densityNormalization" parameterPresent="parameters"/>
      <argument name="mass"                 value="mass"                 parameterPresent="parameters"/>
      <argument name="scaleLength"          value="scaleLength"          parameterPresent="parameters"/>
-     <argument name="virialRadius"         value="virialRadius"         parameterPresent="parameters"/>
+     <argument name="radiusVirial"         value="radiusVirial"         parameterPresent="parameters"/>
      <argument name="concentration"        value="concentration"        parameterPresent="parameters"/>
      <argument name="dimensionless"        value="dimensionless"        parameterPresent="parameters"/>
     </conditionalCall>
@@ -191,7 +191,7 @@ contains
     return
   end function massDistributionEinastoConstructorParameters
 
-  function massDistributionEinastoConstructorInternal(shapeParameter,scaleLength,concentration,densityNormalization,mass,virialRadius,dimensionless,componentType,massType) result(self)
+  function massDistributionEinastoConstructorInternal(shapeParameter,scaleLength,concentration,densityNormalization,mass,radiusVirial,dimensionless,componentType,massType) result(self)
     !!{RST
     Internal constructor for "einasto" mass distribution class.
     !!}
@@ -203,7 +203,7 @@ contains
     double precision                              , intent(in   )           :: shapeParameter
     double precision                              , intent(in   ), optional :: scaleLength         , concentration, &
          &                                                                     densityNormalization, mass         , &
-         &                                                                     virialRadius
+         &                                                                     radiusVirial
     logical                                       , intent(in   ), optional :: dimensionless
     type            (enumerationComponentTypeType), intent(in   ), optional :: componentType
     type            (enumerationMassTypeType     ), intent(in   ), optional :: massType
@@ -219,9 +219,9 @@ contains
        self%scaleLength=scaleLength
     else if (                            &
          &   present(concentration).and. &
-         &   present(virialRadius )      &
+         &   present(radiusVirial )      &
          &  ) then
-       self%scaleLength=virialRadius/concentration
+       self%scaleLength=radiusVirial/concentration
     else
        self%scaleLength=0.0d0
        call Error_Report('no means to determine scale length'//{introspection:location})
@@ -234,15 +234,15 @@ contains
        self%massTotal_          =+4.0d0*Pi*densityNormalization*self%scaleLength**3/shapeParameter/(2.0d0/shapeParameter)**(3.0d0/shapeParameter)*Gamma_Function(3.0d0/shapeParameter)*exp(2.0d0/shapeParameter)
     else if (                                   &
          &   present(mass                ).and. &
-         &   present(virialRadius        )      &
+         &   present(radiusVirial        )      &
          &  ) then
-       radiusScaleFree          =+virialRadius/self%scaleLength
+       radiusScaleFree          =+radiusVirial/self%scaleLength
        self%densityNormalization=+mass/4.0d0/Pi/self%scaleLength**3*shapeParameter*exp(-2.0d0/shapeParameter)*(2.0d0/shapeParameter)**(3.0d0/shapeParameter)/Gamma_Function(3.0d0/shapeParameter)
        self%massTotal_          =+mass
     else
        self%densityNormalization=+0.0d0
        self%massTotal_          =+0.0d0
-       call Error_Report('either "densityNormalization", or "mass" and "virialRadius" must be specified'//{introspection:location})
+       call Error_Report('either "densityNormalization", or "mass" and "radiusVirial" must be specified'//{introspection:location})
     end if
     ! Determine if profile is dimensionless.
     if      (present(dimensionless     )) then

--- a/source/mass_distributions/spherical/NFW.F90
+++ b/source/mass_distributions/spherical/NFW.F90
@@ -110,7 +110,7 @@ contains
     type            (inputParameters    ), intent(inout) :: parameters
     double precision                                     :: mass                , scaleLength  , &
          &                                                  densityNormalization, concentration, &
-         &                                                  virialRadius
+         &                                                  radiusVirial
     logical                                              :: dimensionless
     type            (varying_string     )                :: componentType
     type            (varying_string     )                :: massType
@@ -149,7 +149,7 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>virialRadius</name>
+      <name>radiusVirial</name>
       <defaultValue>1.0d0</defaultValue>
       <description>
       The virial radius (in Mpc) :math:`r_\mathrm{vir}` of the NFW halo, which defines the outer boundary of the profile at which the mean enclosed density equals the virial overdensity threshold.
@@ -185,7 +185,7 @@ contains
      <argument name="densityNormalization" value="densityNormalization" parameterPresent="parameters"/>
      <argument name="mass"                 value="mass"                 parameterPresent="parameters"/>
      <argument name="scaleLength"          value="scaleLength"          parameterPresent="parameters"/>
-     <argument name="virialRadius"         value="virialRadius"         parameterPresent="parameters"/>
+     <argument name="radiusVirial"         value="radiusVirial"         parameterPresent="parameters"/>
      <argument name="concentration"        value="concentration"        parameterPresent="parameters"/>
      <argument name="dimensionless"        value="dimensionless"        parameterPresent="parameters"/>
     </conditionalCall>
@@ -194,7 +194,7 @@ contains
     return
   end function massDistributionNFWConstructorParameters
 
-  function massDistributionNFWConstructorInternal(scaleLength,concentration,densityNormalization,mass,virialRadius,dimensionless,componentType,massType) result(self)
+  function massDistributionNFWConstructorInternal(scaleLength,concentration,densityNormalization,mass,radiusVirial,dimensionless,componentType,massType) result(self)
     !!{RST
     Internal constructor for "nfw" mass distribution class.
     !!}
@@ -202,7 +202,7 @@ contains
     type            (massDistributionNFW         )                          :: self
     double precision                              , intent(in   ), optional :: scaleLength         , concentration, &
          &                                                                     densityNormalization, mass         , &
-         &                                                                     virialRadius
+         &                                                                     radiusVirial
     logical                                       , intent(in   ), optional :: dimensionless
     type            (enumerationComponentTypeType), intent(in   ), optional :: componentType
     type            (enumerationMassTypeType     ), intent(in   ), optional :: massType
@@ -210,11 +210,11 @@ contains
     <constructorAssign variables="componentType, massType"/>
     !!]
 
-    call self%initialize(scaleLength,concentration,densityNormalization,mass,virialRadius,dimensionless)
+    call self%initialize(scaleLength,concentration,densityNormalization,mass,radiusVirial,dimensionless)
     return
   end function massDistributionNFWConstructorInternal
 
-  subroutine nfwInitialize(self,scaleLength,concentration,densityNormalization,mass,virialRadius,dimensionless)
+  subroutine nfwInitialize(self,scaleLength,concentration,densityNormalization,mass,radiusVirial,dimensionless)
     !!{RST
     Initialize the parameters of an NFW mass distribution.
     !!}
@@ -224,7 +224,7 @@ contains
     class           (massDistributionNFW), intent(inout)           :: self
     double precision                     , intent(in   ), optional :: scaleLength         , concentration, &
          &                                                            densityNormalization, mass         , &
-         &                                                            virialRadius
+         &                                                            radiusVirial
     logical                              , intent(in   ), optional :: dimensionless
     double precision                                               :: radiusScaleFree
 
@@ -235,9 +235,9 @@ contains
        self%scaleLength=scaleLength
     else if (                            &
          &   present(concentration).and. &
-         &   present(virialRadius )      &
+         &   present(radiusVirial )      &
          &  ) then
-       self%scaleLength=virialRadius/concentration
+       self%scaleLength=radiusVirial/concentration
     else
        self%scaleLength=0.0d0
        call Error_Report('no means to determine scale length'//{introspection:location})
@@ -249,13 +249,13 @@ contains
        self%densityNormalization=densityNormalization
     else if (                                   &
          &   present(mass                ).and. &
-         &   present(virialRadius        )      &
+         &   present(radiusVirial        )      &
          &  ) then
-       radiusScaleFree          =+virialRadius/self%scaleLength
+       radiusScaleFree          =+radiusVirial/self%scaleLength
        self%densityNormalization=+mass/4.0d0/Pi/self%scaleLength**3/(log(1.0d0+radiusScaleFree)-radiusScaleFree/(1.0d0+radiusScaleFree))
     else
        self%densityNormalization=+0.00
-       call Error_Report('either "densityNormalization", or "mass" and "virialRadius" must be specified'//{introspection:location})
+       call Error_Report('either "densityNormalization", or "mass" and "radiusVirial" must be specified'//{introspection:location})
     end if
     ! Determine if profile is dimensionless.
     if      (present(dimensionless     )) then

--- a/source/mass_distributions/spherical/beta_profile.F90
+++ b/source/mass_distributions/spherical/beta_profile.F90
@@ -32,9 +32,9 @@
      !!{RST
      The :math:`\beta`-profile: :math:`\rho(r)=\rho_0/[1+(r/r_\mathrm{core})^2]^{3\beta/2}`
      !!}
-     double precision :: beta                  , coreRadius           , densityNormalization  , &
+     double precision :: beta                  , radiusCore           , densityNormalization  , &
           &              momentRadial2Previous , momentRadial3Previous, momentRadial2XPrevious, &
-          &              momentRadial3XPrevious, outerRadius
+          &              momentRadial3XPrevious, radiusOuter
      logical          :: betaIsTwoThirds       , truncateAtOuterRadius
    contains
      !![
@@ -74,8 +74,8 @@ contains
     type            (massDistributionBetaProfile)                :: self
     type            (inputParameters            ), intent(inout) :: parameters
     double precision                                             :: beta         , densityNormalization , &
-         &                                                          mass         , outerRadius          , &
-         &                                                          coreRadius
+         &                                                          mass         , radiusOuter          , &
+         &                                                          radiusCore
     logical                                                      :: dimensionless, truncateAtOuterRadius
     type            (varying_string             )                :: componentType
     type            (varying_string             )                :: massType
@@ -106,7 +106,7 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>outerRadius</name>
+      <name>radiusOuter</name>
       <defaultValue>0.0d0</defaultValue>
       <description>
       The outer radius of a :math:`\beta`-model mass distribution.
@@ -114,7 +114,7 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>coreRadius</name>
+      <name>radiusCore</name>
       <defaultValue>0.0d0</defaultValue>
       <description>
       The core radius of a :math:`\beta`-model mass distribution.
@@ -157,8 +157,8 @@ contains
      <call>self=massDistributionBetaProfile(beta,componentType=enumerationComponentTypeEncode(componentType,includesPrefix=.false.),massType=enumerationMassTypeEncode(massType,includesPrefix=.false.){conditions})</call>
      <argument name="densityNormalization"  value="densityNormalization"  parameterPresent="parameters"/>
      <argument name="mass"                  value="mass"                  parameterPresent="parameters"/>
-     <argument name="outerRadius"           value="outerRadius"           parameterPresent="parameters"/>
-     <argument name="coreRadius"            value="coreRadius"            parameterPresent="parameters"/>
+     <argument name="radiusOuter"           value="radiusOuter"           parameterPresent="parameters"/>
+     <argument name="radiusCore"            value="radiusCore"            parameterPresent="parameters"/>
      <argument name="dimensionless"         value="dimensionless"         parameterPresent="parameters"/>
      <argument name="truncateAtOuterRadius" value="truncateAtOuterRadius" parameterPresent="parameters"/>
     </conditionalCall>
@@ -167,7 +167,7 @@ contains
     return
   end function betaProfileConstructorParameters
 
-  function betaProfileConstructorInternal(beta,densityNormalization,mass,outerRadius,coreRadius,dimensionless,truncateAtOuterRadius,componentType,massType) result(self)
+  function betaProfileConstructorInternal(beta,densityNormalization,mass,radiusOuter,radiusCore,dimensionless,truncateAtOuterRadius,componentType,massType) result(self)
     !!{RST
     Constructor for the :galacticus-class:`massDistributionBetaProfile` mass distribution class.
     !!}
@@ -175,7 +175,7 @@ contains
     type            (massDistributionBetaProfile )                          :: self
     double precision                              , intent(in   )           :: beta
     double precision                              , intent(in   ), optional :: densityNormalization, mass                 , &
-         &                                                                     outerRadius         , coreRadius
+         &                                                                     radiusOuter         , radiusCore
     logical                                       , intent(in   ), optional :: dimensionless       , truncateAtOuterRadius
     type            (enumerationComponentTypeType), intent(in   ), optional :: componentType
     type            (enumerationMassTypeType     ), intent(in   ), optional :: massType
@@ -183,11 +183,11 @@ contains
     <constructorAssign variables="componentType, massType"/>
     !!]
 
-    call self%initialize(beta,densityNormalization,mass,outerRadius,coreRadius,dimensionless,truncateAtOuterRadius)
+    call self%initialize(beta,densityNormalization,mass,radiusOuter,radiusCore,dimensionless,truncateAtOuterRadius)
     return
   end function betaProfileConstructorInternal
 
-  subroutine betaProfileInitialize(self,beta,densityNormalization,mass,outerRadius,coreRadius,dimensionless,truncateAtOuterRadius)
+  subroutine betaProfileInitialize(self,beta,densityNormalization,mass,radiusOuter,radiusCore,dimensionless,truncateAtOuterRadius)
     !!{RST
     (Re)initialize the parameters of a :galacticus-class:`massDistributionBetaProfile` mass distribution. Factored out of the constructor so that a pooled object can be re-used (re-initialized for a new :term:`node`) without being reallocated.
     !!}
@@ -201,7 +201,7 @@ contains
     class           (massDistributionBetaProfile ), intent(inout)           :: self
     double precision                              , intent(in   )           :: beta
     double precision                              , intent(in   ), optional :: densityNormalization               , mass                     , &
-         &                                                                     outerRadius                        , coreRadius
+         &                                                                     radiusOuter                        , radiusCore
     logical                                       , intent(in   ), optional :: dimensionless                      , truncateAtOuterRadius
     double precision                              , parameter               :: radiusTiny                  =1.0d-6
     double precision                                                        :: r
@@ -217,20 +217,20 @@ contains
     if (present(dimensionless)) self%dimensionless=dimensionless
     ! If dimensionless, then set scale length and mass to unity.
     if (self%dimensionless) then
-       if (present(coreRadius          )) then
-          if (Values_Differ(coreRadius          ,1.0d0,absTol=1.0d-6)) call Error_Report('coreRadius should be unity for a dimensionless profile (or simply do not specify a scale length)'                  //{introspection:location})
+       if (present(radiusCore          )) then
+          if (Values_Differ(radiusCore          ,1.0d0,absTol=1.0d-6)) call Error_Report('radiusCore should be unity for a dimensionless profile (or simply do not specify a scale length)'                  //{introspection:location})
        end if
        if (present(densityNormalization)) then
           if (Values_Differ(densityNormalization,1.0d0,absTol=1.0d-6)) call Error_Report('densityNormalization should be unity for a dimensionless profile (or simply do not specify a densityNormalization)'//{introspection:location})
        end if
        if (present(mass                ))                              call Error_Report('mass cannot be specified for a dimensionless profile'                                                              //{introspection:location})
-       if (present(outerRadius         ))                              call Error_Report('outer radius cannot be specified for a dimensionless profile'                                                      //{introspection:location})
-       self%coreRadius          =1.0d0
+       if (present(radiusOuter         ))                              call Error_Report('outer radius cannot be specified for a dimensionless profile'                                                      //{introspection:location})
+       self%radiusCore          =1.0d0
        self%densityNormalization=1.0d0
     else
        ! Set core radius.
-       if (.not.present(coreRadius)) call Error_Report('core radius must be specified for dimensionful profiles'//{introspection:location})
-       self%coreRadius=coreRadius
+       if (.not.present(radiusCore)) call Error_Report('core radius must be specified for dimensionful profiles'//{introspection:location})
+       self%radiusCore=radiusCore
        ! Determine density normalization.
        if      (                                   &
             &   present(densityNormalization)      &
@@ -238,10 +238,10 @@ contains
           self%densityNormalization=densityNormalization
        else if (                                   &
             &   present(mass                ).and. &
-            &   present(outerRadius         )      &
+            &   present(radiusOuter         )      &
             &  ) then
-          r=outerRadius/coreRadius
-          if (outerRadius > 0.0d0) then
+          r=radiusOuter/radiusCore
+          if (radiusOuter > 0.0d0) then
              if (self%betaIsTwoThirds) then
                 if (r /= radiusCoreFractionalPrevious) then
                    radiusCoreFractionalPrevious=r
@@ -253,26 +253,26 @@ contains
                       normalizationFactorStored=1.0d0/(r-atan(r))
                    end if
                 end if
-                self%densityNormalization=      mass/4.0d0/Pi/coreRadius **3*normalizationFactorStored
+                self%densityNormalization=      mass/4.0d0/Pi/radiusCore **3*normalizationFactorStored
              else
-                self%densityNormalization=3.0d0*mass/4.0d0/Pi/outerRadius**3/Hypergeometric_2F1([1.5d0,1.5d0*beta],[2.5d0],-r**2)
+                self%densityNormalization=3.0d0*mass/4.0d0/Pi/radiusOuter**3/Hypergeometric_2F1([1.5d0,1.5d0*beta],[2.5d0],-r**2)
              end if
           else
              call Error_Report('unphysical outer radius'//{introspection:location})
           end if
           ! Assert that the mass within the outer radius equals that specified.
           if (displayVerbosity() >= verbosityLevelDebug) then
-             if (.not.Values_Agree(self%massEnclosedBySphere(outerRadius),mass,relTol=1.0d-6,absTol=tiny(0.0d0))) then
+             if (.not.Values_Agree(self%massEnclosedBySphere(radiusOuter),mass,relTol=1.0d-6,absTol=tiny(0.0d0))) then
                 call displayIndent('beta-profile parameters:')
-                write (message,'(a,e12.6)') '    coreRadius: ',coreRadius
+                write (message,'(a,e12.6)') '    radiusCore: ',radiusCore
                 call displayMessage(message)
-                write (message,'(a,e12.6)') '   outerRadius: ',outerRadius
+                write (message,'(a,e12.6)') '   radiusOuter: ',radiusOuter
                 call displayMessage(message)
                 write (message,'(a,e12.6)') '          mass: ',mass
                 call displayMessage(message)
                 write (message,'(a,e12.6)') '          beta: ',beta
                 call displayMessage(message)
-                write (message,'(a,e12.6)') 'mass(<r_outer): ',self%massEnclosedBySphere(outerRadius)
+                write (message,'(a,e12.6)') 'mass(<r_outer): ',self%massEnclosedBySphere(radiusOuter)
                 call displayMessage(message)
                 call displayUnindent('done')
                 call Error_Report('profile normalization failed'//{introspection:location})
@@ -287,8 +287,8 @@ contains
        self%truncateAtOuterRadius=.false.
     end if
     if (self%truncateAtOuterRadius) then
-       if (.not.present(outerRadius)) call Error_Report('can not truncate profile without an outer radius'//{introspection:location})
-       self%outerRadius=outerRadius
+       if (.not.present(radiusOuter)) call Error_Report('can not truncate profile without an outer radius'//{introspection:location})
+       self%radiusOuter=radiusOuter
     end if
     ! Initialize stored results.
     self%momentRadial2XPrevious=-1.0d0
@@ -311,10 +311,10 @@ contains
 
     ! Compute density.
     radius=coordinates%rSpherical()
-    if (self%truncateAtOuterRadius .and. radius > self%outerRadius) then
+    if (self%truncateAtOuterRadius .and. radius > self%radiusOuter) then
        betaProfileDensity=0.0d0
     else
-       betaProfileDensity=self%densityNormalization/(1.0d0+(radius/self%coreRadius)**2)**(1.5d0*self%beta)
+       betaProfileDensity=self%densityNormalization/(1.0d0+(radius/self%radiusCore)**2)**(1.5d0*self%beta)
     end if
     return
   end function betaProfileDensity
@@ -336,12 +336,12 @@ contains
     ! Get position in spherical coordinate system.
     radius=coordinates%rSpherical()
     ! Apply truncation.
-    if (self%truncateAtOuterRadius .and. radius > self%outerRadius) then
+    if (self%truncateAtOuterRadius .and. radius > self%radiusOuter) then
        betaProfileDensityGradientRadial=0.0d0
        return
     end if
     ! Convert to dimensionless radius.
-    radius=radius/self%coreRadius
+    radius=radius/self%radiusCore
     ! Compute density gradient.
     if (logarithmicActual) then
        betaProfileDensityGradientRadial=                  &
@@ -354,7 +354,7 @@ contains
             & -3.0d0                                      &
             & *self%beta                                  &
             & *self%densityNormalization                  &
-            & /self%coreRadius                            &
+            & /self%radiusCore                            &
             & * radius                                    &
             & /(radius**2+1.0d0)**(1.5d0*self%beta+1.0d0)
     end if
@@ -386,12 +386,12 @@ contains
     double precision                              , parameter             :: radiusTiny      =1.0d-6
     double precision                                                      :: fractionalRadius       , radius_
 
-    if (self%truncateAtOuterRadius .and. radius > self%outerRadius) then
-       radius_=self%outerRadius
+    if (self%truncateAtOuterRadius .and. radius > self%radiusOuter) then
+       radius_=self%radiusOuter
     else
        radius_=radius
     end if
-    fractionalRadius=radius_/self%coreRadius
+    fractionalRadius=radius_/self%radiusCore
     if (self%betaIsTwoThirds) then
        ! Solution for special case of β=2/3.
        if (fractionalRadius < radiusTiny) then
@@ -400,7 +400,7 @@ contains
                & +4.0d0                                    &
                & *Pi                                       &
                & *self%densityNormalization                &
-               & *self%coreRadius                 **3      &
+               & *self%radiusCore                 **3      &
                & *                fractionalRadius**3      &
                & *(  +1.0d0/3.0d0+fractionalRadius**2      &
                & * ( -1.0d0/5.0d0+fractionalRadius**2      &
@@ -417,7 +417,7 @@ contains
                &   +     fractionalRadius                  &
                &   -atan(fractionalRadius)                 &
                &  )                                        &
-               & *self%coreRadius**3
+               & *self%radiusCore**3
        end if
     else
        ! General solution.
@@ -466,10 +466,10 @@ contains
     if (present(status)) status=structureErrorCodeSuccess
     ! Compute the potential at this position.
     radius=coordinates%rSpherical()
-    if (self%truncateAtOuterRadius .and. radius > self%outerRadius) then
-       fractionalRadius=self%outerRadius/self%coreRadius
+    if (self%truncateAtOuterRadius .and. radius > self%radiusOuter) then
+       fractionalRadius=self%radiusOuter/self%radiusCore
     else
-       fractionalRadius=          radius/self%coreRadius
+       fractionalRadius=          radius/self%radiusCore
     end if
     if (Values_Agree(self%beta,2.0d0/3.0d0,absTol=1.0d-6)) then
        if (fractionalRadius < fractionalRadiusMinimum) then
@@ -574,8 +574,8 @@ contains
        radiusMaximum_   =    radiusMaximum
     end if
     if (self%truncateAtOuterRadius) then
-       radiusMinimum_   =min(radiusMinimum_,self%outerRadius)
-       radiusMaximum_   =min(radiusMaximum_,self%outerRadius)
+       radiusMinimum_   =min(radiusMinimum_,self%radiusOuter)
+       radiusMaximum_   =min(radiusMaximum_,self%radiusOuter)
        haveRadiusMinimum=.true.
        haveRadiusMaximum=.true.
     end if
@@ -594,7 +594,7 @@ contains
     end if
     if (present(isInfinite)) isInfinite=.false.
     if (haveRadiusMaximum) then
-       fractionalRadiusMaximum=radiusMaximum_/self%coreRadius
+       fractionalRadiusMaximum=radiusMaximum_/self%radiusCore
        if (specialCaseMoment /= -huge(0)) then
           ! Special case for 0ᵗʰ, 1ˢᵗ, 2ⁿᵈ, and 3ʳᵈ moments of a β=2/3 distribution.
           betaProfileDensityRadialMoment=                    &
@@ -627,7 +627,7 @@ contains
        end if
     end if
     if (haveRadiusMinimum) then
-       fractionalRadiusMinimum=radiusMinimum_/self%coreRadius
+       fractionalRadiusMinimum=radiusMinimum_/self%radiusCore
        if (specialCaseMoment /= -huge(0)) then
           ! Special case for 0ᵗʰ, 1ˢᵗ, 2ⁿᵈ, and 3ʳᵈ moments of a β=2/3 distribution.
           betaProfileDensityRadialMoment=                                          &
@@ -659,7 +659,7 @@ contains
     betaProfileDensityRadialMoment                         &
          & =betaProfileDensityRadialMoment                 &
          & *self%densityNormalization                      &
-         & *self%coreRadius               **(1.0d0+moment)
+         & *self%radiusCore               **(1.0d0+moment)
     return
 
   contains
@@ -758,8 +758,8 @@ contains
        radiusMaximum_   =    radiusMaximum
     end if
     if (self%truncateAtOuterRadius) then
-       radiusMinimum_   =min(radiusMinimum_,self%outerRadius)
-       radiusMaximum_   =min(radiusMaximum_,self%outerRadius)
+       radiusMinimum_   =min(radiusMinimum_,self%radiusOuter)
+       radiusMaximum_   =min(radiusMaximum_,self%radiusOuter)
        haveRadiusMinimum=.true.
        haveRadiusMaximum=.true.
     end if
@@ -768,14 +768,14 @@ contains
        ! Compute the integral for the case β=2/3.
        if (haveRadiusMinimum) then
           fractionalRadiusMinimum=+     radiusMinimum_ &
-               &                  /self%coreRadius
+               &                  /self%radiusCore
           betaProfileDensitySquareIntegral=+betaProfileDensitySquareIntegral-4.0d0*Pi*(atan(fractionalRadiusMinimum)/2.0d0-fractionalRadiusMinimum/2.0d0/(1.0d0+fractionalRadiusMinimum**2))
        else
           betaProfileDensitySquareIntegral=+betaProfileDensitySquareIntegral+0.0d0
        end if
        if (haveRadiusMaximum) then
           fractionalRadiusMaximum=+     radiusMaximum_ &
-               &                  /self%coreRadius
+               &                  /self%radiusCore
           betaProfileDensitySquareIntegral=betaProfileDensitySquareIntegral+4.0d0*Pi*(atan(fractionalRadiusMaximum)/2.0d0-fractionalRadiusMaximum/2.0d0/(1.0d0+fractionalRadiusMaximum**2))
        else
           betaProfileDensitySquareIntegral=betaProfileDensitySquareIntegral+Pi**2
@@ -784,14 +784,14 @@ contains
        ! Compute the integral for the general case.
        if (haveRadiusMinimum) then
           fractionalRadiusMinimum=+     radiusMinimum_ &
-               &                  /self%coreRadius
+               &                  /self%radiusCore
           betaProfileDensitySquareIntegral=+betaProfileDensitySquareIntegral-4.0d0*Pi/3.0d0*fractionalRadiusMinimum**3*Hypergeometric_2F1([1.5d0,3.0d0*self%beta],[2.5d0],-fractionalRadiusMinimum**2)
        else
           betaProfileDensitySquareIntegral=+betaProfileDensitySquareIntegral+0.0d0
        end if
        if (haveRadiusMaximum) then
           fractionalRadiusMaximum=+     radiusMaximum_ &
-               &                  /self%coreRadius
+               &                  /self%radiusCore
           betaProfileDensitySquareIntegral=+betaProfileDensitySquareIntegral+4.0d0*Pi/3.0d0*fractionalRadiusMaximum**3*Hypergeometric_2F1([1.5d0,3.0d0*self%beta],[2.5d0],-fractionalRadiusMaximum**2)
        else
           if (self%beta > 2.0d0/3.0d0) then
@@ -809,7 +809,7 @@ contains
     ! Convert to dimensionful units.
     betaProfileDensitySquareIntegral=+betaProfileDensitySquareIntegral    &
          &                           *self%densityNormalization       **2 &
-         &                           *self%coreRadius                 **3
+         &                           *self%radiusCore                 **3
     return
   end function betaProfileDensitySquareIntegral
   
@@ -832,7 +832,7 @@ contains
     call parameters%addParameter('densityNormalization',trim(adjustl(parameterLabel)))
     write (parameterLabel,'(e17.10)') self%beta
     call parameters%addParameter('beta'                ,trim(adjustl(parameterLabel)))
-    write (parameterLabel,'(e17.10)') self%coreRadius
-    call parameters%addParameter('coreRadius'          ,trim(adjustl(parameterLabel)))
+    write (parameterLabel,'(e17.10)') self%radiusCore
+    call parameters%addParameter('radiusCore'          ,trim(adjustl(parameterLabel)))
     return
   end subroutine betaProfileDescriptor

--- a/source/merger_trees/operators/prune_by_filter.F90
+++ b/source/merger_trees/operators/prune_by_filter.F90
@@ -33,7 +33,7 @@ Implements a pruning-by-filter operator on merger trees.
    progenitors. (To prune the complement---i.e. to retain only those nodes which pass some filter---wrap that filter in a
    :galacticus-class:`galacticFilterNot`.) This is intended for cases in which some earlier stage of tree initialization has
    identified nodes which should not be present in the tree, for example by labeling them (see
-   :galacticus-class:`galacticFilterLabelled`).
+   :galacticus-class:`galacticFilterLabeled`).
    </description>
   </mergerTreeOperator>
   !!]

--- a/source/models/likelihoods/mass_function.F90
+++ b/source/models/likelihoods/mass_function.F90
@@ -58,9 +58,9 @@
      class           (haloMassFunctionClass  ), pointer                     :: haloMassFunction_     => null()
      class           (surveyGeometryClass    ), pointer                     :: surveyGeometry_       => null()
      logical                                                                :: useSurveyLimits                , modelSurfaceBrightness
-     double precision                                                       :: haloMassMinimum                , haloMassMaximum       , &
+     double precision                                                       :: massHaloMinimum                , massHaloMaximum       , &
           &                                                                    redshiftMinimum                , redshiftMaximum       , &
-          &                                                                    logHaloMassMinimum             , logHaloMassMaximum    , &
+          &                                                                    logMassHaloMinimum             , logMassHaloMaximum    , &
           &                                                                    surfaceBrightnessLimit
      double precision                         , dimension(:  ), allocatable :: mass                           , massFunctionObserved  , &
           &                                                                    massMinimum                    , massMaximum           , &
@@ -95,7 +95,7 @@ contains
     type            (posteriorSampleLikelihoodMassFunction)                :: self
     type            (inputParameters                      ), intent(inout) :: parameters
     double precision                                                       :: redshiftMinimum       , redshiftMaximum       , &
-         &                                                                    haloMassMinimum       , haloMassMaximum       , &
+         &                                                                    massHaloMinimum       , massHaloMaximum       , &
          &                                                                    surfaceBrightnessLimit
     logical                                                                :: useSurveyLimits       , modelSurfaceBrightness
     type            (varying_string                       )                :: massFunctionFileName
@@ -112,14 +112,14 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>haloMassMinimum</name>
+      <name>massHaloMinimum</name>
       <description>
       The minimum halo mass over which to integrate.
       </description>
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>haloMassMaximum</name>
+      <name>massHaloMaximum</name>
       <description>
       The maximum halo mass over which to integrate.
       </description>
@@ -164,7 +164,7 @@ contains
     <objectBuilder class="haloMassFunction"   name="haloMassFunction_"   source="parameters"/>
     <objectBuilder class="surveyGeometry"     name="surveyGeometry_"     source="parameters"/>
     !!]
-    self=posteriorSampleLikelihoodMassFunction(haloMassMinimum,haloMassMaximum,redshiftMinimum,redshiftMaximum,useSurveyLimits,char(massFunctionFileName),modelSurfaceBrightness,surfaceBrightnessLimit,cosmologyFunctions_,haloMassFunction_,surveyGeometry_)
+    self=posteriorSampleLikelihoodMassFunction(massHaloMinimum,massHaloMaximum,redshiftMinimum,redshiftMaximum,useSurveyLimits,char(massFunctionFileName),modelSurfaceBrightness,surfaceBrightnessLimit,cosmologyFunctions_,haloMassFunction_,surveyGeometry_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="cosmologyFunctions_"/>
@@ -174,7 +174,7 @@ contains
     return
   end function massFunctionConstructorParameters
 
-  function massFunctionConstructorInternal(haloMassMinimum,haloMassMaximum,redshiftMinimum,redshiftMaximum,useSurveyLimits,massFunctionFileName,modelSurfaceBrightness,surfaceBrightnessLimit,cosmologyFunctions_,haloMassFunction_,surveyGeometry_) result(self)
+  function massFunctionConstructorInternal(massHaloMinimum,massHaloMaximum,redshiftMinimum,redshiftMaximum,useSurveyLimits,massFunctionFileName,modelSurfaceBrightness,surfaceBrightnessLimit,cosmologyFunctions_,haloMassFunction_,surveyGeometry_) result(self)
     !!{RST
     Constructor for the :galacticus-class:`posteriorSampleLikelihoodMassFunction` posterior sampling likelihood class.
     !!}
@@ -185,7 +185,7 @@ contains
     use :: Linear_Algebra, only : assignment(=)
     type            (posteriorSampleLikelihoodMassFunction)                              :: self
     double precision                                       , intent(in   )               :: redshiftMinimum        , redshiftMaximum       , &
-         &                                                                                  haloMassMinimum        , haloMassMaximum       , &
+         &                                                                                  massHaloMinimum        , massHaloMaximum       , &
          &                                                                                  surfaceBrightnessLimit
     logical                                                , intent(in   )               :: useSurveyLimits        , modelSurfaceBrightness
     character       (len=*                                ), intent(in   )               :: massFunctionFileName
@@ -198,11 +198,11 @@ contains
     type            (matrix                               )                              :: eigenVectors
     type            (vector                               )                              :: eigenValues
     !![
-    <constructorAssign variables="haloMassMinimum, haloMassMaximum, redshiftMinimum, redshiftMaximum, modelSurfaceBrightness, surfaceBrightnessLimit, useSurveyLimits, massFunctionFileName, *cosmologyFunctions_, *haloMassFunction_, *surveyGeometry_"/>
+    <constructorAssign variables="massHaloMinimum, massHaloMaximum, redshiftMinimum, redshiftMaximum, modelSurfaceBrightness, surfaceBrightnessLimit, useSurveyLimits, massFunctionFileName, *cosmologyFunctions_, *haloMassFunction_, *surveyGeometry_"/>
     !!]
 
-    self%logHaloMassMinimum=log10(haloMassMinimum)
-    self%logHaloMassMaximum=log10(haloMassMaximum)
+    self%logMassHaloMinimum=log10(massHaloMinimum)
+    self%logMassHaloMaximum=log10(massHaloMaximum)
     ! Read the mass function file.
     !$ call hdf5Access%set()
     massFunctionFile=hdf5File(inputPath(pathTypeDataStatic)//massFunctionFileName,readOnly=.true.)
@@ -414,54 +414,54 @@ contains
       integer                                         :: errorStatus
       type            (varying_string)                :: message
       character       (len=14        )                :: label
-      double precision                                :: haloMassMinimum, haloMassMaximum
+      double precision                                :: massHaloMinimum, massHaloMaximum
 
       ! Check for zero contribution from the ends of our halo mass range.
-      haloMassMinimum=10.0d0**self%logHaloMassMinimum
-      haloMassMaximum=10.0d0**self%logHaloMassMaximum
+      massHaloMinimum=10.0d0**self%logMassHaloMinimum
+      massHaloMaximum=10.0d0**self%logMassHaloMaximum
       if          (                                                                                  &
-           &        conditionalMassFunction_%massFunction(      haloMassMinimum,self%massMinimum(i)) &
+           &        conditionalMassFunction_%massFunction(      massHaloMinimum,self%massMinimum(i)) &
            &         ==                                                                              &
-           &        conditionalMassFunction_%massFunction(      haloMassMinimum,self%massMaximum(i)) &
+           &        conditionalMassFunction_%massFunction(      massHaloMinimum,self%massMaximum(i)) &
            &       .and.                                                                             &
-           &        conditionalMassFunction_%massFunction(      haloMassMinimum,self%massMinimum(i)) &
+           &        conditionalMassFunction_%massFunction(      massHaloMinimum,self%massMinimum(i)) &
            &         ==                                                                              &
            &        0.0d0                                                                            &
            &       .and.                                                                             &
-           &        conditionalMassFunction_%massFunction(      haloMassMaximum,self%massMinimum(i)) &
+           &        conditionalMassFunction_%massFunction(      massHaloMaximum,self%massMinimum(i)) &
            &         ==                                                                              &
-           &        conditionalMassFunction_%massFunction(      haloMassMaximum,self%massMaximum(i)) &
+           &        conditionalMassFunction_%massFunction(      massHaloMaximum,self%massMaximum(i)) &
            &       .and.                                                                             &
-           &        conditionalMassFunction_%massFunction(      haloMassMaximum,self%massMinimum(i)) &
+           &        conditionalMassFunction_%massFunction(      massHaloMaximum,self%massMinimum(i)) &
            &         >                                                                               &
            &        0.0d0                                                                            &
            &      ) then
          do while (                                                                                  &
-              &     conditionalMassFunction_%massFunction(2.0d0*haloMassMinimum,self%massMinimum(i)) &
+              &     conditionalMassFunction_%massFunction(2.0d0*massHaloMinimum,self%massMinimum(i)) &
               &      ==                                                                              &
-              &     conditionalMassFunction_%massFunction(2.0d0*haloMassMinimum,self%massMaximum(i)) &
+              &     conditionalMassFunction_%massFunction(2.0d0*massHaloMinimum,self%massMaximum(i)) &
               &    .and.                                                                             &
-              &     conditionalMassFunction_%massFunction(2.0d0*haloMassMinimum,self%massMinimum(i)) &
+              &     conditionalMassFunction_%massFunction(2.0d0*massHaloMinimum,self%massMinimum(i)) &
               &      ==                                                                              &
               &     0.0d0                                                                            &
               &   )
-            haloMassMinimum=2.0d0*haloMassMinimum
+            massHaloMinimum=2.0d0*massHaloMinimum
          end do
          do while (                                                                                  &
-              &     conditionalMassFunction_%massFunction(0.5d0*haloMassMaximum,self%massMinimum(i)) &
+              &     conditionalMassFunction_%massFunction(0.5d0*massHaloMaximum,self%massMinimum(i)) &
               &      ==                                                                              &
-              &     conditionalMassFunction_%massFunction(0.5d0*haloMassMaximum,self%massMaximum(i)) &
+              &     conditionalMassFunction_%massFunction(0.5d0*massHaloMaximum,self%massMaximum(i)) &
               &    .and.                                                                             &
-              &     conditionalMassFunction_%massFunction(0.5d0*haloMassMaximum,self%massMinimum(i)) &
+              &     conditionalMassFunction_%massFunction(0.5d0*massHaloMaximum,self%massMinimum(i)) &
               &      >                                                                               &
               &     0.0d0                                                                            &
               &   )
-            haloMassMaximum=0.5d0*haloMassMaximum
+            massHaloMaximum=0.5d0*massHaloMaximum
          end do
       end if
       time                =timePrime
       integrator_                        = integrator                                               (likelihoodMassFunctionHaloMassIntegrand,toleranceRelative=1.0d-3                ,toleranceAbsolute=1.0d-9     )
-      likelihoodMassFunctionTimeIntegrand=+integrator_                    %integrate                (log10(haloMassMinimum)                 ,                  log10(haloMassMaximum),status           =errorStatus) &
+      likelihoodMassFunctionTimeIntegrand=+integrator_                    %integrate                (log10(massHaloMinimum)                 ,                  log10(massHaloMaximum),status           =errorStatus) &
            &                              *self       %cosmologyFunctions_%comovingVolumeElementTime(timePrime                                                                                                     )
       if (errorStatus /= errorStatusSuccess) then
          message='integration failed - state vector follows'

--- a/source/models/likelihoods/projected_correlation_function.F90
+++ b/source/models/likelihoods/projected_correlation_function.F90
@@ -112,7 +112,7 @@ contains
     class           (darkMatterProfileDMOClass                         ), pointer       :: darkMatterProfileDMO_
     class           (darkMatterHaloBiasClass                           ), pointer       :: darkMatterHaloBias_
     class           (darkMatterProfileScaleRadiusClass                 ), pointer       :: darkMatterProfileScaleRadius_
-    double precision                                                                    :: massHaloMinimum    , massHaloMaximum, &
+    double precision                                                                    :: massHaloMinimum              , massHaloMaximum, &
          &                                                                                 lineOfSightDepth
     logical                                                                             :: halfIntegral
     type            (varying_string                                    )                :: fileName

--- a/source/models/likelihoods/projected_correlation_function.F90
+++ b/source/models/likelihoods/projected_correlation_function.F90
@@ -70,7 +70,7 @@
      class           (darkMatterProfileDMOClass        ), pointer                     :: darkMatterProfileDMO_                => null()
      class           (darkMatterHaloBiasClass          ), pointer                     :: darkMatterHaloBias_                  => null()
      class           (darkMatterProfileScaleRadiusClass), pointer                     :: darkMatterProfileScaleRadius_        => null()
-     double precision                                                                 :: haloMassMinimum                               , haloMassMaximum             , &
+     double precision                                                                 :: massHaloMinimum                               , massHaloMaximum             , &
           &                                                                              lineOfSightDepth
      logical                                                                          :: halfIntegral
      double precision                                   , dimension(:  ), allocatable :: separation                                    , massMaximum                 , &
@@ -112,21 +112,21 @@ contains
     class           (darkMatterProfileDMOClass                         ), pointer       :: darkMatterProfileDMO_
     class           (darkMatterHaloBiasClass                           ), pointer       :: darkMatterHaloBias_
     class           (darkMatterProfileScaleRadiusClass                 ), pointer       :: darkMatterProfileScaleRadius_
-    double precision                                                                    :: haloMassMinimum    , haloMassMaximum, &
+    double precision                                                                    :: massHaloMinimum    , massHaloMaximum, &
          &                                                                                 lineOfSightDepth
     logical                                                                             :: halfIntegral
     type            (varying_string                                    )                :: fileName
 
     !![
     <inputParameter docformat="rst">
-      <name>haloMassMinimum</name>
+      <name>massHaloMinimum</name>
       <description>
       The minimum halo mass over which to integrate.
       </description>
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>haloMassMaximum</name>
+      <name>massHaloMaximum</name>
       <description>
       The maximum halo mass over which to integrate.
       </description>
@@ -162,7 +162,7 @@ contains
     <objectBuilder class="darkMatterHaloBias"           name="darkMatterHaloBias_"           source="parameters"/>
     <objectBuilder class="darkMatterProfileScaleRadius" name="darkMatterProfileScaleRadius_" source="parameters"/>
     !!]
-    self=posteriorSampleLikelihoodPrjctdCorrelationFunction(haloMassMinimum,haloMassMaximum,lineOfSightDepth,halfIntegral,char(fileName),powerSpectrum_,cosmologyFunctions_,surveyGeometry_,darkMatterHaloScale_,haloMassFunction_,darkMatterProfileDMO_,darkMatterHaloBias_,darkMatterProfileScaleRadius_)
+    self=posteriorSampleLikelihoodPrjctdCorrelationFunction(massHaloMinimum,massHaloMaximum,lineOfSightDepth,halfIntegral,char(fileName),powerSpectrum_,cosmologyFunctions_,surveyGeometry_,darkMatterHaloScale_,haloMassFunction_,darkMatterProfileDMO_,darkMatterHaloBias_,darkMatterProfileScaleRadius_)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="powerSpectrum_"               />
@@ -177,7 +177,7 @@ contains
     return
   end function projectedCorrelationFunctionConstructorParameters
 
-  function projectedCorrelationFunctionConstructorInternal(haloMassMinimum,haloMassMaximum,lineOfSightDepth,halfIntegral,fileName,powerSpectrum_,cosmologyFunctions_,surveyGeometry_,darkMatterHaloScale_,haloMassFunction_,darkMatterProfileDMO_,darkMatterHaloBias_,darkMatterProfileScaleRadius_) result(self)
+  function projectedCorrelationFunctionConstructorInternal(massHaloMinimum,massHaloMaximum,lineOfSightDepth,halfIntegral,fileName,powerSpectrum_,cosmologyFunctions_,surveyGeometry_,darkMatterHaloScale_,haloMassFunction_,darkMatterProfileDMO_,darkMatterHaloBias_,darkMatterProfileScaleRadius_) result(self)
     !!{RST
     Constructor for the :galacticus-class:`posteriorSampleLikelihoodPrjctdCorrelationFunction` posterior sampling likelihood class.
     !!}
@@ -188,7 +188,7 @@ contains
     use :: ISO_Varying_String, only : operator(//)
     implicit none
     type            (posteriorSampleLikelihoodPrjctdCorrelationFunction)                        :: self
-    double precision                                                    , intent(in   )         :: haloMassMinimum    , haloMassMaximum, &
+    double precision                                                    , intent(in   )         :: massHaloMinimum    , massHaloMaximum, &
          &                                                                                         lineOfSightDepth
     logical                                                             , intent(in   )         :: halfIntegral
     character       (len=*                                             ), intent(in   )         :: fileName
@@ -202,7 +202,7 @@ contains
     class           (darkMatterProfileScaleRadiusClass                 ), intent(in   ), target :: darkMatterProfileScaleRadius_
     type            (hdf5File                                          )                        :: file
     !![
-    <constructorAssign variables="haloMassMinimum, haloMassMaximum, lineOfSightDepth, halfIntegral, fileName, *powerSpectrum_, *cosmologyFunctions_, *surveyGeometry_, *darkMatterHaloScale_, *haloMassFunction_, *darkMatterProfileDMO_, *darkMatterHaloBias_, *darkMatterProfileScaleRadius_"/>
+    <constructorAssign variables="massHaloMinimum, massHaloMaximum, lineOfSightDepth, halfIntegral, fileName, *powerSpectrum_, *cosmologyFunctions_, *surveyGeometry_, *darkMatterHaloScale_, *haloMassFunction_, *darkMatterProfileDMO_, *darkMatterHaloBias_, *darkMatterProfileScaleRadius_"/>
     !!]
 
     ! Read the projected correlation function file.
@@ -317,8 +317,8 @@ contains
             &                                self%separation                        , &
             &                                self%massMinimum                  (  i), &
             &                                self%massMaximum                  (  i), &
-            &                                self%haloMassMinimum                   , &
-            &                                self%haloMassMaximum                   , &
+            &                                self%massHaloMinimum                   , &
+            &                                self%massHaloMaximum                   , &
             &                                self%lineOfSightDepth                  , &
             &                                self%halfIntegral                      , &
             &                                self%projectedCorrelationFunction (:,i)  &

--- a/source/nodes/operators/physics/dark_matter_profile/prompt_cusp.F90
+++ b/source/nodes/operators/physics/dark_matter_profile/prompt_cusp.F90
@@ -44,7 +44,7 @@
 
       &lt;mergerTreeOperator value="pruneByFilter"&gt;
         &lt;preservePrimaryProgenitor value="false"/&gt;
-        &lt;galacticFilter value="labelled"&gt;
+        &lt;galacticFilter value="labeled"&gt;
           &lt;label value="promptCuspUnformed"/&gt;
         &lt;/galacticFilter&gt;
       &lt;/mergerTreeOperator&gt;
@@ -497,7 +497,7 @@ contains
           ! (https://github.com/galacticusorg/cusp-halo-relation) returns NaN otherwise. Since prompt cusp formation is, by
           ! definition, the formation event of a halo, a halo in which no cusp can form is one which can not itself exist. Such
           ! nodes are assigned no cusp and are labeled, so that they may subsequently be pruned from the tree (for example by a
-          ! `mergerTreeOperatorPruneByFilter` operator using a `galacticFilterLabelled` filter). The case in which no solution
+          ! `mergerTreeOperatorPruneByFilter` operator using a `galacticFilterLabeled` filter). The case in which no solution
           ! exists at all (σ₀Collapse exceeds σ₀(t) at every epoch, which occurs for sufficiently low mass halos, since σ₀(t)
           ! grows only until the Universe becomes Λ-dominated and is constant thereafter) is treated identically - just as in the
           ! reference implementation, where such halos fall off the end of the interpolating table and are likewise assigned no

--- a/source/tasks/halo_mass_function.F90
+++ b/source/tasks/halo_mass_function.F90
@@ -75,7 +75,7 @@
      class           (darkMatterHaloMassAccretionHistoryClass), pointer                   :: darkMatterHaloMassAccretionHistory_ => null()
      class           (darkMatterHaloSplashbackRadiusClass    ), pointer                   :: darkMatterHaloSplashbackRadius_     => null()
      class           (randomNumberGeneratorClass             ), pointer                   :: randomNumberGenerator_              => null()
-     double precision                                                                     :: haloMassMinimum                              , haloMassMaximum                     , &
+     double precision                                                                     :: massHaloMinimum                              , massHaloMaximum                     , &
           &                                                                                  pointsPerDecade
      type            (varying_string                         )                            :: outputGroup
      logical                                                                              :: includeUnevolvedSubhaloMassFunction          , includeMassAccretionRate            , &
@@ -141,7 +141,7 @@ contains
     type            (varying_string                         ), allocatable  , dimension(:) :: labels
     double precision                                         , allocatable  , dimension(:) :: fractionModeMasses
     type            (varying_string                         )                              :: outputGroup
-    double precision                                                                       :: haloMassMinimum                    , haloMassMaximum           , &
+    double precision                                                                       :: massHaloMinimum                    , massHaloMaximum           , &
          &                                                                                    pointsPerDecade
     logical                                                                                :: includeUnevolvedSubhaloMassFunction, includeMassAccretionRate  , &
           &                                                                                   massesRelativeToHalfModeMass       , errorsAreFatal            , &
@@ -164,7 +164,7 @@ contains
     self%nodeComponentsInitialized=.true.
     !![
     <inputParameter docformat="rst">
-      <name>haloMassMinimum</name>
+      <name>massHaloMinimum</name>
       <defaultValue>1.0d10</defaultValue>
       <description>
       The minimum mass at which to tabulate halo mass functions.
@@ -172,7 +172,7 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>haloMassMaximum</name>
+      <name>massHaloMaximum</name>
       <defaultValue>1.0d15</defaultValue>
       <description>
       The maximum mass at which to tabulate halo mass functions.
@@ -304,8 +304,8 @@ contains
     <conditionalCall>
       <call>
 	self=taskHaloMassFunction(                                     &amp;
-         &amp;                    haloMassMinimum                    , &amp;
-         &amp;                    haloMassMaximum                    , &amp;
+         &amp;                    massHaloMinimum                    , &amp;
+         &amp;                    massHaloMaximum                    , &amp;
          &amp;                    pointsPerDecade                    , &amp;
          &amp;                    outputGroup                        , &amp;
          &amp;                    includeUnevolvedSubhaloMassFunction, &amp;
@@ -381,8 +381,8 @@ contains
   end function haloMassFunctionConstructorParameters
 
   function haloMassFunctionConstructorInternal(                                     &
-       &                                       haloMassMinimum                    , &
-       &                                       haloMassMaximum                    , &
+       &                                       massHaloMinimum                    , &
+       &                                       massHaloMaximum                    , &
        &                                       pointsPerDecade                    , &
        &                                       outputGroup                        , &
        &                                       includeUnevolvedSubhaloMassFunction, &
@@ -440,7 +440,7 @@ contains
     class           (randomNumberGeneratorClass             ), intent(in   ), target                 :: randomNumberGenerator_
     type            (virialDensityContrastList              ), intent(in   ), dimension(:)           :: virialDensityContrasts
     type            (varying_string                         ), intent(in   )                         :: outputGroup
-    double precision                                         , intent(in   )                         :: haloMassMinimum                    , haloMassMaximum           , &
+    double precision                                         , intent(in   )                         :: massHaloMinimum                    , massHaloMaximum           , &
          &                                                                                              pointsPerDecade
     logical                                                  , intent(in   )                         :: includeUnevolvedSubhaloMassFunction, includeMassAccretionRate  , &
          &                                                                                              massesRelativeToHalfModeMass       , errorsAreFatal            , &
@@ -449,7 +449,7 @@ contains
     type            (inputParameters                        ), intent(in   ), target                 :: parameters
     integer                                                                                          :: i
     !![
-    <constructorAssign variables="haloMassMinimum, haloMassMaximum, pointsPerDecade, outputGroup, includeUnevolvedSubhaloMassFunction, includeMassAccretionRate, includeSplashbackRadius, massesRelativeToHalfModeMass, errorsAreFatal, fractionModeMasses, *cosmologyParameters_, *cosmologyFunctions_, *virialDensityContrast_, *criticalOverdensity_, *linearGrowth_, *haloMassFunction_, *haloEnvironment_, *unevolvedSubhaloMassFunction_, *darkMatterHaloScale_, *darkMatterProfileScaleRadius_, *darkMatterProfileShape_, *darkMatterHaloMassAccretionHistory_, *darkMatterHaloSplashbackRadius_, *cosmologicalMassVariance_, *darkMatterHaloBias_, *transferFunction_, *transferFunctionReference, *transferFunctionRelative, *outputTimes_, *randomNumberGenerator_"/>
+    <constructorAssign variables="massHaloMinimum, massHaloMaximum, pointsPerDecade, outputGroup, includeUnevolvedSubhaloMassFunction, includeMassAccretionRate, includeSplashbackRadius, massesRelativeToHalfModeMass, errorsAreFatal, fractionModeMasses, *cosmologyParameters_, *cosmologyFunctions_, *virialDensityContrast_, *criticalOverdensity_, *linearGrowth_, *haloMassFunction_, *haloEnvironment_, *unevolvedSubhaloMassFunction_, *darkMatterHaloScale_, *darkMatterProfileScaleRadius_, *darkMatterProfileShape_, *darkMatterHaloMassAccretionHistory_, *darkMatterHaloSplashbackRadius_, *cosmologicalMassVariance_, *darkMatterHaloBias_, *transferFunction_, *transferFunctionReference, *transferFunctionRelative, *outputTimes_, *randomNumberGenerator_"/>
     !!]
 
     self%parameters => parameters
@@ -623,7 +623,7 @@ contains
     allocate(outputTurnaroundRadius                        (outputCount))
     allocate(outputCharacteristicMass                      (outputCount))
     ! Compute number of tabulation points.
-    massCount=int(log10(self%haloMassMaximum/self%haloMassMinimum)*self%pointsPerDecade)+1
+    massCount=int(log10(self%massHaloMaximum/self%massHaloMinimum)*self%pointsPerDecade)+1
     allocate(massHalo                                      (massCount            ))
     allocate(massHaloOutput                                (massCount            ))
     allocate(massFunctionDifferential                      (massCount,outputCount))
@@ -657,11 +657,11 @@ contains
        if (outputCharacteristicMass(iOutput) > 0.0d0) then
           massCritical=outputCharacteristicMass(iOutput)
        else
-          massCritical=self%haloMassMinimum
+          massCritical=self%massHaloMinimum
        end if
        outputCriticalOverdensities(iOutput)=self%criticalOverdensity_  %value                      (mass=     massCritical   ,time=outputTimes           (iOutput))
-       outputVirialDensityContrast(iOutput)=self%virialDensityContrast_%densityContrast            (mass=self%haloMassMinimum,time=outputTimes           (iOutput))
-       outputTurnaroundRadius     (iOutput)=self%virialDensityContrast_%turnAroundOverVirialRadii  (mass=self%haloMassMinimum,time=outputTimes           (iOutput))
+       outputVirialDensityContrast(iOutput)=self%virialDensityContrast_%densityContrast            (mass=self%massHaloMinimum,time=outputTimes           (iOutput))
+       outputTurnaroundRadius     (iOutput)=self%virialDensityContrast_%turnAroundOverVirialRadii  (mass=self%massHaloMinimum,time=outputTimes           (iOutput))
     end do
     ! Get half- and quarter-mode masses.
     massHalfMode   =self%transferFunction_%halfModeMass   (statusHalfModeMass   )
@@ -718,8 +718,8 @@ contains
     ! Initialize warnings state.
     warnedIntegratedFailure=.false.
     ! Build a range of halo masses.
-    massHaloMinimum            =self%haloMassMinimum
-    massHaloMaximum            =self%haloMassMaximum
+    massHaloMinimum            =self%massHaloMinimum
+    massHaloMaximum            =self%massHaloMaximum
     if (self%massesRelativeToHalfModeMass) then
        if (statusHalfModeMassReference /= errorStatusSuccess) call Error_Report('half-mode mass is not defined'//{introspection:location})
        massHaloMinimum=massHaloMinimum*massHalfModeReference

--- a/source/tasks/halo_spin_distribution.F90
+++ b/source/tasks/halo_spin_distribution.F90
@@ -39,7 +39,7 @@
      class           (cosmologyFunctionsClass  ), pointer :: cosmologyFunctions_       => null()
      class           (darkMatterHaloScaleClass ), pointer :: darkMatterHaloScale_      => null()
      double precision                                     :: spinMinimum                         , spinMaximum    , &
-          &                                                  spinPointsPerDecade                 , haloMassMinimum
+          &                                                  spinPointsPerDecade                 , massHaloMinimum
      type            (varying_string           )          :: outputGroup
      ! Pointer to the parameters for this task.
      type            (inputParameters          )          :: parameters
@@ -76,7 +76,7 @@ contains
     type            (inputParameters          ), pointer               :: parametersRoot
     type            (varying_string           )                        :: outputGroup
     double precision                                                   :: spinMinimum          , spinMaximum    , &
-         &                                                                spinPointsPerDecade  , haloMassMinimum
+         &                                                                spinPointsPerDecade  , massHaloMinimum
 
     ! Ensure the nodes objects are initialized.
     if (associated(parameters%parent)) then
@@ -121,8 +121,8 @@ contains
       <source>parameters</source>
     </inputParameter>
     <inputParameter docformat="rst">
-      <name>haloMassMinimum</name>
-      <variable>haloMassMinimum</variable>
+      <name>massHaloMinimum</name>
+      <variable>massHaloMinimum</variable>
       <defaultValue>0.0d0</defaultValue>
       <description>
       Minimum halo mass above which spin distribution should be averaged.
@@ -142,7 +142,7 @@ contains
     <objectBuilder class="cosmologyFunctions"   name="cosmologyFunctions_"   source="parameters"/>
     <objectBuilder class="darkMatterHaloScale"  name="darkMatterHaloScale_"  source="parameters"/>
     !!]
-    self=taskHaloSpinDistribution(spinMinimum,spinMaximum,spinPointsPerDecade,haloMassMinimum,outputGroup,darkMatterHaloScale_,haloSpinDistribution_,outputTimes_,cosmologyFunctions_,parametersRoot)
+    self=taskHaloSpinDistribution(spinMinimum,spinMaximum,spinPointsPerDecade,massHaloMinimum,outputGroup,darkMatterHaloScale_,haloSpinDistribution_,outputTimes_,cosmologyFunctions_,parametersRoot)
     !![
     <inputParametersValidate source="parameters"/>
     <objectDestructor name="haloSpinDistribution_"/>
@@ -153,7 +153,7 @@ contains
     return
   end function haloSpinDistributionConstructorParameters
 
-  function haloSpinDistributionConstructorInternal(spinMinimum,spinMaximum,spinPointsPerDecade,haloMassMinimum,outputGroup,darkMatterHaloScale_,haloSpinDistribution_,outputTimes_,cosmologyFunctions_,parameters) result(self)
+  function haloSpinDistributionConstructorInternal(spinMinimum,spinMaximum,spinPointsPerDecade,massHaloMinimum,outputGroup,darkMatterHaloScale_,haloSpinDistribution_,outputTimes_,cosmologyFunctions_,parameters) result(self)
     !!{RST
     Constructor for the :galacticus-class:`taskHaloSpinDistribution` task class which takes a parameter set as input.
     !!}
@@ -165,10 +165,10 @@ contains
     class           (darkMatterHaloScaleClass ), intent(in   ), target :: darkMatterHaloScale_
     type            (varying_string           ), intent(in   )         :: outputGroup
     double precision                           , intent(in   )         :: spinMinimum          , spinMaximum    , &
-         &                                                                spinPointsPerDecade  , haloMassMinimum
+         &                                                                spinPointsPerDecade  , massHaloMinimum
     type            (inputParameters          ), intent(in   ), target :: parameters
     !![
-    <constructorAssign variables="spinMinimum, spinMaximum, spinPointsPerDecade, haloMassMinimum, outputGroup, *darkMatterHaloScale_, *haloSpinDistribution_, *outputTimes_, *cosmologyFunctions_"/>
+    <constructorAssign variables="spinMinimum, spinMaximum, spinPointsPerDecade, massHaloMinimum, outputGroup, *darkMatterHaloScale_, *haloSpinDistribution_, *outputTimes_, *cosmologyFunctions_"/>
     !!]
 
     self%parameters=inputParameters(parameters)
@@ -250,7 +250,7 @@ contains
           spin(iSpin)=exp(log(self%spinMinimum)+log(self%spinMaximum/self%spinMinimum)*dble(iSpin-1)/dble(spinCount-1))
           call nodeSpin%angularMomentumSet(spin(iSpin)*Dark_Matter_Halo_Angular_Momentum_Scale(node,self%darkMatterHaloScale_))
           ! Evaluate the distribution.
-          if (self%haloMassMinimum <= 0.0d0) then
+          if (self%massHaloMinimum <= 0.0d0) then
              ! No minimum halo mass specified - simply evaluate the spin distribution.
              spinDistribution(iSpin)=self%haloSpinDistribution_%distribution(node)
           else
@@ -258,7 +258,7 @@ contains
              ! supports this.
              select type (haloSpinDistribution_ => self%haloSpinDistribution_)
              class is (haloSpinDistributionNbodyErrors)
-                spinDistribution(iSpin)=haloSpinDistribution_%distributionAveraged(node,self%haloMassMinimum)
+                spinDistribution(iSpin)=haloSpinDistribution_%distributionAveraged(node,self%massHaloMinimum)
              class default
                 call Error_Report('halo spin distribution class does not support averaging over halo mass'//{introspection:location})
              end select

--- a/source/tests/mass_distributions.F90
+++ b/source/tests/mass_distributions.F90
@@ -335,7 +335,7 @@ program Test_Mass_Distributions
   allocate(massDistributionBetaProfile :: massDistribution_)
   select type (massDistribution_)
   type is (massDistributionBetaProfile)
-     massDistribution_=massDistributionBetaProfile(beta=2.0d0/3.0d0,coreRadius=3.8492316686261747d-002,mass=182582297.19568533d0,outerRadius=0.12829569846196026d0)
+     massDistribution_=massDistributionBetaProfile(beta=2.0d0/3.0d0,radiusCore=3.8492316686261747d-002,mass=182582297.19568533d0,radiusOuter=0.12829569846196026d0)
   end select
   select type (massDistribution_)
   class is (massDistributionSpherical)
@@ -583,7 +583,7 @@ program Test_Mass_Distributions
   end select
   select type (massDistribution_ => massDistributions%next%massDistribution_)
   type is (massDistributionExponentialDisk)
-     massDistribution_=massDistributionExponentialDisk(mass=5.7d10,scaleRadius=2.9d-3,scaleHeight=0.3d-3,componentType=componentTypeDisk    )
+     massDistribution_=massDistributionExponentialDisk(mass=5.7d10,radiusScale=2.9d-3,scaleHeight=0.3d-3,componentType=componentTypeDisk    )
   end select
   allocate(massDistributionComposite :: massDistribution_)
   select type (massDistribution_)
@@ -715,7 +715,7 @@ program Test_Mass_Distributions
      end select
      select type (massDistribution_ => massDistributions%next%massDistribution_)
      type is (massDistributionExponentialDisk)
-        massDistribution_=massDistributionExponentialDisk(mass=5.7d10,scaleRadius=2.9d-3,scaleHeight=0.3d-3,componentType=componentTypeDisk    )
+        massDistribution_=massDistributionExponentialDisk(mass=5.7d10,radiusScale=2.9d-3,scaleHeight=0.3d-3,componentType=componentTypeDisk    )
      end select
      allocate(massDistributionComposite :: massDistribution_)
      select type (massDistribution_)
@@ -758,7 +758,7 @@ program Test_Mass_Distributions
   allocate(massDistributionNFW :: massDistributionDMO)
   select type (massDistributionDMO)
   type is (massDistributionNFW)
-     massDistributionDMO=massDistributionNFW(scaleLength=30.0d-3,virialRadius=300.0d-3,mass=1.0d12,dimensionless=.false.)
+     massDistributionDMO=massDistributionNFW(scaleLength=30.0d-3,radiusVirial=300.0d-3,mass=1.0d12,dimensionless=.false.)
   end select
   allocate(massDistributionPatejLoeb2015 :: massDistribution_)
   select type (massDistribution_)
@@ -1122,13 +1122,13 @@ program Test_Mass_Distributions
     ! small-argument series expansion below a half-radius of 1e-3, the cached factor used at exactly one scale radius, and the
     ! point-mass approximation beyond `radiusMaximum`=30 scale radii. r=4 gives a half-radius of 2, inside the seed range;
     ! r=28 gives 14, outside it, and so forces a genuine extension.
-    diskExtended         =massDistributionExponentialDisk(scaleRadius=1.0d0,mass=1.0d0)
+    diskExtended         =massDistributionExponentialDisk(radiusScale=1.0d0,mass=1.0d0)
     velocityProbe        =diskExtended%rotationCurve( 4.0d0)
     velocityFar          =diskExtended%rotationCurve(28.0d0)
     velocityAfterExtension=diskExtended%rotationCurve( 4.0d0)
     call Assert("exponential disk: extension preserves a tabulated rotation curve",velocityAfterExtension == velocityProbe,.true.)
     ! A disk driven straight to the wider range must agree bit-for-bit with one which reached it by extension.
-    diskDirect           =massDistributionExponentialDisk(scaleRadius=1.0d0,mass=1.0d0)
+    diskDirect           =massDistributionExponentialDisk(radiusScale=1.0d0,mass=1.0d0)
     velocityDirect       =diskDirect  %rotationCurve(28.0d0)
     call Assert("exponential disk: rotation curve is independent of the order of requests",velocityDirect == velocityFar,.true.)
     call Assert("exponential disk: probe value is independent of the order of requests",diskDirect%rotationCurve(4.0d0) == velocityProbe,.true.)

--- a/testSuite/parameters/constrainHaloMassFunction.xml
+++ b/testSuite/parameters/constrainHaloMassFunction.xml
@@ -8,8 +8,8 @@
 
   <!-- Task -->
   <task value="haloMassFunction">
-    <haloMassMinimum value="5.61018340369020e08"/>
-    <haloMassMaximum value="8.91236460596131e15"/>
+    <massHaloMinimum value="5.61018340369020e08"/>
+    <massHaloMaximum value="8.91236460596131e15"/>
     <pointsPerDecade value="10"/>
   </task>
   <outputFileName value="testSuite/outputs/constrainHaloMassFunction.hdf5"/>

--- a/testSuite/parameters/decayingDarkMatterHaloMassFunction.xml
+++ b/testSuite/parameters/decayingDarkMatterHaloMassFunction.xml
@@ -18,8 +18,8 @@
 
   <!-- Specify tasks to perform -->
   <task value="haloMassFunction">
-    <haloMassMinimum value="1.0e13"/>
-    <haloMassMaximum value="1.0e16"/>
+    <massHaloMinimum value="1.0e13"/>
+    <massHaloMaximum value="1.0e16"/>
     <pointsPerDecade value="10"/>
     <includeMassAccretionRate value="false"/>
     <errorsAreFatal value="false"/>

--- a/testSuite/parameters/haloMassFunctionsBase.xml
+++ b/testSuite/parameters/haloMassFunctionsBase.xml
@@ -8,8 +8,8 @@
 
   <!-- Task -->
   <task value="haloMassFunction">
-    <haloMassMinimum value="1.0e10"/>
-    <haloMassMaximum value="1.0e15"/>
+    <massHaloMinimum value="1.0e10"/>
+    <massHaloMaximum value="1.0e15"/>
     <pointsPerDecade value="20"/>
   </task>
   <outputFileName value=""/>

--- a/testSuite/parameters/memoryLeakMCMCHMFParameters.xml
+++ b/testSuite/parameters/memoryLeakMCMCHMFParameters.xml
@@ -84,8 +84,8 @@
     <massParticle value="4.02830e05" />
   </simulation>
   <task value="haloMassFunction">
-    <haloMassMaximum value=" 1.122018454e16" />
-    <haloMassMinimum value=" 1.122018454e06" />
+    <massHaloMaximum value=" 1.122018454e16" />
+    <massHaloMinimum value=" 1.122018454e06" />
     <includeMassAccretionRate value="false" />
     <includeUnevolvedSubhaloMassFunction value="false" />
     <pointsPerDecade value="10.0" />

--- a/testSuite/parameters/posteriorSampleProposalLogParameters.xml
+++ b/testSuite/parameters/posteriorSampleProposalLogParameters.xml
@@ -84,8 +84,8 @@
     <massParticle value="4.02830e05" />
   </simulation>
   <task value="haloMassFunction">
-    <haloMassMaximum value=" 1.122018454e16" />
-    <haloMassMinimum value=" 1.122018454e06" />
+    <massHaloMaximum value=" 1.122018454e16" />
+    <massHaloMinimum value=" 1.122018454e06" />
     <includeMassAccretionRate value="false" />
     <includeUnevolvedSubhaloMassFunction value="false" />
     <pointsPerDecade value="10.0" />

--- a/testSuite/parameters/promptCuspsUnformed.xml
+++ b/testSuite/parameters/promptCuspsUnformed.xml
@@ -443,7 +443,7 @@
     <mergerTreeOperator value="pruneByFilter">
       <preservePrimaryProgenitor value="false"/>
       <pruneAllProgenitors       value="true" />
-      <galacticFilter value="labelled">
+      <galacticFilter value="labeled">
         <label value="promptCuspUnformed"/>
       </galacticFilter>
     </mergerTreeOperator>

--- a/testSuite/parameters/splashbackRadius.xml
+++ b/testSuite/parameters/splashbackRadius.xml
@@ -7,8 +7,8 @@
 
   <!-- Specify tasks to perform -->
   <task value="haloMassFunction">
-    <haloMassMinimum value="1.0e12"/>
-    <haloMassMaximum value="1.0e15"/>
+    <massHaloMinimum value="1.0e12"/>
+    <massHaloMaximum value="1.0e15"/>
     <pointsPerDecade value="4"/>
     <includeMassAccretionRate value="true"/>
     <includeSplashbackRadius value="true"/>

--- a/testSuite/parameters/testPromptCuspNFW.xml
+++ b/testSuite/parameters/testPromptCuspNFW.xml
@@ -441,7 +441,7 @@
     <mergerTreeOperator value="pruneByFilter">
       <preservePrimaryProgenitor value="false"/>
       <pruneAllProgenitors       value="true" />
-      <galacticFilter value="labelled">
+      <galacticFilter value="labeled">
         <label value="promptCuspUnformed"/>
       </galacticFilter>
     </mergerTreeOperator>

--- a/testSuite/parameters/testPruneLightconePruned.xml
+++ b/testSuite/parameters/testPruneLightconePruned.xml
@@ -66,7 +66,7 @@
       <mass value="1.0"/>
       <massType value="unknown"/>
       <scaleHeight value="0.137"/>
-      <scaleRadius value="1.0"/>
+      <radiusScale value="1.0"/>
     </massDistributionDisk>
     <diskNegativeAngularMomentumAllowed value="true"/>
     <inactiveLuminositiesStellar value="false"/>

--- a/testSuite/parameters/testPruneLightconeUnpruned.xml
+++ b/testSuite/parameters/testPruneLightconeUnpruned.xml
@@ -66,7 +66,7 @@
       <mass value="1.0"/>
       <massType value="unknown"/>
       <scaleHeight value="0.137"/>
-      <scaleRadius value="1.0"/>
+      <radiusScale value="1.0"/>
     </massDistributionDisk>
     <diskNegativeAngularMomentumAllowed value="true"/>
     <inactiveLuminositiesStellar value="false"/>

--- a/testSuite/parameters/treeFilterLabels.xml
+++ b/testSuite/parameters/treeFilterLabels.xml
@@ -280,7 +280,7 @@
       <label value="memberLMC"/>
       <galacticFilter value="anyDescendantNode">
         <allowSelf value="false"/>
-        <galacticFilter value="labelled">
+        <galacticFilter value="labeled">
           <label value="LMC"/>
         </galacticFilter>
       </galacticFilter>

--- a/testSuite/parameters/validate_baryonicSuppression_mergerTrees.xml
+++ b/testSuite/parameters/validate_baryonicSuppression_mergerTrees.xml
@@ -8,8 +8,8 @@
   <!-- Task -->
   <task value="multi">
     <task value="haloMassFunction"  >
-      <haloMassMinimum value="1.0e05"/>
-      <haloMassMaximum value="1.0e12"/>
+      <massHaloMinimum value="1.0e05"/>
+      <massHaloMaximum value="1.0e12"/>
       <pointsPerDecade value="10"    />
     </task>
     <task value="evolveForests"/>

--- a/testSuite/parameters/validation/haloMassFunction/haloMassFunction_COZMIC.xml
+++ b/testSuite/parameters/validation/haloMassFunction/haloMassFunction_COZMIC.xml
@@ -4,8 +4,8 @@
   <lastModified revision="3c57050dfc00cdbc7396b4210a9dc404b9fda859" time="2026-08-23T04:06:13"/>
   <!-- Task and output -->
   <task value="haloMassFunction">
-    <haloMassMinimum value=" 1.122018454e06"/>
-    <haloMassMaximum value=" 1.122018454e16"/>
+    <massHaloMinimum value=" 1.122018454e06"/>
+    <massHaloMaximum value=" 1.122018454e16"/>
     <pointsPerDecade value="10.0"/>
     <includeMassAccretionRate value="false"/>
     <includeUnevolvedSubhaloMassFunction value="false"/>

--- a/testSuite/parameters/validation/haloMassFunction/haloMassFunction_MDPL.xml
+++ b/testSuite/parameters/validation/haloMassFunction/haloMassFunction_MDPL.xml
@@ -4,8 +4,8 @@
   <lastModified revision="3c57050dfc00cdbc7396b4210a9dc404b9fda859" time="2026-08-23T04:06:13"/>
   <!-- Task and output -->
   <task value="haloMassFunction">
-    <haloMassMinimum value=" 1.122018454e06"/>
-    <haloMassMaximum value=" 1.122018454e16"/>
+    <massHaloMinimum value=" 1.122018454e06"/>
+    <massHaloMaximum value=" 1.122018454e16"/>
     <pointsPerDecade value="10.0"/>
     <includeMassAccretionRate value="false"/>
     <includeUnevolvedSubhaloMassFunction value="false"/>

--- a/testSuite/parameters/validation/haloMassFunction/haloMassFunction_Symphony.xml
+++ b/testSuite/parameters/validation/haloMassFunction/haloMassFunction_Symphony.xml
@@ -4,8 +4,8 @@
   <lastModified revision="3c57050dfc00cdbc7396b4210a9dc404b9fda859" time="2026-08-23T04:06:13"/>
   <!-- Task and output -->
   <task value="haloMassFunction">
-    <haloMassMinimum value=" 1.122018454e06"/>
-    <haloMassMaximum value=" 1.122018454e16"/>
+    <massHaloMinimum value=" 1.122018454e06"/>
+    <massHaloMaximum value=" 1.122018454e16"/>
     <pointsPerDecade value="10.0"/>
     <includeMassAccretionRate value="false"/>
     <includeUnevolvedSubhaloMassFunction value="false"/>

--- a/testSuite/regressions/haloMassFunctionWDMIndeterminateCollapseTime.xml
+++ b/testSuite/regressions/haloMassFunctionWDMIndeterminateCollapseTime.xml
@@ -8,7 +8,7 @@
 
   <!-- Specify tasks to perform -->
   <task value="haloMassFunction">
-    <haloMassMinimum value="1.0e7"/>    
+    <massHaloMinimum value="1.0e7"/>    
   </task>
 
   <!-- Component selection -->

--- a/testSuite/regressions/issue142.xml
+++ b/testSuite/regressions/issue142.xml
@@ -23,8 +23,8 @@
       <pointsPerDecade value="10"/>
     </task>
     <task value="haloMassFunction">
-      <haloMassMinimum value="1.0e06"/>
-      <haloMassMaximum value="1.0e15"/>
+      <massHaloMinimum value="1.0e06"/>
+      <massHaloMaximum value="1.0e15"/>
       <pointsPerDecade value="10"/>
     </task>
     <task value="evolveForests"/>

--- a/testSuite/test-halo-mass-functions.py
+++ b/testSuite/test-halo-mass-functions.py
@@ -62,8 +62,8 @@ for massFunctionType in massFunctionTypes:
     # Construct a parameter file for Galacticus.
     parameters = ET.parse('parameters/haloMassFunctionsBase.xml')
     ET.SubElement  (parameters.getroot(),'haloMassFunction'       ).set('value',                                 massFunctionType['method']             )
-    parameters.find('./task/haloMassMinimum'                      ).set('value',str(mass[ 0]                                                           ))
-    parameters.find('./task/haloMassMaximum'                      ).set('value',str(mass[-1]                                                           ))
+    parameters.find('./task/massHaloMinimum'                      ).set('value',str(mass[ 0]                                                           ))
+    parameters.find('./task/massHaloMaximum'                      ).set('value',str(mass[-1]                                                           ))
     parameters.find('./task/pointsPerDecade'                      ).set('value',str(1.0/parametersHMFCalc['dlog10m']                                   ))
     parameters.find('./cosmologyParameters/temperatureCMB'        ).set('value',str(    parametersHMFCalc['t_cmb'  ]                                   ))
     parameters.find('./cosmologyParameters/OmegaMatter'           ).set('value',str(    parametersHMFCalc['omegam' ]                                   ))


### PR DESCRIPTION
## Summary

Settles six input parameters that existed under two word orders on the noun-first form documented in the coding guide, and renames the last British spelling in a user-facing name. Implements priority 2 of the API naming-consistency audit; PR #1465 is priorities 1 and 5.

| Old | New | Classes |
|---|---|---|
| `scaleRadius` | `radiusScale` | `massDistributionExponentialDisk` |
| `virialRadius` | `radiusVirial` | `massDistributionEinasto`, `massDistributionNFW` |
| `outerRadius` | `radiusOuter` | `massDistributionBetaProfile` |
| `coreRadius` | `radiusCore` | `massDistributionBetaProfile` |
| `haloMassMinimum` | `massHaloMinimum` | 2 × `task`, 2 × `posteriorSampleLikelihood` |
| `haloMassMaximum` | `massHaloMaximum` | 1 × `task`, 2 × `posteriorSampleLikelihood` |

In every case the noun-first spelling **already existed** in other classes, so this removes a duplication rather than inventing a name. Also renames `galacticFilterLabelled` → `galacticFilterLabeled`, with its source file and three module procedures.

## ⚠️ This PR must be merged with a merge commit

`scripts/aux/migrations.xml` keys its new block to `48c5e9fe8`. A squash- or rebase-merge rewrites that hash, and `parametersMigrate.py` matches hashes by exact string equality — a hash absent from history matches nothing and is **silently skipped**, with no error. Users' parameter files would then quietly fail to migrate. This is the repository default (`CONTRIBUTING.md`), noted here because this PR is one of the cases it exists for.

The three commits are ordered deliberately: the rename, then the migrations. A migration cannot live in the commit it migrates, because that commit would have to contain its own hash.

## Scoping: what is deliberately *not* renamed

`outerRadius` is an input parameter of `massDistributionBetaProfile` **and** a `<property>` of the standard and very-simple hot halo components — an HDF5 output name and part of the generated component API. The property is untouched, and the migration rule is scoped (`//*[@value='betaProfile']/outerRadius`) so it cannot reach it. The audit that prompted this work miscounted those two property sites as parameters.

## How to test

```bash
export GALACTICUS_EXEC_PATH=`pwd`
make -j2 Galacticus.exe
./Galacticus.exe parameters/quickTest.xml

# exercises the renamed parameters end-to-end
cd testSuite && python3 test-halo-mass-functions.py

# migration round-trip on a file written in the old form
python3 scripts/aux/parametersMigrate.py old.xml new.xml
```

## Checklist

- [x] **The code builds**: `make -j4 Galacticus.exe` exits 0 and links. This was the check that mattered — the renamed names are Fortran type components, dummy arguments and code-generation directive templates, and an earlier review pass caught ten keyword-argument call sites in the DMO profiles and hot halo mass distributions that a first sweep missed. A clean compile confirms none remain.
- [x] **The quick test passes**: `quickTest.xml` runs to completion and writes its HDF5.
- [x] **The renames are exercised at runtime**: `test-halo-mass-functions.py` reads the renamed elements, sets them through the updated XPaths, and runs three models — `success` for Press-Schechter, Sheth-Tormen and Tinker2008, zero `FAIL`/`FAILED` under the harness's own criterion. That proves the parameters parse (no `unrecognized parameter`), the XPath edits resolve, and the physics is unchanged.
- [x] **Migration round-trip**: verified on a file exercising all eight renames and the filter value, with a `componentHotHalo/outerRadius` property included as a control — every intended rename applied, the property untouched.
- [x] **No new validation errors**: `parameterValidate.py` over 798 files in `parameters`, `constraints` and `testSuite` reports exactly the same 29 pre-existing errors as master, none involving these names.
- [x] Documentation and comments updated — three user-guide tutorials and the `conditionalCall` example quoted in `coding.rst`.
- [ ] If this PR is from a fork: n/a, branch is on this repository.

### Note for reviewers

Both logs above contain `WARNING: parameter file revision check failed`. That is **pre-existing and unrelated**: `parameters/quickTest.xml` records a `lastModified` revision that is not in this checkout's history. No commit here touches that file. It is worth a look independently, since it is the same mechanism that would silence a real migration.

Every rename is the same length as the name it replaces, so no column alignment moves except in the filter class, where the affected declaration blocks are re-padded.

---

Developed with AI assistance and reviewed by a human before submission, per the *AI-Assisted Contributions* section of `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc7FoYV43K9Zt8VjswLBiR
