### PR TITLE
ci(macos)!: retire macOS Intel (x86-64) builds

### DIFF
--- a/.github/actions/buildMacOS/action.yml
+++ b/.github/actions/buildMacOS/action.yml
@@ -17,12 +17,7 @@ runs:
         echo "CCOMPILER=gcc-16" >> $GITHUB_ENV
         echo "CPPCOMPILER=g++-16" >> $GITHUB_ENV
         echo "BUILDPATH=./work/build" >> $GITHUB_ENV
-        if [[ "${ver[0]}" -eq 13 ]]; then
-          # For MacOS 13 force use of the classic linker as the new linker does not support the '-commons' option - see https://trac.macports.org/ticket/68194#comment:15
-          echo "GALACTICUS_FCFLAGS=$GALACTICUS_FCFLAGS -fintrinsic-modules-path /usr/local/finclude -fintrinsic-modules-path /usr/local/include -fintrinsic-modules-path /usr/local/include/gfortran -fintrinsic-modules-path /usr/local/lib/gfortran/modules -L/usr/local/lib -L/opt/local/lib -Wl,-ld_classic" >> $GITHUB_ENV
-        else
-          echo "GALACTICUS_FCFLAGS=$GALACTICUS_FCFLAGS -fintrinsic-modules-path /usr/local/finclude -fintrinsic-modules-path /usr/local/include -fintrinsic-modules-path /usr/local/include/gfortran -fintrinsic-modules-path /usr/local/lib/gfortran/modules -L/usr/local/lib -L/opt/local/lib" >> $GITHUB_ENV
-        fi
+        echo "GALACTICUS_FCFLAGS=$GALACTICUS_FCFLAGS -fintrinsic-modules-path /usr/local/finclude -fintrinsic-modules-path /usr/local/include -fintrinsic-modules-path /usr/local/include/gfortran -fintrinsic-modules-path /usr/local/lib/gfortran/modules -L/usr/local/lib -L/opt/local/lib" >> $GITHUB_ENV
         echo "GALACTICUS_CFLAGS=-I/usr/local/include -I/opt/local/include" >> $GITHUB_ENV
         echo "GALACTICUS_CPPFLAGS=-I/usr/local/include -I/opt/local/include -I/usr/local/include/libqhullcpp" >> $GITHUB_ENV
     - name: Fix broken Apple include file
@@ -31,29 +26,18 @@ runs:
         # This removes syntax not supported by the GCC compiler prior to version 13.3.
         # It should be possible to remove this once a later version of GCC is used.
         # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114007
-        if [[ "${OS_VER}" -ge 14 ]]; then
-           sudo sed -E -i~ s/"clang::"/"clang"/g /Library/Developer/CommandLineTools/SDKs/MacOSX${OS_VER}.sdk/usr/include/sys/cdefs.h
-        fi
+        sudo sed -E -i~ s/"clang::"/"clang"/g /Library/Developer/CommandLineTools/SDKs/MacOSX${OS_VER}.sdk/usr/include/sys/cdefs.h
     - name: Install MacPorts
       shell: bash
       run: |
-        if [[ "${OS_VER}" -eq 11 ]]; then
-           macportsversion=2.7.1
-           macportsbase=2.7.1-11-BigSur
-        elif [[ "${OS_VER}" -eq 12 ]]; then
-           macportsversion=2.9.1
-           macportsbase=2.9.1-12-Monterey
-        elif [[ "${OS_VER}" -eq 13 ]]; then
-           macportsversion=2.9.1
-           macportsbase=2.9.1-13-Ventura
-        elif [[ "${OS_VER}" -eq 14 ]]; then
-           macportsversion=2.9.1
-           macportsbase=2.9.1-14-Sonoma
-        elif [[ "${OS_VER}" -eq 15 ]]; then
+        # Each MacPorts base package is built for one macOS release, so this has to name the release the
+        # runner image actually is. Only macOS 15 (Sequoia) is used: the Intel runners -- the reason older
+        # releases were listed here -- have been retired. Add a branch when moving to a newer image.
+        if [[ "${OS_VER}" -eq 15 ]]; then
            macportsversion=2.11.6
            macportsbase=2.11.6-15-Sequoia
         else
-           echo Unknown MacOS version: ${os_ver}
+           echo "Unknown MacOS version: ${OS_VER}"
            exit 1
         fi
         curl -L --fail --retry 5 --retry-all-errors --retry-max-time 120 https://github.com/macports/macports-base/releases/download/v${macportsversion}/MacPorts-${macportsbase}.pkg --output MacPorts-${macportsbase}.pkg
@@ -156,11 +140,6 @@ runs:
         # libhdf5_hl_f90cstub. The macOS linker (ld-prime on Apple Silicon / macOS 14+) rejects that
         # malformed version. Correct the variable name so the compatibility version becomes `320.0.0`.
         sed -i~ 's/LT_HL_F_VERS_INTERFACE1/LT_HL_F_VERS_INTERFACE/' config/lt_vers.am
-        # For MacOS 13 force use of the classic linker as the new linker does not support the '-commons' option - see https://trac.macports.org/ticket/68194#comment:15
-        linkerFlags=()
-        if [[ "${OS_VER}" -eq 13 ]]; then
-           linkerFlags=(-DCMAKE_EXE_LINKER_FLAGS=-Wl,-ld_classic -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-ld_classic -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-ld_classic)
-        fi
         # Deprecated symbols are disabled to build against the strict HDF5 2.x API surface (Galacticus compiles cleanly against
         # it). Galacticus caps its own output format at the HDF5 1.14 version, so output remains readable by HDF5 1.14 readers.
         # The nonstandard _Float16 feature is disabled: on the Homebrew GCC toolchain HDF5's build-time probe for the FLT16_MAX
@@ -189,8 +168,7 @@ runs:
            -DHDF5_ENABLE_DEPRECATED_SYMBOLS=OFF \
            -DHDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16=OFF \
            -DHDF5_BUILD_WITH_INSTALL_NAME=ON \
-           -DHDF5_DEFAULT_API_VERSION=v200 \
-           "${linkerFlags[@]}"
+           -DHDF5_DEFAULT_API_VERSION=v200
         cmake --build build -j3
         sudo cmake --install build
         cd ..

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -555,199 +555,8 @@ jobs:
             ./datasets.tar.zst
             ./datasets.ref
       - run: echo "This job's status is ${{ job.status }}."
-  ## MacOS
+  ## MacOS (Apple Silicon)
   ### Static executable
