### PR TITLE
feat(functionClass): allow an implementation to declare a readable alias

### DIFF
--- a/docs/manuals/developer-guide/coding.rst
+++ b/docs/manuals/developer-guide/coding.rst
@@ -1042,6 +1042,17 @@ In the above example, we define a "simple" implementation of the cosmologyParame
 Name:
    The name should always be prefixed with the function class name. In this case, we have a ``simple`` implementation of the ``cosmologyParameters`` function class, and so our name is ``cosmologyParametersSimple``.
 
+   The remainder of the name, after the class prefix, is the value which selects this implementation in a parameter file---``simple`` here. Choose a readable one: it is part of the user-facing API, not merely an internal identifier.
+
+   Occasionally a readable name cannot be used, because Fortran limits an identifier to **63 characters** and the build generates further identifiers from this name by appending suffixes (``ConstructorParameters``, a method name, a trailing underscore for the implementation's submodule, and so on). Where that limit forces an abbreviated name, give the directive an ``alias`` attribute carrying the readable form:
+
+   .. code-block:: xml
+
+      <virialDensityContrast name="virialDensityContrastSphericalCollapseClsnlssMttrCsmlgclCnstnt"
+                             alias="sphericalCollapseCollisionlessMatterCosmologicalConstant">
+
+   The alias is the value documented, written into descriptors, and reported by the ``objectType`` method and by the error message listing the available implementations. The abbreviated name continues to be accepted in parameter files, so adding an alias breaks nothing and needs no migration. Use an alias *only* where the length limit forces it---an abbreviation which would fit unabbreviated should simply be renamed.
+
 Extends:
    The base class for the function class is always the function class name suffixed with ``Class``, in this case ``cosmologyParametersClass``. Implementations must always be extensions of either this base class, or of another implementation.
 

--- a/python/Galacticus/Build/SourceTree/Parse/Directives.py
+++ b/python/Galacticus/Build/SourceTree/Parse/Directives.py
@@ -180,6 +180,11 @@ _FUNCTION_CLASS_SCHEMA = """<?xml version="1.0"?>
        </xs:element>
       </xs:sequence>
       <xs:attribute name="name"      use="required"/>
+      <!-- alias="..." gives a readable parameter-file value for an
+           implementation whose Fortran name had to be abbreviated to stay
+           within the 63-character identifier limit. The abbreviated value
+           keeps working; the alias is the documented one. -->
+      <xs:attribute name="alias"     use="optional"/>
       <xs:attribute name="recursive" use="optional" >
        <xs:simpleType>
         <xs:restriction base="xs:string">

--- a/python/Galacticus/Build/SourceTree/Process/FunctionClass/__init__.py
+++ b/python/Galacticus/Build/SourceTree/Process/FunctionClass/__init__.py
@@ -114,6 +114,25 @@ def _short_name(full_name, directive_name):
     return short
 
 
+def _selector_names(non_abstract_class, directive_name):
+    """Return `(canonical, accepted)` parameter-file values for an implementation.
+
+    `accepted` is every value the parameter reader will match, `canonical` the
+    one written into descriptors, documentation, and error listings.
+
+    Where an implementation carries an `alias`, the alias is canonical and the
+    abbreviated short name remains accepted, so existing parameter files keep
+    working.  An alias exists only where the readable name would push a
+    generated Fortran identifier past the 63-character limit -- see the
+    *Naming conventions* section of the developer guide.
+    """
+    short = _short_name(non_abstract_class['name'], directive_name)
+    alias = (non_abstract_class.get('alias') or '').strip()
+    if not alias:
+        return short, [short]
+    return alias, [short, alias]
+
+
 def _xml_escape(s):
     """Escape `&`, `<`, `>`, `"` for XML attribute / text contexts."""
     return xml_escape(s)
@@ -285,14 +304,11 @@ def _build_object_type_method(directive, non_abstract_classes, methods):
     )
     for non_abstract in non_abstract_classes:
         class_name = non_abstract['name']
-        # shortName is computed the same way loadAndSortClasses does —
-        # lowercase the first letter unless the remainder is already an
-        # all-caps acronym of 2+ letters.
-        type_short = class_name
-        if type_short.startswith(directive_name):
-            type_short = type_short[len(directive_name):]
-        if not re.match(r'^[A-Z]{2,}', type_short):
-            type_short = type_short[:1].lower() + type_short[1:]
+        # The short form is the value naming this implementation in a parameter
+        # file: its `alias` where it has one, else the class name with the
+        # directive prefix stripped (lowercasing the first letter unless the
+        # remainder is already an all-caps acronym of 2+ letters).
+        type_short = _selector_names(non_abstract, directive_name)[0]
         code += (
             f"type is ({class_name})\n"
             "if (short_) then\n"
@@ -399,13 +415,18 @@ def _load_and_sort_classes(directive, directive_locations):
         if not re.match(r'^[A-Z]{2,}', short):
             short = short[:1].lower() + short[1:]
         non_abstract['shortName'] = short
+        # An implementation may carry a readable `alias` where its Fortran name
+        # had to be abbreviated; either form may name it as the class default.
+        non_abstract['canonicalName'] = (
+            (non_abstract.get('alias') or '').strip() or short)
 
     # Validate optional `default` attribute.
     if 'default' in directive:
         wanted = directive['default']
-        if not any(wanted == c['shortName'] for c in non_abstract_classes):
+        if not any(wanted in (c['shortName'], c['canonicalName'])
+                   for c in non_abstract_classes):
             allowed = '\n'.join(
-                f"    {c['shortName']}" for c in non_abstract_classes)
+                f"    {c['canonicalName']}" for c in non_abstract_classes)
             raise RuntimeError(
                 f"unrecognized default '{wanted}' for class "
                 f"'{directive['name']}'\n  allowed defaults are:\n{allowed}"
@@ -869,12 +890,7 @@ def _build_descriptor_methods(directive, non_abstract_classes, classes,
         from Galacticus.Build.SourceTree.Process.FunctionClass.Utils \
             import declaration_rank
 
-        short = non_abstract['name']
-        if short.startswith(directive['name']):
-            short = short[len(directive['name']):]
-        if not re.match(r'^[A-Z]{2,}', short):
-            short = short[:1].lower() + short[1:]
-        label = short
+        label = _selector_names(non_abstract, directive['name'])[0]
 
         descriptor_code += f"type is ({non_abstract['name']})\n"
 
@@ -2993,6 +3009,20 @@ def _generate_constructor(directive, classes_ordered, non_abstract_classes,
 
     if 'default' in directive:
         default = directive['default']
+        # `default` names the implementation internally: it builds the class
+        # name looked up below and the OpenMP critical-section identifier, both
+        # of which must stay within Fortran's 63-character limit, so it always
+        # uses the (possibly abbreviated) short name.  `default_value` is the
+        # value written into the parameter tree, which uses the alias where one
+        # exists so a model built from defaults records the readable name.
+        default_value = default
+        for _c in non_abstract_classes:
+            short, accepted = (_short_name(_c['name'], directive_name),
+                               _selector_names(_c, directive_name)[1])
+            if default in accepted:
+                default, default_value = short, _selector_names(
+                    _c, directive_name)[0]
+                break
         default_uc = _ucfirst(default)
         # Find the matching default class entry.
         target_name = directive_name + default_uc
@@ -3017,7 +3047,7 @@ def _generate_constructor(directive, classes_ordered, non_abstract_classes,
             f".and. copyInstance_ == 1 "
             f".and. .not.parameters%isPresent(char(parameterName_))) then\n"
             f"        call parameters%addParameter"
-            f"('{directive_name}','{default}')\n"
+            f"('{directive_name}','{default_value}')\n"
             f"        parameterNode => parameters%node"
             f"('{directive_name}',requireValue=.true.)\n"
         )
@@ -3081,8 +3111,9 @@ def _generate_constructor(directive, classes_ordered, non_abstract_classes,
         '      select case (char(instanceName))\n'
     )
     for c in non_abstract_classes:
-        name = _short_name(c['name'], directive_name)
-        post['content'] += f"     case ('{name}')\n"
+        _, accepted = _selector_names(c, directive_name)
+        labels = ','.join(f"'{a}'" for a in accepted)
+        post['content'] += f"     case ({labels})\n"
         post['content'] += f"        allocate({c['name']} :: self)\n"
         if c.get('recursive') == 'yes':
             # Record the in-progress object on the (already-pushed) build-stack entry so a re-entrant build that
@@ -3101,9 +3132,9 @@ def _generate_constructor(directive, classes_ordered, non_abstract_classes,
         "         message='Unrecognized type \"'//trim(instanceName)//'\" "
         "Available options are:'\n"
     )
-    class_names = sorted([c['name'] for c in non_abstract_classes])
-    for cn in class_names:
-        sn = _short_name(cn, directive_name)
+    for sn in sorted(
+            _selector_names(c, directive_name)[0]
+            for c in non_abstract_classes):
         post['content'] += (
             f"         message=message//char(10)//'   -> {sn}'\n"
         )

--- a/python/Galacticus/Parameters/catalog.py
+++ b/python/Galacticus/Parameters/catalog.py
@@ -463,6 +463,10 @@ def harvest_file(path, base_names, source_root):
         base = registration['type']
         implementation_type = _scalar(registration['directive']['name'])
         label = derive_label(base, implementation_type)
+        # An implementation whose Fortran name had to be abbreviated to stay
+        # within the 63-character identifier limit may carry a readable
+        # `alias`; both it and the abbreviated label select the implementation.
+        alias = _scalar(registration['directive'].get('alias') or '') or None
         constructor = _find_constructor(function_nodes, label, len(registrations))
         scope = constructor if constructor is not None else tree
         parameters, objects = _harvest_parameters(
@@ -472,6 +476,7 @@ def harvest_file(path, base_names, source_root):
             'type':            implementation_type,
             'functionClass':   base,
             'label':           label,
+            'alias':           alias,
             'module':          module,
             'sourceFile':      relative,
             'constructorFound': constructor is not None,
@@ -713,8 +718,10 @@ def build_catalog(source_root, log=None, jobs=None, cache_path=None):
         for entry in entries:
             implementations[entry['type']] = entry
             base = entry['functionClass']
-            if base in bases and entry['label'] not in bases[base]['implementations']:
-                bases[base]['implementations'].append(entry['label'])
+            if base in bases:
+                for selector in (entry['label'], entry.get('alias')):
+                    if selector and selector not in bases[base]['implementations']:
+                        bases[base]['implementations'].append(selector)
 
     # Rebuilt from the files that exist now, so entries for deleted files are
     # dropped rather than accumulating.

--- a/python/Galacticus/Parameters/validate.py
+++ b/python/Galacticus/Parameters/validate.py
@@ -102,10 +102,17 @@ class _Index:
         self.implementations = catalog['implementations']
         self.enumerations = catalog.get('enumerations', {})
         self.base_names = set(self.function_classes)
-        # (base, label) -> implementation type name.
+        # (base, label) -> implementation type name.  An implementation whose
+        # Fortran name had to be abbreviated may also carry a readable `alias`;
+        # both select it, so both must resolve here.  Registering only the
+        # label would leave a file using the alias with no schema, silently
+        # skipping every check on that element's sub-parameters.
         self.type_by_base_label = {}
         for type_name, impl in self.implementations.items():
-            self.type_by_base_label[(impl['functionClass'], impl['label'])] = type_name
+            for label in (impl['label'], impl.get('alias')):
+                if label:
+                    self.type_by_base_label[
+                        (impl['functionClass'], label)] = type_name
         self._schema_cache = {}
 
     def labels_for(self, base):

--- a/schema/parameters.xsd
+++ b/schema/parameters.xsd
@@ -4165,9 +4165,12 @@
           <xs:enumeration value="friendsOfFriends"/>
           <xs:enumeration value="kitayamaSuto1996"/>
           <xs:enumeration value="percolation"/>
+          <xs:enumeration value="sphericalCollapseBaryonsDarkMatterDarkEnergy"/>
           <xs:enumeration value="sphericalCollapseBrynsDrkMttrDrkEnrgy"/>
           <xs:enumeration value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
           <xs:enumeration value="sphericalCollapseClsnlssMttrDrkEnrgy"/>
+          <xs:enumeration value="sphericalCollapseCollisionlessMatterCosmologicalConstant"/>
+          <xs:enumeration value="sphericalCollapseCollisionlessMatterDarkEnergy"/>
          </xs:restriction>
         </xs:simpleType>
        </xs:attribute>

--- a/source/structure_formation/critical_overdensity/spherical_collapse_baryons_darkMatter_darkEnergy.F90
+++ b/source/structure_formation/critical_overdensity/spherical_collapse_baryons_darkMatter_darkEnergy.F90
@@ -30,7 +30,7 @@
   use :: Tables                               , only : table1D
 
   !![
-  <criticalOverdensity name="criticalOverdensitySphericalCollapseBrynsDrkMttrDrkEnrgy" docformat="rst">
+  <criticalOverdensity name="criticalOverdensitySphericalCollapseBrynsDrkMttrDrkEnrgy" alias="sphericalCollapseBaryonsDarkMatterDarkEnergy" docformat="rst">
    <description>
    Critical overdensity for the gravitational collapse of dark matter halos, computed by numerically solving the spherical collapse model in a universe containing baryons, collisionless dark matter, and dark energy. Baryons may be treated as non-clustering relative to dark matter. The normalization of the result can be adjusted via ``[normalization]``, and tabulation can be stored to file for efficiency.
    </description>

--- a/source/structure_formation/critical_overdensity/spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation/critical_overdensity/spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
@@ -28,7 +28,7 @@
   use :: Tables                    , only : table1D
 
   !![
-  <criticalOverdensity name="criticalOverdensitySphericalCollapseClsnlssMttrCsmlgclCnstnt" docformat="rst">
+  <criticalOverdensity name="criticalOverdensitySphericalCollapseClsnlssMttrCsmlgclCnstnt" alias="sphericalCollapseCollisionlessMatterCosmologicalConstant" docformat="rst">
    <description>
    Critical overdensity for collapse based on the spherical collapse in a matter plus cosmological constant universe (see, for example, :cite:author:`percival_cosmological_2005` :cite:year:`percival_cosmological_2005`).
    </description>

--- a/source/structure_formation/critical_overdensity/spherical_collapse_collisionlessMatter_darkEnergy.F90
+++ b/source/structure_formation/critical_overdensity/spherical_collapse_collisionlessMatter_darkEnergy.F90
@@ -22,7 +22,7 @@
   !!}
 
   !![
-  <criticalOverdensity name="criticalOverdensitySphericalCollapseClsnlssMttrDrkEnrgy" docformat="rst">
+  <criticalOverdensity name="criticalOverdensitySphericalCollapseClsnlssMttrDrkEnrgy" alias="sphericalCollapseCollisionlessMatterDarkEnergy" docformat="rst">
    <description>
    Critical overdensity for gravitational collapse of dark matter halos, computed numerically via the spherical collapse model in a universe containing collisionless matter and dark energy. The normalization of the result can be adjusted via ``[normalization]``, and tabulated solutions can be stored to and restored from file for computational efficiency.
    </description>

--- a/source/structure_formation/virial_density_contrast/spherical_collapse_baryons_darkMatter_darkEnergy.F90
+++ b/source/structure_formation/virial_density_contrast/spherical_collapse_baryons_darkMatter_darkEnergy.F90
@@ -30,7 +30,7 @@
   use :: Tables                               , only : table1D
 
   !![
-  <virialDensityContrast name="virialDensityContrastSphericalCollapseBrynsDrkMttrDrkEnrgy" docformat="rst">
+  <virialDensityContrast name="virialDensityContrastSphericalCollapseBrynsDrkMttrDrkEnrgy" alias="sphericalCollapseBaryonsDarkMatterDarkEnergy" docformat="rst">
    <description>
    Dark matter halo virial density contrasts based on the spherical collapse in a matter plus cosmological constant universe.
    </description>

--- a/source/structure_formation/virial_density_contrast/spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
+++ b/source/structure_formation/virial_density_contrast/spherical_collapse_collisionlessMatter_cosmologicalConstant.F90
@@ -28,7 +28,7 @@
   use :: Tables                    , only : table1D
 
   !![
-  <virialDensityContrast name="virialDensityContrastSphericalCollapseClsnlssMttrCsmlgclCnstnt" docformat="rst">
+  <virialDensityContrast name="virialDensityContrastSphericalCollapseClsnlssMttrCsmlgclCnstnt" alias="sphericalCollapseCollisionlessMatterCosmologicalConstant" docformat="rst">
    <description>
    A class implementing dark matter halo virial density contrasts based on the spherical collapse model in a universe which contains collisionless matter and a cosmological constant (see, for example, :cite:author:`percival_cosmological_2005` :cite:year:`percival_cosmological_2005`).
    </description>

--- a/source/structure_formation/virial_density_contrast/spherical_collapse_collisionlessMatter_darkEnergy.F90
+++ b/source/structure_formation/virial_density_contrast/spherical_collapse_collisionlessMatter_darkEnergy.F90
@@ -24,7 +24,7 @@
   use :: Spherical_Collapse_Solvers, only : enumerationCllsnlssMttrDarkEnergyFixedAtType
 
   !![
-  <virialDensityContrast name="virialDensityContrastSphericalCollapseClsnlssMttrDrkEnrgy" docformat="rst">
+  <virialDensityContrast name="virialDensityContrastSphericalCollapseClsnlssMttrDrkEnrgy" alias="sphericalCollapseCollisionlessMatterDarkEnergy" docformat="rst">
    <description>
    Dark matter halo virial density contrasts based on the spherical collapse in a matter plus dark energy universe.
    </description>


### PR DESCRIPTION
## Summary

The value selecting a `functionClass` implementation in a parameter file is its Fortran type name with the class prefix stripped — so the user-facing API inherits whatever the identifier had to be. Fortran caps identifiers at 63 characters, and the build appends further suffixes to that name (`ConstructorParameters`, a method name, a trailing `_` for the implementation's submodule), so a handful of names were vowel-stripped to fit. Users must currently write:

```xml
<virialDensityContrast value="sphericalCollapseClsnlssMttrCsmlgclCnstnt"/>
```

An implementation directive may now carry an `alias` giving the readable form:

```xml
<virialDensityContrast name="virialDensityContrastSphericalCollapseClsnlssMttrCsmlgclCnstnt"
                       alias="sphericalCollapseCollisionlessMatterCosmologicalConstant">
```

**Purely additive.** The abbreviated name stays accepted, existing parameter files keep working *and* keep round-tripping unchanged, and no migration is needed. Fortran identifiers are untouched.

Applied to the six implementations that need it — the spherical-collapse family of `criticalOverdensity` and `virialDensityContrast`, whose readable names reach 67–78 characters.

## Six places have to agree on the name

| where | behaviour |
|---|---|
| build ladder | alias added as a second `select case` label |
| "available options" error | reports the canonical (alias) form |
| `objectType` method | returns the canonical form |
| descriptor / default write | writes the canonical form |
| parameter catalog | registers both forms as selectors |
| validator index | resolves **both** to the implementation type |

That last one is not cosmetic. Registering only the label left a file using the alias with `schema=None`, which silently skipped every check on its sub-parameters — a bogus child was reported under the abbreviated name and waved through under the alias. Caught by the pre-commit review, then reproduced and fixed.

## Why this is a mechanism and not sixteen renames

The audit this came from assumed a 63-character limit forced all the abbreviations. Measured against the 23,742 declared Fortran entities in `work/build`, most of them are *not* forced — those should simply be renamed, and about twenty such names are left for a follow-up. Only these six genuinely cannot fit, which is what the alias exists for. The coding guide says as much: use an alias only where the limit forces it.

For the record, gfortran-16 enforces 63 as a hard error (`Name at (1) is too long`) for modules, submodules, functions, derived types, type-bound bindings and variables alike, and no `-std` setting relaxes it.

## How to test

```bash
export GALACTICUS_EXEC_PATH=`pwd`
make -j2 Galacticus.exe

# same model, selected either way
./Galacticus.exe <file with value="sphericalCollapseCollisionlessMatterCosmologicalConstant">
./Galacticus.exe <file with value="sphericalCollapseClsnlssMttrCsmlgclCnstnt">
```

## Checklist

- [x] **Builds**: `make -j4 Galacticus.exe` exits 0 and links. Essential here — the generator changes touch every class, and a first attempt failed to compile by feeding the alias into an OpenMP critical-section name, producing a 79-character identifier. That is the exact failure this feature prevents, and only a full compile found it.
- [x] **Runtime, both forms**: models selecting the implementation by alias and by abbreviated name each run to completion with no failure markers, and each records in its HDF5 output the form the parameter file used.
- [x] **Validation genuinely runs on aliased elements**: a deliberately invalid sub-parameter is reported under *both* forms. Tested with a file known to be invalid — a clean result on a valid file cannot distinguish "validated" from "not validated at all".
- [x] **No new validation errors**: `parameterValidate.py` over 798 bundled files reports the same 35 pre-existing errors as master, with an identical breakdown.
- [x] 1081 Python tests pass; documentation added to the *Function Classes* section.

### Note for reviewers

The `alias` documentation went into the `Name:` bullet of *Function Classes* rather than the naming-conventions section, because that section is still on #1465. Worth cross-referencing once that merges.

---

Developed with AI assistance and reviewed by a human before submission, per the *AI-Assisted Contributions* section of `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc7FoYV43K9Zt8VjswLBiR