-  Build-Executable-MacOS:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: macos-15-intel
-    steps:
-      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "This job is now running on a ${{ runner.os }} server."
-      - run: echo "The name of the branch is ${{ github.ref }} and the repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Check out repository datasets
-        # Required by the tool build (buildTools.xml) below, which writes into
-        # $GALACTICUS_DATA_PATH (set to $GITHUB_WORKSPACE/datasets by the
-        # buildMacOS action).
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: galacticusorg/datasets
-          path: datasets
-      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
-      - name: Set up build environment
-        uses: ./.github/actions/buildMacOS
-      - name: Build Galacticus
-        run: |
-          set -o pipefail
-          make -j`sysctl -n hw.activecpu` USEGIT2=no Galacticus.exe tests.hashes.cryptographic.exe 2>&1 | tee build.log
-          ./scripts/build/staticRelinker.py `grep '\-o Galacticus.exe' build.log`
-          ./scripts/build/staticRelinker.py `grep '\-o tests.hashes.cryptographic.exe' build.log`
-          dsymutil -o Galacticus.exe.dSYM Galacticus.exe
-          zip -r debugSymbolsMacOS.zip Galacticus.exe.dSYM
-          mv Galacticus.exe Galacticus_MacOS.exe
-      - name: Sign Galacticus executable
-        uses: ./.github/actions/codeSignMacOS
-        with:
-          files: Galacticus_MacOS.exe
-          macos_certificate: ${{ secrets.MACOS_CERTIFICATE }}
-          macos_certificate_password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-          macos_keychain_password: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-          macos_developer_id: ${{ secrets.MACOS_DEVELOPER_ID }}
-      - name: Package notarization ZIP
-        run: |
-          zip Galacticus_MacOS.zip Galacticus_MacOS.exe
-      - name: Upload Galacticus executable
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: galacticus-exec-MacOS
-          path: |
-            Galacticus_MacOS.exe
-            Galacticus_MacOS.zip
-      - name: Upload test code executables
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: test-execs-MacOS
-          path: 'tests.*.exe'
-      - name: Upload Galacticus debug symbols
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: galacticus-debug-MacOS
-          path: 'debugSymbolsMacOS.zip'
-      - name: Build tools
-        id: buildTools
-        run: |
-          classVersion=`awk '{if ($1 == "class:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
-          cambVersion=`awk '{if ($1 == "camb:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
-          forutilsVersion=`awk '{if ($1 == "forutils:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
-          fspsVersion=`awk '{if ($1 == "fsps:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
-          cloudyVersion=`awk '{if ($1 == "cloudy:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
-          mangleVersion=`awk '{if ($1 == "mangle:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
-          axioncambVersion=`awk '{if ($1 == "axioncamb:") print $2}' ${GALACTICUS_EXEC_PATH}/aux/dependencies.yml`
-          # Export the dependency versions so the later "Package" step (a separate shell) can see them.
-          echo "classVersion=${classVersion}"       >> $GITHUB_ENV
-          echo "cambVersion=${cambVersion}"         >> $GITHUB_ENV
-          echo "forutilsVersion=${forutilsVersion}" >> $GITHUB_ENV
-          echo "fspsVersion=${fspsVersion}"         >> $GITHUB_ENV
-          echo "cloudyVersion=${cloudyVersion}"     >> $GITHUB_ENV
-          echo "mangleVersion=${mangleVersion}"     >> $GITHUB_ENV
-          echo "axioncambVersion=${axioncambVersion}" >> $GITHUB_ENV
-          cd $GALACTICUS_EXEC_PATH
-          git config --global --add safe.directory $GALACTICUS_EXEC_PATH
-          mkdir -p $GALACTICUS_DATA_PATH/dynamic
-          set -o pipefail
-          # Use the statically-linked executable already built by this job to build the tools.
-          ./Galacticus_MacOS.exe parameters/buildTools.xml 2>&1 | tee build.log
-          cd $GALACTICUS_DATA_PATH/dynamic/CAMB-${cambVersion}/fortran/
-          $GALACTICUS_EXEC_PATH/scripts/build/staticRelinker.py ${FCCOMPILER} -cpp -Ofast -fopenmp -fintrinsic-modules-path /usr/local/include -L/usr/local/lib -L/opt/local/lib -JRelease -IRelease/ -I"/Users/runner/work/galacticus/galacticus/datasets/dynamic/CAMB-${cambVersion}/fortran/../forutils/Release/" Release/inidriver.o Release/libcamb.a  -L"/Users/runner/work/galacticus/galacticus/datasets/dynamic/CAMB-${cambVersion}/fortran/../forutils/Release/" -lforutils -o camb
-          cd $GALACTICUS_DATA_PATH/dynamic/axionCAMB-${axioncambVersion}/
-          $GALACTICUS_EXEC_PATH/scripts/build/staticRelinker.py ${FCCOMPILER} -O3 -fintrinsic-modules-path /usr/local/include -L/usr/local/lib -L/opt/local/lib constants.o utils.o  subroutines.o inifile.o power_tilt.o recfast_axion.o reionization.o modules.o bessels.o equations_ppf.o halofit_ppf.o lensing.o SeparableBispectrum.o cmbmain.o camb.o axion_background.o inidriver_axion.F90 -o camb
-          cd $GALACTICUS_DATA_PATH/dynamic/class_public-${classVersion}/
-          $GALACTICUS_EXEC_PATH/scripts/build/staticRelinker.py `grep -E '\-o class ' $GALACTICUS_EXEC_PATH/build.log`
-          cd $GALACTICUS_DATA_PATH/dynamic/RecFast/
-          $GALACTICUS_EXEC_PATH/scripts/build/staticRelinker.py ${FCCOMPILER} recfast.for -o recfast.exe -O3 -ffixed-form -ffixed-line-length-none
-          cd $GALACTICUS_DATA_PATH/dynamic/c${cloudyVersion}/source/
-          $GALACTICUS_EXEC_PATH/scripts/build/staticRelinker.py `grep -E '\-o cloudy.exe' $GALACTICUS_EXEC_PATH/build.log`
-          cd $GALACTICUS_DATA_PATH/dynamic/fsps-${fspsVersion}/src
-          $GALACTICUS_EXEC_PATH/scripts/build/staticRelinker.py `grep -E '\-o autosps.exe' $GALACTICUS_EXEC_PATH/build.log`
-          cd $GALACTICUS_DATA_PATH/dynamic/mangle-${mangleVersion}/src/
-          cp ../bin/harmonize .
-          $GALACTICUS_EXEC_PATH/scripts/build/staticRelinker.py `grep -E '\-o harmonize' $GALACTICUS_EXEC_PATH/build.log`
-          echo "camb=${GALACTICUS_DATA_PATH}/dynamic/CAMB-${cambVersion}/fortran/camb" >> "$GITHUB_OUTPUT"
-          echo "axioncamb=${GALACTICUS_DATA_PATH}/dynamic/axionCAMB-${axioncambVersion}/camb" >> "$GITHUB_OUTPUT"
-          echo "class=${GALACTICUS_DATA_PATH}/dynamic/class_public-${classVersion}/class" >> "$GITHUB_OUTPUT"
-          echo "recfast=${GALACTICUS_DATA_PATH}/dynamic/RecFast/recfast.exe" >> "$GITHUB_OUTPUT"
-          echo "cloudy=${GALACTICUS_DATA_PATH}/dynamic/c${cloudyVersion}/source/cloudy.exe" >> "$GITHUB_OUTPUT"
-          echo "fsps=${GALACTICUS_DATA_PATH}/dynamic/fsps-${fspsVersion}/src/autosps.exe" >> "$GITHUB_OUTPUT"
-          echo "mangle=${GALACTICUS_DATA_PATH}/dynamic/mangle-${mangleVersion}/bin/harmonize" >> "$GITHUB_OUTPUT"
-      - name: Sign tool executables
-        uses: ./.github/actions/codeSignMacOS
-        with:
-          files: ${{ steps.buildTools.outputs.camb }} ${{ steps.buildTools.outputs.axioncamb }} ${{ steps.buildTools.outputs.class }} ${{ steps.buildTools.outputs.recfast }} ${{ steps.buildTools.outputs.cloudy }} ${{ steps.buildTools.outputs.fsps }} ${{ steps.buildTools.outputs.mangle }}
-          macos_certificate: ${{ secrets.MACOS_CERTIFICATE }}
-          macos_certificate_password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-          macos_keychain_password: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-          macos_developer_id: ${{ secrets.MACOS_DEVELOPER_ID }}
-      - name: Package
-        run: |
-          # Package the zip with the signed executables
-          cd $GALACTICUS_DATA_PATH
-          # `convert_calpgm` is a helper that Cloudy compiles inside its own data directory to convert the
-          # CDMS/JPL catalogs at data-build time. It is never run by Galacticus, and it is not code-signed
-          # above, so leaving it in the archive causes notarization to reject the whole archive ("the binary
-          # is not signed", "no secure timestamp", "no hardened runtime"). Exclude it and its debug symbols.
-          #
-          # The `forutils` stamp file must be packaged alongside the `camb` executable. At run time
-          # `Interface_CAMB_Initialize` (source/interface/CAMB.F90) rebuilds CAMB unless *both* the
-          # executable and a stamp matching the required `forutils` version are present. Installs made from
-          # the packaged tools (e.g. via PyPI) typically have no Fortran compiler, so a missing stamp turns
-          # into a fatal build attempt rather than a simple use of the pre-built binary.
-          toolProducts=(
-            dynamic/CAMB-${cambVersion}/fortran/camb
-            dynamic/CAMB-${cambVersion}/forutils/.galacticusForUtilsVersion_${forutilsVersion}
-            dynamic/axionCAMB-${axioncambVersion}/camb
-            dynamic/class_public-${classVersion}/class
-            dynamic/RecFast/recfast.exe
-            dynamic/RecFast/currentVersion
-            dynamic/c${cloudyVersion}/source/cloudy.exe
-            dynamic/c${cloudyVersion}/data
-            dynamic/fsps-${fspsVersion}/src/autosps.exe
-            dynamic/fsps-${fspsVersion}/dust
-            dynamic/fsps-${fspsVersion}/data
-            dynamic/fsps-${fspsVersion}/nebular
-            dynamic/fsps-${fspsVersion}/SPECTRA
-            dynamic/fsps-${fspsVersion}/OUTPUTS
-            dynamic/fsps-${fspsVersion}/ISOCHRONES
-            dynamic/mangle-${mangleVersion}/bin/harmonize
-          )
-          # `zip` only warns (and still exits successfully) when a named path does not exist, so any error in
-          # the paths above -- for example an unset version variable -- would silently produce an archive
-          # missing most of the tools. Require every path to be present before packaging.
-          missingProducts=0
-          for toolProduct in "${toolProducts[@]}"; do
-            if [ ! -e "${toolProduct}" ]; then
-              echo "::error::tool product to be packaged does not exist: ${toolProduct}"
-              missingProducts=1
-            fi
-          done
-          [ ${missingProducts} -eq 0 ] || exit 1
-          zip -r toolsMacOS.zip "${toolProducts[@]}" \
-            -x "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm" \
-               "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm.dSYM/*"
-          # The same signed products, packed again as a zstd tar -- which is what the release publishes and
-          # the launcher installs. The zip stays because it is the submission format: `xcrun notarytool
-          # submit` accepts only .zip/.pkg/.dmg, and the signature verification step below reads it too. That
-          # costs nothing at distribution time, because a notarization ticket for loose signed binaries lives
-          # on Apple's servers and is looked up by the code-directory hash of each binary -- it is not stapled
-          # into the archive, so the archive's format is free. The tar wins twice over the zip: it unpacks far
-          # faster, and it records file modes, so the launcher does not have to guess afterwards which of the
-          # unpacked files were meant to be executable.
-          #
-          # COPYFILE_DISABLE stops bsdtar writing AppleDouble `._*` members for extended attributes. Mach-O
-          # code signatures live inside the binaries themselves, so nothing signed is lost; what would be
-          # carried over is quarantine and Finder metadata, which the installed tools have no use for.
-          set -o pipefail
-          COPYFILE_DISABLE=1 tar cf - \
-            --exclude "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm" \
-            --exclude "dynamic/c${cloudyVersion}/data/cdms+jpl/convert_calpgm.dSYM*" \
-            "${toolProducts[@]}" \
-            | zstd -12 -T0 -q -o toolsMacOS.tar.zst
-      - name: Verify all packaged binaries are code-signed
-        uses: ./.github/actions/verifySignedMacOS
-        with:
-          archive: toolsMacOS.zip
-          working_directory: ${{ env.GALACTICUS_DATA_PATH }}
-          macos_certificate: ${{ secrets.MACOS_CERTIFICATE }}
-      - name: Upload tool executables
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: galacticus-tools-MacOS
-          # Already compressed: re-zipping them in the artifact costs minutes and saves nothing.
-          compression-level: 0
-          path: |
-            ./datasets/toolsMacOS.zip
-            ./datasets/toolsMacOS.tar.zst
-  ### Apple Silicon build
   Build-Executable-MacOS-M1:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: macos-15
@@ -773,8 +582,9 @@ jobs:
           set -o pipefail
           # Disable link-time optimization: on Apple Silicon the DWARF emitted by LTO causes the dsymutil
           # step below to be OOM-killed (see the LTO option in the Makefile).
-          make -j`sysctl -n hw.activecpu` USEGIT2=no LTO=disabled Galacticus.exe 2>&1 | tee build.log
+          make -j`sysctl -n hw.activecpu` USEGIT2=no LTO=disabled Galacticus.exe tests.hashes.cryptographic.exe 2>&1 | tee build.log
           ./scripts/build/staticRelinker.py `grep '\-o Galacticus.exe' build.log`
+          ./scripts/build/staticRelinker.py `grep '\-o tests.hashes.cryptographic.exe' build.log`
           dsymutil -o Galacticus.exe.dSYM Galacticus.exe
           zip -r debugSymbolsMacOS-M1.zip Galacticus.exe.dSYM
           mv Galacticus.exe Galacticus_MacOS-M1.exe
@@ -796,6 +606,11 @@ jobs:
           path: |
             Galacticus_MacOS-M1.exe
             Galacticus_MacOS-M1.zip
+      - name: Upload test code executables
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-execs-MacOS-M1
+          path: 'tests.*.exe'
       - name: Upload Galacticus debug symbols
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -937,7 +752,7 @@ jobs:
   ## Library
   Build-Library-MacOS:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: macos-15-intel
+    runs-on: macos-15
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "This job is now running on a ${{ runner.os }} server."
@@ -979,7 +794,9 @@ jobs:
           mkdir galacticus/lib
           mkdir galacticus/python
           # Find all dynamic libraries needed (filtering out any non-"local" ones) and copy to our folder.
-          otool -L libgalacticus.so | awk '{if (NR > 1) print $1}' | grep -e /usr/local -e /opt/local | xargs -n 1 -I{} cp {} galacticus/lib/
+          # `/opt/homebrew` is Homebrew's prefix on Apple Silicon (it is `/usr/local` on Intel), and is where
+          # the GCC run-time libraries the library links against live.
+          otool -L libgalacticus.so | awk '{if (NR > 1) print $1}' | grep -e /usr/local -e /opt/local -e /opt/homebrew | xargs -n 1 -I{} cp {} galacticus/lib/
           mv galacticus.py galacticus/python/
           mv libgalacticus.so galacticus/lib/
           zip -r libgalacticusMacOS.zip galacticus
@@ -994,28 +811,20 @@ jobs:
           ! grep -q -e FAIL pythonTest.log
       - run: echo "This job's status is ${{ job.status }}."
   Submit-Notarization-MacOS:
-    runs-on: macos-15-intel
+    runs-on: macos-15
     if: github.ref == 'refs/heads/master'
     permissions:
       contents: read
-    # The tool artifacts (galacticus-tools-MacOS{,-M1}) are now produced by the
-    # executable build jobs, so those two jobs cover both executables and tools.
-    needs: [ Build-Executable-MacOS, Build-Executable-MacOS-M1 ]
+    # The tool artifact (galacticus-tools-MacOS-M1) is now produced by the
+    # executable build job, so that one job covers both executable and tools.
+    needs: [ Build-Executable-MacOS-M1 ]
     steps:
       - name: Check out repository code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Download artifacts (executable-macos)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: galacticus-exec-MacOS
       - name: Download artifacts (executable-macos-m1)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: galacticus-exec-MacOS-M1
-      - name: Download artifacts (tools-macos)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: galacticus-tools-MacOS
       - name: Download artifacts (tools-macos-m1)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -2119,10 +1928,10 @@ jobs:
           cd $GALACTICUS_EXEC_PATH
           python3 tutorials/executeNotebooks.py
       - run: echo "This job's status is ${{ job.status }}."
-  ## MacOS
+  ## MacOS (Apple Silicon)
   ### Test Codes
   Codes-MacOS:
-    needs: Build-Executable-MacOS
+    needs: Build-Executable-MacOS-M1
     strategy:
       # Ensure all jobs are run, even if some fail.
       fail-fast: false
@@ -2130,9 +1939,9 @@ jobs:
         executable: [ tests.hashes.cryptographic.exe ]
     uses: ./.github/workflows/testCode.yml
     with:
-      runner: macos-15-intel
+      runner: macos-15
       executable: ${{ matrix.executable }}
-      artifact: test-execs-MacOS
+      artifact: test-execs-MacOS-M1
     secrets: inherit
   # Validate, deploy and update
   Validate:
@@ -2617,7 +2426,6 @@ jobs:
              Build-Docker-Linux,
              Build-Tools,
              Package-Datasets,
-             Build-Executable-MacOS,
              Build-Executable-MacOS-M1,
              Build-Library-MacOS,
              Submit-Notarization-MacOS,
@@ -2693,14 +2501,6 @@ jobs:
           gh release upload bleeding-edge ./datasets.tar.zst ./datasets.ref --clobber
           sha256sum datasets.tar.zst datasets.ref >> "${GITHUB_WORKSPACE}/SHA256SUMS"
           rm ./datasets.tar.zst ./datasets.ref
-      - name: Download artifacts (executable-macos)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: galacticus-exec-MacOS
-      - name: Download artifacts (debug-macos)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: galacticus-debug-MacOS
       - name: Download artifacts (executable-macos-m1)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -2713,10 +2513,6 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: galacticus-library-MacOS
-      - name: Download artifacts (tools-macos)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: galacticus-tools-MacOS
       - name: Download artifacts (tools-macos-m1)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -2729,12 +2525,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # The tools zips are deliberately not published: they exist only as the format `xcrun notarytool
-          # submit` accepts, and the release carries the same signed products as the zstd tars the launcher
-          # installs. Publishing both would add ~4 GB of duplicate assets to every release.
-          gh release upload bleeding-edge ./Galacticus_MacOS.exe ./Galacticus_MacOS.zip ./Galacticus_MacOS-M1.exe ./Galacticus_MacOS-M1.zip ./libgalacticusMacOS.zip ./toolsMacOS.tar.zst ./toolsMacOSM1.tar.zst ./debugSymbolsMacOS.zip ./debugSymbolsMacOS-M1.zip ./notarization-requests-*.json --clobber
-          sha256sum Galacticus_MacOS.exe Galacticus_MacOS-M1.exe toolsMacOS.tar.zst toolsMacOSM1.tar.zst >> "${GITHUB_WORKSPACE}/SHA256SUMS"
-          rm -f ./Galacticus_MacOS.exe ./Galacticus_MacOS.zip ./Galacticus_MacOS-M1.exe ./Galacticus_MacOS-M1.zip ./libgalacticusMacOS.zip ./toolsMacOS.zip ./toolsMacOSM1.zip ./toolsMacOS.tar.zst ./toolsMacOSM1.tar.zst ./debugSymbolsMacOS.zip ./debugSymbolsMacOS-M1.zip ./notarization-requests-*.json
+          # The tools zip is deliberately not published: it exists only as the format `xcrun notarytool
+          # submit` accepts, and the release carries the same signed products as the zstd tar the launcher
+          # installs. Publishing both would add ~2 GB of duplicate assets to every release.
+          gh release upload bleeding-edge ./Galacticus_MacOS-M1.exe ./Galacticus_MacOS-M1.zip ./libgalacticusMacOS.zip ./toolsMacOSM1.tar.zst ./debugSymbolsMacOS-M1.zip ./notarization-requests-*.json --clobber
+          sha256sum Galacticus_MacOS-M1.exe toolsMacOSM1.tar.zst >> "${GITHUB_WORKSPACE}/SHA256SUMS"
+          rm -f ./Galacticus_MacOS-M1.exe ./Galacticus_MacOS-M1.zip ./libgalacticusMacOS.zip ./toolsMacOSM1.zip ./toolsMacOSM1.tar.zst ./debugSymbolsMacOS-M1.zip ./notarization-requests-*.json
       - name: Download artifacts (perf-darkMatterOnlySubHalos)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/notarizeMacOS.yml
+++ b/.github/workflows/notarizeMacOS.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   Poll-Notarization:
-    runs-on: macos-15-intel
+    runs-on: macos-15
     permissions:
       contents: write
     concurrency:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,15 +136,18 @@ jobs:
           # next `master` deploy finds only the older names on `bleeding-edge`, and the launcher installs
           # either -- so mirroring whichever exists keeps such a tag usable, rather than leaving it with no
           # tools at all. Missing names are warned about and skipped below.
+          #
+          # The macOS Intel assets (`Galacticus_MacOS.exe`, `toolsMacOS.*`) are deliberately absent: those
+          # builds have been retired (see `Build-Executable-MacOS-M1` in `cicd.yml`), so `bleeding-edge` no
+          # longer refreshes them and mirroring whatever stale copy it still carries onto a new version tag
+          # would publish a binary built from an unrelated commit. Releases cut while they were still built
+          # keep their own copies, so existing macOS Intel installs are unaffected.
           assets=(
             Galacticus.exe
-            Galacticus_MacOS.exe
             Galacticus_MacOS-M1.exe
             tools.tar.zst
-            toolsMacOS.tar.zst
             toolsMacOSM1.tar.zst
             tools.tar.bz2
-            toolsMacOS.zip
             toolsMacOSM1.zip
             datasets.tar.zst
             datasets.ref

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Have questions? Ask in the [discussion forum](https://github.com/galacticusorg/g
 > galacticus run parameters/quickTest.xml
 > ```
 >
-> The first run downloads the right binary, datasets, and tools for your platform (Linux x86-64, macOS Intel, or macOS Apple Silicon) and configures the environment for you. On Windows, run `galacticus install-wsl` first: it sets up WSL 2 and installs Galacticus inside it, after which `galacticus run` works from any Windows command prompt. See the [pip installation guide](https://galacticus.readthedocs.io/en/latest/manuals/user-guide/installation/pip.html). The rest of this section covers building from source, which you need only if you want to modify or extend Galacticus.
+> The first run downloads the right binary, datasets, and tools for your platform (Linux x86-64 or macOS Apple Silicon) and configures the environment for you. On Windows, run `galacticus install-wsl` first: it sets up WSL 2 and installs Galacticus inside it, after which `galacticus run` works from any Windows command prompt. See the [pip installation guide](https://galacticus.readthedocs.io/en/latest/manuals/user-guide/installation/pip.html). The rest of this section covers building from source, which you need only if you want to modify or extend Galacticus.
 
 This section walks you through building and running a minimal Galacticus model for the first time.
 

--- a/aux/words.dict
+++ b/aux/words.dict
@@ -133,6 +133,7 @@ Heger
 Hogg
 Hollenbach
 Holler
+Homebrew
 Hopital
 ICM
 ICM

--- a/docs/manuals/user-guide/installation/binary-macos.rst
+++ b/docs/manuals/user-guide/installation/binary-macos.rst
@@ -5,6 +5,10 @@ Installing a Pre-compiled Binary (macOS)
 
    macOS support is in beta-testing - this may or may not work for you. Please report success or failure in the `discussion forum <https://github.com/galacticusorg/galacticus/discussions>`_.
 
+.. note::
+
+   Pre-compiled binaries are provided for Apple Silicon (M1 and newer) only. Builds for Intel (x86-64) Macs have been retired: GitHub Actions is retiring its Intel macOS runners, and Homebrew no longer publishes pre-built packages for that platform. Releases up to and including `v0.9.12 <https://github.com/galacticusorg/galacticus/releases/tag/v0.9.12>`_ still carry a ``Galacticus_MacOS.exe`` built for Intel; for anything newer on an Intel Mac you must `build from source <https://galacticus.readthedocs.io/en/latest/manuals/user-guide/installation/source-macos.html>`_.
+
 This assumes that you want to install a pre-compiled Galacticus in a folder called ``Galacticus`` from your home directory. (You can also attempt to `install Galacticus from source <https://galacticus.readthedocs.io/en/latest/manuals/user-guide/installation/source-macos.html>`_ - usually necessary only if you want to modify the code.)
 
 #. Download and unpack the `source <https://github.com/galacticusorg/galacticus/archive/master.zip>`_ and `datasets <https://github.com/galacticusorg/datasets>`_ that are needed at run-time:
@@ -22,35 +26,22 @@ This assumes that you want to install a pre-compiled Galacticus in a folder call
 
 #. Download the pre-compiled binary and the tools package, move them to the ``~/Galacticus`` folder, and unpack it:
 
-   * For x86 chips (older Macs):
+   .. code-block:: bash
 
-     .. code-block:: bash
+      cd ~/Galacticus
+      curl -L https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/Galacticus_MacOS-M1.exe --output Galacticus_MacOS-M1.exe
+      mv Galacticus_MacOS-M1.exe galacticus/Galacticus.exe
+      chmod u=wrx galacticus/Galacticus.exe
+      curl -L https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/toolsMacOSM1.tar.zst --output toolsMacOSM1.tar.zst
+      mkdir -p datasets
+      mv toolsMacOSM1.tar.zst datasets/
+      cd datasets
+      tar xf toolsMacOSM1.tar.zst
+      cd ..
 
-        cd ~/Galacticus
-        curl -L https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/Galacticus_MacOS.exe --output Galacticus_MacOS.exe
-        mv Galacticus_MacOS.exe galacticus/Galacticus.exe
-        chmod u=wrx galacticus/Galacticus.exe
-        curl -L https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/toolsMacOS.zip --output toolsMacOS.zip
-        mkdir datasets
-        mv toolsMacOS.zip datasets/
-        cd datasets
-        unzip toolsMacOS.zip
-        cd ..
+   .. note::
 
-   * For Apple Silicon (M1 and newer chips):
-
-     .. code-block:: bash
-
-        cd ~/Galacticus
-        curl -L https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/Galacticus_MacOS.exe --output Galacticus_MacOS-M1.exe
-        mv Galacticus_MacOS-M1.exe galacticus/Galacticus.exe
-        chmod u=wrx galacticus/Galacticus.exe
-        curl -L https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/toolsMacOS.zip --output toolsMacOS-M1.zip
-        mkdir datasets
-        mv toolsMacOS-M1.zip datasets/
-        cd datasets
-        unzip toolsMacOS-M1.zip
-        cd ..
+      The tools archive is compressed with `zstd <https://facebook.github.io/zstd/>`_. The ``tar`` shipped with macOS understands it; if yours does not, install ``zstd`` (for example ``brew install zstd`` or ``sudo port install zstd``) and unpack with ``zstd -d toolsMacOSM1.tar.zst`` followed by ``tar xf toolsMacOSM1.tar``.
 
 #. Set environment variables to indicate the locations at which you downloaded the source and data:
 
@@ -81,4 +72,4 @@ This assumes that you want to install a pre-compiled Galacticus in a folder call
 Debugging
 ---------
 
-If you run into problems using Galacticus under macOS it can be useful to download the `debug symbols <https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/debugSymbolsMacOS.zip>`_ (or these `debug symbols <https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/debugSymbolsMacOS-M1.zip>`_ for Apple Silicon chips) and unpack them into the same folder as your ``Galacticus.exe`` executable to allow backtrace information to be generated.
+If you run into problems using Galacticus under macOS it can be useful to download the `debug symbols <https://github.com/galacticusorg/galacticus/releases/download/bleeding-edge/debugSymbolsMacOS-M1.zip>`_ and unpack them into the same folder as your ``Galacticus.exe`` executable to allow backtrace information to be generated.

--- a/docs/manuals/user-guide/installation/index.rst
+++ b/docs/manuals/user-guide/installation/index.rst
@@ -10,8 +10,9 @@ several ways to install it, listed here from easiest to most involved:
   datasets, and tools on first use and sets the environment up for you; on
   Windows it also sets up WSL 2 (``galacticus install-wsl``). See :doc:`pip`.
 * **Pre-compiled binary** — download and configure the binary yourself; no
-  compilation required. Available for :doc:`Linux <binary>` and
-  :doc:`macOS <binary-macos>`.
+  compilation required. Available for :doc:`Linux <binary>` (x86-64) and
+  :doc:`macOS <binary-macos>` (Apple Silicon only — Intel Macs are no longer
+  built).
 * **Container** — a ready-to-use Docker image with Galacticus already installed;
   see :doc:`container`.
 * **From source** — needed if you want to modify or extend the code. Step-by-step

--- a/docs/manuals/user-guide/installation/pip.rst
+++ b/docs/manuals/user-guide/installation/pip.rst
@@ -11,17 +11,30 @@ run a model, the launcher downloads the pre-built executable, the run-time
 ``datasets``, and the pre-built ``tools`` for your platform, and sets the
 required environment variables for you — so there is nothing else to configure.
 
-Pre-built binaries are available for Linux (x86-64), macOS (Intel x86-64), and
-macOS (Apple Silicon). On Windows the launcher runs the Linux binary through
-WSL 2 and can set that up for you — see :ref:`pip-windows`. On other platforms
-there is no pre-built binary; build :doc:`from source <source-linux>` instead.
+Pre-built binaries are available for Linux (x86-64) and macOS (Apple Silicon).
+On Windows the launcher runs the Linux binary through WSL 2 and can set that up
+for you — see :ref:`pip-windows`. On other platforms there is no pre-built
+binary; build :doc:`from source <source-linux>` instead.
 
 .. note::
 
-   The pre-built macOS binaries are compiled on a recent macOS and will only run
+   The pre-built macOS binary is compiled on a recent macOS and will only run
    on that version or newer. The launcher checks this before running: if your
    macOS is too old it stops with a clear message (rather than a cryptic
    ``dyld`` error) telling you to upgrade macOS or build from source.
+
+.. note::
+
+   **macOS Intel (x86-64) is no longer built.** GitHub Actions is retiring its
+   Intel macOS runners, and Homebrew no longer publishes pre-built packages for
+   that platform, so releases after ``v0.9.12`` carry no macOS Intel binary.
+   Releases up to and including ``v0.9.12`` still do, and an install already made
+   from one of them keeps working, so on an Intel Mac either pin that version::
+
+      pip install 'galacticus==0.9.12'
+
+   or build :doc:`from source <source-macos>`. Asking a newer release for an
+   Intel binary stops with a message saying so rather than failing to download.
 
 Running a model
 ---------------

--- a/python/galacticus_launcher/download.py
+++ b/python/galacticus_launcher/download.py
@@ -55,6 +55,8 @@ from pathlib import Path
 
 import requests
 
+from . import platforms
+
 REPO = "galacticusorg/galacticus"
 DATASETS_REPO = "galacticusorg/datasets"
 
@@ -411,11 +413,40 @@ def _sentinel(directory, name):
     return Path(directory) / f".galacticus-{name}"
 
 
+def _require_published_binary(context):
+    """Refuse, with the reason, to install a retired platform from a release which
+    carries no binary for it.
+
+    A platform whose builds have been retired keeps its entry in
+    :mod:`platforms`, because the releases cut while it was still built do carry
+    its assets and must stay installable.  What has to be caught is the other
+    case -- a newer release, which publishes nothing for it.  The published
+    checksums double as the release's asset manifest, so the absence is visible
+    up front; without this the install would instead grind through the download
+    retry schedule and end in a bare 404.
+
+    A release old enough to publish no checksums at all predates every
+    retirement, so it is left alone.  This is checked only when the executable is
+    about to be fetched, so an install already provisioned from a release which
+    did carry the binary keeps running.
+    """
+    assets, checksums = context.install.assets, context.checksums
+    if not assets.retired or checksums is None:
+        return
+    if _publishes(checksums, assets.binary):
+        return
+    raise platforms.UnsupportedPlatform(
+        f"release {context.install.tag} publishes no {assets.binary} for "
+        f"{assets.key}. {assets.retired}"
+    )
+
+
 def _plan_exec(context):
     install, log = context.install, context.log
     sentinel = _sentinel(install.exec_path, "exec")
     if sentinel.exists() and not context.force:
         return None
+    _require_published_binary(context)
     log(f"Fetching Galacticus source ({install.tag}) ...")
     work = context.workspace(install.exec_path)
     archive = work / "source.zip"

--- a/python/galacticus_launcher/platforms.py
+++ b/python/galacticus_launcher/platforms.py
@@ -18,6 +18,9 @@ from collections import namedtuple
 #                    the switch to zstd, or None if there is no earlier name.
 #   tools_legacy_format -- how to unpack `tools_legacy`.
 #   key           -- short human label for the platform (used in messages).
+#   retired       -- None for a platform still built, or a message explaining
+#                    that it is not, used when a release turns out to publish no
+#                    binary for it (see `download._require_published_binary`).
 #
 # Two tools archives are named per platform because a release only ever carries
 # the format that was current when it was cut: releases published before the
@@ -27,7 +30,26 @@ from collections import namedtuple
 # already-published version tag installable.
 PlatformAssets = namedtuple(
     "PlatformAssets",
-    ["binary", "tools", "tools_format", "tools_legacy", "tools_legacy_format", "key"],
+    ["binary", "tools", "tools_format", "tools_legacy", "tools_legacy_format", "key",
+     "retired"],
+    defaults=(None,),
+)
+
+# The last released version whose assets include a macOS Intel build.
+MACOS_INTEL_FINAL_VERSION = "0.9.12"
+
+# Why no newer release carries a macOS Intel binary.  A retired platform keeps
+# its entry above so that the releases which *do* carry its assets stay
+# installable; only a release which publishes none is refused, and then with
+# this message rather than a bare download failure.
+_MACOS_INTEL_RETIRED = (
+    "Galacticus no longer builds macOS Intel (x86-64) binaries: GitHub Actions is "
+    "retiring its Intel macOS runners, and Homebrew no longer publishes bottles "
+    f"for that platform. Releases up to and including v{MACOS_INTEL_FINAL_VERSION} "
+    f"still carry one -- `pip install 'galacticus=={MACOS_INTEL_FINAL_VERSION}'` "
+    "installs it, and an existing install keeps working. Otherwise build from "
+    "source: https://galacticus.readthedocs.io/en/latest/manuals/user-guide/"
+    "installation/source-macos.html"
 )
 
 
@@ -66,7 +88,8 @@ def detect(system=None, machine=None):
             return PlatformAssets("Galacticus_MacOS.exe",
                                   "toolsMacOS.tar.zst", "tar.zst",
                                   "toolsMacOS.zip", "zip",
-                                  "macOS x86-64")
+                                  "macOS x86-64",
+                                  _MACOS_INTEL_RETIRED)
         if machine in ("arm64", "aarch64"):
             return PlatformAssets("Galacticus_MacOS-M1.exe",
                                   "toolsMacOSM1.tar.zst", "tar.zst",

--- a/python/galacticus_launcher/tests/test_launcher.py
+++ b/python/galacticus_launcher/tests/test_launcher.py
@@ -37,6 +37,22 @@ def test_detect_supported(system, machine, binary, tools, legacy):
     assert assets.tools_legacy == legacy
 
 
+@pytest.mark.parametrize("system,machine,retired", [
+    ("Linux", "x86_64", False),
+    ("Darwin", "arm64", False),
+    # macOS Intel builds have been retired, but the releases which published them
+    # must stay installable, so the platform keeps its asset mapping and is
+    # refused only by a release carrying no binary for it (see
+    # `download._require_published_binary`).
+    ("Darwin", "x86_64", True),
+])
+def test_detect_marks_retired_platforms(system, machine, retired):
+    assets = platforms.detect(system, machine)
+    assert (assets.retired is not None) == retired
+    if retired:
+        assert platforms.MACOS_INTEL_FINAL_VERSION in assets.retired
+
+
 @pytest.mark.parametrize("system,machine", [
     ("Linux", "ppc64le"),
     ("Darwin", "i386"),

--- a/python/galacticus_launcher/tests/test_provision.py
+++ b/python/galacticus_launcher/tests/test_provision.py
@@ -315,3 +315,52 @@ def test_a_failed_catalog_download_does_not_abort_the_install(install, fetched,
     assert (install.exec_path / "parameters" / "quickTest.xml").is_file()
     assert (install.tools_path / "camb").is_file()
     assert _catalog(install) == {"source": "generated"}
+
+
+# --- a platform whose builds have been retired -----------------------------
+
+@pytest.fixture
+def retired_install(install):
+    """The same install, for a platform Galacticus no longer builds."""
+    return install._replace(
+        assets=install.assets._replace(retired="No more of those."))
+
+
+def test_a_retired_platform_installs_from_a_release_which_carries_its_binary(
+        retired_install, fetched, monkeypatch):
+    """Retirement must not break the releases cut while the platform was still
+    built: they publish its binary, and have to stay installable."""
+    monkeypatch.setattr(download, "load_checksums",
+                        lambda tag, log=print: _checksums("Galacticus.exe"))
+    monkeypatch.setattr(download, "_verify", lambda *a, **k: None)
+    assert "exec" in download.provision(retired_install, log=_quiet)
+
+
+def test_a_retired_platform_is_refused_by_a_release_which_carries_no_binary(
+        retired_install, fetched, monkeypatch):
+    monkeypatch.setattr(download, "load_checksums",
+                        lambda tag, log=print: _checksums("tools.tar.zst"))
+    with pytest.raises(platforms.UnsupportedPlatform) as raised:
+        download.provision(retired_install, log=_quiet)
+    # The reason, not a bare download failure.
+    assert "No more of those." in str(raised.value)
+    assert not fetched
+
+
+def test_a_release_publishing_no_checksums_predates_every_retirement(
+        retired_install, fetched, monkeypatch):
+    """Such a release has no manifest to consult, and is old enough that the
+    binary is there; the default `load_checksums` stub already returns None."""
+    monkeypatch.setattr(download, "_verify", lambda *a, **k: None)
+    assert "exec" in download.provision(retired_install, log=_quiet)
+
+
+def test_a_retired_platform_already_installed_keeps_working(
+        retired_install, fetched, monkeypatch):
+    """The check gates the download of the executable, so an install provisioned
+    while the binary was still published is never refused afterwards."""
+    monkeypatch.setattr(download, "_verify", lambda *a, **k: None)
+    download.provision(retired_install, log=_quiet)
+    monkeypatch.setattr(download, "load_checksums",
+                        lambda tag, log=print: _checksums("tools.tar.zst"))
+    assert download.provision(retired_install, log=_quiet) == []

--- a/scripts/aux/notarizationSubmit.py
+++ b/scripts/aux/notarizationSubmit.py
@@ -6,9 +6,7 @@ import subprocess
 import sys
 
 files = [
-    "Galacticus_MacOS.zip",
     "Galacticus_MacOS-M1.zip",
-    "toolsMacOS.zip",
     "toolsMacOSM1.zip"
 ]
 for required in ("APPLE_ID", "APPLE_TEAM_ID", "APPLE_APP_SPECIFIC_PASSWORD"):


### PR DESCRIPTION
Homebrew no longer publishes bottles for macOS on Intel x86-64 (announced August 2025), so the CI macOS Intel jobs now compile GCC from source and exceed the 6 hour GitHub Actions limit — visible in the `Build-Library-MacOS` log on #1455. GitHub Actions is itself retiring its Intel macOS runners in 2027, at which point building for that platform would stop being possible anyway, so this retires the builds rather than working around the bottle loss (e.g. by switching to MacPorts).

## CI

- Remove the `Build-Executable-MacOS` job. Its test executable (`tests.hashes.cryptographic.exe`) is now built, relinked, and uploaded (as `test-execs-MacOS-M1`) by `Build-Executable-MacOS-M1`, and `Codes-MacOS` runs it on the Apple Silicon runner.
- Move `Build-Library-MacOS` and `Submit-Notarization-MacOS` — and the `notarizeMacOS.yml` poller — from `macos-15-intel` to `macos-15`. The library job was the only macOS library / Python-interface build, so it moves rather than being deleted; its `otool -L` dependency sweep now also matches `/opt/homebrew`, Homebrew's Apple Silicon prefix, where the GCC run-time libraries it links against live.
- Drop the Intel artifacts from `Deploy`, so no further release publishes `Galacticus_MacOS.exe`, `toolsMacOS.*`, or `debugSymbolsMacOS.zip`.
- Stop mirroring the Intel assets onto version tags in `publish.yml`. `gh release upload --clobber` never deletes, so the last Intel assets stay on the rolling `bleeding-edge` release; without this a new tag would have silently published a stale binary built from an unrelated commit.
- Trim the now-dead macOS 11/12/13/14 branches from the `buildMacOS` action (the macOS 13 classic-linker workarounds, the older MacPorts base packages, the always-true `OS_VER -ge 14` guard), and fix its unknown-version error message, which interpolated a variable local to an earlier step's shell and so always printed empty.

## PyPI installer

`platforms.detect` keeps the `Darwin`/`x86_64` mapping — the releases cut while the platform was still built do carry its assets and must stay installable — but marks it retired. `download._require_published_binary` uses the `SHA256SUMS` asset manifest to detect a release which publishes no binary for a retired platform and raises `UnsupportedPlatform` with the reason, instead of burning the download retry schedule on a 404:

```
galacticus: release v0.9.13 publishes no Galacticus_MacOS.exe for macOS x86-64.
Galacticus no longer builds macOS Intel (x86-64) binaries: GitHub Actions is
retiring its Intel macOS runners, and Homebrew no longer publishes bottles for
that platform. Releases up to and including v0.9.12 still carry one -- `pip
install 'galacticus==0.9.12'` installs it, and an existing install keeps
working. Otherwise build from source: <source-macos docs>
```

The check is deliberately placed where the executable is about to be fetched, so an install already provisioned from a release that did carry the binary keeps running.

## Docs

The retirement is recorded in the pip and pre-compiled-binary installation guides, the installation index, and the README. While there: the Apple Silicon instructions in `binary-macos.rst` were already wrong — they downloaded the Intel assets (`Galacticus_MacOS.exe`, `toolsMacOS.zip`) under `-M1` output names, and the zip tools archive is no longer published at all, so that path was dead regardless.

## Verification

- Full `pytest` suite: 1088 passed, 1 skipped — including eight new tests covering the retired-platform gate (installs from a release that carries the binary, refusal by one that does not, releases predating `SHA256SUMS`, and an already-provisioned install).
- Every changed workflow and action parses as YAML; every `run` block in `buildMacOS/action.yml` passes `bash -n`.
- Sphinx spelling build reports no new misspellings (`Homebrew`, already flagged on `source-macos.rst`, added to `aux/words.dict`).
- The macOS jobs themselves can only be exercised on CI — this PR's run is the first real test of the Apple Silicon library build and of `Codes-MacOS` on `macos-15`.

## Follow-ups for a human

- **Stale `bleeding-edge` assets.** `Galacticus_MacOS.exe`, `Galacticus_MacOS.zip`, `toolsMacOS.tar.zst`, `debugSymbolsMacOS.zip` will linger on the rolling release. `SHA256SUMS` is regenerated each deploy, so the launcher correctly reports them as unpublished, and `publish.yml` no longer mirrors them — but they stay listed and downloadable. Not automated here, since deleting release assets is irreversible:
  ```bash
  for a in Galacticus_MacOS.exe Galacticus_MacOS.zip toolsMacOS.tar.zst toolsMacOS.zip debugSymbolsMacOS.zip; do
    gh release delete-asset bleeding-edge "$a" --yes || true
  done
  ```
- **`platforms.MACOS_INTEL_FINAL_VERSION = "0.9.12"`** is the last tag published as of this PR. It is named in the error message and in the two docs pages; bump all three if another version is tagged before this merges.

BREAKING CHANGE: no release after v0.9.12 provides a pre-built macOS Intel (x86-64) executable or tools archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NbMgaUFY2MztyBkWkN2fe
